### PR TITLE
[fix] Remove mis-targeted chat completions tests from v1 responses suite

### DIFF
--- a/test/srt/openai_server/basic/test_openai_server.py
+++ b/test/srt/openai_server/basic/test_openai_server.py
@@ -5,7 +5,6 @@ python3 -m unittest openai_server.basic.test_openai_server.TestOpenAIServer.test
 python3 -m unittest openai_server.basic.test_openai_server.TestOpenAIServer.test_chat_completion_stream
 """
 
-import json
 import random
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -600,36 +599,6 @@ class TestOpenAIServerv1Responses(CustomTestCase):
         assert saw_completed
         assert final_usage_ok or True  # final_usage's stats are not done for now
 
-    def test_regex(self):
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-
-        regex = (
-            r"""\{\n"""
-            + r"""   "name": "[\w]+",\n"""
-            + r"""   "population": [\d]+\n"""
-            + r"""\}"""
-        )
-
-        response = client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": "You are a helpful AI assistant"},
-                {"role": "user", "content": "Introduce the capital of France."},
-            ],
-            temperature=0,
-            max_tokens=128,
-            extra_body={"regex": regex},
-        )
-        text = response.choices[0].message.content
-
-        try:
-            js_obj = json.loads(text)
-        except (TypeError, json.decoder.JSONDecodeError):
-            print("JSONDecodeError", text)
-            raise
-        assert isinstance(js_obj["name"], str)
-        assert isinstance(js_obj["population"], int)
-
     def test_error(self):
         url = f"{self.base_url}/responses"
         headers = {
@@ -671,44 +640,6 @@ class TestOpenAIServerv1Responses(CustomTestCase):
         if "usage" in body:
             self.assertIn("prompt_tokens", body["usage"])
             self.assertIn("total_tokens", body["usage"])
-
-    def test_response_prefill(self):
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-
-        response = client.chat.completions.create(
-            model="meta-llama/Llama-3.1-8B-Instruct",
-            messages=[
-                {"role": "system", "content": "You are a helpful AI assistant"},
-                {
-                    "role": "user",
-                    "content": """
-Extract the name, size, price, and color from this product description as a JSON object:
-
-<description>
-The SmartHome Mini is a compact smart home assistant available in black or white for only $49.99. At just 5 inches wide, it lets you control lights, thermostats, and other connected devices via voice or app—no matter where you place it in your home. This affordable little hub brings convenient hands-free control to your smart devices.
-</description>
-""",
-                },
-                {
-                    "role": "assistant",
-                    "content": "{\n",
-                },
-            ],
-            temperature=0,
-            extra_body={"continue_final_message": True},
-        )
-
-        assert (
-            response.choices[0]
-            .message.content.strip()
-            .startswith('"name": "SmartHome Mini",')
-        )
-
-    def test_model_list(self):
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-        models = list(client.models.list())
-        assert len(models) == 1
-        assert isinstance(getattr(models[0], "max_model_len", None), int)
 
 
 class TestOpenAIV1Rerank(CustomTestCase):

--- a/test/srt/openai_server/basic/test_openai_server.py
+++ b/test/srt/openai_server/basic/test_openai_server.py
@@ -668,36 +668,6 @@ class TestOpenAIServerv1Responses(CustomTestCase):
         assert saw_completed
         assert final_usage_ok or True  # final_usage's stats are not done for now
 
-    def test_regex(self):
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-
-        regex = (
-            r"""\{\n"""
-            + r"""   "name": "[\w]+",\n"""
-            + r"""   "population": [\d]+\n"""
-            + r"""\}"""
-        )
-
-        response = client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": "You are a helpful AI assistant"},
-                {"role": "user", "content": "Introduce the capital of France."},
-            ],
-            temperature=0,
-            max_tokens=128,
-            extra_body={"regex": regex},
-        )
-        text = response.choices[0].message.content
-
-        try:
-            js_obj = json.loads(text)
-        except (TypeError, json.decoder.JSONDecodeError):
-            print("JSONDecodeError", text)
-            raise
-        assert isinstance(js_obj["name"], str)
-        assert isinstance(js_obj["population"], int)
-
     def test_error(self):
         url = f"{self.base_url}/responses"
         headers = {
@@ -739,38 +709,6 @@ class TestOpenAIServerv1Responses(CustomTestCase):
         if "usage" in body:
             self.assertIn("prompt_tokens", body["usage"])
             self.assertIn("total_tokens", body["usage"])
-
-    def test_response_prefill(self):
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-
-        response = client.chat.completions.create(
-            model="meta-llama/Llama-3.1-8B-Instruct",
-            messages=[
-                {"role": "system", "content": "You are a helpful AI assistant"},
-                {
-                    "role": "user",
-                    "content": """
-Extract the name, size, price, and color from this product description as a JSON object:
-
-<description>
-The SmartHome Mini is a compact smart home assistant available in black or white for only $49.99. At just 5 inches wide, it lets you control lights, thermostats, and other connected devices via voice or app—no matter where you place it in your home. This affordable little hub brings convenient hands-free control to your smart devices.
-</description>
-""",
-                },
-                {
-                    "role": "assistant",
-                    "content": "{\n",
-                },
-            ],
-            temperature=0,
-            extra_body={"continue_final_message": True},
-        )
-
-        assert (
-            response.choices[0]
-            .message.content.strip()
-            .startswith('"name": "SmartHome Mini",')
-        )
 
     def test_model_list(self):
         client = openai.Client(api_key=self.api_key, base_url=self.base_url)

--- a/test/srt/openai_server/basic/test_openai_server.py
+++ b/test/srt/openai_server/basic/test_openai_server.py
@@ -710,12 +710,6 @@ class TestOpenAIServerv1Responses(CustomTestCase):
             self.assertIn("prompt_tokens", body["usage"])
             self.assertIn("total_tokens", body["usage"])
 
-    def test_model_list(self):
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-        models = list(client.models.list())
-        assert len(models) == 1
-        assert isinstance(getattr(models[0], "max_model_len", None), int)
-
 
 class TestOpenAIV1Rerank(CustomTestCase):
     @classmethod


### PR DESCRIPTION
## Motivation
Fixes issue #16336 where `TestOpenAIServerv1Responses` contained chat-completions tests, leaving `/v1/responses` untested for those cases and duplicating model list coverage.

## Modifications
- Removed `test_regex`, `test_response_prefill`, and `test_model_list` from `TestOpenAIServerv1Responses` in `test/srt/openai_server/basic/test_openai_server.py`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).