### PR TITLE
feat(profiler): Add torch dispatch for shape profiling

### DIFF
--- a/examples/profiler/README.md
+++ b/examples/profiler/README.md
@@ -129,4 +129,10 @@ A summary file (`*_summary.json`) is generated with statistics:
 ## Supported Workers
 
 - **LLM**: `python/sglang/srt/managers/tp_worker.py`
-- **Diffusion**: `python/sglang/multimodal_gen/runtime/managers/gpu_worker.py`
+- **Diffusion**: `python/sglang/multimodal_gen/runtime/managers/gpu_worker.py` (deduplication enabled by default)
+
+## Notes
+
+- For **diffusion models**, deduplication is enabled by default (`SGLANG_PROFILE_SHAPES_DEDUPE=1`) since the same operations run ~50 times during inference
+- For **LLM models**, deduplication is disabled by default since prefill and decode have different shapes
+- Set `SGLANG_PROFILE_SHAPES_DEDUPE=0` to disable deduplication if needed

--- a/examples/profiler/README.md
+++ b/examples/profiler/README.md
@@ -1,0 +1,132 @@
+# Torch Dispatch Shape Profiler
+
+A minimal torch dispatch-based shape logger for profiling tensor shapes and dtypes in SGLang workers.
+
+## Features
+
+- **Shape + Dtype Logging**: Captures input/output tensor shapes AND dtypes for each torch operation
+- **Error Capture**: Logs operation shapes even when kernel errors occur (critical for debugging)
+- **Deduplication**: For diffusion models that run same ops 50 times, only logs unique operations
+- **Forward Pass Tracking**: Markers for prefill/decode phases in LLMs
+- **Crash-Safe**: Immediate flush after every operation ensures data is saved before crashes
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SGLANG_PROFILE_SHAPES` | Enable shape profiling (`1` to enable) | `0` |
+| `SGLANG_PROFILE_SHAPES_RANK` | Only profile on this TP rank | `0` |
+| `SGLANG_PROFILE_SHAPES_FILE` | Output file path | `shapes.jsonl` |
+| `SGLANG_PROFILE_SHAPES_SKIP_WARMUP` | Skip first N forward passes (warmup) | `0` |
+| `SGLANG_PROFILE_SHAPES_LOG_N_PASSES` | Only log first N passes after warmup (0=unlimited) | `0` |
+| `SGLANG_PROFILE_SHAPES_DEDUPE` | Deduplicate ops with same signature (for diffusion) | `0` (LLM), `1` (diffusion) |
+
+## Usage Examples
+
+### Example 1: LLM Model (DeepSeek-V3)
+
+```bash
+SGLANG_PROFILE_SHAPES=1 \
+SGLANG_PROFILE_SHAPES_RANK=0 \
+SGLANG_PROFILE_SHAPES_FILE=deepseek_shapes.jsonl \
+SGLANG_PROFILE_SHAPES_SKIP_WARMUP=26 \
+SGLANG_PROFILE_SHAPES_LOG_N_PASSES=2 \
+python3 -m sglang.bench_one_batch_server \
+  --model-path /data/DeepSeek-V3-0324/ \
+  --tp 8 \
+  --batch-size 1 \
+  --input-len 8192 \
+  --output-len 8 \
+  --disable-cuda-graph \
+  --disable-radix-cache \
+  --trust-remote-code
+```
+
+### Example 2: Debug Kernel Error (GLM-4.5)
+
+```bash
+SGLANG_PROFILE_SHAPES=1 \
+SGLANG_PROFILE_SHAPES_RANK=0 \
+SGLANG_PROFILE_SHAPES_FILE=glm4_shapes.jsonl \
+SGLANG_PROFILE_SHAPES_SKIP_WARMUP=0 \
+SGLANG_PROFILE_SHAPES_LOG_N_PASSES=2 \
+python3 -m sglang.bench_one_batch_server \
+  --model-path zai-org/GLM-4.5-Air-FP8 \
+  --tp 1 \
+  --batch-size 1 \
+  --input-len 1024 \
+  --output-len 512 \
+  --disable-cuda-graph \
+  --disable-radix-cache \
+  --trust-remote-code
+```
+
+### Example 3: Diffusion Model (with deduplication)
+
+```bash
+SGLANG_PROFILE_SHAPES=1 \
+SGLANG_PROFILE_SHAPES_RANK=0 \
+SGLANG_PROFILE_SHAPES_FILE=diffusion_shapes.jsonl \
+SGLANG_PROFILE_SHAPES_DEDUPE=1 \
+python your_diffusion_script.py
+```
+
+## Output Format
+
+The profiler outputs JSONL format with one operation per line:
+
+```json
+{
+  "call_id": 1,
+  "forward_pass": 3,
+  "operation": "aten.mm.default",
+  "inputs": {
+    "self": {"shape": [128, 256], "dtype": "torch.float16"},
+    "mat2": {"shape": [256, 512], "dtype": "torch.float16"}
+  },
+  "outputs": {"shape": [128, 512], "dtype": "torch.float16"}
+}
+```
+
+### Error Capture
+
+When a kernel error occurs, the operation is logged with error info:
+
+```json
+{
+  "call_id": 42,
+  "forward_pass": 1,
+  "operation": "aten.mm.default",
+  "inputs": {...},
+  "outputs": null,
+  "error": {
+    "error_type": "RuntimeError",
+    "error_message": "CUDA error: invalid configuration argument"
+  }
+}
+```
+
+## Summary File
+
+A summary file (`*_summary.json`) is generated with statistics:
+
+```json
+{
+  "rank": 0,
+  "total_operations": 1234,
+  "forward_passes": 2,
+  "unique_operations": 45,
+  "operation_counts": {
+    "aten.mm.default": 100,
+    "aten.add.Tensor": 50
+  },
+  "dedupe_enabled": true,
+  "dedupe_skipped_count": 49000,
+  "unique_op_signatures": 1000
+}
+```
+
+## Supported Workers
+
+- **LLM**: `python/sglang/srt/managers/tp_worker.py`
+- **Diffusion**: `python/sglang/multimodal_gen/runtime/managers/gpu_worker.py`

--- a/examples/profiler/torch_shape_logger_rank.py
+++ b/examples/profiler/torch_shape_logger_rank.py
@@ -1,0 +1,466 @@
+"""
+Rank-Aware Torch Dispatch-based Shape Logger
+
+Minimal logger for profiling tensor shapes and dtypes in TP workers.
+Only logs operations on specified rank to avoid overhead.
+
+Features:
+    - Logs input/output tensor shapes AND dtypes for each operation
+    - Deduplication mode for diffusion models (same ops run 50 times, only log unique)
+    - Forward pass tracking with prefill/decode markers for LLMs
+
+Usage in TP worker (automatically activated by environment variables):
+    SGLANG_PROFILE_SHAPES=1 SGLANG_PROFILE_SHAPES_RANK=0 \\
+    SGLANG_PROFILE_SHAPES_FILE=shapes.jsonl python -m sglang.launch_server ...
+    
+Or with bench_one_batch_server (recommended):
+    SGLANG_PROFILE_SHAPES=1 SGLANG_PROFILE_SHAPES_RANK=0 \\
+    SGLANG_PROFILE_SHAPES_FILE=shapes.jsonl python3 -m sglang.bench_one_batch_server ...
+
+For diffusion models (deduplication enabled by default):
+    SGLANG_PROFILE_SHAPES=1 SGLANG_PROFILE_SHAPES_DEDUPE=1 \\
+    SGLANG_PROFILE_SHAPES_FILE=shapes.jsonl python your_diffusion_script.py
+
+Environment variables:
+    SGLANG_PROFILE_SHAPES=1           - Enable shape profiling
+    SGLANG_PROFILE_SHAPES_RANK=0      - Only profile on this rank (default: 0)
+    SGLANG_PROFILE_SHAPES_FILE=x.jsonl - Output file path
+    SGLANG_PROFILE_SHAPES_SKIP_WARMUP=N - Skip first N forward passes
+    SGLANG_PROFILE_SHAPES_LOG_N_PASSES=N - Only log first N passes after warmup
+    SGLANG_PROFILE_SHAPES_DEDUPE=1    - Deduplicate ops with same signature (for diffusion)
+"""
+
+import atexit
+import inspect
+import json
+import os
+import signal
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+# Try to import CUDA graph and torch.compile detection utilities
+try:
+    from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+    from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
+    _CAN_DETECT_CUDA_GRAPH = True
+except ImportError:
+    _CAN_DETECT_CUDA_GRAPH = False
+    def get_is_capture_mode():
+        return False
+    def is_in_piecewise_cuda_graph():
+        return False
+
+# Try to detect torch.compile mode
+def _is_torch_compile_mode():
+    """Detect if we're inside a torch.compile context."""
+    try:
+        # Check if torch._dynamo is active
+        if hasattr(torch, '_dynamo'):
+            return torch._dynamo.is_compiling() if hasattr(torch._dynamo, 'is_compiling') else False
+    except Exception:
+        pass
+    return False
+
+
+def get_current_rank() -> int:
+    """Get the current process rank (GPU ID)."""
+    if "RANK" in os.environ:
+        return int(os.environ["RANK"])
+    elif "LOCAL_RANK" in os.environ:
+        return int(os.environ["LOCAL_RANK"])
+    elif torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    return 0
+
+
+class CompactRankAwareShapeLogger(TorchDispatchMode):
+    """Compact shape logger that only logs on specified rank."""
+    
+    # Enable support for HigherOrderOperators (triton kernels, etc.)
+    supports_higher_order_operators = True
+
+    def __init__(
+        self,
+        output_file: str = "shapes.jsonl",
+        verbose: bool = False,
+        only_rank: Optional[int] = None,
+        log_first_n_forward_passes: int = 2,
+        skip_first_n_forward_passes: int = 2,
+        dedupe_ops: bool = False,
+    ):
+        super().__init__()
+        self.output_file = output_file
+        self.verbose = verbose
+        self.only_rank = only_rank
+        self.call_count = 0
+        self.op_counts = defaultdict(int)
+        self.file_handle = None
+        self.current_rank = get_current_rank()
+        self.should_log = (only_rank is None) or (self.current_rank == only_rank)
+        self._forward_pass_count = 0
+        self._in_forward_pass = False
+        self.log_first_n_forward_passes = log_first_n_forward_passes
+        self.skip_first_n_forward_passes = skip_first_n_forward_passes
+        self._signal_handler_installed = False
+        # Deduplication: for diffusion models that run same ops 50 times
+        self.dedupe_ops = dedupe_ops or os.environ.get("SGLANG_PROFILE_SHAPES_DEDUPE", "0") == "1"
+        self._seen_op_signatures: set = set()
+        self._dedupe_skip_count = 0
+    
+    def _signal_handler(self, signum, frame):
+        """Handle signals to ensure cleanup on crash."""
+        print(f"[SHAPE_PROFILER] Signal {signum} received, flushing data...", flush=True)
+        self._cleanup()
+        # Re-raise the signal
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    def start_forward_pass(self):
+        """Called by tp_worker to mark start of forward pass."""
+        if self.should_log and not self._in_forward_pass:
+            self._in_forward_pass = True
+            self._forward_pass_count += 1
+            effective_pass = self._forward_pass_count - self.skip_first_n_forward_passes
+            
+            # Add separator markers for prefill and decode
+            # Ensure file handle is open (it should be from __enter__, but check just in case)
+            if effective_pass > 0 and self.file_handle:
+                try:
+                    if effective_pass == 1:
+                        # First forward pass after warmup = prefill
+                        separator = {
+                            "call_id": 0,
+                            "forward_pass": self._forward_pass_count,
+                            "operation": "=" * 80,
+                            "marker": "PREFILL_START",
+                            "inputs": None,
+                            "outputs": None,
+                        }
+                        self.file_handle.write(json.dumps(separator) + "\n")
+                        self.file_handle.write("\n" * 3)  # Large space separator
+                        self.file_handle.flush()
+                        print(f"[SHAPE_PROFILER] Starting PREFILL pass #{self._forward_pass_count} (effective: {effective_pass})", flush=True)
+                    elif effective_pass == 2:
+                        # Second forward pass after warmup = decode
+                        separator = {
+                            "call_id": 0,
+                            "forward_pass": self._forward_pass_count,
+                            "operation": "=" * 80,
+                            "marker": "DECODE_START",
+                            "inputs": None,
+                            "outputs": None,
+                        }
+                        self.file_handle.write(json.dumps(separator) + "\n")
+                        self.file_handle.write("\n" * 3)  # Large space separator
+                        self.file_handle.flush()
+                        print(f"[SHAPE_PROFILER] Starting DECODE pass #{self._forward_pass_count} (effective: {effective_pass})", flush=True)
+                except Exception as e:
+                    if self.verbose:
+                        print(f"[Rank {self.current_rank}] Error writing marker: {e}")
+            
+            if self.verbose:
+                print(f"[Rank {self.current_rank}] Forward pass #{self._forward_pass_count} started (effective: {effective_pass})")
+            
+            # Print status every few passes so user knows profiling is active
+            if effective_pass > 0 and effective_pass <= 5:
+                print(f"[SHAPE_PROFILER] Logging forward pass {effective_pass} → {self.output_file}", flush=True)
+
+    def end_forward_pass(self):
+        """Called by tp_worker to mark end of forward pass."""
+        if self.should_log and self._in_forward_pass:
+            self._in_forward_pass = False
+            if self.verbose:
+                print(f"[Rank {self.current_rank}] Forward pass #{self._forward_pass_count} ended, ops={self.call_count}")
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        
+        # Check if this is a HigherOrderOperator (triton kernels, etc.)
+        # These need special handling - just pass through
+        func_name = str(func)
+        is_higher_order_op = (
+            "HigherOrderOperator" in func_name or 
+            "triton_kernel" in func_name or
+            hasattr(func, '_higher_order_op')
+        )
+        
+        # Skip shape logging during CUDA graph capture (but allow replay) or torch.compile
+        should_skip_logging = is_higher_order_op
+        if not should_skip_logging and _CAN_DETECT_CUDA_GRAPH:
+            # Only skip during capture, not during replay (replay is actual inference we want to log)
+            should_skip_logging = get_is_capture_mode()
+            # Note: We don't skip is_in_piecewise_cuda_graph() because that includes both capture and replay
+            # We want to log replay operations but skip capture
+        if not should_skip_logging:
+            should_skip_logging = _is_torch_compile_mode()
+        
+        # Extract input shapes with argument names (if profiling and not skipping)
+        named_inputs = None
+        if self.should_log and self._in_forward_pass and not should_skip_logging:
+            named_inputs = self._extract_shapes_with_names(func, args, kwargs)
+        
+        # Execute the operation with error handling
+        try:
+            result = func(*args, **kwargs)
+        except Exception as e:
+            # Log the failed operation, save file, and exit
+            print(f"[SHAPE_PROFILER] EXCEPTION CAUGHT in dispatch: {type(e).__name__}: {e}", flush=True)
+            print(f"[SHAPE_PROFILER] should_log={self.should_log}, _in_forward_pass={self._in_forward_pass}, should_skip={should_skip_logging}", flush=True)
+            
+            if self.should_log and self._in_forward_pass and not should_skip_logging:
+                error_info = {
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                }
+                self._log_operation(func, named_inputs, None, error_info=error_info)
+                
+                # Save and close the file immediately
+                print(f"[SHAPE_PROFILER] Calling cleanup to save file...", flush=True)
+                self._cleanup()
+                print(f"[SHAPE_PROFILER] File saved to {self.output_file}. Re-raising exception.", flush=True)
+            else:
+                print(f"[SHAPE_PROFILER] Not logging because: should_log={self.should_log}, in_forward={self._in_forward_pass}, skip={should_skip_logging}", flush=True)
+            
+            # Re-raise the error
+            raise
+        
+        # Log successful operation
+        if self.should_log and self._in_forward_pass and not should_skip_logging:
+            self._log_operation(func, named_inputs, result)
+        
+        return result
+
+    def _extract_shapes(self, obj) -> Optional[Any]:
+        """Extract shapes with dtype information."""
+        if isinstance(obj, torch.Tensor):
+            return {
+                "shape": list(obj.shape),
+                "dtype": str(obj.dtype),
+            }
+        elif isinstance(obj, (list, tuple)):
+            shapes = [self._extract_shapes(item) for item in obj]
+            return [s for s in shapes if s is not None] or None
+        elif isinstance(obj, dict):
+            shapes = {str(k): self._extract_shapes(v) for k, v in obj.items()}
+            return {k: v for k, v in shapes.items() if v is not None} or None
+        return None
+
+    def _extract_shapes_with_names(self, func, args, kwargs) -> Optional[Dict[str, Any]]:
+        """Extract shapes with argument names from function signature."""
+        try:
+            named_args = {}
+            
+            # Try to get function signature to map args to parameter names
+            sig = None
+            try:
+                sig = inspect.signature(func)
+            except (ValueError, TypeError):
+                # Some torch operations don't have inspectable signatures
+                pass
+            
+            if sig:
+                # Map positional args and kwargs to parameter names
+                param_names = list(sig.parameters.keys())
+                bound_args = None
+                try:
+                    bound_args = sig.bind(*args, **kwargs)
+                    bound_args.apply_defaults()
+                except TypeError:
+                    # If binding fails, fall back to positional mapping
+                    pass
+                
+                if bound_args:
+                    # bound_args.arguments includes both positional args and kwargs
+                    for param_name, arg_value in bound_args.arguments.items():
+                        shape = self._extract_shapes(arg_value)
+                        # Include parameter even if shape is None (for non-tensor args like scalars)
+                        # This ensures kwargs names are always visible
+                        if shape is not None:
+                            named_args[param_name] = shape
+                        elif param_name in kwargs:
+                            # Include kwargs even if they're not tensors (e.g., scalars, None)
+                            # This ensures kwargs names are visible
+                            named_args[param_name] = None
+                else:
+                    # Fallback: map positional args by index, then add kwargs separately
+                    for i, arg in enumerate(args):
+                        if i < len(param_names):
+                            shape = self._extract_shapes(arg)
+                            if shape is not None:
+                                named_args[param_names[i]] = shape
+                    # Add kwargs separately in fallback case
+                    for kwarg_name, kwarg_value in kwargs.items():
+                        shape = self._extract_shapes(kwarg_value)
+                        # Always include kwargs names, even if not tensors
+                        if shape is not None:
+                            named_args[kwarg_name] = shape
+                        else:
+                            named_args[kwarg_name] = None
+            else:
+                # No signature available: use positional indices and kwargs
+                for i, arg in enumerate(args):
+                    shape = self._extract_shapes(arg)
+                    if shape is not None:
+                        named_args[f"arg{i}"] = shape
+                # Add kwargs (they already have names)
+                # Always include kwargs names, even if not tensors
+                for kwarg_name, kwarg_value in kwargs.items():
+                    shape = self._extract_shapes(kwarg_value)
+                    if shape is not None:
+                        named_args[kwarg_name] = shape
+                    else:
+                        named_args[kwarg_name] = None
+            
+            return named_args if named_args else None
+        except Exception as e:
+            # Fallback to simple extraction without names
+            result = {}
+            input_shapes = self._extract_shapes(args)
+            if input_shapes:
+                result["args"] = input_shapes
+            # Always include kwargs with their names, even if not tensors
+            if kwargs:
+                for kwarg_name, kwarg_value in kwargs.items():
+                    shape = self._extract_shapes(kwarg_value)
+                    if shape is not None:
+                        result[kwarg_name] = shape
+                    else:
+                        # Include kwargs even if not tensors (e.g., scalars, None)
+                        result[kwarg_name] = None
+            return result if result else None
+
+    def _create_op_signature(self, op_name: str, named_inputs: Optional[Dict], output_shapes: Optional[Any]) -> str:
+        """Create a unique signature for an operation based on name and shapes/dtypes.
+        
+        Used for deduplication in diffusion models where the same ops run 50 times.
+        """
+        sig_parts = [op_name]
+        if named_inputs:
+            # Sort keys for consistent ordering
+            for key in sorted(named_inputs.keys()):
+                val = named_inputs[key]
+                sig_parts.append(f"{key}:{json.dumps(val, sort_keys=True)}")
+        if output_shapes:
+            sig_parts.append(f"out:{json.dumps(output_shapes, sort_keys=True)}")
+        return "|".join(sig_parts)
+
+    def _log_operation(self, func, named_inputs, result, error_info=None):
+        """Log operation with minimal overhead."""
+        # Skip warmup forward passes
+        if self._forward_pass_count <= self.skip_first_n_forward_passes:
+            return
+        
+        # Skip logging if we're limiting to first N forward passes after warmup and this exceeds that
+        effective_pass = self._forward_pass_count - self.skip_first_n_forward_passes
+        if self.log_first_n_forward_passes > 0 and effective_pass > self.log_first_n_forward_passes:
+            return
+        
+        output_shapes = self._extract_shapes(result) if result is not None else None
+        op_name = str(func)
+        
+        # Deduplication check: skip if we've seen this exact op signature before
+        if self.dedupe_ops and not error_info:
+            op_signature = self._create_op_signature(op_name, named_inputs, output_shapes)
+            if op_signature in self._seen_op_signatures:
+                self._dedupe_skip_count += 1
+                return
+            self._seen_op_signatures.add(op_signature)
+        
+        # Log if any shapes present OR if there's an error
+        if named_inputs or output_shapes or error_info:
+            self.call_count += 1
+            self.op_counts[op_name] += 1
+            
+            if self.file_handle:
+                try:
+                    log_entry = {
+                        "call_id": self.call_count,
+                        "forward_pass": self._forward_pass_count,
+                        "operation": op_name,
+                        "outputs": output_shapes,
+                    }
+                    # Add named inputs (includes both positional args with names and kwargs)
+                    if named_inputs:
+                        log_entry["inputs"] = named_inputs
+                    # Add error info if present
+                    if error_info:
+                        log_entry["error"] = error_info
+                        print(f"[SHAPE_PROFILER] LOGGING ERROR: {error_info}", flush=True)
+                    
+                    # Write and flush immediately
+                    json_str = json.dumps(log_entry) + "\n"
+                    self.file_handle.write(json_str)
+                    self.file_handle.flush()
+                    os.fsync(self.file_handle.fileno())
+                    
+                    # Print every 100 ops to show progress
+                    if self.call_count % 100 == 0 or error_info:
+                        print(f"[SHAPE_PROFILER] Logged op #{self.call_count} to {self.output_file}", flush=True)
+                        
+                except Exception as log_err:
+                    print(f"[SHAPE_PROFILER] ERROR logging operation: {log_err}", flush=True)
+                    import traceback
+                    traceback.print_exc()
+
+    def __enter__(self):
+        super().__enter__()
+        if self.should_log:
+            self.call_count = 0
+            self.op_counts.clear()
+            self._forward_pass_count = 0
+            self._in_forward_pass = False
+            # Reset deduplication state
+            self._seen_op_signatures.clear()
+            self._dedupe_skip_count = 0
+            # Open file in write mode, we'll flush after every write
+            self.file_handle = open(self.output_file, "w")
+            atexit.register(self._cleanup)
+            # Register signal handlers for cleanup
+            signal.signal(signal.SIGTERM, self._signal_handler)
+            signal.signal(signal.SIGINT, self._signal_handler)
+            signal.signal(signal.SIGQUIT, self._signal_handler)
+            print(f"[Rank {self.current_rank}] Shape profiling enabled → {self.output_file}", flush=True)
+            dedupe_str = ", dedupe=ON" if self.dedupe_ops else ""
+            print(f"[SHAPE_PROFILER] File opened: {self.output_file}, skip_warmup={self.skip_first_n_forward_passes}, log_n={self.log_first_n_forward_passes}{dedupe_str}", flush=True)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        super().__exit__(exc_type, exc_val, exc_tb)
+        if self.should_log:
+            self._cleanup()
+        return False
+
+    def _cleanup(self):
+        """Save and close."""
+        if self.file_handle:
+            try:
+                print(f"[SHAPE_PROFILER] Flushing and closing {self.output_file}...", flush=True)
+                self.file_handle.flush()
+                os.fsync(self.file_handle.fileno())  # Force OS write
+                self.file_handle.close()
+                self.file_handle = None
+                # Write summary
+                summary_file = self.output_file.replace(".jsonl", "_summary.json")
+                summary = {
+                    "rank": self.current_rank,
+                    "total_operations": self.call_count,
+                    "forward_passes": self._forward_pass_count,
+                    "unique_operations": len(self.op_counts),
+                    "operation_counts": dict(sorted(self.op_counts.items(), key=lambda x: x[1], reverse=True)),
+                }
+                # Add deduplication info if enabled
+                if self.dedupe_ops:
+                    summary["dedupe_enabled"] = True
+                    summary["dedupe_skipped_count"] = self._dedupe_skip_count
+                    summary["unique_op_signatures"] = len(self._seen_op_signatures)
+                with open(summary_file, "w") as f:
+                    json.dump(summary, f, indent=2)
+                dedupe_msg = f" (deduped, skipped {self._dedupe_skip_count} duplicates)" if self.dedupe_ops else ""
+                print(f"[Rank {self.current_rank}] Profiled {self.call_count} ops across {self._forward_pass_count} forward passes{dedupe_msg} → {self.output_file}")
+            except Exception as e:
+                print(f"[SHAPE_PROFILER] Error during cleanup: {e}", flush=True)
+                pass

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
@@ -53,6 +54,27 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+# Minimal shape profiling support (controlled by environment variables)
+_ENABLE_SHAPE_PROFILING = os.environ.get("SGLANG_PROFILE_SHAPES", "0") == "1"
+_SHAPE_PROFILE_RANK = int(os.environ.get("SGLANG_PROFILE_SHAPES_RANK", "0"))
+_SHAPE_PROFILE_FILE = os.environ.get("SGLANG_PROFILE_SHAPES_FILE", "shapes.jsonl")
+_SHAPE_PROFILE_SKIP_WARMUP = int(os.environ.get("SGLANG_PROFILE_SHAPES_SKIP_WARMUP", "0"))
+_SHAPE_PROFILE_LOG_N_PASSES = int(os.environ.get("SGLANG_PROFILE_SHAPES_LOG_N_PASSES", "0"))
+_shape_logger_module = None
+
+if _ENABLE_SHAPE_PROFILING:
+    try:
+        import sys
+        _profiler_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../examples/profiler"))
+        if os.path.exists(_profiler_path):
+            sys.path.insert(0, _profiler_path)
+            from torch_shape_logger_rank import CompactRankAwareShapeLogger
+            _shape_logger_module = CompactRankAwareShapeLogger
+            logger.info(f"Shape profiling enabled: rank={_SHAPE_PROFILE_RANK}, file={_SHAPE_PROFILE_FILE}")
+    except Exception as e:
+        logger.warning(f"Failed to load shape profiling: {e}")
+        _ENABLE_SHAPE_PROFILING = False
 
 
 class BaseTpWorker(ABC):
@@ -264,6 +286,22 @@ class TpModelWorker(BaseTpWorker):
                 )
         self.device = self.model_runner.device
 
+        # Initialize shape profiler if enabled
+        self._shape_logger = None
+        self._shape_profiling_started = False
+        if _ENABLE_SHAPE_PROFILING and _shape_logger_module and self.tp_rank == _SHAPE_PROFILE_RANK:
+            try:
+                self._shape_logger = _shape_logger_module(
+                    output_file=_SHAPE_PROFILE_FILE,
+                    verbose=False,
+                    log_first_n_forward_passes=_SHAPE_PROFILE_LOG_N_PASSES,
+                    skip_first_n_forward_passes=_SHAPE_PROFILE_SKIP_WARMUP,
+                    only_rank=_SHAPE_PROFILE_RANK,
+                )
+                logger.info(f"[TP Rank {self.tp_rank}] Shape profiler initialized")
+            except Exception as e:
+                logger.warning(f"[TP Rank {self.tp_rank}] Failed to init shape profiler: {e}")
+
         # Init nccl groups
         self.pp_group = get_pp_group()
         self.world_group = get_world_group()
@@ -431,6 +469,20 @@ class TpModelWorker(BaseTpWorker):
         # FIXME(lsyin): maybe remove skip_attn_backend_init in forward_batch_generation,
         #               which requires preparing replay to always be in this function
 
+        # Activate shape profiler on first forward pass (lazy activation)
+        if self._shape_logger and not self._shape_profiling_started:
+            try:
+                self._shape_logger.__enter__()
+                self._shape_profiling_started = True
+                logger.info(f"[TP Rank {self.tp_rank}] Shape profiling activated")
+            except Exception as e:
+                logger.warning(f"[TP Rank {self.tp_rank}] Failed to activate profiler: {e}")
+                self._shape_logger = None
+
+        # Mark start of forward pass for profiling
+        if self._shape_logger and self._shape_profiling_started:
+            self._shape_logger.start_forward_pass()
+
         # Get forward batch from model worker batch
         if model_worker_batch is not None:
             # update the consumer index of hicache to the running batch
@@ -442,7 +494,10 @@ class TpModelWorker(BaseTpWorker):
             assert forward_batch is not None
 
         if self.is_dllm():
-            return self._forward_batch_generation_dllm(forward_batch)
+            result = self._forward_batch_generation_dllm(forward_batch)
+            if self._shape_logger and self._shape_profiling_started:
+                self._shape_logger.end_forward_pass()
+            return result
 
         if self.pp_group.is_last_rank:
             out = self.model_runner.forward(
@@ -459,6 +514,8 @@ class TpModelWorker(BaseTpWorker):
 
             if is_verify:
                 # Skip sampling and return logits for target forward
+                if self._shape_logger and self._shape_profiling_started:
+                    self._shape_logger.end_forward_pass()
                 return batch_result
 
             if (
@@ -474,6 +531,8 @@ class TpModelWorker(BaseTpWorker):
                     return batch_result
 
                 batch_result.delay_sample_func = sample_batch_func
+                if self._shape_logger and self._shape_profiling_started:
+                    self._shape_logger.end_forward_pass()
                 return batch_result
 
             if not model_worker_batch.is_prefill_only:
@@ -498,6 +557,8 @@ class TpModelWorker(BaseTpWorker):
                         logits_output, model_worker_batch
                     )
 
+            if self._shape_logger and self._shape_profiling_started:
+                self._shape_logger.end_forward_pass()
             return batch_result
         else:
             out = self.model_runner.forward(
@@ -506,6 +567,8 @@ class TpModelWorker(BaseTpWorker):
                 skip_attn_backend_init=skip_attn_backend_init,
             )
             pp_proxy_tensors, can_run_cuda_graph = out.logits_output, out.can_run_graph
+            if self._shape_logger and self._shape_profiling_started:
+                self._shape_logger.end_forward_pass()
             return GenerationBatchResult(
                 pp_hidden_states_proxy_tensors=pp_proxy_tensors,
                 can_run_cuda_graph=can_run_cuda_graph,


### PR DESCRIPTION
## Summary

Enhanced shape profiler for debugging kernel issues and profiling tensor operations. This is an updated version of PR #14436 with additional features.

## Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| `SGLANG_PROFILE_SHAPES` | Enable shape profiling | `0` |
| `SGLANG_PROFILE_SHAPES_RANK` | Only profile on this TP rank | `0` |
| `SGLANG_PROFILE_SHAPES_FILE` | Output file path | `shapes.jsonl` |
| `SGLANG_PROFILE_SHAPES_SKIP_WARMUP` | Skip first N forward passes | `0` |
| `SGLANG_PROFILE_SHAPES_LOG_N_PASSES` | Only log first N passes after warmup | `0` |
| `SGLANG_PROFILE_SHAPES_DEDUPE` | Deduplicate ops with same signature | `0` (LLM), `1` (diffusion) |

## Usage Examples

### LLM Model (DeepSeek-V3)

```bash
SGLANG_PROFILE_SHAPES=1 \
SGLANG_PROFILE_SHAPES_RANK=0 \
SGLANG_PROFILE_SHAPES_FILE=shapes.jsonl \
SGLANG_PROFILE_SHAPES_SKIP_WARMUP=26 \
SGLANG_PROFILE_SHAPES_LOG_N_PASSES=2 \
python3 -m sglang.bench_one_batch_server \
  --model-path /data/DeepSeek-V3/ \
  --tp 8 --batch-size 1 --input-len 8192 --output-len 8 \
  --disable-cuda-graph --disable-radix-cache
```

### Diffusion Model (with deduplication)

```
SGLANG_PROFILE_SHAPES=1 \
SGLANG_PROFILE_SHAPES_RANK=0 \
SGLANG_PROFILE_SHAPES_FILE=shapes_8gpu.jsonl \
SGLANG_PROFILE_SHAPES_SKIP_WARMUP=0 \
SGLANG_PROFILE_SHAPES_LOG_N_PASSES=2 \
sglang generate \
  --model-path Wan-AI/Wan2.1-I2V-14B-720P-Diffusers \
  --num-gpus 8 \
  --tp-size 1 \
  --sp-degree 8 \
  --ulysses-degree 8 \
  --ring-degree 1 \
  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
  --seed 42 \
  --num-frames 81 \
  --num-inference-steps 40 \
  --enable-torch-compile \
  --image-path "https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" \
  --output-path "./outputs" \
  --save-output
```

## Output Format

```json
{
  "call_id": 1,
  "forward_pass": 3,
  "operation": "aten.mm.default",
  "inputs": {
    "self": {"shape": [128, 256], "dtype": "torch.float16"},
    "mat2": {"shape": [256, 512], "dtype": "torch.float16"}
  },
  "outputs": {"shape": [128, 512], "dtype": "torch.float16"}
}
```

## Files Changed
- `examples/profiler/torch_shape_logger_rank.py` - Core profiler with dtype + deduplication
- `examples/profiler/README.md` - Documentation
- `python/sglang/srt/managers/tp_worker.py` - LLM worker integration
- `python/sglang/multimodal_gen/runtime/managers/gpu_worker.py` - Diffusion worker integration

## Test Plan
- [x] Test with LLM model (DeepSeek-V3)
- [x] Test error capture with failing kernel
- [x] Verify dtype is logged for inputs/outputs
- [x] Test deduplication mode for diffusion