### PR TITLE
Add CI Coverage Overview workflow with detailed test listings

### DIFF
--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -29,10 +29,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
-        run: |
-          pip install -e "python/[dev]"
-
       - name: Generate CI Coverage Report
         run: |
           python scripts/ci/ci_coverage_report.py --output-format ${{ inputs.output_format || 'markdown' }}

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -18,7 +18,8 @@ on:
           - json
 
 jobs:
-  coverage-report:
+  summary:
+    name: Summary
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -29,14 +30,61 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Generate CI Coverage Report
+      - name: Generate Summary Report
         run: |
-          python scripts/ci/ci_coverage_report.py --output-format ${{ inputs.output_format || 'markdown' }}
+          python scripts/ci/ci_coverage_report.py --section summary
+
+  by-folder:
+    name: Tests by Folder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Generate Tests by Folder Report
+        run: |
+          python scripts/ci/ci_coverage_report.py --section by-folder
+
+  by-suite:
+    name: Tests by Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Generate Tests by Suite Report
+        run: |
+          python scripts/ci/ci_coverage_report.py --section by-suite
+
+  json-export:
+    name: JSON Export
+    runs-on: ubuntu-latest
+    if: inputs.output_format == 'json'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Generate JSON Report
+        run: |
+          python scripts/ci/ci_coverage_report.py --output-format json > ci_coverage.json
 
       - name: Upload JSON artifact
-        if: inputs.output_format == 'json'
         uses: actions/upload-artifact@v4
         with:
           name: ci-coverage-report
           path: ci_coverage.json
-          if-no-files-found: ignore

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install numpy
+          pip install -e "python/[dev]"
 
       - name: Generate CI Coverage Report
         run: |

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -1,6 +1,11 @@
 name: CI Coverage Overview
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/ci-coverage-overview.yml'
+      - 'scripts/ci/ci_coverage_report.py'
+      - 'test/registered/**'
   workflow_dispatch:
     inputs:
       output_format:
@@ -26,7 +31,7 @@ jobs:
 
       - name: Generate CI Coverage Report
         run: |
-          python scripts/ci/ci_coverage_report.py --output-format ${{ inputs.output_format }}
+          python scripts/ci/ci_coverage_report.py --output-format ${{ inputs.output_format || 'markdown' }}
 
       - name: Upload JSON artifact
         if: inputs.output_format == 'json'

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -1,6 +1,8 @@
 name: CI Coverage Overview
 
 on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6 AM UTC
   pull_request:
     paths:
       - '.github/workflows/ci-coverage-overview.yml'

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Install dependencies
+        run: |
+          pip install numpy
+
       - name: Generate CI Coverage Report
         run: |
           python scripts/ci/ci_coverage_report.py --output-format ${{ inputs.output_format || 'markdown' }}

--- a/.github/workflows/ci-coverage-overview.yml
+++ b/.github/workflows/ci-coverage-overview.yml
@@ -1,0 +1,37 @@
+name: CI Coverage Overview
+
+on:
+  workflow_dispatch:
+    inputs:
+      output_format:
+        description: 'Output format'
+        required: false
+        default: 'markdown'
+        type: choice
+        options:
+          - markdown
+          - json
+
+jobs:
+  coverage-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Generate CI Coverage Report
+        run: |
+          python scripts/ci/ci_coverage_report.py --output-format ${{ inputs.output_format }}
+
+      - name: Upload JSON artifact
+        if: inputs.output_format == 'json'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-coverage-report
+          path: ci_coverage.json
+          if-no-files-found: ignore

--- a/scripts/ci/ci_coverage_report.py
+++ b/scripts/ci/ci_coverage_report.py
@@ -17,10 +17,10 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# Add the python directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "python"))
+# Add the ci_register module path directly to avoid heavy sglang imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "python" / "sglang" / "test" / "ci"))
 
-from sglang.test.ci.ci_register import CIRegistry, HWBackend, ut_parse_one_file
+from ci_register import CIRegistry, HWBackend, ut_parse_one_file
 
 
 def collect_all_tests(registered_dir: str) -> list[CIRegistry]:

--- a/scripts/ci/ci_coverage_report.py
+++ b/scripts/ci/ci_coverage_report.py
@@ -18,7 +18,9 @@ from collections import defaultdict
 from pathlib import Path
 
 # Add the ci_register module path directly to avoid heavy sglang imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "python" / "sglang" / "test" / "ci"))
+sys.path.insert(
+    0, str(Path(__file__).parent.parent.parent / "python" / "sglang" / "test" / "ci")
+)
 
 from ci_register import CIRegistry, HWBackend, ut_parse_one_file
 
@@ -166,7 +168,9 @@ def generate_by_folder_section(data: dict) -> str:
     for folder in sorted(by_folder.keys()):
         folder_tests = by_folder[folder]
         lines.append("<details>")
-        lines.append(f"<summary><h2>{folder}/ ({len(folder_tests)} tests)</h2></summary>\n")
+        lines.append(
+            f"<summary><h2>{folder}/ ({len(folder_tests)} tests)</h2></summary>\n"
+        )
 
         # Group by backend within folder
         folder_by_backend = defaultdict(list)

--- a/scripts/ci/ci_coverage_report.py
+++ b/scripts/ci/ci_coverage_report.py
@@ -49,12 +49,17 @@ def get_folder_name(filename: str) -> str:
     return "root"
 
 
+def get_test_basename(filename: str) -> str:
+    """Extract just the test file name from the path."""
+    return Path(filename).name
+
+
 def generate_markdown_report(tests: list[CIRegistry]) -> str:
     """Generate markdown report for GitHub step summary."""
     lines = []
     lines.append("# CI Coverage Overview\n")
 
-    # Summary stats
+    # Organize data
     total = len(tests)
     by_backend = defaultdict(list)
     by_folder = defaultdict(list)
@@ -69,10 +74,112 @@ def generate_markdown_report(tests: list[CIRegistry]) -> str:
             disabled_tests.append(t)
 
     enabled = total - len(disabled_tests)
-    lines.append(f"**Total Tests:** {total} ({enabled} enabled, {len(disabled_tests)} disabled)\n")
+    lines.append(
+        f"**Total Tests:** {total} ({enabled} enabled, {len(disabled_tests)} disabled)\n"
+    )
+
+    # =========================================================================
+    # SECTION 1: All Tests Listed by Folder
+    # =========================================================================
+    lines.append("---")
+    lines.append("# 1. All Tests by Folder\n")
+
+    for folder in sorted(by_folder.keys()):
+        folder_tests = by_folder[folder]
+        lines.append(f"## {folder}/ ({len(folder_tests)} tests)\n")
+
+        # Group by backend within folder
+        folder_by_backend = defaultdict(list)
+        for t in folder_tests:
+            folder_by_backend[t.backend.name].append(t)
+
+        for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+            backend_tests = folder_by_backend.get(backend, [])
+            if not backend_tests:
+                continue
+
+            lines.append(f"### {backend} ({len(backend_tests)} tests)\n")
+            lines.append("| Test File | Suite | Est. Time | Status |")
+            lines.append("|-----------|-------|-----------|--------|")
+
+            for t in sorted(backend_tests, key=lambda x: x.filename):
+                test_name = get_test_basename(t.filename)
+                status = (
+                    "Disabled"
+                    if t.disabled
+                    else ("Nightly" if t.nightly else "Per-Commit")
+                )
+                lines.append(
+                    f"| `{test_name}` | {t.suite} | {t.est_time:.0f}s | {status} |"
+                )
+
+            lines.append("")
+
+    # =========================================================================
+    # SECTION 2: All Tests Listed by Test Suite (Backend -> Suite)
+    # =========================================================================
+    lines.append("---")
+    lines.append("# 2. All Tests by Test Suite\n")
+
+    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+        backend_tests = by_backend.get(backend, [])
+        if not backend_tests:
+            continue
+
+        b_total = len(backend_tests)
+        b_disabled = sum(1 for t in backend_tests if t.disabled)
+        b_enabled = b_total - b_disabled
+
+        lines.append(
+            f"## {backend} Backend ({b_enabled} enabled, {b_disabled} disabled)\n"
+        )
+
+        # Group by suite within backend
+        backend_suites = defaultdict(list)
+        for t in backend_tests:
+            backend_suites[t.suite].append(t)
+
+        for suite in sorted(backend_suites.keys()):
+            suite_tests = backend_suites[suite]
+            s_enabled = sum(1 for t in suite_tests if not t.disabled)
+            s_disabled = sum(1 for t in suite_tests if t.disabled)
+            s_est_time = sum(t.est_time for t in suite_tests if not t.disabled)
+            is_nightly = any(t.nightly for t in suite_tests if not t.disabled)
+
+            suite_type = "Nightly" if is_nightly else "Per-Commit"
+            lines.append(
+                f"### {suite} ({s_enabled} enabled, {s_disabled} disabled) - {suite_type}\n"
+            )
+            lines.append(f"*Estimated total time: {s_est_time:.0f}s*\n")
+
+            lines.append("| Test File | Folder | Est. Time | Status |")
+            lines.append("|-----------|--------|-----------|--------|")
+
+            for t in sorted(suite_tests, key=lambda x: x.filename):
+                test_name = get_test_basename(t.filename)
+                folder = get_folder_name(t.filename)
+                if t.disabled:
+                    status = (
+                        f"Disabled: {t.disabled[:30]}..."
+                        if len(t.disabled) > 30
+                        else f"Disabled: {t.disabled}"
+                    )
+                else:
+                    status = "Nightly" if t.nightly else "Per-Commit"
+                lines.append(
+                    f"| `{test_name}` | {folder} | {t.est_time:.0f}s | {status} |"
+                )
+
+            lines.append("")
+
+    # =========================================================================
+    # Summary Tables
+    # =========================================================================
+    lines.append("---")
+    lines.append("# Summary Tables\n")
 
     # Backend summary
-    lines.append("## By Backend\n")
+    lines.append("## Backend Summary\n")
     lines.append("| Backend | Total | Enabled | Disabled | Per-Commit | Nightly |")
     lines.append("|---------|-------|---------|----------|------------|---------|")
 
@@ -85,12 +192,14 @@ def generate_markdown_report(tests: list[CIRegistry]) -> str:
         b_enabled = b_total - b_disabled
         b_per_commit = sum(1 for t in backend_tests if not t.nightly and not t.disabled)
         b_nightly = sum(1 for t in backend_tests if t.nightly and not t.disabled)
-        lines.append(f"| {backend} | {b_total} | {b_enabled} | {b_disabled} | {b_per_commit} | {b_nightly} |")
+        lines.append(
+            f"| {backend} | {b_total} | {b_enabled} | {b_disabled} | {b_per_commit} | {b_nightly} |"
+        )
 
     lines.append("")
 
-    # Folder breakdown
-    lines.append("## By Folder\n")
+    # Folder summary
+    lines.append("## Folder Summary\n")
     lines.append("| Folder | CUDA | AMD | NPU | CPU | Total |")
     lines.append("|--------|------|-----|-----|-----|-------|")
 
@@ -100,112 +209,160 @@ def generate_markdown_report(tests: list[CIRegistry]) -> str:
         amd = sum(1 for t in folder_tests if t.backend == HWBackend.AMD)
         npu = sum(1 for t in folder_tests if t.backend == HWBackend.NPU)
         cpu = sum(1 for t in folder_tests if t.backend == HWBackend.CPU)
-        lines.append(f"| {folder} | {cuda} | {amd} | {npu} | {cpu} | {len(folder_tests)} |")
+        lines.append(
+            f"| {folder} | {cuda} | {amd} | {npu} | {cpu} | {len(folder_tests)} |"
+        )
 
     lines.append("")
 
-    # Suite breakdown (non-NVIDIA focus)
-    lines.append("## Non-NVIDIA Coverage (AMD, NPU, CPU)\n")
-
-    non_nvidia_tests = [t for t in tests if t.backend != HWBackend.CUDA]
-    if non_nvidia_tests:
-        suite_backend = defaultdict(lambda: defaultdict(list))
-        for t in non_nvidia_tests:
-            suite_backend[t.suite][t.backend.name].append(t)
-
-        lines.append("| Suite | Backend | Tests | Est. Time (s) |")
-        lines.append("|-------|---------|-------|---------------|")
-
-        for suite in sorted(suite_backend.keys()):
-            for backend in ["AMD", "NPU", "CPU"]:
-                suite_tests = suite_backend[suite].get(backend, [])
-                if suite_tests:
-                    est_time = sum(t.est_time for t in suite_tests)
-                    lines.append(f"| {suite} | {backend} | {len(suite_tests)} | {est_time:.0f} |")
-    else:
-        lines.append("*No non-NVIDIA tests found.*\n")
-
-    lines.append("")
-
-    # CUDA suite breakdown
-    lines.append("## CUDA Suites\n")
-    lines.append("<details>")
-    lines.append("<summary>Click to expand CUDA suite details</summary>\n")
-
-    cuda_tests = [t for t in tests if t.backend == HWBackend.CUDA]
-    cuda_suites = defaultdict(list)
-    for t in cuda_tests:
-        cuda_suites[t.suite].append(t)
-
-    lines.append("| Suite | Tests | Enabled | Est. Time (s) | Nightly |")
-    lines.append("|-------|-------|---------|---------------|---------|")
-
-    for suite in sorted(cuda_suites.keys()):
-        suite_tests = cuda_suites[suite]
-        s_total = len(suite_tests)
-        s_disabled = sum(1 for t in suite_tests if t.disabled)
-        s_enabled = s_total - s_disabled
-        s_est_time = sum(t.est_time for t in suite_tests if not t.disabled)
-        s_nightly = "Yes" if any(t.nightly for t in suite_tests) else "No"
-        lines.append(f"| {suite} | {s_total} | {s_enabled} | {s_est_time:.0f} | {s_nightly} |")
-
-    lines.append("\n</details>\n")
-
-    # Disabled tests
+    # Disabled tests section
     if disabled_tests:
         lines.append("## Disabled Tests\n")
-        lines.append("<details>")
-        lines.append("<summary>Click to expand disabled tests</summary>\n")
-        lines.append("| File | Backend | Reason |")
-        lines.append("|------|---------|--------|")
-        for t in sorted(disabled_tests, key=lambda x: x.filename):
+        lines.append("| File | Backend | Suite | Reason |")
+        lines.append("|------|---------|-------|--------|")
+        for t in sorted(disabled_tests, key=lambda x: (x.backend.name, x.filename)):
+            test_name = get_test_basename(t.filename)
             reason = t.disabled[:50] + "..." if len(t.disabled) > 50 else t.disabled
-            lines.append(f"| {t.filename} | {t.backend.name} | {reason} |")
-        lines.append("\n</details>\n")
+            lines.append(f"| `{test_name}` | {t.backend.name} | {t.suite} | {reason} |")
+        lines.append("")
 
     return "\n".join(lines)
 
 
 def generate_json_report(tests: list[CIRegistry]) -> str:
-    """Generate JSON report."""
-    data = {
-        "total": len(tests),
-        "by_backend": {},
-        "by_folder": {},
-        "by_suite": {},
-        "tests": [],
-    }
-
+    """Generate JSON report with detailed test listings."""
     by_backend = defaultdict(list)
     by_folder = defaultdict(list)
-    by_suite = defaultdict(list)
 
     for t in tests:
         by_backend[t.backend.name].append(t)
         by_folder[get_folder_name(t.filename)].append(t)
-        by_suite[t.suite].append(t)
 
-        data["tests"].append({
-            "filename": t.filename,
-            "backend": t.backend.name,
-            "suite": t.suite,
-            "est_time": t.est_time,
-            "nightly": t.nightly,
-            "disabled": t.disabled,
-        })
+    disabled_tests = [t for t in tests if t.disabled]
 
-    for backend, tests_list in by_backend.items():
-        data["by_backend"][backend] = {
-            "total": len(tests_list),
-            "enabled": sum(1 for t in tests_list if not t.disabled),
-            "disabled": sum(1 for t in tests_list if t.disabled),
+    # Build structured data
+    data = {
+        "summary": {
+            "total": len(tests),
+            "enabled": len(tests) - len(disabled_tests),
+            "disabled": len(disabled_tests),
+        },
+        "tests_by_folder": {},
+        "tests_by_suite": {},
+        "backend_summary": {},
+        "folder_summary": {},
+        "disabled_tests": [],
+    }
+
+    # Section 1: Tests by Folder
+    for folder in sorted(by_folder.keys()):
+        folder_tests = by_folder[folder]
+        folder_by_backend = defaultdict(list)
+        for t in folder_tests:
+            folder_by_backend[t.backend.name].append(t)
+
+        data["tests_by_folder"][folder] = {
+            "total": len(folder_tests),
+            "backends": {},
         }
 
-    for folder, tests_list in by_folder.items():
-        data["by_folder"][folder] = len(tests_list)
+        for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+            backend_tests = folder_by_backend.get(backend, [])
+            if backend_tests:
+                data["tests_by_folder"][folder]["backends"][backend] = [
+                    {
+                        "filename": get_test_basename(t.filename),
+                        "suite": t.suite,
+                        "est_time": t.est_time,
+                        "status": (
+                            "disabled"
+                            if t.disabled
+                            else ("nightly" if t.nightly else "per-commit")
+                        ),
+                    }
+                    for t in sorted(backend_tests, key=lambda x: x.filename)
+                ]
 
-    for suite, tests_list in by_suite.items():
-        data["by_suite"][suite] = len(tests_list)
+    # Section 2: Tests by Suite (Backend -> Suite)
+    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+        backend_tests = by_backend.get(backend, [])
+        if not backend_tests:
+            continue
+
+        backend_suites = defaultdict(list)
+        for t in backend_tests:
+            backend_suites[t.suite].append(t)
+
+        data["tests_by_suite"][backend] = {
+            "total": len(backend_tests),
+            "enabled": sum(1 for t in backend_tests if not t.disabled),
+            "disabled": sum(1 for t in backend_tests if t.disabled),
+            "suites": {},
+        }
+
+        for suite in sorted(backend_suites.keys()):
+            suite_tests = backend_suites[suite]
+            is_nightly = any(t.nightly for t in suite_tests if not t.disabled)
+
+            data["tests_by_suite"][backend]["suites"][suite] = {
+                "total": len(suite_tests),
+                "enabled": sum(1 for t in suite_tests if not t.disabled),
+                "disabled": sum(1 for t in suite_tests if t.disabled),
+                "est_time": sum(t.est_time for t in suite_tests if not t.disabled),
+                "type": "nightly" if is_nightly else "per-commit",
+                "tests": [
+                    {
+                        "filename": get_test_basename(t.filename),
+                        "folder": get_folder_name(t.filename),
+                        "est_time": t.est_time,
+                        "status": (
+                            "disabled"
+                            if t.disabled
+                            else ("nightly" if t.nightly else "per-commit")
+                        ),
+                        "disabled_reason": t.disabled if t.disabled else None,
+                    }
+                    for t in sorted(suite_tests, key=lambda x: x.filename)
+                ],
+            }
+
+    # Backend summary
+    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+        backend_tests = by_backend.get(backend, [])
+        if backend_tests:
+            data["backend_summary"][backend] = {
+                "total": len(backend_tests),
+                "enabled": sum(1 for t in backend_tests if not t.disabled),
+                "disabled": sum(1 for t in backend_tests if t.disabled),
+                "per_commit": sum(
+                    1 for t in backend_tests if not t.nightly and not t.disabled
+                ),
+                "nightly": sum(
+                    1 for t in backend_tests if t.nightly and not t.disabled
+                ),
+            }
+
+    # Folder summary
+    for folder in sorted(by_folder.keys()):
+        folder_tests = by_folder[folder]
+        data["folder_summary"][folder] = {
+            "CUDA": sum(1 for t in folder_tests if t.backend == HWBackend.CUDA),
+            "AMD": sum(1 for t in folder_tests if t.backend == HWBackend.AMD),
+            "NPU": sum(1 for t in folder_tests if t.backend == HWBackend.NPU),
+            "CPU": sum(1 for t in folder_tests if t.backend == HWBackend.CPU),
+            "total": len(folder_tests),
+        }
+
+    # Disabled tests
+    for t in sorted(disabled_tests, key=lambda x: (x.backend.name, x.filename)):
+        data["disabled_tests"].append(
+            {
+                "filename": get_test_basename(t.filename),
+                "backend": t.backend.name,
+                "suite": t.suite,
+                "reason": t.disabled,
+            }
+        )
 
     return json.dumps(data, indent=2)
 

--- a/scripts/ci/ci_coverage_report.py
+++ b/scripts/ci/ci_coverage_report.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+CI Coverage Report Generator
+
+Collects all CI test registrations from test/registered/ and generates
+a coverage report organized by folder, backend, and suite.
+
+Usage:
+    python scripts/ci/ci_coverage_report.py [--output-format markdown|json]
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Add the python directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "python"))
+
+from sglang.test.ci.ci_register import CIRegistry, HWBackend, ut_parse_one_file
+
+
+def collect_all_tests(registered_dir: str) -> list[CIRegistry]:
+    """Collect all CI registrations from registered directory."""
+    files = glob.glob(f"{registered_dir}/**/*.py", recursive=True)
+    all_tests = []
+
+    for file in sorted(files):
+        try:
+            registries = ut_parse_one_file(file)
+            all_tests.extend(registries)
+        except Exception as e:
+            print(f"Warning: Failed to parse {file}: {e}", file=sys.stderr)
+
+    return all_tests
+
+
+def get_folder_name(filename: str) -> str:
+    """Extract folder name from test filename."""
+    # e.g., "registered/models/test_foo.py" -> "models"
+    parts = Path(filename).parts
+    if "registered" in parts:
+        idx = parts.index("registered")
+        if idx + 1 < len(parts) - 1:  # Has subfolder
+            return parts[idx + 1]
+    return "root"
+
+
+def generate_markdown_report(tests: list[CIRegistry]) -> str:
+    """Generate markdown report for GitHub step summary."""
+    lines = []
+    lines.append("# CI Coverage Overview\n")
+
+    # Summary stats
+    total = len(tests)
+    by_backend = defaultdict(list)
+    by_folder = defaultdict(list)
+    by_suite = defaultdict(list)
+    disabled_tests = []
+
+    for t in tests:
+        by_backend[t.backend.name].append(t)
+        by_folder[get_folder_name(t.filename)].append(t)
+        by_suite[t.suite].append(t)
+        if t.disabled:
+            disabled_tests.append(t)
+
+    enabled = total - len(disabled_tests)
+    lines.append(f"**Total Tests:** {total} ({enabled} enabled, {len(disabled_tests)} disabled)\n")
+
+    # Backend summary
+    lines.append("## By Backend\n")
+    lines.append("| Backend | Total | Enabled | Disabled | Per-Commit | Nightly |")
+    lines.append("|---------|-------|---------|----------|------------|---------|")
+
+    for backend in ["CUDA", "AMD", "NPU", "CPU"]:
+        backend_tests = by_backend.get(backend, [])
+        if not backend_tests:
+            continue
+        b_total = len(backend_tests)
+        b_disabled = sum(1 for t in backend_tests if t.disabled)
+        b_enabled = b_total - b_disabled
+        b_per_commit = sum(1 for t in backend_tests if not t.nightly and not t.disabled)
+        b_nightly = sum(1 for t in backend_tests if t.nightly and not t.disabled)
+        lines.append(f"| {backend} | {b_total} | {b_enabled} | {b_disabled} | {b_per_commit} | {b_nightly} |")
+
+    lines.append("")
+
+    # Folder breakdown
+    lines.append("## By Folder\n")
+    lines.append("| Folder | CUDA | AMD | NPU | CPU | Total |")
+    lines.append("|--------|------|-----|-----|-----|-------|")
+
+    for folder in sorted(by_folder.keys()):
+        folder_tests = by_folder[folder]
+        cuda = sum(1 for t in folder_tests if t.backend == HWBackend.CUDA)
+        amd = sum(1 for t in folder_tests if t.backend == HWBackend.AMD)
+        npu = sum(1 for t in folder_tests if t.backend == HWBackend.NPU)
+        cpu = sum(1 for t in folder_tests if t.backend == HWBackend.CPU)
+        lines.append(f"| {folder} | {cuda} | {amd} | {npu} | {cpu} | {len(folder_tests)} |")
+
+    lines.append("")
+
+    # Suite breakdown (non-NVIDIA focus)
+    lines.append("## Non-NVIDIA Coverage (AMD, NPU, CPU)\n")
+
+    non_nvidia_tests = [t for t in tests if t.backend != HWBackend.CUDA]
+    if non_nvidia_tests:
+        suite_backend = defaultdict(lambda: defaultdict(list))
+        for t in non_nvidia_tests:
+            suite_backend[t.suite][t.backend.name].append(t)
+
+        lines.append("| Suite | Backend | Tests | Est. Time (s) |")
+        lines.append("|-------|---------|-------|---------------|")
+
+        for suite in sorted(suite_backend.keys()):
+            for backend in ["AMD", "NPU", "CPU"]:
+                suite_tests = suite_backend[suite].get(backend, [])
+                if suite_tests:
+                    est_time = sum(t.est_time for t in suite_tests)
+                    lines.append(f"| {suite} | {backend} | {len(suite_tests)} | {est_time:.0f} |")
+    else:
+        lines.append("*No non-NVIDIA tests found.*\n")
+
+    lines.append("")
+
+    # CUDA suite breakdown
+    lines.append("## CUDA Suites\n")
+    lines.append("<details>")
+    lines.append("<summary>Click to expand CUDA suite details</summary>\n")
+
+    cuda_tests = [t for t in tests if t.backend == HWBackend.CUDA]
+    cuda_suites = defaultdict(list)
+    for t in cuda_tests:
+        cuda_suites[t.suite].append(t)
+
+    lines.append("| Suite | Tests | Enabled | Est. Time (s) | Nightly |")
+    lines.append("|-------|-------|---------|---------------|---------|")
+
+    for suite in sorted(cuda_suites.keys()):
+        suite_tests = cuda_suites[suite]
+        s_total = len(suite_tests)
+        s_disabled = sum(1 for t in suite_tests if t.disabled)
+        s_enabled = s_total - s_disabled
+        s_est_time = sum(t.est_time for t in suite_tests if not t.disabled)
+        s_nightly = "Yes" if any(t.nightly for t in suite_tests) else "No"
+        lines.append(f"| {suite} | {s_total} | {s_enabled} | {s_est_time:.0f} | {s_nightly} |")
+
+    lines.append("\n</details>\n")
+
+    # Disabled tests
+    if disabled_tests:
+        lines.append("## Disabled Tests\n")
+        lines.append("<details>")
+        lines.append("<summary>Click to expand disabled tests</summary>\n")
+        lines.append("| File | Backend | Reason |")
+        lines.append("|------|---------|--------|")
+        for t in sorted(disabled_tests, key=lambda x: x.filename):
+            reason = t.disabled[:50] + "..." if len(t.disabled) > 50 else t.disabled
+            lines.append(f"| {t.filename} | {t.backend.name} | {reason} |")
+        lines.append("\n</details>\n")
+
+    return "\n".join(lines)
+
+
+def generate_json_report(tests: list[CIRegistry]) -> str:
+    """Generate JSON report."""
+    data = {
+        "total": len(tests),
+        "by_backend": {},
+        "by_folder": {},
+        "by_suite": {},
+        "tests": [],
+    }
+
+    by_backend = defaultdict(list)
+    by_folder = defaultdict(list)
+    by_suite = defaultdict(list)
+
+    for t in tests:
+        by_backend[t.backend.name].append(t)
+        by_folder[get_folder_name(t.filename)].append(t)
+        by_suite[t.suite].append(t)
+
+        data["tests"].append({
+            "filename": t.filename,
+            "backend": t.backend.name,
+            "suite": t.suite,
+            "est_time": t.est_time,
+            "nightly": t.nightly,
+            "disabled": t.disabled,
+        })
+
+    for backend, tests_list in by_backend.items():
+        data["by_backend"][backend] = {
+            "total": len(tests_list),
+            "enabled": sum(1 for t in tests_list if not t.disabled),
+            "disabled": sum(1 for t in tests_list if t.disabled),
+        }
+
+    for folder, tests_list in by_folder.items():
+        data["by_folder"][folder] = len(tests_list)
+
+    for suite, tests_list in by_suite.items():
+        data["by_suite"][suite] = len(tests_list)
+
+    return json.dumps(data, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate CI coverage report")
+    parser.add_argument(
+        "--output-format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--registered-dir",
+        default="test/registered",
+        help="Path to registered test directory",
+    )
+    args = parser.parse_args()
+
+    # Change to repo root if needed
+    script_dir = Path(__file__).parent
+    repo_root = script_dir.parent.parent
+    os.chdir(repo_root)
+
+    tests = collect_all_tests(args.registered_dir)
+
+    if args.output_format == "markdown":
+        report = generate_markdown_report(tests)
+    else:
+        report = generate_json_report(tests)
+
+    print(report)
+
+    # Write to GITHUB_STEP_SUMMARY if available
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file and args.output_format == "markdown":
+        with open(summary_file, "a") as f:
+            f.write(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a new CI workflow to generate a comprehensive coverage report of all registered tests
- Report shows two organized views:
  1. **All Tests by Folder** - Tests grouped by folder location, then by backend (CUDA/AMD/NPU/CPU)
  2. **All Tests by Test Suite** - Tests grouped by backend, then by suite (stage-a, stage-b-test-small-1-gpu, nightly-8-gpu-common, etc.)
- Each test entry shows: filename, suite/folder, estimated time, and status (Per-Commit/Nightly/Disabled)
- Supports both markdown (for GitHub step summary) and JSON output formats

## Test plan
- [x] Run `python scripts/ci/ci_coverage_report.py` to verify markdown output
- [x] Run `python scripts/ci/ci_coverage_report.py --output-format json` to verify JSON output