### PR TITLE
[Diffusion]: Add FA2 attention backend for Rocm

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/base.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/base.py
@@ -28,6 +28,7 @@ class DiTArchConfig(ArchConfig):
             AttentionBackendEnum.SLIDING_TILE_ATTN,
             AttentionBackendEnum.SAGE_ATTN,
             AttentionBackendEnum.FA,
+            AttentionBackendEnum.FA2,
             AttentionBackendEnum.AITER,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,

--- a/python/sglang/multimodal_gen/configs/models/encoders/base.py
+++ b/python/sglang/multimodal_gen/configs/models/encoders/base.py
@@ -18,6 +18,7 @@ class EncoderArchConfig(ArchConfig):
     _supported_attention_backends: set[AttentionBackendEnum] = field(
         default_factory=lambda: {
             AttentionBackendEnum.FA,
+            AttentionBackendEnum.FA2,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.SAGE_ATTN_3,
         }

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn_2.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn_2.py
@@ -10,9 +10,18 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
     AttentionMetadata,
     AttentionMetadataBuilder,
 )
-from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
-    flash_attn_func,
-)
+
+try:
+    from flash_attn import flash_attn_func  # Use the flash attention v2 function
+except ImportError:
+
+    def _unsupported(*args, **kwargs):
+        raise ImportError(
+            "flash-attn is not installed. Please install it, e.g., `pip install flash-attn`."
+        )
+
+    flash_attn_func = _unsupported
+
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -40,7 +49,7 @@ class FlashAttention2Backend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls() -> type["AttentionMetadataBuilder"]:
-        raise NotImplementedError
+        return None
 
 
 class FlashAttention2Impl(AttentionImpl):
@@ -69,10 +78,6 @@ class FlashAttention2Impl(AttentionImpl):
             q=query,  # type: ignore[no-untyped-call]
             k=key,
             v=value,
-            cu_seqlens_q=None,
-            cu_seqlens_k=None,
-            max_seqlen_q=None,
-            max_seqlen_k=None,
             softmax_scale=self.softmax_scale,
             causal=self.causal,
         )

--- a/python/sglang/multimodal_gen/runtime/models/dits/causal_wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/causal_wanvideo.py
@@ -89,6 +89,7 @@ class CausalWanSelfAttention(nn.Module):
             causal=False,
             supported_attention_backends=(
                 AttentionBackendEnum.FA,
+                AttentionBackendEnum.FA2,
                 AttentionBackendEnum.AITER,
                 AttentionBackendEnum.TORCH_SDPA,
             ),

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -896,6 +896,7 @@ class IndividualTokenRefinerBlock(nn.Module):
             # TODO: remove hardcode; remove STA
             supported_attention_backends=(
                 AttentionBackendEnum.FA,
+                AttentionBackendEnum.FA2,
                 AttentionBackendEnum.AITER,
                 AttentionBackendEnum.TORCH_SDPA,
             ),

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -522,6 +522,7 @@ class QwenImageCrossAttention(nn.Module):
             causal=False,
             supported_attention_backends={
                 AttentionBackendEnum.FA,
+                AttentionBackendEnum.FA2,
                 AttentionBackendEnum.AITER,
                 AttentionBackendEnum.TORCH_SDPA,
                 AttentionBackendEnum.SAGE_ATTN,

--- a/python/sglang/multimodal_gen/runtime/models/encoders/mistral_3.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/mistral_3.py
@@ -99,6 +99,7 @@ class MistralAttention(nn.Module):
             causal=False,
             supported_attention_backends={
                 AttentionBackendEnum.FA,
+                AttentionBackendEnum.FA2,
                 AttentionBackendEnum.TORCH_SDPA,
             },
         )

--- a/python/sglang/multimodal_gen/runtime/models/encoders/qwen2_5vl.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/qwen2_5vl.py
@@ -136,6 +136,7 @@ class Qwen2_5_VLAttention(nn.Module):
             causal=True,
             supported_attention_backends=(
                 AttentionBackendEnum.FA,
+                AttentionBackendEnum.FA2,
                 AttentionBackendEnum.TORCH_SDPA,
             ),
         )

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -96,7 +96,7 @@ class RocmPlatform(Platform):
             logger.info("Using Torch SDPA backend.")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
 
-        elif selected_backend in (AttentionBackendEnum.FA, None):
+        elif selected_backend in (AttentionBackendEnum.FA2, None):
             pass
 
         elif selected_backend == AttentionBackendEnum.AITER:
@@ -121,7 +121,7 @@ class RocmPlatform(Platform):
                 f"Invalid attention backend for {cls.device_name}: {selected_backend}"
             )
 
-        target_backend = AttentionBackendEnum.FA
+        target_backend = AttentionBackendEnum.FA2
         if dtype not in (torch.float16, torch.bfloat16):
             logger.info(
                 "Cannot use FlashAttention backend for dtype other than "
@@ -129,15 +129,15 @@ class RocmPlatform(Platform):
             )
             target_backend = AttentionBackendEnum.TORCH_SDPA
 
-        if target_backend == AttentionBackendEnum.FA:
+        if target_backend == AttentionBackendEnum.FA2:
             try:
                 import flash_attn  # noqa: F401
 
-                from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (  # noqa: F401
-                    FlashAttentionBackend,
+                from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
+                    FlashAttention2Backend,
                 )
 
-                supported_sizes = FlashAttentionBackend.get_supported_head_sizes()
+                supported_sizes = FlashAttention2Backend.get_supported_head_sizes()
                 if head_size not in supported_sizes:
                     logger.info(
                         "Cannot use FlashAttention-2 backend for head size %d.",
@@ -160,7 +160,7 @@ class RocmPlatform(Platform):
 
         logger.info("Using Flash Attention backend.")
 
-        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
+        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add Flash Attention 2 backend for Rocm platform(FA2 is slightly slower than AITER in MI30X/MI35X, but is useful for RDNA which AITER is not fully supported)

## Modifications

1. Add Flash Attention 2 backend.
2. Change Rocm FA version default to FA2.

## Accuracy Tests

```
sglang generate --model-path Wan-AI/Wan1.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output  --attention-backend aiter
sglang generate --model-path Wan-AI/Wan1.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output  --attention-backend fa2
```
AITER and FA2 backend output same quality video.
validated in MI30X/MI35X/R9700/W7900

## Benchmarking and Profiling

1. sglang generate --model-path Wan-AI/Wan1.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output  --attention-backend aiter
```
[aiter] import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO:aiter:import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO 01-12 08:29:25 [__init__.py:241] Automatically detected platform rocm.
[01-12 08:29:26] Automatically enable dit_layerwise_offload for Wan for best performance
[01-12 08:29:26] dit_layerwise_offload is enabled, automatically disabling dit_cpu_offload.
[01-12 08:29:26] Attention backend not specified. Using 'aiter' by default on ROCm to match SGLang SRT defaults.
[01-12 08:29:26] server_args: {"model_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers", "backend": "auto", "attention_backend": "aiter", "diffusers_attention_backend": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": null, "lora_path": null, "lora_nickname": "default", "vae_path": null, "lora_target_modules": null, "dit_cpu_offload": false, "dit_layerwise_offload": true, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": true, "use_fsdp_inference": false, "pin_cpu_memory": true, "mask_strategy_file_path": null, "STA_mode": "STA_inference", "skip_time_steps": 15, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "disable_autocast": false, "VSA_sparsity": 0.0, "moba_config_path": null, "moba_config": {}, "master_port": 30034, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5653, "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true}, "boundary_ratio": null, "log_level": "info"}
[01-12 08:29:26] Local mode: True
[01-12 08:29:26] Starting server...
[aiter] import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO:aiter:import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO 01-12 08:29:33 [__init__.py:241] Automatically detected platform rocm.
[01-12 08:29:34] Scheduler bind at endpoint: tcp://127.0.0.1:5653
[01-12 08:29:34] Initializing distributed environment with world_size=1, device=cuda:0
[01-12 08:29:39] Downloaded model_index.json for Wan-AI/Wan2.1-T2V-1.3B-Diffusers, pipeline: WanPipeline
[01-12 08:29:39] Using native sglang backend for model 'Wan-AI/Wan2.1-T2V-1.3B-Diffusers'
[01-12 08:29:39] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[01-12 08:29:39] Loading pipeline modules...
[01-12 08:29:39] Checking for cached model in HF Hub cache for Wan-AI/Wan2.1-T2V-1.3B-Diffusers...
[01-12 08:29:39] Found complete model in cache at /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b
[01-12 08:29:39] Model path: /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b
[01-12 08:29:39] Diffusers version: 0.33.0.dev0
[01-12 08:29:39] Loading pipeline modules from config: {'_class_name': 'WanPipeline', '_diffusers_version': '0.33.0.dev0', 'scheduler': ['diffusers', 'UniPCMultistepScheduler'], 'text_encoder': ['transformers', 'UMT5EncoderModel'], 'tokenizer': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'WanTransformer3DModel'], 'vae': ['diffusers', 'AutoencoderKLWan']}
[01-12 08:29:39] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                           | 0/5 [00:00<?, ?it/s][01-12 08:29:39] Loading text_encoder from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/text_encoder. avail mem: 184.91 GB
[01-12 08:29:39] HF model config: {'architectures': ['UMT5EncoderModel'], 'classifier_dropout': 0.0, 'd_ff': 10240, 'd_kv': 64, 'd_model': 4096, 'decoder_start_token_id': 0, 'dense_act_fn': 'gelu_new', 'dropout_rate': 0.1, 'eos_token_id': 1, 'feed_forward_proj': 'gated-gelu', 'initializer_factor': 1.0, 'is_encoder_decoder': True, 'is_gated_act': True, 'layer_norm_epsilon': 1e-06, 'num_decoder_layers': 24, 'num_heads': 64, 'num_layers': 24, 'output_past': True, 'pad_token_id': 0, 'relative_attention_max_distance': 128, 'relative_attention_num_buckets': 32, 'scalable_attention': True, 'tie_word_embeddings': False, 'use_cache': True, 'vocab_size': 256384}

Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  20% Completed | 1/5 [00:01<00:05,  1.42s/it]
Loading safetensors checkpoint shards:  40% Completed | 2/5 [00:04<00:06,  2.11s/it]
Loading safetensors checkpoint shards:  60% Completed | 3/5 [00:06<00:04,  2.43s/it]
Loading safetensors checkpoint shards:  80% Completed | 4/5 [00:09<00:02,  2.49s/it]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:12<00:00,  2.41s/it]

[01-12 08:30:34] Loaded text_encoder: FSDPUMT5EncoderModel (sgl-diffusion version). model size: 21.16 GB, avail mem: 183.84 GB
Loading required modules:  20%|███████████████████████                                                                                            | 1/5 [00:54<03:38, 54.69s/it][01-12 08:30:34] Loading tokenizer from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/tokenizer. avail mem: 183.84 GB
[01-12 08:30:34] Loaded tokenizer: T5TokenizerFast (sgl-diffusion version). model size: 0.00 GB, avail mem: 183.84 GB
Loading required modules:  40%|██████████████████████████████████████████████                                                                     | 2/5 [00:55<01:08, 22.73s/it][01-12 08:30:34] Loading vae from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/vae. avail mem: 183.84 GB
[01-12 08:30:34] HF model config: {'attn_scales': [], 'base_dim': 96, 'dim_mult': [1, 2, 4, 4], 'dropout': 0.0, 'latents_mean': [-0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921], 'latents_std': [2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743, 3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.916], 'num_res_blocks': 2, 'temperal_downsample': [False, True, True], 'z_dim': 16}
[01-12 08:30:34] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, avail mem: 183.84 GB
Loading required modules:  60%|█████████████████████████████████████████████████████████████████████                                              | 3/5 [00:55<00:24, 12.44s/it][01-12 08:30:34] Loading transformer from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/transformer. avail mem: 183.84 GB
[01-12 08:30:34] Loading WanTransformer3DModel from 2 safetensors files, default_dtype: torch.bfloat16
[01-12 08:30:34] Using AITer backend on ROCm.

Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00, 15.67it/s]

[01-12 08:30:38] Loaded model with 1.42B parameters
[01-12 08:30:38] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, avail mem: 181.00 GB
Loading required modules:  80%|████████████████████████████████████████████████████████████████████████████████████████████                       | 4/5 [00:58<00:08,  8.87s/it][01-12 08:30:38] Loading scheduler from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/scheduler. avail mem: 181.00 GB
[01-12 08:30:38] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: 0.00 GB, avail mem: 181.00 GB
Loading required modules: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:58<00:00, 11.73s/it]
[01-12 08:30:38] Creating pipeline stages...
[01-12 08:30:38] Using AITer backend on ROCm.
[01-12 08:30:38] Pipeline instantiated
[01-12 08:30:47] LayerwiseOffloadManager initialized
[01-12 08:30:47] Enabled layerwise offload for WanTransformer3DModel on modules: ['blocks']
[01-12 08:30:47] Worker 0: Initialized device, model, and distributed environment.
[01-12 08:30:47] Worker 0: Scheduler loop started.
[01-12 08:30:47] Processing prompt 1/1: A curious raccoon
[01-12 08:30:47] Sampling params:
                       width: 832
                      height: 480
                  num_frames: 81
                      prompt: A curious raccoon
                  neg_prompt: Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards
                        seed: 1024
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 3.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: 3.0
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260112-083047_7f67e54b.mp4

[01-12 08:30:47] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[01-12 08:30:47] [InputValidationStage] started...
[01-12 08:30:47] [InputValidationStage] finished in 0.0001 seconds
[01-12 08:30:47] [TextEncodingStage] started...
[01-12 08:30:56] [TextEncodingStage] finished in 8.8551 seconds
[01-12 08:30:56] [ConditioningStage] started...
[01-12 08:30:56] [ConditioningStage] finished in 0.0000 seconds
[01-12 08:30:56] [TimestepPreparationStage] started...
[01-12 08:30:56] [TimestepPreparationStage] finished in 0.0003 seconds
[01-12 08:30:56] [LatentPreparationStage] started...
[01-12 08:30:56] [LatentPreparationStage] finished in 0.0057 seconds
[01-12 08:30:56] [DenoisingStage] started...
  0%|                                                                                                                                                    | 0/50 [00:00<?, ?it/s]MIOpen(HIP): Error [Init] Not found :30-DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle_V3<256, 128, 128, 64, Default, 32, 32, 2, 2, 8, 8, 8, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v3>
/home/roywan/sglang/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py:452: UserWarning: FlashInfer not available, using Triton fallback for RoPE
  query, key = apply_flashinfer_rope_qk_inplace(
[aiter] import [module_fmha_v3_fwd] under /sgl-workspace/aiter/aiter/jit/module_fmha_v3_fwd.so
[01-12 08:31:01] import [module_fmha_v3_fwd] under /sgl-workspace/aiter/aiter/jit/module_fmha_v3_fwd.so
[aiter] type hints mismatch, override to --> fmha_v3_fwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, dropout_p: float, softmax_scale: float, is_causal: bool, window_size_left: int, window_size_right: int, return_softmax_lse: bool, return_dropout_randval: bool, how_v3_bf16_cvt: int, out: Optional[torch.Tensor] = None, bias: Optional[torch.Tensor] = None, alibi_slopes: Optional[torch.Tensor] = None, gen: Optional[torch.Generator] = None) -> List[torch.Tensor]
[01-12 08:31:01] type hints mismatch, override to --> fmha_v3_fwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, dropout_p: float, softmax_scale: float, is_causal: bool, window_size_left: int, window_size_right: int, return_softmax_lse: bool, return_dropout_randval: bool, how_v3_bf16_cvt: int, out: Optional[torch.Tensor] = None, bias: Optional[torch.Tensor] = None, alibi_slopes: Optional[torch.Tensor] = None, gen: Optional[torch.Generator] = None) -> List[torch.Tensor]
/home/roywan/sglang/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py:452: UserWarning: FlashInfer not available, using Triton fallback for RoPE
  query, key = apply_flashinfer_rope_qk_inplace(
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:30<00:00,  1.81s/it]
[01-12 08:32:27] [DenoisingStage] average time per step: 1.8093 seconds
[01-12 08:32:27] [DenoisingStage] finished in 90.4650 seconds
[01-12 08:32:27] [DecodingStage] started...
[01-12 08:34:28] [DecodingStage] finished in 121.3443 seconds
[01-12 08:34:28] Peak GPU memory: 11.81 GB, Remaining GPU memory at peak: 180.18 GB. Components that can stay resident: ['text_encoder', 'vae', 'transformer']
[01-12 08:34:33] Output saved to outputs/A_curious_raccoon_20260112-083047_7f67e54b.mp4
[01-12 08:34:33] Pixel data generated successfully in 225.60 seconds
[01-12 08:34:33] Completed batch processing. Generated 1 outputs in 225.60 seconds
[01-12 08:34:33] Memory usage - Max peak: 12090.10 MB, Avg peak: 12090.10 MB
[01-12 08:34:33] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
```

2. sglang generate --model-path Wan-AI/Wan1.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output  --attention-backend fa2
```
[aiter] import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO:aiter:import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO 01-12 09:50:09 [__init__.py:241] Automatically detected platform rocm.
[01-12 09:50:10] Automatically enable dit_layerwise_offload for Wan for best performance
[01-12 09:50:10] dit_layerwise_offload is enabled, automatically disabling dit_cpu_offload.
[01-12 09:50:10] server_args: {"model_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers", "backend": "auto", "attention_backend": "fa2", "diffusers_attention_backend": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": null, "lora_path": null, "lora_nickname": "default", "vae_path": null, "lora_target_modules": null, "dit_cpu_offload": false, "dit_layerwise_offload": true, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": true, "use_fsdp_inference": false, "pin_cpu_memory": true, "mask_strategy_file_path": null, "STA_mode": "STA_inference", "skip_time_steps": 15, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "disable_autocast": false, "VSA_sparsity": 0.0, "moba_config_path": null, "moba_config": {}, "master_port": 30096, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5569, "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true}, "boundary_ratio": null, "log_level": "info"}
[01-12 09:50:10] Local mode: True
[01-12 09:50:10] Starting server...
[aiter] import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO:aiter:import [module_aiter_enum] under /sgl-workspace/aiter/aiter/jit/module_aiter_enum.so
INFO 01-12 09:50:17 [__init__.py:241] Automatically detected platform rocm.
[01-12 09:50:18] Scheduler bind at endpoint: tcp://127.0.0.1:5569
[01-12 09:50:18] Initializing distributed environment with world_size=1, device=cuda:0
[01-12 09:50:23] Downloaded model_index.json for Wan-AI/Wan2.1-T2V-1.3B-Diffusers, pipeline: WanPipeline
[01-12 09:50:23] Using native sglang backend for model 'Wan-AI/Wan2.1-T2V-1.3B-Diffusers'
[01-12 09:50:23] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[01-12 09:50:23] Loading pipeline modules...
[01-12 09:50:23] Checking for cached model in HF Hub cache for Wan-AI/Wan2.1-T2V-1.3B-Diffusers...
[01-12 09:50:23] Found complete model in cache at /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b
[01-12 09:50:23] Model path: /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b
[01-12 09:50:23] Diffusers version: 0.33.0.dev0
[01-12 09:50:23] Loading pipeline modules from config: {'_class_name': 'WanPipeline', '_diffusers_version': '0.33.0.dev0', 'scheduler': ['diffusers', 'UniPCMultistepScheduler'], 'text_encoder': ['transformers', 'UMT5EncoderModel'], 'tokenizer': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'WanTransformer3DModel'], 'vae': ['diffusers', 'AutoencoderKLWan']}
[01-12 09:50:23] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                                                                                                          | 0/5 [00:00<?, ?it/s][01-12 09:50:23] Loading text_encoder from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/text_encoder. avail mem: 184.91 GB
[01-12 09:50:23] HF model config: {'architectures': ['UMT5EncoderModel'], 'classifier_dropout': 0.0, 'd_ff': 10240, 'd_kv': 64, 'd_model': 4096, 'decoder_start_token_id': 0, 'dense_act_fn': 'gelu_new', 'dropout_rate': 0.1, 'eos_token_id': 1, 'feed_forward_proj': 'gated-gelu', 'initializer_factor': 1.0, 'is_encoder_decoder': True, 'is_gated_act': True, 'layer_norm_epsilon': 1e-06, 'num_decoder_layers': 24, 'num_heads': 64, 'num_layers': 24, 'output_past': True, 'pad_token_id': 0, 'relative_attention_max_distance': 128, 'relative_attention_num_buckets': 32, 'scalable_attention': True, 'tie_word_embeddings': False, 'use_cache': True, 'vocab_size': 256384}

Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  20% Completed | 1/5 [00:01<00:04,  1.24s/it]
Loading safetensors checkpoint shards:  40% Completed | 2/5 [00:03<00:05,  1.74s/it]
Loading safetensors checkpoint shards:  60% Completed | 3/5 [00:05<00:03,  2.00s/it]
Loading safetensors checkpoint shards:  80% Completed | 4/5 [00:07<00:02,  2.14s/it]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:10<00:00,  2.04s/it]

[01-12 09:50:56] Loaded text_encoder: FSDPUMT5EncoderModel (sgl-diffusion version). model size: 21.16 GB, avail mem: 183.84 GB
Loading required modules:  20%|██████████████████████████████████████▊                                                                                                                                                           | 1/5 [00:33<02:13, 33.40s/it][01-12 09:50:56] Loading tokenizer from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/tokenizer. avail mem: 183.84 GB
[01-12 09:50:56] Loaded tokenizer: T5TokenizerFast (sgl-diffusion version). model size: 0.00 GB, avail mem: 183.84 GB
Loading required modules:  40%|█████████████████████████████████████████████████████████████████████████████▌                                                                                                                    | 2/5 [00:33<00:41, 13.96s/it][01-12 09:50:56] Loading vae from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/vae. avail mem: 183.84 GB
[01-12 09:50:56] HF model config: {'attn_scales': [], 'base_dim': 96, 'dim_mult': [1, 2, 4, 4], 'dropout': 0.0, 'latents_mean': [-0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921], 'latents_std': [2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743, 3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.916], 'num_res_blocks': 2, 'temperal_downsample': [False, True, True], 'z_dim': 16}
[01-12 09:50:56] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, avail mem: 183.84 GB
[01-12 09:50:56] Loading transformer from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/transformer. avail mem: 183.84 GB
[01-12 09:50:56] Loading WanTransformer3DModel from 2 safetensors files, default_dtype: torch.bfloat16
[01-12 09:50:56] Using Flash Attention backend.

Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00, 107.10it/s]

[01-12 09:50:57] Loaded model with 1.42B parameters
[01-12 09:50:57] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, avail mem: 181.00 GB
Loading required modules:  80%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏                                      | 4/5 [00:34<00:05,  5.49s/it][01-12 09:50:57] Loading scheduler from /home/roywan/model/models--Wan-AI--Wan2.1-T2V-1.3B-Diffusers/snapshots/0fad780a534b6463e45facd96134c9f345acfa5b/scheduler. avail mem: 181.00 GB
[01-12 09:50:57] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: 0.00 GB, avail mem: 181.00 GB
Loading required modules: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:34<00:00,  6.93s/it]
[01-12 09:50:57] Creating pipeline stages...
[01-12 09:50:57] Using Flash Attention backend.
[01-12 09:50:57] Pipeline instantiated
[01-12 09:50:58] LayerwiseOffloadManager initialized
[01-12 09:50:58] Enabled layerwise offload for WanTransformer3DModel on modules: ['blocks']
[01-12 09:50:58] Worker 0: Initialized device, model, and distributed environment.
[01-12 09:50:58] Worker 0: Scheduler loop started.
[01-12 09:50:58] Processing prompt 1/1: A curious raccoon
[01-12 09:50:58] Sampling params:
                       width: 832
                      height: 480
                  num_frames: 81
                      prompt: A curious raccoon
                  neg_prompt: Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards
                        seed: 1024
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 3.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: 3.0
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260112-095058_e7ab2fa7.mp4
        
[01-12 09:50:58] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[01-12 09:50:58] [InputValidationStage] started...
[01-12 09:50:58] [InputValidationStage] finished in 0.0001 seconds
[01-12 09:50:58] [TextEncodingStage] started...
[01-12 09:51:06] [TextEncodingStage] finished in 7.8036 seconds
[01-12 09:51:06] [ConditioningStage] started...
[01-12 09:51:06] [ConditioningStage] finished in 0.0000 seconds
[01-12 09:51:06] [TimestepPreparationStage] started...
[01-12 09:51:06] [TimestepPreparationStage] finished in 0.0003 seconds
[01-12 09:51:06] [LatentPreparationStage] started...
[01-12 09:51:06] [LatentPreparationStage] finished in 0.0043 seconds
[01-12 09:51:06] [DenoisingStage] started...
  0%|                                                                                                                                                                                                                                   | 0/50 [00:00<?, ?it/s]/home/roywan/sglang/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py:452: UserWarning: FlashInfer not available, using Triton fallback for RoPE
  query, key = apply_flashinfer_rope_qk_inplace(
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:48<00:00,  2.16s/it]
[01-12 09:52:54] [DenoisingStage] average time per step: 2.1630 seconds
[01-12 09:52:54] [DenoisingStage] finished in 108.1513 seconds
[01-12 09:52:54] [DecodingStage] started...
[01-12 09:53:01] [DecodingStage] finished in 6.1742 seconds
[01-12 09:53:01] Peak GPU memory: 9.31 GB, Remaining GPU memory at peak: 182.67 GB. Components that can stay resident: ['text_encoder', 'vae', 'transformer']
[01-12 09:53:06] Output saved to outputs/A_curious_raccoon_20260112-095058_e7ab2fa7.mp4
[01-12 09:53:06] Pixel data generated successfully in 127.19 seconds
[01-12 09:53:06] Completed batch processing. Generated 1 outputs in 127.20 seconds
[01-12 09:53:06] Memory usage - Max peak: 9536.94 MB, Avg peak: 9536.94 MB
[01-12 09:53:06] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
```



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
6. After green CI and required approvals, ask Merge Oncalls to merge.
