### PR TITLE
Update est_time for stage-b-test-small-1-gpu tests

### DIFF
--- a/test/registered/attention/test_torch_native_attention_backend.py
+++ b/test/registered/attention/test_torch_native_attention_backend.py
@@ -18,7 +18,7 @@ from sglang.test.test_utils import (
 )
 
 # Torch native attention backend integration test with MMLU eval
-register_cuda_ci(est_time=150, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=169, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=150, suite="stage-b-test-small-1-gpu-amd")
 
 

--- a/test/registered/backends/test_torch_compile.py
+++ b/test/registered/backends/test_torch_compile.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=190, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=144, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=1100, suite="stage-b-test-small-1-gpu-amd")
 
 

--- a/test/registered/core/test_deterministic.py
+++ b/test/registered/core/test_deterministic.py
@@ -15,7 +15,7 @@ from sglang.test.test_deterministic_utils import (
     TestDeterministicBase,
 )
 
-register_cuda_ci(est_time=228, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=278, suite="stage-b-test-small-1-gpu")
 
 
 class TestFlashinferDeterministic(TestDeterministicBase):

--- a/test/registered/core/test_gpt_oss_1gpu.py
+++ b/test/registered/core/test_gpt_oss_1gpu.py
@@ -3,7 +3,7 @@ import unittest
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.gpt_oss_common import BaseTestGptOss
 
-register_cuda_ci(est_time=402, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=519, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=750, suite="stage-b-test-small-1-gpu-amd-mi35x")
 
 

--- a/test/registered/cuda_graph/test_piecewise_cuda_graph_small_1_gpu.py
+++ b/test/registered/cuda_graph/test_piecewise_cuda_graph_small_1_gpu.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
 )
 
 # CI Registration - Small 1-GPU tests (24GB GPU sufficient)
-register_cuda_ci(est_time=460, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=539, suite="stage-b-test-small-1-gpu")
 
 
 class TestPiecewiseCudaGraphCorrectness(CustomTestCase):

--- a/test/registered/dllm/test_llada2_mini.py
+++ b/test/registered/dllm/test_llada2_mini.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=520, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=181, suite="stage-b-test-small-1-gpu")
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/hicache/test_hicache_variants.py
+++ b/test/registered/hicache/test_hicache_variants.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=368, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=524, suite="stage-b-test-small-1-gpu")
 
 """
 Consolidated HiCache variant tests.

--- a/test/registered/lora/test_lora_update.py
+++ b/test/registered/lora/test_lora_update.py
@@ -34,7 +34,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=451, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=487, suite="stage-b-test-small-1-gpu")
 
 PROMPTS = [
     "SGL is a",

--- a/test/registered/mla/test_flashmla.py
+++ b/test/registered/mla/test_flashmla.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
 )
 
 # FlashMLA attention backend tests with MTP speculative decoding
-register_cuda_ci(est_time=230, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=284, suite="stage-b-test-small-1-gpu")
 
 
 class TestFlashMLAAttnBackend(unittest.TestCase):

--- a/test/registered/mla/test_mla_int8_deepseek_v3.py
+++ b/test/registered/mla/test_mla_int8_deepseek_v3.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
 )
 
 # DeepSeek-V3 INT8 quantization tests (channel and block INT8)
-register_cuda_ci(est_time=300, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=341, suite="stage-b-test-small-1-gpu")
 
 
 class TestMLADeepseekV3ChannelInt8(CustomTestCase):

--- a/test/registered/models/test_encoder_embedding_models.py
+++ b/test/registered/models/test_encoder_embedding_models.py
@@ -1,7 +1,7 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
 # Encoder embedding model tests (CUDA only)
-register_cuda_ci(est_time=221, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=270, suite="stage-b-test-small-1-gpu")
 
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/registered/models/test_vlm_models.py
+++ b/test/registered/models/test_vlm_models.py
@@ -1,7 +1,7 @@
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 # VLM (Vision Language Model) tests
-register_cuda_ci(est_time=270, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=228, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=420, suite="stage-b-test-small-1-gpu-amd")
 
 import argparse

--- a/test/registered/moe/test_triton_fused_moe.py
+++ b/test/registered/moe/test_triton_fused_moe.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=12, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=89, suite="stage-b-test-small-1-gpu")
 
 import unittest
 

--- a/test/registered/openai_server/features/test_enable_thinking.py
+++ b/test/registered/openai_server/features/test_enable_thinking.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=70, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=103, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=200, suite="stage-b-test-small-1-gpu-amd")
 
 

--- a/test/registered/ops/test_repeat_interleave.py
+++ b/test/registered/ops/test_repeat_interleave.py
@@ -1,7 +1,7 @@
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 # Ops - Repeat Interleave tests (1-GPU)
-register_cuda_ci(est_time=60, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=75, suite="stage-b-test-small-1-gpu-amd")
 
 import time

--- a/test/registered/quant/test_fp8_kernel.py
+++ b/test/registered/quant/test_fp8_kernel.py
@@ -9,7 +9,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=10, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=132, suite="stage-b-test-small-1-gpu")
 
 
 class TestFP8Base(CustomTestCase):

--- a/test/registered/scheduler/test_no_overlap_scheduler.py
+++ b/test/registered/scheduler/test_no_overlap_scheduler.py
@@ -9,7 +9,7 @@ import unittest
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase, run_mmlu_test
 
-register_cuda_ci(est_time=217, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=245, suite="stage-b-test-small-1-gpu")
 
 
 class TestOverlapSchedule(CustomTestCase):

--- a/test/registered/scheduler/test_retract_decode.py
+++ b/test/registered/scheduler/test_retract_decode.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 )
 from sglang.utils import is_in_ci
 
-register_cuda_ci(est_time=259, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=311, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=450, suite="stage-b-test-small-1-gpu-amd")
 
 

--- a/test/registered/spec/eagle/test_eagle_infer_a.py
+++ b/test/registered/spec/eagle/test_eagle_infer_a.py
@@ -22,7 +22,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=500, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=561, suite="stage-b-test-small-1-gpu")
 
 torch_dtype = torch.float16
 prefill_tolerance = 5e-2

--- a/test/registered/spec/eagle/test_eagle_infer_beta.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=194, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=283, suite="stage-b-test-small-1-gpu")
 
 
 class TestEagleServerBase(CustomTestCase, MatchedStopMixin):

--- a/test/registered/spec/test_ngram_speculative_decoding.py
+++ b/test/registered/spec/test_ngram_speculative_decoding.py
@@ -12,7 +12,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=117, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=230, suite="stage-b-test-small-1-gpu")
 
 GSM_DATASET_PATH = None
 

--- a/test/registered/spec/test_standalone_speculative_decoding.py
+++ b/test/registered/spec/test_standalone_speculative_decoding.py
@@ -18,7 +18,7 @@ from sglang.test.test_utils import (
 )
 
 # Standalone speculative decoding tests (FA3, Triton, FlashInfer backends)
-register_cuda_ci(est_time=150, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=308, suite="stage-b-test-small-1-gpu")
 
 GSM_DATASET_PATH = None
 

--- a/test/registered/vlm/test_vision_openai_server_a.py
+++ b/test/registered/vlm/test_vision_openai_server_a.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=890, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=957, suite="stage-b-test-small-1-gpu")
 
 """
 Usage:

--- a/test/registered/vlm/test_vlm_input_format.py
+++ b/test/registered/vlm/test_vlm_input_format.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=430, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=447, suite="stage-b-test-small-1-gpu")
 
 import json
 import unittest


### PR DESCRIPTION
## Summary
- Updated `est_time` for 24 tests in `stage-b-test-small-1-gpu` suite based on actual elapsed times from 3 CI runs
- Only updated tests where difference between estimated and actual time was >50 seconds

**CI runs analyzed:**
- https://github.com/sgl-project/sglang/actions/runs/20851379702
- https://github.com/sgl-project/sglang/actions/runs/20861026466
- https://github.com/sgl-project/sglang/actions/runs/20842927997

**Tests with underestimated times (20):**
| File | Old | New |
|------|-----|-----|
| test_deterministic.py | 228 | 278 |
| test_eagle_infer_a.py | 500 | 561 |
| test_eagle_infer_beta.py | 194 | 283 |
| test_enable_thinking.py | 70 | 103 |
| test_encoder_embedding_models.py | 221 | 270 |
| test_flashmla.py | 230 | 284 |
| test_fp8_kernel.py | 10 | 132 |
| test_gpt_oss_1gpu.py | 402 | 519 |
| test_hicache_variants.py | 368 | 524 |
| test_lora_update.py | 451 | 487 |
| test_mla_int8_deepseek_v3.py | 300 | 341 |
| test_ngram_speculative_decoding.py | 117 | 230 |
| test_no_overlap_scheduler.py | 217 | 245 |
| test_piecewise_cuda_graph_small_1_gpu.py | 460 | 539 |
| test_retract_decode.py | 259 | 311 |
| test_standalone_speculative_decoding.py | 150 | 308 |
| test_torch_native_attention_backend.py | 150 | 169 |
| test_triton_fused_moe.py | 12 | 89 |
| test_vision_openai_server_a.py | 890 | 957 |
| test_vlm_input_format.py | 430 | 447 |

**Tests with overestimated times (4):**
| File | Old | New |
|------|-----|-----|
| test_llada2_mini.py | 520 | 181 |
| test_repeat_interleave.py | 60 | 8 |
| test_torch_compile.py | 190 | 144 |
| test_vlm_models.py | 270 | 228 |