### PR TITLE
test: split Qwen3 Next tests and disable PCG tests due to intermittent failures

### DIFF
--- a/test/srt/models/test_qwen3_next_models.py
+++ b/test/srt/models/test_qwen3_next_models.py
@@ -123,45 +123,5 @@ class TestQwen3Next(CustomTestCase):
         print("test_prefix_cache_branching passed")
 
 
-class TestQwen3NextPiecewiseCudaGraph(CustomTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.model = QWEN3_NEXT_MODEL
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--tp",
-                "4",
-                "--enable-piecewise-cuda-graph",
-                "--piecewise-cuda-graph-compiler",
-                "eager",
-            ],
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def test_gsm8k(self):
-        args = SimpleNamespace(
-            num_shots=5,
-            data_path=None,
-            num_questions=200,
-            max_new_tokens=512,
-            parallel=128,
-            host="http://127.0.0.1",
-            port=int(self.base_url.split(":")[-1]),
-        )
-        metrics = run_eval(args)
-        print(f"{metrics=}")
-        self.assertGreaterEqual(
-            metrics["accuracy"], ACC_THRESHOLDS[self.model]["gsm8k"]
-        )
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/srt/models/test_qwen3_next_models_pcg.py
+++ b/test/srt/models/test_qwen3_next_models_pcg.py
@@ -1,0 +1,70 @@
+"""
+Qwen3 Next piecewise CUDA graph tests.
+
+DISABLED: See https://github.com/sgl-project/sglang/issues/17039
+PCG tests for Qwen3 Next have intermittent failures (5-10% probability).
+Investigation ongoing by @YuweiAn.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+QWEN3_NEXT_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
+
+ACC_THRESHOLDS = {
+    QWEN3_NEXT_MODEL: {"kl_div": 0.0025, "gsm8k": 0.93},
+}
+
+
+@unittest.skip("Disabled: intermittent failures, see #17039")
+class TestQwen3NextPiecewiseCudaGraph(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_NEXT_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp",
+                "4",
+                "--enable-piecewise-cuda-graph",
+                "--piecewise-cuda-graph-compiler",
+                "eager",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreaterEqual(
+            metrics["accuracy"], ACC_THRESHOLDS[self.model]["gsm8k"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -9,7 +9,8 @@ from sglang.test.ci.ci_utils import TestFile, run_unittest_files
 # NOTE: please sort the test cases alphabetically by the test file name
 suites = {
     "per-commit-4-gpu": [
-        TestFile("models/test_qwen3_next_models.py", 650),
+        TestFile("models/test_qwen3_next_models.py", 350),
+        TestFile("models/test_qwen3_next_models_mtp.py", 350),
         TestFile("test_gpt_oss_4gpu.py", 300),
         TestFile("test_multi_instance_release_memory_occupation.py", 64),
         TestFile("test_pp_single_node.py", 500),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -71,7 +71,9 @@ suites = {
         TestFile("test_mistral_large3_basic.py"),
         TestFile("test_prefill_delayer.py"),
         TestFile("test_fla_layernorm_guard.py"),
-        TestFile("models/test_qwen3_next_models_pcg.py"),  # Disabled: intermittent failures, see #17039
+        TestFile(
+            "models/test_qwen3_next_models_pcg.py"
+        ),  # Disabled: intermittent failures, see #17039
     ],
 }
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -71,6 +71,7 @@ suites = {
         TestFile("test_mistral_large3_basic.py"),
         TestFile("test_prefill_delayer.py"),
         TestFile("test_fla_layernorm_guard.py"),
+        TestFile("models/test_qwen3_next_models_pcg.py"),  # Disabled: intermittent failures, see #17039
     ],
 }
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -10,7 +10,7 @@ from sglang.test.ci.ci_utils import TestFile, run_unittest_files
 suites = {
     "per-commit-4-gpu": [
         TestFile("models/test_qwen3_next_models.py", 350),
-        TestFile("models/test_qwen3_next_models_mtp.py", 350),
+        TestFile("models/test_qwen3_next_models_mtp.py", 500),
         TestFile("test_gpt_oss_4gpu.py", 300),
         TestFile("test_multi_instance_release_memory_occupation.py", 64),
         TestFile("test_pp_single_node.py", 500),


### PR DESCRIPTION
## Summary

Split `test_qwen3_next_models.py` to fix CI timeout issues and separate PCG (piecewise CUDA graph) tests.

**Changes:**
- `test_qwen3_next_models.py` - Base Qwen3 Next tests (TestQwen3Next, 4 tests)
- `test_qwen3_next_models_mtp.py` - MTP speculative decoding tests (TestQwen3NextMTP, TestQwen3NextMTPTopk, 7 tests)
- `test_qwen3_next_models_pcg.py` - Piecewise CUDA graph tests (**DISABLED**, see #17039)

**Why:**
- Original file took ~644s, causing timeout when retry is triggered
- PCG tests have intermittent failures (5-10% probability) - investigation ongoing by @YuweiAn

**CI Failure:** https://github.com/sgl-project/sglang/actions/runs/20929884099/job/60168346479

## Test plan

- [x] Split reduces individual file runtime
- [x] PCG test disabled with issue reference