### PR TITLE
[MUSA][1/N] sglang.check_env

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -66,7 +66,6 @@ runtime_common = [
   "grpcio==1.75.1", # keep it align with compile_proto.py
   "grpcio-tools==1.75.1", # keep it align with compile_proto.py
   "grpcio-reflection==1.75.1", # required by srt/entrypoints/grpc_server.py
-  "bidict",
 ]
 
 tracing = [

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -185,6 +185,15 @@ def is_cpu() -> bool:
     return os.getenv("SGLANG_USE_CPU_ENGINE", "0") == "1" and is_host_cpu_supported
 
 
+@lru_cache(maxsize=1)
+def is_musa() -> bool:
+    try:
+        import torchada  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch.version, "musa") and torch.version.musa is not None
+
+
 def is_float4_e2m1fn_x2(dtype) -> bool:
     """Check if dtype is float4_e2m1fn_x2 and CUDA is available."""
     target_dtype = getattr(torch, "float4_e2m1fn_x2", None)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is the first in a series of pull requests (tracked in https://github.com/sgl-project/sglang/issues/16565) to add full support for [Moore Threads](https://en.mthreads.com/) GPUs, leveraging MUSA (Meta-computing Unified System Architecture) to accelerate LLM inference.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. Added `is_musa` to check the basic runtime environment
2. Updated `check_env.py` to fetch the device info, driver version, topology, etc.
3. `bidict` is added in both `pyproject_other.toml` and `pyproject.toml` for futher handling `cuda_wrapper.py` and `pynccl_wrapper.py`

### Testing Done

*Tested in a clean torch_musa container.*

```bash
root@worker3218:/ws# rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
root@worker3218:/ws# pip install -e "python[all_musa]"
root@worker3218:/ws# python3 -m sglang.check_env
Python: 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
MUSA available: True
GPU 0,1,2,3,4,5,6,7: MTT S5000
GPU 0,1,2,3,4,5,6,7 Compute Capability: 3.1
MUSA_HOME: /usr/local/musa
MCC: mcc version 4.3.4
MUSA Driver Version: 3.3.3-server
PyTorch: 2.7.1
sglang: 0.1.dev8833+g2dadf6356.d20260112
sgl_kernel: Module Not Found
flashinfer_python: Module Not Found
flashinfer_cubin: Module Not Found
flashinfer_jit_cache: Module Not Found
triton: 3.1.0
transformers: 4.57.1
torchao: 0.9.0
numpy: 1.26.4
aiohttp: 3.13.3
fastapi: 0.123.5
hf_transfer: 0.1.9
huggingface_hub: 0.36.0
interegular: 0.3.3
modelscope: 1.33.0
orjson: 3.11.5
outlines: 0.1.11
packaging: 25.0
psutil: 7.2.1
pydantic: 2.12.5
python-multipart: 0.0.21
pyzmq: 27.1.0
uvicorn: 0.38.0
uvloop: 0.22.1
vllm: Module Not Found
xgrammar: 0.1.27
openai: 2.6.1
tiktoken: 0.12.0
anthropic: 0.75.0
litellm: Module Not Found
decord2: 3.0.0
MTHREADS Topology: 
         GPU0     GPU1     GPU2     GPU3     GPU4     GPU5     GPU6     GPU7     NIC0     NIC1     NIC2     NIC3     NIC4     NIC5     NIC6     NIC7     NIC8     NIC9     NIC10    CPU Affinity   NUMA Affinity  
GPU0     X        MT2      MT2      MT2      MT2      MT2      MT2      MT2      MPB      MPB      NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU1     MT2      X        MT2      MT2      MT2      MT2      MT2      MT2      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU2     MT2      MT2      X        MT2      MT2      MT2      MT2      MT2      NODE     NODE     MPB      MPB      SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU3     MT2      MT2      MT2      X        MT2      MT2      MT2      MT2      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU4     MT2      MT2      MT2      MT2      X        MT2      MT2      MT2      SYS      SYS      SYS      SYS      NODE     NODE     MPB      MPB      NODE     NODE     SYS      32-63,96-127   1              
GPU5     MT2      MT2      MT2      MT2      MT2      X        MT2      MT2      SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     NODE     NODE     SYS      32-63,96-127   1              
GPU6     MT2      MT2      MT2      MT2      MT2      MT2      X        MT2      SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     MPB      MPB      SYS      32-63,96-127   1              
GPU7     MT2      MT2      MT2      MT2      MT2      MT2      MT2      X        SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     NODE     NODE     SYS      32-63,96-127   1              
NIC0     MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      X        SPB      NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC1     MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      SPB      X        NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC2     NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     X        SPB      SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC3     NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     SPB      X        SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC4     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      X        SPB      NODE     NODE     NODE     NODE     SYS      
NIC5     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SPB      X        NODE     NODE     NODE     NODE     SYS      
NIC6     SYS      SYS      SYS      SYS      MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      NODE     NODE     X        SPB      NODE     NODE     SYS      
NIC7     SYS      SYS      SYS      SYS      MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      NODE     NODE     SPB      X        NODE     NODE     SYS      
NIC8     SYS      SYS      SYS      SYS      NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     X        SPB      SYS      
NIC9     SYS      SYS      SYS      SYS      NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SPB      X        SYS      
NIC10    NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      X        

Legend:
    X = Self
  SYS = Topology path that contains PCIe switches/bridges as well as multiple host bridges across NUMA nodes.
 NODE = Topology path that contains PCIe switches/bridges as well as multiple host bridges within a NUMA node.
  HPB = Topology path that contains PCIe switches/bridges as well as a single host bridge.
  MPB = Topology path that contains multiple PCIe switches/bridges (but no host bridge).
  SPB = Topology path that contains at most one PCIe switch/bridge.
  INT = Topology path that is created internally, for example 2 devices on a single S2000 card.
  MTx = Topology path that is a bonded set of x MTLinks.

NIC Legend:
  NIC0: mlx5_0
  NIC1: mlx5_1
  NIC2: mlx5_2
  NIC3: mlx5_3
  NIC4: mlx5_4
  NIC5: mlx5_5
  NIC6: mlx5_6
  NIC7: mlx5_7
  NIC8: mlx5_8
  NIC9: mlx5_9
 NIC10: mlx5_bond_0


ulimit soft: 1048576
root@worker3218:/ws#
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
