### PR TITLE
[AMD] enable CUDA graph for NSA backend and fix NSA FP8 fused RMSNorm group quant

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
@@ -4,6 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.utils import is_hip
+
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
 
@@ -347,12 +349,17 @@ def _set_k_and_s_triton(
         raise ValueError(
             f"index_k_scale must be 1D or 2D, got shape {index_k_scale.shape}"
         )
-
-    assert buf_numel_per_page == 64 * (128 + 4)
+    if is_hip():
+        assert buf_numel_per_page == 1 * (128 + 4)
+    else:
+        assert buf_numel_per_page == 64 * (128 + 4)
     assert num_tokens_to_write == num_tokens_to_write_ == num_tokens_to_write__
     assert index_head_dim == 128
     assert scale_dim == 1
-    assert page_size == 64
+    if is_hip():
+        assert page_size == 1
+    else:
+        assert page_size == 64
 
     assert buf.dtype == torch.uint8
     assert loc.dtype == torch.int64, f"{loc.dtype=}"  # can be int32

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -389,7 +389,7 @@ class Indexer(MultiPlatformOp):
 
             batch_size, next_n, heads, _ = q_fp8.shape
             logits = torch.full(
-                (heads, batch_size * next_n, max_seq_len),
+                (batch_size * next_n, max_seq_len),
                 float("-inf"),
                 device=q_fp8.device,
                 dtype=torch.float32,
@@ -408,7 +408,6 @@ class Indexer(MultiPlatformOp):
                 TotalCuCount=256,
                 WavePerEU=5,
             )
-            logits = logits.sum(dim=0)
         else:
             logits = deep_gemm.fp8_paged_mqa_logits(
                 q_fp8,

--- a/python/sglang/srt/layers/attention/nsa/tilelang_kernel.py
+++ b/python/sglang/srt/layers/attention/nsa/tilelang_kernel.py
@@ -147,6 +147,8 @@ def fp8_index_kernel(h: int, d: int, clear_accum=True):
                 T.copy(k_s[i_b, i1_n * blk_n1 + i2_n * blk_n2], k_s_frag)
 
                 logits = T.alloc_fragment((blk_n2, h), FP32)
+                if not clear_accum:
+                    T.fill(logits, 0)
                 T.gemm(
                     k_smem,
                     q_smem,

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -174,6 +174,9 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
     def get_page_table_64(self) -> torch.Tensor:
         return self.attn_metadata.real_page_table
 
+    def get_page_table_1(self) -> torch.Tensor:
+        return self.attn_metadata.page_table_1
+
     def get_seqlens_expanded(self) -> torch.Tensor:
         return self.attn_metadata.nsa_seqlens_expanded
 

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -75,7 +75,6 @@ _is_npu = is_npu()
 
 if _use_aiter and _is_gfx95_supported:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
-
     from sglang.srt.layers.quantization.rocm_mxfp4_utils import fused_rms_mxfp4_quant
 elif _is_npu:
     from sglang.srt.hardware_backend.npu.cmo import prepare_weight_cache
@@ -418,68 +417,68 @@ class LayerCommunicator:
                 if residual is None:
                     residual = hidden_states
 
-                    if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
-                        hidden_states, *_, _ = fused_rms_mxfp4_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            None,
-                            None,
-                            None,
-                            None,
-                        )
-                    elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
+                    # if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
+                    #     hidden_states, *_, _ = fused_rms_mxfp4_quant(
+                    #         hidden_states,
+                    #         self.input_layernorm.weight,
+                    #         self.input_layernorm.variance_epsilon,
+                    #         None,
+                    #         None,
+                    #         None,
+                    #         None,
+                    #     )
+                    # elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
 
-                        hidden_states, _, _, _res = fused_rms_fp8_group_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            inp2=None,
-                            inp2_weight=None,
-                            inp2_epsilon=None,
-                            group_size=128,
-                            dtype_quant=torch.float8_e4m3fn,
-                            res1=None,
-                            output_unquantized_inp1=False,
-                        )
+                    #     hidden_states, _, _, _res = fused_rms_fp8_group_quant(
+                    #         hidden_states,
+                    #         self.input_layernorm.weight,
+                    #         self.input_layernorm.variance_epsilon,
+                    #         inp2=None,
+                    #         inp2_weight=None,
+                    #         inp2_epsilon=None,
+                    #         group_size=128,
+                    #         dtype_quant=torch.float8_e4m3fn,
+                    #         res1=None,
+                    #         output_unquantized_inp1=False,
+                    #     )
 
-                    else:
-                        hidden_states = self.input_layernorm(hidden_states, **kwargs)
+                    # else:
+                    hidden_states = self.input_layernorm(hidden_states, **kwargs)
                 else:
 
-                    if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
-                        hidden_states, *_, residual = fused_rms_mxfp4_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            None,
-                            None,
-                            None,
-                            residual,
-                        )
-                    elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
-                        # RMSNorm + FP8 per-group quant
-                        # return hidden_states：
-                        #   out_fp8  : FP8 activation →  a8w8 GEMM
-                        #   out_bs   : block-scale →  gemm_a8w8_blockscale.x_scale
-                        hidden_states, _, _, residual = fused_rms_fp8_group_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            inp2=None,
-                            inp2_weight=None,
-                            inp2_epsilon=None,
-                            group_size=128,
-                            dtype_quant=torch.float8_e4m3fn,
-                            res1=residual,
-                            output_unquantized_inp1=False,
-                        )
-                    else:
-                        hidden_states, residual = self.input_layernorm(
-                            hidden_states,
-                            residual,
-                            **kwargs,
-                        )
+                    # if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
+                    #     hidden_states, *_, residual = fused_rms_mxfp4_quant(
+                    #         hidden_states,
+                    #         self.input_layernorm.weight,
+                    #         self.input_layernorm.variance_epsilon,
+                    #         None,
+                    #         None,
+                    #         None,
+                    #         residual,
+                    #     )
+                    # elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
+                    #     # RMSNorm + FP8 per-group quant
+                    #     # return hidden_states：
+                    #     #   out_fp8  : FP8 activation →  a8w8 GEMM
+                    #     #   out_bs   : block-scale →  gemm_a8w8_blockscale.x_scale
+                    #     hidden_states, _, _, residual = fused_rms_fp8_group_quant(
+                    #         hidden_states,
+                    #         self.input_layernorm.weight,
+                    #         self.input_layernorm.variance_epsilon,
+                    #         inp2=None,
+                    #         inp2_weight=None,
+                    #         inp2_epsilon=None,
+                    #         group_size=128,
+                    #         dtype_quant=torch.float8_e4m3fn,
+                    #         res1=residual,
+                    #         output_unquantized_inp1=False,
+                    #     )
+                    # else:
+                    hidden_states, residual = self.input_layernorm(
+                        hidden_states,
+                        residual,
+                        **kwargs,
+                    )
 
         hidden_states = self._communicate_simple_fn(
             hidden_states=hidden_states,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -52,7 +52,7 @@ from sglang.srt.mem_cache.utils import (
     set_mla_kv_buffer_triton,
     set_mla_kv_scale_buffer_triton,
 )
-from sglang.srt.utils import is_cuda, is_npu, next_power_of_2
+from sglang.srt.utils import is_cuda, is_hip, is_npu, next_power_of_2
 from sglang.srt.utils.custom_op import register_custom_op
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
@@ -68,6 +68,7 @@ logger = logging.getLogger(__name__)
 GB = 1024 * 1024 * 1024
 _is_cuda = is_cuda()
 _is_npu = is_npu()
+_is_hip = is_hip()
 
 
 def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
@@ -1724,7 +1725,10 @@ class NSATokenToKVPool(MLATokenToKVPool):
         # num head == 1 and head dim == 128 for index_k in NSA
         assert index_head_dim == 128
 
-        assert self.page_size == 64
+        if _is_hip:
+            assert self.page_size == 1
+        else:
+            assert self.page_size == 64
         with (
             torch.cuda.use_mem_pool(self.custom_mem_pool)
             if self.custom_mem_pool

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1523,10 +1523,34 @@ class DeepseekV2AttentionMLA(nn.Module):
             # NSA Indexer: cache quantized keys, auto-skip topk for sequences <= nsa_index_topk
 
             if self.use_nsa:
-                q_lora = self.q_a_layernorm(q)
-                q = self.q_b_proj(q_lora)[0].view(
-                    -1, self.num_local_heads, self.qk_head_dim
-                )
+                # NSA requires unquantized q_lora for the indexer. When q_b_proj is FP8
+                # on gfx95, we can still use fused RMSNorm+FP8 quant, but MUST request
+                # the unquantized output for q_lora; otherwise q_lora becomes the (fp8,scale)
+                # tuple.
+                if (
+                    _use_aiter_gfx95
+                    and self.q_b_proj.weight.dtype == torch.float8_e4m3fn
+                ):
+                    q_quanted, q_lora, _, _ = fused_rms_fp8_group_quant(
+                        q,
+                        self.q_a_layernorm.weight,
+                        self.q_a_layernorm.variance_epsilon,
+                        None,
+                        None,
+                        None,
+                        group_size=128,
+                        dtype_quant=torch.float8_e4m3fn,
+                        res1=None,
+                        output_unquantized_inp1=True,
+                    )
+                    q = self.q_b_proj(q_quanted)[0].view(
+                        -1, self.num_local_heads, self.qk_head_dim
+                    )
+                else:
+                    q_lora = self.q_a_layernorm(q)
+                    q = self.q_b_proj(q_lora)[0].view(
+                        -1, self.num_local_heads, self.qk_head_dim
+                    )
                 _ = self.indexer(
                     x=hidden_states,
                     q_lora=q_lora,
@@ -1693,41 +1717,57 @@ class DeepseekV2AttentionMLA(nn.Module):
                     k_nope = self.kv_a_layernorm(k_nope)
                 current_stream.wait_stream(self.alt_stream)
             else:
-                # if _use_aiter_gfx95 and self.q_b_proj.weight.dtype == torch.uint8:
-                #     q, _, k_nope, *_ = fused_rms_mxfp4_quant(
-                #         q,
-                #         self.q_a_layernorm.weight,
-                #         self.q_a_layernorm.variance_epsilon,
-                #         k_nope,
-                #         self.kv_a_layernorm.weight,
-                #         self.kv_a_layernorm.variance_epsilon,
-                #     )
-                # else:
-                #     if (
-                #         _use_aiter_gfx95
-                #         and self.q_b_proj.weight.dtype == torch.float8_e4m3fn
-                #     ):
+                if _use_aiter_gfx95 and self.q_b_proj.weight.dtype == torch.uint8:
+                    q, _, k_nope, *_ = fused_rms_mxfp4_quant(
+                        q,
+                        self.q_a_layernorm.weight,
+                        self.q_a_layernorm.variance_epsilon,
+                        k_nope,
+                        self.kv_a_layernorm.weight,
+                        self.kv_a_layernorm.variance_epsilon,
+                    )
+                else:
+                    q_lora = None
+                    if (
+                        _use_aiter_gfx95
+                        and self.q_b_proj.weight.dtype == torch.float8_e4m3fn
+                    ):
+                        if self.use_nsa:
+                            q_quanted, q_lora, k_nope, _ = fused_rms_fp8_group_quant(
+                                q,
+                                self.q_a_layernorm.weight,
+                                self.q_a_layernorm.variance_epsilon,
+                                k_nope,
+                                self.kv_a_layernorm.weight,
+                                self.kv_a_layernorm.variance_epsilon,
+                                group_size=128,
+                                dtype_quant=torch.float8_e4m3fn,
+                                res1=None,
+                                output_unquantized_inp1=True,
+                            )
+                            q = q_quanted
+                        else:
+                            q, _, k_nope, _ = fused_rms_fp8_group_quant(
+                                q,
+                                self.q_a_layernorm.weight,
+                                self.q_a_layernorm.variance_epsilon,
+                                k_nope,
+                                self.kv_a_layernorm.weight,
+                                self.kv_a_layernorm.variance_epsilon,
+                                group_size=128,
+                                dtype_quant=torch.float8_e4m3fn,
+                                res1=None,
+                                output_unquantized_inp1=False,
+                            )
 
-                #         q, _, k_nope, _ = fused_rms_fp8_group_quant(
-                #             q,
-                #             self.q_a_layernorm.weight,
-                #             self.q_a_layernorm.variance_epsilon,
-                #             k_nope,
-                #             self.kv_a_layernorm.weight,
-                #             self.kv_a_layernorm.variance_epsilon,
-                #             group_size=128,
-                #             dtype_quant=torch.float8_e4m3fn,
-                #             res1=None,
-                #             output_unquantized_inp1=False,
-                #         )
-
-                #     else:
-                q = self.q_a_layernorm(q)
-                k_nope = self.kv_a_layernorm(k_nope)
+                    else:
+                        q = self.q_a_layernorm(q)
+                        k_nope = self.kv_a_layernorm(k_nope)
 
             # q_lora needed by indexer
             if self.use_nsa:
-                q_lora = q
+                if q_lora is None:
+                    q_lora = q
 
             # overlap q_b_proj and indexer during decode
             if (

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1693,37 +1693,37 @@ class DeepseekV2AttentionMLA(nn.Module):
                     k_nope = self.kv_a_layernorm(k_nope)
                 current_stream.wait_stream(self.alt_stream)
             else:
-                if _use_aiter_gfx95 and self.q_b_proj.weight.dtype == torch.uint8:
-                    q, _, k_nope, *_ = fused_rms_mxfp4_quant(
-                        q,
-                        self.q_a_layernorm.weight,
-                        self.q_a_layernorm.variance_epsilon,
-                        k_nope,
-                        self.kv_a_layernorm.weight,
-                        self.kv_a_layernorm.variance_epsilon,
-                    )
-                else:
-                    if (
-                        _use_aiter_gfx95
-                        and self.q_b_proj.weight.dtype == torch.float8_e4m3fn
-                    ):
+                # if _use_aiter_gfx95 and self.q_b_proj.weight.dtype == torch.uint8:
+                #     q, _, k_nope, *_ = fused_rms_mxfp4_quant(
+                #         q,
+                #         self.q_a_layernorm.weight,
+                #         self.q_a_layernorm.variance_epsilon,
+                #         k_nope,
+                #         self.kv_a_layernorm.weight,
+                #         self.kv_a_layernorm.variance_epsilon,
+                #     )
+                # else:
+                #     if (
+                #         _use_aiter_gfx95
+                #         and self.q_b_proj.weight.dtype == torch.float8_e4m3fn
+                #     ):
 
-                        q, _, k_nope, _ = fused_rms_fp8_group_quant(
-                            q,
-                            self.q_a_layernorm.weight,
-                            self.q_a_layernorm.variance_epsilon,
-                            k_nope,
-                            self.kv_a_layernorm.weight,
-                            self.kv_a_layernorm.variance_epsilon,
-                            group_size=128,
-                            dtype_quant=torch.float8_e4m3fn,
-                            res1=None,
-                            output_unquantized_inp1=False,
-                        )
+                #         q, _, k_nope, _ = fused_rms_fp8_group_quant(
+                #             q,
+                #             self.q_a_layernorm.weight,
+                #             self.q_a_layernorm.variance_epsilon,
+                #             k_nope,
+                #             self.kv_a_layernorm.weight,
+                #             self.kv_a_layernorm.variance_epsilon,
+                #             group_size=128,
+                #             dtype_quant=torch.float8_e4m3fn,
+                #             res1=None,
+                #             output_unquantized_inp1=False,
+                #         )
 
-                    else:
-                        q = self.q_a_layernorm(q)
-                        k_nope = self.kv_a_layernorm(k_nope)
+                #     else:
+                q = self.q_a_layernorm(q)
+                k_nope = self.kv_a_layernorm(k_nope)
 
             # q_lora needed by indexer
             if self.use_nsa:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1090,7 +1090,7 @@ class ServerArgs:
                     self.attention_backend = "nsa"
                     logger.info("Use nsa attention backend for DeepSeek with DSA.")
 
-                if not is_npu():  # CUDA GPU
+                if not is_npu():  # CUDA or ROCm GPU
                     if self.enable_nsa_prefill_context_parallel:
                         logger.warning(
                             f"Context parallel feature is still under experiment. It has only been verified on Hopper platform."
@@ -1126,8 +1126,15 @@ class ServerArgs:
                                 f"attn_tp_size={self.tp_size}, attention weights will be sharded across {self.tp_size} ranks."
                             )
 
-                    self.page_size = 64
-                    logger.warning("Setting page size to 64 for DeepSeek DSA.")
+                    if is_hip():
+                        self.page_size = 1
+                        logger.warning(
+                            "Setting page size to 1 for DeepSeek DSA on ROCm."
+                        )
+                    else:
+                        # For CUDA GPU
+                        self.page_size = 64
+                        logger.warning("Setting page size to 64 for DeepSeek DSA.")
 
                     # For Hopper, we support both bf16 and fp8 kv cache; for Blackwell, we support fp8 only currently
                     import torch


### PR DESCRIPTION
Co-author: [@wufann](https://github.com/sgl-project/sglang/commits?author=wufann)
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR enables cuda graph (`--cuda-graph-max-bs 64`) and fixes crashes/memory faults observed when running DeepSeek-V3.2-Exp with NSA (tilelang).


## Modifications

- Tilelang sparse attention + cuda graphs:
  Add/adjust support to run NSA tilelang backends with --cuda-graph-max-bs 64 (stable capture/replay) for DeepSeek-V3.2.

- DeepSeek v2/v3.2 NSA FP8 path:
  Use aiter.ops.triton.fused_fp8_quant.fused_rms_fp8_group_quant(..., output_unquantized_inp1=True) in NSA-related code paths so the indexer receives an unquantized q_lora tensor, while q_b_proj still consumes the quantized (fp8, scale) output.


## Accuracy Tests

- Server
```
python3 -m sglang.launch_server --model /data2/deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --port 8000 --trust-remote-code --nsa-prefill-backend tilelang --nsa-decode-backend tilelang --cuda-graph-max-bs 64

```
- Client
```
python3 benchmark/gsm8k/bench_sglang.py --num-questions 1319 --port 8000

Accuracy: 0.960
Invalid: 0.000
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.


CC: @HaiShaw @kkHuang-amd @1am9trash 
