### PR TITLE
[DSv32] Overlap indexer weights_proj during dual_stream decode

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1666,6 +1666,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 
         q_lora = None
+        topk_indices = None
         if self.q_lora_rank is not None:
             q, latent_cache = (
                 get_attn_tp_context()
@@ -1722,8 +1723,39 @@ class DeepseekV2AttentionMLA(nn.Module):
             if self.use_nsa:
                 q_lora = q
 
-            k_nope = k_nope.unsqueeze(1)
-            q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+            # overlap q_b_proj and indexer during decode
+            if (
+                self.alt_stream is not None
+                and get_is_capture_mode()
+                and forward_batch.forward_mode.is_decode_or_idle()
+                and q_lora is not None
+            ):
+                current_stream = torch.cuda.current_stream()
+                self.alt_stream.wait_stream(current_stream)
+                with torch.cuda.stream(self.alt_stream):
+                    k_nope = k_nope.unsqueeze(1)
+                    q = self.q_b_proj(q)[0].view(
+                        -1, self.num_local_heads, self.qk_head_dim
+                    )
+                topk_indices = self.indexer(
+                    x=hidden_states,
+                    q_lora=q_lora,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                    layer_id=self.layer_id,
+                )
+                current_stream.wait_stream(self.alt_stream)
+            else:
+                k_nope = k_nope.unsqueeze(1)
+                q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+                if q_lora is not None:
+                    topk_indices = self.indexer(
+                        x=hidden_states,
+                        q_lora=q_lora,
+                        positions=positions,
+                        forward_batch=forward_batch,
+                        layer_id=self.layer_id,
+                    )
         else:
             q = self.q_proj(hidden_states)[0].view(
                 -1, self.num_local_heads, self.qk_head_dim
@@ -1817,15 +1849,6 @@ class DeepseekV2AttentionMLA(nn.Module):
             # support allgather+rerrange
             k_nope, k_pe = self.rebuild_cp_kv_cache(
                 latent_cache, forward_batch, k_nope, k_pe
-            )
-        topk_indices = None
-        if q_lora is not None:
-            topk_indices = self.indexer(
-                x=hidden_states,
-                q_lora=q_lora,
-                positions=positions,
-                forward_batch=forward_batch,
-                layer_id=self.layer_id,
             )
 
         return (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The weights_proj in the DSA indexer uses float type, which is slow on modern GPUs. Profiler traces show this accounts for ~20% of decode layer runtime. The traces also reveal that this projection typically uses a grid of (bs, 1, 1), utilizing very few SMs and creating an opportunity for inter-stream overlap.



## Modifications

In this optimization, we overlap the very slow weights_proj with q_b_proj, indexer _get_q_k_bf16, and indexer qk act_quant during dual_stream decode.

## Accuracy Tests
```
BEFORE 
{
  "server_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --enable-dp-attention --kv-cache-dtype bf16 --mem-fraction-static 0.8 --dp 8 --cuda-graph-max-bs 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
  "bench_accuracy_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' cd /sgl-workspace/sglang && python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 4096 --repeat 10 '",
  "benchmark_result": [
    "====================",
    "Repeat: 10, mean: 0.777",
    "Scores: ['0.788', '0.768', '0.808', '0.783', '0.788', '0.758', '0.747', '0.778', '0.778', '0.773']",
    "====================",
    "[METRIC] gpqa_mean_score=0.7767676767676768 labels={\"model\": \"deepseek-ai/DeepSeek-V3.2\", \"eval\": \"gpqa\", \"repeat\": 10}",
    "Writing report to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2.html",
    "{'chars': np.float64(3697.338383838384), 'chars:std': np.float64(2099.168857082937), 'score:std': np.float64(0.4190702026042221), 'scores': ['0.788', '0.768', '0.808', '0.783', '0.788', '0.758', '0.747', '0.778', '0.778', '0.773'], 'mean_score': np.float64(0.7767676767676768)}",
    "Writing results to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2.json"
  ]
}
AFTER
{
  "server_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' cd /sgl-workspace && rm -rf sglang && git clone -b zianglih/DSv32_overlap https://github.com/zianglih/sglang.git && cd sglang && pip install --upgrade pip && pip install -e \"python\" && python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --enable-dp-attention --kv-cache-dtype bf16 --mem-fraction-static 0.8 --dp 8 --cuda-graph-max-bs 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
  "bench_accuracy_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' cd /sgl-workspace && rm -rf sglang && git clone -b zianglih/DSv32_overlap https://github.com/zianglih/sglang.git && cd sglang && pip install --upgrade pip && pip install -e \"python\" && cd /sgl-workspace/sglang && python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 4096 --repeat 10 '",
  "benchmark_result": [
    "====================",
    "Repeat: 10, mean: 0.771",
    "Scores: ['0.737', '0.793', '0.783', '0.747', '0.763', '0.798', '0.753', '0.773', '0.793', '0.773']",
    "====================",
    "[METRIC] gpqa_mean_score=0.7712121212121212 labels={\"model\": \"deepseek-ai/DeepSeek-V3.2\", \"eval\": \"gpqa\", \"repeat\": 10}",
    "Writing report to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2.html",
    "{'chars': np.float64(3708.1464646464647), 'chars:std': np.float64(2132.345340292064), 'score:std': np.float64(0.4190702026042221), 'scores': ['0.737', '0.793', '0.783', '0.747', '0.763', '0.798', '0.753', '0.773', '0.793', '0.773'], 'mean_score': np.float64(0.7712121212121212)}",
    "Writing results to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2.json"
  ]
}
```
## Benchmarking and Profiling
<img width="3456" height="2158" alt="image" src="https://github.com/user-attachments/assets/3bce19ec-b0c5-4eee-b2ca-b35d18584966" />
<img width="1028" height="316" alt="image" src="https://github.com/user-attachments/assets/7a61f589-1038-46cc-824e-642ad7ace80d" />

```
1k/2k BEFORE
{
  "server_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --enable-dp-attention --kv-cache-dtype bf16 --mem-fraction-static 0.8 --dp 8 --cuda-graph-max-bs 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
  "bench_serving_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random --random-range-ratio 0.8 --num-prompts 256 --random-input 1024 --random-output 2048 --host 0.0.0.0 --port 30000 '",
  "benchmark_result": [
    "============ Serving Benchmark Result ============",
    "Backend:                                 sglang",
    "Traffic request rate:                    inf",
    "Max request concurrency:                 not set",
    "Successful requests:                     256",
    "Benchmark duration (s):                  85.95",
    "Total input tokens:                      235251",
    "Total input text tokens:                 235251",
    "Total input vision tokens:               0",
    "Total generated tokens:                  473977",
    "Total generated tokens (retokenized):    473807",
    "Request throughput (req/s):              2.98",
    "Input token throughput (tok/s):          2736.95",
    "Output token throughput (tok/s):         5514.33",
    "Peak output token throughput (tok/s):    6807.00",
    "Peak concurrent requests:                256",
    "Total token throughput (tok/s):          8251.28",
    "Concurrency:                             232.38",
    "----------------End-to-End Latency----------------",
    "Mean E2E Latency (ms):                   78024.30",
    "Median E2E Latency (ms):                 78047.66",
    "P90 E2E Latency (ms):                    84378.09",
    "P99 E2E Latency (ms):                    85878.01",
    "---------------Time to First Token----------------",
    "Mean TTFT (ms):                          4084.06",
    "Median TTFT (ms):                        4083.83",
    "P99 TTFT (ms):                           6333.84",
    "-----Time per Output Token (excl. 1st token)------",
    "Mean TPOT (ms):                          39.96",
    "Median TPOT (ms):                        39.96",
    "P99 TPOT (ms):                           41.53",
    "---------------Inter-Token Latency----------------",
    "Mean ITL (ms):                           39.96",
    "Median ITL (ms):                         38.43",
    "P95 ITL (ms):                            52.08",
    "P99 ITL (ms):                            61.16",
    "Max ITL (ms):                            5643.54",
    "=================================================="
  ]
}
1k/2k AFTER
{
  "server_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' cd /sgl-workspace && rm -rf sglang && git clone -b zianglih/DSv32_overlap https://github.com/zianglih/sglang.git && cd sglang && pip install --upgrade pip && pip install -e \"python\" && python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --enable-dp-attention --kv-cache-dtype bf16 --mem-fraction-static 0.8 --dp 8 --cuda-graph-max-bs 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
  "bench_serving_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random --random-range-ratio 0.8 --num-prompts 256 --random-input 1024 --random-output 2048 --host 0.0.0.0 --port 30000 '",
  "benchmark_result": [
    "============ Serving Benchmark Result ============",
    "Backend:                                 sglang",
    "Traffic request rate:                    inf",
    "Max request concurrency:                 not set",
    "Successful requests:                     256",
    "Benchmark duration (s):                  82.53",
    "Total input tokens:                      235251",
    "Total input text tokens:                 235251",
    "Total input vision tokens:               0",
    "Total generated tokens:                  473977",
    "Total generated tokens (retokenized):    473750",
    "Request throughput (req/s):              3.10",
    "Input token throughput (tok/s):          2850.66",
    "Output token throughput (tok/s):         5743.42",
    "Peak output token throughput (tok/s):    7168.00",
    "Peak concurrent requests:                256",
    "Total token throughput (tok/s):          8594.08",
    "Concurrency:                             231.91",
    "----------------End-to-End Latency----------------",
    "Mean E2E Latency (ms):                   74760.71",
    "Median E2E Latency (ms):                 74710.94",
    "P90 E2E Latency (ms):                    80995.56",
    "P99 E2E Latency (ms):                    82450.48",
    "---------------Time to First Token----------------",
    "Mean TTFT (ms):                          4001.88",
    "Median TTFT (ms):                        4025.09",
    "P99 TTFT (ms):                           6228.64",
    "-----Time per Output Token (excl. 1st token)------",
    "Mean TPOT (ms):                          38.24",
    "Median TPOT (ms):                        38.26",
    "P99 TPOT (ms):                           39.78",
    "---------------Inter-Token Latency----------------",
    "Mean ITL (ms):                           38.24",
    "Median ITL (ms):                         36.74",
    "P95 ITL (ms):                            52.39",
    "P99 ITL (ms):                            65.52",
    "Max ITL (ms):                            5586.01",
    "=================================================="
  ]
}
```
```
8k/2k BEFORE
{
  "server_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --enable-dp-attention --kv-cache-dtype bf16 --mem-fraction-static 0.8 --dp 8 --cuda-graph-max-bs 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
  "bench_serving_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random --random-range-ratio 0.8 --num-prompts 256 --random-input 8192 --random-output 2048 --host 0.0.0.0 --port 30000 '",
  "benchmark_result": [
    "============ Serving Benchmark Result ============",
    "Backend:                                 sglang",
    "Traffic request rate:                    inf",
    "Max request concurrency:                 not set",
    "Successful requests:                     256",
    "Benchmark duration (s):                  132.50",
    "Total input tokens:                      1900585",
    "Total input text tokens:                 1900585",
    "Total input vision tokens:               0",
    "Total generated tokens:                  473587",
    "Total generated tokens (retokenized):    473578",
    "Request throughput (req/s):              1.93",
    "Input token throughput (tok/s):          14344.10",
    "Output token throughput (tok/s):         3574.26",
    "Peak output token throughput (tok/s):    6784.00",
    "Peak concurrent requests:                256",
    "Total token throughput (tok/s):          17918.36",
    "Concurrency:                             240.61",
    "----------------End-to-End Latency----------------",
    "Mean E2E Latency (ms):                   124536.19",
    "Median E2E Latency (ms):                 124556.93",
    "P90 E2E Latency (ms):                    130819.25",
    "P99 E2E Latency (ms):                    132421.32",
    "---------------Time to First Token----------------",
    "Mean TTFT (ms):                          27678.59",
    "Median TTFT (ms):                        27763.26",
    "P99 TTFT (ms):                           52400.84",
    "-----Time per Output Token (excl. 1st token)------",
    "Mean TPOT (ms):                          52.43",
    "Median TPOT (ms):                        52.39",
    "P99 TPOT (ms):                           66.58",
    "---------------Inter-Token Latency----------------",
    "Mean ITL (ms):                           52.39",
    "Median ITL (ms):                         38.38",
    "P95 ITL (ms):                            52.47",
    "P99 ITL (ms):                            61.65",
    "Max ITL (ms):                            50119.64",
    "=================================================="
  ]
}
8k/2k AFTER
{
  "server_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --enable-dp-attention --kv-cache-dtype bf16 --mem-fraction-static 0.8 --dp 8 --cuda-graph-max-bs 256 --trust-remote-code --host 0.0.0.0 --port 30000'",
  "bench_serving_command": "docker run --rm --ipc=host --network=host --privileged --shm-size 256G -e DO_NOT_TRACK=1 -e SGLANG_DG_CACHE_DIR=/data/.cache/deep_gemm --gpus all -v $HOME/dockerx:/dockerx -v /data:/data -v /data/.cache/huggingface:/root/.cache/huggingface -v /data/.cache:/root/.cache -p 30000:30000 lmsysorg/sglang:dev bash -c ' python3 -m sglang.bench_serving --warmup-requests 1 --backend sglang --dataset-name random --random-range-ratio 0.8 --num-prompts 256 --random-input 1024 --random-output 2048 --host 0.0.0.0 --port 30000 '",
  "benchmark_result": [
    "============ Serving Benchmark Result ============",
    "Backend:                                 sglang",
    "Traffic request rate:                    inf",
    "Max request concurrency:                 not set",
    "Successful requests:                     256",
    "Benchmark duration (s):                  85.95",
    "Total input tokens:                      235251",
    "Total input text tokens:                 235251",
    "Total input vision tokens:               0",
    "Total generated tokens:                  473977",
    "Total generated tokens (retokenized):    473807",
    "Request throughput (req/s):              2.98",
    "Input token throughput (tok/s):          2736.95",
    "Output token throughput (tok/s):         5514.33",
    "Peak output token throughput (tok/s):    6807.00",
    "Peak concurrent requests:                256",
    "Total token throughput (tok/s):          8251.28",
    "Concurrency:                             232.38",
    "----------------End-to-End Latency----------------",
    "Mean E2E Latency (ms):                   78024.30",
    "Median E2E Latency (ms):                 78047.66",
    "P90 E2E Latency (ms):                    84378.09",
    "P99 E2E Latency (ms):                    85878.01",
    "---------------Time to First Token----------------",
    "Mean TTFT (ms):                          4084.06",
    "Median TTFT (ms):                        4083.83",
    "P99 TTFT (ms):                           6333.84",
    "-----Time per Output Token (excl. 1st token)------",
    "Mean TPOT (ms):                          39.96",
    "Median TPOT (ms):                        39.96",
    "P99 TPOT (ms):                           41.53",
    "---------------Inter-Token Latency----------------",
    "Mean ITL (ms):                           39.96",
    "Median ITL (ms):                         38.43",
    "P95 ITL (ms):                            52.08",
    "P99 ITL (ms):                            61.16",
    "Max ITL (ms):                            5643.54",
    "=================================================="
  ]
}


```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
