### PR TITLE
support model skywork-reward-gemma2-2-27B-v0.2

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -453,7 +453,8 @@ class ModelConfig:
 
             elif "BaichuanForCausalLM" in self.hf_config.architectures:
                 self.use_alibi = True if self.hf_config.hidden_size !=4096 else False
-
+            elif "Gemma2ForSequenceClassification" in self.hf_config.architectures:
+                self.use_sdpa = True
             self.attention_arch = AttentionArch.MHA
 
         self.num_attention_heads = self.hf_text_config.num_attention_heads
@@ -1041,6 +1042,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
         or "BertForSequenceClassification" in model_architectures
         or "XLMRobertaModel" in model_architectures
         or "XLMRobertaForSequenceClassification" in model_architectures
+        or "Gemma2ForSequenceClassification" in model_architectures
     ):
         return False
     else:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -243,6 +243,10 @@ class AscendAttnBackend(AttentionBackend):
             if hasattr(model_runner.model_config, "not_use_fused_infer_attention_score"):
                 self.not_use_fused_infer_attention_score = True
         else:
+            if hasattr(
+                model_runner.model_config, "use_sdpa"
+            ):
+                self.use_sdpa = True
             self.use_alibi = hasattr(model_runner.model_config, "use_alibi") and model_runner.model_config.use_alibi
         self.native_attn = TorchNativeAttnBackend(model_runner)
         self.graph_metadata = {}
@@ -851,6 +855,21 @@ class AscendAttnBackend(AttentionBackend):
                             is_extend=True
                         )
                 else:
+                    if hasattr(self, "use_sdpa"):
+                        use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
+                        attn_output = torch.nn.functional.scaled_dot_product_attention(
+                            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim).unsqueeze(0).transpose(1, 2),
+                            k.view(-1, layer.tp_k_head_num, layer.qk_head_dim).unsqueeze(0).transpose(1, 2),
+                            v.view(-1, layer.tp_k_head_num, layer.v_head_dim).unsqueeze(0).transpose(1, 2),
+                            attn_mask=None,
+                            dropout_p=0.0,
+                            enable_gqa=use_gqa,
+                            scale=layer.scaling,
+                            is_causal=True,
+                        )
+                        attn_output = attn_output.transpose(1, 2).contiguous()
+                        attn_output = attn_output.squeeze(0).reshape(-1, layer.tp_q_head_num * layer.v_head_dim).contiguous()
+                        return attn_output
                     if layer.qk_head_dim != layer.v_head_dim:
                         attn_output = q.new_empty(
                             (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -243,9 +243,7 @@ class AscendAttnBackend(AttentionBackend):
             if hasattr(model_runner.model_config, "not_use_fused_infer_attention_score"):
                 self.not_use_fused_infer_attention_score = True
         else:
-            if hasattr(
-                model_runner.model_config, "use_sdpa"
-            ):
+            if hasattr(model_runner.model_config, "use_sdpa"):
                 self.use_sdpa = True
             self.use_alibi = hasattr(model_runner.model_config, "use_alibi") and model_runner.model_config.use_alibi
         self.native_attn = TorchNativeAttnBackend(model_runner)
@@ -852,15 +850,21 @@ class AscendAttnBackend(AttentionBackend):
                             scale_value=layer.scaling,
                             num_heads=layer.tp_q_head_num,
                             slopes=slopes,
-                            is_extend=True
+                            is_extend=True,
                         )
                 else:
                     if hasattr(self, "use_sdpa"):
                         use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
                         attn_output = torch.nn.functional.scaled_dot_product_attention(
-                            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim).unsqueeze(0).transpose(1, 2),
-                            k.view(-1, layer.tp_k_head_num, layer.qk_head_dim).unsqueeze(0).transpose(1, 2),
-                            v.view(-1, layer.tp_k_head_num, layer.v_head_dim).unsqueeze(0).transpose(1, 2),
+                            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+                            .unsqueeze(0)
+                            .transpose(1, 2),
+                            k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                            .unsqueeze(0)
+                            .transpose(1, 2),
+                            v.view(-1, layer.tp_k_head_num, layer.v_head_dim)
+                            .unsqueeze(0)
+                            .transpose(1, 2),
                             attn_mask=None,
                             dropout_p=0.0,
                             enable_gqa=use_gqa,
@@ -868,7 +872,11 @@ class AscendAttnBackend(AttentionBackend):
                             is_causal=True,
                         )
                         attn_output = attn_output.transpose(1, 2).contiguous()
-                        attn_output = attn_output.squeeze(0).reshape(-1, layer.tp_q_head_num * layer.v_head_dim).contiguous()
+                        attn_output = (
+                            attn_output.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)
+                            .contiguous()
+                            .squeeze(0)
+                        )
                         return attn_output
                     if layer.qk_head_dim != layer.v_head_dim:
                         attn_output = q.new_empty(

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -131,6 +131,8 @@ class GeluAndMul(CustomOp):
         return self._forward_impl(x)
 
     def forward_npu(self, x: torch.Tensor) -> torch.Tensor:
+        if get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE"):
+            return self.forward_native(x)
         y_npu, gelu_npu = torch_npu.npu_geglu(
             x,
             dim=-1,

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -430,6 +430,8 @@ class GemmaRMSNorm(CustomOp):
         x: torch.Tensor,
         residual: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE"):
+            return self.forward_native(x, residual)
         if residual is not None:
             norm_out, residual = add_gemma_rms_norm(x, self.weight, residual, self.variance_epsilon)
             return norm_out, residual

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -296,7 +296,9 @@ class RotaryEmbedding(CustomOp):
             fused_set_kv_buffer_arg is None
         ), "fused_set_kv_buffer_arg is not supported for npu implementation"
 
-        if (query.dtype == torch.bfloat16 and self.cos_sin_cache.dtype == torch.float) or get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE"):
+        if (
+            query.dtype == torch.bfloat16 and self.cos_sin_cache.dtype == torch.float
+        ) or get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE"):
             return self.forward_native(positions, query, key, offsets)
 
         rotary_mode = "half"

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1187,7 +1187,8 @@ class Scheduler(
 
             # Run sample of the current batch
             # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
-            self.launch_batch_sample_if_needed(batch_result)
+            if self.is_generation:
+                self.launch_batch_sample_if_needed(batch_result)
 
             # Update last_batch
             self.last_batch = batch

--- a/python/sglang/srt/models/gemma2.py
+++ b/python/sglang/srt/models/gemma2.py
@@ -24,6 +24,7 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from sglang.srt.distributed import get_tensor_model_parallel_world_size
+from sglang.srt.layers.activation import GeluAndMul
 from sglang.srt.layers.layernorm import GemmaRMSNorm
 from sglang.srt.layers.linear import (
     MergedColumnParallelLinear,
@@ -47,32 +48,6 @@ from sglang.srt.utils import add_prefix, make_layers
 # SGLang assumes exclusive
 def get_attention_sliding_window_size(config):
     return config.sliding_window - 1
-
-
-class GELUTanh(nn.Module):
-    def __init__(self, use_gelu_tanh_python: bool = False):
-        super().__init__()
-        if use_gelu_tanh_python:
-            self.act = self._gelu_tanh_python
-        else:
-            self.act = functools.partial(nn.functional.gelu, approximate="tanh")
-
-    def _gelu_tanh_python(self, input: torch.tensor) -> torch.tensor:
-        return (
-            input
-            * 0.5
-            * (
-                1.0
-                + torch.tanh(
-                    math.sqrt(2.0 / math.pi)
-                    * (input + 0.044715 * torch.pow(input, 3.0))
-                )
-            )
-        )
-
-    def forward(self, input: torch.tensor) -> torch.tensor:
-        return self.act(input)
-
 
 class Gemma2MLP(nn.Module):
     def __init__(
@@ -105,7 +80,7 @@ class Gemma2MLP(nn.Module):
                 "function. Please set `hidden_act` and `hidden_activation` to "
                 "`gelu_pytorch_tanh`."
             )
-        self.act_fn = GELUTanh()
+        self.act_fn = GeluAndMul()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.gate_up_proj(x)

--- a/python/sglang/srt/models/gemma2.py
+++ b/python/sglang/srt/models/gemma2.py
@@ -42,11 +42,27 @@ from sglang.srt.model_loader.weight_utils import (
 from sglang.srt.utils import add_prefix, make_layers
 
 
+import functools
+import math
+
 # Aligned with HF's implementation, using sliding window inclusive with the last token
 # SGLang assumes exclusive
 def get_attention_sliding_window_size(config):
     return config.sliding_window - 1
 
+class GELUTanh(nn.Module):
+    def __init__(self, use_gelu_tanh_python: bool = False):
+        super().__init__()
+        if use_gelu_tanh_python:
+            self.act = self._gelu_tanh_python
+        else:
+            self.act = functools.partial(nn.functional.gelu, approximate="tanh")
+    
+    def _gelu_tanh_python(self, input: torch.tensor) -> torch.tensor:
+        return input * 0.5 * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))))
+    
+    def forward(self, input: torch.tensor) -> torch.tensor:
+        return self.act(input)
 
 class Gemma2MLP(nn.Module):
     def __init__(
@@ -79,11 +95,13 @@ class Gemma2MLP(nn.Module):
                 "function. Please set `hidden_act` and `hidden_activation` to "
                 "`gelu_pytorch_tanh`."
             )
-        self.act_fn = GeluAndMul()
+        self.act_fn = GELUTanh()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.gate_up_proj(x)
-        x = self.act_fn(gate_up)
+        d = gate_up.shape[-1]//2
+        gate, up = gate_up[..., :d], gate_up[..., d:]
+        x = self.act_fn(gate) * up
         x, _ = self.down_proj(x)
         return x
 

--- a/python/sglang/srt/models/gemma2.py
+++ b/python/sglang/srt/models/gemma2.py
@@ -15,6 +15,8 @@
 # Adapted from:
 # https://github.com/vllm-project/vllm/blob/56b325e977435af744f8b3dca7af0ca209663558/vllm/model_executor/models/gemma2.py
 
+import functools
+import math
 from typing import Iterable, Optional, Set, Tuple
 
 import torch
@@ -22,7 +24,6 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from sglang.srt.distributed import get_tensor_model_parallel_world_size
-from sglang.srt.layers.activation import GeluAndMul
 from sglang.srt.layers.layernorm import GemmaRMSNorm
 from sglang.srt.layers.linear import (
     MergedColumnParallelLinear,
@@ -42,13 +43,11 @@ from sglang.srt.model_loader.weight_utils import (
 from sglang.srt.utils import add_prefix, make_layers
 
 
-import functools
-import math
-
 # Aligned with HF's implementation, using sliding window inclusive with the last token
 # SGLang assumes exclusive
 def get_attention_sliding_window_size(config):
     return config.sliding_window - 1
+
 
 class GELUTanh(nn.Module):
     def __init__(self, use_gelu_tanh_python: bool = False):
@@ -57,12 +56,23 @@ class GELUTanh(nn.Module):
             self.act = self._gelu_tanh_python
         else:
             self.act = functools.partial(nn.functional.gelu, approximate="tanh")
-    
+
     def _gelu_tanh_python(self, input: torch.tensor) -> torch.tensor:
-        return input * 0.5 * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))))
-    
+        return (
+            input
+            * 0.5
+            * (
+                1.0
+                + torch.tanh(
+                    math.sqrt(2.0 / math.pi)
+                    * (input + 0.044715 * torch.pow(input, 3.0))
+                )
+            )
+        )
+
     def forward(self, input: torch.tensor) -> torch.tensor:
         return self.act(input)
+
 
 class Gemma2MLP(nn.Module):
     def __init__(
@@ -99,7 +109,7 @@ class Gemma2MLP(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.gate_up_proj(x)
-        d = gate_up.shape[-1]//2
+        d = gate_up.shape[-1] // 2
         gate, up = gate_up[..., :d], gate_up[..., d:]
         x = self.act_fn(gate) * up
         x, _ = self.down_proj(x)
@@ -312,7 +322,9 @@ class Gemma2Model(nn.Module):
             hidden_states = self.embed_tokens(input_ids)
         else:
             hidden_states = input_embeds
-        normalizer = torch.tensor(self.config.hidden_size**0.5, dtype=torch.float16)
+        normalizer = torch.tensor(
+            self.config.hidden_size**0.5, dtype=hidden_states.dtype
+        )
         hidden_states *= normalizer
 
         residual = None

--- a/python/sglang/test/runners.py
+++ b/python/sglang/test/runners.py
@@ -555,6 +555,7 @@ class SRTRunner:
         json_model_override_args: Optional[dict[str, Any]] = None,
         lora_eviction_policy: str = "lru",
         enable_deterministic_inference: bool = False,
+        enable_torch_compile: bool = False,
     ):
         self.model_type = model_type
         self.is_generation = model_type == "generation"
@@ -612,6 +613,7 @@ class SRTRunner:
             lora_target_modules=lora_target_modules,
             enable_lora=enable_lora,
             max_loaded_loras=max_loaded_loras,
+            enable_torch_compile=enable_torch_compile,
             json_model_override_args=(
                 json.dumps(json_model_override_args)
                 if json_model_override_args


### PR DESCRIPTION

## Motivation
support model skywork-reward-gemma2-2-27B-v0.2

Modifications
As follows. same with my pr https://github.com/sgl-project/sglang/pull/16947

Accuracy Tests
when exporting SGLANG_ENABLE_TORCH_COMPILE=1 or using --enable-torch-compile
accuracy is almost the same with hfrunner (GenericForSequenceClassification, Gemma2ForCausalLM) with tolerance under 4e-2. p.s. dtype should be same with model config (bfloat16). If you set dtype to float16, hf outputs will be nan.
<img width="1134" height="191" alt="image" src="https://github.com/user-attachments/assets/308a0def-b500-4885-8a41-7155e0b2eba5" />
