### PR TITLE
[BugFix]support torch.compile use flash attention v4

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any
+from typing import Any, List, Optional, Tuple
 
 import torch
 
 from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.srt.utils.custom_op import register_custom_op
 
 try:
     from sgl_kernel.flash_attn import flash_attn_varlen_func
@@ -18,6 +19,242 @@ try:
     flash_attn_func = flash_attn_varlen_func
 except ImportError as e:
     raise e
+
+
+def maybe_contiguous(x):
+    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+
+
+def flash_attn_varlen_func_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    qv: Optional[torch.Tensor] = None,
+    q_descale: Optional[torch.Tensor] = None,
+    k_descale: Optional[torch.Tensor] = None,
+    v_descale: Optional[torch.Tensor] = None,
+    window_size: Optional[List[int]] = None,
+    attention_chunk: int = 0,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    sm_margin: int = 0,
+    return_softmax_lse: bool = False,
+    sinks: Optional[torch.Tensor] = None,
+    ver: int = 3,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if window_size is None:
+        window_size = [-1, -1]
+    if ver == 4:
+        q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
+        num_head, head_dim = q.shape[-2:]
+        if cu_seqlens_q is None:
+            batch_size, seqlen_q = q.shape[:2]
+            total_q = batch_size * seqlen_q
+        else:
+            batch_size = cu_seqlens_q.shape[0] - 1
+            seqlen_q = None
+            total_q = q.shape[0]
+        if page_table is not None:
+            assert cu_seqlens_k is None, "page_table is not supported with cu_seqlens_k"
+            assert page_table.dtype == torch.int32, "page_table must be int32"
+            assert (
+                page_table.stride(-1) == 1
+            ), "page_table must be contiguous in the last dimension"
+            max_num_pages_per_seq = page_table.shape[1]
+            assert page_table.shape == (batch_size, max_num_pages_per_seq)
+            num_pages, page_size = k.shape[:2]
+            seqlen_k = num_pages * page_size
+        else:
+            num_pages, page_size = None, None
+            seqlen_k = k.shape[-3]
+        num_head_kv = k.shape[-2]
+        head_dim_v = v.shape[-1]
+        if cu_seqlens_k is None:
+            if page_table is None:
+                assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
+                assert v.shape == (batch_size, seqlen_k, num_head_kv, head_dim_v)
+            else:
+                assert k.shape == (num_pages, page_size, num_head_kv, head_dim)
+                assert v.shape == (num_pages, page_size, num_head_kv, head_dim_v)
+        else:
+            assert k.shape == (seqlen_k, num_head_kv, head_dim)
+            assert v.shape == (seqlen_k, num_head_kv, head_dim_v)
+            assert cu_seqlens_k.shape == (
+                batch_size + 1,
+            ), "cu_seqlens_k must have shape (batch_size + 1,)"
+        if cu_seqlens_q is not None:
+            assert cu_seqlens_q.shape == (
+                batch_size + 1,
+            ), "cu_seqlens_q must have shape (batch_size + 1,)"
+        assert seqused_q is None or seqused_q.shape == (
+            batch_size,
+        ), "seqused_q must have shape (batch_size,)"
+        assert seqused_k is None or seqused_k.shape == (
+            batch_size,
+        ), "seqused_k must have shape (batch_size,)"
+        assert q.dtype in [
+            torch.float16,
+            torch.bfloat16,
+        ], "inputs must be float16 or bfloat16"
+        assert q.dtype == k.dtype == v.dtype, "inputs must have the same dtype"
+        for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
+            if t is not None:
+                assert (
+                    t.dtype == torch.int32
+                ), "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be int32"
+                assert (
+                    t.stride(0) == 1
+                ), "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be contiguous"
+        if sinks is not None:
+            assert sinks.shape == (num_head,)
+            assert sinks.dtype == torch.bfloat16, "sinks must be bfloat16"
+        assert all(
+            t is None or t.is_cuda
+            for t in (
+                q,
+                k,
+                v,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                page_table,
+                sinks,
+            )
+        ), "inputs must be on CUDA device"
+        assert num_head % num_head_kv == 0, "num_head must be divisible by num_head_kv"
+        assert head_dim <= 256, "head_dim must be less than or equal to 256"
+        alignment = 16 // q.element_size()
+        assert head_dim % alignment == 0, f"head_dim must be divisible by {alignment}"
+        assert (
+            head_dim_v % alignment == 0
+        ), f"head_dim_v must be divisible by {alignment}"
+        qhead_per_kvhead = num_head // num_head_kv
+        if pack_gqa is None:
+            pack_gqa = qhead_per_kvhead > 1
+
+        out_torch_dtype = q.dtype
+        device = q.device
+        q_batch_seqlen_shape = (
+            (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
+        )
+        lse_shape = (
+            (batch_size, num_head, seqlen_q)
+            if cu_seqlens_q is None
+            else (num_head, total_q)
+        )
+        requires_grad = q.requires_grad or k.requires_grad or v.requires_grad
+
+        out = torch.empty(
+            *q_batch_seqlen_shape,
+            num_head,
+            head_dim_v,
+            dtype=out_torch_dtype,
+            device=device,
+        )
+        lse = (
+            torch.empty(lse_shape, dtype=torch.float32, device=device)
+            if requires_grad or return_softmax_lse
+            else None
+        )
+        return (out, lse) if return_softmax_lse else out
+    assert ver == 3, "This path only supports Flash Attention v3."
+    return flash_attn_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        page_table=page_table,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        qv=qv,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        window_size=tuple(window_size),
+        attention_chunk=attention_chunk,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        sm_margin=sm_margin,
+        return_softmax_lse=return_softmax_lse,
+        sinks=sinks,
+        ver=ver,
+    )
+
+
+@register_custom_op(fake_impl=flash_attn_varlen_func_fake)
+def flash_attn_varlen_func_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    qv: Optional[torch.Tensor] = None,
+    q_descale: Optional[torch.Tensor] = None,
+    k_descale: Optional[torch.Tensor] = None,
+    v_descale: Optional[torch.Tensor] = None,
+    window_size: Optional[List[int]] = None,
+    attention_chunk: int = 0,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    sm_margin: int = 0,
+    return_softmax_lse: bool = False,
+    sinks: Optional[torch.Tensor] = None,
+    ver: int = 3,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if window_size is None:
+        window_size = [-1, -1]
+    return flash_attn_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        page_table=page_table,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        qv=qv,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        window_size=tuple(window_size),
+        attention_chunk=attention_chunk,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        sm_margin=sm_margin,
+        return_softmax_lse=return_softmax_lse,
+        sinks=sinks,
+        ver=ver,
+    )
 
 
 try:
@@ -221,7 +458,7 @@ class FlashAttentionImpl(AttentionImpl):
                 return out.reshape(bsz, seqlen, nheads_q, -1), softmax_lse
             return out.reshape(bsz, seqlen, nheads_q, d)
 
-        output = flash_attn_func(
+        output = flash_attn_varlen_func_op(
             q=query,  # type: ignore[no-untyped-call]
             k=key,
             v=value,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -50,152 +50,122 @@ def flash_attn_varlen_func_fake(
     sm_margin: int = 0,
     return_softmax_lse: bool = False,
     sinks: Optional[torch.Tensor] = None,
-    ver: int = 3,
+    ver: int = 4,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if window_size is None:
         window_size = [-1, -1]
-    if ver == 4:
-        q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
-        num_head, head_dim = q.shape[-2:]
-        if cu_seqlens_q is None:
-            batch_size, seqlen_q = q.shape[:2]
-            total_q = batch_size * seqlen_q
-        else:
-            batch_size = cu_seqlens_q.shape[0] - 1
-            seqlen_q = None
-            total_q = q.shape[0]
-        if page_table is not None:
-            assert cu_seqlens_k is None, "page_table is not supported with cu_seqlens_k"
-            assert page_table.dtype == torch.int32, "page_table must be int32"
-            assert (
-                page_table.stride(-1) == 1
-            ), "page_table must be contiguous in the last dimension"
-            max_num_pages_per_seq = page_table.shape[1]
-            assert page_table.shape == (batch_size, max_num_pages_per_seq)
-            num_pages, page_size = k.shape[:2]
-            seqlen_k = num_pages * page_size
-        else:
-            num_pages, page_size = None, None
-            seqlen_k = k.shape[-3]
-        num_head_kv = k.shape[-2]
-        head_dim_v = v.shape[-1]
-        if cu_seqlens_k is None:
-            if page_table is None:
-                assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
-                assert v.shape == (batch_size, seqlen_k, num_head_kv, head_dim_v)
-            else:
-                assert k.shape == (num_pages, page_size, num_head_kv, head_dim)
-                assert v.shape == (num_pages, page_size, num_head_kv, head_dim_v)
-        else:
-            assert k.shape == (seqlen_k, num_head_kv, head_dim)
-            assert v.shape == (seqlen_k, num_head_kv, head_dim_v)
-            assert cu_seqlens_k.shape == (
-                batch_size + 1,
-            ), "cu_seqlens_k must have shape (batch_size + 1,)"
-        if cu_seqlens_q is not None:
-            assert cu_seqlens_q.shape == (
-                batch_size + 1,
-            ), "cu_seqlens_q must have shape (batch_size + 1,)"
-        assert seqused_q is None or seqused_q.shape == (
-            batch_size,
-        ), "seqused_q must have shape (batch_size,)"
-        assert seqused_k is None or seqused_k.shape == (
-            batch_size,
-        ), "seqused_k must have shape (batch_size,)"
-        assert q.dtype in [
-            torch.float16,
-            torch.bfloat16,
-        ], "inputs must be float16 or bfloat16"
-        assert q.dtype == k.dtype == v.dtype, "inputs must have the same dtype"
-        for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
-            if t is not None:
-                assert (
-                    t.dtype == torch.int32
-                ), "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be int32"
-                assert (
-                    t.stride(0) == 1
-                ), "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be contiguous"
-        if sinks is not None:
-            assert sinks.shape == (num_head,)
-            assert sinks.dtype == torch.bfloat16, "sinks must be bfloat16"
-        assert all(
-            t is None or t.is_cuda
-            for t in (
-                q,
-                k,
-                v,
-                cu_seqlens_q,
-                cu_seqlens_k,
-                seqused_q,
-                seqused_k,
-                page_table,
-                sinks,
-            )
-        ), "inputs must be on CUDA device"
-        assert num_head % num_head_kv == 0, "num_head must be divisible by num_head_kv"
-        assert head_dim <= 256, "head_dim must be less than or equal to 256"
-        alignment = 16 // q.element_size()
-        assert head_dim % alignment == 0, f"head_dim must be divisible by {alignment}"
+    assert ver == 4, "only support flash attention v4"
+    q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
+    num_head, head_dim = q.shape[-2:]
+    if cu_seqlens_q is None:
+        batch_size, seqlen_q = q.shape[:2]
+        total_q = batch_size * seqlen_q
+    else:
+        batch_size = cu_seqlens_q.shape[0] - 1
+        seqlen_q = None
+        total_q = q.shape[0]
+    if page_table is not None:
+        assert cu_seqlens_k is None, "page_table is not supported with cu_seqlens_k"
+        assert page_table.dtype == torch.int32, "page_table must be int32"
         assert (
-            head_dim_v % alignment == 0
-        ), f"head_dim_v must be divisible by {alignment}"
-        qhead_per_kvhead = num_head // num_head_kv
-        if pack_gqa is None:
-            pack_gqa = qhead_per_kvhead > 1
+            page_table.stride(-1) == 1
+        ), "page_table must be contiguous in the last dimension"
+        max_num_pages_per_seq = page_table.shape[1]
+        assert page_table.shape == (batch_size, max_num_pages_per_seq)
+        num_pages, page_size = k.shape[:2]
+        seqlen_k = num_pages * page_size
+    else:
+        num_pages, page_size = None, None
+        seqlen_k = k.shape[-3]
+    num_head_kv = k.shape[-2]
+    head_dim_v = v.shape[-1]
+    if cu_seqlens_k is None:
+        if page_table is None:
+            assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
+            assert v.shape == (batch_size, seqlen_k, num_head_kv, head_dim_v)
+        else:
+            assert k.shape == (num_pages, page_size, num_head_kv, head_dim)
+            assert v.shape == (num_pages, page_size, num_head_kv, head_dim_v)
+    else:
+        assert k.shape == (seqlen_k, num_head_kv, head_dim)
+        assert v.shape == (seqlen_k, num_head_kv, head_dim_v)
+        assert cu_seqlens_k.shape == (
+            batch_size + 1,
+        ), "cu_seqlens_k must have shape (batch_size + 1,)"
+    if cu_seqlens_q is not None:
+        assert cu_seqlens_q.shape == (
+            batch_size + 1,
+        ), "cu_seqlens_q must have shape (batch_size + 1,)"
+    assert seqused_q is None or seqused_q.shape == (
+        batch_size,
+    ), "seqused_q must have shape (batch_size,)"
+    assert seqused_k is None or seqused_k.shape == (
+        batch_size,
+    ), "seqused_k must have shape (batch_size,)"
+    assert q.dtype in [
+        torch.float16,
+        torch.bfloat16,
+    ], "inputs must be float16 or bfloat16"
+    assert q.dtype == k.dtype == v.dtype, "inputs must have the same dtype"
+    for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
+        if t is not None:
+            assert (
+                t.dtype == torch.int32
+            ), "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be int32"
+            assert (
+                t.stride(0) == 1
+            ), "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be contiguous"
+    if sinks is not None:
+        assert sinks.shape == (num_head,)
+        assert sinks.dtype == torch.bfloat16, "sinks must be bfloat16"
+    assert all(
+        t is None or t.is_cuda
+        for t in (
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_q,
+            seqused_k,
+            page_table,
+            sinks,
+        )
+    ), "inputs must be on CUDA device"
+    assert num_head % num_head_kv == 0, "num_head must be divisible by num_head_kv"
+    assert head_dim <= 256, "head_dim must be less than or equal to 256"
+    alignment = 16 // q.element_size()
+    assert head_dim % alignment == 0, f"head_dim must be divisible by {alignment}"
+    assert head_dim_v % alignment == 0, f"head_dim_v must be divisible by {alignment}"
+    qhead_per_kvhead = num_head // num_head_kv
+    if pack_gqa is None:
+        pack_gqa = qhead_per_kvhead > 1
 
-        out_torch_dtype = q.dtype
-        device = q.device
-        q_batch_seqlen_shape = (
-            (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
-        )
-        lse_shape = (
-            (batch_size, num_head, seqlen_q)
-            if cu_seqlens_q is None
-            else (num_head, total_q)
-        )
-        requires_grad = q.requires_grad or k.requires_grad or v.requires_grad
-
-        out = torch.empty(
-            *q_batch_seqlen_shape,
-            num_head,
-            head_dim_v,
-            dtype=out_torch_dtype,
-            device=device,
-        )
-        lse = (
-            torch.empty(lse_shape, dtype=torch.float32, device=device)
-            if requires_grad or return_softmax_lse
-            else None
-        )
-        return (out, lse) if return_softmax_lse else out
-    assert ver == 3, "This path only supports Flash Attention v3."
-    return flash_attn_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        seqused_q=seqused_q,
-        seqused_k=seqused_k,
-        page_table=page_table,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        qv=qv,
-        q_descale=q_descale,
-        k_descale=k_descale,
-        v_descale=v_descale,
-        window_size=tuple(window_size),
-        attention_chunk=attention_chunk,
-        softcap=softcap,
-        num_splits=num_splits,
-        pack_gqa=pack_gqa,
-        sm_margin=sm_margin,
-        return_softmax_lse=return_softmax_lse,
-        sinks=sinks,
-        ver=ver,
+    out_torch_dtype = q.dtype
+    device = q.device
+    q_batch_seqlen_shape = (
+        (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
     )
+    lse_shape = (
+        (batch_size, num_head, seqlen_q)
+        if cu_seqlens_q is None
+        else (num_head, total_q)
+    )
+    requires_grad = q.requires_grad or k.requires_grad or v.requires_grad
+
+    out = torch.empty(
+        *q_batch_seqlen_shape,
+        num_head,
+        head_dim_v,
+        dtype=out_torch_dtype,
+        device=device,
+    )
+    lse = (
+        torch.empty(lse_shape, dtype=torch.float32, device=device)
+        if requires_grad or return_softmax_lse
+        else None
+    )
+    return (out, lse) if return_softmax_lse else out
 
 
 @register_custom_op(fake_impl=flash_attn_varlen_func_fake)
@@ -224,7 +194,7 @@ def flash_attn_varlen_func_op(
     sm_margin: int = 0,
     return_softmax_lse: bool = False,
     sinks: Optional[torch.Tensor] = None,
-    ver: int = 3,
+    ver: int = 4,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if window_size is None:
         window_size = [-1, -1]
@@ -458,7 +428,14 @@ class FlashAttentionImpl(AttentionImpl):
                 return out.reshape(bsz, seqlen, nheads_q, -1), softmax_lse
             return out.reshape(bsz, seqlen, nheads_q, d)
 
-        output = flash_attn_varlen_func_op(
+        if fa_ver == 3:
+            flash_attn_op = flash_attn_func
+        elif fa_ver == 4:
+            flash_attn_op = flash_attn_varlen_func_op
+        else:
+            raise ValueError(f"flash attention version {fa_ver} not supported.")
+
+        output = flash_attn_op(
             q=query,  # type: ignore[no-untyped-call]
             k=key,
             v=value,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using sglang to generate video on B200, I find that after enabling the --enable-torch-compile option, an error occurs at the end of the run.  

The command to  generate  video is:

```python
SGLANG_CACHE_DIT_ENABLED=true \
SGLANG_CACHE_DIT_WARMUP=4 \
SGLANG_CACHE_DIT_MC=8 \
SGLANG_CACHE_DIT_RDT=0.24 \
SGLANG_CACHE_DIT_FN=1 \
SGLANG_CACHE_DIT_BN=0 \
SGLANG_CACHE_DIT_TAYLORSEER=true \
SGLANG_CACHE_DIT_SECONDARY_WARMUP=2 \
SGLANG_CACHE_DIT_SECONDARY_MC=20 \
SGLANG_CACHE_DIT_SECONDARY_RDT=0.24 \
SGLANG_CACHE_DIT_SECONDARY_FN=1 \
SGLANG_CACHE_DIT_SECONDARY_BN=0 \
SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true \
SGLANG_CACHE_DIT_SCM_PRESET=fast \
SGLANG_CACHE_DIT_SCM_POLICY=dynamic \
sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers  --pin-cpu-memory  --num-gpus 4  --ulysses-degree 2 --ring-degree 2 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."  --save-output --output-path outputs --output-file-name "output1_video.mp4"  --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" --720p --num-frames 81  --fps 16 --guidance-scale 3.5 --guidance-scale-2 4 --num-inference-steps 27 --warmup --dit-cpu-offload false --enable-torch-compile
``` 

The error message is as follows:
```python
...

  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 4332, in inline_call_
    self.run()
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 1500, in run
    while self.step():
          ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 1348, in step
    self.dispatch_table[inst.opcode](self, inst)
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 904, in wrapper
    return inner_fn(self, inst)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 3428, in CALL
    self._call(inst)
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 3422, in _call
    self.call_function(fn, args, kwargs)
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/symbolic_convert.py", line 1266, in call_function
    self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/variables/misc.py", line 1115, in call_function
    return self.obj.call_method(tx, self.name, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/variables/tensor.py", line 713, in call_method
    return wrap_fx_proxy(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/variables/builder.py", line 2645, in wrap_fx_proxy
    return wrap_fx_proxy_cls(target_cls=TensorVariable, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/variables/builder.py", line 2711, in wrap_fx_proxy_cls
    return _wrap_fx_proxy(
           ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/variables/builder.py", line 2809, in _wrap_fx_proxy
    example_value = get_fake_value(proxy.node, tx, allow_non_graph_fake=True)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/utils.py", line 3478, in get_fake_value
    raise TorchRuntimeError(str(e)).with_traceback(e.__traceback__) from None
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/utils.py", line 3376, in get_fake_value
    ret_val = wrap_fake_exception(
              ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/utils.py", line 2864, in wrap_fake_exception
    return fn()
           ^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/utils.py", line 3377, in <lambda>
    lambda: run_node(tx.output, node, args, kwargs, nnmodule)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/utils.py", line 3587, in run_node
    raise RuntimeError(make_error_message(e)).with_traceback(
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/utils.py", line 3557, in run_node
    return getattr(args[0], node.target)(*args[1:], **kwargs)  # type: ignore[arg-type]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_tensor.py", line 1782, in __dlpack__
    return _C._to_dlpack(self, dl_device=dl_device, copy=copy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_method __dlpack__(*(FakeTensor(..., device='cuda:0', size=(1, 18360, 20, 128),
           dtype=torch.bfloat16),), **{}): got RuntimeError("Cannot access data pointer of Tensor (e.g. FakeTensor, FunctionalTensor). If you're using torch.compile/export/fx, it is likely that we are erroneously tracing into a custom kernel. To fix this, please wrap the custom kernel into an opaque custom op. Please see the following for details: https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html")

...

``` 

## Modifications

I review the code and identify that the runtime error caused by enabling --enable-torch-compile is due to the Flash Attention v4 used in the current SGLang framework. 

I fix this problem by modify the python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py file,
wrapping the flash attention v4 function call in a torch operator by register_custom_op，and provide an fake flash attention v4 function call to support torch.compile.


## Accuracy Tests

### B200

command : 

```shell
SGLANG_CACHE_DIT_ENABLED=true \
SGLANG_CACHE_DIT_WARMUP=4 \
SGLANG_CACHE_DIT_MC=8 \
SGLANG_CACHE_DIT_RDT=0.24 \
SGLANG_CACHE_DIT_FN=1 \
SGLANG_CACHE_DIT_BN=0 \
SGLANG_CACHE_DIT_TAYLORSEER=true \
SGLANG_CACHE_DIT_SECONDARY_WARMUP=2 \
SGLANG_CACHE_DIT_SECONDARY_MC=20 \
SGLANG_CACHE_DIT_SECONDARY_RDT=0.24 \
SGLANG_CACHE_DIT_SECONDARY_FN=1 \
SGLANG_CACHE_DIT_SECONDARY_BN=0 \
SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true \
SGLANG_CACHE_DIT_SCM_PRESET=fast \
SGLANG_CACHE_DIT_SCM_POLICY=dynamic \
sglang generate --model-path Wan-AI/Wan2.2-I2V-A14B-Diffusers  --pin-cpu-memory  --num-gpus 4  --ulysses-degree 2 --ring-degree 2 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."  --save-output --output-path outputs --output-file-name "output1_video.mp4"  --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true" --720p --num-frames 81  --fps 16 --guidance-scale 3.5 --guidance-scale-2 4 --num-inference-steps 27 --warmup --dit-cpu-offload false --enable-torch-compile
``` 

```python
[01-12 16:36:54] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'image_latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[01-12 16:36:54] [InputValidationStage] started...
[01-12 16:36:55] [InputValidationStage] finished in 0.3024 seconds
[01-12 16:36:55] [TextEncodingStage] started...
[01-12 16:36:56] [TextEncodingStage] finished in 1.1367 seconds
[01-12 16:36:56] [ConditioningStage] started...
[01-12 16:36:56] [ConditioningStage] finished in 0.0000 seconds
[01-12 16:36:56] [TimestepPreparationStage] started...
[01-12 16:36:56] [TimestepPreparationStage] finished in 0.0003 seconds
[01-12 16:36:56] [LatentPreparationStage] started...
[01-12 16:36:56] [LatentPreparationStage] finished in 0.0002 seconds
[01-12 16:36:56] [ImageVAEEncodingStage] started...
[01-12 16:36:57] [ImageVAEEncodingStage] finished in 1.3232 seconds
[01-12 16:36:57] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 27/27 [00:16<00:00,  1.61it/s]
[01-12 16:37:14] [DenoisingStage] average time per step: 0.6229 seconds
[01-12 16:37:14] [DenoisingStage] finished in 16.8254 seconds
[01-12 16:37:14] [DecodingStage] started...
[01-12 16:37:16] [DecodingStage] finished in 1.7638 seconds
[01-12 16:37:16] Peak GPU memory: 65.22 GB, Remaining GPU memory at peak: 113.84 GB. Components that can stay resident: ['text_encoder', 'vae']
[01-12 16:37:19] Output saved to outputs/output1_video.mp4
[01-12 16:37:19] Pixel data generated successfully in 152.95 seconds
[01-12 16:37:19] Completed batch processing. Generated 1 outputs in 152.96 seconds
[01-12 16:37:19] Warmed-up request processed in 21.35 seconds (with warmup excluded)
[01-12 16:37:19] Memory usage - Max peak: 66782.96 MB, Avg peak: 66782.96 MB
``` 

generated video

https://github.com/user-attachments/assets/2b09cbb9-e45d-44d1-9da9-55ecf32f3353


## Benchmarking and Profiling


### B200  4 gpus

|   |InputValidation | TextEncoding | Conditioning | TimestepPreparation | LatentPreparation | ImageVAEEncoding | Denoising | Decoding | Total |
|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
| without torch compile | 0.3362 | 1.1379 | 0.0000 | 0.0006 |0.0002 |1.4460 |24.6012 |1.7678 | 29.29|
| with torch compile | 0.3024 | 1.1367 | 0.0000 | 0.0003 |0.0002 |1.3232 |16.8254 |1.7638 |21.35 |


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
