### PR TITLE
Add Soft Fp8 Support for Atlas A2/A3 NPU

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -192,7 +192,9 @@ def forward_mla_prepare_npu(
         k_pe = latent_cache[..., m.kv_lora_rank :].unsqueeze(1)
 
         if m.w_kc.dtype == torch.uint8:
-            q_nope_out = torch.ops.npu.fp8_w8a16_batch_matmul(q_nope.transpose(0, 1).contiguous(), m.w_kc, m.w_scale_k, "bf16")
+            q_nope_out = torch.ops.npu.fp8_w8a16_batch_matmul(
+                q_nope.transpose(0, 1).contiguous(), m.w_kc, m.w_scale_k, "bf16"
+            )
         else:
             q_nope_out = torch.bmm(q_nope.transpose(0, 1), m.w_kc)
 
@@ -254,7 +256,9 @@ def forward_mla_core_npu(
     attn_output = attn_output.view(-1, m.num_local_heads, m.kv_lora_rank)
 
     if m.w_vc.dtype == torch.uint8:
-        attn_bmm_output = torch.ops.npu.fp8_w8a16_batch_matmul(attn_output.transpose(0, 1).contiguous(), m.w_vc, m.w_scale_v, "bf16")
+        attn_bmm_output = torch.ops.npu.fp8_w8a16_batch_matmul(
+            attn_output.transpose(0, 1).contiguous(), m.w_vc, m.w_scale_v, "bf16"
+        )
         attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
     else:
         attn_bmm_output = torch.empty(

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -371,6 +371,12 @@ class DeepEPMoE(FusedMoE):
                 hidden_states = npu_fused_moe_without_routing_weights_bf16(
                     self, hidden_states, group_list_type, group_list, output_dtype
                 )
+            elif self.w13_weight.dtype == torch.uint8:
+                hidden_states = self.quant_method.apply_without_routing_weights(
+                    self,
+                    hidden_states,
+                    group_list,
+                )
             else:
                 input_quant = get_bool_env_var("DEEP_NORMAL_MODE_USE_INT8_QUANT")
                 if not input_quant and not isinstance(
@@ -404,6 +410,12 @@ class DeepEPMoE(FusedMoE):
             if self.w13_weight.dtype == torch.bfloat16:
                 hidden_states = npu_fused_moe_without_routing_weights_bf16(
                     self, hidden_states, group_list_type, group_list, output_dtype
+                )
+            elif self.w13_weight.dtype == torch.uint8:
+                hidden_states = self.quant_method.apply_without_routing_weights(
+                    self,
+                    hidden_states,
+                    group_list,
                 )
             else:
                 hidden_states = self.quant_method.apply_without_routing_weights(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -100,8 +100,8 @@ if _use_aiter or _use_hip_int4:
     from aiter.ops.shuffle import shuffle_weight
 
 if _is_npu:
-    import torch_npu  # noqa: F401
     import sgl_kernel_npu  # noqa: F401
+    import torch_npu  # noqa: F401
 
 
 ACTIVATION_SCHEMES = ["static", "dynamic"]

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1150,7 +1150,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             # TODO(cwan): refactor other backends
             pass
 
-
     # fusedmoe
     def npu_fused_experts_fp8(
         self,
@@ -1219,7 +1218,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if len(original_shape) == 3:
             final_hidden_states = final_hidden_states.view(original_shape)
         return final_hidden_states
-
 
     # deepep
     def apply_without_routing_weights(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -100,8 +100,8 @@ if _use_aiter or _use_hip_int4:
     from aiter.ops.shuffle import shuffle_weight
 
 if _is_npu:
-    import torch_npu # noqa: F401
-    import sgl_kernel_npu # noqa: F401
+    import torch_npu  # noqa: F401
+    import sgl_kernel_npu  # noqa: F401
 
 
 ACTIVATION_SCHEMES = ["static", "dynamic"]

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -100,8 +100,8 @@ if _use_aiter or _use_hip_int4:
     from aiter.ops.shuffle import shuffle_weight
 
 if _is_npu:
-    import torch_npu
-    import sgl_kernel_npu
+    import torch_npu # noqa: F401
+    import sgl_kernel_npu # noqa: F401
 
 
 ACTIVATION_SCHEMES = ["static", "dynamic"]

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -76,6 +76,7 @@ if _is_cuda:
         N = mat_b.shape[-1]
         return mat_a.new_empty((M, N), dtype=out_dtype)
 
+
 if _is_npu:
     import torch_npu
     import sgl_kernel_npu
@@ -1183,7 +1184,9 @@ def soft_fp8_blockfp8_matmul_npu(
     input_scale: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    assert input_scale is None, "input_scale is not supported for soft_fp8_blockfp8_matmul_npu"
+    assert (
+        input_scale is None
+    ), "input_scale is not supported for soft_fp8_blockfp8_matmul_npu"
     assert bias is None, "bias is not supported for soft_fp8_blockfp8_matmul_npu"
     output = torch.ops.npu.fp8_w8a16_matmul(input, weight, weight_scale, "bf16")
     return output

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -78,8 +78,8 @@ if _is_cuda:
 
 
 if _is_npu:
-    import torch_npu
-    import sgl_kernel_npu
+    import torch_npu # noqa: F401
+    import sgl_kernel_npu # noqa: F401
 
 
 use_vllm_cutlass_w8a8_fp8_kernel = get_bool_env_var("USE_VLLM_CUTLASS_W8A8_FP8_KERNEL")

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -78,8 +78,8 @@ if _is_cuda:
 
 
 if _is_npu:
-    import torch_npu # noqa: F401
-    import sgl_kernel_npu # noqa: F401
+    import torch_npu  # noqa: F401
+    import sgl_kernel_npu  # noqa: F401
 
 
 use_vllm_cutlass_w8a8_fp8_kernel = get_bool_env_var("USE_VLLM_CUTLASS_W8A8_FP8_KERNEL")

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -78,8 +78,8 @@ if _is_cuda:
 
 
 if _is_npu:
-    import torch_npu  # noqa: F401
     import sgl_kernel_npu  # noqa: F401
+    import torch_npu  # noqa: F401
 
 
 use_vllm_cutlass_w8a8_fp8_kernel = get_bool_env_var("USE_VLLM_CUTLASS_W8A8_FP8_KERNEL")

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -76,7 +76,7 @@ if _is_cuda:
         N = mat_b.shape[-1]
         return mat_a.new_empty((M, N), dtype=out_dtype)
 
-if _is_npu: 
+if _is_npu:
     import torch_npu
     import sgl_kernel_npu
 
@@ -1183,6 +1183,8 @@ def soft_fp8_blockfp8_matmul_npu(
     input_scale: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    assert input_scale is None, "input_scale is not supported for soft_fp8_blockfp8_matmul_npu"
+    assert bias is None, "bias is not supported for soft_fp8_blockfp8_matmul_npu"
     output = torch.ops.npu.fp8_w8a16_matmul(input, weight, weight_scale, "bf16")
     return output
 
@@ -1193,5 +1195,7 @@ def soft_fp8_blockfp8_gmm_npu(
     weight_scale: torch.Tensor,
     group_list: torch.Tensor,
 ) -> torch.Tensor:
-    output = torch.ops.npu.fp8_w8a16_grouped_matmul(input, weight, weight_scale, group_list, "bf16")
+    output = torch.ops.npu.fp8_w8a16_grouped_matmul(
+        input, weight, weight_scale, group_list, "bf16"
+    )
     return output

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3607,7 +3607,9 @@ class DeepseekV2ForCausalLM(nn.Module):
                 self_attn.w_kc = bind_or_assign(
                     self_attn.w_kc, w_kc.view(torch.uint8).contiguous()
                 )
-                self_attn.w_vc = bind_or_assign(self_attn.w_vc, w_vc.view(torch.uint8).transpose(1, 2).contiguous())
+                self_attn.w_vc = bind_or_assign(
+                    self_attn.w_vc, w_vc.view(torch.uint8).transpose(1, 2).contiguous()
+                )
             elif not use_deep_gemm_bmm:
                 self_attn.w_kc = bind_or_assign(
                     self_attn.w_kc, w_kc.transpose(1, 2).contiguous().transpose(1, 2)


### PR DESCRIPTION
## Motivation

This PR adds soft FP8 (W8A16) support on Ascend Atlas A2/A3 NPU so that FP8 checkpoints can run without requiring native FP8 compute.

On Ascend Atlas A2/A3 NPUs, native FP8 GEMM is unavailable. Running FP8 checkpoints on Atlas A2/A3 often requires dequantizing weights to BF16 or re-quantizing to INT8. This PR provides an NPU-only fallback path that keeps FP8 weights in a compact uint8 representation and uses block-wise scales (e.g., 128×128) to dequantize weights from FP8
/ to BF16 and run BF16 matmuls, producing BF16 outputs via NPU custom ops. It enables running FP8 models such as DeepSeek-R1 and Qwen3-MoE-30B-A3B on NPU (as validated on this branch).

## Modifications

- Add NPU soft-fp8 matmul backend dispatch and wrappers
- NPU MoE execution path (FP8 weights) in FP8 quantization runtime
- DeepSeekV2 MLA attention path: batch matmul for soft-fp8 projections on NPU
- DeepSeekV2 weight post-processing for NPU soft-fp8
- DeepEP / EP-MoE layer support for uint8 expert weights on NPU

## Accuracy Tests

GSM8K (first 200 questions) using deepseekR1 on NPU:
(TP16 + DeepEP + Graph)
- Accuracy: 0.98
- Invalid: 0.0

GSM8K (first 200 questions) using deepseekR1 on NVIDIA H20:
(TP8 + DeepEP + Graph)
- Accuracy: 0.985
- Invalid: 0.0

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.