### PR TITLE
Fix sgl-kernel jobs to skip when target_stage is specified

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -299,7 +299,9 @@ jobs:
 
   sgl-kernel-mla-test:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      !inputs.target_stage &&
+      needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
     env:
       RUNNER_LABELS: 1-gpu-runner
@@ -332,7 +334,9 @@ jobs:
 
   sgl-kernel-benchmark-test:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      !inputs.target_stage &&
+      needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
     env:
       CI: true
@@ -378,7 +382,9 @@ jobs:
 
   sgl-kernel-b200-test:
     needs: [check-changes, sgl-kernel-build-wheels]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      !inputs.target_stage &&
+      needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     env:
       RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -177,7 +177,9 @@ jobs:
 
   sgl-kernel-build-wheels:
     needs: [check-changes, call-gate]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      !inputs.target_stage &&
+      needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: x64-kernel-build-node
     strategy:
       matrix:
@@ -218,7 +220,9 @@ jobs:
 
   sgl-kernel-build-wheels-arm:
     needs: [check-changes, call-gate]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      !inputs.target_stage &&
+      needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: arm-kernel-build-node
     strategy:
       matrix:
@@ -260,7 +264,9 @@ jobs:
 
   sgl-kernel-unit-test:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      !inputs.target_stage &&
+      needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
     env:
       RUNNER_LABELS: 1-gpu-runner


### PR DESCRIPTION
## Summary
- Add `!inputs.target_stage` check to all sgl-kernel jobs to skip them when `/rerun-stage` targets a specific stage

**Jobs fixed:**
- `sgl-kernel-build-wheels`
- `sgl-kernel-build-wheels-arm`
- `sgl-kernel-unit-test`
- `sgl-kernel-mla-test`
- `sgl-kernel-benchmark-test`
- `sgl-kernel-b200-test`

This fixes an issue where Build Wheel and kernel tests were incorrectly running when using `/rerun-stage` to target a specific stage.

**Note:** Even though the test jobs (`mla-test`, `benchmark-test`, `b200-test`) have `needs: sgl-kernel-build-wheels`, they still run when the build-wheels job is *skipped* (not failed) because GitHub Actions allows dependent jobs to proceed when needed jobs are skipped.

**Error example:** https://github.com/sgl-project/sglang/actions/runs/20664406187

Followup to #16128