### PR TITLE
Add SM120 (Blackwell desktop) MXFP4 support

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -118,8 +118,10 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         value_layout, value_layout_opts = layout.make_default_matmul_mxfp4_w_layout(
             mx_axis=1
         )
-        scale_layout, scale_layout_opts = layout.make_default_matmul_mxfp4_w_scale_layout(
-            mx_axis=1, num_warps=num_warps
+        scale_layout, scale_layout_opts = (
+            layout.make_default_matmul_mxfp4_w_scale_layout(
+                mx_axis=1, num_warps=num_warps
+            )
         )
         if _is_sm100_supported:
             constraints = {

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1266,6 +1266,13 @@ class ServerArgs:
                     logger.warning(
                         "Enable piecewise CUDA graph, enabling auto MOE kernel."
                     )
+                elif is_sm120_supported() and is_mxfp4_quant_format:
+                    # SM120 (Blackwell desktop) doesn't support flashinfer_mxfp4
+                    # due to persistent kernel / TMA limitations
+                    self.moe_runner_backend = "triton_kernel"
+                    logger.warning(
+                        "Detected SM120 and MXFP4 quantization format for GPT-OSS model, enabling triton_kernel MOE kernel."
+                    )
                 elif is_blackwell_supported() and is_mxfp4_quant_format:
                     self.moe_runner_backend = "flashinfer_mxfp4"
                     logger.warning(


### PR DESCRIPTION
SM120 (RTX PRO 6000, RTX 5090) doesn't support persistent kernels the same way SM100 does. This adds SM120-specific configuration following the same pattern as vLLM PR vllm-project/vllm#31089:

- Use `StridedLayout` instead of TMA block layout
- Set `is_persistent=False` and `num_stages=1`

Tested with GPT-OSS-120B on RTX PRO 6000:
- 4K: 151 tok/s
- 131K: 57 tok/s

Fixes #13061, related to #9707, #12695