### PR TITLE
[smg] Work around sglang's notorious orphan process problem

### DIFF
--- a/sgl-model-gateway/e2e_test/infra/constants.py
+++ b/sgl-model-gateway/e2e_test/infra/constants.py
@@ -61,7 +61,9 @@ HEALTH_CHECK_INTERVAL = 2  # Check every 2s (was 5s)
 
 # Model loading configuration
 INITIAL_GRACE_PERIOD = 30  # Wait before first health check (model loading time)
-LAUNCH_STAGGER_DELAY = 5  # Delay between launching multiple workers
+LAUNCH_STAGGER_DELAY = (
+    10  # Delay between launching multiple workers (avoid I/O contention)
+)
 
 # Retry configuration
 MAX_RETRY_ATTEMPTS = (


### PR DESCRIPTION
sglang is notorious for getting stuck during model loading and leaving orphan child processes (TP workers) hanging around holding GPU memory. There's even a dedicated killall_sglang.sh script for this very reason.

This commit works around these issues in e2e tests:
- Kill entire process group on terminate() instead of just parent process, since sglang doesn't clean up its children when the parent dies
- Increase LAUNCH_STAGGER_DELAY from 5s to 10s because sglang can't handle multiple servers loading weights simultaneously without choking

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
