### PR TITLE
[Diffusion] Ring Attention support sage backend

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/sage_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/sage_attn.py
@@ -68,4 +68,7 @@ class SageAttentionImpl(AttentionImpl):
             sm_scale=self.softmax_scale,
             return_lse=return_softmax_lse,
         )
+        if return_softmax_lse:
+            output, softmax_lse = output
+            return output, softmax_lse
         return output

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -756,14 +756,17 @@ class ServerArgs:
             logger.debug(f"Ring degree not set, using default value {self.ring_degree}")
 
         if self.ring_degree > 1:
-            if self.attention_backend is not None and self.attention_backend != "fa":
+            if self.attention_backend is not None and self.attention_backend not in (
+                "fa",
+                "sage_attn",
+            ):
                 raise ValueError(
-                    "Ring Attention is only supported for flash attention backend for now"
+                    "Ring Attention is only supported for flash attention or sage attention backend for now"
                 )
-            else:
+            if self.attention_backend is None:
                 self.attention_backend = "fa"
                 logger.info(
-                    "Ring Attention is currently only supported for flash attention, attention_backend has been automatically set to flash attention"
+                    "Ring Attention is currently only supported for flash attention or sage attention; attention_backend has been automatically set to flash attention"
                 )
 
         if self.sp_degree == -1:


### PR DESCRIPTION
## H100 4GPUs

### FA3 Ring Attention

```shell
CUDA_VISIBLE_DEVICES=4,5,6,7  sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers --pin-cpu-memory --num-gpus 4 --ulysses-degree 2 --ring-degree 2 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."  --save-output  --output-path outputs  --output-file-name "output1_video.mp4"  --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" --720p --num-frames 81  --fps 16  --guidance-scale 3.5 --guidance-scale-2 4 --num-inference-steps 27 --enable-warmup --dit-layerwise-offload true  --enable-torch-compile
```

```shell
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 27/27 [00:54<00:00,  2.03s/it]
[01-05 12:39:58] [DenoisingStage] average time per step: 2.0330 seconds
[01-05 12:39:58] [DenoisingStage] finished in 54.9003 seconds
[01-05 12:39:58] [DecodingStage] started...
[01-05 12:40:01] [DecodingStage] finished in 3.4961 seconds
[01-05 12:40:01] Peak GPU memory: 11.79 GB, Remaining GPU memory at peak: 67.86 GB. Components that can stay resident: ['text_encoder', 'vae', 'transformer']
[01-05 12:40:05] Output saved to outputs/output1_video.mp4
```


https://github.com/user-attachments/assets/541b64ad-e2a7-496a-ac5c-506b1eba653f




### Sage Ring Attention

```shell
CUDA_VISIBLE_DEVICES=4,5,6,7  sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers --pin-cpu-memory --num-gpus 4 --ulysses-degree 2 --ring-degree 2 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."  --save-output  --output-path outputs  --output-file-name "output1_video.mp4"  --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" --720p --num-frames 81  --fps 16  --guidance-scale 3.5 --guidance-scale-2 4 --num-inference-steps 27 --enable-warmup --dit-layerwise-offload true  --enable-torch-compile --attention-backend sage_attn
```

```shell
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 27/27 [00:57<00:00,  2.13s/it]
[01-05 12:54:52] [DenoisingStage] average time per step: 2.1275 seconds
[01-05 12:54:52] [DenoisingStage] finished in 57.4453 seconds
[01-05 12:54:52] [DecodingStage] started...
[01-05 12:54:55] [DecodingStage] finished in 3.4954 seconds
[01-05 12:54:55] Peak GPU memory: 11.79 GB, Remaining GPU memory at peak: 67.86 GB. Components that can stay resident: ['text_encoder', 'vae', 'transformer']
[01-05 12:54:59] Output saved to outputs/output1_video.mp4
```


https://github.com/user-attachments/assets/ec8284b3-7691-4942-95f8-394bf728a979

