### PR TITLE
fix(deepseek_v2): Add power-of-two check for MLA concat kernel

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2542,7 +2542,11 @@ class DeepseekV2AttentionMLA(nn.Module):
         ):
             k = k_nope.new_empty(*k_shape)
             concat_mla_k(k=k, k_nope=k_nope, k_rope=k_pe)
-        elif _is_cuda:
+        elif _is_cuda and all(
+            # (i.bit_count() == 1) == (is_power_of_two(i))
+            i.bit_count() == 1
+            for i in (k_shape[1], k_nope.shape[-1], k_pe.shape[-1])
+        ):
             # fa3 mha support fp8 inputs
             if (
                 self.current_attention_backend == "fa3"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The `concat_and_cast_mha_k_triton` kernel in `DeepseekV2AttentionMLA._concat_and_cast_mha_k` requires tensor dimensions to be powers of 2. When dimensions are not powers of 2, the kernel may crash or produce incorrect results.

This fix adds a validation check before using the Triton kernel, falling back to the safe Python implementation when dimensions don't meet the requirement.

Related issue: [THUDM/slime#1316](https://github.com/THUDM/slime/issues/1316) (patch migration tracking)

## Modifications

Modified `python/sglang/srt/models/deepseek_v2.py`:

- Added power-of-two validation in `_concat_and_cast_mha_k` method before calling `concat_and_cast_mha_k_triton`
- Uses `int.bit_count() == 1` to efficiently check if dimensions are powers of 2
- Validates: `num_local_heads`, `k_nope` head dim, and `k_pe` head dim

```python
elif _is_cuda and all(
    # (i.bit_count() == 1) == (is_power_of_two(i))
    i.bit_count() == 1
    for i in (k_shape[1], k_nope.shape[-1], k_pe.shape[-1])
):
```

## Accuracy Tests

Tested with DeepSeek-V2-Lite-Chat model:

- Launched server: python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-V2-Lite-Chat --trust-remote-code
- Ran evaluation: python3 -m sglang.test.few_shot_gsm8k --num-questions 50
- Result: Model runs correctly with the patch applied

## Benchmarking and Profiling

Performance impact: Negligible (<0.001%)

This change adds a validation check that runs on CPU only:

- .shape accesses tensor metadata (CPU-side, no GPU sync)
- int.bit_count() is a pure Python CPU operation
- Only 3 integer comparisons per attention forward pass (~nanoseconds)
- Compared to kernel execution time (microseconds to milliseconds), overhead is negligible
No benchmark regression expected - this is a correctness fix to prevent crashes on non-power-of-2 dimensions.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

