### PR TITLE
Fix inverted logic in apply_gptq_quant_layer for FusedMoE

### DIFF
--- a/python/sglang/srt/layers/quantization/auto_round.py
+++ b/python/sglang/srt/layers/quantization/auto_round.py
@@ -364,19 +364,17 @@ class AutoRoundConfig(QuantizationConfig):
 
         if isinstance(layer, FusedMoE):
             if use_marlin:
-                from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
+                return GPTQMarlinMoEMethod(quant_args_marlin)
+            from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 
-                config = {
-                    "quant_method": "gptq",
-                    "bits": weight_bits,
-                    "group_size": group_size,
-                    "sym": sym,
-                    "lm_head": False,
-                }
-                return MoeWNA16Config.from_config(config).get_quant_method(
-                    layer, prefix
-                )
-            return GPTQMarlinMoEMethod(quant_args_marlin)
+            config = {
+                "quant_method": "gptq",
+                "bits": weight_bits,
+                "group_size": group_size,
+                "sym": sym,
+                "lm_head": False,
+            }
+            return MoeWNA16Config.from_config(config).get_quant_method(layer, prefix)
 
         if isinstance(layer, (LinearBase, ParallelLMHead)):
             if use_marlin:


### PR DESCRIPTION
## Summary
- Fix logical inversion in `apply_gptq_quant_layer` for FusedMoE layers in `auto_round.py`
- When `use_marlin=True`, incorrectly returned `MoeWNA16Config` instead of `GPTQMarlinMoEMethod`
- When `use_marlin=False`, would crash with `NameError` since `quant_args_marlin` is only defined in the `use_marlin=True` branch

The fix swaps the conditional branches to match the correct AWQ implementation pattern.

Fixes #16060

## Test plan
- [x] Verified fix matches AWQ pattern at lines 280-292
- [x] Pre-commit checks pass (isort, ruff, black, codespell)