### PR TITLE
Add openai to test dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -111,6 +111,7 @@ test = [
   "expecttest",
   "jsonlines",
   "matplotlib",
+  "openai>=1.0.0",
   "pandas",
   "parameterized",
   "peft",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -97,6 +97,7 @@ test = [
   "gguf",
   "jsonlines",
   "matplotlib",
+  "openai>=1.0.0",
   "pandas",
   "peft",
   "pytest",


### PR DESCRIPTION
Add openai>=1.0.0 to the test extras in pyproject.toml and pyproject_other.toml.

Tests using the openai client were failing on AMD CI with ModuleNotFoundError: No module named 'openai'.

Example failure: https://github.com/sgl-project/sglang/actions/runs/20802527047/job/59750995738?pr=16529