### PR TITLE
[BugFix] fix gpt-oss-120b launch failure with --enable-piecewise-cuda-graph

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -565,10 +565,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             from triton_kernels.numerics_details.mxfp import upcast_from_mxfp
 
             w13_weight = upcast_from_mxfp(
-                layer.w13_weight, layer.w13_weight_scale, dtype=torch.bfloat16, axis=-1
+                layer.w13_weight,
+                layer.w13_weight_scale,
+                target_dtype=torch.bfloat16,
+                axis=-1,
             )
             w2_weight = upcast_from_mxfp(
-                layer.w2_weight, layer.w2_weight_scale, dtype=torch.bfloat16, axis=-1
+                layer.w2_weight,
+                layer.w2_weight_scale,
+                target_dtype=torch.bfloat16,
+                axis=-1,
             )
             del layer.w13_weight
             del layer.w2_weight


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
fix gpt-oss-120b launch with --enable-piecewise-cuda-graph

`python3 -m sglang.launch_server --model-path /shared/public/elr-models/openai/gpt-oss-120b-new/ --trust-remote-code --tp 2 --reasoning-parser gpt-oss --enable-piecewise-cuda-graph
`
Without the change:
```
[2026-01-08 23:03:49 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/scheduler.py", line 2936, in run_scheduler_process
    scheduler = Scheduler(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/scheduler.py", line 336, in __init__
    self.init_model_worker()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/scheduler.py", line 546, in init_model_worker
    self.init_tp_model_worker()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/scheduler.py", line 474, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/tp_worker.py", line 240, in __init__
    self._init_model_runner()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/tp_worker.py", line 323, in _init_model_runner
    self._model_runner = ModelRunner(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/model_executor/model_runner.py", line 381, in __init__
    self.initialize(min_per_gpu_memory)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/model_executor/model_runner.py", line 458, in initialize
    self.load_model()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/model_executor/model_runner.py", line 882, in load_model
    self.model = self.loader.load_model(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/model_loader/loader.py", line 645, in load_model
    self.load_weights_and_postprocess(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/model_loader/loader.py", line 664, in load_weights_and_postprocess
    quant_method.process_weights_after_loading(module)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/quantization/mxfp4.py", line 567, in process_weights_after_loading
    w13_weight = upcast_from_mxfp(
TypeError: upcast_from_mxfp() got an unexpected keyword argument 'dtype'
```

With the fix:
```
[2026-01-08 23:05:45] INFO:     Application startup complete.
[2026-01-08 23:05:45] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-01-08 23:05:46] INFO:     127.0.0.1:44154 - "GET /model_info HTTP/1.1" 200 OK
[2026-01-08 23:05:46 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
[2026-01-08 23:05:46] INFO:     127.0.0.1:44164 - "POST /generate HTTP/1.1" 200 OK
[2026-01-08 23:05:46] The server is fired up and ready to roll!
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python benchmark/gsm8k/bench_sglang.py --data-path /shared/public/data/gsm8k/test.jsonl
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:25<00:00,  7.84it/s]
Accuracy: 0.880
Invalid: 0.005
Latency: 25.567 s
Output throughput: 2500.237 token/s
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
