### PR TITLE
ci: migrate quantization kernel tests to test/registered/quant/

### DIFF
--- a/test/registered/quant/test_autoround.py
+++ b/test/registered/quant/test_autoround.py
@@ -7,6 +7,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_AUTOROUND_MODEL_NAME_FOR_TEST,
@@ -15,6 +16,9 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
+
+# AutoRound quantization tests
+register_cuda_ci(est_time=77, suite="stage-b-test-small-1-gpu")
 
 
 class TestAutoRound(CustomTestCase):

--- a/test/registered/quant/test_awq_dequant.py
+++ b/test/registered/quant/test_awq_dequant.py
@@ -16,7 +16,11 @@ from sglang.srt.layers.quantization.awq_triton import (
     awq_dequantize_triton,
     awq_gemm_triton,
 )
+from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.test_utils import CustomTestCase
+
+# AWQ dequantization tests (AMD only)
+register_amd_ci(est_time=2, suite="stage-a-test-1")
 
 device = "cuda"
 

--- a/test/registered/quant/test_block_int8.py
+++ b/test/registered/quant/test_block_int8.py
@@ -7,7 +7,12 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+# Block INT8 quantization kernel tests
+register_cuda_ci(est_time=44, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=22, suite="stage-a-test-1")
 
 
 # For test

--- a/test/registered/quant/test_fp8_kernel.py
+++ b/test/registered/quant/test_fp8_kernel.py
@@ -6,7 +6,11 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_fp8,
     w8a8_block_fp8_matmul,
 )
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+# FP8 quantization kernel tests
+register_cuda_ci(est_time=10, suite="stage-b-test-small-1-gpu")
 
 
 class TestFP8Base(CustomTestCase):

--- a/test/registered/quant/test_fused_rms_fp8_group_quant.py
+++ b/test/registered/quant/test_fused_rms_fp8_group_quant.py
@@ -1,11 +1,14 @@
-# test/srt/quant/test_fused_rms_fp8_group_quant.py
 import itertools
 import unittest
 
 import torch
 import torch.nn.functional as F
 
+from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.test_utils import CustomTestCase
+
+# Fused RMS FP8 group quantization tests (AMD/ROCm only)
+register_amd_ci(est_time=10, suite="stage-a-test-1")
 
 
 def _fp8_available() -> bool:

--- a/test/registered/quant/test_int8_kernel.py
+++ b/test/registered/quant/test_int8_kernel.py
@@ -8,7 +8,11 @@ from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.srt.layers.quantization.int8_kernel import per_token_quant_int8
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+# INT8 quantization kernel tests
+register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
 
 
 def native_w8a8_per_token_matmul(A, B, As, Bs, output_dtype=torch.float16):

--- a/test/registered/quant/test_triton_scaled_mm.py
+++ b/test/registered/quant/test_triton_scaled_mm.py
@@ -5,7 +5,12 @@ import torch
 import torch.testing
 
 from sglang.srt.layers.quantization.fp8_kernel import triton_scaled_mm
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+# Triton scaled matrix multiplication tests
+register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=12, suite="stage-a-test-1")
 
 
 def torch_scaled_mm(

--- a/test/registered/quant/test_w8a8_quantization.py
+++ b/test/registered/quant/test_w8a8_quantization.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -12,6 +13,9 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
+
+# W8A8 quantization server integration tests
+register_cuda_ci(est_time=160, suite="stage-b-test-small-1-gpu")
 
 
 class BaseW8A8Test(CustomTestCase):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -41,12 +41,7 @@ suites = {
         TestFile("openai_server/validation/test_openai_server_ignore_eos.py", 6),
         TestFile("openai_server/validation/test_request_length_validation.py", 38),
         TestFile("ops/test_repeat_interleave.py", 60),
-        TestFile("quant/test_block_int8.py", 44),
-        TestFile("quant/test_fp8_kernel.py", 10),
-        TestFile("quant/test_int8_kernel.py", 8),
-        TestFile("quant/test_triton_scaled_mm.py", 8),
-        TestFile("quant/test_w8a8_quantization.py", 160),
-        TestFile("quant/test_autoround.py", 77),
+        # quant tests moved to test/registered/quant/
         TestFile("rl/test_fp32_lm_head.py", 9),
         # TestFile("rl/test_update_weights_from_disk.py", 210),  # Temporarily disabled, see https://github.com/sgl-project/sglang/pull/13998
         TestFile("rl/test_update_weights_from_tensor.py", 195),
@@ -226,10 +221,7 @@ suite_amd = {
         TestFile("openai_server/validation/test_openai_server_ignore_eos.py", 85),
         TestFile("openai_server/validation/test_request_length_validation.py", 31),
         TestFile("ops/test_repeat_interleave.py", 75),
-        TestFile("quant/test_awq_dequant.py", 2),
-        TestFile("quant/test_block_int8.py", 22),
-        TestFile("quant/test_fused_rms_fp8_group_quant.py", 10),
-        TestFile("quant/test_triton_scaled_mm.py", 12),
+        # quant tests moved to test/registered/quant/
         TestFile("rl/test_fp32_lm_head.py", 15),
         # TestFile("rl/test_update_weights_from_disk.py", 210),  # Temporarily disabled, see https://github.com/sgl-project/sglang/pull/13998
         TestFile("rotary_embedding/test_mrope.py", 15),


### PR DESCRIPTION
## Summary
- Migrate 8 quantization kernel test files from `test/srt/quant/` to `test/registered/quant/` with CI registry decorators
- Part of #13808 (CI suites organization roadmap)

### Tests migrated
| Test File | CUDA Suite | AMD Suite | Est. Time |
|-----------|------------|-----------|-----------|
| test_block_int8.py | stage-b-test-small-1-gpu | stage-a-test-1 | 44s / 22s |
| test_fp8_kernel.py | stage-b-test-small-1-gpu | - | 10s |
| test_int8_kernel.py | stage-b-test-small-1-gpu | - | 8s |
| test_triton_scaled_mm.py | stage-b-test-small-1-gpu | stage-a-test-1 | 8s / 12s |
| test_w8a8_quantization.py | stage-b-test-small-1-gpu | - | 160s |
| test_autoround.py | stage-b-test-small-1-gpu | - | 77s |
| test_awq_dequant.py | - | stage-a-test-1 | 2s |
| test_fused_rms_fp8_group_quant.py | - | stage-a-test-1 | 10s |

**Total CUDA est_time**: ~307s (~5.1 min)
**Total AMD est_time**: ~46s (~0.8 min)

### Changes
- Created `test/registered/quant/` directory
- Added CI registry decorators to all migrated test files
- Removed test entries from legacy `test/srt/run_suite.py`
- Deleted original test files from `test/srt/quant/`

### Remaining in test/srt/quant/
The following tests remain in `test/srt/quant/` as they're not 1-GPU tests:
- `test_awq.py` - part of `quantization_test` suite
- `test_marlin_moe.py` - part of `quantization_test` suite
- `test_w4a8_deepseek_v3.py` - part of `per-commit-8-gpu-h20` suite

## Test plan
- [ ] CI discovers new tests in `test/registered/quant/`
- [ ] Tests run successfully on CUDA and AMD runners
- [ ] No regression in existing test coverage