### PR TITLE
Migrate attention unit tests to test/registered/attention/

### DIFF
--- a/test/registered/attention/test_mamba_unittest.py
+++ b/test/registered/attention/test_mamba_unittest.py
@@ -4,6 +4,9 @@ import unittest
 import torch
 
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=9, suite="stage-b-test-small-1-gpu")
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams

--- a/test/registered/attention/test_mamba_unittest.py
+++ b/test/registered/attention/test_mamba_unittest.py
@@ -4,9 +4,6 @@ import unittest
 import torch
 
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
-from sglang.test.ci.ci_register import register_cuda_ci
-
-register_cuda_ci(est_time=9, suite="stage-b-test-small-1-gpu")
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
@@ -14,6 +11,9 @@ from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, HybridReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=9, suite="stage-b-test-small-1-gpu")
 
 
 class TestMamba(unittest.TestCase):

--- a/test/registered/attention/test_swa_unittest.py
+++ b/test/registered/attention/test_swa_unittest.py
@@ -3,6 +3,10 @@ import unittest
 import torch
 
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=10, suite="stage-b-test-small-1-gpu")
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllocator

--- a/test/registered/attention/test_swa_unittest.py
+++ b/test/registered/attention/test_swa_unittest.py
@@ -3,14 +3,14 @@ import unittest
 import torch
 
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-
-register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=10, suite="stage-b-test-small-1-gpu")
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=10, suite="stage-b-test-small-1-gpu")
 
 
 class TestSWA(unittest.TestCase):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -17,7 +17,6 @@ suites = {
         TestFile("test_input_embeddings.py", 38),
         TestFile("test_io_struct.py", 8),
         TestFile("test_jinja_template_utils.py", 7),
-        TestFile("test_mamba_unittest.py", 9),
         TestFile("test_model_hooks.py", 6),
         TestFile("test_modelopt_loader.py", 11),
         TestFile("test_multi_tokenizer.py", 230),
@@ -31,7 +30,6 @@ suites = {
         TestFile("test_start_profile.py", 41),
         TestFile("test_profile_merger.py", 8),
         TestFile("test_profile_merger_http_api.py", 9),
-        TestFile("test_swa_unittest.py", 8),
         TestFile("test_utils_update_weights.py", 29),
         TestFile("test_video_utils.py", 5),
         TestFile("test_modelopt_export.py", 9),
@@ -140,7 +138,6 @@ suite_amd = {
         TestFile("test_srt_endpoint.py", 130),
         TestFile("test_srt_engine.py", 261),
         TestFile("test_start_profile.py", 60),
-        TestFile("test_swa_unittest.py", 10),
         # TestFile("test_torch_compile_moe.py", 210), # Disabled temporarily, see https://github.com/sgl-project/sglang/issues/13107
         TestFile("test_type_based_dispatcher.py", 10),
         TestFile("test_video_utils.py", 8),


### PR DESCRIPTION
## Summary
- Extends `test/registered/attention/` directory with 2 unit tests
- Migrates SWA and Mamba cache unit tests
- All tests registered for `stage-b-test-small-1-gpu` suite
- AMD support for test_swa_unittest.py

Part of #13808

## Test plan
- [x] CI passes for stage-b-test-small-1-gpu (CUDA)
- [x] CI passes for stage-b-test-small-1-gpu (AMD) for test_swa_unittest.py
- [ ] Verify estimated times are accurate after CI run