### PR TITLE
[FP8] Fix weight_scale shape to match with x_scale shape for per-tensor quant under torch.compile

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1041,7 +1041,9 @@ def apply_fp8_linear(
             return _process_scaled_mm_output(output, input_2d.shape, output_shape)
 
     if per_tensor_weights and per_tensor_activations:
-        # Fused GEMM_DQ
+        # Fused GEMM_DQ; _scaled_mm with torch.compile requires len(weight_scale.shape) == len(x_scale.shape)
+        if weight_scale.ndim == 0 and x_scale.ndim == 1:
+            weight_scale = weight_scale.unsqueeze(0)
         output = torch._scaled_mm(
             qinput,
             weight,


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Error:
```
     lib/python3.13/site-packages/torch/_inductor/template_heuristics/triton.py", line 1673, in adjust_kernel_inputs
    # assert len(scale_a.get_size()) == len(scale_b.get_size())


torch._inductor.exc.InductorError: LoweringException: AssertionError: 
  target: aten._scaled_mm.default
  args[0]: TensorBox(StorageBox(
    ComputedBuffer(name='buf12', layout=FixedLayout('cuda:0', torch.float8_e4m3fnuz, size=[23773, 4096], stride=[4096, 1]), data=Pointwise(device=device(type='cuda', index=0), dtype=torch.float8_e4m3fnuz, inner_fn=<function _full.<locals>.inner_fn at 0x79a83f9274c0>, ranges=[0, 0]))
  ))
  args[1]: TensorBox(StorageBox(
    InputBuffer(name='arg5_1', layout=FixedLayout('cuda:0', torch.float8_e4m3fnuz, size=[4096, 4096], stride=[1, 4096]))
  ))
  args[2]: TensorBox(StorageBox(
    ComputedBuffer(name='buf13', layout=FixedLayout('cuda:0', torch.float32, size=[1], stride=[1]), data=Pointwise(device=device(type='cuda', index=0), dtype=torch.float32, inner_fn=<function _full.<locals>.inner_fn at 0x79a83f924860>, ranges=[1]))
  ))
  args[3]: TensorBox(StorageBox(
    InputBuffer(name='arg6_1', layout=FixedLayout('cuda:0', torch.float32, size=[], stride=[]))
  ))
  args[4]: None
  args[5]: None
  args[6]: torch.bfloat16
  kwargs: {'use_fast_accum': False}
```

The issue is because the weight_scale and x_scale tensors shape mismatch: size=[] v.s. size=[1] so we need to manually unsqueeze weight_scale match with size=[1]

<img width="338" height="114" alt="image" src="https://github.com/user-attachments/assets/3529cf32-7c4d-4550-ad41-ecfeddae05a5" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
