### PR TITLE
[Diffusion] Fix `--warmup` conflicts with CacheDiT by preserving real step count for CacheDiT init

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -189,6 +189,9 @@ class Scheduler:
             if isinstance(req, Req):
                 warmup_req = deepcopy(req)
                 warmup_req.is_warmup = True
+                warmup_req.extra["cache_dit_num_inference_steps"] = (
+                    req.num_inference_steps
+                )
                 warmup_req.num_inference_steps = 1
                 recv_reqs.insert(0, (identity, warmup_req))
                 self.warmed_up = True

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -487,6 +487,9 @@ class DenoisingStage(PipelineStage):
         """
         assert self.transformer is not None
         pipeline = self.pipeline() if self.pipeline else None
+        cache_dit_num_inference_steps = batch.extra.get(
+            "cache_dit_num_inference_steps", batch.num_inference_steps
+        )
         if not server_args.model_loaded["transformer"]:
             # FIXME: reuse more code
             loader = TransformerLoader()
@@ -494,13 +497,13 @@ class DenoisingStage(PipelineStage):
                 server_args.model_paths["transformer"], server_args, "transformer"
             )
             # enable cache-dit before torch.compile (delayed mounting)
-            self._maybe_enable_cache_dit(batch.num_inference_steps)
+            self._maybe_enable_cache_dit(cache_dit_num_inference_steps)
             self.compile_module_with_torch_compile(self.transformer)
             if pipeline:
                 pipeline.add_module("transformer", self.transformer)
             server_args.model_loaded["transformer"] = True
         else:
-            self._maybe_enable_cache_dit(batch.num_inference_steps)
+            self._maybe_enable_cache_dit(cache_dit_num_inference_steps)
 
         # Prepare extra step kwargs for scheduler
         extra_step_kwargs = self.prepare_extra_func_kwargs(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

```shell
CUDA_VISIBLE_DEVICES=4,5,6,7 \
SGLANG_CACHE_DIT_ENABLED=true \
SGLANG_CACHE_DIT_WARMUP=4 \
SGLANG_CACHE_DIT_MC=8 \
SGLANG_CACHE_DIT_RDT=0.24 \
SGLANG_CACHE_DIT_FN=1 \
SGLANG_CACHE_DIT_BN=0 \
SGLANG_CACHE_DIT_TAYLORSEER=true \
SGLANG_CACHE_DIT_SECONDARY_WARMUP=2 \
SGLANG_CACHE_DIT_SECONDARY_MC=20 \
SGLANG_CACHE_DIT_SECONDARY_RDT=0.24 \
SGLANG_CACHE_DIT_SECONDARY_FN=1 \
SGLANG_CACHE_DIT_SECONDARY_BN=0 \
SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true \
SGLANG_CACHE_DIT_SCM_PRESET=fast \
SGLANG_CACHE_DIT_SCM_POLICY=dynamic \
sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers --pin-cpu-memory --num-gpus 4 --ulysses-degree 2 --ring-degree 2 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."  --save-output  --output-path outputs  --output-file-name "output1_video.mp4"  --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" --720p --num-frames 81  --fps 16  --guidance-scale 3.5 --guidance-scale-2 4 --num-inference-steps 27 --enable-warmup
```

This PR fixes a crash when running diffusion `generate` with both CacheDiT enabled and `--enable-warmup`. The warmup request uses `num_inference_steps=1`, which previously caused CacheDiT’s SCM mask generation to fail (e.g., `total_steps=1` assertion).

CacheDiT SCM presets don’t support very small `total_steps` (e.g., 1), which makes warmup crash and can cascade into scheduler/worker failures. This preserves the warmup semantics while ensuring CacheDiT is configured using the real inference step count.

main:

<img width="2046" height="880" alt="图片" src="https://github.com/user-attachments/assets/d05c5cc3-6b7d-4275-accd-c1b5e891adbe" />

pr:

<img width="2288" height="958" alt="图片" src="https://github.com/user-attachments/assets/ed49909c-6317-4b5f-b788-4beb4844b6cb" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
