### PR TITLE
Fix pytest tests to exit with proper exit code

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -29,7 +29,7 @@ python3 test_choices.py
 - Create new test files under `test/srt` or `test/lang` depending on the type of test.
 - For nightly tests, place them in `test/srt/nightly/`. Use the `NightlyBenchmarkRunner` helper class in `nightly_utils.py` for performance benchmarking tests.
 - Ensure they are referenced in the respective `run_suite.py` (e.g., `test/srt/run_suite.py`) so they are picked up in CI. For most small test cases, they can be added to the `per-commit-1-gpu` suite. Sort the test cases alphabetically by name.
-- Ensure you added `unittest.main()` for unittest and `pytest.main([__file__])` for pytest in the scripts. The CI run them via `python3 test_file.py`.
+- Ensure you added `unittest.main()` for unittest and `sys.exit(pytest.main([__file__]))` for pytest in the scripts. The CI run them via `python3 test_file.py`.
 - The CI will run some suites such as `per-commit-1-gpu`, `per-commit-2-gpu`, and `nightly-1-gpu` automatically. If you need special setup or custom test groups, you may modify the workflows in [`.github/workflows/`](https://github.com/sgl-project/sglang/tree/main/.github/workflows).
 
 ## CI Registry Quick Peek

--- a/test/registered/function_call/test_unknown_tool_name.py
+++ b/test/registered/function_call/test_unknown_tool_name.py
@@ -78,4 +78,6 @@ def test_unknown_tool_name_forwarded(caplog):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/layers/mamba/test_causal_conv1d.py
+++ b/test/registered/layers/mamba/test_causal_conv1d.py
@@ -380,4 +380,6 @@ def test_causal_conv1d_varlen(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/layers/mamba/test_mamba2_mixer.py
+++ b/test/registered/layers/mamba/test_mamba2_mixer.py
@@ -144,4 +144,6 @@ def mixer2_gated_norm_tensor_parallel(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/layers/mamba/test_mamba_ssm.py
+++ b/test/registered/layers/mamba/test_mamba_ssm.py
@@ -297,4 +297,6 @@ def test_selective_state_update_with_heads_with_batch_indices(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/layers/mamba/test_mamba_ssm_ssd.py
+++ b/test/registered/layers/mamba/test_mamba_ssm_ssd.py
@@ -607,4 +607,6 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/vlm/test_evs.py
+++ b/test/registered/vlm/test_evs.py
@@ -3,7 +3,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import run_doctests
+
+register_cpu_ci(est_time=20, suite="stage-a-cpu-only")
 
 
 def test_resolve_evs_config():

--- a/test/srt/test_evs.py
+++ b/test/srt/test_evs.py
@@ -51,4 +51,6 @@ def test_replace_offsets_with_tokens_per_frame():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/srt/test_evs.py
+++ b/test/srt/test_evs.py
@@ -3,10 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import run_doctests
-
-register_cpu_ci(est_time=20, suite="stage-a-cpu-only")
 
 
 def test_resolve_evs_config():

--- a/test/srt/test_video_utils.py
+++ b/test/srt/test_video_utils.py
@@ -56,4 +56,6 @@ def test_sample_video_frames_lengths(case: Case):
     assert result == case.expected_frames
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    import sys
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
Fix pytest-based tests to properly propagate exit codes so CI fails when tests fail. Changed `pytest.main([__file__])` to `sys.exit(pytest.main([__file__]))` in all affected test files.

## Test plan
CI should now properly fail when pytest tests fail.