### PR TITLE
[DeepSeek 3.2] Support and optimize pipeline parallelis when context pipeline enabled

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -23,6 +24,7 @@ if is_npu():
     import torch_npu
     from sglang.srt.hardware_backend.npu.utils import get_indexer_weight_stream
 
+from sglang.srt.distributed.parallel_state import get_pp_group
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.attention.nsa.utils import (
     cp_all_gather_rerange_output,
@@ -146,6 +148,7 @@ class Indexer(MultiPlatformOp):
         if is_cuda():
             self.sm_count = deep_gemm.get_num_sms()
             self.half_device_sm_count = ceil_align(self.sm_count // 2, 8)
+            self.pp_size = get_global_server_args().pp_size
 
         self.wq_b = ReplicatedLinear(
             self.q_lora_rank,
@@ -183,6 +186,21 @@ class Indexer(MultiPlatformOp):
         self.block_size = block_size
         self.scale_fmt = scale_fmt
         self.softmax_scale = self.head_dim**-0.5
+
+    @contextlib.contextmanager
+    def _with_real_sm_count(self):
+        # When pipeline parallelism is enabled, each PP rank initiates a recv operation after the _pp_launch_batch
+        # request to receive the PP proxy tensor or output from the previous stage, occupying one SM resource.
+        # Model execution runs in parallel with the recv operation, so the SMs available to the indexer must be reduced
+        # by 1. Currently, the last rank starts the send result + recv request only after waiting for execution results.
+        if is_cuda() and self.pp_size > 1 and not get_pp_group().is_last_rank:
+            pp_recv_sm_count = 1
+            with deep_gemm_wrapper.configure_deep_gemm_num_sms(
+                self.sm_count - pp_recv_sm_count
+            ):
+                yield
+        else:
+            yield
 
     @torch.compile(dynamic=True)
     def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
@@ -333,7 +351,6 @@ class Indexer(MultiPlatformOp):
         )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
-
         logits = deep_gemm.fp8_paged_mqa_logits(
             q_fp8,
             kv_cache_fp8,
@@ -432,14 +449,15 @@ class Indexer(MultiPlatformOp):
 
         if not need_chunk:
             assert q_fp8[:q_offset].shape[0] != 0
-            logits = deep_gemm.fp8_mqa_logits(
-                q_fp8[:q_offset],
-                kv_fp8,
-                weights[:q_offset],
-                ks,
-                ke,
-                clean_logits=False,
-            )
+            with self._with_real_sm_count():
+                logits = deep_gemm.fp8_mqa_logits(
+                    q_fp8[:q_offset],
+                    kv_fp8,
+                    weights[:q_offset],
+                    ks,
+                    ke,
+                    clean_logits=False,
+                )
             assert logits.shape[0] == len(seq_lens_expanded)
             assert logits.shape[1] == k_offset
 
@@ -468,14 +486,15 @@ class Indexer(MultiPlatformOp):
         while start < q_offset:
             end = min(start + max_rows, q_offset)
 
-            logits_chunk = deep_gemm.fp8_mqa_logits(
-                q_fp8[start:end],
-                kv_fp8,
-                weights[start:end],
-                ks[start:end],
-                ke[start:end],
-                clean_logits=False,
-            )
+            with self._with_real_sm_count():
+                logits_chunk = deep_gemm.fp8_mqa_logits(
+                    q_fp8[start:end],
+                    kv_fp8,
+                    weights[start:end],
+                    ks[start:end],
+                    ke[start:end],
+                    clean_logits=False,
+                )
 
             lengths_chunk = seq_lens_expanded[start:end]
 
@@ -630,14 +649,15 @@ class Indexer(MultiPlatformOp):
             ke_offset = torch.cat(ke_offset_list, dim=0)
             ke = ks + ke_offset
             actual_seq_q = torch.cat(actual_seq_q_list, dim=0)
-            logits = deep_gemm.fp8_mqa_logits(
-                q_fp8,
-                kv_fp8,
-                weights,
-                ks,
-                ke,
-                clean_logits=False,
-            )
+            with self._with_real_sm_count():
+                logits = deep_gemm.fp8_mqa_logits(
+                    q_fp8,
+                    kv_fp8,
+                    weights,
+                    ks,
+                    ke,
+                    clean_logits=False,
+                )
             topk_result = metadata.topk_transform(
                 logits,
                 self.index_topk,
@@ -675,14 +695,15 @@ class Indexer(MultiPlatformOp):
             )
             ke = ks + ke_offset
 
-            logits = deep_gemm.fp8_mqa_logits(
-                q_fp8,
-                kv_fp8,
-                weights,
-                ks,
-                ke,
-                clean_logits=False,
-            )
+            with self._with_real_sm_count():
+                logits = deep_gemm.fp8_mqa_logits(
+                    q_fp8,
+                    kv_fp8,
+                    weights,
+                    ks,
+                    ke,
+                    clean_logits=False,
+                )
             actual_seq_q = torch.tensor([actual_seq_q], dtype=torch.int32).to(
                 device="cuda", non_blocking=True
             )

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -506,8 +506,7 @@ class SchedulerPPMixin:
         self.pp_loop_size: int = self.pp_size + self.server_args.pp_async_batch_depth
         # In CP mode, attention weights are duplicated, eliminating the need for the attention TP all-gather operation.
         self.require_attn_tp_allgather = (
-            self.pp_size == 1
-            or not self.server_args.enable_nsa_prefill_context_parallel
+            not self.server_args.enable_nsa_prefill_context_parallel
         )
         self.mbs = [None] * self.pp_loop_size
         self.last_mbs = [None] * self.pp_loop_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

For issue #15358. CC  @whybeyoung

<!-- Describe the purpose and goals of this pull request. -->

Support pipeline parallelism for the Prefill CP scenario (`--enable-nsa-prefill-context-parallel`). In this scenario, the linear layer of attention uses repeated weights, and the received input is scattered. Therefore, the attention TP group does not need to perform an `all_gather` operation during PP send/recv.

Optimize the indexer as follows: In the case of PP parallelism, part of the model execution may run in parallel with the PP recv operation, which occupies an additional SM resource. Thus, the total number of SMs allocated to the indexer’s `deep_gemm.fp8_mqa_logits` must be reduced by 1.

As shown in the figure below, for `deep_gemm.fp8_mqa_logits` on the first node (i.e., PP rank = 0), the latency is 1.312 ms when it does not overlap with the PP `recv` operation, and increases to 2.211 ms when overlapped with the `recv` operator.
Analysis reveals that `deep_gemm.fp8_mqa_logits` occupies all SMs by default. In the H20 scenario, the grid is (78,). However, since the recv operator already occupies 1 SM, the latency of `deep_gemm.fp8_mqa_logits` increases significantly.
Solution: In the PP scenario, we reduce the number of SMs for `deep_gemm.fp8_mqa_logits` by calling `deep_gemm.set_num_sms`, so as to maintain the performance of `deep_gemm.fp8_mqa_logits`.

<img width="2792" height="1204" alt="image" src="https://github.com/user-attachments/assets/b23cca93-38c5-426b-937e-aa56a5e7ae64" />

In 2* 8*H20(96GB), 48.5K inputs, TTFT 3.11 s.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. Support pipeline parallelism for the Prefill CP scenario 
2. Optimize the indexer, the total number of SMs allocated to the indexer’s deep_gemm.fp8_mqa_logits must be reduced by 1 when pp is enabled and is not last pp rank.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

In 2* 8*H20(96GB).

```
export SGLANG_PP_LAYER_PARTITION=30,31
python3 -m sglang.launch_server --model-path $MODEL_PATH --nnodes 2 --port 8000 --dist-init-addr ${node_rank_ip}:62001 \
--node-rank 0 --tp 8 --pp-size 2  --trust-remote-code --disable-radix-cache --mem-fraction-static 0.8 \
--max-running-requests 128 --watchdog-timeout 3600  --host 0.0.0.0 \
--chunked-prefill-size 8192 \
--enable-nsa-prefill-context-parallel \
--nsa-prefill-cp-mode round-robin-split \
--attention-backend nsa \
--nsa-decode-backend fa3 \
--tool-call-parser deepseekv32 \
--reasoning-parser deepseek-v3
```

```
export SGLANG_PP_LAYER_PARTITION=30,31
python3 -m sglang.launch_server --model-path $MODEL_PATH  --nnodes 2 --port 8000 --dist-init-addr ${node_rank_ip}:62001 \
--node-rank 1 --tp 8 --pp-size 2  --trust-remote-code --disable-radix-cache --mem-fraction-static 0.8 \
--max-running-requests 128 --watchdog-timeout 3600 \
--chunked-prefill-size 8192 \
--enable-nsa-prefill-context-parallel \
--nsa-prefill-cp-mode round-robin-split \
--nsa-decode-backend fa3 \
--attention-backend nsa \
--tool-call-parser deepseekv32 \
--reasoning-parser deepseek-v3
```

```
# gsm8k
100%|██████████| 1319/1319 [05:51<00:00,  3.75it/s]
Accuracy: 0.948
Invalid: 0.000
Latency: 357.199 s
Output throughput: 342.630 token/s
```

```
# mmlu
100%|██████████| 14042/14042 [17:44<00:00, 13.19it/s] 
subject: abstract_algebra, #q:100, acc: 0.780
subject: anatomy, #q:135, acc: 0.867
subject: astronomy, #q:152, acc: 0.961
subject: business_ethics, #q:100, acc: 0.860
subject: clinical_knowledge, #q:265, acc: 0.921
subject: college_biology, #q:144, acc: 0.972
subject: college_chemistry, #q:100, acc: 0.650
subject: college_computer_science, #q:100, acc: 0.870
subject: college_mathematics, #q:100, acc: 0.870
subject: college_medicine, #q:173, acc: 0.867
subject: college_physics, #q:102, acc: 0.892
subject: computer_security, #q:100, acc: 0.910
subject: conceptual_physics, #q:235, acc: 0.928
subject: econometrics, #q:114, acc: 0.772
subject: electrical_engineering, #q:145, acc: 0.883
subject: elementary_mathematics, #q:378, acc: 0.944
subject: formal_logic, #q:126, acc: 0.802
subject: global_facts, #q:100, acc: 0.720
subject: high_school_biology, #q:310, acc: 0.961
subject: high_school_chemistry, #q:203, acc: 0.877
subject: high_school_computer_science, #q:100, acc: 0.930
subject: high_school_european_history, #q:165, acc: 0.885
subject: high_school_geography, #q:198, acc: 0.965
subject: high_school_government_and_politics, #q:193, acc: 0.979
subject: high_school_macroeconomics, #q:390, acc: 0.921
subject: high_school_mathematics, #q:270, acc: 0.789
subject: high_school_microeconomics, #q:238, acc: 0.962
subject: high_school_physics, #q:151, acc: 0.841
subject: high_school_psychology, #q:545, acc: 0.969
subject: high_school_statistics, #q:216, acc: 0.875
subject: high_school_us_history, #q:204, acc: 0.966
subject: high_school_world_history, #q:237, acc: 0.954
subject: human_aging, #q:223, acc: 0.843
subject: human_sexuality, #q:131, acc: 0.924
subject: international_law, #q:121, acc: 0.967
subject: jurisprudence, #q:108, acc: 0.917
subject: logical_fallacies, #q:163, acc: 0.933
subject: machine_learning, #q:112, acc: 0.812
subject: management, #q:103, acc: 0.932
subject: marketing, #q:234, acc: 0.949
subject: medical_genetics, #q:100, acc: 0.940
subject: miscellaneous, #q:783, acc: 0.962
subject: moral_disputes, #q:346, acc: 0.879
subject: moral_scenarios, #q:895, acc: 0.799
subject: nutrition, #q:306, acc: 0.928
subject: philosophy, #q:311, acc: 0.920
subject: prehistory, #q:324, acc: 0.932
subject: professional_accounting, #q:282, acc: 0.883
subject: professional_law, #q:1534, acc: 0.726
subject: professional_medicine, #q:272, acc: 0.949
subject: professional_psychology, #q:612, acc: 0.908
subject: public_relations, #q:110, acc: 0.818
subject: security_studies, #q:245, acc: 0.882
subject: sociology, #q:201, acc: 0.965
subject: us_foreign_policy, #q:100, acc: 0.950
subject: virology, #q:166, acc: 0.590
subject: world_religions, #q:171, acc: 0.936
Total latency: 1064.955
Average accuracy: 0.880
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Before optimize the indexer:
<img width="2792" height="1204" alt="image" src="https://github.com/user-attachments/assets/b23cca93-38c5-426b-937e-aa56a5e7ae64" />
<img width="2346" height="422" alt="image" src="https://github.com/user-attachments/assets/eba1d934-ca1d-41e9-9ed7-675cbe4c1380" />

After optimize the indexer:
<img width="2314" height="536" alt="image" src="https://github.com/user-attachments/assets/6103a5a0-92ab-4feb-99ad-acdffee797b2" />
<img width="2336" height="372" alt="image" src="https://github.com/user-attachments/assets/beb9d70b-ed2e-452a-9ab3-2b802e16c22e" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
5. After green CI and required approvals, ask Merge Oncalls to merge.
