### PR TITLE
[DeepSeek v3.2] Opt MTP decode cuda batch sizes and nsa implementation

### DIFF
--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1267,7 +1267,7 @@ class NativeSparseAttnBackend(
             self.nsa_decode_impl
             if (
                 forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend()
+                or forward_batch.forward_mode.is_draft_extend(include_v2=True)
             )
             else self.nsa_prefill_impl
         )

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -314,19 +314,6 @@ class NativeSparseAttnBackend(
             model_runner.server_args.speculative_num_draft_tokens
         )
         self.speculative_step_id = speculative_step_id
-        if self.speculative_num_draft_tokens is not None:
-            self.spec_tokens_range = torch.arange(
-                1,
-                self.speculative_num_draft_tokens + 1,
-                dtype=torch.int32,
-                device=self.device,
-            )
-            self.spec_tokens_neg_range = torch.arange(
-                -self.speculative_num_draft_tokens + 1,
-                1,
-                dtype=torch.int32,
-                device=self.device,
-            )
 
         self.device_capability = torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
@@ -452,6 +439,21 @@ class NativeSparseAttnBackend(
                 dtype=torch.int32,
                 device=device,
             )
+            seqlens_expanded = torch.cat(
+                [
+                    torch.arange(
+                        kv_len - qo_len + 1,
+                        kv_len + 1,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                    for qo_len, kv_len in zip(
+                        forward_batch.extend_seq_lens_cpu,
+                        forward_batch.seq_lens_cpu.tolist(),
+                        strict=True,
+                    )
+                ]
+            )
             if forward_batch.forward_mode.is_draft_extend_v2():
                 # DRAFT_EXTEND_V2: V2 worker pre-fills draft KV cache with ALL speculated
                 # tokens upfront. All requests extend by the same fixed
@@ -459,31 +461,12 @@ class NativeSparseAttnBackend(
                 page_table = torch.repeat_interleave(
                     page_table, repeats=self.speculative_num_draft_tokens, dim=0
                 )
-                seqlens_expanded = (
-                    forward_batch.seq_lens.to(torch.int32).view(-1, 1)
-                    + self.spec_tokens_neg_range
-                ).view(-1)
             else:
                 # DRAFT_EXTEND (v1): V1 worker extends by (accept_length + 1) per request
                 # after verification. Lengths vary per request based on how many tokens
                 # were accepted.
                 page_table = torch.repeat_interleave(
                     page_table, repeats=forward_batch.extend_seq_lens, dim=0
-                )
-                seqlens_expanded = torch.cat(
-                    [
-                        torch.arange(
-                            kv_len - qo_len + 1,
-                            kv_len + 1,
-                            dtype=torch.int32,
-                            device=device,
-                        )
-                        for qo_len, kv_len in zip(
-                            forward_batch.extend_seq_lens_cpu,
-                            forward_batch.seq_lens_cpu.tolist(),
-                            strict=True,
-                        )
-                    ]
                 )
         elif forward_batch.forward_mode.is_extend():
             assert (
@@ -841,9 +824,28 @@ class NativeSparseAttnBackend(
                 dtype=torch.int32,
                 device=self.device,
             )
-            seqlens_expanded = (
-                seq_lens.to(torch.int32).view(-1, 1) + self.spec_tokens_range
-            ).view(-1)
+
+            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+
+            seqlens_int32_cpu = [
+                self.speculative_num_draft_tokens + kv_len
+                for kv_len in seq_lens.tolist()
+            ]
+            seqlens_expanded = torch.cat(
+                [
+                    torch.arange(
+                        kv_len - qo_len + 1,
+                        kv_len + 1,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    for qo_len, kv_len in zip(
+                        extend_seq_lens_cpu,
+                        seqlens_int32_cpu,
+                        strict=True,
+                    )
+                ]
+            )
             nsa_cache_seqlens_int32 = compute_nsa_seqlens(
                 seqlens_expanded, nsa_index_topk=self.nsa_index_topk
             )
@@ -966,7 +968,27 @@ class NativeSparseAttnBackend(
                 page_indices, repeats=self.speculative_num_draft_tokens, dim=0
             )
             metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
-            seqlens_expanded = (seq_lens.view(-1, 1) + self.spec_tokens_range).view(-1)
+            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+
+            seqlens_int32_cpu = [
+                self.speculative_num_draft_tokens + kv_len
+                for kv_len in seq_lens_cpu.tolist()
+            ]
+            seqlens_expanded = torch.cat(
+                [
+                    torch.arange(
+                        kv_len - qo_len + 1,
+                        kv_len + 1,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    for qo_len, kv_len in zip(
+                        extend_seq_lens_cpu,
+                        seqlens_int32_cpu,
+                        strict=True,
+                    )
+                ]
+            )
             metadata.nsa_seqlens_expanded.copy_(seqlens_expanded)
             nsa_cache_seqlens = compute_nsa_seqlens(
                 seqlens_expanded, self.nsa_index_topk
@@ -979,38 +1001,32 @@ class NativeSparseAttnBackend(
             metadata.cu_seqlens_k[1:].copy_(
                 torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
             )
-            page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
-            if forward_mode.is_draft_extend_v2():
-                page_indices = torch.repeat_interleave(
-                    page_indices, repeats=self.speculative_num_draft_tokens, dim=0
-                )
-                seqlens_expanded = (
-                    seq_lens.to(torch.int32).view(-1, 1) + self.spec_tokens_neg_range
-                ).view(-1)
-            else:
-                extend_seq_lens = spec_info.accept_length[:bs]
-                extend_seq_lens_cpu = extend_seq_lens.tolist()
 
-                page_indices = torch.repeat_interleave(
-                    page_indices, repeats=extend_seq_lens, dim=0
-                )
-                seqlens_expanded = torch.cat(
-                    [
-                        torch.arange(
-                            kv_len - qo_len + 1,
-                            kv_len + 1,
-                            dtype=torch.int32,
-                            device=self.device,
-                        )
-                        for qo_len, kv_len in zip(
-                            extend_seq_lens_cpu,
-                            seq_lens_cpu.tolist(),
-                            strict=True,
-                        )
-                    ]
-                )
+            extend_seq_lens = spec_info.accept_length[:bs]
+            extend_seq_lens_cpu = extend_seq_lens.tolist()
+
+            page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
+            page_indices = torch.repeat_interleave(
+                page_indices, repeats=extend_seq_lens, dim=0
+            )
             metadata.page_table_1[: page_indices.shape[0], :max_seqlen_k].copy_(
                 page_indices
+            )
+
+            seqlens_expanded = torch.cat(
+                [
+                    torch.arange(
+                        kv_len - qo_len + 1,
+                        kv_len + 1,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    for qo_len, kv_len in zip(
+                        extend_seq_lens_cpu,
+                        seq_lens_cpu.tolist(),
+                        strict=True,
+                    )
+                ]
             )
             metadata.nsa_seqlens_expanded[: seqlens_expanded.shape[0]].copy_(
                 seqlens_expanded

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -186,7 +186,7 @@ def set_torch_compile_config():
     monkey_patch_torch_compile()
 
 
-def get_batch_sizes_to_capture(model_runner: ModelRunner):
+def get_batch_sizes_to_capture(model_runner: ModelRunner, num_tokens_per_bs=1):
     server_args = model_runner.server_args
     capture_bs = server_args.cuda_graph_bs
 
@@ -203,7 +203,7 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner):
     if require_gathered_buffer(server_args):
         mul_base *= get_attention_tp_size()
 
-    capture_bs = [bs for bs in capture_bs if bs % mul_base == 0]
+    capture_bs = [bs for bs in capture_bs if bs * num_tokens_per_bs % mul_base == 0]
 
     capture_bs = [bs for bs in capture_bs if bs <= model_runner.req_to_token_pool.size]
     capture_bs = list(sorted(set(capture_bs)))
@@ -267,11 +267,6 @@ class CudaGraphRunner:
         self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
         self.is_dllm = self.dllm_config is not None
 
-        # Batch sizes to capture
-        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(model_runner)
-        log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
-        if KTRANSFORMERS_AVAILABLE:
-            KTMoEWrapper.set_capture_batch_sizes(self.capture_bs)
         self.capture_forward_mode = ForwardMode.DECODE
         self.capture_hidden_mode = CaptureHiddenMode.NULL
         self.num_tokens_per_bs = 1
@@ -290,6 +285,14 @@ class CudaGraphRunner:
         elif self.is_dllm:
             self.capture_forward_mode = ForwardMode.DLLM_EXTEND
             self.num_tokens_per_bs = self.dllm_config.block_size
+
+        # Batch sizes to capture
+        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(
+            model_runner, self.num_tokens_per_bs
+        )
+        log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
+        if KTRANSFORMERS_AVAILABLE:
+            KTMoEWrapper.set_capture_batch_sizes(self.capture_bs)
 
         # If returning hidden states is enabled, set initial capture hidden mode to full to avoid double-capture on startup
         if model_runner.server_args.enable_return_hidden_states:

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -199,10 +199,12 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner, num_tokens_per_bs=1):
 
     if server_args.enable_two_batch_overlap:
         mul_base *= 2
+        num_tokens_per_bs = 1  # tbo not test, set num_tokens_per_bs to 1
 
     if require_gathered_buffer(server_args):
         mul_base *= get_attention_tp_size()
 
+    # Model input token count = bs * num_tokens_per_bs; must be a multiple of attn_tp_size.
     capture_bs = [bs for bs in capture_bs if bs * num_tokens_per_bs % mul_base == 0]
 
     capture_bs = [bs for bs in capture_bs if bs <= model_runner.req_to_token_pool.size]

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -12,6 +12,7 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_extend_npu_graph_r
 from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner import (
     EAGLEDraftNpuGraphRunner,
 )
+from sglang.srt.layers.attention.nsa_backend import NativeSparseAttnMultiStepBackend
 from sglang.srt.layers.attention.triton_backend import TritonMultiStepDraftBackend
 from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.layers.moe.utils import (
@@ -275,7 +276,10 @@ class EagleDraftWorker(BaseDraftWorker):
             _is_npu
             or (
                 _is_cuda
-                and isinstance(self.draft_attn_backend, TritonMultiStepDraftBackend)
+                and isinstance(
+                    self.draft_attn_backend,
+                    (TritonMultiStepDraftBackend, NativeSparseAttnMultiStepBackend),
+                )
             )
         ):
             tic = time.perf_counter()

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -12,7 +12,6 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_extend_npu_graph_r
 from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner import (
     EAGLEDraftNpuGraphRunner,
 )
-from sglang.srt.layers.attention.nsa_backend import NativeSparseAttnMultiStepBackend
 from sglang.srt.layers.attention.triton_backend import TritonMultiStepDraftBackend
 from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.layers.moe.utils import (
@@ -276,10 +275,7 @@ class EagleDraftWorker(BaseDraftWorker):
             _is_npu
             or (
                 _is_cuda
-                and isinstance(
-                    self.draft_attn_backend,
-                    (TritonMultiStepDraftBackend, NativeSparseAttnMultiStepBackend),
-                )
+                and isinstance(self.draft_attn_backend, TritonMultiStepDraftBackend)
             )
         ):
             tic = time.perf_counter()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
1、`draft_extend` and `target_verify` use `nsa_decode_backend` as backend implementation instead of `nsa_prefill_backend`
In the MTP scenario, the NSA attention implementation selected for `prefill`, `draft_extend`, and `target_verify` is all `nsa_prefill_backend`, which is typically set to `flashmla_sparse`. For `draft_extend` and `target_verify` scenarios with a small number of tokens, we observed that `fa3` delivers better performance. However, when `flashmla_sparse` is chosen for `prefill,` there is no interface to additionally specify the NSA attention implementation for `draft_extend` and `target_verify`. This PR modifies the backend implementation of `draft_extend` and `target_verify` to `nsa_decode_backend` —in practice, their CUDA Graph initialization and replay already use `nsa_decode_impl`.

num_draft_tokens=4, TPOT:
| batch size | flashmla_sparse | fa3   |
|------------|-----------------|-------|
| 1          | 11.87           | 9.44  |
| 2          | 13.34           | 13.08 |
| 8          | 15.25           | 15.87 |
| 16         | 21.25           | 21.50|
| 32         | 32.94           | 33.79 |

2、Opt cuda graph batch sizes when MTP:
In the Prefill CP scenario, `require_gathered_buffer` is set to True. Assuming the number of MTP num_draft_tokens is `4`, the CUDA Graph tokens in the MTP scenario are calculated as follows:
`get_batch_sizes_to_capture` returns batch sizes that are multiples of `attn_tp_size`, i.e., `[8, 16, 24, 32, ....]`.
In `capture_one_batch_size`, `num_tokens = bs * self.num_tokens_per_bs`, meaning the actual number of tokens is `[32, 64, 96, 128, ...]`.
When `bs=1`, the number of tokens is `4` but needs to be padded to `32`, resulting in significant performance overhead. In reality, `num_tokens` only needs to be a multiple of `attn_tp_size`.
Modification: `get_batch_sizes_to_capture` is updated to return batch sizes where `batch size * num_draft_tokens` is divisible by `attn_tp_size`, i.e., `[2, 4, 6, 8, ....]`.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
MODEL_PATH=/home/models/DeepSeek-V3.2/

python3 -m sglang.launch_server --model-path $MODEL_PATH --trust-remote-code \
--port 8000 --host 0.0.0.0 --attention-backend  nsa \
--enable-metrics --mem-fraction-static 0.8 --max-running-requests 128 --enable-cache-report --page-size 64 \
--tp-size 8 --moe-dense-tp-size 1 \
--tool-call-parser deepseekv32 \
--reasoning-parser deepseek-v3 \
--moe-dense-tp-size 1 \
--chunked-prefill-size 16384 \
--nsa-decode-backend fa3 \
--enable-nsa-prefill-context-parallel \
--nsa-prefill-cp-mode round-robin-split \
--speculative-algorithm EAGLE \
--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
```

```
# gsm8k
Accuracy: 0.948
Invalid: 0.000
Latency: 192.326 s
Output throughput: 630.665 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
