### PR TITLE
[Bugfix] remove non_blocking=True parameter in memcpy from gpu to cpu

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -171,7 +171,7 @@ class DecodingStage(PipelineStage):
         self.maybe_free_model_hooks()
 
         if self.server_args.vae_cpu_offload:
-            self.vae.to("cpu", non_blocking=True)
+            self.vae.to("cpu")
 
         if torch.backends.mps.is_available():
             del self.vae

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -49,7 +49,7 @@ class ExpertDistributionMetrics:
     eplb_balancedness: torch.Tensor
 
     def copy_to_cpu(self):
-        self.eplb_balancedness = self.eplb_balancedness.to("cpu", non_blocking=True)
+        self.eplb_balancedness = self.eplb_balancedness.to("cpu")
 
 
 class ExpertDistributionRecorder(ABC):

--- a/python/sglang/srt/layers/moe/routed_experts_capturer.py
+++ b/python/sglang/srt/layers/moe/routed_experts_capturer.py
@@ -92,7 +92,7 @@ class _RoutedExpertsHostCache:
         return get_tensor_size_bytes(self.buffer)
 
     def set_experts_buffer(self, layer_id: int, loc: torch.Tensor, top_k: torch.Tensor):
-        self.buffer[layer_id, loc, :] = top_k.to(device="cpu", non_blocking=True)
+        self.buffer[layer_id, loc, :] = top_k.to(device="cpu")
 
     def _finalize_allocation_log(self):
         """Common logging and memory usage computation for captured experts buffers."""

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1091,7 +1091,7 @@ def general_mm_embed_routine(
                         for mm_item in mm_input_obj.mm_items:
                             feature = getattr(mm_item, "feature", None)
                             if isinstance(feature, torch.Tensor) and feature.is_cuda:
-                                mm_item.feature = feature.to("cpu", non_blocking=True)
+                                mm_item.feature = feature.to("cpu")
             forward_batch.mm_inputs = None
         else:
             input_embeds = embed_tokens(input_ids)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -376,7 +376,7 @@ class MultimodalInputs:
         if envs.SGLANG_MM_BUFFER_SIZE_MB.get() > 0:
             for item in ret.mm_items:
                 if item.feature is not None:
-                    item.feature = item.feature.to("cpu", non_blocking=True)
+                    item.feature = item.feature.to("cpu")
 
         optional_args = [
             "mrope_positions",


### PR DESCRIPTION
Remove non_blocking=True parameter in memcpy from gpu to cpu which is not followed by manual synchronization.

According to official document of pytorch, memcpy from gpu to cpu should not use non_blocking=True unless there is a device synchronization before the target data is accessed.

<img width="800" height="170" alt="image" src="https://github.com/user-attachments/assets/171c8953-4a77-42f7-ac66-afc88581067d" />

https://docs.pytorch.org/tutorials/intermediate/pinmem_nonblock.html#other-copy-directions-gpu-cpu-cpu-mps
