### PR TITLE
[model-gateway] Tighten visibility across `data_connector` and `grpc` module

### DIFF
--- a/sgl-model-gateway/src/data_connector/common.rs
+++ b/sgl-model-gateway/src/data_connector/common.rs
@@ -2,28 +2,28 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
-pub fn parse_tool_calls(raw: Option<String>) -> Result<Vec<Value>, String> {
+pub(super) fn parse_tool_calls(raw: Option<String>) -> Result<Vec<Value>, String> {
     match raw {
         Some(s) if !s.is_empty() => serde_json::from_str(&s).map_err(|e| e.to_string()),
         _ => Ok(Vec::new()),
     }
 }
 
-pub fn parse_metadata(raw: Option<String>) -> Result<HashMap<String, Value>, String> {
+pub(super) fn parse_metadata(raw: Option<String>) -> Result<HashMap<String, Value>, String> {
     match raw {
         Some(s) if !s.is_empty() => serde_json::from_str(&s).map_err(|e| e.to_string()),
         _ => Ok(HashMap::new()),
     }
 }
 
-pub fn parse_raw_response(raw: Option<String>) -> Result<Value, String> {
+pub(super) fn parse_raw_response(raw: Option<String>) -> Result<Value, String> {
     match raw {
         Some(s) if !s.is_empty() => serde_json::from_str(&s).map_err(|e| e.to_string()),
         _ => Ok(Value::Null),
     }
 }
 
-pub fn parse_json_value(raw: Option<String>) -> Result<Value, String> {
+pub(super) fn parse_json_value(raw: Option<String>) -> Result<Value, String> {
     match raw {
         Some(s) if !s.is_empty() => serde_json::from_str(&s).map_err(|e| e.to_string()),
         _ => Ok(Value::Array(vec![])),

--- a/sgl-model-gateway/src/data_connector/memory.rs
+++ b/sgl-model-gateway/src/data_connector/memory.rs
@@ -288,7 +288,8 @@ impl MemoryResponseStorage {
     }
 
     /// Get statistics about the store
-    pub fn stats(&self) -> MemoryStoreStats {
+    #[allow(dead_code)]
+    pub(super) fn stats(&self) -> MemoryStoreStats {
         let store = self.store.read();
         MemoryStoreStats {
             response_count: store.responses.len(),
@@ -459,7 +460,8 @@ impl ResponseStorage for MemoryResponseStorage {
 
 /// Statistics for the memory store
 #[derive(Debug, Clone)]
-pub struct MemoryStoreStats {
+#[allow(dead_code)]
+pub(super) struct MemoryStoreStats {
     pub response_count: usize,
     pub identifier_count: usize,
 }

--- a/sgl-model-gateway/src/data_connector/noop.rs
+++ b/sgl-model-gateway/src/data_connector/noop.rs
@@ -18,7 +18,7 @@ use super::core::*;
 
 /// No-op implementation that synthesizes conversation responses without persistence
 #[derive(Default, Debug, Clone)]
-pub struct NoOpConversationStorage;
+pub(super) struct NoOpConversationStorage;
 
 impl NoOpConversationStorage {
     pub fn new() -> Self {
@@ -61,7 +61,7 @@ impl ConversationStorage for NoOpConversationStorage {
 
 /// No-op conversation item storage (does nothing)
 #[derive(Clone, Copy, Default)]
-pub struct NoOpConversationItemStorage;
+pub(super) struct NoOpConversationItemStorage;
 
 impl NoOpConversationItemStorage {
     pub fn new() -> Self {
@@ -136,7 +136,7 @@ impl ConversationItemStorage for NoOpConversationItemStorage {
 // ============================================================================
 
 /// No-op implementation of response storage (does nothing)
-pub struct NoOpResponseStorage;
+pub(super) struct NoOpResponseStorage;
 
 impl NoOpResponseStorage {
     pub fn new() -> Self {

--- a/sgl-model-gateway/src/data_connector/oracle.rs
+++ b/sgl-model-gateway/src/data_connector/oracle.rs
@@ -232,7 +232,7 @@ impl Manager for OracleConnectionManager {
 // ============================================================================
 
 #[derive(Clone)]
-pub struct OracleConversationStorage {
+pub(super) struct OracleConversationStorage {
     store: OracleStore,
 }
 
@@ -420,7 +420,7 @@ impl ConversationStorage for OracleConversationStorage {
 // ============================================================================
 
 #[derive(Clone)]
-pub struct OracleConversationItemStorage {
+pub(super) struct OracleConversationItemStorage {
     store: OracleStore,
 }
 
@@ -775,7 +775,7 @@ const SELECT_BASE: &str = "SELECT id, previous_response_id, input, instructions,
     tool_calls, metadata, created_at, safety_identifier, model, conversation_id, raw_response FROM responses";
 
 #[derive(Clone)]
-pub struct OracleResponseStorage {
+pub(super) struct OracleResponseStorage {
     store: OracleStore,
 }
 

--- a/sgl-model-gateway/src/data_connector/postgres.rs
+++ b/sgl-model-gateway/src/data_connector/postgres.rs
@@ -58,7 +58,7 @@ impl Clone for PostgresStore {
     }
 }
 
-pub struct PostgresConversationStorage {
+pub(super) struct PostgresConversationStorage {
     store: PostgresStore,
 }
 
@@ -198,7 +198,7 @@ impl ConversationStorage for PostgresConversationStorage {
     }
 }
 
-pub struct PostgresConversationItemStorage {
+pub(super) struct PostgresConversationItemStorage {
     store: PostgresStore,
 }
 
@@ -477,7 +477,7 @@ impl ConversationItemStorage for PostgresConversationItemStorage {
     }
 }
 
-pub struct PostgresResponseStorage {
+pub(super) struct PostgresResponseStorage {
     store: PostgresStore,
 }
 

--- a/sgl-model-gateway/src/routers/grpc/common/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/mod.rs
@@ -1,6 +1,6 @@
 //! Shared code for both regular and harmony routers
 
-pub mod response_collection;
-pub mod response_formatting;
-pub mod responses;
-pub mod stages;
+pub(crate) mod response_collection;
+pub(crate) mod response_formatting;
+pub(crate) mod responses;
+pub(crate) mod stages;

--- a/sgl-model-gateway/src/routers/grpc/common/response_collection.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_collection.rs
@@ -21,7 +21,7 @@ use crate::routers::{
 ///
 /// # Returns
 /// Vector of GenerateComplete responses, one per index (n parameter)
-pub async fn collect_responses(
+pub(crate) async fn collect_responses(
     execution_result: ExecutionResult,
     merge_logprobs: bool,
 ) -> Result<Vec<ProtoGenerateComplete>, Response> {

--- a/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
@@ -16,7 +16,7 @@ use crate::{protocols::common::Usage, routers::grpc::proto_wrapper::ProtoGenerat
 ///
 /// # Returns
 /// Usage object with aggregated token counts
-pub fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
+pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
     let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens() as u32).sum();
     let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens() as u32).sum();
 

--- a/sgl-model-gateway/src/routers/grpc/common/responses/handlers.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/handlers.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Retrieves a stored response from the database.
 /// Used by both regular and harmony implementations.
-pub async fn get_response_impl(ctx: &ResponsesContext, response_id: &str) -> Response {
+pub(crate) async fn get_response_impl(ctx: &ResponsesContext, response_id: &str) -> Response {
     let resp_id = ResponseId::from(response_id);
 
     // Retrieve response from storage
@@ -38,7 +38,7 @@ pub async fn get_response_impl(ctx: &ResponsesContext, response_id: &str) -> Res
 /// Implementation for POST /v1/responses/{response_id}/cancel
 ///
 /// Cancels a background response if it's still in progress.
-pub async fn cancel_response_impl(ctx: &ResponsesContext, response_id: &str) -> Response {
+pub(crate) async fn cancel_response_impl(ctx: &ResponsesContext, response_id: &str) -> Response {
     let resp_id = ResponseId::from(response_id);
 
     // Retrieve response from storage to check if it exists and get current status

--- a/sgl-model-gateway/src/routers/grpc/common/responses/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/mod.rs
@@ -1,9 +1,9 @@
 //! Shared response functionality used by both regular and harmony implementations
 
-pub mod handlers;
-pub mod streaming;
-pub mod utils;
+pub(crate) mod handlers;
+pub(crate) mod streaming;
+pub(crate) mod utils;
 
-pub use handlers::{cancel_response_impl, get_response_impl};
-pub use streaming::{build_sse_response, OutputItemType, ResponseStreamEventEmitter};
-pub use utils::{ensure_mcp_connection, persist_response_if_needed};
+// Re-export commonly used items
+pub(crate) use streaming::build_sse_response;
+pub(crate) use utils::{ensure_mcp_connection, persist_response_if_needed};

--- a/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
@@ -25,7 +25,7 @@ use crate::{
     routers::grpc::harmony::responses::ToolResult,
 };
 
-pub enum OutputItemType {
+pub(crate) enum OutputItemType {
     Message,
     McpListTools,
     McpCall,
@@ -67,7 +67,7 @@ struct OutputItemState {
 /// - response.mcp_call_arguments.done
 /// - response.mcp_call.completed
 /// - response.mcp_call.failed
-pub struct ResponseStreamEventEmitter {
+pub(crate) struct ResponseStreamEventEmitter {
     sequence_number: u64,
     pub response_id: String,
     model: String,
@@ -828,7 +828,9 @@ impl ResponseStreamEventEmitter {
 /// Build a Server-Sent Events (SSE) response
 ///
 /// Creates a Response with proper SSE headers and streaming body.
-pub fn build_sse_response(rx: mpsc::UnboundedReceiver<Result<Bytes, std::io::Error>>) -> Response {
+pub(crate) fn build_sse_response(
+    rx: mpsc::UnboundedReceiver<Result<Bytes, std::io::Error>>,
+) -> Response {
     let stream = UnboundedReceiverStream::new(rx);
     Response::builder()
         .status(StatusCode::OK)

--- a/sgl-model-gateway/src/routers/grpc/common/responses/utils.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/utils.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// Checks if request declares MCP tools, and if so, validates that
 /// the MCP client can be created and connected.
-pub async fn ensure_mcp_connection(
+pub(crate) async fn ensure_mcp_connection(
     mcp_manager: &Arc<McpManager>,
     tools: Option<&[ResponseTool]>,
 ) -> Result<bool, Response> {
@@ -56,7 +56,7 @@ pub async fn ensure_mcp_connection(
 }
 
 /// Validate that workers are available for the requested model
-pub fn validate_worker_availability(
+pub(crate) fn validate_worker_availability(
     worker_registry: &Arc<WorkerRegistry>,
     model: &str,
 ) -> Option<Response> {
@@ -90,7 +90,7 @@ pub fn validate_worker_availability(
 ///   the initial conversion from ResponsesRequest to ChatCompletionRequest. MCP tools
 ///   are merged later by the tool loop before being sent to the chat pipeline, where
 ///   tool_choice constraints are generated for ALL tools (function + MCP combined).
-pub fn extract_tools_from_response_tools(
+pub(crate) fn extract_tools_from_response_tools(
     response_tools: Option<&[ResponseTool]>,
     include_mcp: bool,
 ) -> Vec<Tool> {
@@ -124,7 +124,7 @@ pub fn extract_tools_from_response_tools(
 ///
 /// Common helper function to avoid duplication across sync and streaming paths
 /// in both harmony and regular responses implementations.
-pub async fn persist_response_if_needed(
+pub(crate) async fn persist_response_if_needed(
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
     response_storage: Arc<dyn ResponseStorage>,

--- a/sgl-model-gateway/src/routers/grpc/common/stages/client_acquisition.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/client_acquisition.rs
@@ -14,7 +14,7 @@ use crate::routers::{
 };
 
 /// Client acquisition stage: Get gRPC clients from selected workers
-pub struct ClientAcquisitionStage;
+pub(crate) struct ClientAcquisitionStage;
 
 #[async_trait]
 impl PipelineStage for ClientAcquisitionStage {

--- a/sgl-model-gateway/src/routers/grpc/common/stages/dispatch_metadata.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/dispatch_metadata.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// Dispatch metadata stage: Prepare metadata for dispatch
-pub struct DispatchMetadataStage;
+pub(crate) struct DispatchMetadataStage;
 
 #[async_trait]
 impl PipelineStage for DispatchMetadataStage {

--- a/sgl-model-gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/helpers.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Used by both chat and generate request building stages when in PD mode.
 /// Only SGLang supports PD (prefill/decode) disaggregated mode.
-pub fn inject_bootstrap_metadata(
+pub(crate) fn inject_bootstrap_metadata(
     request: &mut ProtoGenerateRequest,
     prefill_worker: &Arc<dyn Worker>,
 ) {

--- a/sgl-model-gateway/src/routers/grpc/common/stages/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/mod.rs
@@ -28,12 +28,12 @@ pub trait PipelineStage: Send + Sync {
 
 mod client_acquisition;
 mod dispatch_metadata;
-pub mod helpers;
+pub(crate) mod helpers;
 mod request_execution;
 mod worker_selection;
 
 // Export stage implementations
-pub use client_acquisition::ClientAcquisitionStage;
-pub use dispatch_metadata::DispatchMetadataStage;
-pub use request_execution::{ExecutionMode, RequestExecutionStage};
-pub use worker_selection::{WorkerSelectionMode, WorkerSelectionStage};
+pub(crate) use client_acquisition::ClientAcquisitionStage;
+pub(crate) use dispatch_metadata::DispatchMetadataStage;
+pub(crate) use request_execution::{ExecutionMode, RequestExecutionStage};
+pub(crate) use worker_selection::{WorkerSelectionMode, WorkerSelectionStage};

--- a/sgl-model-gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -19,12 +19,12 @@ use crate::routers::{
 type StreamResult = Result<ProtoStream, Box<dyn std::error::Error + Send + Sync>>;
 
 /// Request execution stage: Execute gRPC requests (single or dual dispatch)
-pub struct RequestExecutionStage {
+pub(crate) struct RequestExecutionStage {
     mode: ExecutionMode,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum ExecutionMode {
+pub(crate) enum ExecutionMode {
     /// Regular mode: single worker execution
     Single,
     /// PD mode: dual dispatch to prefill + decode workers

--- a/sgl-model-gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -18,13 +18,13 @@ use crate::{
 };
 
 /// Worker selection stage: Select appropriate worker(s) based on routing mode
-pub struct WorkerSelectionStage {
+pub(crate) struct WorkerSelectionStage {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
     mode: WorkerSelectionMode,
 }
 
-pub enum WorkerSelectionMode {
+pub(crate) enum WorkerSelectionMode {
     /// Regular mode: select single worker
     Regular,
     /// PD mode: select prefill + decode workers

--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -32,14 +32,14 @@ use crate::{
 /// This is the single source of truth for all request state as it flows
 /// through the pipeline stages. Uses Rust's type system to enforce proper
 /// stage ordering at compile time.
-pub struct RequestContext {
+pub(crate) struct RequestContext {
     pub input: RequestInput,
     pub components: Arc<SharedComponents>,
     pub state: ProcessingState,
 }
 
 /// Immutable request input
-pub struct RequestInput {
+pub(crate) struct RequestInput {
     pub request_type: RequestType,
     pub headers: Option<HeaderMap>,
     pub model_id: Option<String>,
@@ -47,7 +47,7 @@ pub struct RequestInput {
 
 /// Request type variants
 /// Using Arc instead of Box to enable cheap cloning for background tasks
-pub enum RequestType {
+pub(crate) enum RequestType {
     Chat(Arc<ChatCompletionRequest>),
     Generate(Arc<GenerateRequest>),
     Responses(Arc<ResponsesRequest>),
@@ -56,7 +56,8 @@ pub enum RequestType {
 }
 
 /// Shared components (injected once at creation)
-pub struct SharedComponents {
+#[allow(dead_code)]
+pub(crate) struct SharedComponents {
     pub tokenizer_registry: Arc<TokenizerRegistry>,
     pub tool_parser_factory: ToolParserFactory,
     pub reasoning_parser_factory: ReasoningParserFactory,
@@ -64,7 +65,7 @@ pub struct SharedComponents {
 
 /// Mutable processing state (evolves through pipeline stages)
 #[derive(Default)]
-pub struct ProcessingState {
+pub(crate) struct ProcessingState {
     // Stage 1: Preparation outputs
     pub preparation: Option<PreparationOutput>,
 
@@ -92,7 +93,8 @@ pub struct ProcessingState {
 }
 
 /// Output from preparation stage (Step 1)
-pub struct PreparationOutput {
+#[allow(dead_code)]
+pub(crate) struct PreparationOutput {
     /// Original text (for chat) or resolved text (for generate)
     pub original_text: Option<String>,
 
@@ -123,7 +125,7 @@ pub struct PreparationOutput {
 }
 
 /// Worker selection (Step 2)
-pub enum WorkerSelection {
+pub(crate) enum WorkerSelection {
     Single {
         worker: Arc<dyn Worker>,
     },
@@ -134,7 +136,7 @@ pub enum WorkerSelection {
 }
 
 /// Client selection (Step 3)
-pub enum ClientSelection {
+pub(crate) enum ClientSelection {
     Single {
         client: GrpcClient,
     },
@@ -146,7 +148,8 @@ pub enum ClientSelection {
 
 /// Dispatch metadata (Step 5)
 #[derive(Clone)]
-pub struct DispatchMetadata {
+#[allow(dead_code)]
+pub(crate) struct DispatchMetadata {
     pub request_id: String,
     pub model: String,
     pub created: u64,
@@ -156,7 +159,7 @@ pub struct DispatchMetadata {
 
 /// Load guards for worker load tracking
 /// Automatically decrements load when dropped
-pub enum LoadGuards {
+pub(crate) enum LoadGuards {
     Single(WorkerLoadGuard),
     Dual {
         prefill: WorkerLoadGuard,
@@ -200,7 +203,8 @@ impl LoadGuards {
 
 /// Response processing state (Step 6)
 #[derive(Default)]
-pub struct ResponseState {
+#[allow(dead_code)]
+pub(crate) struct ResponseState {
     /// Stop sequence decoder
     pub stop_decoder: Option<StopSequenceDecoder>,
 
@@ -232,7 +236,8 @@ pub struct ResponseState {
 
 /// Streaming state (per-choice tracking)
 #[derive(Default)]
-pub struct StreamingState {
+#[allow(dead_code)]
+pub(crate) struct StreamingState {
     pub is_firsts: HashMap<u32, bool>,
     pub stream_buffers: HashMap<u32, String>,
     pub finish_reasons: HashMap<u32, String>,
@@ -249,6 +254,7 @@ pub struct StreamingState {
     pub has_tool_calls: HashMap<u32, bool>,
 }
 
+#[allow(dead_code)]
 impl RequestContext {
     /// Create context for chat completion request
     pub fn for_chat(
@@ -445,6 +451,7 @@ impl RequestContext {
     }
 }
 
+#[allow(dead_code)]
 impl WorkerSelection {
     pub fn is_dual(&self) -> bool {
         matches!(self, Self::Dual { .. })
@@ -499,6 +506,7 @@ impl WorkerSelection {
     }
 }
 
+#[allow(dead_code)]
 impl ClientSelection {
     pub fn is_dual(&self) -> bool {
         matches!(self, Self::Dual { .. })
@@ -563,7 +571,7 @@ impl ClientSelection {
 
 /// Result of request execution (streams from workers)
 /// Uses ProtoStream to automatically abort on cancellation
-pub enum ExecutionResult {
+pub(crate) enum ExecutionResult {
     Single {
         stream: ProtoStream,
     },
@@ -579,7 +587,8 @@ pub enum ExecutionResult {
 
 /// Final processed response
 #[derive(Debug)]
-pub enum FinalResponse {
+#[allow(dead_code)]
+pub(crate) enum FinalResponse {
     Chat(ChatCompletionResponse),
     /// Generate response is a Vec of GenerateResponse (n=1 returns single item, n>1 returns multiple)
     Generate(Vec<GenerateResponse>),

--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -517,10 +517,8 @@ pub(crate) enum FinalResponse {
     Chat(ChatCompletionResponse),
     /// Generate response is a Vec of GenerateResponse (n=1 returns single item, n>1 returns multiple)
     Generate(Vec<GenerateResponse>),
-    /// Embedding response (inner data written but never read - response comes from execution result)
-    #[allow(dead_code)]
+    /// Embedding response
     Embedding(EmbeddingResponse),
-    /// Classification response (inner data written but never read - response comes from execution result)
-    #[allow(dead_code)]
+    /// Classification response
     Classify(ClassifyResponse),
 }

--- a/sgl-model-gateway/src/routers/grpc/harmony/builder.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/builder.rs
@@ -113,7 +113,7 @@ fn has_custom_tools(tool_types: &[&str]) -> bool {
 ///
 /// Converts OpenAI-format requests into Harmony-encoded format with input_ids,
 /// stop tokens, and selection text for worker routing.
-pub struct HarmonyBuilder {
+pub(crate) struct HarmonyBuilder {
     encoding: &'static HarmonyEncoding,
 }
 

--- a/sgl-model-gateway/src/routers/grpc/harmony/detector.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/detector.rs
@@ -5,7 +5,7 @@ use crate::core::{Worker, WorkerRegistry};
 /// Harmony model detector
 ///
 /// Detects if a model name indicates support for Harmony encoding/parsing.
-pub struct HarmonyDetector;
+pub(crate) struct HarmonyDetector;
 
 impl HarmonyDetector {
     /// Check if a worker is a Harmony/GPT-OSS model.

--- a/sgl-model-gateway/src/routers/grpc/harmony/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/mod.rs
@@ -29,28 +29,22 @@
 //! }
 //! ```
 
-pub mod builder;
-pub mod detector;
-pub mod parser;
-pub mod processor;
-pub mod responses;
-pub mod stages;
-pub mod streaming;
-pub mod types;
+pub(crate) mod builder;
+pub(crate) mod detector;
+pub(crate) mod parser;
+pub(crate) mod processor;
+pub(crate) mod responses;
+pub(crate) mod stages;
+pub(crate) mod streaming;
+pub(crate) mod types;
 
-// Re-export main types for convenience
-pub use builder::HarmonyBuilder;
-pub use detector::HarmonyDetector;
-pub use parser::HarmonyParserAdapter;
-pub use processor::{HarmonyResponseProcessor, ResponsesIterationResult};
-pub use responses::{
+// Re-export types that are accessed via harmony::TypeName
+pub(crate) use builder::HarmonyBuilder;
+pub(crate) use detector::HarmonyDetector;
+pub(crate) use parser::HarmonyParserAdapter;
+pub(crate) use processor::{HarmonyResponseProcessor, ResponsesIterationResult};
+pub(crate) use responses::{
     serve_harmony_responses, serve_harmony_responses_stream, HarmonyResponsesContext,
 };
-pub use stages::{
-    HarmonyPreparationStage, HarmonyRequestBuildingStage, HarmonyResponseProcessingStage,
-};
-pub use streaming::HarmonyStreamingProcessor;
-pub use types::{
-    FunctionDelta, HarmonyBuildOutput, HarmonyChannelDelta, HarmonyChannelOutput, HarmonyMessage,
-    ToolCallDelta,
-};
+pub(crate) use streaming::HarmonyStreamingProcessor;
+pub(crate) use types::HarmonyMessage;

--- a/sgl-model-gateway/src/routers/grpc/harmony/parser.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/parser.rs
@@ -20,7 +20,7 @@ fn get_harmony_encoding() -> &'static HarmonyEncoding {
 ///
 /// Wraps openai_harmony::StreamableParser and provides methods for parsing
 /// complete responses and streaming chunks.
-pub struct HarmonyParserAdapter {
+pub(crate) struct HarmonyParserAdapter {
     parser: StreamableParser,
     prev_recipient: Option<String>,
     reasoning_token_count: u32,
@@ -517,6 +517,7 @@ impl HarmonyParserAdapter {
     /// Reset parser state
     ///
     /// Resets the parser to initial state for reuse
+    #[allow(dead_code)]
     pub fn reset(&mut self) -> Result<(), String> {
         // Create a new parser instance (StreamableParser doesn't have a reset method)
         let encoding = get_harmony_encoding();

--- a/sgl-model-gateway/src/routers/grpc/harmony/processor.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/processor.rs
@@ -29,7 +29,7 @@ use crate::{
 ///
 /// Collects all output tokens from execution and parses them using
 /// HarmonyParserAdapter to extract the complete response.
-pub struct HarmonyResponseProcessor;
+pub(crate) struct HarmonyResponseProcessor;
 
 impl HarmonyResponseProcessor {
     /// Create a new Harmony response processor
@@ -155,7 +155,7 @@ impl Default for HarmonyResponseProcessor {
 ///
 /// Used by the MCP tool loop to determine whether to continue
 /// executing tools or return the final response.
-pub enum ResponsesIterationResult {
+pub(crate) enum ResponsesIterationResult {
     /// Tool calls found in commentary channel - continue MCP loop
     ToolCallsFound {
         tool_calls: Vec<ToolCall>,

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/context.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
-
 use crate::{
     data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage},
     mcp::McpManager,
@@ -33,13 +31,8 @@ pub(crate) struct HarmonyResponsesContext {
 
     /// Conversation item storage for persisting conversation items
     pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
-
-    /// Optional streaming sender (for future streaming support)
-    #[allow(dead_code)]
-    pub stream_tx: Option<mpsc::UnboundedSender<Result<String, String>>>,
 }
 
-#[allow(dead_code)]
 impl HarmonyResponsesContext {
     /// Create a new Harmony Responses context
     pub fn new(
@@ -57,28 +50,6 @@ impl HarmonyResponsesContext {
             response_storage,
             conversation_storage,
             conversation_item_storage,
-            stream_tx: None,
-        }
-    }
-
-    /// Create with streaming support
-    pub fn with_streaming(
-        pipeline: Arc<RequestPipeline>,
-        components: Arc<SharedComponents>,
-        mcp_manager: Arc<McpManager>,
-        response_storage: Arc<dyn ResponseStorage>,
-        conversation_storage: Arc<dyn ConversationStorage>,
-        conversation_item_storage: Arc<dyn ConversationItemStorage>,
-        stream_tx: mpsc::UnboundedSender<Result<String, String>>,
-    ) -> Self {
-        Self {
-            pipeline,
-            components,
-            mcp_manager,
-            response_storage,
-            conversation_storage,
-            conversation_item_storage,
-            stream_tx: Some(stream_tx),
         }
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/context.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Contains all dependencies needed for multi-turn Responses API execution.
 /// Cheap to clone (all Arc references).
 #[derive(Clone)]
-pub struct HarmonyResponsesContext {
+pub(crate) struct HarmonyResponsesContext {
     /// Pipeline for executing Harmony requests
     pub pipeline: Arc<RequestPipeline>,
 
@@ -35,9 +35,11 @@ pub struct HarmonyResponsesContext {
     pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
 
     /// Optional streaming sender (for future streaming support)
+    #[allow(dead_code)]
     pub stream_tx: Option<mpsc::UnboundedSender<Result<String, String>>>,
 }
 
+#[allow(dead_code)]
 impl HarmonyResponsesContext {
     /// Create a new Harmony Responses context
     pub fn new(

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -20,7 +20,7 @@ use crate::{
 /// Tool execution result
 ///
 /// Contains the result of executing a single MCP tool.
-pub struct ToolResult {
+pub(crate) struct ToolResult {
     /// Tool call ID (for matching with request)
     pub call_id: String,
 
@@ -202,7 +202,7 @@ pub(super) async fn execute_mcp_tools(
 ///
 /// Converts MCP Tool entries (from rmcp SDK) to ResponseTool format so the model
 /// knows about available MCP tools when making tool calls.
-pub fn convert_mcp_tools_to_response_tools(mcp_tools: &[mcp::Tool]) -> Vec<ResponseTool> {
+pub(crate) fn convert_mcp_tools_to_response_tools(mcp_tools: &[mcp::Tool]) -> Vec<ResponseTool> {
     mcp_tools
         .iter()
         .map(|tool_info| ResponseTool {

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/mod.rs
@@ -19,14 +19,14 @@
 //! - `execution` - MCP tool execution logic
 //! - `common` - Shared helpers and state tracking
 
-mod common;
-mod context;
-mod execution;
-mod non_streaming;
-mod streaming;
+pub(crate) mod common;
+pub(crate) mod context;
+pub(crate) mod execution;
+pub(crate) mod non_streaming;
+pub(crate) mod streaming;
 
-// Public exports
-pub use context::HarmonyResponsesContext;
-pub use execution::{convert_mcp_tools_to_response_tools, ToolResult};
-pub use non_streaming::serve_harmony_responses;
-pub use streaming::serve_harmony_responses_stream;
+// Re-export types accessed via harmony::responses::TypeName
+pub(crate) use context::HarmonyResponsesContext;
+pub(crate) use execution::ToolResult;
+pub(crate) use non_streaming::serve_harmony_responses;
+pub(crate) use streaming::serve_harmony_responses_stream;

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -46,7 +46,7 @@ use crate::{
 ///    - Build next request with tool results
 ///    - Repeat from step 1 (full pipeline re-execution)
 /// 4. If no tool calls, return final response
-pub async fn serve_harmony_responses(
+pub(crate) async fn serve_harmony_responses(
     ctx: &HarmonyResponsesContext,
     request: ResponsesRequest,
 ) -> Result<ResponsesResponse, Response> {

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -36,7 +36,7 @@ use crate::{
 ///
 /// This is the streaming equivalent of `serve_harmony_responses()`.
 /// Emits SSE events for lifecycle, MCP list_tools, and per-iteration streaming.
-pub async fn serve_harmony_responses_stream(
+pub(crate) async fn serve_harmony_responses_stream(
     ctx: &HarmonyResponsesContext,
     request: ResponsesRequest,
 ) -> Response {

--- a/sgl-model-gateway/src/routers/grpc/harmony/stages/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/stages/mod.rs
@@ -5,10 +5,10 @@
 //! - HarmonyRequestBuildingStage: Token-based request building
 //! - HarmonyResponseProcessingStage: Harmony channel parsing
 
-pub mod preparation;
-pub mod request_building;
-pub mod response_processing;
+pub(crate) mod preparation;
+pub(crate) mod request_building;
+pub(crate) mod response_processing;
 
-pub use preparation::HarmonyPreparationStage;
-pub use request_building::HarmonyRequestBuildingStage;
-pub use response_processing::HarmonyResponseProcessingStage;
+pub(crate) use preparation::HarmonyPreparationStage;
+pub(crate) use request_building::HarmonyRequestBuildingStage;
+pub(crate) use response_processing::HarmonyResponseProcessingStage;

--- a/sgl-model-gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -26,7 +26,7 @@ use crate::{
 ///
 /// Replaces the regular PreparationStage for Harmony models.
 /// Converts chat/generate requests to Harmony-encoded token_ids and extraction_text.
-pub struct HarmonyPreparationStage {
+pub(crate) struct HarmonyPreparationStage {
     builder: HarmonyBuilder,
 }
 
@@ -387,7 +387,9 @@ impl HarmonyPreparationStage {
 /// - Without reasoning: triggers on `<|channel|>final` (goes directly to final channel)
 ///
 /// This is used for the Responses API text.format field (json_object or json_schema).
-pub fn build_text_format_structural_tag(schema: &serde_json::Value) -> Result<String, String> {
+pub(crate) fn build_text_format_structural_tag(
+    schema: &serde_json::Value,
+) -> Result<String, String> {
     let structural_tag = json!({
         "format": {
             "type": "triggered_tags",

--- a/sgl-model-gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -18,7 +18,7 @@ use crate::routers::{
 ///
 /// Takes the Harmony-encoded input_ids from preparation and builds a proto::GenerateRequest.
 /// Unlike regular request building, this uses token_ids directly (Harmony encoding handles messages).
-pub struct HarmonyRequestBuildingStage {
+pub(crate) struct HarmonyRequestBuildingStage {
     inject_pd_metadata: bool,
 }
 

--- a/sgl-model-gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -19,7 +19,7 @@ use crate::routers::{
 ///
 /// Takes output tokens from execution and parses them using HarmonyParserAdapter
 /// to extract analysis, tool calls, and final response text from Harmony channels.
-pub struct HarmonyResponseProcessingStage {
+pub(crate) struct HarmonyResponseProcessingStage {
     processor: HarmonyResponseProcessor,
     streaming_processor: Arc<HarmonyStreamingProcessor>,
 }

--- a/sgl-model-gateway/src/routers/grpc/harmony/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/streaming.rs
@@ -105,7 +105,7 @@ impl ToolCallMode {
 ///
 /// Returns an SSE stream that parses Harmony tokens incrementally and
 /// emits ChatCompletionChunk events for streaming responses.
-pub struct HarmonyStreamingProcessor;
+pub(crate) struct HarmonyStreamingProcessor;
 
 impl HarmonyStreamingProcessor {
     /// Create a new Harmony streaming processor

--- a/sgl-model-gateway/src/routers/grpc/harmony/types.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/types.rs
@@ -10,11 +10,12 @@ use crate::protocols::common::ToolCall;
 ///
 /// Represents messages in the Harmony encoding format with role and content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HarmonyMessage {
+pub(crate) struct HarmonyMessage {
     pub role: String,
     pub content: String,
 }
 
+#[allow(dead_code)]
 impl HarmonyMessage {
     pub fn new(role: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
@@ -67,7 +68,7 @@ impl HarmonyMessage {
 /// Contains the encoded input_ids, stop tokens, selection text for worker routing,
 /// and the Harmony message history.
 #[derive(Debug, Clone)]
-pub struct HarmonyBuildOutput {
+pub(crate) struct HarmonyBuildOutput {
     /// Encoded token IDs to send to the model
     pub input_ids: Vec<u32>,
 
@@ -85,7 +86,7 @@ pub struct HarmonyBuildOutput {
 ///
 /// Represents the complete response after parsing analysis, commentary, and final channels.
 #[derive(Debug, Clone)]
-pub struct HarmonyChannelOutput {
+pub(crate) struct HarmonyChannelOutput {
     /// Analysis/reasoning content (from analysis channel)
     pub analysis: Option<String>,
 
@@ -109,7 +110,8 @@ pub struct HarmonyChannelOutput {
 ///
 /// Represents incremental updates as tokens are parsed from the stream.
 #[derive(Debug, Clone)]
-pub struct HarmonyChannelDelta {
+#[allow(dead_code)]
+pub(crate) struct HarmonyChannelDelta {
     /// Delta for analysis/reasoning content
     pub analysis_delta: Option<String>,
 
@@ -125,7 +127,7 @@ pub struct HarmonyChannelDelta {
 
 /// Tool call delta for streaming
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolCallDelta {
+pub(crate) struct ToolCallDelta {
     pub index: usize,
     pub id: Option<String>,
     pub function: Option<FunctionDelta>,
@@ -133,7 +135,7 @@ pub struct ToolCallDelta {
 
 /// Function call delta for streaming
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FunctionDelta {
+pub(crate) struct FunctionDelta {
     pub name: Option<String>,
     pub arguments: Option<String>,
 }

--- a/sgl-model-gateway/src/routers/grpc/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/mod.rs
@@ -2,20 +2,21 @@
 
 use crate::{grpc_client::sglang_proto::MultimodalInputs, protocols::common::StringOrArray};
 
-pub mod client;
-pub mod common;
-pub mod context;
-pub mod harmony;
-pub mod pd_router;
-pub mod pipeline;
-pub mod proto_wrapper;
-pub mod regular;
-pub mod router;
-pub mod utils;
+pub mod client; // Used by core/
+pub(crate) mod common;
+pub(crate) mod context;
+pub(crate) mod harmony;
+pub(crate) mod pd_router; // Used by routers/factory
+pub(crate) mod pipeline;
+pub(crate) mod proto_wrapper;
+pub(crate) mod regular;
+pub(crate) mod router; // Used by routers/factory
+pub(crate) mod utils; // Used by routers/http
 
 /// Processed chat messages ready for gRPC generation
 #[derive(Debug)]
-pub struct ProcessedMessages {
+#[allow(dead_code)]
+pub(crate) struct ProcessedMessages {
     pub text: String,
     pub multimodal_inputs: Option<MultimodalInputs>,
     pub stop_sequences: Option<StringOrArray>,

--- a/sgl-model-gateway/src/routers/grpc/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/mod.rs
@@ -15,9 +15,9 @@ pub(crate) mod utils; // Used by routers/http
 
 /// Processed chat messages ready for gRPC generation
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) struct ProcessedMessages {
     pub text: String,
     pub multimodal_inputs: Option<MultimodalInputs>,
+    #[allow(dead_code)]
     pub stop_sequences: Option<StringOrArray>,
 }

--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -542,9 +542,7 @@ impl RequestPipeline {
             ctx.state.response.final_response
         );
         match ctx.state.response.final_response {
-            Some(FinalResponse::Embedding(_)) => {
-                error!("execute_embeddings: Embedding FinalResponse found, but pipeline finished without returning response directly. This should be handled by the last stage.");
-                // Already handled in ResponseProcessingStage, but just in case
+            Some(FinalResponse::Embedding(response)) => {
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
@@ -553,11 +551,7 @@ impl RequestPipeline {
                     metrics_labels::ENDPOINT_EMBEDDINGS,
                     start.elapsed(),
                 );
-                // The response should have been returned by the last stage
-                error::internal_error(
-                    "pipeline_fallthrough",
-                    "Pipeline finished without returning response",
-                )
+                axum::Json(response).into_response()
             }
             Some(_) => {
                 error!(function = "execute_embeddings", "Wrong response type");
@@ -648,8 +642,7 @@ impl RequestPipeline {
             ctx.state.response.final_response
         );
         match ctx.state.response.final_response {
-            Some(FinalResponse::Classify(_)) => {
-                error!("execute_classify: Classify FinalResponse found, but pipeline finished without returning response directly. This should be handled by the last stage.");
+            Some(FinalResponse::Classify(response)) => {
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
@@ -658,10 +651,7 @@ impl RequestPipeline {
                     metrics_labels::ENDPOINT_CLASSIFY,
                     start.elapsed(),
                 );
-                error::internal_error(
-                    "pipeline_fallthrough",
-                    "Pipeline finished without returning response",
-                )
+                axum::Json(response).into_response()
             }
             Some(_) => {
                 error!(function = "execute_classify", "Wrong response type");

--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -48,7 +48,7 @@ use crate::{
 /// Orchestrates all stages from request preparation to response delivery.
 /// Configured differently for regular vs PD mode.
 #[derive(Clone)]
-pub struct RequestPipeline {
+pub(crate) struct RequestPipeline {
     stages: Arc<Vec<Box<dyn PipelineStage>>>,
     /// Backend type for metrics labeling
     backend_type: &'static str,
@@ -129,6 +129,7 @@ impl RequestPipeline {
     }
 
     /// Create a Harmony PD (prefill-decode) pipeline
+    #[allow(dead_code)]
     pub fn new_harmony_pd(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,

--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -370,9 +370,6 @@ impl RequestPipeline {
         components: Arc<SharedComponents>,
     ) -> Response {
         let start = Instant::now();
-        // Clone model_id for metrics before moving into context
-        // GenerateRequest doesn't have a model field, so we use model_id
-        let model_for_metrics = model_id.clone();
         let streaming = request.stream;
 
         // Record request start
@@ -380,12 +377,12 @@ impl RequestPipeline {
             metrics_labels::ROUTER_GRPC,
             self.backend_type,
             metrics_labels::CONNECTION_GRPC,
-            model_for_metrics.as_deref().unwrap_or("unknown"),
+            model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
             metrics_labels::ENDPOINT_GENERATE,
             bool_to_static_str(streaming),
         );
 
-        let mut ctx = RequestContext::for_generate(request, headers, model_id, components);
+        let mut ctx = RequestContext::for_generate(request, headers, model_id.clone(), components);
 
         for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
@@ -394,7 +391,7 @@ impl RequestPipeline {
                         metrics_labels::ROUTER_GRPC,
                         self.backend_type,
                         metrics_labels::CONNECTION_GRPC,
-                        model_for_metrics.as_deref().unwrap_or("unknown"),
+                        model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
                         metrics_labels::ENDPOINT_GENERATE,
                         start.elapsed(),
                     );
@@ -406,7 +403,7 @@ impl RequestPipeline {
                         metrics_labels::ROUTER_GRPC,
                         self.backend_type,
                         metrics_labels::CONNECTION_GRPC,
-                        model_for_metrics.as_deref().unwrap_or("unknown"),
+                        model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
                         metrics_labels::ENDPOINT_GENERATE,
                         error_type_from_status(response.status()),
                     );
@@ -426,7 +423,7 @@ impl RequestPipeline {
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
                     metrics_labels::CONNECTION_GRPC,
-                    model_for_metrics.as_deref().unwrap_or("unknown"),
+                    model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
                     metrics_labels::ENDPOINT_GENERATE,
                     start.elapsed(),
                 );
@@ -443,7 +440,7 @@ impl RequestPipeline {
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
                     metrics_labels::CONNECTION_GRPC,
-                    model_for_metrics.as_deref().unwrap_or("unknown"),
+                    model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
                     metrics_labels::ENDPOINT_GENERATE,
                     metrics_labels::ERROR_INTERNAL,
                 );
@@ -458,7 +455,7 @@ impl RequestPipeline {
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
                     metrics_labels::CONNECTION_GRPC,
-                    model_for_metrics.as_deref().unwrap_or("unknown"),
+                    model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
                     metrics_labels::ENDPOINT_GENERATE,
                     metrics_labels::ERROR_INTERNAL,
                 );

--- a/sgl-model-gateway/src/routers/grpc/proto_wrapper.rs
+++ b/sgl-model-gateway/src/routers/grpc/proto_wrapper.rs
@@ -19,22 +19,8 @@ pub enum ProtoRequest {
     Embed(ProtoEmbedRequest),
 }
 
-#[allow(dead_code)]
 impl ProtoRequest {
-    pub fn as_generate(&self) -> &ProtoGenerateRequest {
-        match self {
-            Self::Generate(req) => req,
-            _ => panic!("Expected Generate request"),
-        }
-    }
-
-    pub fn as_embed(&self) -> &ProtoEmbedRequest {
-        match self {
-            Self::Embed(req) => req,
-            _ => panic!("Expected Embed request"),
-        }
-    }
-
+    /// Get request ID from either variant
     pub fn request_id(&self) -> &str {
         match self {
             Self::Generate(req) => req.request_id(),

--- a/sgl-model-gateway/src/routers/grpc/proto_wrapper.rs
+++ b/sgl-model-gateway/src/routers/grpc/proto_wrapper.rs
@@ -19,6 +19,7 @@ pub enum ProtoRequest {
     Embed(ProtoEmbedRequest),
 }
 
+#[allow(dead_code)]
 impl ProtoRequest {
     pub fn as_generate(&self) -> &ProtoGenerateRequest {
         match self {

--- a/sgl-model-gateway/src/routers/grpc/regular/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/mod.rs
@@ -3,7 +3,7 @@
 //! This module contains all code specific to regular tokenizer-based models,
 //! including pipeline stages, response processing, and streaming.
 
-pub mod processor;
-pub mod responses;
-pub mod stages;
-pub mod streaming;
+pub(crate) mod processor;
+pub(crate) mod responses;
+pub(crate) mod stages;
+pub(crate) mod streaming;

--- a/sgl-model-gateway/src/routers/grpc/regular/processor.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/processor.rs
@@ -34,7 +34,7 @@ use crate::{
 
 /// Unified response processor for both routers
 #[derive(Clone)]
-pub struct ResponseProcessor {
+pub(crate) struct ResponseProcessor {
     pub tool_parser_factory: ToolParserFactory,
     pub reasoning_parser_factory: ReasoningParserFactory,
     pub configured_tool_parser: Option<String>,

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/context.rs
@@ -19,7 +19,7 @@ use crate::{
 ///
 /// This struct enables cancelling both the Rust task AND the Python scheduler processing.
 /// The client field is lazily initialized during pipeline execution.
-pub struct BackgroundTaskInfo {
+pub(crate) struct BackgroundTaskInfo {
     /// Tokio task handle for aborting the Rust task
     pub handle: JoinHandle<()>,
     /// gRPC request_id sent to Python scheduler (chatcmpl-* prefix)
@@ -32,7 +32,7 @@ pub struct BackgroundTaskInfo {
 ///
 /// All fields are Arc/shared references, so cloning this context is cheap.
 #[derive(Clone)]
-pub struct ResponsesContext {
+pub(crate) struct ResponsesContext {
     /// Chat pipeline for executing requests
     pub pipeline: Arc<RequestPipeline>,
 
@@ -40,6 +40,7 @@ pub struct ResponsesContext {
     pub components: Arc<SharedComponents>,
 
     /// Worker registry for validation
+    #[allow(dead_code)]
     pub worker_registry: Arc<WorkerRegistry>,
 
     /// Response storage backend

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -33,7 +33,7 @@ use crate::{
 /// - `tools` → function tools extracted from ResponseTools
 /// - `tool_choice` → passed through from request
 /// - Response-specific fields (previous_response_id, conversation) are handled by router
-pub fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletionRequest, String> {
+pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletionRequest, String> {
     let mut messages = Vec::new();
 
     // 1. Add system message if instructions provided
@@ -271,7 +271,7 @@ fn map_text_to_response_format(text: &Option<TextConfig>) -> Option<ResponseForm
 /// - `choices[0].message` → `output` array (convert to ResponseOutputItem::Message)
 /// - `choices[0].finish_reason` → determines `status` (stop/length → Completed)
 /// - `created` timestamp → `created_at`
-pub fn chat_to_responses(
+pub(crate) fn chat_to_responses(
     chat_resp: &ChatCompletionResponse,
     original_req: &ResponsesRequest,
     response_id_override: Option<String>,

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -46,7 +46,7 @@ use crate::{
 /// Main handler for POST /v1/responses
 ///
 /// Validates request, determines execution mode (sync/streaming), and delegates
-pub async fn route_responses(
+pub(crate) async fn route_responses(
     ctx: &ResponsesContext,
     request: Arc<ResponsesRequest>,
     headers: Option<http::HeaderMap>,

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/mod.rs
@@ -19,5 +19,5 @@ mod non_streaming;
 mod streaming;
 
 // Public exports
-pub use context::{BackgroundTaskInfo, ResponsesContext};
-pub use handlers::route_responses;
+pub(crate) use context::ResponsesContext;
+pub(crate) use handlers::route_responses;

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/mod.rs
@@ -7,6 +7,6 @@ mod preparation;
 mod request_building;
 mod response_processing;
 
-pub use preparation::ChatPreparationStage;
-pub use request_building::ChatRequestBuildingStage;
-pub use response_processing::ChatResponseProcessingStage;
+pub(crate) use preparation::ChatPreparationStage;
+pub(crate) use request_building::ChatRequestBuildingStage;
+pub(crate) use response_processing::ChatResponseProcessingStage;

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -22,7 +22,7 @@ use crate::{
 ///
 /// Extracts chat-specific preparation logic from the old unified PreparationStage.
 /// This is a direct extraction without architectural changes.
-pub struct ChatPreparationStage;
+pub(crate) struct ChatPreparationStage;
 
 #[async_trait]
 impl PipelineStage for ChatPreparationStage {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -18,7 +18,7 @@ use crate::routers::{
 /// Chat request building stage
 ///
 /// Extracts chat-specific request building logic from the old unified RequestBuildingStage.
-pub struct ChatRequestBuildingStage {
+pub(crate) struct ChatRequestBuildingStage {
     inject_pd_metadata: bool,
 }
 

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -19,8 +19,6 @@ use crate::routers::{
 };
 
 /// Chat response processing stage
-///
-/// Extracts chat-specific response processing logic from the old unified ResponseProcessingStage.
 pub(crate) struct ChatResponseProcessingStage {
     processor: processor::ResponseProcessor,
     streaming_processor: Arc<streaming::StreamingProcessor>,

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -21,7 +21,7 @@ use crate::routers::{
 /// Chat response processing stage
 ///
 /// Extracts chat-specific response processing logic from the old unified ResponseProcessingStage.
-pub struct ChatResponseProcessingStage {
+pub(crate) struct ChatResponseProcessingStage {
     processor: processor::ResponseProcessor,
     streaming_processor: Arc<streaming::StreamingProcessor>,
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/classify/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/classify/mod.rs
@@ -4,6 +4,6 @@
 //! as the scheduler treats classify as an embedding request and returns logits.
 //! Only response processing is classify-specific (softmax + label mapping).
 
-pub mod response_processing;
+pub(crate) mod response_processing;
 
-pub use response_processing::ClassifyResponseProcessingStage;
+pub(crate) use response_processing::ClassifyResponseProcessingStage;

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
@@ -37,7 +37,7 @@ use crate::{
 ///
 /// The stage is stateless - id2label mapping is obtained from the
 /// selected worker's model card at runtime.
-pub struct ClassifyResponseProcessingStage;
+pub(crate) struct ClassifyResponseProcessingStage;
 
 impl ClassifyResponseProcessingStage {
     /// Create a new classify response processing stage.

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
@@ -10,10 +10,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use axum::{
-    response::{IntoResponse, Response},
-    Json,
-};
+use axum::response::Response;
 use tracing::error;
 
 use crate::{
@@ -205,11 +202,10 @@ impl PipelineStage for ClassifyResponseProcessingStage {
             usage,
         );
 
-        // Store in context
-        ctx.state.response.final_response = Some(FinalResponse::Classify(response.clone()));
+        // Store in context for pipeline to extract
+        ctx.state.response.final_response = Some(FinalResponse::Classify(response));
 
-        // Return HTTP response
-        Ok(Some(Json(response).into_response()))
+        Ok(None)
     }
 
     fn name(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/mod.rs
@@ -1,3 +1,3 @@
-pub mod preparation;
-pub mod request_building;
-pub mod response_processing;
+pub(crate) mod preparation;
+pub(crate) mod request_building;
+pub(crate) mod response_processing;

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-pub struct EmbeddingPreparationStage;
+pub(crate) struct EmbeddingPreparationStage;
 
 impl EmbeddingPreparationStage {
     pub fn new() -> Self {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -15,7 +15,7 @@ use crate::routers::{
 };
 
 /// Request building stage for embedding requests
-pub struct EmbeddingRequestBuildingStage;
+pub(crate) struct EmbeddingRequestBuildingStage;
 
 impl EmbeddingRequestBuildingStage {
     pub fn new() -> Self {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
@@ -1,10 +1,7 @@
 //! Response processing stage for embedding requests
 
 use async_trait::async_trait;
-use axum::{
-    response::{IntoResponse, Response},
-    Json,
-};
+use axum::response::Response;
 use tracing::error;
 
 use crate::{
@@ -65,12 +62,10 @@ impl PipelineStage for EmbeddingResponseProcessingStage {
             .convert_response(ctx, proto_response)
             .map_err(|boxed_err| *boxed_err)?;
 
-        // Store in context
-        ctx.state.response.final_response =
-            Some(FinalResponse::Embedding(embedding_response.clone()));
+        // Store in context for pipeline to extract
+        ctx.state.response.final_response = Some(FinalResponse::Embedding(embedding_response));
 
-        // Return the HTTP response directly
-        Ok(Some(Json(embedding_response).into_response()))
+        Ok(None)
     }
 
     fn name(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Response processing stage for embedding requests
-pub struct EmbeddingResponseProcessingStage;
+pub(crate) struct EmbeddingResponseProcessingStage;
 
 impl EmbeddingResponseProcessingStage {
     pub fn new() -> Self {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/generate/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/generate/mod.rs
@@ -7,6 +7,6 @@ mod preparation;
 mod request_building;
 mod response_processing;
 
-pub use preparation::GeneratePreparationStage;
-pub use request_building::GenerateRequestBuildingStage;
-pub use response_processing::GenerateResponseProcessingStage;
+pub(crate) use preparation::GeneratePreparationStage;
+pub(crate) use request_building::GenerateRequestBuildingStage;
+pub(crate) use response_processing::GenerateResponseProcessingStage;

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// Extracts generate-specific preparation logic from the old unified PreparationStage.
 /// This is a direct extraction without architectural changes.
-pub struct GeneratePreparationStage;
+pub(crate) struct GeneratePreparationStage;
 
 #[async_trait]
 impl PipelineStage for GeneratePreparationStage {

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -18,7 +18,7 @@ use crate::routers::{
 /// Generate request building stage
 ///
 /// Extracts generate-specific request building logic from the old unified RequestBuildingStage.
-pub struct GenerateRequestBuildingStage {
+pub(crate) struct GenerateRequestBuildingStage {
     inject_pd_metadata: bool,
 }
 

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
@@ -18,7 +18,7 @@ use crate::routers::{
 /// Generate response processing stage
 ///
 /// Extracts generate-specific response processing logic from the old unified ResponseProcessingStage.
-pub struct GenerateResponseProcessingStage {
+pub(crate) struct GenerateResponseProcessingStage {
     processor: processor::ResponseProcessor,
     streaming_processor: Arc<streaming::StreamingProcessor>,
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/mod.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/mod.rs
@@ -2,19 +2,15 @@
 //!
 //! This module defines stages specific to regular tokenizer-based models.
 
-pub mod chat;
-pub mod classify;
-pub mod embedding;
-pub mod generate;
-mod preparation;
-mod request_building;
-mod response_processing;
+pub(crate) mod chat;
+pub(crate) mod classify;
+pub(crate) mod embedding;
+pub(crate) mod generate;
+pub(crate) mod preparation;
+pub(crate) mod request_building;
+pub(crate) mod response_processing;
 
-pub use chat::{ChatPreparationStage, ChatRequestBuildingStage, ChatResponseProcessingStage};
-pub use classify::ClassifyResponseProcessingStage;
-pub use generate::{
-    GeneratePreparationStage, GenerateRequestBuildingStage, GenerateResponseProcessingStage,
-};
-pub use preparation::PreparationStage;
-pub use request_building::RequestBuildingStage;
-pub use response_processing::ResponseProcessingStage;
+// Re-export main stages used by pipeline
+pub(crate) use preparation::PreparationStage;
+pub(crate) use request_building::RequestBuildingStage;
+pub(crate) use response_processing::ResponseProcessingStage;

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/preparation.rs
@@ -20,7 +20,7 @@ use crate::routers::{
 };
 
 /// Preparation stage (delegates to endpoint-specific implementations)
-pub struct PreparationStage {
+pub(crate) struct PreparationStage {
     chat_stage: ChatPreparationStage,
     generate_stage: GeneratePreparationStage,
     embedding_stage: EmbeddingPreparationStage,

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/request_building.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/request_building.rs
@@ -17,7 +17,7 @@ use crate::routers::{
 };
 
 /// Request building stage (delegates to endpoint-specific implementations)
-pub struct RequestBuildingStage {
+pub(crate) struct RequestBuildingStage {
     chat_stage: ChatRequestBuildingStage,
     generate_stage: GenerateRequestBuildingStage,
     embedding_stage: EmbeddingRequestBuildingStage,

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/response_processing.rs
@@ -21,7 +21,7 @@ use crate::routers::{
 };
 
 /// Response processing stage (delegates to endpoint-specific implementations)
-pub struct ResponseProcessingStage {
+pub(crate) struct ResponseProcessingStage {
     chat_stage: ChatResponseProcessingStage,
     generate_stage: GenerateResponseProcessingStage,
     embedding_stage: EmbeddingResponseProcessingStage,

--- a/sgl-model-gateway/src/routers/grpc/regular/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/streaming.rs
@@ -38,7 +38,7 @@ use crate::{
 
 /// Shared streaming processor for both single and dual dispatch modes
 #[derive(Clone)]
-pub struct StreamingProcessor {
+pub(crate) struct StreamingProcessor {
     tool_parser_factory: ToolParserFactory,
     reasoning_parser_factory: ReasoningParserFactory,
     configured_tool_parser: Option<String>,
@@ -1324,7 +1324,9 @@ impl StreamingProcessor {
 }
 
 /// Build SSE response with proper headers
-pub fn build_sse_response(rx: mpsc::UnboundedReceiver<Result<Bytes, io::Error>>) -> Response {
+pub(crate) fn build_sse_response(
+    rx: mpsc::UnboundedReceiver<Result<Bytes, io::Error>>,
+) -> Response {
     let stream = UnboundedReceiverStream::new(rx);
     let mut response = Response::new(Body::from_stream(stream));
     *response.status_mut() = StatusCode::OK;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR tightens the visibility of structs and functions across the source files in sgl-model-gateway, mainly `data_connector` and `grpc` module.

As a result, some dead code are appearing (as clippy masks dead code when it is `pub`), the unused methods are removed.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Tighten visibility across the repo.
- Add `allow(dead_code)` to the code that are unused.
- Removed dead code in grpc/context.rs
  1. `StreamingState` struct - Removed entirely. The streaming implementation uses local variables within functions instead of this struct.
  2. Removed fields from ResponseState:
    - `streaming: StreamingState`
    - `collected: Option<Vec<ProtoGenerateComplete>>`
    - `collected_embeddings: Option<Vec<ProtoEmbedComplete>>`
    - `harmony_parser: Option<HarmonyParserAdapter>`
    - `harmony_parser_per_index: Option<HashMap<...>>`
  3. Removed unused accessor methods from impl RequestContext:
    - `request()`
    - `responses_request()`
    - `embedding_request()`
    - `embedding_request_arc()`
    - `classify_request()`
    - `classify_request_arc()`
  4. Removed unused imports: `HashMap, Value, ProtoGenerateComplete`

- Remove unused methods in `impl ProtoRequest`
  - Removed `as_generate()` and `as_embed()` methods since they were truly unused (code uses pattern matching instead)
- Remove unused methods in `impl HarmonyResponsesContext`
- Fix inconsistent patterns in Embedding and Classify
  1. `embedding/response_processing.rs`:
    - Removed `.clone()` and `Ok(Some(Json(...)))`
    - Now returns `Ok(None)` like Chat/Generate
  2. classify/response_processing.rs:
    - Same change - returns Ok(None)
  3. pipeline.rs execute_embeddings:
    - Changed from error case to extract response from FinalResponse::Embedding(response)
    - Returns axum::Json(response).into_response()
  4. pipeline.rs execute_classify:
    - Same pattern - extracts and returns the response
  5. context.rs FinalResponse:
    - Removed `#[allow(dead_code)]` from Embedding and Classify variants

  All four endpoint types (Chat, Generate, Embedding, Classify) now follow the same pipeline pattern:
  - Stage stores response in FinalResponse::Variant(response) and returns Ok(None)
  - Pipeline extracts response from FinalResponse and converts to HTTP response
- Fix inconsistencies in model_id during metrics recording in `pipeline.rs`
  - Fix `execute_generate` to use hardcoded `UNKNOWN_MODEL_ID` constant
  - Remove unnecessary `model_for_metrics` clone

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
