### PR TITLE
[ci hot fix] fix global server args init for mamba ut

### DIFF
--- a/test/registered/attention/test_mamba_unittest.py
+++ b/test/registered/attention/test_mamba_unittest.py
@@ -11,6 +11,7 @@ from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, HybridReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=9, suite="stage-b-test-small-1-gpu")
@@ -130,6 +131,9 @@ class TestMamba(unittest.TestCase):
         assert req_to_token_pool.mamba_pool.available_size() == mamba_cache_size - 1
 
     def test_mamba_radix_cache_1(self):
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", page_size=1)
+        )
         # kv cache
         size = 128
         dtype = torch.bfloat16


### PR DESCRIPTION
Introduced in https://github.com/sgl-project/sglang/pull/16768

Errors:

```bash
======================================================================
ERROR: test_mamba_radix_cache_1 (__main__.TestMamba.test_mamba_radix_cache_1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/sglang/test/registered/attention/test_mamba_unittest.py", line 287, in test_mamba_radix_cache_1
    result = tree.match_prefix(RadixKey(req5_token_ids))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/common_sync/sglang/python/sglang/srt/mem_cache/mamba_radix_cache.py", line 439, in match_prefix
    value, last_node, mamba_branching_seqlen = self._match_prefix_helper(key)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/common_sync/sglang/python/sglang/srt/mem_cache/mamba_radix_cache.py", line 959, in _match_prefix_helper
    mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
                             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/host_home/common_sync/sglang/python/sglang/srt/server_args.py", line 5068, in get_global_server_args
    raise ValueError("Global server args is not set yet!")
ValueError: Global server args is not set yet!

----------------------------------------------------------------------
Ran 3 tests in 0.209s

FAILED (errors=1)
```