### PR TITLE
[VLM] Adopt jit qk_norm kernel in VLM

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_qknorm.py
+++ b/python/sglang/jit_kernel/benchmark/bench_qknorm.py
@@ -5,6 +5,10 @@ from typing import Tuple
 import torch
 import triton
 import triton.testing
+from sgl_kernel import rmsnorm
+
+from sglang.jit_kernel.norm import fused_inplace_qknorm
+from sglang.srt.utils import get_current_device_stream_fast
 
 IS_CI = (
     os.getenv("CI", "false").lower() == "true"
@@ -20,13 +24,12 @@ def sglang_aot_qknorm(
     q_weight: torch.Tensor,
     k_weight: torch.Tensor,
 ) -> None:
-    from sgl_kernel import rmsnorm
 
     head_dim = q.shape[-1]
     q = q.view(-1, head_dim)
     k = k.view(-1, head_dim)
 
-    current_stream = torch.cuda.current_stream()
+    current_stream = get_current_device_stream_fast()
     alt_stream.wait_stream(current_stream)
     rmsnorm(q, q_weight, out=q)
     with torch.cuda.stream(alt_stream):
@@ -40,7 +43,6 @@ def sglang_jit_qknorm(
     q_weight: torch.Tensor,
     k_weight: torch.Tensor,
 ) -> None:
-    from sglang.jit_kernel.norm import fused_inplace_qknorm
 
     fused_inplace_qknorm(q, k, q_weight, k_weight)
 
@@ -51,7 +53,6 @@ def flashinfer_qknorm(
     q_weight: torch.Tensor,
     k_weight: torch.Tensor,
 ) -> None:
-    from flashinfer.norm import rmsnorm
 
     rmsnorm(q, q_weight, out=q)
     rmsnorm(k, k_weight, out=k)

--- a/python/sglang/jit_kernel/norm.py
+++ b/python/sglang/jit_kernel/norm.py
@@ -30,7 +30,7 @@ def _jit_norm_module(head_dims: int) -> Module:
 @cache_once
 def can_use_fused_inplace_qknorm(head_dim: int) -> bool:
     logger = logging.getLogger(__name__)
-    if head_dim not in [64, 128, 256]:
+    if head_dim not in [64, 128, 256, 512, 1024]:
         logger.warning(f"Unsupported head_dim={head_dim} for JIT QK-Norm kernel")
         return False
     try:

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -25,6 +25,7 @@ from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_q
 from sglang.jit_kernel.utils import register_jit_op
 from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_cuda
 
@@ -223,7 +224,6 @@ def apply_qk_norm(
     Returns:
         Tuple of normalized query and key tensors
     """
-    from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 
     batch_size = q.size(0)
     q_eps = q_norm.variance_epsilon


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
https://github.com/sgl-project/sglang/pull/15835 introduced jit qk_norm kernel which is powerful.
This PR is to adopt it in VLM VisionAttention to boost up.

<img width="2836" height="1596" alt="image" src="https://github.com/user-attachments/assets/ce8b2acf-92be-43da-bdc2-78b6f0d1ecd2" />
<img width="2848" height="1606" alt="image" src="https://github.com/user-attachments/assets/40896fef-841f-48f8-b5b2-190655c148b7" />


Introduced a kernel dispatcher: when the JIT kernel compilation occasionally fails, we fall back to the legacy fused kernel as a safeguard. In addition, neither the JIT kernel nor its internal fallback path supports tp > 1. The legacy kernel performs better in this scenario, so it’s worth keeping.
```
[2025-12-30 14:47:38] INFO:     Application startup complete.
[2025-12-30 14:47:38] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2025-12-30 14:47:39] INFO:     127.0.0.1:42520 - "GET /model_info HTTP/1.1" 200 OK
[2025-12-30 14:47:39] [internvl][internlm2] placeholders img_context=1
[2025-12-30 14:47:40] Prefill batch, #new-seq: 1, #new-token: 2615, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-30 14:47:43] Failed to load JIT QK-Norm kernel: ninja exited with status 255
stdout:
[1/2] /usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output cuda_0.o.d -Xcompiler -fPIC -std=c++17 -O2 -gencode=arch=compute_89,code=sm_89 -std=c++20 -O3 --expt-relaxed-constexpr -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/sglang/jit_kernel/include -c /root/.cache/tvm-ffi/sgl_kernel_jit_norm_64_true_f31c0cb10adc6473/cuda.cu -o cuda_0.o
FAILED: [code=255] cuda_0.o 
/usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output cuda_0.o.d -Xcompiler -fPIC -std=c++17 -O2 -gencode=arch=compute_89,code=sm_89 -std=c++20 -O3 --expt-relaxed-constexpr -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/sglang/jit_kernel/include -c /root/.cache/tvm-ffi/sgl_kernel_jit_norm_64_true_f31c0cb10adc6473/cuda.cu -o cuda_0.o
nvcc warning : incompatible redefinition for option 'std', the last value of this option was used
nvcc warning : incompatible redefinition for option 'optimize', the last value of this option was used
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 37; error   : Modifier '.wait' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 37; error   : Instruction 'griddepcontrol' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 162; error   : Modifier '.launch_dependents' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 162; error   : Instruction 'griddepcontrol' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 189; error   : Modifier '.wait' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 189; error   : Instruction 'griddepcontrol' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 326; error   : Modifier '.launch_dependents' requires .target sm_90 or higher
ptxas /tmp/tmpxft_00040bd4_00000000-6_cuda.ptx, line 326; error   : Instruction 'griddepcontrol' requires .target sm_90 or higher
ptxas fatal   : Ptx assembly aborted due to errors
ninja: build stopped: subcommand failed.

[2025-12-30 14:47:44] INFO:     127.0.0.1:42524 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-12-30 14:47:44] The server is fired up and ready to roll!


[2025-12-30 14:51:52] [internvl][internlm2] placeholders img_context=1
[2025-12-30 14:51:52] Prefill batch, #new-seq: 1, #new-token: 2317, #cached-token: 42, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-30 14:51:52] Decode batch, #running-req: 1, #token: 2392, token usage: 0.00, cuda graph: True, gen throughput (token/s): 0.15, #queue-req: 0, 
[2025-12-30 14:51:52] INFO:     127.0.0.1:58922 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
Introduced another potential speedup point per https://github.com/sgl-project/sglang/pull/15835/files#r2649676428.

Manually test passed.
```
root@6996fb46042d:/sgl-workspace/bench_script# bash bench_n_image.sh 
{"id":"fbd937e829374b08943bce9ef069e7c9","object":"chat.completion","created":1767106312,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中是一种植物，看起来像是欧防风（Dendrolycopodium），学名是Dendrolycopodium dendroideum。它是一种多年生草本植物，常见于亚洲和北美的园林景观中。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":92542}],"usage":{"prompt_tokens":2359,"total_tokens":2408,"completion_tokens":49,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m0.232s
user    0m0.001s
sys     0m0.004s
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
