### PR TITLE
[Diffusion] model: fix zimage tp

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -119,14 +119,14 @@ class ZImageAttention(nn.Module):
         self.num_kv_heads = num_kv_heads
         self.qk_norm = qk_norm
 
-        # assert num_heads % get_tp_world_size() == 0, f"num_heads {num_heads} must be divisible by tp world size {get_tp_world_size()}"
-        # assert num_kv_heads % get_tp_world_size() == 0, f"num_kv_heads {num_kv_heads} must be divisible by tp world size {get_tp_world_size()}"
-        # self.local_num_heads = num_heads // get_tp_world_size()
-        # self.local_num_kv_heads = num_kv_heads // get_tp_world_size()
+        assert num_heads % get_tp_world_size() == 0, f"num_heads {num_heads} must be divisible by tp world size {get_tp_world_size()}"
+        assert num_kv_heads % get_tp_world_size() == 0, f"num_kv_heads {num_kv_heads} must be divisible by tp world size {get_tp_world_size()}"
+        self.local_num_heads = num_heads // get_tp_world_size()
+        self.local_num_kv_heads = num_kv_heads // get_tp_world_size()
 
-        self.to_q = ColumnParallelLinear(dim, dim, bias=False, gather_output=True)
-        self.to_k = ColumnParallelLinear(dim, self.head_dim * num_kv_heads, bias=False, gather_output=True)
-        self.to_v = ColumnParallelLinear(dim, self.head_dim * num_kv_heads, bias=False, gather_output=True)
+        self.to_q = ColumnParallelLinear(dim, dim, bias=False, gather_output=False)
+        self.to_k = ColumnParallelLinear(dim, self.head_dim * num_kv_heads, bias=False, gather_output=False)
+        self.to_v = ColumnParallelLinear(dim, self.head_dim * num_kv_heads, bias=False, gather_output=False)
 
         if self.qk_norm:
             self.norm_q = RMSNorm(self.head_dim, eps=eps)
@@ -136,14 +136,13 @@ class ZImageAttention(nn.Module):
             self.norm_k = None
 
         self.to_out = nn.ModuleList(
-            # [RowParallelLinear(dim, dim, bias=False, input_is_parallel=True)]
-            [ColumnParallelLinear(dim, dim, bias=False, gather_output=True)]
+            [RowParallelLinear(dim, dim, bias=False, input_is_parallel=True)]
         )
 
         self.attn = USPAttention(
-            num_heads=self.num_heads,
+            num_heads=self.local_num_heads,
             head_size=self.head_dim,
-            num_kv_heads=self.num_kv_heads,
+            num_kv_heads=self.local_num_kv_heads,
             dropout_rate=0,
             softmax_scale=None,
             causal=False,
@@ -157,9 +156,9 @@ class ZImageAttention(nn.Module):
         q, _ = self.to_q(hidden_states)
         k, _ = self.to_k(hidden_states)
         v, _ = self.to_v(hidden_states)
-        q = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
-        k = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
-        v = v.view(*v.shape[:-1], self.num_kv_heads, self.head_dim)
+        q = q.view(*q.shape[:-1], self.local_num_heads, self.head_dim)
+        k = k.view(*k.shape[:-1], self.local_num_kv_heads, self.head_dim)
+        v = v.view(*v.shape[:-1], self.local_num_kv_heads, self.head_dim)
 
         if self.qk_norm:
             if (

--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -119,10 +119,11 @@ class ZImageAttention(nn.Module):
         self.num_kv_heads = num_kv_heads
         self.qk_norm = qk_norm
 
-        assert num_heads % get_tp_world_size() == 0, f"num_heads {num_heads} must be divisible by tp world size {get_tp_world_size()}"
-        assert num_kv_heads % get_tp_world_size() == 0, f"num_kv_heads {num_kv_heads} must be divisible by tp world size {get_tp_world_size()}"
-        self.local_num_heads = num_heads // get_tp_world_size()
-        self.local_num_kv_heads = num_kv_heads // get_tp_world_size()
+        tp_size = get_tp_world_size()
+        assert num_heads % tp_size == 0, f"num_heads {num_heads} must be divisible by tp world size {tp_size}"
+        assert num_kv_heads % tp_size == 0, f"num_kv_heads {num_kv_heads} must be divisible by tp world size {tp_size}"
+        self.local_num_heads = num_heads // tp_size
+        self.local_num_kv_heads = num_kv_heads // tp_size
 
         self.to_q = ColumnParallelLinear(dim, dim, bias=False, gather_output=False)
         self.to_k = ColumnParallelLinear(dim, self.head_dim * num_kv_heads, bias=False, gather_output=False)


### PR DESCRIPTION
# Tensor Parallelism Support for Z-Image Model

In Z-Image, there is a bug when TP > 1: qkv uses ReplicatedLinear but o uses row linear, which causes a size mismatch error when tensor parallelism is enabled.

## Test Environment
- **Hardware**: NVIDIA H100 GPU
- **Model**: Z-Image-Turbo
- **Image Resolution**: 2048×2048 pixels

## Performance Results Summary

| Configuration | GPUs | TP Type | Execution Time | Speedup vs TP1 | Scaling Efficiency |
|--------------|------|---------|----------------|----------------|-------------------|
| **TP1** | 1 | None | 5.38 seconds | 1.00× | 100% |
| **TP2** | 2 | Col+Row | 3.74 seconds | **1.44×** | **72%** |
| **TP2** | 2 | Col+Col | 4.93 seconds | 1.09× | 54.5% |

## Server && Request

### server
```bash
#!/bin/bash
export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so.1
# Script to serve Tongyi-MAI/Z-Image-Turbo using SGLang multimodal_gen with optimizations
# This model is a multimodal image generation model (diffusion model)

# Set default values
MODEL_PATH="Tongyi-MAI/Z-Image-Turbo"
PORT=30000
HOST="0.0.0.0"
NUM_GPUS=2
TP_SIZE=2
USP_SIZE=1

# Parse command line arguments
while [[ $# -gt 0 ]]; do
  case $1 in
    --model-path)
      MODEL_PATH="$2"
      shift 2
      ;;
    --port)
      PORT="$2"
      shift 2
      ;;
    --host)
      HOST="$2"
      shift 2
      ;;
    --num-gpus)
      NUM_GPUS="$2"
      shift 2
      ;;
    --tp-size)
      TP_SIZE="$2"
      shift 2
      ;;
    *)
      echo "Unknown option: $1"
      exit 1
      ;;
  esac
done

# export SGLANG_CACHE_DIT_ENABLED=true
# export SGLANG_CACHE_DIT_WARMUP=4
# export SGLANG_CACHE_DIT_MC=8
# export SGLANG_CACHE_DIT_RDT=0.24
# export SGLANG_CACHE_DIT_FN=1
# export SGLANG_CACHE_DIT_BN=0
# export SGLANG_CACHE_DIT_TAYLORSEER=true
# export SGLANG_CACHE_DIT_SECONDARY_WARMUP=2
# export SGLANG_CACHE_DIT_SECONDARY_MC=20
# export SGLANG_CACHE_DIT_SECONDARY_RDT=0.24
# export SGLANG_CACHE_DIT_SECONDARY_FN=1
# export SGLANG_CACHE_DIT_SECONDARY_BN=0
# export SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true
# export SGLANG_CACHE_DIT_SCM_PRESET=fast
# export SGLANG_CACHE_DIT_SCM_POLICY=dynamic

# Enable JIT kernels and fused operators (from SGLang SRT)
export SGLANG_ENABLE_JIT_DEEPGEMM=true
export SGLANG_JIT_DEEPGEMM_PRECOMPILE=true
export SGLANG_JIT_DEEPGEMM_COMPILE_WORKERS=4

# Launch the multimodal_gen server with optimizations enabled
python -m sglang.multimodal_gen.runtime.launch_server \
  --model-path "$MODEL_PATH" \
  --port "$PORT" \
  --host "$HOST" \
  --num-gpus "$NUM_GPUS" \
  --tp-size "$TP_SIZE" \
  --ulysses-degree "$USP_SIZE" \
  --attention-backend fa3 \
  --pin-cpu-memory \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --vae-cpu-offload false \
  --warmup \

echo "Server started successfully with optimizations enabled!"
```

### Request
```python
#!/usr/bin/env python3
"""
Test script for Tongyi-MAI/Z-Image-Turbo model served by SGLang multimodal_gen.
This script demonstrates how to generate images using the Z-Image-Turbo model via OpenAI-compatible API.
"""

import argparse
import json
import requests
from typing import Optional


def test_image_generation(
    host: str = "127.0.0.1",
    port: int = 30000,
    prompt: str = "A beautiful sunset over mountains",
    negative_prompt: Optional[str] = None,
    width: int = 1024,
    height: int = 768,
    num_inference_steps: int = 8,
    guidance_scale: float = 3.5,
    seed: Optional[int] = None,
    save_output: bool = True,
    output_path: str = "./outputs"
):
    """
    Test image generation with Z-Image-Turbo model using OpenAI-compatible API.
    """
    url = f"http://{host}:{port}/v1/images/generations"

    # Prepare the request data (OpenAI-compatible format)
    data = {
        "prompt": prompt,
        "model": "Tongyi-MAI/Z-Image-Turbo",
        "size": f"{width}x{height}",
        "num_inference_steps": num_inference_steps,
        "guidance_scale": guidance_scale,
        "response_format": "b64_json",  # Only b64_json is supported for generations endpoint
        "n": 1
    }

    if negative_prompt:
        data["negative_prompt"] = negative_prompt
    if seed is not None:
        data["seed"] = seed

    print(f"Sending request to {url}")
    print(f"Prompt: {prompt}")
    print(f"Image size: {width}x{height}")
    print(f"Inference steps: {num_inference_steps}")
    print(f"Guidance scale: {guidance_scale}")
    if negative_prompt:
        print(f"Negative prompt: {negative_prompt}")
    if seed is not None:
        print(f"Seed: {seed}")

    try:
        response = requests.post(url, json=data, timeout=300)  # 5 minute timeout
        response.raise_for_status()

        result = response.json()
        print("\nResponse received:")
        # import pdb; pdb.set_trace()
        # print(json.dumps(result, indent=2))

        # Check if generation was successful
        if "data" in result and len(result["data"]) > 0:
            image_data = result["data"][0].get("b64_json")
            if image_data:
                # Decode and save the base64 image
                import base64
                image_bytes = base64.b64decode(image_data)
                output_file = f"generated_image_{seed if seed is not None else 'random'}.png"
                with open(output_file, "wb") as f:
                    f.write(image_bytes)
                print(f"\nImage saved as: {output_file}")
                print(f"Image size: {len(image_bytes)} bytes")
            else:
                print("Warning: No image data received in response")
                print(f"Response data keys: {list(result['data'][0].keys())}")

        return True

    except requests.exceptions.RequestException as e:
        print(f"Error making request: {e}")
        if hasattr(e, 'response') and e.response:
            print(f"Response status: {e.response.status_code}")
            print(f"Response content: {e.response.text}")
        return False
    except json.JSONDecodeError as e:
        print(f"Error parsing response: {e}")
        print(f"Raw response: {response.text}")
        return False


def test_generation_via_sglang_cli(
    prompt: str = "A beautiful sunset over mountains",
    negative_prompt: Optional[str] = None,
    width: int = 1024,
    height: int = 1024,
    num_inference_steps: int = 8,
    guidance_scale: float = 3.5,
    seed: Optional[int] = None
):
    """
    Alternative: Test using sglang generate command directly.
    """
    import subprocess
    import sys

    cmd = [
        sys.executable, "-m", "sglang.multimodal_gen.runtime.entrypoints.cli.main",
        "generate",
        "--model-path", "Tongyi-MAI/Z-Image-Turbo",
        "--prompt", prompt,
        "--width", str(width),
        "--height", str(height),
        "--num-inference-steps", str(num_inference_steps),
        "--guidance-scale", str(guidance_scale),
        "--save-output",
        "--output-path", "./outputs"
    ]

    if negative_prompt:
        cmd.extend(["--negative-prompt", negative_prompt])
    if seed is not None:
        cmd.extend(["--seed", str(seed)])

    print(f"Running command: {' '.join(cmd)}")

    try:
        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
        print("STDOUT:")
        print(result.stdout)
        if result.stderr:
            print("STDERR:")
            print(result.stderr)
        return result.returncode == 0
    except subprocess.TimeoutExpired:
        print("Command timed out")
        return False
    except Exception as e:
        print(f"Error running command: {e}")
        return False


def main():
    parser = argparse.ArgumentParser(description="Test Z-Image-Turbo model")
    parser.add_argument("--host", type=str, default="127.0.0.1", help="Server host")
    parser.add_argument("--port", type=int, default=30000, help="Server port")
    parser.add_argument("--prompt", type=str, default="A beautiful sunset over mountains", help="Image generation prompt")
    parser.add_argument("--negative-prompt", type=str, help="Negative prompt")
    parser.add_argument("--width", type=int, default=1024, help="Image width")
    parser.add_argument("--height", type=int, default=768, help="Image height")
    parser.add_argument("--steps", type=int, default=8, help="Number of inference steps")
    parser.add_argument("--guidance-scale", type=float, default=3.5, help="Guidance scale")
    parser.add_argument("--seed", type=int, help="Random seed")
    parser.add_argument("--use-cli", action="store_true", help="Use sglang CLI instead of server API")
    parser.add_argument("--output-path", type=str, default="./outputs", help="Output path for generated images")

    args = parser.parse_args()

    if args.use_cli:
        success = test_generation_via_sglang_cli(
            prompt=args.prompt,
            negative_prompt=args.negative_prompt,
            width=args.width,
            height=args.height,
            num_inference_steps=args.steps,
            guidance_scale=args.guidance_scale,
            seed=args.seed
        )
    else:
        success = test_image_generation(
            host=args.host,
            port=args.port,
            prompt=args.prompt,
            negative_prompt=args.negative_prompt,
            width=args.width,
            height=args.height,
            num_inference_steps=args.steps,
            guidance_scale=args.guidance_scale,
            seed=args.seed,
            output_path=args.output_path
        )

    if success:
        print("\nTest completed successfully!")
        return 0
    else:
        print("\nTest failed!")
        return 1


if __name__ == "__main__":
    import sys
    sys.exit(main())
```