### PR TITLE
[Diffusion] Zimage opt with qknorm and flashinfer rope

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding.py
@@ -76,7 +76,7 @@ def apply_flashinfer_rope_qk_inplace(
         ) from e
 
     if positions is None:
-        pos_1d = torch.arange(seqlen, device="cpu", dtype=torch.long)
+        pos_1d = torch.arange(seqlen, device=q.device, dtype=torch.long)
         positions = pos_1d if bsz == 1 else pos_1d.repeat(bsz)
     else:
         if not (

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding.py
@@ -76,7 +76,7 @@ def apply_flashinfer_rope_qk_inplace(
         ) from e
 
     if positions is None:
-        pos_1d = torch.arange(seqlen, device=q.device, dtype=torch.long)
+        pos_1d = torch.arange(seqlen, device="cpu", dtype=torch.long)
         positions = pos_1d if bsz == 1 else pos_1d.repeat(bsz)
     else:
         if not (

--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -154,7 +154,7 @@ class ZImageAttention(nn.Module):
         k = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
         v = v.view(*v.shape[:-1], self.num_kv_heads, self.head_dim)
 
-        if self.qk_norm and (self.norm_q is not None) and (self.norm_k is not None):
+        if self.qk_norm:
             if (
                 q.is_cuda
                 and (self.norm_q.variance_epsilon == self.norm_k.variance_epsilon)

--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -4,17 +4,21 @@ from typing import Any, List, Optional, Tuple
 import torch
 import torch.nn as nn
 
+from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm
 from sglang.multimodal_gen.configs.models.dits.zimage import ZImageDitConfig
 from sglang.multimodal_gen.runtime.layers.activation import SiluAndMul
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
-from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
+from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
 from sglang.multimodal_gen.runtime.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
-from sglang.multimodal_gen.runtime.layers.rotary_embedding import _apply_rotary_emb
+from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
+    _apply_rotary_emb,
+    apply_flashinfer_rope_qk_inplace,
+)
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -150,23 +154,40 @@ class ZImageAttention(nn.Module):
         k = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
         v = v.view(*v.shape[:-1], self.num_kv_heads, self.head_dim)
 
-        if self.norm_q is not None:
-            q = self.norm_q(q)
-        if self.norm_k is not None:
-            k = self.norm_k(k)
-
-        # Apply RoPE
-        def apply_rotary_emb(
-            x_in: torch.Tensor,
-            freqs_cis: torch.Tensor,
-        ) -> Tuple[torch.Tensor, torch.Tensor]:
-            cos, sin = freqs_cis
-            x_out = _apply_rotary_emb(x_in, cos, sin, is_neox_style=False)
-            return x_out
+        if self.qk_norm and (self.norm_q is not None) and (self.norm_k is not None):
+            if (
+                q.is_cuda
+                and (self.norm_q.variance_epsilon == self.norm_k.variance_epsilon)
+                and can_use_fused_inplace_qknorm(self.head_dim)
+            ):
+                q, k = apply_qk_norm(
+                    q=q,
+                    k=k,
+                    q_norm=self.norm_q,
+                    k_norm=self.norm_k,
+                    head_dim=self.head_dim,
+                    allow_inplace=True,
+                )
+            else:
+                q = self.norm_q(q)
+                k = self.norm_k(k)
 
         if freqs_cis is not None:
-            q = apply_rotary_emb(q, freqs_cis)
-            k = apply_rotary_emb(k, freqs_cis)
+            cos, sin = freqs_cis
+            if q.is_cuda and q.shape == k.shape:
+                cos_sin_cache = torch.cat(
+                    [
+                        cos.to(dtype=torch.float32).contiguous(),
+                        sin.to(dtype=torch.float32).contiguous(),
+                    ],
+                    dim=-1,
+                )
+                q, k = apply_flashinfer_rope_qk_inplace(
+                    q, k, cos_sin_cache, is_neox=False
+                )
+            else:
+                q = _apply_rotary_emb(q, cos, sin, is_neox_style=False)
+                k = _apply_rotary_emb(k, cos, sin, is_neox_style=False)
 
         hidden_states = self.attn(q, k, v)
         hidden_states = hidden_states.flatten(2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## SGLang generate main

sglang generate --model-path Tongyi-MAI/Z-Image-Turbo  --prompt "A cat is sitting on a chair" --tp-size 1 --height 1024 --width 1024

```shell
100%|██████████████████████████████████████████████████████| 9/9 [00:03<00:00,  2.26it/s]
[12-30 00:55:27] [DenoisingStage] average time per step: 0.4424 seconds
[12-30 00:55:27] [DenoisingStage] finished in 3.9857 seconds
```

sglang generate --model-path Tongyi-MAI/Z-Image-Turbo  --prompt "A cat is sitting on a chair" --tp-size 1 --height 2048 --width 2048

```shell
100%|██████████████████████████████████████████████████████| 9/9 [00:06<00:00,  1.34it/s]
[12-30 00:57:26] [DenoisingStage] average time per step: 0.7456 seconds
[12-30 00:57:26] [DenoisingStage] finished in 6.7150 seconds
```

## SGLang generate: qk norm + flashinfer rope

sglang generate --model-path Tongyi-MAI/Z-Image-Turbo  --prompt "A cat is sitting on a chair" --tp-size 1 --height 1024 --width 1024

```shell
100%|██████████████████████████████████████████████████████| 9/9 [00:02<00:00,  4.41it/s]
[12-30 02:05:34] [DenoisingStage] average time per step: 0.2269 seconds
[12-30 02:05:34] [DenoisingStage] finished in 2.0471 seconds
```

sglang generate --model-path Tongyi-MAI/Z-Image-Turbo  --prompt "A cat is sitting on a chair" --tp-size 1 --height 2048 --width 2048

```shell
100%|██████████████████████████████████████████████████████████████████| 9/9 [00:05<00:00,  1.54it/s]
[12-30 08:06:58] [DenoisingStage] average time per step: 0.6485 seconds
[12-30 08:06:58] [DenoisingStage] finished in 5.8410 seconds
```

<img width="812" height="824" alt="图片" src="https://github.com/user-attachments/assets/6b1984dd-20cb-4fb7-b84d-eadb74ddbbc8" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
