### PR TITLE
[diffusion] Enable Cache‑DiT config for diffusers backend

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -96,7 +96,7 @@ diffusion = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer",
-  "cache-dit==1.1.8"
+  "cache-dit==1.2.0"
 ]
 
 tracing = [

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -463,7 +463,9 @@ class SamplingParams:
                 # Re-raise if it's not a safetensors file issue
                 raise
 
-        user_sampling_params = SamplingParams(*args, **kwargs)
+        user_kwargs = dict(kwargs)
+        user_kwargs.pop("diffusers_kwargs", None)
+        user_sampling_params = SamplingParams(*args, **user_kwargs)
         # TODO: refactor
         sampling_params._merge_with_user_params(user_sampling_params)
         sampling_params._adjust(server_args)

--- a/python/sglang/multimodal_gen/docs/attention_backends.md
+++ b/python/sglang/multimodal_gen/docs/attention_backends.md
@@ -8,13 +8,16 @@ Attention backends are defined by `AttentionBackendEnum` (`sglang.multimodal_gen
 
 Backend selection is performed by the shared attention layers (e.g. `LocalAttention` / `USPAttention` / `UlyssesAttention` in `sglang.multimodal_gen.runtime.layers.attention.layer`) and therefore applies to any model component using these layers (e.g. diffusion transformer / DiT and encoders).
 
+When using the diffusers backend, `--attention-backend` is passed through to diffusers'
+`set_attention_backend` (e.g., `flash`, `_flash_3_hub`, `sage`, `xformers`, `native`).
+
 - **CUDA**: prefers FlashAttention (FA3/FA4) when supported; otherwise falls back to PyTorch SDPA.
 - **ROCm**: uses FlashAttention when available; otherwise falls back to PyTorch SDPA.
 - **MPS**: always uses PyTorch SDPA.
 
 ## Backend options
 
-The CLI accepts the lowercase names of `AttentionBackendEnum`. The table below lists the backends implemented by the built-in platforms. `fa3`/`fa4` are accepted as aliases for `fa`.
+For SGLang-native pipelines, the CLI accepts the lowercase names of `AttentionBackendEnum`. The table below lists the backends implemented by the built-in platforms. `fa3`/`fa4` are accepted as aliases for `fa`.
 
 | CLI value | Enum value | Notes |
 |---|---|---|

--- a/python/sglang/multimodal_gen/docs/cache/cache_dit.md
+++ b/python/sglang/multimodal_gen/docs/cache/cache_dit.md
@@ -24,39 +24,6 @@ sglang generate --model-path Qwen/Qwen-Image \
     --prompt "A beautiful sunset over the mountains"
 ```
 
-## Diffusers Backend
-
-To enable Cache-DiT for the diffusers backend, pass a cache-dit config file:
-
-```bash
-sglang generate --model-path Qwen/Qwen-Image \
-    --backend diffusers \
-    --cache-dit-config ./cache_dit_config.yaml \
-    --prompt "A curious raccoon"
-```
-
-Cache-DiT accepts its native config format. SGLang also supports a nested layout
-with `cache_config` and `parallelism_config`:
-
-```yaml
-cache_config:
-  cache_type: DBCache
-  Fn_compute_blocks: 1
-  Bn_compute_blocks: 0
-  max_warmup_steps: 8
-  warmup_interval: 2
-  max_cached_steps: -1
-  max_continuous_cached_steps: 2
-  residual_diff_threshold: 0.12
-  enable_taylorseer: true
-  taylorseer_order: 1
-parallelism_config:
-  ulysses_size: 4
-  parallel_kwargs:
-    attention_backend: native
-    extra_parallel_modules: ["text_encoder", "vae"]
-```
-
 ## Advanced Configuration
 
 ### DBCache Parameters

--- a/python/sglang/multimodal_gen/docs/cache/cache_dit.md
+++ b/python/sglang/multimodal_gen/docs/cache/cache_dit.md
@@ -152,7 +152,7 @@ SGLang Diffusion x Cache-DiT supports almost all models originally supported in 
 ## Limitations
 
 - **SGLang-native pipelines**: Distributed support (TP/SP) is not yet validated; Cache-DiT will be automatically
-  disabled when `world_size > 1`. The diffusers backend uses cache-dit's native parallelism when configured.
+  disabled when `world_size > 1`.
 - **SCM minimum steps**: SCM requires >= 8 inference steps to be effective
 - **Model support**: Only models registered in Cache-DiT's BlockAdapterRegister are supported
 

--- a/python/sglang/multimodal_gen/docs/cache/cache_dit.md
+++ b/python/sglang/multimodal_gen/docs/cache/cache_dit.md
@@ -24,6 +24,39 @@ sglang generate --model-path Qwen/Qwen-Image \
     --prompt "A beautiful sunset over the mountains"
 ```
 
+## Diffusers Backend
+
+To enable Cache-DiT for the diffusers backend, pass a cache-dit config file:
+
+```bash
+sglang generate --model-path Qwen/Qwen-Image \
+    --backend diffusers \
+    --cache-dit-config ./cache_dit_config.yaml \
+    --prompt "A curious raccoon"
+```
+
+Cache-DiT accepts its native config format. SGLang also supports a nested layout
+with `cache_config` and `parallelism_config`:
+
+```yaml
+cache_config:
+  cache_type: DBCache
+  Fn_compute_blocks: 1
+  Bn_compute_blocks: 0
+  max_warmup_steps: 8
+  warmup_interval: 2
+  max_cached_steps: -1
+  max_continuous_cached_steps: 2
+  residual_diff_threshold: 0.12
+  enable_taylorseer: true
+  taylorseer_order: 1
+parallelism_config:
+  ulysses_size: 4
+  parallel_kwargs:
+    attention_backend: native
+    extra_parallel_modules: ["text_encoder", "vae"]
+```
+
 ## Advanced Configuration
 
 ### DBCache Parameters
@@ -151,8 +184,8 @@ SGLang Diffusion x Cache-DiT supports almost all models originally supported in 
 
 ## Limitations
 
-- **Single GPU only**: Distributed support (TP/SP) is not yet validated; Cache-DiT will be automatically disabled when
-  `world_size > 1`
+- **SGLang-native pipelines**: Distributed support (TP/SP) is not yet validated; Cache-DiT will be automatically
+  disabled when `world_size > 1`. The diffusers backend uses cache-dit's native parallelism when configured.
 - **SCM minimum steps**: SCM requires >= 8 inference steps to be effective
 - **Model support**: Only models registered in Cache-DiT's BlockAdapterRegister are supported
 

--- a/python/sglang/multimodal_gen/docs/cache/cache_dit.md
+++ b/python/sglang/multimodal_gen/docs/cache/cache_dit.md
@@ -24,6 +24,72 @@ sglang generate --model-path Qwen/Qwen-Image \
     --prompt "A beautiful sunset over the mountains"
 ```
 
+## Diffusers Backend Configuration
+
+Cache-DiT supports loading acceleration configs from a custom YAML file. For
+diffusers pipelines, pass the YAML/JSON path via `--cache-dit-config`. This
+flow requires cache-dit >= 1.2.0 (`cache_dit.load_configs`).
+
+### Single GPU inference
+
+Define a `config.yaml` file that contains:
+
+```yaml
+cache_config:
+  max_warmup_steps: 8
+  warmup_interval: 2
+  max_cached_steps: -1
+  max_continuous_cached_steps: 2
+  Fn_compute_blocks: 1
+  Bn_compute_blocks: 0
+  residual_diff_threshold: 0.12
+  enable_taylorseer: true
+  taylorseer_order: 1
+```
+
+Then apply the config with:
+
+```bash
+sglang generate --backend diffusers \
+  --model-path Qwen/Qwen-Image \
+  --cache-dit-config config.yaml \
+  --prompt "A beautiful sunset over the mountains"
+```
+
+### Distributed inference
+
+Define a `parallel_config.yaml` file that contains:
+
+```yaml
+cache_config:
+  max_warmup_steps: 8
+  warmup_interval: 2
+  max_cached_steps: -1
+  max_continuous_cached_steps: 2
+  Fn_compute_blocks: 1
+  Bn_compute_blocks: 0
+  residual_diff_threshold: 0.12
+  enable_taylorseer: true
+  taylorseer_order: 1
+parallelism_config:
+  ulysses_size: auto
+  parallel_kwargs:
+    attention_backend: native
+    extra_parallel_modules: ["text_encoder", "vae"]
+```
+
+`ulysses_size: auto` means cache-dit will auto-detect the world_size. Otherwise,
+set it to a specific integer (e.g., `4`).
+
+Then apply the distributed config with:
+
+```bash
+sglang generate --backend diffusers \
+  --model-path Qwen/Qwen-Image \
+  --cache-dit-config parallel_config.yaml \
+  --prompt "A futuristic cityscape at sunset"
+```
+
 ## Advanced Configuration
 
 ### DBCache Parameters

--- a/python/sglang/multimodal_gen/docs/cli.md
+++ b/python/sglang/multimodal_gen/docs/cli.md
@@ -21,6 +21,7 @@ The SGLang-diffusion CLI provides a quick way to access the inference pipeline f
 - `--sp-degree {SP_SIZE}`: Sequence parallelism size (typically should match the number of GPUs)
 - `--ulysses-degree {ULYSSES_DEGREE}`: The degree of DeepSpeed-Ulysses-style SP in USP
 - `--ring-degree {RING_DEGREE}`: The degree of ring attention-style SP in USP
+- `--attention-backend {BACKEND}`: Attention backend to use. For SGLang-native pipelines use `fa`, `torch_sdpa`, `sage_attn`, etc. For diffusers pipelines use diffusers backend names like `flash`, `_flash_3_hub`, `sage`, `xformers`.
 - `--cache-dit-config {PATH}`: Path to a Cache-DiT YAML/JSON config (diffusers backend only)
 
 

--- a/python/sglang/multimodal_gen/docs/cli.md
+++ b/python/sglang/multimodal_gen/docs/cli.md
@@ -21,6 +21,7 @@ The SGLang-diffusion CLI provides a quick way to access the inference pipeline f
 - `--sp-degree {SP_SIZE}`: Sequence parallelism size (typically should match the number of GPUs)
 - `--ulysses-degree {ULYSSES_DEGREE}`: The degree of DeepSpeed-Ulysses-style SP in USP
 - `--ring-degree {RING_DEGREE}`: The degree of ring attention-style SP in USP
+- `--cache-dit-config {PATH}`: Path to a Cache-DiT YAML/JSON config (diffusers backend only)
 
 
 ### Sampling Parameters

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -411,7 +411,7 @@ class DiffusersPipeline(ComposedPipelineBase):
             load_kwargs["device_map"] = device_map
 
         # Add quantization config if provided (e.g., BitsAndBytesConfig for 4/8-bit)
-        config = getattr(server_args, "pipeline_config", None)
+        config = server_args.pipeline_config
         if config is not None:
             quant_config = getattr(config, "quantization_config", None)
             if quant_config is not None:
@@ -479,7 +479,7 @@ class DiffusersPipeline(ComposedPipelineBase):
 
     def _apply_vae_optimizations(self, pipe: Any, server_args: ServerArgs) -> None:
         """Apply VAE memory optimizations (tiling, slicing) from pipeline config."""
-        config = getattr(server_args, "pipeline_config", None)
+        config = server_args.pipeline_config
         if config is None:
             return
 
@@ -503,10 +503,10 @@ class DiffusersPipeline(ComposedPipelineBase):
         See: https://huggingface.co/docs/diffusers/main/en/optimization/attention_backends
         Available backends: flash, _flash_3_hub, sage, xformers, native, etc.
         """
-        backend = getattr(server_args, "attention_backend", None)
+        backend = server_args.attention_backend
 
         if backend is None:
-            config = getattr(server_args, "pipeline_config", None)
+            config = server_args.pipeline_config
             if config is not None:
                 backend = getattr(config, "diffusers_attention_backend", None)
 
@@ -545,7 +545,7 @@ class DiffusersPipeline(ComposedPipelineBase):
 
     def _apply_cache_dit(self, pipe: Any, server_args: ServerArgs) -> Any:
         """Enable cache-dit for diffusers pipeline if configured."""
-        cache_dit_config = getattr(server_args, "cache_dit_config", None)
+        cache_dit_config = server_args.cache_dit_config
         if not cache_dit_config:
             return pipe
 
@@ -596,7 +596,7 @@ class DiffusersPipeline(ComposedPipelineBase):
         dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
 
         if hasattr(server_args, "pipeline_config") and server_args.pipeline_config:
-            dit_precision = getattr(server_args.pipeline_config, "dit_precision", None)
+            dit_precision = server_args.pipeline_config.dit_precision
             if dit_precision == "fp16":
                 dtype = torch.float16
             elif dit_precision == "bf16":

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -554,6 +554,7 @@ class DiffusersPipeline(ComposedPipelineBase):
         try:
             pipe = cache_dit.enable_cache(pipe, **cache_options)
         except Exception:
+            # cache-dit is an external integration and can raise a variety of errors.
             logger.exception("Failed to enable cache-dit for diffusers pipeline")
             raise
 
@@ -641,7 +642,10 @@ class DiffusersPipeline(ComposedPipelineBase):
             if encoder is not None:
                 return encoder
         except Exception:
-            pass
+            logger.debug(
+                "cache-dit get_text_encoder_from_pipe failed; falling back to attribute lookup",
+                exc_info=True,
+            )
 
         for attr in ["text_encoder_2", "text_encoder_3", "text_encoder"]:
             if hasattr(pipe, attr):

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -236,6 +236,9 @@ class ServerArgs:
     # Attention
     attention_backend: str = None
     diffusers_attention_backend: str = None  # for diffusers backend only
+    cache_dit_config: str | dict[str, Any] | None = (
+        None  # cache-dit config for diffusers
+    )
 
     # Distributed executor backend
     nccl_port: Optional[int] = None
@@ -461,6 +464,12 @@ class ServerArgs:
             default=None,
             help="Attention backend for diffusers pipelines (e.g., flash, _flash_3_hub, sage, xformers). "
             "See: https://huggingface.co/docs/diffusers/main/en/optimization/attention_backends",
+        )
+        parser.add_argument(
+            "--cache-dit-config",
+            type=str,
+            default=ServerArgs.cache_dit_config,
+            help="Path to a Cache-DiT YAML/JSON config. Enables cache-dit for diffusers backend.",
         )
 
         # HuggingFace specific parameters

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -235,7 +235,6 @@ class ServerArgs:
 
     # Attention
     attention_backend: str = None
-    diffusers_attention_backend: str = None  # for diffusers backend only
     cache_dit_config: str | dict[str, Any] | None = (
         None  # cache-dit config for diffusers
     )
@@ -455,15 +454,19 @@ class ServerArgs:
             "--attention-backend",
             type=str,
             default=None,
-            choices=[e.name.lower() for e in AttentionBackendEnum] + ["fa3", "fa4"],
-            help="The attention backend to use. If not specified, the backend is automatically selected based on hardware and installed packages.",
+            help=(
+                "The attention backend to use. For SGLang-native pipelines, use "
+                "values like fa, torch_sdpa, sage_attn, etc. For diffusers pipelines, "
+                "use diffusers attention backend names such as flash, _flash_3_hub, "
+                "sage, or xformers."
+            ),
         )
         parser.add_argument(
             "--diffusers-attention-backend",
             type=str,
+            dest="attention_backend",
             default=None,
-            help="Attention backend for diffusers pipelines (e.g., flash, _flash_3_hub, sage, xformers). "
-            "See: https://huggingface.co/docs/diffusers/main/en/optimization/attention_backends",
+            help=argparse.SUPPRESS,
         )
         parser.add_argument(
             "--cache-dit-config",
@@ -1008,7 +1011,7 @@ class ServerArgs:
             raise ValueError("pipeline_config is not set in ServerArgs")
 
         self.pipeline_config.check_pipeline_config()
-        if self.attention_backend is None:
+        if self.attention_backend is None and self.backend != Backend.DIFFUSERS:
             self._set_default_attention_backend()
 
         # parallelism


### PR DESCRIPTION
## Motivation
Addressing #16642, enabling Cache‑DiT acceleration for any diffusers pipeline in SGLang by allowing a cache‑dit config file to be passed through the diffusers backend.

## Modifications
- `--cache-dit-config` server arg in `python/sglang/multimodal_gen/runtime/server_args.py`
- cache‑dit when using diffusers pipelines, including config loading and module resolution: `python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py`.
- fixed cli `--diffusers-kwargs` path to avoid `SamplingParams` init errors: `python/sglang/multimodal_gen/configs/sample/sampling_params.py`.

## Accuracy Tests

## Benchmarking and Profiling
2x RTX Pro 6000 WS

- Cache‑DiT config:
```bash
cat > /tmp/cache_dit_config.yaml <<'EOF'
cache_config:
  max_warmup_steps: 8
  warmup_interval: 2
  max_cached_steps: -1
  max_continuous_cached_steps: 2
  Fn_compute_blocks: 1
  Bn_compute_blocks: 0
  residual_diff_threshold: 0.12
  enable_taylorseer: true
  taylorseer_order: 1
parallelism_config:
  ulysses_size: 2
  parallel_kwargs:
    attention_backend: native
    extra_parallel_modules: ["text_encoder", "vae"]
EOF
```

## Test 1

- Baseline:
  - 43.79s, peak 67.80 GB
  - Command:
```bash
CUDA_VISIBLE_DEVICES=0,1 sglang generate \
  --model-path Qwen/Qwen-Image \
  --backend diffusers \
  --num-gpus 2 \
  --sp-degree 2 \
  --ulysses-degree 2 \
  --tp-size 1 \
  --prompt 'A coffee shop entrance features a chalkboard sign reading "Qwen Coffee $2 per cup," with a neon light beside it displaying "通义千问". Next to it hangs a poster showing a beautiful Chinese woman, and beneath the poster is written "π≈3.1415926-53589793-23846264-33832795-02384197". Ultra HD, 4K, cinematic composition.' \
  --negative-prompt " " \
  --width 1664 \
  --height 928 \
  --num-inference-steps 50 \
  --seed 42 \
  --save-output \
  --output-path outputs \
  --output-file-name baseline-2gpu-a.png
```
<img width="1664" height="928" alt="baseline-2gpu-a" src="https://github.com/user-attachments/assets/2c467396-582c-4387-92d4-a07dd86e98be" />

- Cache‑DiT:
  - 14.69s, peak 67.98 GB (~2.98x faster)
  - Command:
```bash
CUDA_VISIBLE_DEVICES=0,1 sglang generate \
  --model-path Qwen/Qwen-Image \
  --backend diffusers \
  --num-gpus 2 \
  --sp-degree 2 \
  --ulysses-degree 2 \
  --tp-size 1 \
  --cache-dit-config /tmp/cache_dit_config.yaml \
  --prompt 'A coffee shop entrance features a chalkboard sign reading "Qwen Coffee $2 per cup," with a neon light beside it displaying "通义千问". Next to it hangs a poster showing a beautiful Chinese woman, and beneath the poster is written "π≈3.1415926-53589793-23846264-33832795-02384197". Ultra HD, 4K, cinematic composition.' \
  --negative-prompt " " \
  --width 1664 \
  --height 928 \
  --num-inference-steps 50 \
  --seed 42 \
  --diffusers-kwargs '{"max_sequence_length":512}' \
  --save-output \
  --output-path outputs \
  --output-file-name cachedit-2gpu-a.png
```
<img width="1664" height="928" alt="cachedit-2gpu-a" src="https://github.com/user-attachments/assets/07c26e28-0013-46fd-b47d-1281d8224564" />

## Test 2

- Baseline:
  - 44.26s, peak 67.80 GB
  - Command:
```bash
CUDA_VISIBLE_DEVICES=0,1 sglang generate \
  --model-path Qwen/Qwen-Image \
  --backend diffusers \
  --num-gpus 2 \
  --sp-degree 2 \
  --ulysses-degree 2 \
  --tp-size 1 \
  --prompt 'A modern metro station poster wall with three ads: 1) a neon sign that reads "TOKYO MIDNIGHT - 24/7" in English, 2) a handwritten Chinese banner reading "欢迎来到未来城市", 3) a chalkboard menu listing "Espresso $2.50, Latte $3.75, Matcha $4.00". Include a small QR code in the corner and a timestamp "2025-01-08 18:30". Ultra-detailed, sharp typography, cinematic lighting, 4K.' \
  --negative-prompt " " \
  --width 1664 \
  --height 928 \
  --num-inference-steps 50 \
  --seed 42 \
  --save-output \
  --output-path outputs \
  --output-file-name baseline-2gpu-b.png
```
<img width="1664" height="928" alt="baseline-2gpu-b" src="https://github.com/user-attachments/assets/924c4dbd-e09b-4530-afd2-0e468d317fc5" />

- Cache‑DiT:
  - 14.41s, peak 67.98 GB (~3.07x faster)
  - Command:
```bash
CUDA_VISIBLE_DEVICES=0,1 sglang generate \
  --model-path Qwen/Qwen-Image \
  --backend diffusers \
  --num-gpus 2 \
  --sp-degree 2 \
  --ulysses-degree 2 \
  --tp-size 1 \
  --cache-dit-config /tmp/cache_dit_config.yaml \
  --prompt 'A modern metro station poster wall with three ads: 1) a neon sign that reads "TOKYO MIDNIGHT - 24/7" in English, 2) a handwritten Chinese banner reading "欢迎来到未来城市", 3) a chalkboard menu listing "Espresso $2.50, Latte $3.75, Matcha $4.00". Include a small QR code in the corner and a timestamp "2025-01-08 18:30". Ultra-detailed, sharp typography, cinematic lighting, 4K.' \
  --negative-prompt " " \
  --width 1664 \
  --height 928 \
  --num-inference-steps 50 \
  --guidance-scale 4.0 \
  --seed 42 \
  --diffusers-kwargs '{"max_sequence_length":512}' \
  --save-output \
  --output-path outputs \
  --output-file-name cachedit-2gpu-b.png
```
<img width="1664" height="928" alt="cachedit-2gpu-b" src="https://github.com/user-attachments/assets/9117fce6-bdde-40c4-8888-1c8a6939e094" />

## Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [x] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.