### PR TITLE
Fix crash dump replay script for image data replay

### DIFF
--- a/scripts/playground/replay_request_dump.py
+++ b/scripts/playground/replay_request_dump.py
@@ -23,14 +23,12 @@ from sglang.utils import get_exception_traceback
 
 
 def normalize_mm_data_item(item):
-    """Convert {'url': '...'} dict back to plain URL string."""
     if isinstance(item, dict) and "url" in item:
         return item["url"]
     return item
 
 
 def normalize_mm_data(data):
-    """Normalize multimodal data field (handles nested lists)."""
     if data is None:
         return None
     if isinstance(data, list):
@@ -46,11 +44,7 @@ def normalize_mm_data(data):
 
 
 def normalize_request_data(json_data):
-    """Normalize multimodal fields in request data for replay compatibility.
-
-    When using asdict() on request dataclasses, ImageData objects are converted
-    to {'url': '...'} dicts, but the /generate API expects plain URL strings.
-    """
+    """Normalize multimodal fields in request data for replay compatibility."""
     for field in ["image_data", "video_data", "audio_data"]:
         if field in json_data and json_data[field] is not None:
             json_data[field] = normalize_mm_data(json_data[field])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
When replaying crash dumps containing multimodal requests (**images**/videos/audio), asdict() converts ImageData objects to `{'url': '...'}` dicts, but the /generate API expects plain URL strings. This causes replay failures for multimodal requests.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Added `normalize_mm_data_item()`: Converts `{'url': '...'}` dict back to plain URL string
Added `normalize_mm_data()`: Handles nested list structures in multimodal data fields
Added `normalize_request_data()`: Normalizes image_data, video_data, audio_data fields after asdict() conversion
Updated `run_one_request_internal()` to use the normalization pipeline
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A
Just script update and have verified locally, no need to do Accuracy and Benchmarking test. 
## Benchmarking and Profiling
N/A
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
