### PR TITLE
[SPEC_V2] Fix Acclen drop when enabling DP Attention for Spec-Overlap

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -491,7 +491,7 @@ class EagleDraftWorker(BaseDraftWorker):
         draft_input = EagleDraftInput(
             hidden_states=batch_result.logits_output.hidden_states,
             num_tokens_per_batch=self.speculative_num_steps + 1,
-            num_tokens_for_logprob_per_batch=1,
+            num_tokens_for_logprob_per_batch=self.speculative_num_steps + 1,
         )
         select_index = (
             torch.arange(len(batch.seq_lens), device=self.device)


### PR DESCRIPTION
## Motivation

Fix [#16274](https://github.com/sgl-project/sglang/issues/16274): SPEC_V2 EAGLE speculative decoding accept length degraded (~37% drop) when DP Attention is enabled.

## Modifications

Set `num_tokens_for_logprob_per_batch` to match `num_tokens_per_batch` in `_draft_extend_for_decode`.

**Root Cause**: `num_tokens_for_logprob_per_batch=1` caused `LogitsMetadata.compute_dp_attention_metadata` to calculate incorrect `dp_local_num_tokens` (4 instead of 12), resulting in MLP sync only processing partial tokens.
<img width="2642" height="536" alt="image" src="https://github.com/user-attachments/assets/eb456a41-a393-466c-8939-45ee81dc1041" />

## Accuracy Tests

```
python -m sglang.test.run_eval --eval-name longbench_v2 --host 127.0.0.1 --port 30000 --model nvidia/DeepSeek-R1-0528-NVFP4-v2 --max-context-length 128000 --max-tokens 16384 --num-threads 16

Loaded 503 examples from LongBench-v2
Context length filter: None-128000 characters
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=16384 self.reasoning_effort=None self.extra_body={}
  0%|          | 0/503 [00:00<?, ?it/s]Token indices sequence length is longer than the specified maximum sequence length for this model (135859 > 131072). Running this sequence through the model will result in indexing errors
100%|██████████| 503/503 [51:49<00:00,  6.18s/it]  
Total latency: 3109.123 s
Score: 0.588
```

**Before (accept_len ~1.5)**:
```
[DP2 TP2] Decode batch, accept len: 1.62, accept rate: 0.54
[DP1 TP1] Decode batch, accept len: 1.48, accept rate: 0.49
[DP3 TP3] Decode batch, accept len: 1.55, accept rate: 0.52
```

**After (accept_len ~2.4)**:
```
[DP1 TP1] Decode batch, accept len: 2.37, accept rate: 0.79
[DP2 TP2] Decode batch, accept len: 2.34, accept rate: 0.78
[DP3 TP3] Decode batch, accept len: 2.43, accept rate: 0.81
```

## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

