### PR TITLE
[Feature] [ROCM] Optimized Qwen3-VL model with rmsnorm + fp8 dynamic quant fusion

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -77,6 +77,11 @@ _is_gfx95_supported = is_gfx95_supported()
 _is_npu = is_npu()
 _use_ag_after_qlora = envs.SGLANG_USE_AG_AFTER_QLORA.get()
 
+if _use_aiter:
+    from aiter import (
+        rmsnorm2d_fwd_with_add_dynamicquant,
+        rmsnorm2d_fwd_with_dynamicquant,
+    )
 if _use_aiter and _is_gfx95_supported:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 
@@ -405,13 +410,17 @@ class LayerCommunicator:
         residual: torch.Tensor,
         forward_batch: ForwardBatch,
         captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
+        quant_format: str = "",
         post_residual_addition: Optional[torch.Tensor] = None,
+        **kwargs,
     ):
         hidden_states, residual = self.prepare_attn(
             hidden_states,
             residual,
             forward_batch,
             post_residual_addition=post_residual_addition,
+            quant_format=quant_format,
+            **kwargs,
         )
         if captured_last_layer_outputs is not None:
             gathered_last_layer_output = self._communicate_simple_fn(
@@ -488,7 +497,27 @@ class LayerCommunicator:
                             res1=None,
                             output_unquantized_inp1=False,
                         )
-
+                    elif _use_aiter and ("fp8_e4m3fnuz" in quant_format):
+                        y_scale = torch.empty(
+                            hidden_states.shape[0],
+                            1,
+                            dtype=torch.float32,
+                            device=hidden_states.device,
+                        )
+                        output = torch.empty_like(
+                            hidden_states,
+                            dtype=torch.float8_e4m3fnuz,
+                            device=hidden_states.device,
+                        )
+                        rmsnorm2d_fwd_with_dynamicquant(
+                            output,
+                            hidden_states,
+                            y_scale,
+                            self.input_layernorm.weight,
+                            self.input_layernorm.variance_epsilon,
+                            use_model_sensitive_rmsnorm=0,
+                        )
+                        hidden_states = (output, y_scale)
                     else:
                         hidden_states = self.input_layernorm(hidden_states)
                 else:
@@ -520,6 +549,30 @@ class LayerCommunicator:
                             res1=residual,
                             output_unquantized_inp1=False,
                         )
+                    elif _use_aiter and ("fp8_e4m3fnuz" in quant_format):
+                        y_scale = torch.empty(
+                            hidden_states.shape[0],
+                            1,
+                            dtype=torch.float32,
+                            device=hidden_states.device,
+                        )
+                        output = torch.empty_like(
+                            hidden_states,
+                            dtype=torch.float8_e4m3fnuz,
+                            device=hidden_states.device,
+                        )
+                        residual_out = torch.empty_like(residual)
+                        rmsnorm2d_fwd_with_add_dynamicquant(
+                            output,
+                            hidden_states,
+                            residual,
+                            residual_out,
+                            y_scale,
+                            self.input_layernorm.weight,
+                            self.input_layernorm.variance_epsilon,
+                            use_model_sensitive_rmsnorm=0,
+                        )
+                        hidden_states, residual = (output, y_scale), residual_out
                     else:
                         hidden_states, residual = self.input_layernorm(
                             hidden_states,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -223,11 +223,17 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             )
 
         if _use_aiter and self.strategy == QuantizationStrategy.CHANNEL:
+            if isinstance(x, tuple):
+                input = x[0]
+                input_scale = x[1]
+            else:
+                input = x
+                input_scale = layer.input_scale
             return apply_fp8_ptpc_linear(
-                input=x,
+                input=input,
                 weight=layer.weight,
                 weight_scale=layer.weight_scale,
-                input_scale=layer.input_scale,
+                input_scale=input_scale,
                 bias=bias,
                 use_per_token_if_dynamic=True,
                 compressed_tensor_quant=True,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1518,7 +1518,12 @@ def apply_fp8_ptpc_linear(
     # weight is transposed (K, N)
     output_shape = [*input.shape[:-1], weight.shape[1]]
 
-    q_input, x_scale = aiter.per_token_quant_hip(input_2d, quant_dtype=aiter.dtypes.fp8)
+    if input_scale is not None:
+        q_input, x_scale = input_2d, input_scale
+    else:
+        q_input, x_scale = aiter.per_token_quant_hip(
+            input_2d, quant_dtype=aiter.dtypes.fp8
+        )
 
     per_tensor_weights = (weight_scale.numel() == 1) and weight_scale.dim() < 2
     per_tensor_activations = (x_scale.numel() == 1) and x_scale.dim() < 2
@@ -1528,7 +1533,12 @@ def apply_fp8_ptpc_linear(
         output_shape = [*input.shape[:-1], weight.shape[0]]
 
     output = aiter.gemm_a8w8_bpreshuffle(
-        q_input, weight, x_scale, weight_scale, None, input.dtype
+        q_input,
+        weight,
+        x_scale,
+        weight_scale,
+        None,
+        dtype=torch.bfloat16 if input_scale is not None else input.dtype,
     )
     if bias is not None:
         output = output + bias

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -73,13 +73,17 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    get_bool_env_var,
     is_cuda,
     is_flashinfer_available,
+    is_hip,
     is_non_idle_and_non_empty,
     is_npu,
 )
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_cuda:
     from sgl_kernel import fused_qk_norm_rope
@@ -618,7 +622,9 @@ class Qwen3MoeAttention(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ):
-        if hidden_states.shape[0] == 0:
+        if (isinstance(hidden_states, tuple) and hidden_states[0].shape[0] == 0) or (
+            isinstance(hidden_states, torch.Tensor) and hidden_states.shape[0] == 0
+        ):
             return hidden_states, forward_batch, None
         if (
             not _is_npu
@@ -768,18 +774,26 @@ class Qwen3MoeDecoderLayer(nn.Module):
         captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-
+        if _use_aiter and self.self_attn.qkv_proj.weight.dtype == getattr(
+            torch, "float8_e4m3fnuz", None
+        ):
+            quant_format = "fp8_e4m3fnuz"
+        else:
+            quant_format = ""
         hidden_states, residual = (
             self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
                 hidden_states,
                 residual,
                 forward_batch,
                 captured_last_layer_outputs=captured_last_layer_outputs,
+                quant_format=quant_format,
                 **kwargs,
             )
         )
 
-        if hidden_states.shape[0] != 0:
+        if (isinstance(hidden_states, tuple) and hidden_states[0].shape[0] != 0) or (
+            isinstance(hidden_states, torch.Tensor) and hidden_states.shape[0] != 0
+        ):
             hidden_states = self.self_attn(
                 positions=positions,
                 hidden_states=hidden_states,


### PR DESCRIPTION
## Motivation

Boost the performance of Qwen3-VL by fusing the RMSNorm and FP8 dynamic quantization kernels.
**before:**
<img width="1340" height="92" alt="image" src="https://github.com/user-attachments/assets/a34db309-f9dc-4e6a-be01-ec8ab25ac549" />

**after:**
<img width="1327" height="94" alt="image" src="https://github.com/user-attachments/assets/21af0de9-3321-47a8-a13e-fb75cff975d5" />

## Accuracy Tests
This is my scripts:

**Server:**
```
export SGLANG_USE_AITER=1
model=/mnt/raid0/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/
TP=8
EP=1

echo "launching ${model}"
echo "TP=${TP}"
echo "EP=${EP}"

python3 -m sglang.launch_server \
    --model-path ${model} \
    --host localhost \
    --port 9000 \
    --tp-size ${TP} \
    --ep-size ${EP} \
    --trust-remote-code \
    --chunked-prefill-size 16384 \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --max-prefill-tokens 16384 \
    --cuda-graph-max-bs 128 \
    --max-running-requests 128 \
    --mm-attention-backend aiter_attn \
```

**Client:**
```
python3 benchmark/mmmu/bench_sglang.py --port 9000 --concurrency 16
```
This is the result:
```
answers saved to: ./answer_sglang.json
{'Accounting': {'acc': 0.433, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.267, 'num': 30},
 'Art': {'acc': 0.767, 'num': 30},
 'Art_Theory': {'acc': 0.9, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.8, 'num': 30},
 'Biology': {'acc': 0.6, 'num': 30},
 'Chemistry': {'acc': 0.6, 'num': 30},
 'Clinical_Medicine': {'acc': 0.8, 'num': 30},
 'Computer_Science': {'acc': 0.6, 'num': 30},
 'Design': {'acc': 0.867, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.467, 'num': 30},
 'Economics': {'acc': 0.8, 'num': 30},
 'Electronics': {'acc': 0.333, 'num': 30},
 'Energy_and_Power': {'acc': 0.433, 'num': 30},
 'Finance': {'acc': 0.467, 'num': 30},
 'Geography': {'acc': 0.5, 'num': 30},
 'History': {'acc': 0.8, 'num': 30},
 'Literature': {'acc': 0.867, 'num': 30},
 'Manage': {'acc': 0.5, 'num': 30},
 'Marketing': {'acc': 0.733, 'num': 30},
 'Materials': {'acc': 0.433, 'num': 30},
 'Math': {'acc': 0.367, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.3, 'num': 30},
 'Music': {'acc': 0.367, 'num': 30},
 'Overall': {'acc': 0.61, 'num': 900},
 'Overall-Art and Design': {'acc': 0.725, 'num': 120},
 'Overall-Business': {'acc': 0.587, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.747, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.775, 'num': 120},
 'Overall-Science': {'acc': 0.547, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.414, 'num': 210},
 'Pharmacy': {'acc': 0.867, 'num': 30},
 'Physics': {'acc': 0.667, 'num': 30},
 'Psychology': {'acc': 0.733, 'num': 30},
 'Public_Health': {'acc': 0.8, 'num': 30},
 'Sociology': {'acc': 0.7, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.61
```

## Benchmarking 

This is my benchmark scripts:
```
export SGLANG_USE_AITER=1
model=/mnt/raid0/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/

input_tokens=4000
output_tokens=1000
max_concurrency=1
num_prompts=$((max_concurrency * 3))
image_count=1
image_resolution=800x800

python3 -m sglang.bench_serving \
    --backend sglang-oai-chat \
    --port 9000 \
    --dataset-name image \
    --num-prompts ${num_prompts} \
    --image-count ${image_count} \
    --image-resolution ${image_resolution} \
    --random-input-len ${input_tokens} \
    --random-output-len ${output_tokens} \
    --max-concurrency ${max_concurrency} \
    --random-range-ratio 1.0 \
```
As the table shows, we got 1-6% uplift for E2E latency and 1-2% uplift for throughput performance gain with this fusion.
<img width="495" height="191" alt="rms_fp8quant_fuse" src="https://github.com/user-attachments/assets/b3aa0f60-17d1-439d-853f-f6f49a1a407d" />
