### PR TITLE
fix: handle empty NUMA node in lscpu output on WSL

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3102,12 +3102,19 @@ def parse_lscpu_topology():
     except Exception as e:
         raise RuntimeError(f"Unexpected error running 'lscpu': {e}")
 
-    # Parse only data lines (skip comments)
+    # Parse only data lines (skip comments and empty lines)
+    # Note: On WSL, the Node column may be empty (e.g., "0,0,0,"), default to 0
     cpu_info = []
     for line in output.splitlines():
-        if not line.startswith("#"):
-            cpu, core, socket, node = map(int, line.strip().split(","))
-            cpu_info.append((cpu, core, socket, node))
+        line = line.strip()
+        if line and not line.startswith("#"):
+            parts = line.split(",")
+            if len(parts) >= 3:
+                cpu = int(parts[0])
+                core = int(parts[1])
+                socket = int(parts[2])
+                node = int(parts[3]) if len(parts) > 3 and parts[3].strip() else 0
+                cpu_info.append((cpu, core, socket, node))
 
     # [(0,0,0,0),(1,1,0,0),...,(43,43,0,1),...,(256,0,0,0),...]
     return cpu_info


### PR DESCRIPTION

This is because WSL doesn't have real NUMA architecture, so the Node information is not available.

## Modifications

- Handle empty Node column by defaulting to node 0
- Skip empty lines during parsing  
- Add more robust validation of parsed fields (check `len(parts) >= 3` before accessing)

## Accuracy Tests

N/A - This is a bug fix for lscpu output parsing, does not affect model outputs.

## Benchmarking and Profiling

N/A - This change only affects CPU topology parsing during initialization, no impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Testing

Tested on WSL2 with AMD Ryzen 7 8845H (16 logical CPUs, no NUMA support). The fix correctly parses the lscpu output and defaults Node to 0.