### PR TITLE
[responses API] Add list_tools_for_servers and threading server_keys in routers

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/common.rs
@@ -1,7 +1,5 @@
 //! Shared helpers and state tracking for Harmony Responses
 
-use std::sync::Arc;
-
 use axum::response::Response;
 use serde_json::{from_value, json, to_string, Value};
 use tracing::{debug, error, warn};
@@ -10,7 +8,7 @@ use uuid::Uuid;
 use super::{context::HarmonyResponsesContext, execution::ToolResult};
 use crate::{
     data_connector::ResponseId,
-    mcp::McpManager,
+    mcp,
     protocols::{
         common::{ToolCall, ToolChoice, ToolChoiceValue},
         responses::{
@@ -217,10 +215,10 @@ pub(super) fn build_next_request_with_tools(
 pub(super) fn inject_mcp_metadata(
     response: &mut ResponsesResponse,
     tracking: &McpCallTracking,
-    mcp_manager: &Arc<McpManager>,
+    mcp_tools: &[mcp::Tool],
 ) {
     // Build mcp_list_tools item
-    let tools = mcp_manager.list_tools();
+    let tools = mcp_tools;
     let tools_info: Vec<McpToolInfo> = tools
         .iter()
         .map(|t| McpToolInfo {

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/context.rs
@@ -1,6 +1,6 @@
 //! Context for Harmony Responses execution
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as StdRwLock};
 
 use crate::{
     data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage},
@@ -22,6 +22,9 @@ pub(crate) struct HarmonyResponsesContext {
 
     /// MCP manager for tool execution
     pub mcp_manager: Arc<McpManager>,
+
+    /// Server keys for MCP tools requested in this context
+    pub requested_servers: Arc<StdRwLock<Vec<String>>>,
 
     /// Response storage for loading conversation history
     pub response_storage: Arc<dyn ResponseStorage>,
@@ -47,6 +50,7 @@ impl HarmonyResponsesContext {
             pipeline,
             components,
             mcp_manager,
+            requested_servers: Arc::new(StdRwLock::new(Vec::new())),
             response_storage,
             conversation_storage,
             conversation_item_storage,

--- a/sgl-model-gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -57,8 +57,14 @@ pub(crate) async fn serve_harmony_responses(
     let current_request = load_previous_messages(ctx, request).await?;
 
     // Check MCP connection and get whether MCP tools are present
-    let has_mcp_tools =
+    let (has_mcp_tools, server_keys) =
         ensure_mcp_connection(&ctx.mcp_manager, current_request.tools.as_deref()).await?;
+
+    // Set the server keys in the context
+    {
+        let mut servers = ctx.requested_servers.write().unwrap();
+        *servers = server_keys;
+    }
 
     let response = if has_mcp_tools {
         execute_with_mcp_loop(ctx, current_request).await?
@@ -96,8 +102,11 @@ async fn execute_with_mcp_loop(
     // Extract user's max_tool_calls limit (if set)
     let max_tool_calls = current_request.max_tool_calls.map(|n| n as usize);
 
-    // Add static MCP tools from inventory to the request
-    let mcp_tools = ctx.mcp_manager.list_tools();
+    // Add filtered MCP tools (static + requested dynamic) to the request
+    let mcp_tools = {
+        let servers = ctx.requested_servers.read().unwrap();
+        ctx.mcp_manager.list_tools_for_servers(&servers)
+    };
     if !mcp_tools.is_empty() {
         let mcp_response_tools = convert_mcp_tools_to_response_tools(&mcp_tools);
 
@@ -216,7 +225,7 @@ async fn execute_with_mcp_loop(
 
                     // Inject MCP metadata if any calls were executed
                     if mcp_tracking.total_calls() > 0 {
-                        inject_mcp_metadata(&mut response, &mcp_tracking, &ctx.mcp_manager);
+                        inject_mcp_metadata(&mut response, &mcp_tracking, &mcp_tools);
                     }
 
                     return Ok(response);
@@ -258,7 +267,7 @@ async fn execute_with_mcp_loop(
 
                     // Inject MCP metadata for all executed calls
                     if mcp_tracking.total_calls() > 0 {
-                        inject_mcp_metadata(&mut response, &mcp_tracking, &ctx.mcp_manager);
+                        inject_mcp_metadata(&mut response, &mcp_tracking, &mcp_tools);
                     }
 
                     return Ok(response);
@@ -291,7 +300,7 @@ async fn execute_with_mcp_loop(
                 );
 
                 // Inject MCP metadata into final response
-                inject_mcp_metadata(&mut response, &mcp_tracking, &ctx.mcp_manager);
+                inject_mcp_metadata(&mut response, &mcp_tracking, &mcp_tools);
 
                 debug!(
                     mcp_calls = mcp_tracking.total_calls(),

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/common.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/common.rs
@@ -175,8 +175,9 @@ pub(super) fn generate_mcp_id(prefix: &str) -> String {
 pub(super) fn build_mcp_list_tools_item(
     mcp: &Arc<McpManager>,
     server_label: &str,
+    server_keys: &[String],
 ) -> ResponseOutputItem {
-    let tools = mcp.list_tools();
+    let tools = mcp.list_tools_for_servers(server_keys);
     let tools_info: Vec<McpToolInfo> = tools
         .iter()
         .map(|t| McpToolInfo {

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/context.rs
@@ -3,7 +3,10 @@
 //! Bundles all dependencies needed by responses handlers to avoid passing
 //! 10+ parameters to every function.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock as StdRwLock},
+};
 
 use tokio::{sync::RwLock, task::JoinHandle};
 
@@ -55,6 +58,9 @@ pub(crate) struct ResponsesContext {
     /// MCP manager for tool support
     pub mcp_manager: Arc<McpManager>,
 
+    /// Server keys for MCP tools requested in this context
+    pub requested_servers: Arc<StdRwLock<Vec<String>>>,
+
     /// Background task handles for cancellation support
     pub background_tasks: Arc<RwLock<HashMap<String, BackgroundTaskInfo>>>,
 }
@@ -78,6 +84,7 @@ impl ResponsesContext {
             conversation_storage,
             conversation_item_storage,
             mcp_manager,
+            requested_servers: Arc::new(StdRwLock::new(Vec::new())),
             background_tasks: Arc::new(RwLock::new(HashMap::new())),
         }
     }

--- a/sgl-model-gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -110,11 +110,17 @@ async fn route_responses_streaming(
     };
 
     // 2. Check MCP connection and get whether MCP tools are present
-    let has_mcp_tools =
+    let (has_mcp_tools, server_keys) =
         match ensure_mcp_connection(&ctx.mcp_manager, request.tools.as_deref()).await {
-            Ok(has_mcp) => has_mcp,
+            Ok(result) => result,
             Err(response) => return response,
         };
+
+    // Set the server keys in the context
+    {
+        let mut servers = ctx.requested_servers.write().unwrap();
+        *servers = server_keys;
+    }
 
     if has_mcp_tools {
         debug!("MCP tools detected in streaming mode, using streaming tool loop");

--- a/sgl-model-gateway/src/routers/mcp_utils.rs
+++ b/sgl-model-gateway/src/routers/mcp_utils.rs
@@ -88,7 +88,7 @@ pub async fn ensure_request_mcp_client(
     let mut server_keys = Vec::new();
     let mut has_mcp_tools = false;
 
-    // Process ALL MCP tools, not just the first one
+    // Process all MCP tools
     for tool in tools {
         if matches!(tool.r#type, ResponseToolType::Mcp) && tool.server_url.is_some() {
             has_mcp_tools = true;

--- a/sgl-model-gateway/src/routers/mcp_utils.rs
+++ b/sgl-model-gateway/src/routers/mcp_utils.rs
@@ -34,12 +34,16 @@ pub struct McpLoopConfig {
     /// Maximum iterations as safety limit (default: DEFAULT_MAX_ITERATIONS).
     /// Prevents infinite loops when max_tool_calls is not set by user.
     pub max_iterations: usize,
+    /// Server keys for filtering MCP tools.
+    /// Contains keys for dynamic servers that were connected for this request.
+    pub server_keys: Vec<String>,
 }
 
 impl Default for McpLoopConfig {
     fn default() -> Self {
         Self {
             max_iterations: DEFAULT_MAX_ITERATIONS,
+            server_keys: Vec::new(),
         }
     }
 }
@@ -70,67 +74,90 @@ pub fn extract_server_label(tools: Option<&[ResponseTool]>, default_label: &str)
 // MCP Connection
 // ============================================================================
 
-/// Ensure MCP client is connected for request-level MCP tools.
+/// Ensure MCP clients are connected for all request-level MCP tools.
 ///
-/// This function extracts MCP server configuration from request tools (server_url, authorization)
-/// and ensures a client connection is established via the connection pool.
+/// This function extracts MCP server configurations from ALL request tools (server_url, authorization)
+/// and ensures client connections are established via the connection pool.
 ///
-/// Returns `Some(())` if a dynamic MCP tool was found and client was created/retrieved,
-/// `None` if no MCP tools with server_url were found or connection failed.
+/// Returns `Some((manager, server_keys))` if MCP tools were found and clients created,
+/// `None` if no MCP tools with server_url were found.
 pub async fn ensure_request_mcp_client(
     mcp_manager: &Arc<McpManager>,
     tools: &[ResponseTool],
-) -> Option<()> {
-    // Find an MCP tool with a server_url
-    let tool = tools
-        .iter()
-        .find(|t| matches!(t.r#type, ResponseToolType::Mcp) && t.server_url.is_some())?;
+) -> Option<(Arc<McpManager>, Vec<String>)> {
+    let mut server_keys = Vec::new();
+    let mut has_mcp_tools = false;
 
-    let server_url = tool.server_url.as_ref()?.trim().to_string();
+    // Process ALL MCP tools, not just the first one
+    for tool in tools {
+        if matches!(tool.r#type, ResponseToolType::Mcp) && tool.server_url.is_some() {
+            has_mcp_tools = true;
+            let Some(server_url) = tool.server_url.as_ref().map(|s| s.trim().to_string()) else {
+                continue;
+            };
 
-    // Validate URL scheme
-    if !(server_url.starts_with("http://") || server_url.starts_with("https://")) {
-        warn!(
-            "Ignoring MCP server_url with unsupported scheme: {}",
-            server_url
-        );
-        return None;
+            // Validate URL scheme
+            if !(server_url.starts_with("http://") || server_url.starts_with("https://")) {
+                warn!(
+                    "Ignoring MCP server_url with unsupported scheme: {}",
+                    server_url
+                );
+                continue;
+            }
+
+            // Extract server label and auth token
+            let name = tool
+                .server_label
+                .clone()
+                .unwrap_or_else(|| "request-mcp".to_string());
+            let token = tool.authorization.clone();
+
+            // Determine transport type based on URL pattern
+            let transport = if server_url.contains("/sse") {
+                McpTransport::Sse {
+                    url: server_url.clone(),
+                    token,
+                }
+            } else {
+                McpTransport::Streamable {
+                    url: server_url.clone(),
+                    token,
+                }
+            };
+
+            // Create server config
+            let server_config = McpServerConfig {
+                name,
+                transport,
+                proxy: None,
+                required: false,
+            };
+
+            // Get the server key for tracking
+            let server_key = McpManager::server_key(&server_config);
+
+            // Use get_or_create_client to establish connection
+            match mcp_manager.get_or_create_client(server_config).await {
+                Ok(_client) => {
+                    // Track this server for filtering
+                    if !server_keys.contains(&server_key) {
+                        server_keys.push(server_key);
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "Failed to get/create MCP connection for {}: {}",
+                        server_key, err
+                    );
+                    // Continue processing other tools
+                }
+            }
+        }
     }
 
-    // Extract server label and auth token
-    let name = tool
-        .server_label
-        .clone()
-        .unwrap_or_else(|| "request-mcp".to_string());
-    let token = tool.authorization.clone();
-
-    // Determine transport type based on URL pattern
-    let transport = if server_url.contains("/sse") {
-        McpTransport::Sse {
-            url: server_url.clone(),
-            token,
-        }
+    if has_mcp_tools && !server_keys.is_empty() {
+        Some((mcp_manager.clone(), server_keys))
     } else {
-        McpTransport::Streamable {
-            url: server_url.clone(),
-            token,
-        }
-    };
-
-    // Create server config
-    let server_config = McpServerConfig {
-        name,
-        transport,
-        proxy: None,
-        required: false,
-    };
-
-    // Use get_or_create_client to establish connection
-    match mcp_manager.get_or_create_client(server_config).await {
-        Ok(_client) => Some(()),
-        Err(err) => {
-            warn!("Failed to get/create MCP connection: {}", err);
-            None
-        }
+        None
     }
 }

--- a/sgl-model-gateway/src/routers/openai/context.rs
+++ b/sgl-model-gateway/src/routers/openai/context.rs
@@ -238,6 +238,7 @@ pub struct StreamingEventContext<'a> {
     pub server_label: &'a str,
     pub original_request: &'a ResponsesRequest,
     pub previous_response_id: Option<&'a str>,
+    pub server_keys: &'a [String],
 }
 
 pub type StreamingRequest = OwnedStreamingContext;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes mcp tool leakage issue in grpc and openai routers.

When multiple requests use different MCP servers, there was a tool leakage issue:

```
  ┌─────────────────────────────────────────────────────────────────────────────┐
  │                           BEFORE (Broken)                                   │
  ├─────────────────────────────────────────────────────────────────────────────┤
  │                                                                             │
  │  Request A                              Request B                           │
  │  tools: [{ server_url: "server-a" }]   tools: [{ server_url: "server-b" }]  │
  │           │                                      │                          │
  │           ▼                                      ▼                          │
  │     Connect to server-a                   Connect to server-b               │
  │           │                                      │                          │
  │           └──────────────┬───────────────────────┘                          │
  │                          ▼                                                  │
  │              ┌─────────────────────┐                                        │
  │              │   MCP Inventory     │                                        │
  │              │   (Global Pool)     │                                        │
  │              │                     │                                        │
  │              │  - static tools     │                                        │
  │              │  - server-a tools   │  ← Added by Request A                  │
  │              │  - server-b tools   │  ← Added by Request B                  │
  │              └──────────┬──────────┘                                        │
  │                         │                                                   │
  │                         ▼                                                   │
  │              list_tools() returns ALL                                       │
  │                         │                                                   │
  │           ┌─────────────┴─────────────┐                                     │
  │           ▼                           ▼                                     │
  │    Request A sees:              Request B sees:                             │
  │    - static tools               - static tools                              │
  │    - server-a tools             - server-a tools  ← WRONG! Leaked           │
  │    - server-b tools ← WRONG!    - server-b tools                            │
  │                                                                             │
  └─────────────────────────────────────────────────────────────────────────────┘
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Add `list_tools_for_servers` in `McpManager` that filters tools to static servers + specified dynamic servers
- Add `is_static_server_by_key` to identify static servers (always visible)
- Update `ensure_mcp_connection` to return server keys for a request
- Added `requested_servers: Arc<StdRwLock<Vec<String>>>` in gRPC contexts to store per-request server keys


Threading Approaches

The commit uses two different approaches to pass server_keys:

  | Router                 | Approach                                       |
  |------------------------|------------------------------------------------|
  | gRPC (Harmony/Regular) | Store in context: ctx.requested_servers        |
  | OpenAI                 | Pass through params: McpLoopConfig.server_keys |


### Solution in Flow Chart

```
  ┌─────────────────────────────────────────────────────────────────────────────┐
  │                           AFTER (Fixed)                                     │
  ├─────────────────────────────────────────────────────────────────────────────┤
  │                                                                             │
  │  Request A                              Request B                           │
  │  tools: [{ server_url: "server-a" }]   tools: [{ server_url: "server-b" }]  │
  │           │                                      │                          │
  │           ▼                                      ▼                          │
  │  ensure_mcp_connection()               ensure_mcp_connection()              │
  │  returns: (true, ["server-a"])         returns: (true, ["server-b"])        │
  │           │                                      │                          │
  │           ▼                                      ▼                          │
  │  ctx.requested_servers = ["server-a"]  ctx.requested_servers = ["server-b"] │
  │           │                                      │                          │
  │           ▼                                      ▼                          │
  │  list_tools_for_servers(["server-a"])  list_tools_for_servers(["server-b"]) │
  │           │                                      │                          │
  │           ▼                                      ▼                          │
  │    Request A sees:                       Request B sees:                    │
  │    - static tools ✓                      - static tools ✓                   │
  │    - server-a tools ✓                    - server-b tools ✓                 │
  │    - server-b tools ✗ (filtered out)     - server-a tools ✗ (filtered out)  │
  │                                                                             │
  └─────────────────────────────────────────────────────────────────────────────┘
```
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

The test sends two requests to the same grpc worker (regular). The first request contains a dynamic server A, the second request contains a dynamic server B. The two responses shows the mcp tools from their scope. 

No static server is set up for this test.

- 1st Request:

Mcp: brave search server:

```
curl http://localhost:3002/v1/responses \
-H "Content-Type: application/json" \
-d '{
  "model": "/models/meta-llama/Llama-3.1-8B-Instruct",
  "tools": [
    {
      "type": "mcp",
      "server_label": "brave",
      "server_description": "A Tool to do web search",
      "server_url": "http://localhost:8001/sse",
      "require_approval": "never"
    }
  ],
  "input": "could you show me one simple news about sglang",
  "reasoning": {"effort": "low"}
}' | jq
```

Response:

`mcp_list_tools` shows tools from brave_web_search

<img width="953" height="1170" alt="Screenshot 2026-01-05 at 10 25 02 PM" src="https://github.com/user-attachments/assets/1cbb6765-05ae-431b-a2f8-84a73c5f2420" />


<details>
<summary>Click to view the detailed response</summary>

```
{
  "id": "resp_df551e47-12a1-408d-92da-6b0ca17a3597",
  "object": "response",
  "created_at": 1767680604,
  "status": "completed",
  "model": "/models/meta-llama/Llama-3.1-8B-Instruct",
  "output": [
    {
      "type": "mcp_list_tools",
      "id": "mcpl_8a4e6860-d111-4a1d-b7a2-1fe2b232053f",
      "server_label": "brave",
      "tools": [
        {
          "name": "brave_web_search",
          "description": "Performs a web search using the Brave Search API, ideal for general queries, news, articles, and online content. Use this for broad information gathering, recent events, or when you need diverse web sources. Supports pagination, content filtering, and freshness controls. Maximum 20 results per request, with offset for pagination. ",
          "input_schema": {
            "type": "object",
            "properties": {
              "query": {
                "type": "string",
                "description": "Search query (max 400 chars, 50 words)"
              },
              "count": {
                "type": "number",
                "description": "Number of results (1-20, default 10)",
                "default": 10
              },
              "offset": {
                "type": "number",
                "description": "Pagination offset (max 9, default 0)",
                "default": 0
              }
            },
            "required": [
              "query"
            ]
          },
          "annotations": {
            "read_only": false
          }
        },
        {
          "name": "brave_local_search",
          "description": "Searches for local businesses and places using Brave's Local Search API. Best for queries related to physical locations, businesses, restaurants, services, etc. Returns detailed information including:\n- Business names and addresses\n- Ratings and review counts\n- Phone numbers and opening hours\nUse this when the query implies 'near me' or mentions specific locations. Automatically falls back to web search if no local results are found.",
          "input_schema": {
            "type": "object",
            "properties": {
              "query": {
                "type": "string",
                "description": "Local search query (e.g. 'pizza near Central Park')"
              },
              "count": {
                "type": "number",
                "description": "Number of results (1-20, default 5)",
                "default": 5
              }
            },
            "required": [
              "query"
            ]
          },
          "annotations": {
            "read_only": false
          }
        }
      ]
    },
    {
      "type": "message",
      "id": "msg_chatcmpl-3364698a-c892-4e50-a800-4893de36311b",
      "role": "assistant",
      "content": [
        {
          "type": "output_text",
          "text": "The function \"brave_web_search\" with the query \"sglang\" returns a piece of news about Sglang, a high-performance serving framework for large language models and multimodal models."
        }
      ],
      "status": "completed"
    },
    {
      "type": "mcp_call",
      "id": "mcp_799fead2-8d51-49b0-8cc6-2a91a9ca8210",
      "status": "completed",
      "arguments": "{\"query\":\"sglang\",\"count\":1,\"offset\":0}",
      "name": "brave_web_search",
      "output": "{\"content\":[{\"type\":\"text\",\"text\":\"Title: GitHub - sgl-project/sglang: SGLang is a high-performance serving framework for large language models and multimodal models.\\nDescription: SGLang is <strong>a high-performance serving framework for large language models and multimodal models</strong>. It is designed to deliver low-latency and high-throughput inference across a wide range of setups, from a single GPU to large distributed clusters.\\nURL: https://github.com/sgl-project/sglang\"}],\"isError\":false}",
      "server_label": "brave"
    }
  ],
  "parallel_tool_calls": true,
  "store": true,
  "temperature": 1,
  "tool_choice": "\"auto\"",
  "tools": [
    {
      "type": "mcp",
      "server_url": "http://localhost:8001/sse",
      "server_label": "brave",
      "server_description": "A Tool to do web search",
      "require_approval": "never"
    }
  ],
  "top_p": 1,
  "usage": {
    "prompt_tokens": 707,
    "completion_tokens": 40,
    "total_tokens": 747
  },
  "metadata": {}
}
```
</details>

- 2nd Request:

Mcp: deepwiki

```
curl http://localhost:3002/v1/responses \
-H "Content-Type: application/json" \
-d '{
  "model": "/models/meta-llama/Llama-3.1-8B-Instruct",
  "tools": [
    {
        "type": "mcp",
        "server_label": "deepwiki",
        "server_url": "https://mcp.deepwiki.com/mcp",
        "require_approval": "never"
      }
  ],
  "input": "could you show me one simple news about sglang",
  "reasoning": {"effort": "low"}
}' | jq
```

Response:

`mcp_list_tools` shows only `deepwiki` tools

<img width="921" height="1167" alt="Screenshot 2026-01-05 at 10 25 34 PM" src="https://github.com/user-attachments/assets/fa4771f9-0b72-4eaa-9c3d-bb7fe10958d5" />

<details>
<summary>Click to view the detailed response</summary>

```
{
  "id": "resp_66ca2fda-f4eb-49b7-8640-f03be3058a91",
  "object": "response",
  "created_at": 1767680707,
  "status": "completed",
  "model": "/models/meta-llama/Llama-3.1-8B-Instruct",
  "output": [
    {
      "type": "mcp_list_tools",
      "id": "mcpl_a00ebe03-5d3f-4f72-8211-7f695b4e7e6c",
      "server_label": "deepwiki",
      "tools": [
        {
          "name": "read_wiki_contents",
          "description": "View documentation about a GitHub repository",
          "input_schema": {
            "type": "object",
            "properties": {
              "repoName": {
                "type": "string",
                "description": "GitHub repository: owner/repo (e.g. \"facebook/react\")"
              }
            },
            "required": [
              "repoName"
            ],
            "additionalProperties": false,
            "$schema": "http://json-schema.org/draft-07/schema#"
          },
          "annotations": {
            "read_only": false
          }
        },
        {
          "name": "ask_question",
          "description": "Ask any question about a GitHub repository",
          "input_schema": {
            "type": "object",
            "properties": {
              "repoName": {
                "type": "string",
                "description": "GitHub repository: owner/repo (e.g. \"facebook/react\")"
              },
              "question": {
                "type": "string",
                "description": "The question to ask about the repository"
              }
            },
            "required": [
              "repoName",
              "question"
            ],
            "additionalProperties": false,
            "$schema": "http://json-schema.org/draft-07/schema#"
          },
          "annotations": {
            "read_only": false
          }
        },
        {
          "name": "read_wiki_structure",
          "description": "Get a list of documentation topics for a GitHub repository",
          "input_schema": {
            "type": "object",
            "properties": {
              "repoName": {
                "type": "string",
                "description": "GitHub repository: owner/repo (e.g. \"facebook/react\")"
              }
            },
            "required": [
              "repoName"
            ],
            "additionalProperties": false,
            "$schema": "http://json-schema.org/draft-07/schema#"
          },
          "annotations": {
            "read_only": false
          }
        }
      ]
    },
    {
      "type": "message",
      "id": "msg_chatcmpl-27732c9e-7f2e-45f1-8fba-832462c7563d",
      "role": "assistant",
      "content": [
        {
          "type": "output_text",
          "text": "The function `ask_question` is called with the repository `facebook/sglang` and the question \"What is one simple news about sglang?\". However, since `facebook/sglang` is not a valid repository, the function returns an error message. To get the news, you need to index the repository first by visiting the provided link."
        }
      ],
      "status": "completed"
    },
    {
      "type": "mcp_call",
      "id": "mcp_66b0deee-95f4-4397-9bdd-21221c386660",
      "status": "completed",
      "arguments": "{\"question\":\"What is one simple news about sglang?\",\"repoName\":\"facebook/sglang\"}",
      "name": "ask_question",
      "output": "{\"content\":[{\"type\":\"text\",\"text\":\"Error processing question: Repository not found. Visit https://deepwiki.com/facebook/sglang to index it.\"}]}",
      "server_label": "deepwiki"
    }
  ],
  "parallel_tool_calls": true,
  "store": true,
  "temperature": 1,
  "tool_choice": "\"auto\"",
  "tools": [
    {
      "type": "mcp",
      "server_url": "https://mcp.deepwiki.com/mcp",
      "server_label": "deepwiki",
      "require_approval": "never"
    }
  ],
  "top_p": 1,
  "usage": {
    "prompt_tokens": 602,
    "completion_tokens": 72,
    "total_tokens": 674
  },
  "metadata": {}
}
```

</details>


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
