### PR TITLE
[grpc] Fix protobuf compilation in isolated build environments

### DIFF
--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -1,6 +1,6 @@
 # https://docs.sglang.io/platforms/cpu_server.html
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel", "grpcio-tools==1.75.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel", "grpcio-tools==1.75.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel", "grpcio-tools==1.75.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,8 +6,7 @@ to automatically generate gRPC/protobuf Python files from .proto sources
 when building the wheel or doing editable installs.
 """
 
-import subprocess
-import sys
+import os
 from pathlib import Path
 
 from setuptools import setup
@@ -32,31 +31,44 @@ def compile_proto():
     output_dir = proto_path.parent
     proto_dir = proto_path.parent
 
-    # Build the protoc command
-    cmd = [
-        sys.executable,
-        "-m",
-        "grpc_tools.protoc",
+    # Import grpc_tools.protoc directly instead of running as subprocess.
+    # This ensures we use the grpcio-tools installed in the build environment,
+    # since sys.executable may point to the main Python interpreter in
+    # pip's isolated build environments.
+    try:
+        import grpc_tools
+        from grpc_tools import protoc
+    except ImportError as e:
+        raise SetupError(
+            f"Failed to import grpc_tools: {e}. "
+            "Ensure grpcio-tools is listed in build-system.requires in pyproject.toml"
+        )
+
+    # Get the path to well-known proto files bundled with grpcio-tools
+    # (e.g., google/protobuf/timestamp.proto, google/protobuf/struct.proto)
+    grpc_tools_proto_path = Path(grpc_tools.__file__).parent / "_proto"
+
+    # Build the protoc arguments (protoc.main expects argv-style list)
+    args = [
+        "protoc",  # argv[0] is the program name
         f"-I{proto_dir}",
+        f"-I{grpc_tools_proto_path}",  # Include path for well-known protos
         f"--python_out={output_dir}",
         f"--grpc_python_out={output_dir}",
         f"--pyi_out={output_dir}",
-        proto_path.name,
+        str(proto_dir / proto_path.name),
     ]
 
-    print(f"Running: {' '.join(cmd)}")
+    print(f"Running protoc with args: {args[1:]}")
 
+    # Save and restore cwd since protoc may change it
+    original_cwd = os.getcwd()
     try:
-        subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=proto_dir,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        error_msg = e.stderr or e.stdout or "Unknown error"
-        raise SetupError(f"protoc failed with exit code {e.returncode}: {error_msg}")
+        result = protoc.main(args)
+        if result != 0:
+            raise SetupError(f"protoc failed with exit code {result}")
+    finally:
+        os.chdir(original_cwd)
 
     # Fix imports in generated grpc file (change absolute to relative imports)
     _fix_imports(output_dir, proto_path.stem)


### PR DESCRIPTION
- Use grpc_tools.protoc directly via Python import instead of subprocess to ensure the build environment's grpcio-tools is used (sys.executable points to main Python in pip's isolated builds)
- Add grpcio-tools to build-system.requires in all pyproject variant files (pyproject_other.toml, pyproject_cpu.toml, pyproject_xpu.toml)

Fixes AMD CI failure caused by missing grpcio-tools in pyproject_other.toml



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
