### PR TITLE
[Diffusion] Make dit cpu offload work in video and support hybind Parallel with cache-dit

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -189,6 +189,9 @@ class Scheduler:
             if isinstance(req, Req):
                 warmup_req = deepcopy(req)
                 warmup_req.is_warmup = True
+                warmup_req.extra["cache_dit_num_inference_steps"] = (
+                    req.num_inference_steps
+                )
                 warmup_req.num_inference_steps = 1
                 recv_reqs.insert(0, (identity, warmup_req))
                 self.warmed_up = True

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -487,6 +487,9 @@ class DenoisingStage(PipelineStage):
         """
         assert self.transformer is not None
         pipeline = self.pipeline() if self.pipeline else None
+        cache_dit_num_inference_steps = batch.extra.get(
+            "cache_dit_num_inference_steps", batch.num_inference_steps
+        )
         if not server_args.model_loaded["transformer"]:
             # FIXME: reuse more code
             loader = TransformerLoader()
@@ -494,13 +497,13 @@ class DenoisingStage(PipelineStage):
                 server_args.model_paths["transformer"], server_args, "transformer"
             )
             # enable cache-dit before torch.compile (delayed mounting)
-            self._maybe_enable_cache_dit(batch.num_inference_steps)
+            self._maybe_enable_cache_dit(cache_dit_num_inference_steps)
             self.compile_module_with_torch_compile(self.transformer)
             if pipeline:
                 pipeline.add_module("transformer", self.transformer)
             server_args.model_loaded["transformer"] = True
         else:
-            self._maybe_enable_cache_dit(batch.num_inference_steps)
+            self._maybe_enable_cache_dit(cache_dit_num_inference_steps)
 
         # Prepare extra step kwargs for scheduler
         extra_step_kwargs = self.prepare_extra_func_kwargs(

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -864,9 +864,9 @@ class ServerArgs:
             has_sp = self.sp_degree > 1
             has_tp = self.tp_size > 1
             if has_sp and has_tp:
-                raise ValueError(
-                    "cache-dit does not support hybrid parallelism (SP + TP). "
-                    "Please use either sequence parallelism or tensor parallelism, not both."
+                logger.warning(
+                    "cache-dit is enabled with hybrid parallelism (SP + TP). "
+                    "Proceeding anyway (SGLang integration may support this mode)."
                 )
 
     def _set_default_attention_backend(self) -> None:

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -277,10 +277,14 @@ class ServerArgs:
             if self.vae_cpu_offload is None:
                 self.vae_cpu_offload = False
         else:
-            self.dit_cpu_offload = True
-            self.text_encoder_cpu_offload = True
-            self.image_encoder_cpu_offload = True
-            self.vae_cpu_offload = True
+            if self.dit_cpu_offload is None:
+                self.dit_cpu_offload = True
+            if self.text_encoder_cpu_offload is None:
+                self.text_encoder_cpu_offload = True
+            if self.image_encoder_cpu_offload is None:
+                self.image_encoder_cpu_offload = True
+            if self.vae_cpu_offload is None:
+                self.vae_cpu_offload = True
 
     def __post_init__(self):
         # configure logger before use

--- a/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
@@ -27,6 +27,7 @@ from cache_dit import (
 )
 from cache_dit.caching.block_adapters import BlockAdapterRegister
 from cache_dit.parallelism import ParallelismBackend, ParallelismConfig
+from sglang.multimodal_gen.runtime.distributed.parallel_state import get_dit_group
 
 _original_similarity = None
 
@@ -322,10 +323,6 @@ def enable_cache_on_transformer(
             # as a conservative superset group; fallback to None.
             tp_sp_group = None
             if sp_group is not None and tp_group is not None:
-                from sglang.multimodal_gen.runtime.distributed.parallel_state import (
-                    get_dit_group,
-                )
-
                 tp_sp_group = get_dit_group()
 
             context_manager._sglang_tp_sp_group = tp_sp_group
@@ -504,10 +501,6 @@ def enable_cache_on_dual_transformer(
                 tp_sp_group = None
                 if sp_group is not None and tp_group is not None:
                     try:
-                        from sglang.multimodal_gen.runtime.distributed.parallel_state import (
-                            get_dit_group,
-                        )
-
                         tp_sp_group = get_dit_group()
                     except Exception:
                         tp_sp_group = None


### PR DESCRIPTION
8xH100

Before:

https://github.com/sgl-project/sglang/pull/16532

DenoisingStage 49s.

PR:

DenoisingStage 30s.


```shell
SGLANG_CACHE_DIT_ENABLED=true \
SGLANG_CACHE_DIT_WARMUP=4 \
SGLANG_CACHE_DIT_MC=8 \
SGLANG_CACHE_DIT_RDT=0.24 \
SGLANG_CACHE_DIT_FN=1 \
SGLANG_CACHE_DIT_BN=0 \
SGLANG_CACHE_DIT_TAYLORSEER=true \
SGLANG_CACHE_DIT_SECONDARY_WARMUP=2 \
SGLANG_CACHE_DIT_SECONDARY_MC=20 \
SGLANG_CACHE_DIT_SECONDARY_RDT=0.24 \
SGLANG_CACHE_DIT_SECONDARY_FN=1 \
SGLANG_CACHE_DIT_SECONDARY_BN=0 \
SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true \
SGLANG_CACHE_DIT_SCM_PRESET=fast \
SGLANG_CACHE_DIT_SCM_POLICY=dynamic \
sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers --pin-cpu-memory --num-gpus 8  --tp-size 2 --ulysses-degree 2  --ring-degree 2 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."  --save-output  --output-path outputs  --output-file-name "output1_video.mp4"  --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" --720p --num-frames 81  --fps 16  --guidance-scale 3.5 --guidance-scale-2 4 --num-inference-steps 27 --enable-warmup --dit-cpu-offload false --enable-torch-compile 


100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 27/27 [00:30<00:00,  1.11s/it]
[01-06 05:29:24] [DenoisingStage] average time per step: 1.1136 seconds
[01-06 05:29:24] [DenoisingStage] finished in 30.0721 seconds
[01-06 05:29:24] [DecodingStage] started...
[01-06 05:29:28] [DecodingStage] finished in 3.4980 seconds
[01-06 05:29:28] Peak GPU memory: 38.34 GB, Remaining GPU memory at peak: 41.31 GB. Components that can stay resident: ['text_encoder', 'vae']
[01-06 05:29:32] Output saved to outputs/output1_video.mp4
[01-06 05:29:32] Pixel data generated successfully in 74.95 seconds
[01-06 05:29:32] Completed batch processing. Generated 1 outputs in 74.95 seconds
[01-06 05:29:32] Warmed-up request processed in 37.34 seconds (with warmup excluded)
[01-06 05:29:32] Memory usage - Max peak: 39257.08 MB, Avg peak: 39257.08 MB
[01-06 05:29:32] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
/usr/lib/python3.12/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 8 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```




https://github.com/user-attachments/assets/3cbe767f-ef17-4123-b835-9e9013a566ab




