### PR TITLE
fix: update AMD CI estimated time for test_torch_compile

### DIFF
--- a/test/registered/backends/test_torch_compile.py
+++ b/test/registered/backends/test_torch_compile.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=190, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=169, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=993, suite="stage-b-test-small-1-gpu")
 
 
 class TestTorchCompile(CustomTestCase):


### PR DESCRIPTION
## Summary

Followup to #16468

Update amd ci estimated time for `test/registered/backends/test_torch_compile.py` from 169 to 993 seconds to match observed runtime.

CI failure example: https://github.com/sgl-project/sglang/actions/runs/20771027013/job/59648073820?pr=16457#step:6:2600
