### PR TITLE
Allow editable install without `.git` with add fallback version in `pyproject.toml`

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,6 +172,8 @@ exclude = [
 root = ".."
 version_file = "sglang/_version.py"
 git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
+# Allow editable installs even when .git metadata is not available.
+fallback_version = "0.0.0.dev0"
 
 [tool.codespell]
 ignore-words-list = "ans, als, hel, boostrap, childs, te, vas, hsa, ment"


### PR DESCRIPTION
When building without `.git` (usually in dev mode):

```bash
      Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

      For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj

      Alternatively, set the version with the environment variable SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described in https://setuptools-scm.readthedocs.io/en/latest/config/
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
```

As the fallback logic has already been in `sglang.version`, add the same dev `0.0.0.dev0` version in `setuptools_scm`'s config.

```toml
fallback_version = "0.0.0.dev0"
```

then without `.git`, we can still install the dev package:

```bash
Successfully built sglang
Installing collected packages: sglang
  Attempting uninstall: sglang
    Found existing installation: sglang 0.0.0.dev0
    Uninstalling sglang-0.0.0.dev0:
      Successfully uninstalled sglang-0.0.0.dev0
Successfully installed sglang-0.0.0.dev0
```

cc @Kangyan-Zhou 