### PR TITLE
[AMD] Fix aiter page-size handling, DeepSeek MLA tuple inputs, and HiCache/FA3 decode-backend override

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -279,7 +279,7 @@ class AiterAttnBackend(AttentionBackend):
     ):
 
         nhead_kv = 1
-        page_size = 1
+        page_size = self.page_size
         dtype = self.kv_cache_dtype
 
         meta = get_mla_metadata_v1(
@@ -1654,7 +1654,6 @@ class AiterMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
         self.page_size = model_runner.server_args.page_size
-        assert self.page_size == 1, "Page size must be 1"
 
     def common_template(
         self, forward_batch: ForwardBatch, kv_indices_buffer: torch.Tensor, call_fn: int

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2234,8 +2234,15 @@ class DeepseekV2AttentionMLA(nn.Module):
         enable_rope_fusion = (
             os.getenv("SGLANG_FUSED_MLA_ENABLE_ROPE_FUSION", "1") == "1"
         )
-        q_len = hidden_states.shape[0]
-        q_input = hidden_states.new_empty(
+        # NOTE: hidden_states can be a tuple for some quantization paths.
+        # For shape/device/dtype, use the first tensor; still pass the original
+        # hidden_states through linear ops which may accept tuple inputs.
+        hidden_states_tensor = (
+            hidden_states[0] if isinstance(hidden_states, tuple) else hidden_states
+        )
+
+        q_len = hidden_states_tensor.shape[0]
+        q_input = hidden_states_tensor.new_empty(
             q_len, self.num_local_heads, self.kv_lora_rank + self.qk_rope_head_dim
         )
         if self.q_lora_rank is not None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1993,21 +1993,31 @@ class ServerArgs:
             or self.disaggregation_decode_enable_offload_kvcache
         ) and self.hicache_io_backend == "kernel":
             # fix for the compatibility issue with FlashAttention3 decoding and HiCache kernel backend
-            if self.decode_attention_backend is None:
-                if not self.use_mla_backend():
-                    self.decode_attention_backend = (
-                        "flashinfer" if is_flashinfer_available() else "triton"
-                    )
+            # Only override when the *effective* decode backend would be FA3.
+            # Otherwise, respect the user's chosen attention backend (e.g., aiter on ROCm).
+            effective_decode_backend = (
+                self.decode_attention_backend
+                if self.decode_attention_backend is not None
+                else self.attention_backend
+            )
+            if effective_decode_backend == "fa3":
+                if self.decode_attention_backend is None:
+                    # If decode backend wasn't explicitly set, pick a safe default that works with HiCache kernel IO.
+                    if not self.use_mla_backend():
+                        self.decode_attention_backend = (
+                            "flashinfer" if is_flashinfer_available() else "triton"
+                        )
+                    else:
+                        self.decode_attention_backend = (
+                            "flashinfer" if is_sm100_supported() else "triton"
+                        )
                 else:
-                    self.decode_attention_backend = (
-                        "flashinfer" if is_sm100_supported() else "triton"
+                    # If user explicitly requested FA3 decode, fall back to direct IO.
+                    self.hicache_io_backend = "direct"
+                    logger.warning(
+                        "FlashAttention3 decode backend is not compatible with hierarchical cache. "
+                        "Setting hicache_io_backend to vanilla I/O, which may lead to suboptimal performance with small page sizes."
                     )
-            elif self.decode_attention_backend == "fa3":
-                self.hicache_io_backend = "direct"
-                logger.warning(
-                    "FlashAttention3 decode backend is not compatible with hierarchical cache. "
-                    "Setting hicache_io_backend to vanilla I/O, which may lead to suboptimal performance with small page sizes."
-                )
 
     def _handle_speculative_decoding(self):
         if (


### PR DESCRIPTION
## Motivation

I hit a few issues while running DeepSeek-R1 MXFP4 on ROCm with aiter + hierarchical cache:

- aiter MLA metadata creation was effectively hard-coding `page_size=1`, and the draft backend also asserted `page_size==1`, which breaks configs like `--page-size 64`.
- `DeepseekV2AttentionMLA` can receive `hidden_states` as a tuple in some quantization paths, which makes shape-based allocations fail.
- When HiCache kernel I/O is enabled, the FlashAttention3 compatibility workaround should only kick in when the *effective* decode backend is FA3; otherwise we should not override the user’s chosen backend (e.g., `aiter` on ROCm).

## Modifications

- **aiter attention backend**
  - Use the backend’s configured `page_size` when building MLA metadata (instead of hard-coding `1`).
  - Remove the strict `page_size == 1` assertion in the multistep draft backend to allow non-1 page sizes.
- **DeepSeek v2 MLA forward**
  - Handle `hidden_states` being a tuple by using the first tensor for `shape/device/dtype` when allocating `q_input`, while still passing the original `hidden_states` through the linear ops.
- **Server args / backend selection**
  - Only apply the HiCache-kernel/FA3 workaround when the *effective* decode backend would be `fa3` (respect user-selected `--attention-backend aiter` otherwise).
  - If the user explicitly requests FA3 decode under hierarchical cache, fall back to direct I/O and warn.

## Accuracy Tests

### Setup / Launch command

```bash
SGLANG_AITER_MLA_PERSIST=1 \
AITER_MXFP4_MOE_SF=1 \
SGLANG_USE_AITER_AR=0 \
SGLANG_USE_AITER=1 \
RCCL_MSCCL_ENABLE=0 \
SGLANG_INT4_WEIGHT=0 \
SGLANG_MOE_PADDING=1 \
SGLANG_SET_CPU_AFFINITY=1 \
SGLANG_ROCM_FUSED_DECODE_MLA=1 \
SGLANG_USE_ROCM700A=1 \
python3 -m sglang.launch_server \
  --model-path /data/deepseek-ai/DeepSeek-R1-MXFP4-Preview \
  --tensor-parallel-size 8 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 8000 \
  --mem-fraction-static 0.90 \
  --chunked-prefill-size 131072 \
  --attention-backend aiter \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --speculative-draft-model-path lmsys/DeepSeek-R1-NextN \
  --max-running-requests 128 \
  --kv-cache-dtype fp8_e4m3 \
  --enable-cache-report \
  --page-size 64 \
  --enable-hierarchical-cache \
  --hicache-io-backend kernel \
  --hicache-write-policy write_through \
  --hicache-ratio 1
```

### GSM8k

```bash
python3 benchmark/gsm8k/bench_sglang.py --parallel 1400 --num-questions 1400 --port 8000
```

- Run 1: **Accuracy 0.942**, **Invalid 0.000**
- Run 2: **Accuracy 0.944**, **Invalid 0.000**

## Benchmarking and Profiling

Not measured in this PR (focus is correctness + respecting user-selected backends). If you want, I can add a short throughput/latency benchmark comparison for the same configuration above.



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.

CC: @HaiShaw @kkHuang-amd @yctseng0211 