### PR TITLE
[Fix CI] Fix test_mamba_unittest.py

### DIFF
--- a/test/registered/attention/test_mamba_unittest.py
+++ b/test/registered/attention/test_mamba_unittest.py
@@ -11,6 +11,7 @@ from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, HybridReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=9, suite="stage-b-test-small-1-gpu")
@@ -19,7 +20,10 @@ register_cuda_ci(est_time=9, suite="stage-b-test-small-1-gpu")
 class TestMamba(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        pass
+        server_args = ServerArgs(model_path="dummy")
+        server_args.enable_dp_attention = False
+        server_args.page_size = 1
+        set_global_server_args_for_scheduler(server_args)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix CI test_mamba_unittest.py
https://github.com/sgl-project/sglang/pull/16768 introduced server_args, but not initialized it in test_mamba unit test. This PR fixed it.

https://github.com/sgl-project/sglang/actions/runs/20844699378/job/59914340819?pr=16732

```
============================================================
Test Summary: 9/12 passed
============================================================
✓ PASSED:
  registered/scheduler/test_chunked_prefill.py
  registered/mla/test_mla_flashinfer.py
  registered/tokenizer/test_multi_tokenizer.py
  registered/rl/test_update_weights_from_tensor.py
  registered/vlm/test_vision_chunked_prefill.py
  registered/quant/test_torchao.py
  registered/models/test_embedding_models.py
  registered/quant/test_block_int8.py
  registered/openai_server/basic/test_serving_chat.py

✗ FAILED:
  registered/attention/test_mamba_unittest.py (exit code 1) 
============================================================
```


Before fix:
```
root@6996fb46042d:/sgl-workspace/sglang# python ./test/registered/attention/test_mamba_unittest.py



..[Start] allocator mamba available size: 20, full available size: 128
req1: inserting, req1_token_ids: [1, 2, 3], req1_kv_indices: tensor([1, 2, 3], device='cuda:0')
req1: prefix_len: (0, False), allocator mamba available size: 19, full available size: 125
req2: inserting, req2_token_ids: [1, 2, 3, 4, 5, 6, 7], req2_kv_indices: tensor([ 4,  5,  6,  7,  8,  9, 10], device='cuda:0')
req2: prefix_len: (3, False), allocator mamba available size: 18, full available size: 118
req3: inserting, req3_token_ids: [10, 11, 12], req3_kv_indices: tensor([11, 12, 13], device='cuda:0')
req3: prefix_len: (0, False), allocator mamba available size: 17, full available size: 115
req4: inserting, req4_token_ids: [1, 2, 3, 4, 5, 60, 70], req4_kv_indices: tensor([14, 15, 16, 17, 18, 19, 20], device='cuda:0')
req4: prefix_len: (5, False), allocator mamba available size: 16, full available size: 108
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [7] 3 fr=0 mr=0 fll=True mll=True mv=tensor([2], device='cuda:0')
   [5] 3 fr=0 mr=0 fll=True mll=True mv=tensor([0], device='cuda:0')
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [9] 2 fr=0 mr=0 fll=True mll=True mv=tensor([3], device='cuda:0')
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 12, #mamba_num: 4
evicting 1 full token
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [5] 3 fr=0 mr=0 fll=True mll=True mv=tensor([0], device='cuda:0')
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [9] 2 fr=0 mr=0 fll=True mll=True mv=tensor([3], device='cuda:0')
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 9, #mamba_num: 3
evicting 1 mamba
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [5] 3 fr=0 mr=0 fll=True mll=False mv=None
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [9] 2 fr=0 mr=0 fll=True mll=True mv=tensor([3], device='cuda:0')
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 9, #mamba_num: 2
E
======================================================================
ERROR: test_mamba_radix_cache_1 (__main__.TestMamba.test_mamba_radix_cache_1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/sgl-workspace/sglang/./test/registered/attention/test_mamba_unittest.py", line 287, in test_mamba_radix_cache_1
    result = tree.match_prefix(RadixKey(req5_token_ids))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/mem_cache/mamba_radix_cache.py", line 439, in match_prefix
    value, last_node, mamba_branching_seqlen = self._match_prefix_helper(key)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/mem_cache/mamba_radix_cache.py", line 959, in _match_prefix_helper
    mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
                             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/server_args.py", line 5062, in get_global_server_args
    raise ValueError("Global server args is not set yet!")
ValueError: Global server args is not set yet!

----------------------------------------------------------------------
Ran 3 tests in 0.143s

FAILED (errors=1)
```

After fix:
```
root@6996fb46042d:/sgl-workspace/sglang# python ./test/registered/attention/test_mamba_unittest.py
..[Start] allocator mamba available size: 20, full available size: 128
req1: inserting, req1_token_ids: [1, 2, 3], req1_kv_indices: tensor([1, 2, 3], device='cuda:0')
req1: prefix_len: (0, False), allocator mamba available size: 19, full available size: 125
req2: inserting, req2_token_ids: [1, 2, 3, 4, 5, 6, 7], req2_kv_indices: tensor([ 4,  5,  6,  7,  8,  9, 10], device='cuda:0')
req2: prefix_len: (3, False), allocator mamba available size: 18, full available size: 118
req3: inserting, req3_token_ids: [10, 11, 12], req3_kv_indices: tensor([11, 12, 13], device='cuda:0')
req3: prefix_len: (0, False), allocator mamba available size: 17, full available size: 115
req4: inserting, req4_token_ids: [1, 2, 3, 4, 5, 60, 70], req4_kv_indices: tensor([14, 15, 16, 17, 18, 19, 20], device='cuda:0')
req4: prefix_len: (5, False), allocator mamba available size: 16, full available size: 108
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [7] 3 fr=0 mr=0 fll=True mll=True mv=tensor([2], device='cuda:0')
   [5] 3 fr=0 mr=0 fll=True mll=True mv=tensor([0], device='cuda:0')
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [9] 2 fr=0 mr=0 fll=True mll=True mv=tensor([3], device='cuda:0')
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 12, #mamba_num: 4
evicting 1 full token
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [5] 3 fr=0 mr=0 fll=True mll=True mv=tensor([0], device='cuda:0')
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [9] 2 fr=0 mr=0 fll=True mll=True mv=tensor([3], device='cuda:0')
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 9, #mamba_num: 3
evicting 1 mamba
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [5] 3 fr=0 mr=0 fll=True mll=False mv=None
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [9] 2 fr=0 mr=0 fll=True mll=True mv=tensor([3], device='cuda:0')
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 9, #mamba_num: 2
req5: token_ids: [1, 2, 3, 4, 5], matched kv_indices: tensor([], device='cuda:0', dtype=torch.int64), last_node.key: RadixKey(extra_key=None, token_ids=[])
req6: token_ids: [1, 2, 3, 4, 5, 60, 70], matched kv_indices: tensor([ 1,  2,  3,  7,  8, 19, 20], device='cuda:0'), last_node.key: RadixKey(extra_key=None, token_ids=[60, 70])
req7: token_ids: [1, 2, 3, 4, 5, 6, 7], matched kv_indices: tensor([ 1,  2,  3,  7,  8,  9, 10], device='cuda:0'), last_node.key: RadixKey(extra_key=None, token_ids=[6, 7])
evicting 1 mamba
 [0] 0 fr=1 mr=1 fll=False mll=False mv=None
   [5] 3 fr=0 mr=0 fll=True mll=False mv=None
     [8] 2 fr=0 mr=0 fll=True mll=False mv=None
       [6] 2 fr=0 mr=0 fll=True mll=True mv=tensor([1], device='cuda:0')
#full_tokens: 7, #mamba_num: 1
req8: token_ids: [1, 2, 3, 4, 5, 60, 70], matched kv_indices: tensor([], device='cuda:0', dtype=torch.int64), last_node.key: RadixKey(extra_key=None, token_ids=[])
.
----------------------------------------------------------------------
Ran 3 tests in 0.204s

OK
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
