### PR TITLE
[model-gateway]: Support engine workload-aware policy in router

### DIFF
--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -12,6 +12,7 @@ pub enum PolicyType {
     CacheAware,
     PowerOfTwo,
     Bucket,
+    WorkloadAware,
     Manual,
     ConsistentHashing,
     PrefixHash,
@@ -382,6 +383,7 @@ struct Router {
     enable_trace: bool,
     otlp_traces_endpoint: String,
     control_plane_auth: Option<PyControlPlaneAuthConfig>,
+    max_waiting_per_worker: usize,
 }
 
 impl Router {
@@ -426,6 +428,10 @@ impl Router {
                 PolicyType::PrefixHash => ConfigPolicyConfig::PrefixHash {
                     prefix_token_count: 256,
                     load_factor: 1.25,
+                },
+                PolicyType::WorkloadAware => ConfigPolicyConfig::WorkloadAware {
+                    num_waiting_reqs: self.max_waiting_per_worker,
+                    api_key: self.api_key.clone(),
                 },
             }
         };
@@ -662,6 +668,7 @@ impl Router {
         enable_trace = false,
         otlp_traces_endpoint = String::from("localhost:4317"),
         control_plane_auth = None,
+        max_waiting_per_worker = 10,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -745,6 +752,7 @@ impl Router {
         enable_trace: bool,
         otlp_traces_endpoint: String,
         control_plane_auth: Option<PyControlPlaneAuthConfig>,
+        max_waiting_per_worker: usize,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -842,6 +850,7 @@ impl Router {
             enable_trace,
             otlp_traces_endpoint,
             control_plane_auth,
+            max_waiting_per_worker,
         })
     }
 

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router.py
@@ -28,6 +28,7 @@ def policy_from_str(policy_str: Optional[str]) -> PolicyType:
         "manual": PolicyType.Manual,
         "consistent_hashing": PolicyType.ConsistentHashing,
         "prefix_hash": PolicyType.PrefixHash,
+        "workload_aware": PolicyType.WorkloadAware,
     }
     return policy_map[policy_str]
 

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
@@ -136,6 +136,8 @@ class RouterArgs:
     jwt_audience: Optional[str] = None
     jwt_jwks_uri: Optional[str] = None
     jwt_role_mapping: Dict[str, str] = dataclasses.field(default_factory=dict)
+    # Workload aware configuration
+    max_waiting_per_worker: int = 10
 
     @staticmethod
     def add_cli_args(
@@ -252,6 +254,7 @@ class RouterArgs:
                 "power_of_two",
                 "manual",
                 "bucket",
+                "workload_aware",
             ],
             help="Specific policy for prefill nodes in PD mode. If not specified, uses the main policy",
         )
@@ -777,6 +780,12 @@ class RouterArgs:
             type=str,
             default="localhost:4317",
             help="Config opentelemetry collector endpoint if --enable-trace is set. format: <ip>:<port>",
+        )
+        parser.add_argument(
+            f"--{prefix}max-waiting-per-worker",
+            type=int,
+            default=RouterArgs.max_waiting_per_worker,
+            help="Maximum number of waiting requests per worker for workload aware policy (default: 10)",
         )
 
         # Control plane authentication

--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -337,6 +337,14 @@ pub enum PolicyConfig {
         bucket_adjust_interval_secs: usize,
     },
 
+    #[serde(rename = "workload_aware")]
+    WorkloadAware {
+        /// Threshold for num_waiting_reqs - workers above this are considered busy
+        num_waiting_reqs: usize,
+        /// API key for authentication (optional)
+        api_key: Option<String>,
+    },
+
     /// Manual routing policy with sticky sessions using DashMap.
     /// - X-SMG-Routing-Key: Routes to a cached worker or assigns a new one
     /// - Provides true sticky sessions with zero key redistribution on worker add
@@ -403,6 +411,7 @@ impl PolicyConfig {
             PolicyConfig::Manual { .. } => "manual",
             PolicyConfig::ConsistentHashing => "consistent_hashing",
             PolicyConfig::PrefixHash { .. } => "prefix_hash",
+            PolicyConfig::WorkloadAware { .. } => "workload_aware",
         }
     }
 }

--- a/sgl-model-gateway/src/config/validation.rs
+++ b/sgl-model-gateway/src/config/validation.rs
@@ -151,6 +151,23 @@ impl ConfigValidator {
             | PolicyConfig::RoundRobin
             | PolicyConfig::Manual { .. }
             | PolicyConfig::ConsistentHashing => {}
+            PolicyConfig::WorkloadAware {
+                num_waiting_reqs,
+                api_key,
+            } => {
+                if *num_waiting_reqs == 0 {
+                    return Err(ConfigError::InvalidValue {
+                        field: "num_waiting_reqs".to_string(),
+                        value: num_waiting_reqs.to_string(),
+                        reason: "Must be > 0".to_string(),
+                    });
+                }
+                if api_key.is_none() {
+                    return Err(ConfigError::MissingRequired {
+                        field: "api_key".to_string(),
+                    });
+                }
+            },
             PolicyConfig::CacheAware {
                 cache_threshold,
                 balance_abs_threshold: _,

--- a/sgl-model-gateway/src/policies/mod.rs
+++ b/sgl-model-gateway/src/policies/mod.rs
@@ -19,6 +19,8 @@ mod registry;
 mod round_robin;
 pub mod tree;
 pub(crate) mod utils;
+mod workload_aware;
+
 pub use bucket::BucketPolicy;
 pub use cache_aware::CacheAwarePolicy;
 pub use consistent_hashing::ConsistentHashingPolicy;
@@ -30,6 +32,7 @@ pub use random::RandomPolicy;
 pub use registry::PolicyRegistry;
 pub use round_robin::RoundRobinPolicy;
 pub use tree::PrefixMatchResult;
+pub use workload_aware::WorkloadAwarePolicy;
 
 /// Core trait for load balancing policies
 ///
@@ -98,6 +101,21 @@ impl Default for CacheAwareConfig {
             balance_rel_threshold: 1.1,
             eviction_interval_secs: 30,
             max_tree_size: 10000,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkloadAwareConfig {
+    pub num_waiting_reqs: usize,
+    pub api_key: Option<String>,
+}
+
+impl Default for WorkloadAwareConfig {
+    fn default() -> Self {
+        Self {
+            num_waiting_reqs: 10,
+            api_key: None,
         }
     }
 }

--- a/sgl-model-gateway/src/policies/workload_aware.rs
+++ b/sgl-model-gateway/src/policies/workload_aware.rs
@@ -1,0 +1,328 @@
+//! Workload-aware load balancing policy
+//!
+//! This policy checks the waiting queue size (num_waiting_reqs) for each worker
+//! and filters out workers that exceed a threshold before selecting one.
+
+use std::{
+    collections::HashMap,
+    env,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use rand::Rng;
+use reqwest::Client;
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use super::{get_healthy_worker_indices, LoadBalancingPolicy, WorkloadAwareConfig, SelectWorkerInfo};
+use crate::core::Worker;
+
+/// Cache entry for worker waiting count
+#[derive(Clone, Debug)]
+struct WaitingCountCache {
+    num_waiting_reqs: usize,
+    last_check_time: Instant,
+}
+
+/// Workload-aware selection policy
+///
+/// Selects workers randomly among healthy workers that have num_waiting_reqs
+/// below the configured threshold. Workers with high waiting queue sizes are excluded.
+#[derive(Debug)]
+pub struct WorkloadAwarePolicy {
+    /// Threshold for num_waiting_reqs - workers above this are considered busy
+    num_waiting_reqs: usize,
+    /// Cache for worker waiting counts (URL -> cache entry)
+    /// Shared between main thread and background thread
+    waiting_count_cache: Arc<Mutex<HashMap<String, WaitingCountCache>>>,
+    /// Cache expiration threshold in seconds
+    cache_expiration_secs: f64,
+    /// Channel sender for triggering background async updates
+    update_sender: mpsc::UnboundedSender<String>,
+    /// Handle to the background thread
+    background_handle: Option<thread::JoinHandle<()>>,
+    /// Flag to signal the background thread to stop
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl WorkloadAwarePolicy {
+    /// Create a new WorkloadAwarePolicy with default threshold of 10
+    pub fn new() -> Self {
+        Self::with_config(WorkloadAwareConfig {
+            num_waiting_reqs: 10,
+            api_key: None,
+        })
+    }
+
+    /// Create a new WorkloadAwarePolicy with a custom threshold and optional API key
+    pub fn with_config(config: WorkloadAwareConfig) -> Self {
+        // Read cache expiration from environment variable, default to 1.0 seconds
+        let cache_expiration_secs = env::var("SGL_ROUTER_CHECK_WORKLOAD_AWARE_INTERVAL")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(1.0);
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("Failed to create workload aware HTTP client");
+
+        // Create channel for triggering background updates
+        let (tx, rx) = mpsc::unbounded_channel();
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+
+        // Create shared cache that will be used by both main thread and background thread
+        let waiting_count_cache = Arc::new(Mutex::new(HashMap::<String, WaitingCountCache>::new()));
+
+        // Clone necessary data for background thread
+        let client_clone = client.clone();
+        let api_key_clone = config.api_key.clone();
+        let cache_clone = Arc::clone(&waiting_count_cache);
+        let shutdown_clone = Arc::clone(&shutdown_flag);
+
+        // Start background thread with tokio runtime
+        let background_handle = thread::spawn(move || {
+            // Create a new tokio runtime for the background thread
+            let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+            rt.block_on(async move {
+                let mut rx: mpsc::UnboundedReceiver<String> = rx;
+                while !shutdown_clone.load(Ordering::Relaxed) {
+                    tokio::select! {
+                        // Wait for event to trigger update
+                        worker_url_opt = rx.recv() => {
+                            let worker_url_opt: Option<String> = worker_url_opt;
+                            if let Some(worker_url) = worker_url_opt {
+                                // Call async function to get num_waiting_reqs
+                                let load_url = format!("{}/get_load", worker_url);
+                                let mut request_builder = client_clone.get(&load_url);
+                                if let Some(ref api_key) = api_key_clone {
+                                    request_builder = request_builder.bearer_auth(api_key);
+                                }
+
+                                match request_builder.send().await {
+                                    Ok(response) if response.status().is_success() => {
+                                        if let Ok(json) = response.json::<Value>().await {
+                                            let num_waiting_reqs = if let Some(obj) = json.as_object() {
+                                                obj.get("num_waiting_reqs")
+                                                    .and_then(|v| v.as_u64())
+                                                    .map(|v| v as usize)
+                                            } else if let Some(array) = json.as_array() {
+                                                let sum: usize = array
+                                                    .iter()
+                                                    .filter_map(|entry| {
+                                                        entry
+                                                            .get("num_waiting_reqs")
+                                                            .and_then(|v| v.as_u64())
+                                                            .map(|v| v as usize)
+                                                    })
+                                                    .sum();
+                                                Some(sum)
+                                            } else {
+                                                None
+                                            };
+
+                                            if let Some(queue_size) = num_waiting_reqs {
+                                                let mut cache = cache_clone.lock().unwrap();
+                                                cache.insert(
+                                                    worker_url.clone(),
+                                                    WaitingCountCache {
+                                                        num_waiting_reqs: queue_size,
+                                                        last_check_time: Instant::now(),
+                                                    },
+                                                );
+                                                debug!(
+                                                    "Background thread updated cache for worker {}: num_waiting_reqs={}",
+                                                    worker_url, queue_size
+                                                );
+                                            }
+                                        }
+                                    }
+                                    Ok(response) => {
+                                        warn!(
+                                            "Background thread: get_load request to {} returned status: {}",
+                                            worker_url, response.status()
+                                        );
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "Background thread: Failed to call /get_load on {}: {}",
+                                            worker_url, e
+                                        );
+                                    }
+                                }
+                            } else {
+                                // Channel closed, exit loop
+                                break;
+                            }
+                        }
+                        // Check shutdown flag periodically
+                        _ = tokio::time::sleep(Duration::from_millis(100)) => {
+                            // Continue loop to check shutdown flag
+                        }
+                    }
+                }
+            });
+        });
+
+        Self {
+            num_waiting_reqs: config.num_waiting_reqs,
+            waiting_count_cache,
+            cache_expiration_secs,
+            update_sender: tx,
+            background_handle: Some(background_handle),
+            shutdown_flag,
+        }
+    }
+
+    /// Trigger background update for a worker
+    pub fn trigger_update(&self, worker_url: &str) {
+        if let Err(e) = self.update_sender.send(worker_url.to_string()) {
+            warn!("Failed to send update event for worker {}: {}", worker_url, e);
+        }
+    }
+
+    /// Query num_waiting_reqs from a worker's /get_load endpoint
+    /// Uses caching to avoid frequent API calls
+    fn get_num_waiting_reqs(&self, worker_url: &str) -> Option<usize> {
+        let now = Instant::now();
+        let cache = self.waiting_count_cache.lock().unwrap();
+        if let Some(cached) = cache.get(worker_url) {
+            let elapsed = now.duration_since(cached.last_check_time);
+            if elapsed.as_secs_f64() < self.cache_expiration_secs {
+                debug!(
+                    "Using cached num_waiting_reqs for {}: {} (cached {}ms ago)",
+                    worker_url,
+                    cached.num_waiting_reqs,
+                    elapsed.as_millis()
+                );
+            } else {
+                self.trigger_update(worker_url);
+            }
+            return Some(cached.num_waiting_reqs);
+        } else {
+            self.trigger_update(worker_url);
+            None
+        }
+    }
+}
+
+impl Default for WorkloadAwarePolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for WorkloadAwarePolicy {
+    fn drop(&mut self) {
+        // Signal shutdown
+        self.shutdown_flag.store(true, Ordering::Relaxed);
+        // Close the channel to wake up the background thread
+        drop(self.update_sender.clone());
+        // Wait for background thread to finish
+        if let Some(handle) = self.background_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl LoadBalancingPolicy for WorkloadAwarePolicy {
+    fn select_worker(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        _info: &SelectWorkerInfo
+    ) -> Option<usize> {
+        let healthy_indices = get_healthy_worker_indices(workers);
+
+        if healthy_indices.is_empty() {
+            return None;
+        }
+
+        // Filter workers by checking their num_waiting_reqs
+        let mut available_indices = Vec::new();
+        for &idx in &healthy_indices {
+            let worker = &workers[idx];
+            let worker_url = worker.url();
+
+            // Trigger background update for this worker
+            self.trigger_update(worker_url);
+
+            // Query num_waiting_reqs from the worker (may use cached value)
+            if let Some(num_waiting) = self.get_num_waiting_reqs(worker_url) {
+                if num_waiting <= self.num_waiting_reqs {
+                    available_indices.push(idx);
+                    debug!(
+                        "Worker {} has num_waiting_reqs={}, within threshold={}",
+                        worker_url, num_waiting, self.num_waiting_reqs
+                    );
+                } else {
+                    debug!(
+                        "Worker {} has num_waiting_reqs={}, exceeds threshold={}, skipping",
+                        worker_url, num_waiting, self.num_waiting_reqs
+                    );
+                }
+            } else {
+                // If we can't get load info, include the worker anyway (fail-open)
+                // This ensures we don't exclude all workers if monitoring fails
+                debug!(
+                    "Could not get load info for worker {}, including anyway",
+                    worker_url
+                );
+                available_indices.push(idx);
+            }
+        }
+
+        if available_indices.is_empty() {
+            warn!(
+                "No workers available after filtering by workload (threshold={})",
+                self.num_waiting_reqs
+            );
+            return None;
+        }
+
+        // Randomly select from available workers
+        let mut rng = rand::rng();
+        let random_idx = rng.random_range(0..available_indices.len());
+
+        Some(available_indices[random_idx])
+    }
+
+    fn name(&self) -> &'static str {
+        "workload_aware"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_workload_aware_creation() {
+        let policy = WorkloadAwarePolicy::new();
+        assert_eq!(policy.name(), "workload_aware");
+        assert_eq!(policy.num_waiting_reqs, 10);
+
+        let policy = WorkloadAwarePolicy::with_config(WorkloadAwareConfig {
+            num_waiting_reqs: 5,
+            api_key: None,
+        });
+        assert_eq!(policy.num_waiting_reqs, 5);
+    }
+
+    #[test]
+    fn test_workload_aware_with_api_key() {
+        let policy = WorkloadAwarePolicy::with_config(WorkloadAwareConfig {
+            num_waiting_reqs: 10,
+            api_key: Some("test_key".to_string()),
+        });
+        assert_eq!(policy.num_waiting_reqs, 10);
+    }
+}

--- a/sgl-model-gateway/src/routers/error.rs
+++ b/sgl-model-gateway/src/routers/error.rs
@@ -52,6 +52,10 @@ pub fn method_not_allowed(code: impl Into<String>, message: impl Into<String>) -
     create_error(StatusCode::METHOD_NOT_ALLOWED, code, message)
 }
 
+pub fn too_many_requests(code: impl Into<String>, message: impl Into<String>) -> Response {
+    create_error(StatusCode::TOO_MANY_REQUESTS, code, message)
+}
+
 pub fn create_error(
     status: StatusCode,
     code: impl Into<String>,

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -168,6 +168,12 @@ impl PDRouter {
 
     fn handle_server_selection_error(error: String) -> Response {
         error!("Failed to select PD pair error={}", error);
+        if error.contains("workload_aware") {
+            return error::too_many_requests(
+                "too_many_requests",
+                "limited by workload_aware policy",
+            );
+        }
         error::service_unavailable(
             "server_selection_failed",
             format!("No available servers: {}", error),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In real production environments, we try to handle as many requests as possible to achieve high system throughput. However, this easily leads to engine overload, causing request queuing, and degraded service quality. Additionally, the request length could also influence workload across engines. Without awareness of engine workload information, the gateway cannot accurately schedule requests to appropriate workers, often causing either engine overload or underload.

To address this, we propose workload-aware scheduling policy: during request scheduling, timely query the workload status of all workers, add low workloaded workers as candidates, avoid assigning requests to workers with over-workloaded. If all workers are overloaded, the request should be rejected with a 429 (TOO_MANY_REQUESTS) response.

## Modifications

Introduce a workload_aware policy option in the --policy parameter.
Add a --max-waiting-per-worker parameter (default: 10) to specify the maximum number of waiting requests each worker can accept.
For each scheduling decision, the model-gateway checks every worker's workload status, currently use waiting number as workload metrics.
If a worker’s reported waiting request count exceeds the --max-waiting-per-worker threshold, it is deemed overloaded and excluded from the candidate worker list.
If the candidate list is empty (i.e., all workers are overloaded), the gateway rejects the request and returns 429 (TOO_MANY_REQUESTS).

Take an example, the router launching command for PD disaggregation is as below:
```bash
sgl-model-gateway --host 0.0.0.0 --port 9100 --pd-disaggregation --prefill-policy workload_aware --max-waiting-per-worker 10 --decode-policy random --prefill http://10.1.3.4:30000 8998 --decode http://10.1.3.5:30000
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
