### PR TITLE
[diffusion] apply tp optim to cross-attn for the wan2.2 model

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -139,18 +139,20 @@ class WanSelfAttention(nn.Module):
         self.qk_norm = qk_norm
         self.eps = eps
         self.parallel_attention = parallel_attention
+        self.tp_size = get_tensor_model_parallel_world_size()
 
         # layers
-        self.to_q = ColumnParallelLinear(dim, dim, gather_output=True)
-        self.to_k = ColumnParallelLinear(dim, dim, gather_output=True)
-        self.to_v = ColumnParallelLinear(dim, dim, gather_output=True)
-        self.to_out = ColumnParallelLinear(dim, dim, gather_output=True)
+        self.to_q = ColumnParallelLinear(dim, dim, gather_output=False)
+        self.to_k = ColumnParallelLinear(dim, dim, gather_output=False)
+        self.to_v = ColumnParallelLinear(dim, dim, gather_output=False)
+        self.to_out = RowParallelLinear(dim, dim, input_is_parallel=True)
         self.norm_q = RMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
         self.norm_k = RMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
+        self.tp_rmsnorm = self.tp_size > 1 and qk_norm
 
         # Scaled dot product attention
         self.attn = USPAttention(
-            num_heads=num_heads,
+            num_heads=num_heads // self.tp_size,
             head_size=self.head_dim,
             dropout_rate=0,
             softmax_scale=None,
@@ -171,7 +173,7 @@ class WanSelfAttention(nn.Module):
 
 class WanT2VCrossAttention(WanSelfAttention):
 
-    def forward(self, x, context, context_lens, crossattn_cache=None):
+    def forward(self, x, context, context_lens):
         r"""
         Args:
             x(Tensor): Shape [B, L1, C]
@@ -179,23 +181,24 @@ class WanT2VCrossAttention(WanSelfAttention):
             context_lens(Tensor): Shape [B]
         """
         b, n, d = x.size(0), self.num_heads, self.head_dim
+        num_heads_per_rank = n // self.tp_size
 
-        # compute query, key, value
-        q = self.norm_q(self.to_q(x)[0]).view(b, -1, n, d)
-
-        if crossattn_cache is not None:
-            if not crossattn_cache["is_init"]:
-                crossattn_cache["is_init"] = True
-                k = self.norm_k(self.to_k(context)[0]).view(b, -1, n, d)
-                v = self.to_v(context)[0].view(b, -1, n, d)
-                crossattn_cache["k"] = k
-                crossattn_cache["v"] = v
-            else:
-                k = crossattn_cache["k"]
-                v = crossattn_cache["v"]
+        q, _ = self.to_q(x)
+        if self.tp_rmsnorm:
+            q = tensor_parallel_rms_norm(q, self.norm_q)
         else:
-            k = self.norm_k(self.to_k(context)[0]).view(b, -1, n, d)
-            v = self.to_v(context)[0].view(b, -1, n, d)
+            q = self.norm_q(q)
+        q = q.view(b, -1, num_heads_per_rank, d)
+
+        k, _ = self.to_k(context)
+        if self.tp_rmsnorm:
+            k = tensor_parallel_rms_norm(k, self.norm_k)
+        else:
+            k = self.norm_k(k)
+        k = k.view(b, -1, num_heads_per_rank, d)
+
+        v, _ = self.to_v(context)
+        v = v.view(b, -1, num_heads_per_rank, d)
 
         # compute attention
         x = self.attn(q, k, v)
@@ -227,10 +230,9 @@ class WanI2VCrossAttention(WanSelfAttention):
             supported_attention_backends=supported_attention_backends,
         )
 
-        self.add_k_proj = ColumnParallelLinear(dim, dim, gather_output=True)
-        self.add_v_proj = ColumnParallelLinear(dim, dim, gather_output=True)
+        self.add_k_proj = ColumnParallelLinear(dim, dim, gather_output=False)
+        self.add_v_proj = ColumnParallelLinear(dim, dim, gather_output=False)
         self.norm_added_k = RMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
-        self.norm_added_q = RMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
 
     def forward(self, x, context, context_lens):
         r"""
@@ -242,15 +244,36 @@ class WanI2VCrossAttention(WanSelfAttention):
         context_img = context[:, :257]
         context = context[:, 257:]
         b, n, d = x.size(0), self.num_heads, self.head_dim
+        num_heads_per_rank = n // self.tp_size
 
-        # compute query, key, value
-        q = self.norm_q(self.to_q(x)[0]).view(b, -1, n, d)
-        k = self.norm_k(self.to_k(context)[0]).view(b, -1, n, d)
-        v = self.to_v(context)[0].view(b, -1, n, d)
-        k_img = self.norm_added_k(self.add_k_proj(context_img)[0]).view(b, -1, n, d)
-        v_img = self.add_v_proj(context_img)[0].view(b, -1, n, d)
+        q, _ = self.to_q(x)
+        if self.tp_rmsnorm:
+            q = tensor_parallel_rms_norm(q, self.norm_q)
+        else:
+            q = self.norm_q(q)
+        q = q.view(b, -1, num_heads_per_rank, d)
+
+        k, _ = self.to_k(context)
+        if self.tp_rmsnorm:
+            k = tensor_parallel_rms_norm(k, self.norm_k)
+        else:
+            k = self.norm_k(k)
+        k = k.view(b, -1, num_heads_per_rank, d)
+
+        v, _ = self.to_v(context)
+        v = v.view(b, -1, num_heads_per_rank, d)
+
+        k_img, _ = self.add_k_proj(context_img)
+        if self.tp_rmsnorm:
+            k_img = tensor_parallel_rms_norm(k_img, self.norm_added_k)
+        else:
+            k_img = self.norm_added_k(k_img)
+        k_img = k_img.view(b, -1, num_heads_per_rank, d)
+
+        v_img, _ = self.add_v_proj(context_img)
+        v_img = v_img.view(b, -1, num_heads_per_rank, d)
+
         img_x = self.attn(q, k_img, v_img)
-        # compute attention
         x = self.attn(q, k, v)
 
         # output


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Apply the optimizations from PR https://github.com/sgl-project/sglang/pull/16720 to the cross-attention (previously only the self-attention was optimized).

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

#### Test Script
machine: 8xH100

```bash
SGLANG_CACHE_DIT_ENABLED=true \
SGLANG_CACHE_DIT_WARMUP=4 \
SGLANG_CACHE_DIT_MC=8 \
SGLANG_CACHE_DIT_RDT=0.24 \
SGLANG_CACHE_DIT_FN=1 \
SGLANG_CACHE_DIT_BN=0 \
SGLANG_CACHE_DIT_TAYLORSEER=true \
SGLANG_CACHE_DIT_SECONDARY_WARMUP=2 \
SGLANG_CACHE_DIT_SECONDARY_MC=20 \
SGLANG_CACHE_DIT_SECONDARY_RDT=0.24 \
SGLANG_CACHE_DIT_SECONDARY_FN=1 \
SGLANG_CACHE_DIT_SECONDARY_BN=0 \
SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true \
SGLANG_CACHE_DIT_SCM_PRESET=fast \
SGLANG_CACHE_DIT_SCM_POLICY=dynamic \
sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers \
    --pin-cpu-memory \
    --num-gpus 8 \
    --tp-size 2 \
    --ulysses-degree 4 \
    --ring-degree 1 \
    --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
    --save-output \
    --output-path outputs \
    --output-file-name "output.mp4" \
    --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true"
    --720p \
    --num-frames 81 \
    --fps 16 \
    --guidance-scale 3.5 \
    --guidance-scale-2 4 \
    --num-inference-steps 27 \
    --dit-layerwise-offload false \
    --dit-cpu-offload false \
    --text-encoder-cpu-offload false \
    --image-encoder-cpu-offload false \
    --vae-cpu-offload false \
    --warmup \
    --enable-torch-compile \
```

#### Before Optim Cross-Attn
DenoisingStage: **19.5203 s**
```
[01-09 06:46:26] [DenoisingStage] average time per step: 0.7228 seconds
[01-09 06:46:26] [DenoisingStage] finished in 19.5203 seconds
[01-09 06:46:26] [DecodingStage] started...
[01-09 06:46:30] [DecodingStage] finished in 3.3123 seconds
[01-09 06:46:30] Peak GPU memory: 48.97 GB, Remaining GPU memory at peak: 30.67 GB. Components that can stay resident: []
[01-09 06:46:34] Output saved to outputs/output.mp4
[01-09 06:46:34] Pixel data generated successfully in 54.22 seconds
[01-09 06:46:34] Completed batch processing. Generated 1 outputs in 54.22 seconds
[01-09 06:46:34] Warmed-up request processed in 25.74 seconds (with warmup excluded)
[01-09 06:46:34] Memory usage - Max peak: 50147.94 MB, Avg peak: 50147.94 MB
[01-09 06:46:34] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
```

#### After Optim Cross-Attn
DenoisingStage: **18.2986 s**
```
[01-09 06:23:50] [DenoisingStage] average time per step: 0.6775 seconds
[01-09 06:23:50] [DenoisingStage] finished in 18.2986 seconds
[01-09 06:23:50] [DecodingStage] started...
[01-09 06:23:53] [DecodingStage] finished in 3.3106 seconds
[01-09 06:23:53] Peak GPU memory: 48.97 GB, Remaining GPU memory at peak: 30.67 GB. Components that can stay resident: []
[01-09 06:23:58] Output saved to outputs/output.mp4
[01-09 06:23:58] Pixel data generated successfully in 112.04 seconds
[01-09 06:23:58] Completed batch processing. Generated 1 outputs in 112.04 seconds
[01-09 06:23:58] Warmed-up request processed in 24.44 seconds (with warmup excluded)
[01-09 06:23:58] Memory usage - Max peak: 50148.65 MB, Avg peak: 50148.65 MB
[01-09 06:23:58] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
```

https://github.com/user-attachments/assets/8a846739-71af-413a-b835-440caf423a93

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
