### PR TITLE
[grpc] Refactor openai module

### DIFF
--- a/sgl-model-gateway/src/routers/openai/mod.rs
+++ b/sgl-model-gateway/src/routers/openai/mod.rs
@@ -7,15 +7,9 @@
 //! - Multi-turn tool execution loops
 //! - SSE (Server-Sent Events) streaming
 
-mod accumulator;
 mod context;
-pub mod mcp;
-pub mod provider;
-mod responses;
+mod provider;
+pub mod responses;
 mod router;
-mod streaming;
-mod tool_handler;
 
-// Re-export the main types for external use
-pub use provider::{Provider, ProviderError, ProviderRegistry};
 pub use router::OpenAIRouter;

--- a/sgl-model-gateway/src/routers/openai/provider.rs
+++ b/sgl-model-gateway/src/routers/openai/provider.rs
@@ -218,6 +218,7 @@ impl ProviderRegistry {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get(&self, provider_type: &ProviderType) -> &dyn Provider {
         self.providers
             .get(provider_type)
@@ -232,6 +233,7 @@ impl ProviderRegistry {
             .unwrap_or_else(|| Arc::clone(&self.default_provider))
     }
 
+    #[allow(dead_code)]
     pub fn get_for_model(&self, model_name: &str) -> &dyn Provider {
         match ProviderType::from_model_name(model_name) {
             Some(pt) => self.get(&pt),
@@ -239,6 +241,7 @@ impl ProviderRegistry {
         }
     }
 
+    #[allow(dead_code)]
     pub fn default_provider(&self) -> &dyn Provider {
         self.default_provider.as_ref()
     }

--- a/sgl-model-gateway/src/routers/openai/responses/accumulator.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/accumulator.rs
@@ -12,7 +12,7 @@ use crate::protocols::event_types::{OutputItemEvent, ResponseEvent};
 
 /// Helper that parses SSE frames from the OpenAI responses stream and
 /// accumulates enough information to persist the final response locally.
-pub struct StreamingResponseAccumulator {
+pub(super) struct StreamingResponseAccumulator {
     /// The initial `response.created` payload (if emitted).
     initial_response: Option<Value>,
     /// The final `response.completed` payload (if emitted).

--- a/sgl-model-gateway/src/routers/openai/responses/accumulator.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/accumulator.rs
@@ -3,7 +3,7 @@
 use serde_json::Value;
 use tracing::warn;
 
-use super::streaming::{extract_output_index, get_event_type};
+use super::common::{extract_output_index, get_event_type};
 use crate::protocols::event_types::{OutputItemEvent, ResponseEvent};
 
 // ============================================================================
@@ -12,7 +12,7 @@ use crate::protocols::event_types::{OutputItemEvent, ResponseEvent};
 
 /// Helper that parses SSE frames from the OpenAI responses stream and
 /// accumulates enough information to persist the final response locally.
-pub(super) struct StreamingResponseAccumulator {
+pub struct StreamingResponseAccumulator {
     /// The initial `response.created` payload (if emitted).
     initial_response: Option<Value>,
     /// The final `response.completed` payload (if emitted).

--- a/sgl-model-gateway/src/routers/openai/responses/common.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/common.rs
@@ -1,0 +1,113 @@
+//! Common SSE parsing and processing utilities for OpenAI responses
+//!
+//! This module contains shared helpers used by both streaming and accumulator modules.
+
+use std::borrow::Cow;
+
+use serde_json::Value;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Extract output_index from a JSON value
+#[inline]
+pub fn extract_output_index(value: &Value) -> Option<usize> {
+    value.get("output_index")?.as_u64().map(|v| v as usize)
+}
+
+/// Get event type from event name or parsed JSON, returning a reference to avoid allocation
+#[inline]
+pub fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value) -> &'a str {
+    event_name
+        .or_else(|| parsed.get("type").and_then(|v| v.as_str()))
+        .unwrap_or("")
+}
+
+// ============================================================================
+// Chunk Processor
+// ============================================================================
+
+/// Processes incoming byte chunks into complete SSE blocks.
+/// Handles buffering of partial chunks and CRLF normalization.
+pub struct ChunkProcessor {
+    pending: String,
+}
+
+impl ChunkProcessor {
+    pub fn new() -> Self {
+        Self {
+            pending: String::new(),
+        }
+    }
+
+    /// Append a chunk to the buffer, normalizing line endings
+    pub fn push_chunk(&mut self, chunk: &[u8]) {
+        let chunk_str = match std::str::from_utf8(chunk) {
+            Ok(s) => Cow::Borrowed(s),
+            Err(_) => Cow::Owned(String::from_utf8_lossy(chunk).into_owned()),
+        };
+        // Normalize CRLF to LF without extra allocation
+        let mut chars = chunk_str.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\r' && chars.peek() == Some(&'\n') {
+                // Skip \r when followed by \n
+                continue;
+            }
+            self.pending.push(c);
+        }
+    }
+
+    /// Extract the next complete SSE block from the buffer, if available
+    pub fn next_block(&mut self) -> Option<String> {
+        loop {
+            let pos = self.pending.find("\n\n")?;
+            let block = self.pending[..pos].to_string();
+            self.pending.drain(..pos + 2);
+
+            if !block.trim().is_empty() {
+                return Some(block);
+            }
+            // If block is empty, loop again to find the next one
+        }
+    }
+
+    /// Check if there's remaining content in the buffer
+    pub fn has_remaining(&self) -> bool {
+        !self.pending.trim().is_empty()
+    }
+
+    /// Take any remaining content from the buffer
+    pub fn take_remaining(&mut self) -> String {
+        std::mem::take(&mut self.pending)
+    }
+}
+
+// ============================================================================
+// SSE Parsing
+// ============================================================================
+
+/// Parse an SSE block into event name and data
+///
+/// Returns borrowed strings when possible to avoid allocations in hot paths.
+/// Only allocates when multiple data lines need to be joined.
+pub fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
+    let mut event_name: Option<&str> = None;
+    let mut data_lines: Vec<&str> = Vec::new();
+
+    for line in block.lines() {
+        if let Some(rest) = line.strip_prefix("event:") {
+            event_name = Some(rest.trim());
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.trim_start());
+        }
+    }
+
+    let data = if data_lines.len() == 1 {
+        Cow::Borrowed(data_lines[0])
+    } else {
+        Cow::Owned(data_lines.join("\n"))
+    };
+
+    (event_name, data)
+}

--- a/sgl-model-gateway/src/routers/openai/responses/common.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/common.rs
@@ -12,13 +12,13 @@ use serde_json::Value;
 
 /// Extract output_index from a JSON value
 #[inline]
-pub fn extract_output_index(value: &Value) -> Option<usize> {
+pub(super) fn extract_output_index(value: &Value) -> Option<usize> {
     value.get("output_index")?.as_u64().map(|v| v as usize)
 }
 
 /// Get event type from event name or parsed JSON, returning a reference to avoid allocation
 #[inline]
-pub fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value) -> &'a str {
+pub(super) fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value) -> &'a str {
     event_name
         .or_else(|| parsed.get("type").and_then(|v| v.as_str()))
         .unwrap_or("")
@@ -30,7 +30,7 @@ pub fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value) -> &'a
 
 /// Processes incoming byte chunks into complete SSE blocks.
 /// Handles buffering of partial chunks and CRLF normalization.
-pub struct ChunkProcessor {
+pub(super) struct ChunkProcessor {
     pending: String,
 }
 
@@ -91,7 +91,7 @@ impl ChunkProcessor {
 ///
 /// Returns borrowed strings when possible to avoid allocations in hot paths.
 /// Only allocates when multiple data lines need to be joined.
-pub fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
+pub(super) fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
     let mut event_name: Option<&str> = None;
     let mut data_lines: Vec<&str> = Vec::new();
 

--- a/sgl-model-gateway/src/routers/openai/responses/mcp.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/mcp.rs
@@ -33,7 +33,7 @@ use crate::{
 // ============================================================================
 
 /// State for tracking multi-turn tool calling loop
-pub(crate) struct ToolLoopState {
+pub struct ToolLoopState {
     /// Current iteration number (starts at 0, increments with each tool call)
     pub iteration: usize,
     /// Total number of tool calls executed
@@ -83,7 +83,7 @@ impl ToolLoopState {
 
 /// Represents a function call being accumulated across delta events
 #[derive(Debug, Clone)]
-pub(crate) struct FunctionCallInProgress {
+pub struct FunctionCallInProgress {
     pub call_id: String,
     pub name: String,
     pub arguments_buffer: String,
@@ -120,7 +120,7 @@ impl FunctionCallInProgress {
 
 /// Execute detected tool calls and send completion events to client
 /// Returns false if client disconnected during execution
-pub(super) async fn execute_streaming_tool_calls(
+pub async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
     active_mcp: &Arc<mcp::McpManager>,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
@@ -199,10 +199,7 @@ pub(super) async fn execute_streaming_tool_calls(
 // ============================================================================
 
 /// Transform payload to replace MCP tools with function tools for streaming
-pub(super) fn prepare_mcp_payload_for_streaming(
-    payload: &mut Value,
-    active_mcp: &Arc<mcp::McpManager>,
-) {
+pub fn prepare_mcp_payload_for_streaming(payload: &mut Value, active_mcp: &Arc<mcp::McpManager>) {
     if let Some(obj) = payload.as_object_mut() {
         // Remove any non-function tools from outgoing payload
         if let Some(v) = obj.get_mut("tools") {
@@ -237,7 +234,7 @@ pub(super) fn prepare_mcp_payload_for_streaming(
 }
 
 /// Build a resume payload with conversation history
-pub(super) fn build_resume_payload(
+pub fn build_resume_payload(
     base_payload: &Value,
     conversation_history: &[Value],
     original_input: &ResponseInput,
@@ -304,7 +301,7 @@ pub(super) fn build_resume_payload(
 
 /// Send mcp_list_tools events to client at the start of streaming
 /// Returns false if client disconnected
-pub(super) fn send_mcp_list_tools_events(
+pub fn send_mcp_list_tools_events(
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     mcp: &Arc<mcp::McpManager>,
     server_label: &str,
@@ -392,7 +389,7 @@ pub(super) fn send_mcp_list_tools_events(
 
 /// Send mcp_call completion events after tool execution
 /// Returns false if client disconnected
-pub(super) fn send_mcp_call_completion_events_with_error(
+pub fn send_mcp_call_completion_events_with_error(
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     call: &FunctionCallInProgress,
     output: &str,
@@ -459,7 +456,7 @@ pub(super) fn send_mcp_call_completion_events_with_error(
 // ============================================================================
 
 /// Inject MCP metadata into a streaming response
-pub(super) fn inject_mcp_metadata_streaming(
+pub fn inject_mcp_metadata_streaming(
     response: &mut Value,
     state: &ToolLoopState,
     mcp: &Arc<mcp::McpManager>,
@@ -496,7 +493,7 @@ pub(super) fn inject_mcp_metadata_streaming(
 // ============================================================================
 
 /// Execute the tool calling loop
-pub(super) async fn execute_tool_loop(
+pub async fn execute_tool_loop(
     client: &reqwest::Client,
     url: &str,
     headers: Option<&HeaderMap>,
@@ -662,7 +659,7 @@ pub(super) async fn execute_tool_loop(
 }
 
 /// Build an incomplete response when limits are exceeded
-pub(super) fn build_incomplete_response(
+pub fn build_incomplete_response(
     mut response: Value,
     state: ToolLoopState,
     reason: &str,
@@ -758,7 +755,7 @@ pub(super) fn build_incomplete_response(
 // ============================================================================
 
 /// Build a mcp_list_tools output item
-pub(super) fn build_mcp_list_tools_item(mcp: &Arc<mcp::McpManager>, server_label: &str) -> Value {
+pub fn build_mcp_list_tools_item(mcp: &Arc<mcp::McpManager>, server_label: &str) -> Value {
     let tools = mcp.list_tools();
     let tools_json: Vec<Value> = tools
         .iter()
@@ -783,7 +780,7 @@ pub(super) fn build_mcp_list_tools_item(mcp: &Arc<mcp::McpManager>, server_label
 }
 
 /// Build a mcp_call output item
-pub(super) fn build_mcp_call_item(
+pub fn build_mcp_call_item(
     tool_name: &str,
     arguments: &str,
     output: &str,
@@ -805,7 +802,7 @@ pub(super) fn build_mcp_call_item(
 }
 
 /// Helper function to build mcp_call items from executed tool calls in conversation history
-pub(super) fn build_executed_mcp_call_items(
+pub fn build_executed_mcp_call_items(
     conversation_history: &[Value],
     server_label: &str,
 ) -> Vec<Value> {
@@ -859,7 +856,7 @@ pub(super) fn build_executed_mcp_call_items(
 // ============================================================================
 
 /// Extract function call from a response
-pub(super) fn extract_function_call(resp: &Value) -> Option<(String, String, String)> {
+pub fn extract_function_call(resp: &Value) -> Option<(String, String, String)> {
     let output = resp.get("output")?.as_array()?;
     for item in output {
         let obj = item.as_object()?;

--- a/sgl-model-gateway/src/routers/openai/responses/mod.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/mod.rs
@@ -9,16 +9,11 @@
 
 mod accumulator;
 mod common;
-pub mod mcp;
+mod mcp;
 mod non_streaming;
 mod streaming;
 mod tool_handler;
 mod utils;
 
-// Re-export the main entry point handlers
-// Re-export MCP functions for non-streaming path
-pub use mcp::{execute_tool_loop, prepare_mcp_payload_for_streaming};
 pub use non_streaming::handle_non_streaming_response;
 pub use streaming::handle_streaming_response;
-// Re-export utility functions used by router
-pub use utils::{mask_tools_as_mcp, patch_streaming_response_json};

--- a/sgl-model-gateway/src/routers/openai/responses/mod.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/mod.rs
@@ -1,0 +1,24 @@
+//! OpenAI-compatible responses handling module
+//!
+//! This module provides comprehensive support for OpenAI Responses API with:
+//! - Streaming and non-streaming response handling
+//! - MCP (Model Context Protocol) tool interception and execution
+//! - SSE (Server-Sent Events) parsing and forwarding
+//! - Response accumulation for persistence
+//! - Tool call detection and output index remapping
+
+mod accumulator;
+mod common;
+pub mod mcp;
+mod non_streaming;
+mod streaming;
+mod tool_handler;
+mod utils;
+
+// Re-export the main entry point handlers
+// Re-export MCP functions for non-streaming path
+pub use mcp::{execute_tool_loop, prepare_mcp_payload_for_streaming};
+pub use non_streaming::handle_non_streaming_response;
+pub use streaming::handle_streaming_response;
+// Re-export utility functions used by router
+pub use utils::{mask_tools_as_mcp, patch_streaming_response_json};

--- a/sgl-model-gateway/src/routers/openai/responses/non_streaming.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/non_streaming.rs
@@ -1,0 +1,164 @@
+//! Non-streaming response handling for OpenAI-compatible responses
+//!
+//! This module handles non-streaming Responses API requests with MCP tool support.
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::{json, Value};
+use tracing::warn;
+
+use super::{
+    mcp::{execute_tool_loop, prepare_mcp_payload_for_streaming},
+    utils::{mask_tools_as_mcp, patch_streaming_response_json},
+};
+use crate::routers::{
+    header_utils::{apply_provider_headers, extract_auth_header},
+    mcp_utils::{ensure_request_mcp_client, McpLoopConfig},
+    openai::context::{PayloadState, RequestContext},
+    persistence_utils::persist_conversation_items,
+};
+
+/// Handle a non-streaming responses request
+pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response {
+    let payload_state = match ctx.state.payload.take() {
+        Some(ps) => ps,
+        None => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Payload not prepared").into_response();
+        }
+    };
+
+    let PayloadState {
+        json: mut payload,
+        url,
+        previous_response_id,
+    } = payload_state;
+
+    let original_body = ctx.responses_request();
+    let worker = match ctx.worker() {
+        Some(w) => w.clone(),
+        None => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Worker not selected").into_response();
+        }
+    };
+    let mcp_manager = match ctx.components.mcp_manager() {
+        Some(m) => m,
+        None => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "MCP manager required").into_response();
+        }
+    };
+
+    if let Some(ref tools) = original_body.tools {
+        ensure_request_mcp_client(mcp_manager, tools.as_slice()).await;
+    }
+
+    let active_mcp = if mcp_manager.list_tools().is_empty() {
+        None
+    } else {
+        Some(mcp_manager)
+    };
+
+    let mut response_json: Value;
+
+    if let Some(mcp) = active_mcp {
+        let config = McpLoopConfig::default();
+        prepare_mcp_payload_for_streaming(&mut payload, mcp);
+
+        match execute_tool_loop(
+            ctx.components.client(),
+            &url,
+            ctx.headers(),
+            payload,
+            original_body,
+            mcp,
+            &config,
+        )
+        .await
+        {
+            Ok(resp) => response_json = resp,
+            Err(err) => {
+                worker.circuit_breaker().record_failure();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": {"message": err}})),
+                )
+                    .into_response();
+            }
+        }
+    } else {
+        let mut request_builder = ctx.components.client().post(&url).json(&payload);
+        let auth_header = extract_auth_header(ctx.headers(), worker.api_key());
+        request_builder = apply_provider_headers(request_builder, &url, auth_header.as_ref());
+
+        let response = match request_builder.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                worker.circuit_breaker().record_failure();
+                tracing::error!(
+                    url = %url,
+                    error = %e,
+                    "Failed to forward request to OpenAI"
+                );
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    format!("Failed to forward request to OpenAI: {}", e),
+                )
+                    .into_response();
+            }
+        };
+
+        if !response.status().is_success() {
+            worker.circuit_breaker().record_failure();
+            let status = StatusCode::from_u16(response.status().as_u16())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let body = response.text().await.unwrap_or_default();
+            return (status, body).into_response();
+        }
+
+        response_json = match response.json::<Value>().await {
+            Ok(r) => r,
+            Err(e) => {
+                worker.circuit_breaker().record_failure();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to parse upstream response: {}", e),
+                )
+                    .into_response();
+            }
+        };
+
+        worker.circuit_breaker().record_success();
+    }
+
+    mask_tools_as_mcp(&mut response_json, original_body);
+    patch_streaming_response_json(
+        &mut response_json,
+        original_body,
+        previous_response_id.as_deref(),
+    );
+
+    if let Err(err) = persist_conversation_items(
+        ctx.components
+            .conversation_storage()
+            .expect("Conversation storage required")
+            .clone(),
+        ctx.components
+            .conversation_item_storage()
+            .expect("Conversation item storage required")
+            .clone(),
+        ctx.components
+            .response_storage()
+            .expect("Response storage required")
+            .clone(),
+        &response_json,
+        original_body,
+    )
+    .await
+    {
+        warn!("Failed to persist conversation items: {}", err);
+    }
+
+    (StatusCode::OK, Json(response_json)).into_response()
+}

--- a/sgl-model-gateway/src/routers/openai/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/streaming.rs
@@ -21,16 +21,15 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::warn;
 
-// Import from sibling modules
-use super::accumulator::StreamingResponseAccumulator;
 use super::{
-    context::{RequestContext, StreamingEventContext, StreamingRequest},
+    accumulator::StreamingResponseAccumulator,
+    common::{extract_output_index, get_event_type, parse_sse_block, ChunkProcessor},
     mcp::{
         build_resume_payload, execute_streaming_tool_calls, inject_mcp_metadata_streaming,
         prepare_mcp_payload_for_streaming, send_mcp_list_tools_events, ToolLoopState,
     },
-    responses::{mask_tools_as_mcp, patch_streaming_response_json, rewrite_streaming_block},
     tool_handler::{StreamAction, StreamingToolHandler},
+    utils::{mask_tools_as_mcp, patch_streaming_response_json, rewrite_streaming_block},
 };
 use crate::{
     protocols::{
@@ -43,115 +42,10 @@ use crate::{
     routers::{
         header_utils::{apply_request_headers, preserve_response_headers},
         mcp_utils::{ensure_request_mcp_client, McpLoopConfig},
+        openai::context::{RequestContext, StreamingEventContext, StreamingRequest},
         persistence_utils::persist_conversation_items,
     },
 };
-
-// ============================================================================
-// Helper Functions
-// ============================================================================
-
-/// Extract output_index from a JSON value
-#[inline]
-pub(super) fn extract_output_index(value: &Value) -> Option<usize> {
-    value.get("output_index")?.as_u64().map(|v| v as usize)
-}
-
-/// Get event type from event name or parsed JSON, returning a reference to avoid allocation
-#[inline]
-pub(super) fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value) -> &'a str {
-    event_name
-        .or_else(|| parsed.get("type").and_then(|v| v.as_str()))
-        .unwrap_or("")
-}
-
-// ============================================================================
-// Chunk Processor
-// ============================================================================
-
-/// Processes incoming byte chunks into complete SSE blocks.
-/// Handles buffering of partial chunks and CRLF normalization.
-pub(super) struct ChunkProcessor {
-    pending: String,
-}
-
-impl ChunkProcessor {
-    pub fn new() -> Self {
-        Self {
-            pending: String::new(),
-        }
-    }
-
-    /// Append a chunk to the buffer, normalizing line endings
-    pub fn push_chunk(&mut self, chunk: &[u8]) {
-        let chunk_str = match std::str::from_utf8(chunk) {
-            Ok(s) => Cow::Borrowed(s),
-            Err(_) => Cow::Owned(String::from_utf8_lossy(chunk).into_owned()),
-        };
-        // Normalize CRLF to LF without extra allocation
-        let mut chars = chunk_str.chars().peekable();
-        while let Some(c) = chars.next() {
-            if c == '\r' && chars.peek() == Some(&'\n') {
-                // Skip \r when followed by \n
-                continue;
-            }
-            self.pending.push(c);
-        }
-    }
-
-    /// Extract the next complete SSE block from the buffer, if available
-    pub fn next_block(&mut self) -> Option<String> {
-        loop {
-            let pos = self.pending.find("\n\n")?;
-            let block = self.pending[..pos].to_string();
-            self.pending.drain(..pos + 2);
-
-            if !block.trim().is_empty() {
-                return Some(block);
-            }
-            // If block is empty, loop again to find the next one
-        }
-    }
-
-    /// Check if there's remaining content in the buffer
-    pub fn has_remaining(&self) -> bool {
-        !self.pending.trim().is_empty()
-    }
-
-    /// Take any remaining content from the buffer
-    pub fn take_remaining(&mut self) -> String {
-        std::mem::take(&mut self.pending)
-    }
-}
-
-// ============================================================================
-// SSE Parsing
-// ============================================================================
-
-/// Parse an SSE block into event name and data
-///
-/// Returns borrowed strings when possible to avoid allocations in hot paths.
-/// Only allocates when multiple data lines need to be joined.
-pub(super) fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
-    let mut event_name: Option<&str> = None;
-    let mut data_lines: Vec<&str> = Vec::new();
-
-    for line in block.lines() {
-        if let Some(rest) = line.strip_prefix("event:") {
-            event_name = Some(rest.trim());
-        } else if let Some(rest) = line.strip_prefix("data:") {
-            data_lines.push(rest.trim_start());
-        }
-    }
-
-    let data = if data_lines.len() == 1 {
-        Cow::Borrowed(data_lines[0])
-    } else {
-        Cow::Owned(data_lines.join("\n"))
-    };
-
-    (event_name, data)
-}
 
 // ============================================================================
 // Event Transformation and Forwarding
@@ -160,7 +54,7 @@ pub(super) fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
 /// Apply all transformations to event data in-place (rewrite + transform)
 /// Optimized to parse JSON only once instead of multiple times
 /// Returns true if any changes were made
-pub(super) fn apply_event_transformations_inplace(
+pub fn apply_event_transformations_inplace(
     parsed_data: &mut Value,
     ctx: &StreamingEventContext<'_>,
 ) -> bool {
@@ -390,7 +284,7 @@ fn send_buffered_arguments(
 
 /// Forward and transform a streaming event to the client
 /// Returns false if client disconnected
-pub(super) fn forward_streaming_event(
+pub fn forward_streaming_event(
     raw_block: &str,
     event_name: Option<&str>,
     data: &str,
@@ -525,7 +419,7 @@ fn maybe_inject_mcp_in_progress(
 
 /// Send final response.completed event to client
 /// Returns false if client disconnected
-pub(super) fn send_final_response_event(
+pub fn send_final_response_event(
     handler: &StreamingToolHandler,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     sequence_number: &mut u64,
@@ -582,7 +476,7 @@ pub(super) fn send_final_response_event(
 // ============================================================================
 
 /// Simple pass-through streaming without MCP interception
-pub(super) async fn handle_simple_streaming_passthrough(
+pub async fn handle_simple_streaming_passthrough(
     client: &reqwest::Client,
     circuit_breaker: &crate::core::CircuitBreaker,
     headers: Option<&HeaderMap>,
@@ -733,7 +627,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
 }
 
 /// Handle streaming WITH MCP tool call interception and execution
-pub(super) async fn handle_streaming_with_tool_interception(
+pub async fn handle_streaming_with_tool_interception(
     client: &reqwest::Client,
     headers: Option<&HeaderMap>,
     req: StreamingRequest,
@@ -1075,7 +969,8 @@ pub(super) async fn handle_streaming_with_tool_interception(
     response
 }
 
-pub(super) async fn handle_streaming_response(ctx: RequestContext) -> Response {
+/// Main entry point for streaming responses
+pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
     let worker = ctx.worker().expect("Worker not selected").clone();
     let circuit_breaker = worker.circuit_breaker();
     let headers = ctx.headers().cloned();

--- a/sgl-model-gateway/src/routers/openai/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/streaming.rs
@@ -54,7 +54,7 @@ use crate::{
 /// Apply all transformations to event data in-place (rewrite + transform)
 /// Optimized to parse JSON only once instead of multiple times
 /// Returns true if any changes were made
-pub fn apply_event_transformations_inplace(
+pub(super) fn apply_event_transformations_inplace(
     parsed_data: &mut Value,
     ctx: &StreamingEventContext<'_>,
 ) -> bool {
@@ -284,7 +284,7 @@ fn send_buffered_arguments(
 
 /// Forward and transform a streaming event to the client
 /// Returns false if client disconnected
-pub fn forward_streaming_event(
+pub(super) fn forward_streaming_event(
     raw_block: &str,
     event_name: Option<&str>,
     data: &str,
@@ -419,7 +419,7 @@ fn maybe_inject_mcp_in_progress(
 
 /// Send final response.completed event to client
 /// Returns false if client disconnected
-pub fn send_final_response_event(
+pub(super) fn send_final_response_event(
     handler: &StreamingToolHandler,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     sequence_number: &mut u64,
@@ -476,7 +476,7 @@ pub fn send_final_response_event(
 // ============================================================================
 
 /// Simple pass-through streaming without MCP interception
-pub async fn handle_simple_streaming_passthrough(
+pub(super) async fn handle_simple_streaming_passthrough(
     client: &reqwest::Client,
     circuit_breaker: &crate::core::CircuitBreaker,
     headers: Option<&HeaderMap>,
@@ -627,7 +627,7 @@ pub async fn handle_simple_streaming_passthrough(
 }
 
 /// Handle streaming WITH MCP tool call interception and execution
-pub async fn handle_streaming_with_tool_interception(
+pub(super) async fn handle_streaming_with_tool_interception(
     client: &reqwest::Client,
     headers: Option<&HeaderMap>,
     req: StreamingRequest,

--- a/sgl-model-gateway/src/routers/openai/responses/tool_handler.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/tool_handler.rs
@@ -20,7 +20,7 @@ use crate::protocols::event_types::{
 
 /// Action to take based on streaming event processing
 #[derive(Debug)]
-pub enum StreamAction {
+pub(super) enum StreamAction {
     Forward,      // Pass event to client
     Buffer,       // Accumulate for tool execution
     ExecuteTools, // Function call complete, execute now
@@ -32,7 +32,7 @@ pub enum StreamAction {
 
 /// Maps upstream output indices to sequential downstream indices
 #[derive(Debug, Default)]
-pub struct OutputIndexMapper {
+pub(super) struct OutputIndexMapper {
     next_index: usize,
     // Map upstream output_index -> remapped output_index
     assigned: HashMap<usize, usize>,
@@ -74,7 +74,7 @@ impl OutputIndexMapper {
 // ============================================================================
 
 /// Handles streaming responses with MCP tool call interception
-pub struct StreamingToolHandler {
+pub(super) struct StreamingToolHandler {
     /// Accumulator for response persistence
     pub accumulator: StreamingResponseAccumulator,
     /// Function calls being built from deltas

--- a/sgl-model-gateway/src/routers/openai/responses/tool_handler.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/tool_handler.rs
@@ -7,8 +7,8 @@ use tracing::warn;
 
 use super::{
     accumulator::StreamingResponseAccumulator,
+    common::{extract_output_index, get_event_type},
     mcp::FunctionCallInProgress,
-    streaming::{extract_output_index, get_event_type},
 };
 use crate::protocols::event_types::{
     is_function_call_type, FunctionCallEvent, OutputItemEvent, ResponseEvent,
@@ -20,7 +20,7 @@ use crate::protocols::event_types::{
 
 /// Action to take based on streaming event processing
 #[derive(Debug)]
-pub(crate) enum StreamAction {
+pub enum StreamAction {
     Forward,      // Pass event to client
     Buffer,       // Accumulate for tool execution
     ExecuteTools, // Function call complete, execute now
@@ -32,7 +32,7 @@ pub(crate) enum StreamAction {
 
 /// Maps upstream output indices to sequential downstream indices
 #[derive(Debug, Default)]
-pub(crate) struct OutputIndexMapper {
+pub struct OutputIndexMapper {
     next_index: usize,
     // Map upstream output_index -> remapped output_index
     assigned: HashMap<usize, usize>,
@@ -74,7 +74,7 @@ impl OutputIndexMapper {
 // ============================================================================
 
 /// Handles streaming responses with MCP tool call interception
-pub(super) struct StreamingToolHandler {
+pub struct StreamingToolHandler {
     /// Accumulator for response persistence
     pub accumulator: StreamingResponseAccumulator,
     /// Function calls being built from deltas

--- a/sgl-model-gateway/src/routers/openai/responses/utils.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/utils.rs
@@ -1,3 +1,5 @@
+//! Response patching and transformation utilities for OpenAI responses
+
 use serde_json::{json, Map, Value};
 use tracing::warn;
 
@@ -25,7 +27,7 @@ where
 }
 
 /// Patch streaming response JSON with metadata from original request
-pub(super) fn patch_streaming_response_json(
+pub fn patch_streaming_response_json(
     response_json: &mut Value,
     original_body: &ResponsesRequest,
     original_previous_response_id: Option<&str>,
@@ -125,7 +127,7 @@ fn rebuild_sse_block(block: &str, new_payload: &str) -> String {
 }
 
 /// Rewrite streaming SSE block to include metadata from original request
-pub(super) fn rewrite_streaming_block(
+pub fn rewrite_streaming_block(
     block: &str,
     original_body: &ResponsesRequest,
     original_previous_response_id: Option<&str>,
@@ -192,7 +194,7 @@ fn insert_optional_string(map: &mut Map<String, Value>, key: &str, value: &Optio
 }
 
 /// Mask function tools as MCP tools in response for client
-pub(super) fn mask_tools_as_mcp(resp: &mut Value, original_body: &ResponsesRequest) {
+pub fn mask_tools_as_mcp(resp: &mut Value, original_body: &ResponsesRequest) {
     let mcp_tool = original_body.tools.as_ref().and_then(|tools| {
         tools
             .iter()

--- a/sgl-model-gateway/src/routers/openai/responses/utils.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/utils.rs
@@ -27,7 +27,7 @@ where
 }
 
 /// Patch streaming response JSON with metadata from original request
-pub fn patch_streaming_response_json(
+pub(super) fn patch_streaming_response_json(
     response_json: &mut Value,
     original_body: &ResponsesRequest,
     original_previous_response_id: Option<&str>,
@@ -127,7 +127,7 @@ fn rebuild_sse_block(block: &str, new_payload: &str) -> String {
 }
 
 /// Rewrite streaming SSE block to include metadata from original request
-pub fn rewrite_streaming_block(
+pub(super) fn rewrite_streaming_block(
     block: &str,
     original_body: &ResponsesRequest,
     original_previous_response_id: Option<&str>,
@@ -194,7 +194,7 @@ fn insert_optional_string(map: &mut Map<String, Value>, key: &str, value: &Optio
 }
 
 /// Mask function tools as MCP tools in response for client
-pub fn mask_tools_as_mcp(resp: &mut Value, original_body: &ResponsesRequest) {
+pub(super) fn mask_tools_as_mcp(resp: &mut Value, original_body: &ResponsesRequest) {
     let mcp_tool = original_body.tools.as_ref().and_then(|tools| {
         tools
             .iter()

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -23,10 +23,8 @@ use super::{
         ComponentRefs, PayloadState, RequestContext, ResponsesComponents, SharedComponents,
         WorkerSelection,
     },
-    mcp::{execute_tool_loop, prepare_mcp_payload_for_streaming},
     provider::ProviderRegistry,
-    responses::{mask_tools_as_mcp, patch_streaming_response_json},
-    streaming::handle_streaming_response,
+    responses::{handle_non_streaming_response, handle_streaming_response},
 };
 use crate::{
     app_context::AppContext,
@@ -44,11 +42,7 @@ use crate::{
             ResponsesGetParams, ResponsesRequest,
         },
     },
-    routers::{
-        header_utils::{apply_provider_headers, extract_auth_header},
-        mcp_utils::{ensure_request_mcp_client, McpLoopConfig},
-        persistence_utils::persist_conversation_items,
-    },
+    routers::header_utils::{apply_provider_headers, extract_auth_header},
 };
 
 pub struct OpenAIRouter {
@@ -366,128 +360,6 @@ impl OpenAIRouter {
                 }
             }
         }
-    }
-
-    async fn handle_non_streaming_response(&self, mut ctx: RequestContext) -> Response {
-        let payload_state = ctx.take_payload().expect("Payload not prepared");
-        let mut payload = payload_state.json;
-        let url = payload_state.url;
-        let previous_response_id = payload_state.previous_response_id;
-        let original_body = ctx.responses_request();
-        let worker = ctx.worker().expect("Worker not selected");
-        let mcp_manager = ctx.components.mcp_manager().expect("MCP manager required");
-
-        if let Some(ref tools) = original_body.tools {
-            ensure_request_mcp_client(mcp_manager, tools.as_slice()).await;
-        }
-
-        let active_mcp = if mcp_manager.list_tools().is_empty() {
-            None
-        } else {
-            Some(mcp_manager)
-        };
-
-        let mut response_json: Value;
-
-        if let Some(mcp) = active_mcp {
-            let config = McpLoopConfig::default();
-            prepare_mcp_payload_for_streaming(&mut payload, mcp);
-
-            match execute_tool_loop(
-                ctx.components.client(),
-                &url,
-                ctx.headers(),
-                payload,
-                original_body,
-                mcp,
-                &config,
-            )
-            .await
-            {
-                Ok(resp) => response_json = resp,
-                Err(err) => {
-                    worker.circuit_breaker().record_failure();
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!({"error": {"message": err}})),
-                    )
-                        .into_response();
-                }
-            }
-        } else {
-            let mut request_builder = ctx.components.client().post(&url).json(&payload);
-            let auth_header = extract_auth_header(ctx.headers(), worker.api_key());
-            request_builder = apply_provider_headers(request_builder, &url, auth_header.as_ref());
-
-            let response = match request_builder.send().await {
-                Ok(r) => r,
-                Err(e) => {
-                    worker.circuit_breaker().record_failure();
-                    tracing::error!(
-                        url = %url,
-                        error = %e,
-                        "Failed to forward request to OpenAI"
-                    );
-                    return (
-                        StatusCode::BAD_GATEWAY,
-                        format!("Failed to forward request to OpenAI: {}", e),
-                    )
-                        .into_response();
-                }
-            };
-
-            if !response.status().is_success() {
-                worker.circuit_breaker().record_failure();
-                let status = StatusCode::from_u16(response.status().as_u16())
-                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                let body = response.text().await.unwrap_or_default();
-                return (status, body).into_response();
-            }
-
-            response_json = match response.json::<Value>().await {
-                Ok(r) => r,
-                Err(e) => {
-                    worker.circuit_breaker().record_failure();
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to parse upstream response: {}", e),
-                    )
-                        .into_response();
-                }
-            };
-
-            worker.circuit_breaker().record_success();
-        }
-
-        mask_tools_as_mcp(&mut response_json, original_body);
-        patch_streaming_response_json(
-            &mut response_json,
-            original_body,
-            previous_response_id.as_deref(),
-        );
-
-        if let Err(err) = persist_conversation_items(
-            ctx.components
-                .conversation_storage()
-                .expect("Conversation storage required")
-                .clone(),
-            ctx.components
-                .conversation_item_storage()
-                .expect("Conversation item storage required")
-                .clone(),
-            ctx.components
-                .response_storage()
-                .expect("Response storage required")
-                .clone(),
-            &response_json,
-            original_body,
-        )
-        .await
-        {
-            warn!("Failed to persist conversation items: {}", err);
-        }
-
-        (StatusCode::OK, Json(response_json)).into_response()
     }
 }
 
@@ -1078,7 +950,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let response = if ctx.is_streaming() {
             handle_streaming_response(ctx).await
         } else {
-            self.handle_non_streaming_response(ctx).await
+            handle_non_streaming_response(ctx).await
         };
 
         // Record duration only for successful requests (errors tracked inside handlers)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

openai router module has the following problems:

1. `route_responses()` is 270 lines of inline logic (830-1097)

```
route_responses() in router.rs:
├── Metrics recording
├── Worker selection
├── Previous response chain loading (~30 lines)
├── Conversation history loading (~90 lines)
├── Payload transformation
├── Context building
└── Finally: dispatch to streaming/non-streaming
```

Compare to gRPC's `route_responses_impl()` (~50 lines):

```
// gRPC just validates and delegates
validate_worker_availability(&self.worker_registry, model);
if is_harmony {
    serve_harmony_responses(&harmony_ctx, body.clone()).await
} else {
    responses::route_responses(&self.responses_context, ...).await
}
```

2. `handle_non_streaming_response()` is inline in router.rs (371-491)

This 120-line function should be in a separate file like Harmony's non_streaming.rs.

3. Circular dependency between files:

`accumulator.rs` ──imports──> `streaming.rs` (`extract_output_index`, `get_event_type`)

These helpers should be in a common utilities file, not `streaming.rs`.

4. Mixed responsibilities:

| File         | What it has                                          | What it SHOULD have      |
|--------------|------------------------------------------------------|--------------------------|
| router.rs    | Route + non-streaming handler + conversation loading | Just routing (like gRPC) |
| responses.rs | Tiny utils only (225 lines)                          | Could be the entry point |
| streaming.rs | Handlers + SSE helpers                               | Just handlers            |
| mcp.rs       | Non-streaming loop + streaming execution             | Tool execution only      |


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

  1. Moved files from openai/ into `openai/responses/` subdirectory
  2. Extracted `handle_non_streaming_response()` from `router.rs` to `responses/non_streaming.rs`
  3. Created `common.rs` with shared SSE helpers used by both streaming and accumulator
  4. Removed unused re-exports of `Provider, ProviderError, ProviderRegistry`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
