### PR TITLE
Support customizing the image factor in the video config for qwen vl processor

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -163,6 +163,7 @@ async def preprocess_video(
     nframes, _, height, width = video.shape
     min_pixels = video_config.get("min_pixels", VIDEO_MIN_PIXELS)
     total_pixels = video_config.get("total_pixels", VIDEO_TOTAL_PIXELS)
+    video_factor = video_config.get("factor", image_factor)
     max_pixels = max(
         min(
             video_config.get("max_pixels", VIDEO_MAX_PIXELS),
@@ -184,13 +185,13 @@ async def preprocess_video(
         resized_height, resized_width = smart_resize(
             video_config["resized_height"],
             video_config["resized_width"],
-            factor=image_factor,
+            factor=video_factor,
         )
     else:
         resized_height, resized_width = smart_resize(
             height,
             width,
-            factor=image_factor,
+            factor=video_factor,
             min_pixels=min_pixels,
             max_pixels=max_pixels,
         )


### PR DESCRIPTION
In the previous implementation, when the Qwen-VL model processed video frames, its smart_resize force to use image_factor = 28. This submission has removed this restriction and added the ability to customize the factor for the video preprocessing process of qwen_vl.