### PR TITLE
Add v1/models endpoint to diffusion model APIs so that they can be discovered by model gateway

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -55,9 +55,15 @@ async def health():
     return {"status": "ok"}
 
 
-@health_router.get("/models")
+@health_router.get("/models", deprecated=True)
 async def get_models(request: Request):
-    """Get information about the model served by this server."""
+    """
+    Get information about the model served by this server.
+
+    .. deprecated::
+        Use /v1/models instead for OpenAI-compatible model discovery.
+        This endpoint will be removed in a future version.
+    """
     from sglang.multimodal_gen.registry import get_model_info
 
     server_args: ServerArgs = request.app.state.server_args

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Body, HTTPException
 from fastapi.responses import ORJSONResponse
 
+from sglang.multimodal_gen.registry import get_model_info
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
     MergeLoraWeightsReq,
     SetLoraReq,
@@ -12,10 +13,21 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBa
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.srt.entrypoints.openai.protocol import ModelCard, ModelList
+from sglang.srt.entrypoints.openai.protocol import ModelCard
 
 router = APIRouter(prefix="/v1")
 logger = init_logger(__name__)
+
+
+class DiffusionModelCard(ModelCard):
+    """Extended ModelCard with diffusion-specific fields."""
+
+    num_gpus: Optional[int] = None
+    task_type: Optional[str] = None
+    dit_precision: Optional[str] = None
+    vae_precision: Optional[str] = None
+    pipeline_name: Optional[str] = None
+    pipeline_class: Optional[str] = None
 
 
 async def _handle_lora_request(req: Any, success_msg: str, failure_msg: str):
@@ -123,24 +135,36 @@ async def model_info():
 
 @router.get("/models", response_class=ORJSONResponse)
 async def available_models():
-    """Show available models. OpenAI-compatible endpoint."""
+    """Show available models. OpenAI-compatible endpoint with extended diffusion info."""
     server_args = get_global_server_args()
     if not server_args:
         raise HTTPException(status_code=500, detail="Server args not initialized")
 
-    model_cards = [
-        ModelCard(
-            id=server_args.model_path,
-            root=server_args.model_path,
-        )
-    ]
+    model_info = get_model_info(server_args.model_path)
 
-    return ModelList(data=model_cards)
+    card_kwargs = {
+        "id": server_args.model_path,
+        "root": server_args.model_path,
+        # Extended diffusion-specific fields
+        "num_gpus": server_args.num_gpus,
+        "task_type": server_args.pipeline_config.task_type.name,
+        "dit_precision": server_args.pipeline_config.dit_precision,
+        "vae_precision": server_args.pipeline_config.vae_precision,
+    }
+
+    if model_info:
+        card_kwargs["pipeline_name"] = model_info.pipeline_cls.pipeline_name
+        card_kwargs["pipeline_class"] = model_info.pipeline_cls.__name__
+
+    model_card = DiffusionModelCard(**card_kwargs)
+
+    # Return dict directly to preserve extended fields (ModelList strips them)
+    return {"object": "list", "data": [model_card.model_dump()]}
 
 
 @router.get("/models/{model:path}", response_class=ORJSONResponse)
 async def retrieve_model(model: str):
-    """Retrieve a model instance. OpenAI-compatible endpoint."""
+    """Retrieve a model instance. OpenAI-compatible endpoint with extended diffusion info."""
     server_args = get_global_server_args()
     if not server_args:
         raise HTTPException(status_code=500, detail="Server args not initialized")
@@ -158,7 +182,20 @@ async def retrieve_model(model: str):
             },
         )
 
-    return ModelCard(
-        id=model,
-        root=model,
-    )
+    model_info = get_model_info(server_args.model_path)
+
+    card_kwargs = {
+        "id": model,
+        "root": model,
+        "num_gpus": server_args.num_gpus,
+        "task_type": server_args.pipeline_config.task_type.name,
+        "dit_precision": server_args.pipeline_config.dit_precision,
+        "vae_precision": server_args.pipeline_config.vae_precision,
+    }
+
+    if model_info:
+        card_kwargs["pipeline_name"] = model_info.pipeline_cls.pipeline_name
+        card_kwargs["pipeline_class"] = model_info.pipeline_cls.__name__
+
+    # Return dict to preserve extended fields
+    return DiffusionModelCard(**card_kwargs).model_dump()

--- a/python/sglang/multimodal_gen/test/run_suite.py
+++ b/python/sglang/multimodal_gen/test/run_suite.py
@@ -153,8 +153,10 @@ def run_pytest(files, filter_expr=None):
         cmd = list(base_cmd)
         if i > 0:
             cmd.append("--last-failed")
-        else:
-            cmd.extend(files)
+        # Always include files to constrain test discovery scope
+        # This prevents pytest from scanning the entire rootdir and
+        # discovering unrelated tests that may have missing dependencies
+        cmd.extend(files)
 
         if i > 0:
             print(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

- Introduce OpenAI compatible API v1/models with additional info from diffusion server
- Mark the models/ endpoint as deprecated

## Accuracy Tests


curl 207.210.107.189:30001/v1/models | jq
{
  "object": "list",
  "data": [
    {
      "id": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
      "object": "model",
      "created": 1767658791,
      "owned_by": "sglang",
      "root": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
      "parent": null,
      "max_model_len": null,
      "num_gpus": 1,
      "task_type": "T2V",
      "dit_precision": "bf16",
      "vae_precision": "fp32",
      "pipeline_name": "WanPipeline",
      "pipeline_class": "WanPipeline"
    }
  ]
}