### PR TITLE
fix: correct page_table_size_1 shape documentation in fast_topk_transform_fused

### DIFF
--- a/sgl-kernel/python/sgl_kernel/top_k.py
+++ b/sgl-kernel/python/sgl_kernel/top_k.py
@@ -58,7 +58,7 @@ def fast_topk_transform_fused(
             between the query and the key whose layout is either ragged or paged.
             row_starts is only required when the key is ragged.
         lengths: The lengths tensor of shape (B)
-        page_table_size_1: The page table tensor of shape (Batch, topk)
+        page_table_size_1: The page table tensor of shape (Batch, L)
         cu_seqlens_q: The cumulative sequence lengths tensor of shape (Batch + 1)
         topk: The number of topk indices to get
         row_starts: The start index of each row in the score tensor of shape (B).


### PR DESCRIPTION
## Motivation

Fix documentation error in fast_topk_transform_fused function - correct page_table_size_1 shape from (Batch, topk) to (Batch, L).

## Modifications

Updated docstring only: changed page_table_size_1 parameter shape from (Batch, topk) to (Batch, L) in function documentation.

## Accuracy Tests

N/A - documentation-only change. All existing tests pass.

## Benchmarking and Profiling

N/A - no code logic changes, no performance impact.

## Checklist

- Update documentation (this PR fixes documentation)
- Other items N/A (documentation-only change)