### PR TITLE
[Feature] [ROCM] Support Add & LayerNorm fused for Qwen3-VL VIT

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -67,6 +67,7 @@ if _is_cuda or _is_xpu:
     )
 _has_vllm_rms_norm = False
 if _use_aiter:
+    from aiter import layer_norm, layernorm2d_fwd_with_add
     from aiter import rmsnorm2d_fwd as rms_norm
     from aiter import rmsnorm2d_fwd_with_add as fused_add_rms_norm
 
@@ -367,6 +368,9 @@ class LayerNorm(MultiPlatformOp):
         self.bias = nn.Parameter(torch.zeros(hidden_size, dtype=self.dtype))
         self.weight = nn.Parameter(torch.ones(hidden_size, dtype=self.dtype))
 
+        if _use_aiter:
+            self._forward_method = self.forward_aiter
+
     def forward_cuda(
         self,
         x: torch.Tensor,
@@ -418,6 +422,29 @@ class LayerNorm(MultiPlatformOp):
             )
         else:
             return self.forward_native(x)
+
+    def forward_aiter(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if self.weight.dtype != x.dtype:
+            self.weight.data = self.weight.data.to(x.dtype)
+            self.bias.data = self.bias.data.to(x.dtype)
+        if residual is not None:
+            residual_out = torch.empty_like(x)
+            output = torch.empty_like(x)
+            layernorm2d_fwd_with_add(
+                output,
+                x,
+                residual,
+                residual_out,
+                self.weight.data,
+                self.bias.data,
+                self.variance_epsilon,
+            )
+            return output, residual_out
+        return layer_norm(x, self.weight.data, self.bias.data, self.variance_epsilon)
 
 
 class GemmaRMSNorm(MultiPlatformOp):

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -42,6 +42,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_size,
     is_dp_attention_enabled,
 )
+from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.pooler import Pooler, PoolingType
@@ -72,7 +73,7 @@ from sglang.srt.models.utils import (
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
 from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix, get_int_env_var, is_npu, round_up
+from sglang.srt.utils import add_prefix, get_int_env_var, is_hip, is_npu, round_up
 from sglang.srt.utils.hf_transformers_utils import get_processor
 
 _is_npu = is_npu()
@@ -86,6 +87,8 @@ if _is_npu:
 
 
 logger = logging.getLogger(__name__)
+_is_hip = is_hip()
+_use_aiter = get_int_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 class Qwen3_VisionMLP(nn.Module):
@@ -178,7 +181,10 @@ class Qwen3_VisionBlock(nn.Module):
     ) -> None:
         super().__init__()
         if norm_layer is None:
-            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+            if _use_aiter:
+                norm_layer = partial(LayerNorm, eps=1e-6)
+            else:
+                norm_layer = partial(nn.LayerNorm, eps=1e-6)
         self.norm1 = norm_layer(dim)
         self.norm2 = norm_layer(dim)
 
@@ -214,8 +220,21 @@ class Qwen3_VisionBlock(nn.Module):
         output_ws: Optional[torch.Tensor] = None,
         max_seqlen: Optional[torch.Tensor] = None,
         sequence_lengths: Optional[torch.Tensor] = None,
+        residual: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        hidden_states = self.norm1(x)
+        _use_fused_layernorm = isinstance(self.norm1, LayerNorm)
+        # First norm
+        if _use_fused_layernorm:
+            # Fused add + norm1 path (aiter)
+            if residual is None:
+                hidden_states = self.norm1(x)
+                residual = x
+            else:
+                hidden_states, residual = self.norm1(x, residual=residual)
+        else:
+            # Original path
+            hidden_states = self.norm1(x)
+
         hidden_states = rearrange(hidden_states, "s b ... -> b s ...")
         attn = self.attn(
             hidden_states,
@@ -227,11 +246,19 @@ class Qwen3_VisionBlock(nn.Module):
             sequence_lengths=sequence_lengths,
         )
         attn = rearrange(attn, "b s ... -> s b ...")
-        x += attn
-        norm2 = self.norm2(x)
-        mlp = self.mlp(norm2)
-        x += mlp
-        return x
+        # Second norm
+        if _use_fused_layernorm:
+            # Fused add + norm2 path (aiter)
+            norm2, x = self.norm2(attn, residual=residual)
+            mlp = self.mlp(norm2)
+            return mlp, x
+        else:
+            # Original path
+            x += attn
+            norm2 = self.norm2(x)
+            mlp = self.mlp(norm2)
+            x += mlp
+            return x
 
 
 class Qwen3VLMoeVisionPatchMerger(nn.Module):
@@ -280,11 +307,23 @@ class Qwen3VLMoeVisionPatchMerger(nn.Module):
             use_dp_attention_reduce=is_dp_attention_enabled(),
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, residual: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         if self.use_postshuffle_norm:
-            x = self.norm(x.view(-1, self.hidden_size))
+            if residual is not None:
+                x, _ = self.norm(
+                    x.view(-1, self.hidden_size),
+                    residual=residual.view(-1, self.hidden_size),
+                )
+            else:
+                x = self.norm(x.view(-1, self.hidden_size))
         else:
-            x = self.norm(x).view(-1, self.hidden_size)
+            if residual is not None:
+                x, _ = self.norm(x, residual=residual)
+                x = x.view(-1, self.hidden_size)
+            else:
+                x = self.norm(x).view(-1, self.hidden_size)
 
         x_parallel, _ = self.linear_fc1(x)
         x_parallel = self.act_fn(x_parallel)
@@ -334,7 +373,10 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
         else:
             self.pos_embed = PPMissingLayer()
 
-        norm_layer = partial(nn.LayerNorm, eps=norm_eps)
+        if _use_aiter:
+            norm_layer = partial(LayerNorm, eps=norm_eps)
+        else:
+            norm_layer = partial(nn.LayerNorm, eps=norm_eps)
         head_dim = self.hidden_size // self.num_heads
         self.rotary_pos_emb = get_rope(
             head_size=head_dim,
@@ -813,24 +855,27 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
         deepstack_feature_lists = []
         num_deepstack_captured = 0
+        residual = None
 
         for layer_num, blk in enumerate(self.blocks):
-            x = blk(
+            x, residual = blk(
                 x,
                 cu_seqlens=cu_seqlens,
                 rotary_pos_emb_cos=rotary_pos_emb_cos,
                 rotary_pos_emb_sin=rotary_pos_emb_sin,
                 max_seqlen=max_seqlen,
                 sequence_lengths=sequence_lengths,
+                residual=residual,
             )
 
             if layer_num in self.deepstack_visual_indexes:
                 deepstack_feature = self.deepstack_merger_list[num_deepstack_captured](
-                    x
+                    x,
+                    residual=residual,
                 )
                 deepstack_feature_lists.append(deepstack_feature)
                 num_deepstack_captured += 1
-        x = self.merger(x)
+        x = self.merger(x, residual=residual)
         hidden_states = torch.cat(
             [x] + deepstack_feature_lists, dim=1
         )  # [seq_len, hidden_size * (1 + depth_of_deepstack)]


### PR DESCRIPTION
## Motivation
Support Add & LayerNorm fused for Qwen3.5-Next VIT
before：
<img width="1201" height="148" alt="image" src="https://github.com/user-attachments/assets/64c307e7-500a-41ef-9313-4f8facec6bc8" />

after：
<img width="680" height="45" alt="image" src="https://github.com/user-attachments/assets/4741ff15-94fe-4cd7-8196-de561e2fd06c" />

## Modifications

**layernorm.py :**

- In LayerNorm.__init__: when _use_aiter is True, set _forward_method = self.forward_aiter
- In forward_native: added residual parameter support, implementing manual add + layernorm
- Added forward_aiter: uses layernorm2d_fwd_with_add kernel to implement fused add + layernorm
- forward_cuda, forward_npu, forward_cpu remain unchanged

**qwen3_vl.py :**

- In Qwen3_VisionBlock.__init__: when _use_aiter is True, use custom LayerNorm instead of nn.LayerNorm
- In Qwen3_VisionBlock.forward: use isinstance(self.norm1, LayerNorm) to check, aiter path uses fused residual, non-aiter path maintains original logic
- In Qwen3VLMoeVisionPatchMerger.forward: added residual parameter to support fused norm
- In Qwen3VLMoeVisionModel.__init__: norm_layer is selected based on _use_aiter
- In Qwen3VLMoeVisionModel.forward: track residual in the loop, pass to block, deepstack merger, and merger

## Accuracy Tests
**lauch server:**
```
model=/data/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/
TP=8
EP=1

export SGLANG_USE_AITER=1 

python3 -m sglang.launch_server \
    --model-path ${model} \
    --host localhost \
    --port 9000 \
    --tp-size ${TP} \
    --ep-size ${EP} \
    --trust-remote-code \
    --chunked-prefill-size 32768 \
    --mem-fraction-static 0.85 \
    --disable-radix-cache \
    --max-prefill-tokens 32768 \
    --cuda-graph-max-bs 128 \
    --max-running-requests 128 \
    --mm-attention-backend aiter_attn \
```
**test the accuracy:**
```
python3 /home/sglang/benchmark/mmmu/bench_sglang.py --port 9000 --concurrency 16
```
The result is:
```
Evaluating...
answers saved to: ./answer_sglang.json
{'Accounting': {'acc': 0.5, 'num': 30},
 'Agriculture': {'acc': 0.567, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.267, 'num': 30},
 'Art': {'acc': 0.767, 'num': 30},
 'Art_Theory': {'acc': 0.9, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.833, 'num': 30},
 'Biology': {'acc': 0.6, 'num': 30},
 'Chemistry': {'acc': 0.6, 'num': 30},
 'Clinical_Medicine': {'acc': 0.8, 'num': 30},
 'Computer_Science': {'acc': 0.567, 'num': 30},
 'Design': {'acc': 0.867, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.5, 'num': 30},
 'Economics': {'acc': 0.767, 'num': 30},
 'Electronics': {'acc': 0.4, 'num': 30},
 'Energy_and_Power': {'acc': 0.5, 'num': 30},
 'Finance': {'acc': 0.333, 'num': 30},
 'Geography': {'acc': 0.6, 'num': 30},
 'History': {'acc': 0.8, 'num': 30},
 'Literature': {'acc': 0.867, 'num': 30},
 'Manage': {'acc': 0.533, 'num': 30},
 'Marketing': {'acc': 0.567, 'num': 30},
 'Materials': {'acc': 0.4, 'num': 30},
 'Math': {'acc': 0.433, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.167, 'num': 30},
 'Music': {'acc': 0.4, 'num': 30},
 'Overall': {'acc': 0.613, 'num': 900},
 'Overall-Art and Design': {'acc': 0.733, 'num': 120},
 'Overall-Business': {'acc': 0.54, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.78, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.775, 'num': 120},
 'Overall-Science': {'acc': 0.58, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.41, 'num': 210},
 'Pharmacy': {'acc': 0.867, 'num': 30},
 'Physics': {'acc': 0.667, 'num': 30},
 'Psychology': {'acc': 0.7, 'num': 30},
 'Public_Health': {'acc': 0.9, 'num': 30},
 'Sociology': {'acc': 0.733, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.613
```
## Benchmarking and Profiling
Here is the script:
```
export SGLANG_USE_AITER=1
model=/data/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/

input_tokens=8000
output_tokens=500
max_concurrency=1
num_prompts=10
image_count=5
image_resolution=960x1280

python3 -m sglang.bench_serving \
    --backend sglang-oai-chat \
    --port 9000 \
    --dataset-name image \
    --num-prompts ${num_prompts} \
    --image-count ${image_count} \
    --image-resolution ${image_resolution} \
    --random-input-len ${input_tokens} \
    --random-output-len ${output_tokens} \
    --max-concurrency ${max_concurrency} \
    --random-range-ratio 1.0 \
```
The result is :
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     10        
Benchmark duration (s):                  97.36     
Total input tokens:                      144340    
Total input text tokens:                 84240     
Total input vision tokens:               60100     
Total generated tokens:                  5000      
Total generated tokens (retokenized):    2480      
Request throughput (req/s):              0.10      
Input token throughput (tok/s):          1482.55   
Output token throughput (tok/s):         51.36     
Peak output token throughput (tok/s):    76.00     
Peak concurrent requests:                2         
Total token throughput (tok/s):          1533.91   
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   9732.77   
Median E2E Latency (ms):                 9730.42   
P90 E2E Latency (ms):                    9823.73   
P99 E2E Latency (ms):                    9825.24   
---------------Time to First Token----------------
Mean TTFT (ms):                          3134.53   
Median TTFT (ms):                        3133.23   
P99 TTFT (ms):                           3227.76   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          13.22     
Median TPOT (ms):                        13.22     
P99 TPOT (ms):                           13.28     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           18.49     
Median ITL (ms):                         13.19     
P95 ITL (ms):                            39.50     
P99 ITL (ms):                            39.60     
Max ITL (ms):                            75.79     
==================================================
```
