### PR TITLE
Bug: fix none lora eviction in scheduler

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2006,14 +2006,11 @@ class Scheduler(
                     | set([req.lora_id])
                 )
                 if not self.tp_worker.can_run_lora_batch(new_lora_set):
-                    # If this is a LoRA request that would exceed the LoRA slot limit,
-                    # skip it and continue to try scheduling non-LoRA requests.
-                    # Non-LoRA requests (lora_id=None) share a single reserved slot
-                    # and should never cause this check to fail.
-                    if req.lora_id is not None:
-                        # Skip this LoRA request - it would trigger adapter eviction/loading
-                        # which is slow. We'll try to schedule it in a future iteration.
-                        continue
+                    # Batch would exceed the LoRA slot limit.
+                    # Skip this request and try scheduling it in a future iteration.
+                    # Note: When eviction is needed, the eviction policy prefers to
+                    # evict LoRA adapters over base model (None) - see mem_pool.py.
+                    continue
 
             running_bs = len(self.running_batch.reqs)
             if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The scheduler's LoRA batch scheduling logic had a flawed assumption: it only skipped LoRA requests `(lora_id != None)` when the batch would exceed the LoRA slot limit, assuming non-LoRA (base model) requests could never trigger this check. This was incorrect because when running mixed LoRA/non-LoRA workloads with eviction enabled, adding a base model request can still exceed the slot limit if the None slot needs to be loaded/evicted.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Simplified the `can_run_lora_batch` check in scheduler.py to skip any request that would cause the batch to exceed the LoRA slot limit, regardless of whether it's a LoRA or base model request. The eviction policy already correctly handles this by preferring to evict LoRA adapters over the base model slot (see `eviction_policy.py`).

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
No changes to model forward code. Existing LoRA tests pass.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
Ran concurrent non-LoRA (B1) + 16-adapter LoRA (B2) benchmark with --num-prompts 100 --request-rate 2 --random-input-len 2048 --random-output-len 1024:


Benchmark 1 (B3) command

```
python3 -m sglang.bench_serving \
  --backend sglang \
  --base-url http://localhost:30001 \
  --dataset-name random \
  --num-prompts 100 \
  --request-rate 2 \
  --random-input-len 2048 \
  --random-output-len 1024 \
  --disable-ignore-eos \
  --disable-tqdm

```

Benchmark 2 (B4) command

```jsx
python3 -m sglang.bench_serving \
  --backend sglang \
  --base-url http://localhost:30000 \
  --dataset-name random \
  --num-prompts 100 \
  --request-rate 2 \
  --random-input-len 2048 \
  --random-output-len 1024 \
  --disable-ignore-eos \
  --disable-tqdm \
  --lora-name \
    adapter1 \
    adapter2 \
    adapter3 \
    adapter4 \
    adapter5 \
    adapter6 \
    adapter7 \
    adapter8 \
    adapter9 \
    adapter10 \
    adapter11 \
    adapter12 \
    adapter13 \
    adapter14 \
    adapter15 \
    adapter16
```

The non-LoRA workload shows a slight increase in `TTFT (~75ms mean, ~50ms median) `due to proper scheduling deferral when slots are full, while throughput and generation latency remain unchanged. The LoRA workload performance is essentially identical. This is expected behavior as the fix ensures correctness by deferring requests rather than attempting invalid batches.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
