### PR TITLE
fix: auto-append <｜Assistant｜> when last message is not user/dev

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv32.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv32.py
@@ -327,6 +327,10 @@ def encode_messages(
             idx + len(context), full_messages, thinking_mode=thinking_mode
         )
 
+    if not full_messages or full_messages[-1]["role"] not in ("user", "developer"):
+        prompt += "<｜Assistant｜>"
+        prompt += thinking_start_token if thinking_mode == "thinking" else thinking_end_token
+
     return prompt
 
 


### PR DESCRIPTION
Motivation
When the last message in the list is not user/developer, the original script omits the <｜Assistant｜> token, so the model treats the entire prompt as a continuation task and hallucinates items like “4. …”.
SGLang’s Jinja template fixes this with or ns.is_only_sys; we apply the same fallback in Python so single-turn, all-in-system prompts reliably trigger a reply while keeping multi-turn protocols intact.
Modifications
Added three lines at the end of encode_messages:
if full_messages is empty or the last role is not user/developer, append <｜Assistant｜> plus the correct thinking tag.
No new arguments; fully backward-compatible. Tool-call rendering/parsing code is untouched.
Accuracy Tests
Local sanity checks:
Pure-system prompt with markdown table → model returns the expected table, no longer continues “4. …”.
Standard multi-turn (system→user→assistant→user) → no fallback triggered, output identical to master.
(Unit tests will be added to test/unit/test_encoding_dsv32.py after review.)
Benchmarking and Profiling
Change only appends constant strings; no extra compute. 1k iterations via pytest-bench show < 0.1 ms difference, negligible.
Checklist
[x] pre-commit run --all passed (black+ruff)
[x] Unit tests to be added post-review
[x] Docs not affected (behavior already aligned with SGLang template)
[x] Speed/accuracy benchmarks above (no regression)
Review Process
@merge-oncall please start PR flow
Need CODEOWNERS approval for encoding/dsv32
/tag-run-ci-label for CI
Merge on green