### PR TITLE
[VLM] Support ViT CUDA Graph for InternVL

### DIFF
--- a/python/sglang/srt/multimodal/internvl_vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/internvl_vit_cuda_graph_runner.py
@@ -1,0 +1,183 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""ViT CUDA Graph Runner class."""
+from __future__ import annotations
+
+from typing import Dict, Hashable, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.layers.attention.vision import VisionAttention
+from sglang.srt.server_args import get_global_server_args
+
+
+class InternViTCudaGraphRunner:
+    """CUDA Graph runner for InternVL vision encoder.
+
+    Captures:
+      y = layer_N(...layer_2(layer_1(x)))
+
+    Keyed by (B, S). This is REQUIRED because InternVL uses [B,S,H].
+    """
+
+    def __init__(self, encoder: nn.Module) -> None:
+        self.encoder = encoder
+
+        # key -> graph & stable buffers
+        self.graphs: Dict[Hashable, torch.cuda.CUDAGraph] = {}
+        self.inp: Dict[Hashable, torch.Tensor] = {}
+        self.ws: Dict[Hashable, torch.Tensor] = {}
+        self.out: Dict[Hashable, torch.Tensor] = {}
+
+        # key -> stable cu_seqlens buffers (addresses must be stable)
+        self.cu: Dict[Hashable, torch.Tensor] = {}
+        self.cu_kk: Dict[Hashable, torch.Tensor] = {}
+
+        # cache attention metadata
+        first_layer = encoder.layers[0]
+        # InternAttention wraps VisionAttention as first_layer.attn.attn
+        self._attn: VisionAttention = first_layer.attn.attn  # type: ignore
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.encoder.parameters()).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.encoder.parameters()).dtype
+
+    def _graph_key(self, x: torch.Tensor) -> Tuple[int, int]:
+        # x: [B,S,H]
+        return (x.shape[0], x.shape[1])
+
+    def _build_cu(self, B: int, S: int, device: torch.device) -> torch.Tensor:
+        # [0, S, 2S, ..., B*S]
+        return torch.arange(0, (B + 1) * S, step=S, device=device, dtype=torch.int32)
+
+    def _alloc_ws(
+        self, B: int, S: int, H: int, device: torch.device, dtype: torch.dtype
+    ) -> torch.Tensor:
+        # InternVL shape: [tokens, nheads, head_dim]
+        tokens = B * S
+
+        num_heads = getattr(self._attn, "num_attention_heads_per_partition", None)
+        if num_heads is None:
+            num_heads = getattr(self._attn, "num_heads", None)
+        if num_heads is None:
+            raise RuntimeError("Cannot infer num_heads from VisionAttention")
+
+        head_dim = getattr(self._attn, "head_size", None)
+        if head_dim is None:
+            # fallback (should rarely happen)
+            head_dim = H // int(num_heads)
+
+        return torch.empty(
+            tokens,
+            int(num_heads),
+            int(head_dim),
+            device=device,
+            dtype=dtype,
+        )
+
+    def _warmup_once(self, key: Hashable) -> None:
+        """Run a tiny eager warmup on the preallocated buffers to trigger lazy init."""
+        override_backend = get_global_server_args().mm_attention_backend
+        cu = self.cu[key]
+        cu_kk = self.cu_kk[key]
+        max_len = int(cu_kk.max().item()) if cu_kk.numel() else 0
+
+        if override_backend == "triton_attn":
+            cu_ws = [cu, cu_kk, max_len]
+        elif override_backend == "fa3":
+            cu_ws = [cu, max_len]
+        else:
+            raise RuntimeError("Not supported ViT attention backend for InternVL CG")
+
+        x = self.inp[key]
+        y = x
+        with torch.no_grad():
+            for blk in self.encoder.layers:
+                y = blk(y, cu_seqlens=cu_ws, output_ws=self.ws[key])
+
+    def _capture_graph(self, key: Hashable) -> None:
+        g = torch.cuda.CUDAGraph()
+        override_backend = get_global_server_args().mm_attention_backend
+
+        cu = self.cu[key]
+        cu_kk = self.cu_kk[key]
+        max_len = int(cu_kk.max().item()) if cu_kk.numel() else 0
+
+        if override_backend == "triton_attn":
+            cu_ws = [cu, cu_kk, max_len]
+        elif override_backend == "fa3":
+            cu_ws = [cu, max_len]
+        else:
+            raise RuntimeError("Not supported ViT attention backend for InternVL CG")
+
+        torch.cuda.synchronize()
+
+        with torch.cuda.graph(g):
+            y = self.inp[key]
+            for blk in self.encoder.layers:
+                y = blk(y, cu_seqlens=cu_ws, output_ws=self.ws[key])
+            # y is a stable output tensor produced during capture; keep reference
+            self.out[key] = y
+
+        self.graphs[key] = g
+
+    def create_graph(self, x: torch.Tensor) -> Hashable:
+        # x: [B, S, H]
+        x = x.contiguous()
+        key = self._graph_key(x)
+        if key in self.graphs:
+            return key
+
+        B, S, H = x.shape
+        device = x.device
+        dtype = x.dtype
+
+        # stable input buffer
+        self.inp[key] = torch.empty_like(x, device=device).contiguous()
+
+        # stable cu buffers
+        cu = self._build_cu(B, S, device=device)
+        self.cu[key] = cu
+        self.cu_kk[key] = cu[1:] - cu[:-1]
+
+        # stable attention workspace
+        self.ws[key] = self._alloc_ws(B, S, H, device=device, dtype=dtype)
+
+        self.inp[key].copy_(x)
+        self._warmup_once(key)
+
+        # capture
+        self._capture_graph(key)
+        return key
+
+    def run(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, S, H]
+        x = x.contiguous()
+        key = self._graph_key(x)
+        if key not in self.graphs:
+            self.create_graph(x)
+
+        # update input content (address stable)
+        self.inp[key].copy_(x)
+
+        # replay
+        self.graphs[key].replay()
+
+        return self.out[key]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to support ViT CUDA Graph for InternVL family. 
InternVL model is different from Qwen2.5-VL and Qwen3-VL which setting flatten_batch=True, InternVL model's flatten_batch is False. It increases the implementation complexity. In order to handling this requirement, this PR introduced a new InternViTCudaGraphRunner dedicatedly.

Setting input x shape to [B,S,H], not flattening B to 1 as how Qwen-VL ViT CUDA Graph does.
The graph key should be [B, S].
The cu_seqlen should be built as [0, S, 2S, ..., B*S].

<img width="3038" height="1406" alt="image" src="https://github.com/user-attachments/assets/6a6bd865-393a-41b5-a34f-cc90e9de40fb" />
<img width="3294" height="1454" alt="image" src="https://github.com/user-attachments/assets/1bbcea92-6fc7-43a9-b726-ee1da3e17cf1" />

E2E performances increases about 5%. 

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
No acc drop.
```
root@6996fb46042d:/sgl-workspace/lmms-eval# python3 -m lmms_eval --model openai_compatible   --model_args model_version=OpenGVLab/InternVL3_5-8B   --tasks mmmu_val   --batch_size 16
2026-01-08 12:37:17 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2026-01-08 12:37:19 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2026-01-08 12:37:19 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2026-01-08 12:37:19 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-01-08 12:37:22 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2026-01-08 12:37:22 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13868.68it/s]
2026-01-08 12:37:22 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:11<00:00,  2.38s/it]2026-01-08 12:40:33 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1601.739s, Total tokens: 2017, Avg speed: 1.3 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:11<00:00,  3.36s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11627.59it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.75}, 'Art': {'num': 30, 'acc': 0.8}, 'Art_Theory': {'num': 30, 'acc': 0.86667}, 'Design': {'num': 30, 'acc': 0.9}, 'Music': {'num': 30, 'acc': 0.43333}, 'Overall-Business': {'num': 150, 'acc': 0.46667}, 'Accounting': {'num': 30, 'acc': 0.36667}, 'Economics': {'num': 30, 'acc': 0.7}, 'Finance': {'num': 30, 'acc': 0.26667}, 'Manage': {'num': 30, 'acc': 0.4}, 'Marketing': {'num': 30, 'acc': 0.6}, 'Overall-Science': {'num': 150, 'acc': 0.48}, 'Biology': {'num': 30, 'acc': 0.46667}, 'Chemistry': {'num': 30, 'acc': 0.33333}, 'Geography': {'num': 30, 'acc': 0.66667}, 'Math': {'num': 30, 'acc': 0.23333}, 'Physics': {'num': 30, 'acc': 0.7}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.64667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.76667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.53333}, 'Pharmacy': {'num': 30, 'acc': 0.53333}, 'Public_Health': {'num': 30, 'acc': 0.76667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.775}, 'History': {'num': 30, 'acc': 0.83333}, 'Literature': {'num': 30, 'acc': 0.9}, 'Sociology': {'num': 30, 'acc': 0.73333}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.42857}, 'Agriculture': {'num': 30, 'acc': 0.46667}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.36667}, 'Computer_Science': {'num': 30, 'acc': 0.46667}, 'Electronics': {'num': 30, 'acc': 0.43333}, 'Energy_and_Power': {'num': 30, 'acc': 0.4}, 'Materials': {'num': 30, 'acc': 0.43333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.43333}, 'Overall': {'num': 900, 'acc': 0.56889}}
2026-01-08 12:40:33 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=OpenGVLab/InternVL3_5-8B), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5689|±  |   N/A|
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
