### PR TITLE
[Build] Enable full kernel in aarch64 wheel

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -47,6 +47,7 @@ jobs:
           ./build.sh "${{ matrix.python-version }}" "${{ matrix.cuda-version }}" ${{ matrix.arch == 'aarch64' && 'aarch64' || '' }}
         env:
           USE_CCACHE: 0
+          CMAKE_EXTRA_ARGS: ${{ matrix.arch == 'aarch64' && '-DENABLE_BELOW_SM90=ON' || '' }}
 
       - name: Upload to PyPI
         working-directory: sgl-kernel

--- a/sgl-kernel/Dockerfile
+++ b/sgl-kernel/Dockerfile
@@ -96,6 +96,8 @@ COPY . /sgl-kernel/
 # Optional: enable CMake/Ninja profiling (pass non-empty via --build-arg ENABLE_*)
 ARG ENABLE_CMAKE_PROFILE
 ARG ENABLE_BUILD_PROFILE
+# Optional: cmake extra args for aarch64 full kernel build (pass non-empty via --build-arg CMAKE_EXTRA_ARGS)
+ARG CMAKE_EXTRA_ARGS
 ARG ARCH=x86_64
 ARG USE_CCACHE=1
 
@@ -128,6 +130,9 @@ RUN --mount=type=cache,id=sgl-kernel-ccache,target=/ccache \
       echo "CMake profiling enabled - will save to /sgl-kernel/cmake-profile.json"; \
       export CMAKE_ARGS="--profiling-output=/sgl-kernel/cmake-profile.json --profiling-format=google-trace"; \
     fi; \
+    # Merge Extra CMake options into CMAKE_ARGS \
+    export CMAKE_ARGS="${CMAKE_ARGS:+${CMAKE_ARGS} }${CMAKE_EXTRA_ARGS:-}"; \
+    echo "CMAKE_ARGS= [$CMAKE_ARGS]"; \
     ${PYTHON_ROOT_PATH}/bin/python -m uv build --wheel -Cbuild-dir=build . --color=always --no-build-isolation; \
     ./rename_wheels.sh; \
     if [ -n "${ENABLE_BUILD_PROFILE:-}" ] && [ -f /sgl-kernel/build/.ninja_log ]; then \

--- a/sgl-kernel/build.sh
+++ b/sgl-kernel/build.sh
@@ -48,10 +48,12 @@ echo "Buildx cache:   ${BUILDX_CACHE_DIR}"
 echo "Builder:        ${BUILDER_NAME}"
 echo "----------------------------------------"
 
-# Optional profiling build-args (empty string disables)
 BUILD_ARGS=()
+# Optional profiling build-args (empty string disables)
 [ -n "${ENABLE_CMAKE_PROFILE:-}" ] && BUILD_ARGS+=(--build-arg ENABLE_CMAKE_PROFILE="${ENABLE_CMAKE_PROFILE}")
 [ -n "${ENABLE_BUILD_PROFILE:-}" ] && BUILD_ARGS+=(--build-arg ENABLE_BUILD_PROFILE="${ENABLE_BUILD_PROFILE}")
+# Optional extra cmake build-args (empty string disables)
+[ -n "${CMAKE_EXTRA_ARGS:-}" ] && BUILD_ARGS+=(--build-arg CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS}")
 
 docker buildx build \
   --builder "${BUILDER_NAME}" \


### PR DESCRIPTION
Use environment variables to make the aarch64 kernel wheel include support for all NV GPU kernels. To avoid impacting CI efficiency, this full build is only enabled when publishing the sgl-kernel wheel.

## Motivation

Currently, compared with x86, the sgl-kernel wheel on aarch64 lacks support for certain GPUs, mainly those with gpu arch <sm90. This results in users being unable to use some older GPUs out of the box on general-purpose arm64 servers.

## Modifications

Introduce environment variable to control full kernel build on aarch64 platform. Enable it in the wheel release workflow.

## Tests

The test of releasing workflow has not done, which needs to do in the github repo.
.
