### PR TITLE
[model-gateway] Restore response streaming by optimizing WASM middleware buffering

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -150,6 +150,10 @@ serial_test = "3.0"
 rsa = { version = "0.9", features = ["sha2"] }
 
 [[bench]]
+name = "wasm_middleware_latency"
+harness = false
+path = "benches/wasm_middleware_latency.rs"
+[[bench]]
 name = "request_processing"
 harness = false
 path = "benches/request_processing.rs"

--- a/sgl-model-gateway/benches/wasm_middleware_latency.rs
+++ b/sgl-model-gateway/benches/wasm_middleware_latency.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, Response, StatusCode},
+    middleware::Next,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures::StreamExt;
+use smg::{
+    app_context::AppContext, config::RouterConfig, middleware::wasm_middleware, server::AppState,
+};
+use tokio::runtime::Runtime;
+
+// Mock the 'Next' service to return a streaming body that takes time to complete
+async fn mock_next_streaming(req: Request<Body>) -> Response<Body> {
+    let (mut tx, body) = Body::channel();
+
+    tokio::spawn(async move {
+        // Send first chunk immediately
+        tx.send_data("chunk 1 ".into()).await.unwrap();
+        // Simulate generation delay
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        // Send final chunk
+        tx.send_data("chunk 2".into()).await.unwrap();
+    });
+
+    Response::new(body)
+}
+
+fn bench_wasm_middleware_buffering(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    // Setup minimal AppState with WASM enabled (or mock it to trigger the code path)
+    let config = RouterConfig::default(); // Adjust based on actual config struct
+    let context = rt.block_on(AppContext::from_config(config, 30)).unwrap();
+    let app_state = Arc::new(AppState {
+        router: Arc::new(smg::routers::mock::MockRouter::new()),
+        context: Arc::new(context),
+        concurrency_queue_tx: None,
+        router_manager: None,
+    });
+
+    c.bench_function("wasm_middleware_pre_fix_latency", |b| {
+        b.to_async(&rt).iter(|| async {
+            let req = Request::builder()
+                .uri("/v1/chat/completions")
+                .body(Body::empty())
+                .unwrap();
+
+            // Run the middleware
+            // In the pre-fix state, this .await will wait for the 500ms delay
+            // inside wasm_middleware because of axum::body::to_bytes
+            let response = wasm_middleware(
+                axum::extract::State(app_state.clone()),
+                req,
+                Next::from_fn(mock_next_streaming),
+            )
+            .await
+            .unwrap();
+
+            // Measure how long it takes to get the FIRST chunk
+            let mut stream = response.into_body().into_data_stream();
+            let _first_chunk = stream.next().await;
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10); // Low sample size as each run takes >500ms
+    targets = bench_wasm_middleware_buffering
+}
+criterion_main!(benches);

--- a/sgl-model-gateway/benches/wasm_middleware_latency.rs
+++ b/sgl-model-gateway/benches/wasm_middleware_latency.rs
@@ -15,7 +15,6 @@ use smg::{
 use tokio::runtime::Runtime;
 use tower::{Layer, Service};
 
-/// Dummy router to satisfy AppState requirements for the benchmark
 #[derive(Debug)]
 struct MockRouter;
 

--- a/sgl-model-gateway/benches/wasm_middleware_latency.rs
+++ b/sgl-model-gateway/benches/wasm_middleware_latency.rs
@@ -2,73 +2,109 @@ use std::sync::Arc;
 
 use axum::{
     body::Body,
-    http::{Request, Response, StatusCode},
-    middleware::Next,
+    http::{HeaderMap, Request, Response, StatusCode},
+    middleware,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::StreamExt;
+use http_body_util::BodyExt;
 use smg::{
-    app_context::AppContext, config::RouterConfig, middleware::wasm_middleware, server::AppState,
+    app_context::AppContext, config::RouterConfig, middleware::wasm_middleware,
+    protocols::chat::ChatCompletionRequest, routers::RouterTrait, server::AppState,
 };
 use tokio::runtime::Runtime;
+use tower::{Service, ServiceExt};
 
-// Mock the 'Next' service to return a streaming body that takes time to complete
-async fn mock_next_streaming(req: Request<Body>) -> Response<Body> {
-    let (mut tx, body) = Body::channel();
+/// Dummy router to satisfy AppState requirements for the benchmark
+#[derive(Debug)]
+struct MockRouter;
+
+#[async_trait::async_trait]
+impl RouterTrait for MockRouter {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    async fn route_chat(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &ChatCompletionRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        StatusCode::OK.into_response()
+    }
+    fn router_type(&self) -> &'static str {
+        "mock"
+    }
+}
+
+/// Mock service that simulates a streaming response with a 500ms delay.
+/// This delay represents the worker's generation time.
+async fn mock_next_streaming(_req: Request<Body>) -> Response {
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
 
     tokio::spawn(async move {
         // Send first chunk immediately
-        tx.send_data("chunk 1 ".into()).await.unwrap();
+        let _ = tx
+            .send(Ok::<_, std::io::Error>(bytes::Bytes::from("chunk 1 ")))
+            .await;
         // Simulate generation delay
+        // IN THE PRE-FIX STATE: the middleware will block here for 500ms!
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         // Send final chunk
-        tx.send_data("chunk 2".into()).await.unwrap();
+        let _ = tx
+            .send(Ok::<_, std::io::Error>(bytes::Bytes::from("chunk 2")))
+            .await;
     });
 
-    Response::new(body)
+    Response::new(Body::from_stream(
+        tokio_stream::wrappers::ReceiverStream::new(rx),
+    ))
 }
 
 fn bench_wasm_middleware_buffering(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
 
-    // Setup minimal AppState with WASM enabled (or mock it to trigger the code path)
-    let config = RouterConfig::default(); // Adjust based on actual config struct
+    // Setup AppContext with WASM enabled (required to hit the buffering path)
+    let config = RouterConfig::builder().enable_wasm(true).build_unchecked();
+
     let context = rt.block_on(AppContext::from_config(config, 30)).unwrap();
     let app_state = Arc::new(AppState {
-        router: Arc::new(smg::routers::mock::MockRouter::new()),
+        router: Arc::new(MockRouter),
         context: Arc::new(context),
         concurrency_queue_tx: None,
         router_manager: None,
     });
 
     c.bench_function("wasm_middleware_pre_fix_latency", |b| {
-        b.to_async(&rt).iter(|| async {
-            let req = Request::builder()
-                .uri("/v1/chat/completions")
-                .body(Body::empty())
-                .unwrap();
+        b.iter(|| {
+            rt.block_on(async {
+                let req = Request::builder()
+                    .uri("/v1/chat/completions")
+                    .body(Body::empty())
+                    .unwrap();
 
-            // Run the middleware
-            // In the pre-fix state, this .await will wait for the 500ms delay
-            // inside wasm_middleware because of axum::body::to_bytes
-            let response = wasm_middleware(
-                axum::extract::State(app_state.clone()),
-                req,
-                Next::from_fn(mock_next_streaming),
-            )
-            .await
-            .unwrap();
+                // Build a Tower service applying the middleware to our mock streamer
+                let mut service =
+                    middleware::from_fn_with_state(app_state.clone(), wasm_middleware).layer(
+                        tower::service_fn(|req: Request<Body>| async move {
+                            Ok::<_, std::convert::Infallible>(mock_next_streaming(req).await)
+                        }),
+                    );
 
-            // Measure how long it takes to get the FIRST chunk
-            let mut stream = response.into_body().into_data_stream();
-            let _first_chunk = stream.next().await;
+                // Call the service and wait for the response header
+                let response = service.call(req).await.unwrap();
+
+                // Measure how long it takes to receive the FIRST frame (chunk)
+                let mut body = response.into_body();
+                let _first_frame = body.frame().await;
+            });
         });
     });
 }
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(10); // Low sample size as each run takes >500ms
+    config = Criterion::default().sample_size(10);
     targets = bench_wasm_middleware_buffering
 }
 criterion_main!(benches);

--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -772,101 +772,92 @@ pub async fn wasm_middleware(
                 return Ok(next.run(request).await);
             }
         };
-    if modules_on_request.is_empty() {
-        let response = next.run(request).await;
-        return self::wasm_middleware_response_phase(app_state, response, wasm_manager, request_id)
-            .await;
-    }
 
-    // Extract request body once before processing modules
-    let method = request.method().clone();
-    let uri = request.uri().clone();
-    let mut headers = request.headers().clone();
-    let max_body_size = wasm_manager.get_max_body_size();
-    let body_bytes = match axum::body::to_bytes(request.into_body(), max_body_size).await {
-        Ok(bytes) => bytes.to_vec(),
-        Err(e) => {
-            error!("Failed to read request body: {}", e);
-            // Create a minimal request with empty body for error recovery
-            let error_request = Request::builder()
-                .uri(uri)
-                .body(Body::empty())
-                .unwrap_or_else(|_| Request::new(Body::empty()));
-            return Ok(next.run(error_request).await);
-        }
-    };
-
-    // Process each OnRequest module
-    let mut modified_body = body_bytes;
-
-    // Pre-compute strings once before the loop to avoid repeated allocations
-    let method_str = method.to_string();
-    let path_str = uri.path().to_string();
-    let query_str = uri.query().unwrap_or("").to_string();
-
-    for module in modules_on_request {
-        // Build WebAssembly request from collected data
-        let wasm_headers = build_wasm_headers_from_axum_headers(&headers);
-        let wasm_request = WasmRequest {
-            method: method_str.clone(),
-            path: path_str.clone(),
-            query: query_str.clone(),
-            headers: wasm_headers,
-            body: modified_body.clone(),
-            request_id: request_id.clone(),
-            now_epoch_ms: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_else(|_| {
-                    // Fallback to 0 if system time is before UNIX_EPOCH
-                    // This should never happen in practice, but provides a safe fallback
-                    Duration::from_millis(0)
-                })
-                .as_millis() as u64,
+    let response = if modules_on_request.is_empty() {
+        next.run(request).await
+    } else {
+        // Extract request body once before processing modules
+        let method = request.method().clone();
+        let uri = request.uri().clone();
+        let mut headers = request.headers().clone();
+        let max_body_size = wasm_manager.get_max_body_size();
+        let body_bytes = match axum::body::to_bytes(request.into_body(), max_body_size).await {
+            Ok(bytes) => bytes.to_vec(),
+            Err(e) => {
+                error!("Failed to read request body: {}", e);
+                // Create a minimal request with empty body for error recovery
+                let error_request = Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap_or_else(|_| Request::new(Body::empty()));
+                return Ok(next.run(error_request).await);
+            }
         };
 
-        // Execute WASM component
-        let action = match wasm_manager
-            .execute_module_for_attach_point(
-                &module,
-                on_request_attach_point.clone(),
-                WasmComponentInput::MiddlewareRequest(wasm_request),
-            )
-            .await
-        {
-            Some(action) => action,
-            None => continue, // Continue to next module on error
-        };
+        // Process each OnRequest module
+        let mut modified_body = body_bytes;
 
-        // Process action
-        match action {
-            Action::Continue => {
-                // Continue to next module or request processing
-            }
-            Action::Reject(status) => {
-                // Immediately reject the request
-                return Err(StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_REQUEST));
-            }
-            Action::Modify(modify) => {
-                // Apply modifications to headers and body
-                apply_modify_action_to_headers(&mut headers, &modify);
-                // Apply body_replace
-                if let Some(body_bytes) = modify.body_replace {
-                    modified_body = body_bytes;
+        // Pre-compute strings once before the loop to avoid repeated allocations
+        let method_str = method.to_string();
+        let path_str = uri.path().to_string();
+        let query_str = uri.query().unwrap_or("").to_string();
+
+        for module in modules_on_request {
+            // Build WebAssembly request from collected data
+            let wasm_headers = build_wasm_headers_from_axum_headers(&headers);
+            let wasm_request = WasmRequest {
+                method: method_str.clone(),
+                path: path_str.clone(),
+                query: query_str.clone(),
+                headers: wasm_headers,
+                body: modified_body.clone(),
+                request_id: request_id.clone(),
+                now_epoch_ms: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_else(|_| Duration::from_millis(0))
+                    .as_millis() as u64,
+            };
+
+            // Execute WASM component
+            let action = match wasm_manager
+                .execute_module_for_attach_point(
+                    &module,
+                    on_request_attach_point.clone(),
+                    WasmComponentInput::MiddlewareRequest(wasm_request),
+                )
+                .await
+            {
+                Some(action) => action,
+                None => continue, // Continue to next module on error
+            };
+
+            // Process action
+            match action {
+                Action::Continue => {}
+                Action::Reject(status) => {
+                    return Err(StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_REQUEST));
+                }
+                Action::Modify(modify) => {
+                    // Apply modifications to headers and body
+                    apply_modify_action_to_headers(&mut headers, &modify);
+                    if let Some(body_bytes) = modify.body_replace {
+                        modified_body = body_bytes;
+                    }
                 }
             }
         }
-    }
 
-    // Reconstruct request with modifications
-    let mut final_request = Request::builder()
-        .method(method)
-        .uri(uri)
-        .body(Body::from(modified_body))
-        .unwrap_or_else(|_| Request::new(Body::empty()));
-    *final_request.headers_mut() = headers;
+        // Reconstruct request with modifications
+        let mut final_request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(Body::from(modified_body))
+            .unwrap_or_else(|_| Request::new(Body::empty()));
+        *final_request.headers_mut() = headers;
 
-    // Continue with request processing
-    let response = next.run(final_request).await;
+        // Continue with request processing
+        next.run(final_request).await
+    };
 
     // ===== OnResponse Phase =====
     let on_response_attach_point =
@@ -886,6 +877,7 @@ pub async fn wasm_middleware(
     // Extract response data once before processing modules
     let mut status = response.status();
     let mut headers = response.headers().clone();
+    let max_body_size = wasm_manager.get_max_body_size();
     let mut body_bytes = match axum::body::to_bytes(response.into_body(), max_body_size).await {
         Ok(bytes) => bytes.to_vec(),
         Err(e) => {
@@ -924,9 +916,7 @@ pub async fn wasm_middleware(
 
         // Process action - apply modifications incrementally
         match action {
-            Action::Continue => {
-                // Continue to next module
-            }
+            Action::Continue => {}
             Action::Reject(status_code) => {
                 // Override response status
                 status = StatusCode::from_u16(status_code).unwrap_or(StatusCode::BAD_REQUEST);

--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -916,7 +916,9 @@ pub async fn wasm_middleware(
 
         // Process action - apply modifications incrementally
         match action {
-            Action::Continue => {}
+            Action::Continue => {
+                // Continue to next module
+            }
             Action::Reject(status_code) => {
                 // Override response status
                 status = StatusCode::from_u16(status_code).unwrap_or(StatusCode::BAD_REQUEST);

--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -772,6 +772,11 @@ pub async fn wasm_middleware(
                 return Ok(next.run(request).await);
             }
         };
+    if modules_on_request.is_empty() {
+        let response = next.run(request).await;
+        return self::wasm_middleware_response_phase(app_state, response, wasm_manager, request_id)
+            .await;
+    }
 
     // Extract request body once before processing modules
     let method = request.method().clone();
@@ -875,7 +880,9 @@ pub async fn wasm_middleware(
                 return Ok(response);
             }
         };
-
+    if modules_on_response.is_empty() {
+        return Ok(response);
+    }
     // Extract response data once before processing modules
     let mut status = response.status();
     let mut headers = response.headers().clone();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->



## Motivation

The previous implementation of the WebAssembly (WASM) middleware in `src/middleware.rs` introduced a performance bottleneck . Whenever WASM was enabled, the middleware unconditionally called `axum::body::to_bytes` on both the incoming request body and the outgoing response body.

This approach had two major negative impacts:

1. **Broken Streaming**: Calling `to_bytes` on a response forces the gateway to buffer the entire generated output before sending the first token to the client. This completely negates the low-latency benefits of LLM streaming.
2. **High Latency (TTFT)**: Clients experienced a Time-To-First-Token (TTFT) delay equal to the full generation time of the model.


## Modifications

The `wasm_middleware` function was refactored to implement a "fast-path" mechanism that avoids buffering unless a WASM module is actually registered to process the payload at a specific attach point:

* **Request Phase Optimization**: Added a check to determine if any modules are registered for the `OnRequest` attach point. If no modules are active, the request is passed to the next service immediately without buffering the body.
* **Response Phase Optimization**: Added an early return check after receiving the response from the worker. If no modules are registered for the `OnResponse` attach point, the response stream is returned to the client immediately.
* **Code Structure**: Integrated the response phase logic directly into the flow to ensure the stream is preserved and handed back to Axum as early as possible.

## Accuracy Tests

This PR does not modify the model kernel or forward logic. It strictly optimizes the HTTP proxying layer. 

## Benchmarking and Profiling

A benchmark was conducted using a mock worker that simulates a 500ms delay between the first and second response chunks to represent model generation time.

| Metric | Pre-fix (Unconditional Buffering) | Post-fix (Fast-path Optimization) | Improvement |
| --- | --- | --- | --- |
| **First Frame Latency** | **~501.35 ms** | **~26.71 µs** | **~18,700x faster** |



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
