### PR TITLE
ci: increase stage-b-test-small-1-gpu partitions from 4 to 5

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -516,7 +516,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [0, 1, 2, 3]
+        partition: [0, 1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -543,7 +543,7 @@ jobs:
           if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
             CONTINUE_ON_ERROR_FLAG="--continue-on-error"
           fi
-          python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 5 $CONTINUE_ON_ERROR_FLAG
 
   stage-b-test-large-1-gpu:
     needs: [check-changes, call-gate, stage-a-test-1, sgl-kernel-build-wheels]


### PR DESCRIPTION
## Summary
- Increase `stage-b-test-small-1-gpu` partition count from 4 to 5
- This reduces per-job runtime from ~25+ min to ~20 min

Part of #13808 (CI suites organization)

## Issue Example
Jobs are currently timing out or running close to the 30-min limit:
https://github.com/sgl-project/sglang/actions/runs/20613258960/job/59201759267

## Test plan
- [ ] CI jobs complete within ~20 minutes per partition