### PR TITLE
Fix: Allow build-wheels to run when target_stage is set

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -177,9 +177,7 @@ jobs:
 
   sgl-kernel-build-wheels:
     needs: [check-changes, call-gate]
-    if: |
-      !inputs.target_stage &&
-      needs.check-changes.outputs.sgl_kernel == 'true'
+    if: needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: x64-kernel-build-node
     strategy:
       matrix:
@@ -220,9 +218,7 @@ jobs:
 
   sgl-kernel-build-wheels-arm:
     needs: [check-changes, call-gate]
-    if: |
-      !inputs.target_stage &&
-      needs.check-changes.outputs.sgl_kernel == 'true'
+    if: needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: arm-kernel-build-node
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Revert the `!inputs.target_stage` check from `sgl-kernel-build-wheels` and `sgl-kernel-build-wheels-arm` jobs.

**Problem:** PR #16308 incorrectly added `!inputs.target_stage` to the build-wheels jobs, causing them to be skipped when `/rerun-stage` is used. This broke stage jobs that depend on the built wheel artifacts.

**Error:**
```
+ ls -alh sgl-kernel/dist
ls: cannot access 'sgl-kernel/dist': No such file or directory
```

**Fix:** Build-wheel jobs must run when `sgl_kernel == 'true'` regardless of `target_stage`, because stage jobs need the wheel artifacts. Only the kernel TEST jobs (`sgl-kernel-unit-test`, `sgl-kernel-mla-test`, `sgl-kernel-benchmark-test`, `sgl-kernel-b200-test`) should have the `!inputs.target_stage` check since they don't produce artifacts needed by other jobs.

**Error example:** https://github.com/sgl-project/sglang/actions/runs/20669833795

Followup to #16308