### PR TITLE
[bugfix] fix qwen3-next alt_stream none issue

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -358,7 +358,11 @@ class Qwen3GatedDeltaNet(nn.Module):
             DUAL_STREAM_TOKEN_THRESHOLD = 1024
 
         seq_len, _ = hidden_states.shape
-        if seq_len < DUAL_STREAM_TOKEN_THRESHOLD:
+        if (
+            seq_len < DUAL_STREAM_TOKEN_THRESHOLD
+            and self.alt_stream is not None
+            and get_is_capture_mode()
+        ):
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This patch is to solve the alt_stream None issue for qwen3-next on other non-cuda platform

The command for how to reproduce on AMD MI300X:
```bash
HIP_VISIBLE_DEVICES="6,7" python -m sglang.launch_server   --model Qwen/Qwen3-Next-80B-A3B-Thinking-FP8   --tp 2    --attention-backend triton
```

The error trace:
```bash
File "/billhe/sglang-qwen3next/python/sglang/srt/models/qwen3_next.py", line 544, in forward
hidden_states = self.linear_attn(
File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
return forward_call(*args, **kwargs)
File "/billhe/sglang-qwen3next/python/sglang/srt/models/qwen3_next.py", line 387, in forward
return self._forward(hidden_states, forward_batch)
File "/billhe/sglang-qwen3next/python/sglang/srt/models/qwen3_next.py", line 397, in _forward
projected_states_qkvz, projected_states_ba = self._forward_input_proj(
File "/billhe/sglang-qwen3next/python/sglang/srt/models/qwen3_next.py", line 363, in _forward_input_proj
self.alt_stream.wait_stream(current_stream)
AttributeError: 'NoneType' object has no attribute 'wait_stream'

```

The root cause:
alt_stream is only initialized on cuda platform
```python
alt_stream = torch.cuda.Stream() if _is_cuda else None 
```

After applying this patch:

```
python /sgl-workspace/sglang/benchmark/gsm8k/bench_sglang.py --num-questions 200 --port 30000
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 48.6MB/s]                                                                                                                                                                                                                                                            
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:40<00:00,  4.89it/s]
Accuracy: 0.940
Invalid: 0.000
Latency: 43.095 s
Output throughput: 763.337 token/s
```



## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
