### PR TITLE
Tiny fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@
 
 --------------------------------------------------------------------------------
 
-| [**Blog**](https://lmsys.org/blog/)
-| [**Documentation**](https://docs.sglang.io/)
-| [**Roadmap**](https://roadmap.sglang.io/)
-| [**Join Slack**](https://slack.sglang.io/)
-| [**Weekly Dev Meeting**](https://meet.sglang.io/)
-| [**Slides**](https://github.com/sgl-project/sgl-learning-materials?tab=readme-ov-file#slides) |
+<p align="center">
+<a href="https://lmsys.org/blog/"><b>Blog</b></a> |
+<a href="https://docs.sglang.io/"><b>Documentation</b></a> |
+<a href="https://roadmap.sglang.io/"><b>Roadmap</b></a> |
+<a href="https://slack.sglang.io/"><b>Join Slack</b></a> |
+<a href="https://meet.sglang.io/"><b>Weekly Dev Meeting</b></a> |
+<a href="https://github.com/sgl-project/sgl-learning-materials?tab=readme-ov-file#slides"><b>Slides</b></a>
+</p>
 
 ## News
 - [2025/12] SGLang provides day-0 support for latest open models ([MiMo-V2-Flash](https://lmsys.org/blog/2025-12-16-mimo-v2-flash/), [Nemotron 3 Nano](https://lmsys.org/blog/2025-12-15-run-nvidia-nemotron-3-nano/), [Mistral Large 3](https://github.com/sgl-project/sglang/pull/14213), [LLaDA 2.0 Diffusion LLM](https://lmsys.org/blog/2025-12-19-diffusion-llm/), [MiniMax M2](https://lmsys.org/blog/2025-11-04-miminmax-m2/)).


### PR DESCRIPTION
This PR updates the link section near the top of README.md (Blog / Documentation / Roadmap / Slack / Weekly Dev Meeting / Slides) to be center-aligned for better visual presentation.

before:

<img width="824" height="313" alt="170cb2e5-892b-4f94-b078-b3582971add9" src="https://github.com/user-attachments/assets/2cd1b5cf-41c4-4daf-868c-8ccc9a80cd60" />

after:

<img width="827" height="312" alt="3603c6dc-5f8a-4c6a-b815-3640306d55cf" src="https://github.com/user-attachments/assets/e7ef11a1-7f55-4c6e-9f24-9541c543f4ee" />

