### PR TITLE
Fix AMD GPU visibility by setting HIP_VISIBLE_DEVICES

### DIFF
--- a/test/registered/models/test_transformers_models.py
+++ b/test/registered/models/test_transformers_models.py
@@ -1,6 +1,5 @@
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
-# Transformers fallback model tests
 register_cuda_ci(est_time=245, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=320, suite="stage-b-test-small-1-gpu")
 


### PR DESCRIPTION
## Summary
Fix flaky AMD CI failures caused by HIP device ordinal errors.

The `maybe_reindex_device_id` function was only setting `CUDA_VISIBLE_DEVICES` but not `HIP_VISIBLE_DEVICES` for AMD GPUs. On ROCm, `HIP_VISIBLE_DEVICES` is the more reliable way to control GPU visibility.

## Changes
- Set `HIP_VISIBLE_DEVICES` in addition to `CUDA_VISIBLE_DEVICES` when running on AMD GPUs
- Properly restore `HIP_VISIBLE_DEVICES` after subprocess launch
- Remove unnecessary comment from test file

## Test plan
- CI will validate the fix on AMD runners