### PR TITLE
[diffusion] Upgrade multimodal benchmarks for diverse applications and create a prettier, more intuitive logger.

### DIFF
--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -801,7 +801,7 @@ if __name__ == "__main__":
         "--backend",
         type=str,
         default=None,
-        help="DEPRECATED, we don't use backend anymore, and we will auto infer backend from --model.",
+        help="DEPRECATED: --task is deprecated and will be ignored. The task will be inferred from --model.",
     )
     parser.add_argument(
         "--base-url",
@@ -830,7 +830,7 @@ if __name__ == "__main__":
             "video-to-video",
         ],
         default=None,
-        help="Task type. If no task is provided, we will use pipeline_tag from huggingface_hub",
+        help="The task will be inferred from huggingface pipeline_tag. When huggingface pipeline_tag is not provided, --task will be used.",
     )
     parser.add_argument(
         "--dataset-path",

--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -99,9 +99,9 @@ class VBenchDataset(BaseDataset):
         self.items = self._load_data()
 
     def _load_data(self) -> List[Dict[str, Any]]:
-        if self.args.task_name in ["text-to-video", "text-to-image", "video-to-video"]:
+        if self.args.task_name in ("text-to-video", "text-to-image", "video-to-video"):
             return self._load_t2v_prompts()
-        elif self.args.task_name in ["image-to-video", "image-to-image"]:
+        elif self.args.task_name in ("image-to-video", "image-to-image"):
             return self._load_i2v_data()
         else:
             raise ValueError(
@@ -666,7 +666,7 @@ async def benchmark(args):
     if task_name in ("text-to-video", "image-to-video", "video-to-video"):
         api_url = f"{args.base_url}/v1/videos"
         request_func = async_request_video_sglang
-    elif task_name in ["text-to-image", "image-to-image"]:
+    elif task_name in ("text-to-image", "image-to-image"):
         if task_name == "image-to-image":
             api_url = f"{args.base_url}/v1/images/edits"
         else:

--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -637,11 +637,6 @@ async def benchmark(args):
     if args.base_url is None:
         args.base_url = f"http://{args.host}:{args.port}"
 
-    if args.backend is not None:
-        logger.info(
-            f"DEPRECATED, we don't use backend anymore, and we will auto infer backend from --model."
-        )
-
     # Wait for service
     wait_for_service(args.base_url)
 
@@ -726,71 +721,65 @@ async def benchmark(args):
     # Calculate metrics
     metrics = calculate_metrics(outputs, total_duration)
 
-    logger.info("\n{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=60, c="="))
+    print("\n{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=60, c="="))
 
     # Section 1: Configuration
-    logger.info("{:<40} {:<15}".format("Task:", task_name))
-    logger.info("{:<40} {:<15}".format("Model:", args.model))
-    logger.info("{:<40} {:<15}".format("Dataset:", args.dataset))
+    print("{:<40} {:<15}".format("Task:", task_name))
+    print("{:<40} {:<15}".format("Model:", args.model))
+    print("{:<40} {:<15}".format("Dataset:", args.dataset))
 
     # Section 2: Execution & Traffic
-    logger.info(f"{'-' * 50}")
-    logger.info(
-        "{:<40} {:<15.2f}".format("Benchmark duration (s):", metrics["duration"])
-    )
-    logger.info("{:<40} {:<15}".format("Request rate:", str(args.request_rate)))
-    logger.info(
+    print(f"{'-' * 50}")
+    print("{:<40} {:<15.2f}".format("Benchmark duration (s):", metrics["duration"]))
+    print("{:<40} {:<15}".format("Request rate:", str(args.request_rate)))
+    print(
         "{:<40} {:<15}".format(
             "Max request concurrency:",
             str(args.max_concurrency) if args.max_concurrency else "not set",
         )
     )
-    logger.info(
+    print(
         "{:<40} {}/{:<15}".format(
             "Successful requests:", metrics["completed_requests"], len(requests_list)
         )
     )
 
     # Section 3: Performance Metrics
-    logger.info(f"{'-' * 50}")
+    print(f"{'-' * 50}")
 
-    logger.info(
+    print(
         "{:<40} {:<15.2f}".format(
             "Request throughput (req/s):", metrics["throughput_qps"]
         )
     )
-    logger.debug(
-        "{:<40} {:<15.4f}".format("Latency Mean (s):", metrics["latency_mean"])
-    )
-    logger.info(
-        "{:<40} {:<15.4f}".format("Latency Median (s):", metrics["latency_median"])
-    )
-    logger.info("{:<40} {:<15.4f}".format("Latency P99 (s):", metrics["latency_p99"]))
+    print("{:<40} {:<15.4f}".format("Latency Mean (s):", metrics["latency_mean"]))
+    print("{:<40} {:<15.4f}".format("Latency Median (s):", metrics["latency_median"]))
+    print("{:<40} {:<15.4f}".format("Latency P99 (s):", metrics["latency_p99"]))
 
     if metrics["peak_memory_mb_max"] > 0:
-        logger.info(f"{'-' * 50}")
-        logger.info(
+        print(f"{'-' * 50}")
+        print(
             "{:<40} {:<15.2f}".format(
                 "Peak Memory Max (MB):", metrics["peak_memory_mb_max"]
             )
         )
-        logger.info(
+        print(
             "{:<40} {:<15.2f}".format(
                 "Peak Memory Mean (MB):", metrics["peak_memory_mb_mean"]
             )
         )
-        logger.info(
+        print(
             "{:<40} {:<15.2f}".format(
                 "Peak Memory Median (MB):", metrics["peak_memory_mb_median"]
             )
         )
 
-    logger.info("=" * 60)
+    print("=" * 60)
 
     if args.output_file:
         with open(args.output_file, "w") as f:
             json.dump(metrics, f, indent=2)
-        logger.info(f"Metrics saved to {args.output_file}")
+        print(f"Metrics saved to {args.output_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Modifications

- Deprecate --task and --backend arguments, these args will be inferred from `pipeline.task_info`.

<!-- Detail the changes made in this pull request. -->

## Log examples
```
[01-02 15:37:32] DEPRECATED, we don't use backend anymore, and we will auto infer backend from --model.
[01-02 15:37:32] Waiting for service at http://localhost:1231...
[01-02 15:37:32] Service is ready.
[01-02 15:37:32] Updated model name from server: black-forest-labs/FLUX.1-dev
[01-02 15:37:32] Task from args None is different from huggingface pipeline_tag text-to-image, args.task will be ignored!
[01-02 15:37:32] Loading requests...
[01-02 15:37:32] Prepared 3 requests from vbench dataset.
100%|███████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:24<00:00,  8.32s/it]
[01-02 15:37:57] 
================= Serving Benchmark Result =================
Task:                                    text-to-image  
Model:                                   black-forest-labs/FLUX.1-dev
Dataset:                                 vbench         
--------------------------------------------------
Benchmark duration (s):                  24.96          
Request rate:                            inf            
Max request concurrency:                 1              
Successful requests:                     3/3              
--------------------------------------------------
Request throughput (req/s):              0.12           
Latency Median (s):                      8.3244         
Latency P99 (s):                         8.3337         
 --------------------------------------------------
Peak Memory Max (MB):                    27955.81       
Peak Memory Mean (MB):                   27955.81       
Peak Memory Median (MB):                 27955.81       
 ============================================================
```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
