### PR TITLE
Gateway supports dp rank scheduling and scheduling with the minimun number of tokens

### DIFF
--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -342,6 +342,7 @@ struct Router {
     policy: PolicyType,
     worker_startup_timeout_secs: u64,
     worker_startup_check_interval: u64,
+    worker_load_check_interval: u64,
     cache_threshold: f32,
     balance_abs_threshold: usize,
     balance_rel_threshold: f32,
@@ -351,6 +352,7 @@ struct Router {
     assignment_mode: String,
     max_payload_size: usize,
     dp_aware: bool,
+    dp_minimum_tokens_scheduler: bool,
     api_key: Option<String>,
     log_dir: Option<String>,
     log_level: Option<String>,
@@ -570,6 +572,7 @@ impl Router {
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
+            .worker_load_check_interval_secs(self.worker_load_check_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
@@ -632,6 +635,7 @@ impl Router {
                 self.server_cert_path.as_ref(),
                 self.server_key_path.as_ref(),
             )
+            .dp_minimum_tokens_scheduler(self.dp_minimum_tokens_scheduler)
             .build()
     }
 }
@@ -646,6 +650,7 @@ impl Router {
         port = 3001,
         worker_startup_timeout_secs = 600,
         worker_startup_check_interval = 30,
+        worker_load_check_interval = 10,
         cache_threshold = 0.3,
         balance_abs_threshold = 64,
         balance_rel_threshold = 1.5,
@@ -655,6 +660,7 @@ impl Router {
         assignment_mode = String::from("random"),
         max_payload_size = 512 * 1024 * 1024,
         dp_aware = false,
+        dp_minimum_tokens_scheduler = false,
         api_key = None,
         log_dir = None,
         log_level = None,
@@ -733,6 +739,7 @@ impl Router {
         port: u16,
         worker_startup_timeout_secs: u64,
         worker_startup_check_interval: u64,
+        worker_load_check_interval: u64,
         cache_threshold: f32,
         balance_abs_threshold: usize,
         balance_rel_threshold: f32,
@@ -742,6 +749,7 @@ impl Router {
         assignment_mode: String,
         max_payload_size: usize,
         dp_aware: bool,
+        dp_minimum_tokens_scheduler: bool,
         api_key: Option<String>,
         log_dir: Option<String>,
         log_level: Option<String>,
@@ -833,6 +841,7 @@ impl Router {
             policy,
             worker_startup_timeout_secs,
             worker_startup_check_interval,
+            worker_load_check_interval,
             cache_threshold,
             balance_abs_threshold,
             balance_rel_threshold,
@@ -842,6 +851,7 @@ impl Router {
             assignment_mode,
             max_payload_size,
             dp_aware,
+            dp_minimum_tokens_scheduler,
             api_key,
             log_dir,
             log_level,

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router.py
@@ -140,6 +140,7 @@ class Router:
         port: Port number to bind the router server. Default: 3001
         worker_startup_timeout_secs: Timeout in seconds for worker startup and registration. Large models can take significant time to load into GPU memory. Default: 1800 (30 minutes)
         worker_startup_check_interval: Interval in seconds between checks for worker initialization. Default: 10
+        worker_load_check_interval: Interval in seconds between get loads for worker initialization. Default: 10
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to cached worker
             if the match rate exceeds threshold, otherwise routes to the worker with the smallest
             tree. Default: 0.5
@@ -152,6 +153,7 @@ class Router:
         max_payload_size: Maximum payload size in bytes. Default: 256MB
         max_tree_size: Maximum size of the approximation tree for cache-aware routing. Default: 2^24
         dp_aware: Enable data parallelism aware schedule. Default: False
+        dp_minimum_tokens_scheduler: Enable minimum tokens scheduler for data parallel group. Default: False
         enable_igw: Enable IGW (Inference-Gateway) mode for multi-model support. When enabled,
             the router can manage multiple models simultaneously with per-model load balancing
             policies. Default: False

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
@@ -31,6 +31,7 @@ class RouterArgs:
     decode_policy: Optional[str] = None  # Specific policy for decode nodes in PD mode
     worker_startup_timeout_secs: int = 1800
     worker_startup_check_interval: int = 30
+    worker_load_check_interval: int = 10
     cache_threshold: float = 0.3
     balance_abs_threshold: int = 64
     balance_rel_threshold: float = 1.5
@@ -41,6 +42,7 @@ class RouterArgs:
     max_payload_size: int = 512 * 1024 * 1024  # 512MB default for large batches
     bucket_adjust_interval_secs: int = 5
     dp_aware: bool = False
+    dp_minimum_tokens_scheduler: bool = False
     enable_igw: bool = False  # Enable IGW (Inter-Gateway) mode for multi-model support
     api_key: Optional[str] = None
     log_dir: Optional[str] = None
@@ -351,6 +353,11 @@ class RouterArgs:
             help="Enable data parallelism aware schedule",
         )
         routing_group.add_argument(
+            f"--{prefix}dp-minimum-tokens-scheduler",
+            action="store_true",
+            help="Enable minimum tokens scheduler for data parallel group",
+        )
+        routing_group.add_argument(
             f"--{prefix}enable-igw",
             action="store_true",
             help="Enable IGW (Inference-Gateway) mode for multi-model support",
@@ -398,6 +405,12 @@ class RouterArgs:
             type=int,
             default=RouterArgs.worker_startup_check_interval,
             help="Interval in seconds between checks for worker startup",
+        )
+        pd_group.add_argument(
+            f"--{prefix}worker-load-check-interval",
+            type=int,
+            default=RouterArgs.worker_load_check_interval,
+            help="Interval in seconds between checks for worker load",
         )
 
         # Logging configuration

--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -462,7 +462,7 @@ impl AppContextBuilder {
                 .expect("policy_registry must be set")
                 .clone(),
             client.clone(),
-            config.worker_startup_check_interval_secs,
+            config.worker_load_check_interval_secs,
         )));
         self
     }

--- a/sgl-model-gateway/src/config/builder.rs
+++ b/sgl-model-gateway/src/config/builder.rs
@@ -187,6 +187,10 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn worker_load_check_interval_secs(mut self, interval: u64) -> Self {
+        self.config.worker_load_check_interval_secs = interval;
+        self
+    }
     // ==================== Rate Limiting ====================
 
     pub fn max_concurrent_requests(mut self, max: i32) -> Self {
@@ -468,6 +472,11 @@ impl RouterConfigBuilder {
 
     pub fn igw(mut self, enable: bool) -> Self {
         self.config.enable_igw = enable;
+        self
+    }
+
+    pub fn dp_minimum_tokens_scheduler(mut self, enable: bool) -> Self {
+        self.config.dp_minimum_tokens_scheduler = enable;
         self
     }
 

--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -20,7 +20,9 @@ pub struct RouterConfig {
     pub request_timeout_secs: u64,
     pub worker_startup_timeout_secs: u64,
     pub worker_startup_check_interval_secs: u64,
+    pub worker_load_check_interval_secs: u64,
     pub dp_aware: bool,
+    pub dp_minimum_tokens_scheduler: bool,
     pub api_key: Option<String>,
     pub discovery: Option<DiscoveryConfig>,
     pub metrics: Option<MetricsConfig>,
@@ -484,7 +486,9 @@ impl Default for RouterConfig {
             request_timeout_secs: 1800,        // 30 minutes
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_check_interval_secs: 30,
+            worker_load_check_interval_secs: 10,
             dp_aware: false,
+            dp_minimum_tokens_scheduler: false,
             api_key: None,
             discovery: None,
             metrics: None,

--- a/sgl-model-gateway/src/core/metrics_manager.rs
+++ b/sgl-model-gateway/src/core/metrics_manager.rs
@@ -1,5 +1,9 @@
+use std::collections::HashMap;
+
 use anyhow::ensure;
-use openmetrics_parser::{MetricFamily, MetricsExposition, PrometheusType, PrometheusValue};
+use openmetrics_parser::{
+    MetricFamily, MetricNumber, MetricsExposition, PrometheusType, PrometheusValue,
+};
 use tracing::warn;
 
 #[derive(Debug)]
@@ -88,4 +92,79 @@ where
     };
 
     Ok(Some(it.try_fold(first, f)?))
+}
+
+pub fn extract_gauge_metrics(text: String, target_metric_family: &str) -> HashMap<isize, isize> {
+    let metrics_text = text.replace(":", "_");
+    let exposition = match openmetrics_parser::prometheus::parse_prometheus(&metrics_text) {
+        Ok(x) => x,
+        Err(err) => {
+            warn!(
+                "parse_load_response error when parsing text: pack={:?} err={:?}",
+                metrics_text, err
+            );
+            return HashMap::new();
+        }
+    };
+    extract_metrics(
+        &exposition,
+        target_metric_family,
+        &PrometheusValue::Gauge(MetricNumber::Float(0.0)),
+    )
+}
+
+pub fn extract_metrics(
+    exposition: &PrometheusExposition,
+    target_metric_family: &str,
+    target_value_type: &PrometheusValue,
+) -> HashMap<isize, isize> {
+    let mut result = HashMap::new();
+    let Some(target_families) = exposition.families.get(target_metric_family) else {
+        warn!("{} don't exist!", target_metric_family);
+        return result;
+    };
+
+    for sample in target_families.iter_samples() {
+        let label_set = match sample.get_labelset() {
+            Ok(l_set) => l_set,
+            Err(e) => {
+                warn!("The metric is missing the dp_rank label{}, skipping.", e);
+                continue;
+            }
+        };
+
+        let dp_rank_str = match label_set.get_label_value("dp_rank") {
+            Some(val) => val,
+            None => {
+                warn!("Don't find dp_rank");
+                "0"
+            }
+        };
+
+        let dp_rank = match dp_rank_str.parse::<isize>() {
+            Ok(rank_num) => rank_num,
+            Err(e) => {
+                warn!(
+                    "Failed to parse dp_rank value {} as number: {}",
+                    dp_rank_str, e
+                );
+                0
+            }
+        };
+
+        let metric_value = match (&target_value_type, &sample.value) {
+            (PrometheusValue::Gauge(_), PrometheusValue::Gauge(val)) => val.as_f64(),
+            (target_type, actual_type) => {
+                warn!(
+                    "Unadapted PrometheusValue. Expected:{:?}, Actual:{:?}.",
+                    target_type, actual_type
+                );
+                continue;
+            }
+        };
+
+        let value = metric_value as isize;
+        result.insert(dp_rank, value);
+    }
+    result
 }

--- a/sgl-model-gateway/src/core/mod.rs
+++ b/sgl-model-gateway/src/core/mod.rs
@@ -15,7 +15,7 @@ pub use crate::protocols::UNKNOWN_MODEL_ID;
 pub mod circuit_breaker;
 pub mod error;
 pub mod job_queue;
-pub mod metrics_aggregator;
+pub mod metrics_manager;
 pub mod model_card;
 pub mod model_type;
 pub mod retry;
@@ -23,6 +23,7 @@ pub mod steps;
 pub mod token_bucket;
 pub mod worker;
 pub mod worker_builder;
+pub mod worker_load;
 pub mod worker_manager;
 pub mod worker_registry;
 pub mod worker_service;
@@ -38,6 +39,7 @@ pub use worker::{
     WorkerType,
 };
 pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
+pub use worker_load::WorkerLoadManager;
 pub use worker_manager::{LoadMonitor, WorkerManager};
 pub use worker_registry::{HashRing, WorkerRegistry};
 pub use worker_service::WorkerService;

--- a/sgl-model-gateway/src/core/worker_load.rs
+++ b/sgl-model-gateway/src/core/worker_load.rs
@@ -1,0 +1,148 @@
+//! Worker load
+//!
+//! Record and manage the DP group load of workers.
+use std::{collections::HashMap, fmt::Debug, sync::RwLock};
+
+use tracing::debug;
+
+use crate::core::Worker;
+
+#[derive(Debug, Default)]
+pub struct WorkerLoadManager {
+    // <worker, <dp_rank, loads>>
+    dp_cached_loads: RwLock<HashMap<String, HashMap<isize, isize>>>,
+}
+
+impl WorkerLoadManager {
+    pub fn new() -> Self {
+        Self {
+            dp_cached_loads: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn update_dp_loads(&self, loads: &HashMap<String, HashMap<isize, isize>>) {
+        debug!("WorkerLoadManager update_dp_loads map:{:?}", loads);
+        if let Ok(mut cached) = self.dp_cached_loads.write() {
+            *cached = loads.clone();
+        }
+    }
+
+    pub fn get_lowest_dp_load(&self, worker: &dyn Worker) -> Option<isize> {
+        if let Ok(cached_loads) = self.dp_cached_loads.read() {
+            if let Some(loads) = cached_loads.get(worker.url()) {
+                return loads
+                    .iter()
+                    .min_by_key(|&(_, load)| load)
+                    .map(|(&rand_id, _)| rand_id);
+            }
+        }
+        None
+    }
+
+    pub fn load_increment(&self, worker: &dyn Worker, dp_rank: isize, increment: isize) {
+        // Add an increment to the load of dp group,
+        // to prevent all request from being scheduled to the same DP group during the interval between two load reports.
+        if let Ok(mut cached_loads) = self.dp_cached_loads.write() {
+            debug!(
+                "WorkerLoadManager load_increment map:{:?}, increment:{}",
+                cached_loads, increment
+            );
+            if let Some(loads) = cached_loads.get_mut(worker.url()) {
+                if let Some(dp_load) = loads.get_mut(&dp_rank) {
+                    *dp_load += increment;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod dp_load_manager_tests {
+    use super::*;
+    use crate::core::{BasicWorkerBuilder, WorkerType};
+
+    #[test]
+    fn test_new_dp_load_manager_instance() {
+        let dp_load_manager = WorkerLoadManager::new();
+        let cached = dp_load_manager.dp_cached_loads.read().unwrap();
+        assert!(cached.is_empty());
+    }
+
+    #[test]
+    fn test_update_dp_load() {
+        let manager = WorkerLoadManager::new();
+        let mut loads = HashMap::new();
+
+        // insert worker1_load
+        let mut worker1_load = HashMap::new();
+        worker1_load.insert(0, 2);
+        worker1_load.insert(1, 1);
+        loads.insert("http://worker1:8080".to_string(), worker1_load);
+
+        // insert worker2.load
+        let mut worker2_load = HashMap::new();
+        worker2_load.insert(0, 3);
+        loads.insert("http://worker2:8080".to_string(), worker2_load);
+
+        // update
+        manager.update_dp_loads(&loads);
+
+        // assert
+        let cached = manager.dp_cached_loads.read().unwrap();
+        assert_eq!(cached.len(), 2);
+
+        let worker2_cache = cached.get("http://worker2:8080").unwrap();
+        assert_eq!(worker2_cache.get(&0), Some(&3));
+    }
+
+    #[test]
+    fn test_get_lowest_dp_load() {
+        let worker1 = BasicWorkerBuilder::new("http://worker1:8080")
+            .worker_type(WorkerType::Regular)
+            .api_key("test_api_key2")
+            .build();
+
+        let manager = WorkerLoadManager::new();
+        let mut loads = HashMap::new();
+        // insert worker1_load
+        let mut worker1_load = HashMap::new();
+        worker1_load.insert(0, 2);
+        worker1_load.insert(1, 1);
+        worker1_load.insert(3, 3);
+        loads.insert(worker1.url().to_string(), worker1_load);
+        manager.update_dp_loads(&loads);
+
+        // Verify that the worker1 with the lowest load is dp_rank = 1
+        assert_eq!(manager.get_lowest_dp_load(&worker1), Some(1));
+    }
+
+    #[test]
+    fn test_load_increment() {
+        let worker2 = BasicWorkerBuilder::new("http://worker2:8080")
+            .worker_type(WorkerType::Regular)
+            .api_key("test_api_key2")
+            .build();
+
+        let manager = WorkerLoadManager::new();
+        manager.load_increment(&worker2, 0, 5);
+        let cached = manager.dp_cached_loads.read().expect("Rwlock read1 failed");
+        assert!(cached.get(worker2.url()).is_none());
+        drop(cached);
+
+        // insert worker2.load
+        let mut worker2_load = HashMap::new();
+        worker2_load.insert(0, 2);
+        let mut loads = HashMap::new();
+        loads.insert(worker2.url().to_string(), worker2_load);
+        manager.update_dp_loads(&loads);
+
+        // load increment
+        manager.load_increment(&worker2, 0, 5);
+        let cached = manager.dp_cached_loads.read().expect("Rwlock read2 failed");
+        let worker2_cache = cached
+            .get(worker2.url())
+            .expect("worker2 not found in cache");
+        // 2 + 5 = 7
+        assert_eq!(worker2_cache.get(&0), Some(&7));
+    }
+}

--- a/sgl-model-gateway/src/core/worker_manager.rs
+++ b/sgl-model-gateway/src/core/worker_manager.rs
@@ -10,7 +10,6 @@ use futures::{
     stream::{self, StreamExt},
 };
 use http::StatusCode;
-use serde_json::Value;
 use tokio::{
     sync::{watch, Mutex},
     task::JoinHandle,
@@ -18,7 +17,10 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
-    core::{metrics_aggregator::MetricPack, ConnectionMode, Worker, WorkerRegistry, WorkerType},
+    core::{
+        metrics_manager::MetricPack, ConnectionMode, Worker, WorkerLoadManager, WorkerRegistry,
+        WorkerType,
+    },
     policies::PolicyRegistry,
     protocols::worker_spec::{FlushCacheResult, WorkerLoadInfo, WorkerLoadsResult},
 };
@@ -160,7 +162,7 @@ impl WorkerManager {
     pub async fn get_all_worker_loads(
         worker_registry: &WorkerRegistry,
         client: &reqwest::Client,
-    ) -> WorkerLoadsResult {
+    ) -> (WorkerLoadsResult, HashMap<String, HashMap<isize, isize>>) {
         let workers = worker_registry.get_all();
         let total_workers = workers.len();
 
@@ -178,54 +180,70 @@ impl WorkerManager {
                 let client = client.clone();
 
                 async move {
-                    let load = if is_http {
+                    let dp_rank_loads = if is_http {
                         Self::parse_load_response(&client, &url, api_key.as_deref()).await
+                    } else {
+                        HashMap::new()
+                    };
+
+                    let load = if !dp_rank_loads.is_empty() {
+                        dp_rank_loads.values().sum::<isize>()
                     } else {
                         -1
                     };
-                    WorkerLoadInfo {
+
+                    let worker_load_info = WorkerLoadInfo {
                         worker: url,
                         worker_type,
                         load,
-                    }
+                    };
+
+                    (worker_load_info, dp_rank_loads)
                 }
             })
             .collect();
 
-        let loads = future::join_all(futures).await;
+        let load_results = future::join_all(futures).await;
+        let mut loads = Vec::new();
+        let mut dp_rank_loads: HashMap<String, HashMap<isize, isize>> = HashMap::new();
+        for (worker_load_info, dp_rank_load) in load_results {
+            dp_rank_loads.insert(worker_load_info.worker.clone(), dp_rank_load);
+            loads.push(worker_load_info);
+        }
         let successful = loads.iter().filter(|l| l.load >= 0).count();
         let failed = loads.iter().filter(|l| l.load < 0).count();
 
-        WorkerLoadsResult {
+        let worker_loads_result = WorkerLoadsResult {
             loads,
             total_workers,
             successful,
             failed,
-        }
+        };
+        (worker_loads_result, dp_rank_loads)
     }
 
     async fn parse_load_response(
         client: &reqwest::Client,
         url: &str,
         api_key: Option<&str>,
-    ) -> isize {
-        let load_url = format!("{}/get_load", url);
+    ) -> HashMap<isize, isize> {
+        let load_url = format!("{}/metrics", url);
         let mut req = client.get(&load_url).timeout(REQUEST_TIMEOUT);
         if let Some(key) = api_key {
             req = req.bearer_auth(key);
         }
 
         match req.send().await {
-            Ok(r) if r.status().is_success() => match r.json::<Value>().await {
-                Ok(json) if json.is_array() => json
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .filter_map(|e| e.get("num_tokens").and_then(|v| v.as_i64()))
-                    .sum::<i64>() as isize,
-                _ => -1,
-            },
-            _ => -1,
+            Ok(r) if r.status().is_success() => {
+                if let Ok(text) = r.text().await {
+                    return crate::core::metrics_manager::extract_gauge_metrics(
+                        text,
+                        "sglang_num_used_tokens",
+                    );
+                }
+                HashMap::new()
+            }
+            _ => HashMap::new(),
         }
     }
 
@@ -259,7 +277,7 @@ impl WorkerManager {
             return EngineMetricsResult::Err("All backend requests failed".to_string());
         }
 
-        match crate::core::metrics_aggregator::aggregate_metrics(metric_packs) {
+        match crate::core::metrics_manager::aggregate_metrics(metric_packs) {
             Ok(text) => EngineMetricsResult::Ok(text),
             Err(e) => EngineMetricsResult::Err(format!("Failed to aggregate metrics: {}", e)),
         }
@@ -270,6 +288,7 @@ impl WorkerManager {
 pub struct LoadMonitor {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
+    pub worker_load_manager: Arc<WorkerLoadManager>,
     client: reqwest::Client,
     interval: Duration,
     tx: watch::Sender<HashMap<String, isize>>,
@@ -289,6 +308,7 @@ impl LoadMonitor {
         Self {
             worker_registry,
             policy_registry,
+            worker_load_manager: Arc::new(WorkerLoadManager::new()),
             client,
             interval: Duration::from_secs(interval_secs),
             tx,
@@ -311,12 +331,21 @@ impl LoadMonitor {
 
         let worker_registry = Arc::clone(&self.worker_registry);
         let policy_registry = Arc::clone(&self.policy_registry);
+        let worker_load_manager = Arc::clone(&self.worker_load_manager);
         let client = self.client.clone();
         let interval = self.interval;
         let tx = self.tx.clone();
 
         let handle = tokio::spawn(async move {
-            Self::monitor_loop(worker_registry, policy_registry, client, interval, tx).await;
+            Self::monitor_loop(
+                worker_registry,
+                policy_registry,
+                worker_load_manager,
+                client,
+                interval,
+                tx,
+            )
+            .await;
         });
 
         *handle_guard = Some(handle);
@@ -338,6 +367,7 @@ impl LoadMonitor {
     async fn monitor_loop(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
+        worker_load_manager: Arc<WorkerLoadManager>,
         client: reqwest::Client,
         interval: Duration,
         tx: watch::Sender<HashMap<String, isize>>,
@@ -346,15 +376,15 @@ impl LoadMonitor {
 
         loop {
             interval_timer.tick().await;
-
             let power_of_two_policies = policy_registry.get_all_power_of_two_policies();
 
-            if power_of_two_policies.is_empty() {
+            if power_of_two_policies.is_empty() && policy_registry.get_dp_rank_policy().is_none() {
                 debug!("No PowerOfTwo policies found, skipping load fetch");
                 continue;
             }
 
-            let result = WorkerManager::get_all_worker_loads(&worker_registry, &client).await;
+            let (result, dp_rank_loads) =
+                WorkerManager::get_all_worker_loads(&worker_registry, &client).await;
 
             let mut loads = HashMap::new();
             for load_info in result.loads {
@@ -370,6 +400,7 @@ impl LoadMonitor {
                 for policy in &power_of_two_policies {
                     policy.update_loads(&loads);
                 }
+                worker_load_manager.update_dp_loads(&dp_rank_loads);
                 let _ = tx.send(loads);
             } else {
                 warn!("No loads fetched from workers");

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -193,6 +193,9 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     enable_igw: bool,
 
+    #[arg(long, default_value_t = false)]
+    dp_minimum_tokens_scheduler: bool,
+
     // ==================== PD Disaggregation ====================
     /// Enable PD (Prefill-Decode) disaggregated mode
     #[arg(long, default_value_t = false, help_heading = "PD Disaggregation")]
@@ -217,6 +220,9 @@ struct CliArgs {
     /// Interval in seconds between worker startup checks
     #[arg(long, default_value_t = 30, help_heading = "PD Disaggregation")]
     worker_startup_check_interval: u64,
+
+    #[arg(long, default_value_t = 10)]
+    worker_load_check_interval: u64,
 
     // ==================== Service Discovery (Kubernetes) ====================
     /// Enable Kubernetes service discovery
@@ -972,6 +978,7 @@ impl CliArgs {
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
+            .worker_load_check_interval_secs(self.worker_load_check_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
@@ -1024,6 +1031,7 @@ impl CliArgs {
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .dp_aware(self.dp_aware)
+            .dp_minimum_tokens_scheduler(self.dp_minimum_tokens_scheduler)
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
             .enable_wasm(self.enable_wasm)

--- a/sgl-model-gateway/src/policies/dp_min_token.rs
+++ b/sgl-model-gateway/src/policies/dp_min_token.rs
@@ -1,0 +1,38 @@
+//! dp minimum tokens policy
+//！
+//! Engine support external DP dispatch
+//！ this policy select dp_rank with the minimum number of tokens
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::DPRankLoadPolicy;
+use crate::core::{Worker, WorkerLoadManager};
+
+#[derive(Debug)]
+pub struct MinimumTokensPolicy {
+    worker_load_manager: Option<Arc<WorkerLoadManager>>,
+}
+
+impl MinimumTokensPolicy {
+    pub fn new(worker_load_manager: Option<Arc<WorkerLoadManager>>) -> Self {
+        Self {
+            worker_load_manager,
+        }
+    }
+}
+
+#[async_trait]
+impl DPRankLoadPolicy for MinimumTokensPolicy {
+    async fn select_dp_rank(&self, worker: &dyn Worker, text_str: isize) -> Option<isize> {
+        if let Some(worker_load) = self.worker_load_manager.as_ref() {
+            let lowest_tokens_dp_rank = worker_load.get_lowest_dp_load(worker);
+            if let Some(dp_rank) = lowest_tokens_dp_rank {
+                worker_load.load_increment(worker, dp_rank, text_str);
+            }
+            return lowest_tokens_dp_rank;
+        }
+        None
+    }
+}

--- a/sgl-model-gateway/src/policies/mod.rs
+++ b/sgl-model-gateway/src/policies/mod.rs
@@ -13,6 +13,7 @@ use crate::core::{HashRing, Worker};
 mod bucket;
 mod cache_aware;
 mod consistent_hashing;
+mod dp_min_token;
 mod factory;
 mod manual;
 mod power_of_two;
@@ -25,6 +26,7 @@ pub(crate) mod utils;
 pub use bucket::BucketPolicy;
 pub use cache_aware::CacheAwarePolicy;
 pub use consistent_hashing::ConsistentHashingPolicy;
+pub use dp_min_token::MinimumTokensPolicy;
 pub use factory::PolicyFactory;
 pub use manual::{ManualConfig, ManualPolicy};
 pub use power_of_two::PowerOfTwoPolicy;
@@ -91,6 +93,11 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
 
     /// Get as Any for downcasting
     fn as_any(&self) -> &dyn std::any::Any;
+}
+
+#[async_trait]
+pub trait DPRankLoadPolicy: Send + Sync + Debug {
+    async fn select_dp_rank(&self, worker: &dyn Worker, text_str: isize) -> Option<isize>;
 }
 
 /// Configuration for cache-aware policy

--- a/sgl-model-gateway/src/policies/registry.rs
+++ b/sgl-model-gateway/src/policies/registry.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info, warn};
 /// When the first worker of a new model is added, it determines the policy for that model.
 /// All subsequent workers of the same model use the established policy.
 /// When the last worker of a model is removed, the policy mapping is cleaned up.
-use super::{BucketPolicy, CacheAwarePolicy, LoadBalancingPolicy, PolicyFactory};
+use super::{BucketPolicy, CacheAwarePolicy, DPRankLoadPolicy, LoadBalancingPolicy, PolicyFactory};
 use crate::{config::types::PolicyConfig, core::Worker};
 
 /// Registry for managing model-to-policy mappings
@@ -36,6 +36,9 @@ pub struct PolicyRegistry {
     /// When None, the registry works independently without mesh synchronization
     /// Uses RwLock for thread-safe access when setting mesh_sync after initialization
     mesh_sync: Arc<RwLock<OptionalMeshSyncManager>>,
+
+    // DP-rank policy: Supports the selection of dp-rank outside the engine.
+    dp_rank_policy: Arc<OnceLock<Arc<dyn DPRankLoadPolicy>>>,
 }
 
 impl PolicyRegistry {
@@ -50,6 +53,7 @@ impl PolicyRegistry {
             prefill_policy: Arc::new(OnceLock::new()),
             decode_policy: Arc::new(OnceLock::new()),
             mesh_sync: Arc::new(RwLock::new(None)),
+            dp_rank_policy: Arc::new(OnceLock::new()),
         }
     }
 
@@ -229,6 +233,16 @@ impl PolicyRegistry {
         // OnceLock::set returns Err if already set, which we ignore since
         // the policy should only be set once at startup
         let _ = self.prefill_policy.set(policy);
+    }
+
+    pub fn set_dp_rank_policy(&self, policy: Arc<dyn DPRankLoadPolicy>) {
+        // OnceLock::set returns Err if already set, which we ignore since
+        // the policy should only be set once at startup
+        let _ = self.dp_rank_policy.set(policy);
+    }
+
+    pub fn get_dp_rank_policy(&self) -> Option<Arc<dyn DPRankLoadPolicy>> {
+        self.dp_rank_policy.get().map(Arc::clone)
     }
 
     /// Set the decode policy for PD mode (lock-free, set once at startup)

--- a/sgl-model-gateway/src/routers/factory.rs
+++ b/sgl-model-gateway/src/routers/factory.rs
@@ -12,7 +12,7 @@ use crate::{
     app_context::AppContext,
     config::{PolicyConfig, RoutingMode},
     core::ConnectionMode,
-    policies::PolicyFactory,
+    policies::{DPRankLoadPolicy, MinimumTokensPolicy, PolicyFactory},
 };
 
 /// Factory for creating router instances based on configuration
@@ -85,6 +85,17 @@ impl RouterFactory {
         ctx.policy_registry.set_prefill_policy(prefill_policy);
         ctx.policy_registry.set_decode_policy(decode_policy);
 
+        let config = ctx.router_config.clone();
+        if config.dp_minimum_tokens_scheduler {
+            let mini_tokens_policy = MinimumTokensPolicy::new(
+                ctx.load_monitor
+                    .as_ref()
+                    .map(|load_monitor_arc| load_monitor_arc.worker_load_manager.clone()),
+            );
+            let dp_rank_policy: Arc<dyn DPRankLoadPolicy> = Arc::new(mini_tokens_policy);
+            ctx.policy_registry.set_dp_rank_policy(dp_rank_policy);
+        }
+
         let router = PDRouter::new(ctx).await?;
 
         Ok(Box::new(router))
@@ -111,6 +122,7 @@ impl RouterFactory {
 
         ctx.policy_registry.set_prefill_policy(prefill_policy);
         ctx.policy_registry.set_decode_policy(decode_policy);
+
         let router = GrpcPDRouter::new(ctx).await?;
 
         Ok(Box::new(router))

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -274,6 +274,12 @@ impl PDRouter {
         Ok(original)
     }
 
+    fn inject_dp_rank_to_json(json_val: &mut Value, rank: isize, rank_key: &str) {
+        if let Some(obj) = json_val.as_object_mut() {
+            obj.insert(rank_key.to_string(), Value::Number(rank.into()));
+        }
+    }
+
     async fn execute_dual_dispatch<T: Serialize + Clone>(
         &self,
         headers: Option<&HeaderMap>,
@@ -341,10 +347,46 @@ impl PDRouter {
                             Err(e) => return Self::handle_serialization_error(e),
                         };
 
+                        let mut prefill_json_request = json_request.clone();
+                        let mut decode_json_request = json_request;
+
+                        let dp_rank_policy_opt = self.policy_registry.get_dp_rank_policy();
+                        if let Some(dp_rank_policy) = dp_rank_policy_opt.as_ref() {
+                            let text_length: isize = match context.request_text.as_ref() {
+                                Some(text) => text.len().try_into().unwrap_or(0),
+                                None => 0,
+                            };
+                            let prefill_rank = dp_rank_policy
+                                .select_dp_rank(prefill.as_ref(), text_length)
+                                .await;
+                            let decode_rank = dp_rank_policy
+                                .select_dp_rank(decode.as_ref(), text_length)
+                                .await;
+                            if let (Some(p_rank), Some(d_rank)) = (prefill_rank, decode_rank) {
+                                debug!("prefill_rank is {}, decode_rank {}", p_rank, d_rank);
+                                Self::inject_dp_rank_to_json(
+                                    &mut prefill_json_request,
+                                    p_rank,
+                                    "routed_dp_rank",
+                                );
+                                Self::inject_dp_rank_to_json(
+                                    &mut decode_json_request,
+                                    d_rank,
+                                    "routed_dp_rank",
+                                );
+                                Self::inject_dp_rank_to_json(
+                                    &mut decode_json_request,
+                                    p_rank,
+                                    "disagg_prefill_dp_rank",
+                                );
+                            }
+                        }
+
                         let response = self
                             .execute_dual_dispatch_internal(
                                 headers,
-                                json_request,
+                                prefill_json_request,
+                                decode_json_request,
                                 context,
                                 Arc::clone(&prefill),
                                 Arc::clone(&decode),
@@ -530,10 +572,12 @@ impl PDRouter {
     }
 
     // Internal method that performs the actual dual dispatch (without retry logic)
+    #[allow(clippy::too_many_arguments)]
     async fn execute_dual_dispatch_internal(
         &self,
         headers: Option<&HeaderMap>,
-        json_request: Value,
+        prefill_json_request: Value,
+        decode_json_request: Value,
         context: PDRequestContext<'_>,
         prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
@@ -555,7 +599,7 @@ impl PDRouter {
             &self.client,
             prefill.url(),
             context.route,
-            &json_request,
+            &prefill_json_request,
             headers,
             false,
         );
@@ -563,7 +607,7 @@ impl PDRouter {
             &self.client,
             decode.url(),
             context.route,
-            &json_request,
+            &decode_json_request,
             headers,
             false,
         );

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -416,9 +416,10 @@ async fn flush_cache(State(state): State<Arc<AppState>>, _req: Request) -> Respo
 }
 
 async fn get_loads(State(state): State<Arc<AppState>>, _req: Request) -> Response {
-    WorkerManager::get_all_worker_loads(&state.context.worker_registry, &state.context.client)
-        .await
-        .into_response()
+    let (loads_result, _) =
+        WorkerManager::get_all_worker_loads(&state.context.worker_registry, &state.context.client)
+            .await;
+    loads_result.into_response()
 }
 
 async fn create_worker(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
#19268 The `routed_dp_rank` and `disagg_prefill_dp_rank` support external DP dispatch w/ PD-disaggregation mode. This modification supports this function in the gateway and schedules requests to the dprank with the minimum number of tokens.


<!-- Describe the purpose and goals of this pull request. -->
In the current PD-Disaggregation mode. the prefill instances only support the round_robin scheduling policy. Under this scheduling policy, which DP group a request is routed to is determined by the result of `bootstrap_room` mod `dpsize`. This can lead to load imbalance among DP groups, and this imbalance becomes more pronounced when the input requests are variable-length sequences.
Based on the above situation, I have added a new feature to select the DP group with the lightest load to process requests, thereby achieving and supporting DP load balance for PD-Disaggregation mode. The current load is measured by the number of tokens, which can be adjusted as needed in the future.The enabling or disabling of this feature is controlled by the parameter `dp_minimum_tokens_scheduler`.
## Key Changes

<!-- Detail the changes made in this pull request. -->
### 1.Load Collection
The /metrics interface is used instead of /get_load to obtain the instance load. A new WorkerLoadManager class has been added to manage the engine's load, storing the number of used tokens (num_used_tokens) for each DP group as the load.
）Modify the load query interface, add the `extract_gauge_metrics` method to parse the response returned by Prometheus.
```rust
        let load_url = format!("{}/metrics", url);
        let mut req = client.get(&load_url).timeout(REQUEST_TIMEOUT);
        if let Some(key) = api_key {
            req = req.bearer_auth(key);
        }

        match req.send().await {
            Ok(r) if r.status().is_success() => {
                if let Ok(text) = r.text().await {
                    return crate::core::metrics_manager::extract_gauge_metrics(text, "sglang_num_used_tokens");
                }
                HashMap::new()
            },
            _ => HashMap::new(),
        }
```
### 2. Load Management
A new `DPLoadManager` struct has been added to manage loads, providing three methods:  `update_dp_loads` ,`get_lowest_dp_load` , and `load_increment`.
```rust
#[derive(Debug, Default)]
pub struct WorkerLoadManager {
    // <worker, <dp_rank, loads>>
    dp_cached_loads: RwLock<HashMap<String, HashMap<isize, isize>>>,
}
```
1. The `update_dp_loads` method updates the load. After periodically collecting load data, the LoadMonitor calls this method to perform the update.
2. The `get_lowest_dp_load` method takes a worker as input and returns the dp_rank with the lowest load among the workers.
3. The `load_increment` method is used to add an increment to the load of a specific dp_rank for a worker. This is done to prevent all requests from being scheduled to the same DP group during the interval between two load reports.

### 3. New interfaces are added.
The DPRankLoadPolicy and MinimumTokensPolicy APIs are added. The worker is passed in, and the dpRank with the minimum number of tokens is selected.
```
#[async_trait]
pub trait DPRankLoadPolicy: Send + Sync + Debug {
    async fn select_dp_rank(&self, worker: &dyn Worker, text_str: isize) -> Option<isize>;
}

impl DPRankLoadPolicy for MinimumTokensPolicy {
    async fn select_dp_rank(&self, worker: &dyn Worker, text_str: isize) -> Option<isize> {
        if let Some(worker_load) = self.worker_load_manager.as_ref() {
            let lowest_tokens_dp_rank = worker_load.get_lowest_dp_load(worker);
            if let Some(dp_rank) = lowest_tokens_dp_rank {
                worker_load.load_increment(worker, dp_rank, text_str);
            }
            return lowest_tokens_dp_rank;
        }
        None
    }
}
```
### 4. Configuration Parameters
1. A new configuration parameter `dp-minimum-tokens-scheduler` has been added to enable scheduling of the minimum load DP group when declaring the parameter.
2. A new configuration parameter `worker-load-check-interval` has been added to specify the interval for load collection. Previously, the load collection interval reused the configuration of `worker-startup-check-interval`. Now, this new configuration item is separate from the startup check.
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Comparing the performance gains of several scheduling strategies on variable-length datasets before and after enabling dp-minimum-tokens-scheduler, the Mean TPOP performance improved by approximately 9%, and the Mean TTFT (with max_out_len=1 set to eliminate the impact of decoding on prefill) performance improved by about 15%. The specific data is as follows:
| Policy      | Mean  TTFT(ms) max_out_len=1 |                           |             | Mean  TPOT (ms)|                            |             |
| ----------- | ---------------------------- | ------------------------- | ----------- | ---------- | -------------------------- | ----------- |
|             | benckmark                    | enable dp minimum  tokens | Performance | benckmark  | enable dp minimum  tokense | Performance |
| Random      | 2631                         | 2249                      | +14.52%      | 53.41      | 48.15                      | +9.85%       |
| Round_robin | 2646                         | 2164                      | +18.22%       | 55.42      | 49.02                      | +11.55%      |
| Cache_aware | 2601                         | 2216                      | +14.80%      | 52.67      | 48.48                      | +7.96%       |

router
```shell
python -m sglang_router.launch_router   --pd-disaggregation   --prefill-policy cache_aware --dp-minimum-tokens-scheduler --worker-load-check-interval 1   --prefill grpc://141.61.29.204:6699   --decode grpc://127.0.0.1:7699   --model-path /home/weights/DeepSeek-R1_w8a8   --tokenizer-path /home/weights/DeepSeek-R1_w8a8   --host 0.0.0.0 --port 4567
```

prefill
```shell
python3 -m sglang.launch_server --model-path ${MODEL_PATH} --tp-size 1 --dp-size 2 --base-gpu-id 8 --disaggregation-mode prefill --trust-remote-code --attention-backend ascend --disaggregation-transfer-backend ascend --device npu --quantization modelslim --watchdog-timeout 9000 --host 141.61.29.204 --grpc-mode --metrics-port 10000 --port 6699 --cuda-graph-bs 8 16 24 28 32 36 --mem-fraction-static 0.71 --max-running-requests 144 --chunked-prefill-size -1  --dtype bfloat16 --load-balance-method round_robin --disable-overlap-schedule --enable-metrics
```
decode
```shell
python3 -m sglang.launch_server --model-path ${MODEL_PATH} --tp-size 1 --dp-size 2 --base-gpu-id 12 --disaggregation-mode decode --trust-remote-code --attention-backend ascend --disaggregation-transfer-backend ascend --device npu --quantization modelslim --watchdog-timeout 9000 --host 141.61.29.204 --grpc-mode --metrics-port 10001 --port 7699 --cuda-graph-bs 8 16 24 28 32 36 --mem-fraction-static 0.71 --max-running-requests 144 --chunked-prefill-size -1  --dtype bfloat16 --load-balance-method round_robin --disable-overlap-schedule --load-balance-method round_robin --prefill-round-robin-balance --enable-metrics
```
benchmark
The model evaluation tool I used is AISBench. Click the link below to learn more: [AISBench](https://gitee.com/aisbench/benchmark/blob/master/README_en.md). Variable-length datasets are prone to load imbalance scenarios. During testing, I constructed a variable-length dataset. When using the benchmark's `--dataset-name random` option to specify the dataset, the input prompts were being split. Therefore, I used AISBench to replace the original dataset with a variable-length dataset during the test runs.
```bash
ais_bench --models vllm_api_stream_chat --datasets gsm8k_gen_0_shot_cot_str_perf  --debug --summarizer default_perf --mode perf

╒══════════════════════════╤═════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤══════╕
│ Performance Parameters   │ Stage   │ Average         │ Min             │ Max             │ Median          │ P75             │ P90             │ P99             │  N   │
╞══════════════════════════╪═════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪══════╡
│ E2EL                     │ total   │ 55044.4573 ms   │ 11143.2514 ms   │ 195472.4726 ms  │ 35057.9889 ms   │ 69464.8019 ms   │ 132295.1279 ms  │ 185509.4833 ms  │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ TTFT                     │ total   │ 893.5725 ms     │ 348.2403 ms     │ 1549.0416 ms    │ 901.9457 ms     │ 1084.3782 ms    │ 1215.7292 ms    │ 1469.2704 ms    │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ TPOT                     │ total   │ 48.4854 ms      │ 33.7401 ms      │ 63.8094 ms      │ 48.7747 ms      │ 52.4151 ms      │ 55.4097 ms      │ 59.9007 ms      │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ ITL                      │ total   │ 114.1014 ms     │ 0.0068 ms       │ 594.2452 ms     │ 115.7806 ms     │ 119.678 ms      │ 123.1585 ms     │ 251.8668 ms     │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ InputTokens              │ total   │ 2560.5243       │ 1481.0          │ 4120.0          │ 2216.0          │ 3402.25         │ 3943.3          │ 4107.49         │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ OutputTokens             │ total   │ 1159.8058       │ 187.0           │ 4068.0          │ 715.5           │ 1358.0          │ 2769.4          │ 4068.0          │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ OutputTokenThroughput    │ total   │ 20.3425 token/s │ 14.7171 token/s │ 28.1505 token/s │ 19.9678 token/s │ 22.0362 token/s │ 23.6102 token/s │ 26.6782 token/s │ 1000 │
╘══════════════════════════╧═════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧══════╛
╒══════════════════════════╤═════════╤═══════════════════╕
│ Common Metric            │ Stage   │ Value             │
╞══════════════════════════╪═════════╪═══════════════════╡
│ Benchmark Duration       │ total   │ 392829.9277 ms    │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Requests           │ total   │ 1000              │
├──────────────────────────┼─────────┼───────────────────┤
│ Failed Requests          │ total   │ 0                 │
├──────────────────────────┼─────────┼───────────────────┤
│ Success Requests         │ total   │ 1000              │
├──────────────────────────┼─────────┼───────────────────┤
│ Concurrency              │ total   │ 86.5959           │
├──────────────────────────┼─────────┼───────────────────┤
│ Max Concurrency          │ total   │ 270               │
├──────────────────────────┼─────────┼───────────────────┤
│ Request Throughput       │ total   │ 2.5456 req/s      │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Input Tokens       │ total   │ 1582404           │
├──────────────────────────┼─────────┼───────────────────┤
│ Prefill Token Throughput │ total   │ 2865.4913 token/s │
├──────────────────────────┼─────────┼───────────────────┤
│ Total generated tokens   │ total   │ 716760            │
├──────────────────────────┼─────────┼───────────────────┤
│ Input Token Throughput   │ total   │ 4028.2165 token/s │
├──────────────────────────┼─────────┼───────────────────┤
│ Output Token Throughput  │ total   │ 1824.6064 token/s │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Token Throughput   │ total   │ 5852.8229 token/s │
╘══════════════════════════╧═════════╧═══════════════════╛

```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
