### PR TITLE
Revert "[sgl-kernel] Update flashmla to include fp8 sparse_mla optimizations"

### DIFF
--- a/sgl-kernel/cmake/flashmla.cmake
+++ b/sgl-kernel/cmake/flashmla.cmake
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
     repo-flashmla
     GIT_REPOSITORY https://github.com/sgl-project/FlashMLA
-    GIT_TAG b1860dc4949e94241eb38503abd7b62eb62d36f6
+    GIT_TAG be055fb7df0090fde45f08e9cb5b8b4c0272da73
     GIT_SHALLOW OFF
 )
 FetchContent_Populate(repo-flashmla)


### PR DESCRIPTION
Reverts sgl-project/sglang#15242

This update is breaking the nvfp4 Deepseek checkpoint, leading to 0 accuracy with gsm8k 8 shots. It works fine with the fp8 checkpoint, however.

Debug notes:
With gsm8k, 0 shots with running max batch_size = 1 works. If I do not limit the max batch_size, I get 0 accuracy.

Comparing the upstream flash_mla (main branch) flash_mla_with_kvcache kernel results to sgl_kernel.flash_mla when running gsm8k 8 shots (DP4, cuda graph off):
```
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 467, NaNs in o: 0, NaNs in o_test: 19
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 263168, NaNs in o: 0, NaNs in o_test: 263168
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 267264, NaNs in o: 0, NaNs in o_test: 267264
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 467, NaNs in o: 0, NaNs in o_test: 18
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 255488, NaNs in o: 0, NaNs in o_test: 255488
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 251904, NaNs in o: 0, NaNs in o_test: 251904
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 244736, NaNs in o: 0, NaNs in o_test: 244736
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 246784, NaNs in o: 0, NaNs in o_test: 246784
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 249856, NaNs in o: 0, NaNs in o_test: 249856
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 239104, NaNs in o: 0, NaNs in o_test: 239104
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 239104, NaNs in o: 0, NaNs in o_test: 239104
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 235008, NaNs in o: 0, NaNs in o_test: 235008
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 228352, NaNs in o: 0, NaNs in o_test: 228352
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 217600, NaNs in o: 0, NaNs in o_test: 217600
Detected mismatch in FlashMLA kernel: diff_absmax: nan, mismatch count: 222720, NaNs in o: 0, NaNs in o_test: 222720
```