### PR TITLE
[DeepSeek V3.2] Enable trtllm NSA with bf16 kvcache

### DIFF
--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -322,11 +322,10 @@ class NativeSparseAttnBackend(
         self.device_sm_major = self.device_capability[0]
 
         # Allocate global workspace buffer for TRT-LLM kernels (ragged attention on SM100/B200, or trtllm_gen decode)
-        # Use torch.zeros() for zero-initialization required by TRT-LLM Gen multi-block reduction
         if self.device_sm_major >= 10 or self.nsa_decode_impl == "trtllm_gen":
             global global_workspace_buffer
             if global_workspace_buffer is None:
-                global_workspace_buffer = torch.zeros(
+                global_workspace_buffer = torch.empty(
                     envs.SGLANG_FLASHINFER_WORKSPACE_SIZE.get(),
                     dtype=torch.uint8,
                     device=model_runner.device,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -163,7 +163,7 @@ NSA_CHOICES = [
     "fa3",
     "tilelang",
     "aiter",
-    "trtllm_gen",
+    "trtllm",
 ]
 
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu"]
@@ -437,8 +437,12 @@ class ServerArgs:
     mm_attention_backend: Optional[str] = None
     fp8_gemm_runner_backend: str = "auto"
     fp4_gemm_runner_backend: str = "auto"
-    nsa_prefill_backend: Optional[str] = None  # None = auto-detect based on hardware/kv_cache_dtype
-    nsa_decode_backend: Optional[str] = None  # auto-detect based on hardware/kv_cache_dtype
+    nsa_prefill_backend: Optional[str] = (
+        None  # None = auto-detect based on hardware/kv_cache_dtype
+    )
+    nsa_decode_backend: Optional[str] = (
+        None  # auto-detect based on hardware/kv_cache_dtype
+    )
     disable_flashinfer_autotune: bool = False
 
     # Speculative decoding
@@ -1087,6 +1091,59 @@ class ServerArgs:
 
         return capture_sizes
 
+    def _set_default_nsa_kv_cache_dtype(self, major: int) -> str:
+        user_set_prefill = self.nsa_prefill_backend is not None
+        user_set_decode = self.nsa_decode_backend is not None
+
+        # If user specified a backend but didn't explicitly set kv_cache_dtype,
+        # suggest them to be explicit about kv_cache_dtype to avoid surprises
+        if (user_set_prefill or user_set_decode) and self.kv_cache_dtype == "auto":
+            logger.warning(
+                f"When specifying --nsa-prefill-backend or --nsa-decode-backend, "
+                f"you should also explicitly set --kv-cache-dtype (e.g., 'fp8_e4m3' or 'bfloat16'). "
+                f"DeepSeek V3.2 defaults to FP8 KV cache which may not be compatible with all backends."
+            )
+
+        if self.kv_cache_dtype == "auto":
+            self.kv_cache_dtype = "fp8_e4m3" if major >= 10 else "bfloat16"
+            logger.warning(
+                f"Setting KV cache dtype to {self.kv_cache_dtype} for DeepSeek DSA on SM{major} device."
+            )
+        if self.kv_cache_dtype == "bf16":
+            self.kv_cache_dtype = "bfloat16"
+        assert self.kv_cache_dtype in [
+            "bfloat16",
+            "fp8_e4m3",
+        ], "DeepSeek DSA only supports bf16/bfloat16 or fp8_e4m3 kv_cache_dtype"
+
+    def _set_default_nsa_backends(self, kv_cache_dtype: str, major: int) -> str:
+        user_set_prefill = self.nsa_prefill_backend is not None
+        user_set_decode = self.nsa_decode_backend is not None
+
+        if kv_cache_dtype == "fp8_e4m3":
+            # flashmla_auto dispatches to flashmla_sparse/flashmla_kv based on hardware and heuristics
+            if not user_set_prefill:
+                self.nsa_prefill_backend = "flashmla_auto"
+            if not user_set_decode:
+                self.nsa_decode_backend = "flashmla_kv"
+        else:
+            # set prefill/decode backends based on hardware architecture.
+            if major >= 10:
+                if not user_set_prefill:
+                    self.nsa_prefill_backend = "flashmla_sparse"
+                if not user_set_decode:
+                    self.nsa_decode_backend = "trtllm"
+            else:
+                # Hopper defaults for bfloat16
+                if not user_set_prefill:
+                    self.nsa_prefill_backend = "flashmla_sparse"
+                if not user_set_decode:
+                    self.nsa_decode_backend = "fa3"
+
+        logger.warning(
+            f"Set NSA backends for {self.kv_cache_dtype} KV Cache: prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend}."
+        )
+
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import is_deepseek_nsa
 
@@ -1159,56 +1216,11 @@ class ServerArgs:
                         self.page_size = 64
                         logger.warning("Setting page size to 64 for DeepSeek DSA.")
 
-                    # For Hopper, we support both bf16 and fp8 kv cache; for Blackwell, we support fp8 only currently
                     import torch
 
-                    user_set_prefill = self.nsa_prefill_backend is not None
-                    user_set_decode = self.nsa_decode_backend is not None
-
-                    # If user specified a backend but didn't explicitly set kv_cache_dtype,
-                    # require them to be explicit about kv_cache_dtype to avoid surprises
-                    if (user_set_prefill or user_set_decode) and self.kv_cache_dtype == "auto":
-                        logger.warning(
-                            f"When specifying --nsa-prefill-backend or --nsa-decode-backend, "
-                            f"you should also explicitly set --kv-cache-dtype (e.g., 'fp8_e4m3' or 'bfloat16'). "
-                            f"DeepSeek V3.2 defaults to FP8 KV cache which may not be compatible with all backends."
-                        )
-
                     major, _ = torch.cuda.get_device_capability()
-                    if self.kv_cache_dtype == "auto":
-                        self.kv_cache_dtype = "fp8_e4m3" if major >= 10 else "bfloat16"
-                        logger.warning(
-                            f"Setting KV cache dtype to {self.kv_cache_dtype} for DeepSeek DSA on SM{major} device."
-                        )
-                    if self.kv_cache_dtype == "bf16":
-                        self.kv_cache_dtype = "bfloat16"
-                    assert self.kv_cache_dtype in [
-                        "bfloat16",
-                        "fp8_e4m3",
-                    ], "DeepSeek DSA only supports bf16/bfloat16 or fp8_e4m3 kv_cache_dtype"
-
-                    if self.kv_cache_dtype == "fp8_e4m3":
-                        # flashmla_auto dispatches to flashmla_sparse/flashmla_kv based on hardware and heuristics
-                        if not user_set_prefill:
-                            self.nsa_prefill_backend = "flashmla_auto"
-                        if not user_set_decode:
-                            self.nsa_decode_backend = "flashmla_kv"
-                        logger.warning(
-                            f"Set NSA backends for FP8 KV Cache: prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend}."
-                        )
-                    else:
-                        # set prefill/decode backends based on hardware architecture.
-                        if major >= 10:
-                            if not user_set_prefill:
-                                self.nsa_prefill_backend = "flashmla_sparse"
-                            if not user_set_decode:
-                                self.nsa_decode_backend = "trtllm_gen"
-                        else:
-                            # Hopper defaults for bfloat16
-                            if not user_set_prefill:
-                                self.nsa_prefill_backend = "flashmla_sparse"
-                            if not user_set_decode:
-                                self.nsa_decode_backend = "fa3"
+                    self._set_default_nsa_kv_cache_dtype(major)
+                    self._set_default_nsa_backends(self.kv_cache_dtype, major)
 
                 if self.enable_nsa_prefill_context_parallel:
                     assert (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1168,9 +1168,9 @@ class ServerArgs:
                     # If user specified a backend but didn't explicitly set kv_cache_dtype,
                     # require them to be explicit about kv_cache_dtype to avoid surprises
                     if (user_set_prefill or user_set_decode) and self.kv_cache_dtype == "auto":
-                        raise ValueError(
+                        logger.warning(
                             f"When specifying --nsa-prefill-backend or --nsa-decode-backend, "
-                            f"you must also explicitly set --kv-cache-dtype (e.g., 'fp8_e4m3' or 'bfloat16'). "
+                            f"you should also explicitly set --kv-cache-dtype (e.g., 'fp8_e4m3' or 'bfloat16'). "
                             f"DeepSeek V3.2 defaults to FP8 KV cache which may not be compatible with all backends."
                         )
 
@@ -1197,12 +1197,12 @@ class ServerArgs:
                             f"Set NSA backends for FP8 KV Cache: prefill={self.nsa_prefill_backend}, decode={self.nsa_decode_backend}."
                         )
                     else:
-                        # set prefill/decode backends to flashmla_sparse based on architecture.
+                        # set prefill/decode backends based on hardware architecture.
                         if major >= 10:
                             if not user_set_prefill:
                                 self.nsa_prefill_backend = "flashmla_sparse"
                             if not user_set_decode:
-                                self.nsa_decode_backend = "flashmla_sparse"
+                                self.nsa_decode_backend = "trtllm_gen"
                         else:
                             # Hopper defaults for bfloat16
                             if not user_set_prefill:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enables NSA backend with trtllm kernels for sparse attention. This can be more efficient than FlashMLA when the head size isn't a multiple of 64 and hence requires padding. This PR enables with BF16 KVCache, FP8 will follow in another PR.

## Modifications

This change interfaces with the new kernel added in flashinfer to use trtllm kernel for decode in NSA backend. There are also modifications made to `server_args.py` to enable the new option.

## Accuracy Tests

```
python -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --tp 8 --dp 8 --enable-dp-attention --nsa-decode-backend trtllm --kv-cache-dtype bfloat16 --reasoning-parser deepseek-v3 --trust-remote-code

python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 120000 --repeat 8 --thinking-mode deepseek-v3 |& tee logs/trtllm_mla_sparse_gpqa.log

Repeat: 8, mean: 0.853
Scores: ['0.854', '0.854', '0.859', '0.879', '0.848', '0.838', '0.859', '0.833']
```

Testing MTP `--speculative-algorithm EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3`

GPQA:
```
Repeat: 8, mean: 0.84898 [1:19:07<04:19, 23.58s/it]
Scores: ['0.838', '0.854', '0.869', '0.818', '0.848', '0.843', '0.874', '0.838']

Avg accept len: 2.3740
Min accept len: 1.9800
Max accept len: 2.8500

Avg accept rate: 0.7913
Min accept rate: 0.6600
Max accept rate: 0.9500
```

LongBenchV2:
`python -m sglang.test.run_eval \
    --eval-name longbench_v2 \
    --host 127.0.0.1 \
    --port 30000 \
    --model deepseek-ai/DeepSeek-V3.2 \
    --max-context-length 128000 \
    --max-tokens 16384 \
    --num-threads 16
`

```
Total latency: 1313.224 s
Score: 0.550

Avg accept len: 2.5248
Min accept len: 2.0000
Max accept len: 2.9800

Avg accept rate: 0.8419
Min accept rate: 0.6700
Max accept rate: 0.9900
```

## Benchmarking and Profiling

Trace shows the new kernel call 
(about 14 microseconds):

<img width="626" height="49" alt="image" src="https://github.com/user-attachments/assets/5b3743e4-d1e3-4a23-803b-fa7300428356" />

<img width="426" height="281" alt="image" src="https://github.com/user-attachments/assets/7cd410bf-7654-4948-88ca-8df49b32fc95" />

Trace with the FlashMLA path with bf16 KVCache shows the FlashMLA sparse kernel is slower (about 26.5 microseconds):

<img width="1004" height="38" alt="image" src="https://github.com/user-attachments/assets/dcb4dd79-c859-4db7-a855-5d3a6296107f" />

<img width="416" height="255" alt="image" src="https://github.com/user-attachments/assets/9220db80-4daa-460a-a822-f37b2d4fa95c" />

Comparing FlashMLA sparse and TRTLLM (both with bf16 kvcache) shows similar average results for decode.

`python3 -m sglang.bench_serving --model deepseek-ai/DeepSeek-V3.2 --warmup-requests 5 --max-concurrency 16 --num-prompts 80 --random-range-ratio 0.8 --random-input-len 4096 --random-output-len 4096 --profile --profile-by-stage` 

FlashMLA Sparse (BF16 KVCache)
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     80        
Benchmark duration (s):                  57.26     
Total input tokens:                      29016     
Total input text tokens:                 29016     
Total generated tokens:                  17012     
Total generated tokens (retokenized):    16921     
Request throughput (req/s):              1.40      
Input token throughput (tok/s):          506.74    
Output token throughput (tok/s):         297.10    
Peak output token throughput (tok/s):    576.00    
Peak concurrent requests:                21        
Total token throughput (tok/s):          803.83    
Concurrency:                             10.87     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   7780.15   
Median E2E Latency (ms):                 5522.24   
P90 E2E Latency (ms):                    17340.74  
P99 E2E Latency (ms):                    33557.02  
---------------Time to First Token----------------
Mean TTFT (ms):                          348.70    
Median TTFT (ms):                        276.23    
P99 TTFT (ms):                           683.36    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          34.78     
Median TPOT (ms):                        36.56     
P99 TPOT (ms):                           57.35     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           35.21     
Median ITL (ms):                         28.07     
P95 ITL (ms):                            151.14    
P99 ITL (ms):                            185.14    
Max ITL (ms):                            333.13   
```

TRTLLM Sparse NSA
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     80        
Benchmark duration (s):                  58.32     
Total input tokens:                      29016     
Total input text tokens:                 29016     
Total generated tokens:                  17012     
Total generated tokens (retokenized):    16922     
Request throughput (req/s):              1.37      
Input token throughput (tok/s):          497.55    
Output token throughput (tok/s):         291.71    
Peak output token throughput (tok/s):    592.00    
Peak concurrent requests:                21        
Total token throughput (tok/s):          789.27    
Concurrency:                             11.27     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   8217.63   
Median E2E Latency (ms):                 6536.17   
P90 E2E Latency (ms):                    18150.71  
P99 E2E Latency (ms):                    33348.26  
---------------Time to First Token----------------
Mean TTFT (ms):                          659.34    
Median TTFT (ms):                        287.29    
P99 TTFT (ms):                           2945.19   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.39     
Median TPOT (ms):                        37.52     
P99 TPOT (ms):                           90.29     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           35.82     
Median ITL (ms):                         27.18     
P95 ITL (ms):                            152.73    
P99 ITL (ms):                            189.19    
Max ITL (ms):                            2460.31 
```

Unit benchmarking shows higher bandwidth for the new trtllm kernel compared to flashmla.

<img width="1785" height="772" alt="bf16kvcache_comparison_bandwidth_vs_seqlen_bar" src="https://github.com/user-attachments/assets/1da389c8-6c55-4516-8233-1eb3e5dc2337" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) (`/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls to merge.
