### PR TITLE
Bug: fixed multi_chain_reasoning test

### DIFF
--- a/benchmark/multi_chain_reasoning/bench_other.py
+++ b/benchmark/multi_chain_reasoning/bench_other.py
@@ -89,7 +89,7 @@ async def multi_chain_gsm8k_async(question, num_chains, call_generate):
 
 
 def main(args):
-    lines = read_jsonl(args.data_path)
+    lines = list(read_jsonl(args.data_path))
 
     # Construct prompts
     k = args.num_shot

--- a/benchmark/multi_chain_reasoning/bench_sglang.py
+++ b/benchmark/multi_chain_reasoning/bench_sglang.py
@@ -37,7 +37,7 @@ prompt_lib = [
 
 
 def main(args):
-    lines = read_jsonl(args.data_path)
+    lines = list(read_jsonl(args.data_path))
 
     # Construct prompts
     # k = args.num_shot


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Multi chain Reasoning test in the `benchmark/multi_chain_reasoning` directory not working for both Sglang and Other backends

Fix for Issue #16191 

### Before Fix

```bash
sglang/benchmark/multi_chain_reasoning on  main via 🐍 v3.11.14 via 🅒 sglang took 2s 
❯ python3 bench_other.py --num-questions 64 --backend vllm
Traceback (most recent call last):
  File "sglang/benchmark/multi_chain_reasoning/bench_other.py", line 186, in <module>
    main(args)
  File "sglang/benchmark/multi_chain_reasoning/bench_other.py", line 99, in main
    for i in range(len(lines[: args.num_questions])):
                       ~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'generator' object is not subscriptable

sglang/benchmark/multi_chain_reasoning on  main via 🐍 v3.11.14 via 🅒 sglang took 4s 
❯ python3 bench_sglang.py --num-questions 64
Traceback (most recent call last):
  File "sglang/benchmark/multi_chain_reasoning/bench_sglang.py", line 140, in <module>
    main(args)
  File "sglang/benchmark/multi_chain_reasoning/bench_sglang.py", line 48, in main
    for i in range(len(lines[: args.num_questions])):
                       ~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'generator' object is not subscriptable
```


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Wrapped the Generator with a list to make it subscriptable for both files.

 
### After Fix

```bash
sglang/benchmark/multi_chain_reasoning on  bug/multi_chain_reasoning_test_fix [!] via 🐍 v3.11.14 via 🅒 sglang 
❯ python3 bench_sglang.py --num-questions 64
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [01:10<00:00,  1.11s/it]
Latency: 70.991
Invalid: 0.000
Accuracy: 0.797

sglang/benchmark/multi_chain_reasoning on  bug/multi_chain_reasoning_test_fix [!] via 🐍 v3.11.14 via 🅒 sglang took 1m15s 
❯ python3 bench_other.py --num-questions 64 --backend vllm
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 64/64 [01:43<00:00,  1.61s/it]
Latency: 103.293
Invalid: 0.000
Accuracy: 0.812
```




<!-- Detail the changes made in this pull request. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
