### PR TITLE
[Diffusion] safe fallback for fused QK-norm

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+from math import prod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -17,11 +18,7 @@ from diffusers.models.normalization import AdaLayerNormContinuous
 from sglang.multimodal_gen.configs.models.dits.qwenimage import QwenImageDitConfig
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
-from sglang.multimodal_gen.runtime.layers.layernorm import (
-    LayerNorm,
-    RMSNorm,
-    apply_qk_norm,
-)
+from sglang.multimodal_gen.runtime.layers.layernorm import LayerNorm, RMSNorm
 from sglang.multimodal_gen.runtime.layers.linear import ReplicatedLinear
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     apply_flashinfer_rope_qk_inplace,
@@ -552,23 +549,14 @@ class QwenImageCrossAttention(nn.Module):
         txt_value = txt_value.unflatten(-1, (self.num_heads, -1))
 
         # Apply QK normalization
-        if self.qk_norm:
-            img_query, img_key = apply_qk_norm(
-                q=img_query,
-                k=img_key,
-                q_norm=self.norm_q,
-                k_norm=self.norm_k,
-                head_dim=img_query.shape[-1],
-                allow_inplace=True,
-            )
-            txt_query, txt_key = apply_qk_norm(
-                q=txt_query,
-                k=txt_key,
-                q_norm=self.norm_added_q,
-                k_norm=self.norm_added_k,
-                head_dim=txt_query.shape[-1],
-                allow_inplace=True,
-            )
+        if self.norm_q is not None:
+            img_query = self.norm_q(img_query)
+        if self.norm_k is not None:
+            img_key = self.norm_k(img_key)
+        if self.norm_added_q is not None:
+            txt_query = self.norm_added_q(txt_query)
+        if self.norm_added_k is not None:
+            txt_key = self.norm_added_k(txt_key)
 
         # Apply RoPE
         if image_rotary_emb is not None:
@@ -793,12 +781,6 @@ class QwenImageTransformerBlock(nn.Module):
         return encoder_hidden_states, hidden_states
 
 
-def to_hashable(obj):
-    if isinstance(obj, list):
-        return tuple(to_hashable(x) for x in obj)
-    return obj
-
-
 class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
     """
     The Transformer model introduced in Qwen.
@@ -948,9 +930,16 @@ class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
         timestep = (timestep / 1000).to(hidden_states.dtype)
 
         if self.zero_cond_t:
-            timestep = torch.cat([timestep, self.timestep_zero], dim=0)
-            device = timestep.device
-            modulate_index = self.build_modulate_index(to_hashable(img_shapes), device)
+            timestep = torch.cat([timestep, timestep * 0], dim=0)
+            # Use torch operations for GPU efficiency
+            modulate_index = torch.tensor(
+                [
+                    [0] * prod(sample[0]) + [1] * sum([prod(s) for s in sample[1:]])
+                    for sample in img_shapes
+                ],
+                device=timestep.device,
+                dtype=torch.int,
+            )
         else:
             modulate_index = None
 

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -228,22 +228,46 @@ def apply_qk_norm(
     batch_size = q.size(0)
     q_eps = q_norm.variance_epsilon
     k_eps = k_norm.variance_epsilon
+
+    def can_view_as_bnhd(x: torch.Tensor) -> bool:
+        """Whether `x` can be viewed as [batch, *, head_dim] without a copy."""
+        if (
+            x.dim() < 2
+            or x.size(0) != batch_size
+            or x.size(-1) != head_dim
+            or x.stride(-1) != 1
+            or x.stride(-2) != head_dim
+        ):
+            return False
+        try:
+            x.view(batch_size, -1, head_dim)
+            return True
+        except RuntimeError:
+            return False
+
     if (
-        _is_cuda  # TODO(dark): have not tested on ROCm or other backends
-        and allow_inplace  # TODO(dark): this can be relaxed if needed
-        and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
+        _is_cuda
+        and (torch.version.cuda is not None)  # avoid NVIDIA-only kernel on ROCm
+        and allow_inplace
+        and (q_eps == k_eps)
         and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
+        and can_view_as_bnhd(q)
+        and can_view_as_bnhd(k)
         and can_use_fused_inplace_qknorm(head_dim)
     ):
-        fused_inplace_qknorm(
-            q=q.view(batch_size, -1, head_dim),
-            k=k.view(batch_size, -1, head_dim),
-            q_weight=q_norm.weight,
-            k_weight=k_norm.weight,
-            head_dim=head_dim,
-            eps=q_eps,
-        )
-        return q, k
+        try:
+            fused_inplace_qknorm(
+                q=q.view(batch_size, -1, head_dim),
+                k=k.view(batch_size, -1, head_dim),
+                q_weight=q_norm.weight,
+                k_weight=k_norm.weight,
+                head_dim=head_dim,
+                eps=q_eps,
+            )
+            return q, k
+        except RuntimeError as e:
+            if "QK-norm is not applicable" not in str(e):
+                raise
 
     if alt_stream is not None and get_is_capture_mode():
         current_stream = torch.cuda.current_stream()


### PR DESCRIPTION
## Motivation

The fused QK-norm kernel used here was introduced in #16062, and this PR ensures it does not break on non-applicable layouts or ROCm (AMD CI) while keeping QK-norm behavior consistent when enabled.
<img width="2764" height="1496" alt="1272abe947e43703ca5e5f99c10c5e47" src="https://github.com/user-attachments/assets/aecae764-8ca4-4947-a632-b3448cf13556" />

## Modifications

Remove `_is_cuda()` gating at callsites; always call `apply_qk_norm` when` self.qk_norm` is enabled.

In `apply_qk_norm`, only call the fused kernel on NVIDIA CUDA (q.is_cuda and torch.version.cuda is not None) and valid layouts; if it raises "QK-norm is not applicable", fall back to the RMSNorm path; re-raise other errors.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
