### PR TITLE
Fix FP8 MoE NaN with DeepGEMM on Blackwell

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -807,7 +807,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 # For fp8 moe run with deepgemm, the expert weights and scales need be requantized to ue8m0
                 from sglang.srt.layers import deep_gemm_wrapper
                 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE
-                from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
                 from sglang.srt.layers.moe.utils import get_moe_a2a_backend
                 from sglang.srt.model_loader.utils import (
                     should_deepgemm_weight_requant_ue8m0,
@@ -819,7 +818,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 will_use_deepgemm = moe_runner_backend.is_deep_gemm()
                 if moe_runner_backend.is_auto():
                     will_use_deepgemm = deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and (
-                        get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake()
+                        get_moe_a2a_backend().is_deepep()
+                        or get_moe_a2a_backend().is_mooncake()
                     )
 
                 if (

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -565,7 +565,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             assert is_sm100_supported() or is_sm90_supported()
 
     @staticmethod
-    def is_deepgemm_enabled() -> bool:
+    def is_deepgemm_moe_runner_backend_enabled() -> bool:
         """Check if MoE will actually use DeepGEMM runner for FP8."""
         from sglang.srt.layers import deep_gemm_wrapper
         from sglang.srt.layers.moe.utils import get_moe_a2a_backend
@@ -826,7 +826,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 )
 
                 # Check if MoE will actually use DeepGEMM runner
-                will_use_deepgemm = self.is_deepgemm_enabled()
+                will_use_deepgemm = self.is_deepgemm_moe_runner_backend_enabled()
 
                 if (
                     should_deepgemm_weight_requant_ue8m0(
@@ -1127,7 +1127,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         moe_runner_backend = get_moe_runner_backend()
 
         if moe_runner_backend.is_auto():
-            if self.is_deepgemm_enabled():
+            if self.is_deepgemm_moe_runner_backend_enabled():
                 moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fix NaN issue in FP8 quantized MoE models (e.g., Qwen3-MoE) when using DeepGEMM on Blackwell GPUs. The root cause is that the UE8M0 scale requantization condition in process_weights_after_loading was not triggered correctly when MOE_RUNNER_BACKEND is AUTO but DeepGEMM is actually used (via --moe-a2a-backend deepep/mooncake).

## Modifications
Fixed DeepGEMM detection logic: Added logic in Fp8MoEMethod.process_weights_after_loading to accurately detect whether MoE will actually use DeepGEMM runner, mirroring the logic in create_moe_runner.

Extended MoE type support: Expanded UE8M0 requantization support from DeepEPMoE only to both DeepEPMoE and FusedMoE, as both need UE8M0 format scales when using DeepGEMM runner.

Key changes in python/sglang/srt/layers/quantization/fp8.py

## Accuracy Tests
Test scenario: Qwen3-MoE FP8 model on Blackwell GPU with --moe-a2a-backend deepep

Before fix:
<img width="3438" height="958" alt="image" src="https://github.com/user-attachments/assets/a1da3e8e-4fec-4aed-8bdf-a2a41e3b67cb" />

After fix:
<img width="3422" height="1234" alt="image" src="https://github.com/user-attachments/assets/cd52837a-c6e1-43a0-9d58-b611e41f971f" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
