### PR TITLE
fix editable install 

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -171,6 +171,7 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
 
 [tool.codespell]
 ignore-words-list = "ans, als, hel, boostrap, childs, te, vas, hsa, ment"

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -132,6 +132,7 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
 
 [tool.codespell]
 ignore-words-list = "ans, als, hel, boostrap, childs, te, vas, hsa, ment"

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -171,6 +171,7 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
 
 [tool.codespell]
 ignore-words-list = "ans, als, hel, boostrap, childs, te, vas, hsa, ment"

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -136,6 +136,7 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
 
 [tool.codespell]
 ignore-words-list = "ans, als, hel, boostrap, childs, te, vas, hsa, ment"


### PR DESCRIPTION
In a fresh env i try to editable install sglang

```
ubuntu in 🌐 ip-172-31-44-124 in sglang on  main [$?⇡] via 🐍 v3.12.11 (dynamo)
❯ uv pip install -e "python"
Using Python 3.12.11 environment at: /home/ubuntu/dynamo/.venv
Resolved 164 packages in 1.30s
      Built sglang @ file:///home/ubuntu/sglang/python
Prepared 1 package in 873ms
Uninstalled 1 package in 0.46ms
Installed 1 package in 1ms
 - sglang==0.5.6.post2 (from file:///home/ubuntu/sglang/python)
 + sglang==0.3.1.dev217+g2acebda10 (from file:///home/ubuntu/sglang/python)

ubuntu in 🌐 ip-172-31-44-124 in sglang on  main [$?⇡] via 🐍 v3.12.11 (dynamo)
❯ uv pip install -e "python" --prerelease=allow
Using Python 3.12.11 environment at: /home/ubuntu/dynamo/.venv
Resolved 164 packages in 1.19s
      Built sglang @ file:///home/ubuntu/sglang/python
Prepared 1 package in 814ms
Uninstalled 1 package in 0.48ms
Installed 1 package in 1ms
 ~ sglang==0.3.1.dev217+g2acebda10 (from file:///home/ubuntu/sglang/python)
```

After I add a the git describe command here

```
[tool.setuptools_scm]
root = ".."
version_file = "sglang/_version.py"
git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
```

Things work

```
ubuntu in 🌐 ip-172-31-44-124 in sglang on  main [$!?⇡] via 🐍 v3.12.11 (dynamo)
❯ uv pip install -e "python" --prerelease=allow
Using Python 3.12.11 environment at: /home/ubuntu/dynamo/.venv
Resolved 164 packages in 1.24s
      Built sglang @ file:///home/ubuntu/sglang/python
Prepared 1 package in 837ms
Uninstalled 1 package in 0.46ms
Installed 1 package in 1ms
 - sglang==0.3.1.dev217+g2acebda10 (from file:///home/ubuntu/sglang/python)
 + sglang==0.5.6.post3.dev691+g2acebda10 (from file:///home/ubuntu/sglang/python)
```
