### PR TITLE
[model-gateway] Improve Health Check Logging

### DIFF
--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -838,7 +838,7 @@ impl Worker for BasicWorker {
         let url = self.normalised_url()?;
         let health_url = format!("{}{}", url, self.metadata.health_config.endpoint);
 
-        let mut req = WORKER_CLIENT.get(health_url).timeout(timeout);
+        let mut req = WORKER_CLIENT.get(&health_url).timeout(timeout);
         if let Some(api_key) = &self.metadata.api_key {
             req = req.bearer_auth(api_key);
         }
@@ -851,17 +851,14 @@ impl Worker for BasicWorker {
                 } else {
                     tracing::warn!(
                         "HTTP health check returned non-success status for {}: {}",
-                        self.metadata.url,
+                        health_url,
                         status
                     );
                     Ok(false)
                 }
             }
             Err(err) => {
-                tracing::warn!(
-                    "HTTP health check failed for {}: {err:?}",
-                    self.metadata.url
-                );
+                tracing::warn!("HTTP health check failed for {}: {err:?}", health_url);
                 Ok(false)
             }
         }

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -844,7 +844,19 @@ impl Worker for BasicWorker {
         }
 
         match req.send().await {
-            Ok(resp) => Ok(resp.status().is_success()),
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    Ok(true)
+                } else {
+                    tracing::warn!(
+                        "HTTP health check returned non-success status for {}: {}",
+                        self.metadata.url,
+                        status
+                    );
+                    Ok(false)
+                }
+            }
             Err(err) => {
                 tracing::warn!(
                     "HTTP health check failed for {}: {err:?}",


### PR DESCRIPTION
## Motivation
The current worker health check will only log transport level errors, but won't warn on 400/500 status code.

Example

```
python3 -m sglang_router.launch_router \
	--host 0.0.0.0 \
	--port 30000 \
	--backend openai \
	--api-key XXXXXXX \
	--worker-urls https://api.openai.com \
	--log-level debug \
	--prometheus-port 31010
```

With the above configuration:

- The router defaults to health check endpoint /health
- OpenAI API returns 404 Not Found for https://api.openai.com/health
- No warning logs are generated, making it difficult to diagnose why the worker failed

Checking the /workers endpoint shows:


```
{
  "workers": [{
    "url": "https://api.openai.com",
    "is_healthy": false,
    ...
  }]
}
```
But there are no logs explaining why is_healthy became false.

## Modifications
- Extract and check the HTTP status code from successful responses
- Log a warning when status code indicates failure (4xx, 5xx)

## Accuracy Tests
<img width="1860" height="58" alt="Screenshot 2026-01-12 at 2 10 27 PM" src="https://github.com/user-attachments/assets/9daedac5-f5ec-47d8-8ecb-12c0aa91c63c" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
