### PR TITLE
bugfix: prevent excessive token slot reservation

### DIFF
--- a/test/registered/scheduler/test_prefill_adder.py
+++ b/test/registered/scheduler/test_prefill_adder.py
@@ -77,6 +77,10 @@ class TestPrefillAdder(CustomTestCase):
         req.output_ids = [0] * output_len
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)
         req.time_stats = SimpleNamespace(wait_queue_entry_time=wait_time)
+        req.estimate_remain_tokens = min(
+            max(max_new_tokens - output_len, 0),
+            4096,
+        )
         return req
 
     def create_adder(self, running_batch):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
When reserving token slots for future decoding during `prefillAdder` construction, we execute the logic for `running_batch` to calculate the `rem_total_token_offset`. 
```
if running_batch is not None:
    self.rem_total_token_offset += sum(
        [
            min(
                (r.sampling_params.max_new_tokens - len(r.output_ids)),
                CLIP_MAX_NEW_TOKENS_ESTIMATION,
            )
            * self.new_token_ratio
            for r in running_batch.reqs
        ]
    )
```
While ignoring `req.output_ids` is acceptable for standard prefill requests (as they are empty), it becomes problematic for preempted requests undergoing re-prefill. Since preempted requests already have non-empty `req.output_ids` and `req.extend_input_len` might contain partial data from `req.output_ids`, we should only reserve `sampling_params.max_new_tokens - len(req.output_ids)` token slots for them to avoid excessive token reservation in `self._update_prefill_budget(..., extend_input_len, max_new_tokens, ...)` and other scenarios combining `extend_input_len` and `max_new_tokens` just like
```
total_tokens = req.extend_input_len + min(
            max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
            CLIP_MAX_NEW_TOKENS,
        )
```

I suspect this might be a bug, and I'd like to get your thoughts on it.

PTAL @harrisonlimh @cctry Thank you so much

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
