### PR TITLE
[Rfork] zmq for weight info calling of multi-node cases

### DIFF
--- a/docs/advanced_features/rfork.md
+++ b/docs/advanced_features/rfork.md
@@ -47,3 +47,23 @@ python -m sglang.launch_server [args] \
   --remote-instance-weight-loader-seed-instance-service-port [seed_instance_service_port] \
   --remote-instance-weight-loader-backend transfer_engine
 ```
+
+### Multi-node scenarios
+
+when users are trying to launch servers with multi-node settings,  `weight` R-fork will use zmq to build the communication between different nodes,
+so that the api call `get_remote_instance_transfer_engine_info` could also work for the gpus of nodes with the `node_rank > 1`.
+
+Users need to add `--node-hosts` and `--inter-node-transfer-engine-info-port`.
+
+`--node-hosts`: a dict of {`node_rank`: `address_of_node`} ;
+`--inter-node-transfer-engine-info-port`: port for zmq communication .
+
+For example:
+
+```
+# Node 0:
+python3 -m sglang.launch_server --model-path /data/models/Moonlight-16B-A3B-Instruct --tp 16 --trust-remote-code  --mem-frac 0.85 --host 0.0.0.0 --port 30000 --dist-init-addr node-0-addr:5000 --nnodes 2 --node-rank 0 --remote-instance-weight-loader-start-seed-via-transfer-engine --node-hosts '{"0":"node-0-addr","1":"node-1-addr"}' --inter-node-transfer-engine-info-port 15036
+
+# Node 1:
+python3 -m sglang.launch_server --model-path /data/models/Moonlight-16B-A3B-Instruct --tp 16 --trust-remote-code  --mem-frac 0.85 --host 0.0.0.0 --port 30000 --dist-init-addr node-0-addr:5000 --nnodes 2 --node-rank 1 --remote-instance-weight-loader-start-seed-via-transfer-engine --node-hosts '{"0":"node-0-addr","1":"node-1-addr"}' --inter-node-transfer-engine-info-port 15036
+```

--- a/docs/advanced_features/rfork.md
+++ b/docs/advanced_features/rfork.md
@@ -50,8 +50,7 @@ python -m sglang.launch_server [args] \
 
 ### Multi-node scenarios
 
-when users are trying to launch servers with multi-node settings,  `weight` R-fork will use zmq to build the communication between different nodes,
-so that the api call `get_remote_instance_transfer_engine_info` could also work for the gpus of nodes with the `node_rank > 1`.
+when users are trying to launch servers with multi-node settings, R-fork will use zmq to build the communication between different nodes, so that the api call `get_remote_instance_transfer_engine_info` could also work for the gpus of nodes with the `node_rank > 1`.
 
 Users need to add `--node-hosts` and `--inter-node-transfer-engine-info-port`.
 

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -957,7 +957,6 @@ def _launch_subprocesses(
         scheduler_infos = _wait_for_scheduler_ready(
             scheduler_pipe_readers, scheduler_procs
         )
-        # TODO(xinji1): refine the following codes with a bonus function
         # Start ZMQ server on non-head nodes to serve transfer engine info
         if (
             server_args.nnodes > 1

--- a/python/sglang/srt/model_loader/inter_node_transfer_engine_comm.py
+++ b/python/sglang/srt/model_loader/inter_node_transfer_engine_comm.py
@@ -1,0 +1,261 @@
+"""
+Inter-Node Transfer Engine Info Communication
+
+This module provides ZMQ-based communication between nodes for sharing
+transfer engine information in multi-node setups.
+"""
+
+import json
+import logging
+import threading
+from typing import Dict, Optional, Tuple
+
+import zmq
+
+logger = logging.getLogger(__name__)
+
+
+class TransferEngineInfoServer:
+    """
+    ZMQ server that runs on non-head nodes to serve transfer engine info
+    for their local TP ranks.
+    """
+
+    def __init__(self, port: int, node_rank: int):
+        self.port = port
+        self.node_rank = node_rank
+        self.context = zmq.Context()
+        self.socket = None
+        self.transfer_engine_info: Dict[int, Tuple] = {}
+        self.running = False
+        self.server_thread = None
+
+    def set_transfer_engine_info(self, transfer_engine_info: Dict[int, Tuple]):
+        """
+        Set the transfer engine info that this server will serve.
+
+        Args:
+            transfer_engine_info: Dictionary mapping TP ranks to
+                                 (session_id, weights_info_dict) tuples
+        """
+        self.transfer_engine_info = transfer_engine_info
+        logger.info(
+            f"Node {self.node_rank}: Set transfer engine info for ranks {list(transfer_engine_info.keys())}"
+        )
+
+    def start(self):
+        """Start the ZMQ server in a background thread."""
+        if self.running:
+            logger.warning(
+                f"Node {self.node_rank}: Transfer engine info server already running"
+            )
+            return
+
+        self.running = True
+        self.server_thread = threading.Thread(target=self._run_server, daemon=True)
+        self.server_thread.start()
+        logger.info(
+            f"Node {self.node_rank}: Started transfer engine info server on port {self.port}"
+        )
+
+    def stop(self):
+        """Stop the ZMQ server."""
+        if not self.running:
+            return
+
+        self.running = False
+        if self.socket:
+            self.socket.close()
+        if self.server_thread:
+            self.server_thread.join(timeout=5.0)
+        self.context.term()
+        logger.info(f"Node {self.node_rank}: Stopped transfer engine info server")
+
+    def _run_server(self):
+        """Main server loop running in background thread."""
+        try:
+            self.socket = self.context.socket(zmq.REP)
+            self.socket.bind(f"tcp://*:{self.port}")
+            logger.info(
+                f"Node {self.node_rank}: ZMQ server listening on port {self.port}"
+            )
+
+            while self.running:
+                try:
+                    # Set receive timeout to check self.running periodically
+                    self.socket.RCVTIMEO = 1000  # 1 second timeout
+
+                    # Receive request
+                    message = self.socket.recv_string()
+                    request = json.loads(message)
+
+                    logger.debug(f"Node {self.node_rank}: Received request: {request}")
+
+                    # Process request
+                    response = self._handle_request(request)
+
+                    # Send response
+                    self.socket.send_string(json.dumps(response))
+
+                except zmq.Again:
+                    # Timeout - continue loop to check self.running
+                    continue
+                except Exception as e:
+                    logger.error(f"Node {self.node_rank}: Error in server loop: {e}")
+                    if self.running:  # Only send error response if still running
+                        try:
+                            error_response = {"success": False, "error": str(e)}
+                            self.socket.send_string(json.dumps(error_response))
+                        except Exception:
+                            pass  # Ignore errors when sending error response
+
+        except Exception as e:
+            logger.error(f"Node {self.node_rank}: Failed to start ZMQ server: {e}")
+        finally:
+            if self.socket:
+                self.socket.close()
+
+    def _handle_request(self, request: dict) -> dict:
+        """
+        Handle incoming request for transfer engine info.
+
+        Args:
+            request: Dictionary with 'action' and 'rank' fields
+
+        Returns:
+            Dictionary with response data
+        """
+        action = request.get("action")
+        rank = request.get("rank")
+
+        if action == "get_transfer_engine_info":
+            if rank is None:
+                return {"success": False, "error": "Missing rank parameter"}
+
+            if rank not in self.transfer_engine_info:
+                return {
+                    "success": False,
+                    "error": f"Rank {rank} not available on node {self.node_rank}",
+                }
+
+            # Return the transfer engine info for the requested rank
+            session_id, weights_info_dict = self.transfer_engine_info[rank]
+            return {
+                "success": True,
+                "rank": rank,
+                "remote_instance_transfer_engine_info": (session_id, weights_info_dict),
+            }
+
+        else:
+            return {"success": False, "error": f"Unknown action: {action}"}
+
+
+class TransferEngineInfoClient:
+    """
+    ZMQ client that runs on head node to request transfer engine info
+    from other nodes.
+    """
+
+    def __init__(self, timeout_ms: int = 5000):
+        self.timeout_ms = timeout_ms
+        self.context = zmq.Context()
+
+    def get_transfer_engine_info(
+        self, host: str, port: int, rank: int
+    ) -> Optional[Tuple]:
+        """
+        Request transfer engine info for a specific rank from a remote node.
+
+        Args:
+            host: Target node hostname/IP
+            port: Target node ZMQ server port
+            rank: TP rank to query
+
+        Returns:
+            (session_id, weights_info_dict) tuple or None if failed
+        """
+        socket = None
+        try:
+            socket = self.context.socket(zmq.REQ)
+            socket.RCVTIMEO = self.timeout_ms
+            socket.SNDTIMEO = self.timeout_ms
+
+            # Connect to remote node
+            remote_address = f"tcp://{host}:{port}"
+            socket.connect(remote_address)
+            logger.debug(f"Connected to {remote_address} for rank {rank}")
+
+            # Send request
+            request = {"action": "get_transfer_engine_info", "rank": rank}
+            socket.send_string(json.dumps(request))
+
+            # Receive response
+            response_str = socket.recv_string()
+            response = json.loads(response_str)
+
+            logger.debug(f"Received response from {remote_address}: {response}")
+
+            if response.get("success"):
+                return response.get("remote_instance_transfer_engine_info")
+            else:
+                logger.error(
+                    f"Request to {remote_address} failed: {response.get('error')}"
+                )
+                return None
+
+        except zmq.Again:
+            logger.error(f"Timeout requesting rank {rank} from {host}:{port}")
+            return None
+        except Exception as e:
+            logger.error(f"Error requesting rank {rank} from {host}:{port}: {e}")
+            return None
+        finally:
+            if socket:
+                socket.close()
+
+    def close(self):
+        """Close the ZMQ context."""
+        self.context.term()
+
+
+# Global instances for server and client
+_transfer_engine_info_server: Optional[TransferEngineInfoServer] = None
+_transfer_engine_info_client: Optional[TransferEngineInfoClient] = None
+
+
+def get_transfer_engine_info_client() -> Optional[TransferEngineInfoClient]:
+    """Get the global transfer engine info client instance."""
+    return _transfer_engine_info_client
+
+
+def init_transfer_engine_info_server(
+    port: int, node_rank: int
+) -> TransferEngineInfoServer:
+    """Initialize the global transfer engine info server."""
+    global _transfer_engine_info_server
+    if _transfer_engine_info_server is not None:
+        _transfer_engine_info_server.stop()
+
+    _transfer_engine_info_server = TransferEngineInfoServer(port, node_rank)
+    return _transfer_engine_info_server
+
+
+def init_transfer_engine_info_client() -> TransferEngineInfoClient:
+    """Initialize the global transfer engine info client."""
+    global _transfer_engine_info_client
+    if _transfer_engine_info_client is None:
+        _transfer_engine_info_client = TransferEngineInfoClient()
+    return _transfer_engine_info_client
+
+
+def cleanup_transfer_engine_info_comm():
+    """Cleanup global communication instances."""
+    global _transfer_engine_info_server, _transfer_engine_info_client
+
+    if _transfer_engine_info_server:
+        _transfer_engine_info_server.stop()
+        _transfer_engine_info_server = None
+
+    if _transfer_engine_info_client:
+        _transfer_engine_info_client.close()
+        _transfer_engine_info_client = None

--- a/python/sglang/srt/model_loader/node_registry.py
+++ b/python/sglang/srt/model_loader/node_registry.py
@@ -32,7 +32,7 @@ class NodeRegistry:
     """Registry for mapping tp_ranks to nodes in a distributed setup."""
 
     def __init__(self, server_args: ServerArgs):
-        # TODO: here we may need to assume that tp_size always equal to world_size?
+        # NOTE: Assuming that in sglang, tp_size * pp_size = world_size.
         self.server_args = server_args
         self.nodes: Dict[int, NodeInfo] = {}
         if hasattr(self.server_args, "node_hosts") and self.server_args.node_hosts:

--- a/python/sglang/srt/model_loader/node_registry.py
+++ b/python/sglang/srt/model_loader/node_registry.py
@@ -1,0 +1,95 @@
+"""
+Node Registry for Cross-Node Communication
+
+This module provides functionality to map tp_ranks to their hosting nodes
+and facilitate cross-node communication for remote instance transfer engine info.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NodeInfo:
+    """Information about a node in the distributed setup."""
+
+    node_rank: int
+    host: str
+    tp_rank_range: range
+
+    def __contains__(self, tp_rank: int) -> bool:
+        """Check if this node hosts the given tp_rank."""
+        return tp_rank in self.tp_rank_range
+
+
+class NodeRegistry:
+    """Registry for mapping tp_ranks to nodes in a distributed setup."""
+
+    def __init__(self, server_args: ServerArgs):
+        # TODO: here we may need to assume that tp_size always equal to world_size?
+        self.server_args = server_args
+        self.nodes: Dict[int, NodeInfo] = {}
+        if hasattr(self.server_args, "node_hosts") and self.server_args.node_hosts:
+            self.noderank2host = json.loads(self.server_args.node_hosts)
+        else:
+            self.noderank2host = None
+        self._populate_node_mapping()
+
+    def _populate_node_mapping(self):
+        """Build node registry using same logic as scheduler_launcher.py"""
+        # Same calculation logic as in scheduler_launcher.py:90-95
+        nnodes_per_tp_group = max(
+            self.server_args.nnodes // self.server_args.pp_size, 1
+        )
+        tp_size_per_node = self.server_args.tp_size // nnodes_per_tp_group
+
+        logger.info(
+            f"Building node registry: nnodes={self.server_args.nnodes}, "
+            f"tp_size={self.server_args.tp_size}, pp_size={self.server_args.pp_size}"
+        )
+        logger.info(
+            f"Calculated: nnodes_per_tp_group={nnodes_per_tp_group}, "
+            f"tp_size_per_node={tp_size_per_node}"
+        )
+
+        for node_rank in range(self.server_args.nnodes):
+            tp_start = tp_size_per_node * (node_rank % nnodes_per_tp_group)
+            tp_end = tp_size_per_node * (node_rank % nnodes_per_tp_group + 1)
+
+            host = self._get_node_host(node_rank)
+
+            node_info = NodeInfo(
+                node_rank=node_rank, host=host, tp_rank_range=range(tp_start, tp_end)
+            )
+
+            self.nodes[node_rank] = node_info
+            logger.info(
+                f"Node {node_rank}: host={host}, tp_ranks={list(node_info.tp_rank_range)}"
+            )
+
+    def _get_node_host(self, node_rank: int) -> str:
+        """
+        Determine host for a given node_rank.
+        """
+        return (
+            getattr(self.server_args, "host", "127.0.0.1")
+            if self.noderank2host is None
+            else self.noderank2host[str(node_rank)]
+        )
+
+    def get_node_for_rank(self, tp_rank: int) -> Optional[NodeInfo]:
+        """Get the node info for a given tp_rank."""
+        for node_info in self.nodes.values():
+            if tp_rank in node_info:
+                return node_info
+        return None
+
+    def validate_tp_rank(self, tp_rank: int) -> bool:
+        """Validate if the tp_rank is within the valid range."""
+        return 0 <= tp_rank < self.server_args.tp_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In current Rfork methods,  when users are trying to launch servers with multi-node settings, the api call `get_remote_instance_transfer_engine_info` of http_server will not work when the `gpu_rank > num_gpus_per_node`. This PR builds the zmq communication between different nodes for multi-node scenarios. Users could get `remote_instance_transfer_engine_info` from gpus of `node_rank > 1`.



## Modifications

<!-- Detail the changes made in this pull request. -->
1. New Module: `inter_node_transfer_engine_comm.py`.
- Implement `TransferEngineInfoServer` - a ZMQ REP server running on non-head nodes to serve transfer engine info for their local TP ranks
- Implement `TransferEngineInfoClient` - a ZMQ REQ client used by the head node to query transfer engine info from other nodes
- Provide global instance management and cleanup functions

2. New Module: `node_registry.py`
- `NodeRegistry` class that maps TP ranks to their hosting nodes
- Calculate which node hosts which TP ranks based on `nnodes`, `tp_size`, and `pp_size` (assume that in sglang, `tp_size * pp_size = world_size`).
- Support custom node host addresses via a new `--node-hosts` argument


3. Changes in `engine.py`.

- On non-head nodes (`node_rank >= 1`), this pr starts a ZMQ server to serve local transfer engine info when multi-node transfer engine is enabled

4. Changes in `http_server.py`
- `/get_remote_instance_transfer_engine_info` endpoint enhanced to query remote nodes via ZMQ when rank info isn't available locally
- Initialize `NodeRegistry` for multi-node setups
- Cleanup of ZMQ resources on shutdown

5. Changes in `server_args.py`

- New args: `--inter-node-transfer-engine-info-port` and `--node-hosts`
- Port availability checking for multi-node setups


## Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Tested on 2 nodes of h100-80g, with the model `/Moonlight-16B-A3B-Instruct`.
cmd:
```


# Node 0:
python3 -m sglang.launch_server --model-path /data/models/Moonlight-16B-A3B-Instruct --tp 16 --trust-remote-code  --mem-frac 0.85 --host 0.0.0.0 --port 30000 --dist-init-addr node-0-addr:5000 --nnodes 2 --node-rank 0 --remote-instance-weight-loader-start-seed-via-transfer-engine --node-hosts '{"0":"node-0-addr","1":"node-1-addr"}' --inter-node-transfer-engine-info-port 15036

# Node 1:
python3 -m sglang.launch_server --model-path /data/models/Moonlight-16B-A3B-Instruct --tp 16 --trust-remote-code  --mem-frac 0.85 --host 0.0.0.0 --port 30000 --dist-init-addr node-0-addr:5000 --nnodes 2 --node-rank 1 --remote-instance-weight-loader-start-seed-via-transfer-engine --node-hosts '{"0":"node-0-addr","1":"node-1-addr"}' --inter-node-transfer-engine-info-port 15036
```

Results:
- sending the following 3 requests to test:
```
curl "http://node-0-addr:30000/get_remote_instance_transfer_engine_info?rank=0"
curl "http://node-0-addr:30000/get_remote_instance_transfer_engine_info?rank=8"
curl "http://node-0-addr:30000/get_remote_instance_transfer_engine_info?rank=16"
```
- from the logs:

```
[2026-01-11 08:03:38] INFO:     xxxxx - "POST /generate HTTP/1.1" 200 OK
[2026-01-11 08:03:38] The server is fired up and ready to roll!

# call from rank 0 (node 0)
[2026-01-11 08:03:53] Serving rank 0 locally
[2026-01-11 08:03:53] INFO:     xxxxx  - "GET /get_remote_instance_transfer_engine_info?rank=0 HTTP/1.1" 200 OK

# call from rank 8 (node 1)
[2026-01-11 08:03:59] Using ZMQ to request rank 8 from node 1 at  node-1-addr:15036
[2026-01-11 08:03:59] Successfully retrieved rank 8 info via ZMQ
[2026-01-11 08:03:59] INFO:     xxxxx - "GET /get_remote_instance_transfer_engine_info?rank=8 HTTP/1.1" 200 OK

# call from rank 16 (invalid)
[2026-01-11 08:04:04] Invalid tp_rank 16, must be 0 <= rank < 16
[2026-01-11 08:04:04] INFO:     xxxxx - "GET /get_remote_instance_transfer_engine_info?rank=16 HTTP/1.1" 400 Bad Request
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
6. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
7. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
8. After green CI and required approvals, ask Merge Oncalls to merge.
