### PR TITLE
fix: 8-gpu-b200 increase timeout length

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -386,7 +386,7 @@ jobs:
 
       - name: Run common 8-GPU model tests
         if: always()
-        timeout-minutes: 200
+        timeout-minutes: 300
         env:
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}


### PR DESCRIPTION
## Motivation

**TLDR: Timeout is too tight for Dpsk v32, so relaxing the total suite timeout limit to 300 should give plenty of room for variance.**

The B200 nightly 8-GPU tests sometimes times out due to insufficient time budget. Analysis of CI logs shows the timeout is a structural problem, not a flaky test.

**Failed run:** https://github.com/sgl-project/sglang/actions/runs/20766554118/job/59647300496
**Successful run:** https://github.com/sgl-project/sglang/actions/runs/20733676806/job/59627365421

### Test Duration Analysis

**Failed B200 Run (timed out but was running without error):**

| Test | Duration |
|------|----------|
| test_deepseek_v31.py | 22 min |
| test_qwen3_235b.py | 15 min |
| test_minimax_m2.py | 10 min |
| test_mistral_large3.py | 22 min |
| test_kimi_k2.py | 23 min |
| test_glm_46.py | 20 min |
| test_glm_46_fp8.py | 24 min |
| **Subtotal** | **~136 min** |
| test_deepseek_v32.py | started, then **timed out** |

**B200 Run (no timeout):**

| Test | Duration |
|------|----------|
| test_deepseek_v31.py | 23 min |
| test_deepseek_v32.py | **62 min** |
| test_glm_46.py | 11 min |
| test_glm_46_fp8.py | 13 min |
| test_kimi_k2.py | 17 min |
| test_minimax_m2.py | 6 min |
| test_mistral_large3.py | 15 min |
| test_qwen3_235b.py | 8 min |
| **Total** | **~155 min** |

Dpsk v32 usually takes 60 minutes (+/- some variation). With a 200 minute timeout, if the other tests take more than 120 minutes, this puts too much pressure for Dpsk v32 to complete within an hour. 

## Modifications

Increase B200 8-GPU common tests timeout from 200 → 300 minutes.

## Accuracy Tests

n/a

## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
