### PR TITLE
[Perf] Use `flashinfer_trtllm` by default for `speculative_moe_runner_backend`

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2000,21 +2000,6 @@ class ServerArgs:
         ):
             self.speculative_draft_model_revision = "main"
 
-        # Avoid using flashinfer_trtllm for speculative MoE runner backend by default
-        # TODO: Remove this block after verifying no accuracy regression with flashinfer_trtllm speculative backend
-        from sglang.srt.layers.moe.utils import MoeRunnerBackend
-
-        if self.speculative_moe_runner_backend is None:
-            self.speculative_moe_runner_backend = (
-                "auto"
-                if self.moe_runner_backend == "flashinfer_trtllm"
-                else self.moe_runner_backend
-            )
-        else:
-            assert not MoeRunnerBackend(
-                self.speculative_moe_runner_backend
-            ).is_flashinfer_trtllm(), "Currently speculative MoE runner backend cannot be flashinfer_trtllm for risk in some draft models."
-
         if self.speculative_algorithm == "NEXTN":
             self.speculative_algorithm = "EAGLE"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Depends on Flashinfer 0.6.0

Currently, the MTP layer (BF16 x BF16) use Triton for the Fused MoE backend. The drafting stage is a small portion of E2E performance, but it can make a bigger difference at higher concurrency.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Remove the change from `auto` to `triton`, as RoutingMethodType=DeepseekV3 is supported in https://github.com/flashinfer-ai/flashinfer/pull/2234 commit of Flashinfer

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
SGLANG_ENABLE_SPEC_V2=1 \
python3 -m sglang.launch_server \
    --model-path nvidia/DeepSeek-V3-0324-FP4 \
    --trust-remote-code \
    --tp 4 \
    --quantization modelopt_fp4 \
    --speculative-algorithm EAGLE \
    --speculative-moe-runner-backend=flashinfer_trtllm \
    --moe-runner-backend=flashinfer_trtllm
```

TODO: after the acceptance length issue is fixed.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

Draft layer

```
export SGLANG_TORCH_PROFILER_DIR="./"

python -m sglang.bench_one_batch_server \
  --model nvidia/DeepSeek-V3-0324-FP4 \
  --batch-size 8 \
  --input-len 2048 \
  --output-len 256 \
  --profile \
  --profile-steps 10 \
  --show-report
```

### Before:
<img width="629" height="763" alt="Screenshot 2026-01-01 at 8 31 59 PM" src="https://github.com/user-attachments/assets/fd3a53d6-fed9-445f-afa9-8afb56ee39fd" />

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    3.867    |  1024  |   2.844    |     264.80      |
+-------------+--------+------------+-----------------+
```


### After:
<img width="733" height="674" alt="Screenshot 2026-01-01 at 8 30 58 PM" src="https://github.com/user-attachments/assets/cce56ac4-762a-45da-981e-5b612779b9bd" />

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    4.078    |  1024  |   2.646    |     251.08      |
+-------------+--------+------------+-----------------+
```

Anyway, the root problem is the acceptance length drop, likely because the routing method for MTP layer may not be correctly inferred. Investigating the issue. @samuellees 

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
