### PR TITLE
[Fix] DSV3.2 W4AFP8 MTP use FP8 draft model  

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -609,55 +609,32 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         input_global_scale = self.quant_config.get("input_global_scale", None)
         if input_global_scale is not None:
             use_nvfp4 = True
-        elif not envs.SGLANG_DEEPEP_BF16_DISPATCH.get():
+        elif not envs.SGLANG_DEEPEP_BF16_DISPATCH.get() or self.quant_config.get("dispatch_input_scale") is None:
             use_fp8 = True
 
         buffer = self._get_buffer()
-        try:
-            packed_recv_hidden, self.packed_recv_count, self.handle, event, hook = (
-                buffer.low_latency_dispatch(
-                    hidden_states,
-                    topk_ids,
-                    self.num_max_dispatch_tokens_per_rank,
-                    self.num_experts,
-                    use_fp8=use_fp8,
-                    **(dict(use_nvfp4=True) if use_nvfp4 else dict()),
-                    **(
-                        dict(x_global_scale=input_global_scale)
-                        if input_global_scale is not None
-                        else dict()
-                    ),
-                    async_finish=not self.return_recv_hook,
-                    return_recv_hook=self.return_recv_hook,
-                    round_scale=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                    and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
-                    use_ue8m0=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                    and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
-                )
+        packed_recv_hidden, self.packed_recv_count, self.handle, event, hook = (
+            buffer.low_latency_dispatch(
+                hidden_states,
+                topk_ids,
+                self.num_max_dispatch_tokens_per_rank,
+                self.num_experts,
+                use_fp8=use_fp8,
+                **(dict(use_nvfp4=True) if use_nvfp4 else dict()),
+                **(
+                    dict(x_global_scale=input_global_scale)
+                    if input_global_scale is not None
+                    else dict()
+                ),
+                async_finish=not self.return_recv_hook,
+                return_recv_hook=self.return_recv_hook,
+                round_scale=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+                and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
+                use_ue8m0=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+                and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
             )
-        except Exception as e:
-            use_fp8 = True
-            packed_recv_hidden, self.packed_recv_count, self.handle, event, hook = (
-                buffer.low_latency_dispatch(
-                    hidden_states,
-                    topk_ids,
-                    self.num_max_dispatch_tokens_per_rank,
-                    self.num_experts,
-                    use_fp8=use_fp8,
-                    **(dict(use_nvfp4=True) if use_nvfp4 else dict()),
-                    **(
-                        dict(x_global_scale=input_global_scale)
-                        if input_global_scale is not None
-                        else dict()
-                    ),
-                    async_finish=not self.return_recv_hook,
-                    return_recv_hook=self.return_recv_hook,
-                    round_scale=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                    and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
-                    use_ue8m0=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                    and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
-                )
-            )
+        )
+        
         return packed_recv_hidden, self.packed_recv_count, event, hook
 
     def combine_a(

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -609,7 +609,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         input_global_scale = self.quant_config.get("input_global_scale", None)
         if input_global_scale is not None:
             use_nvfp4 = True
-        elif not envs.SGLANG_DEEPEP_BF16_DISPATCH.get() or self.quant_config.get("dispatch_input_scale") is None:
+        elif not envs.SGLANG_DEEPEP_BF16_DISPATCH.get() or self.quant_config.get("dispatch_weight_scale") is None:
             use_fp8 = True
 
         buffer = self._get_buffer()

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -283,7 +283,7 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
             [w2_input_scale_max], dtype=torch.float32, device=device
         )
         layer.w2_input_scale = Parameter(new_w2_input_scale, requires_grad=False)
-        self.dispatcher.set_quant_config({"dispatch_input_scale", (layer.w13_weight_scale_inv)})
+        self.dispatcher.set_quant_config({"dispatch_weight_scale", (layer.w13_weight_scale_inv)})
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -283,6 +283,7 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
             [w2_input_scale_max], dtype=torch.float32, device=device
         )
         layer.w2_input_scale = Parameter(new_w2_input_scale, requires_grad=False)
+        self.dispatcher.set_quant_config({"dispatch_input_scale", (layer.w13_weight_scale_inv)})
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -283,7 +283,7 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
             [w2_input_scale_max], dtype=torch.float32, device=device
         )
         layer.w2_input_scale = Parameter(new_w2_input_scale, requires_grad=False)
-        self.dispatcher.set_quant_config({"dispatch_weight_scale", (layer.w13_weight_scale_inv)})
+        layer.dispatcher.set_quant_config({"dispatch_weight_scale", (layer.w13_weight_scale_inv)})
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
DeepSeekV3.2 W4A8 MTP acceptance rate is very low use this commad:

`SGLANG_DEEPEP_BF16_DISPATCH=1 SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600  SGLANG_DISAGGREGATION_THREAD_POOL_SIZE=128 SGLANG_DISAGGREGATION_QUEUE_SIZE=128 SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=164 GLOO_SOCKET_IFNAME=eth0 NCCL_IB_DISABLE=0 NCCL_SOCKET_IFNAME=eth0 SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 NCCL_MIN_NCHANNELS=24 NCCL_IB_QPS_PER_CONNECTION=8 SGLANG_ENABLE_JIT_DEEPGEMM=1 SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 python3 -m sglang.launch_server --attention-backend nsa --nsa-decode-backend flashmla_kv --model-path /data00/DeepSeek-V3.2-W4AFP8-1209/ --tp 8 --disaggregation-mode decode  --disaggregation-ib-device  "mlx5_1,mlx5_2,mlx5_3,mlx5_4" --host 0.0.0.0 --port 30300 --moe-a2a-backend deepep --deepep-mode low_latency  --disable-radix-cache --mem-fraction-static 0.74 --max-running-requests 256 --moe-dense-tp-size 1 --cuda-graph-bs 1 2 4 8 10 12 14 16 18 20 22 24 26 28 30 32 --watchdog-timeout 1000000  --enable-dp-attention --dp-size 8 --trust-remote-code  --page-size 64 --show-time-cost --enable-dp-lm-head --speculative-algo EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3 --moe-runner-backend auto --prefill-round-robin-balance --speculative-moe-runner-backend deep_gemm --kv-cache-dtype fp8_e4m3 `

[2025-12-30 08:08:34 DP1 TP1 EP1] Decode batch, #running-req: 1, #token: 4096, token usage: 0.02, accept len: 1.00, accept rate: 0.33, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 18.67, #queue-req: 0,

so we use this draft model is FP8 this command:
`SGLANG_DEEPEP_BF16_DISPATCH=1 SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600  SGLANG_DISAGGREGATION_THREAD_POOL_SIZE=128 SGLANG_DISAGGREGATION_QUEUE_SIZE=128 SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=164 GLOO_SOCKET_IFNAME=eth0 NCCL_IB_DISABLE=0 NCCL_SOCKET_IFNAME=eth0 SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 NCCL_MIN_NCHANNELS=24 NCCL_IB_QPS_PER_CONNECTION=8 SGLANG_ENABLE_JIT_DEEPGEMM=1 SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 python3 -m sglang.launch_server --attention-backend nsa --nsa-decode-backend flashmla_kv --model-path /data00/DeepSeek-V3.2-W4AFP8-1209/ --tp 8 --disaggregation-mode decode  --disaggregation-ib-device  "mlx5_1,mlx5_2,mlx5_3,mlx5_4" --host 0.0.0.0 --port 30300 --moe-a2a-backend deepep --deepep-mode low_latency  --disable-radix-cache --mem-fraction-static 0.74 --max-running-requests 256 --moe-dense-tp-size 1 --cuda-graph-bs 1 2 4 8 10 12 14 16 18 20 22 24 26 28 30 32 --watchdog-timeout 1000000  --enable-dp-attention --dp-size 8 --trust-remote-code  --page-size 64 --show-time-cost --enable-dp-lm-head --speculative-algo EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3 --moe-runner-backend auto --prefill-round-robin-balance --speculative-draft-model-path /data00/DeepSeek-V3.2-MTP/ --speculative-moe-runner-backend deep_gemm --kv-cache-dtype fp8_e4m3 `


but has this error

Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2653, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 347, in __init__
    self.draft_worker = self.spec_algorithm.create_draft_worker(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/spec_info.py", line 179, in create_draft_worker
    return self._draft_worker_factory(self, **factory_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/spec_info.py", line 197, in _factory
    return worker_cls(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/spec_info.py", line 273, in _create_eagle_worker
    return EAGLEWorker(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/eagle_worker.py", line 186, in __init__
    self.init_cuda_graphs()
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/eagle_worker.py", line 232, in init_cuda_graphs
    self.cuda_graph_runner = Device2DraftCudaGraphRunner[
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py", line 131, in __init__
    raise Exception(
Exception: Capture cuda graph failed: Assertion error (/sgl-kernel/build/_deps/repo-deepgemm-src/csrc/apis/../jit_kernels/impls/smxx_layout.hpp:102): dim == 2 or dim == 3

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
