### PR TITLE
Add 1-hour job timeout to all PR test jobs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -58,6 +58,7 @@ jobs:
   # =============================================== check changes ====================================================
   check-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       main_package: ${{ steps.filter.outputs.main_package || steps.run-mode.outputs.run_all_tests }}
       sgl_kernel: ${{ steps.filter.outputs.sgl_kernel }} # sgl-kernel tests only run when kernels are rebuilt
@@ -182,6 +183,7 @@ jobs:
     needs: [check-changes, call-gate]
     if: needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: x64-kernel-build-node
+    timeout-minutes: 60
     strategy:
       matrix:
         include:
@@ -229,6 +231,7 @@ jobs:
     needs: [check-changes, call-gate]
     if: needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: arm-kernel-build-node
+    timeout-minutes: 60
     strategy:
       matrix:
         include:
@@ -279,6 +282,7 @@ jobs:
       !inputs.target_stage &&
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -315,6 +319,7 @@ jobs:
       !inputs.target_stage &&
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -351,6 +356,7 @@ jobs:
       !inputs.target_stage &&
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       CI: true
       RUNNER_LABELS: 1-gpu-runner
@@ -400,6 +406,7 @@ jobs:
       !inputs.target_stage &&
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     steps:
@@ -469,6 +476,7 @@ jobs:
       !inputs.target_stage &&
       needs.check-changes.outputs.jit_kernel == 'true'
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -502,6 +510,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -548,6 +557,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Free disk space
         run: |
@@ -592,6 +602,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     strategy:
@@ -641,6 +652,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -685,6 +697,7 @@ jobs:
         )
       )
     runs-on: 2-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 2-gpu-runner
     strategy:
@@ -733,6 +746,7 @@ jobs:
         )
       )
     runs-on: 4-gpu-h100
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 4-gpu-h100
     steps:
@@ -777,6 +791,7 @@ jobs:
         )
       )
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     steps:
@@ -817,6 +832,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -867,6 +883,7 @@ jobs:
         )
       )
     runs-on: 2-gpu-runner
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -963,6 +980,7 @@ jobs:
         )
       )
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     strategy:
@@ -1010,6 +1028,7 @@ jobs:
         )
       )
     runs-on: 4-gpu-h100
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 4-gpu-h100
     strategy:
@@ -1062,6 +1081,7 @@ jobs:
         )
       )
     runs-on: 8-gpu-h200
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 8-gpu-h200
     strategy:
@@ -1120,6 +1140,7 @@ jobs:
         )
       )
     runs-on: 8-gpu-h20
+    timeout-minutes: 60
     env:
       SGLANG_CI_RDMA_ALL_DEVICES: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
       RUNNER_LABELS: 8-gpu-h20
@@ -1173,6 +1194,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -1245,6 +1267,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -1309,6 +1332,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -1367,6 +1391,7 @@ jobs:
         )
       )
     runs-on: 2-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 2-gpu-runner
     steps:
@@ -1437,6 +1462,7 @@ jobs:
         )
       )
     runs-on: 1-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -1480,6 +1506,7 @@ jobs:
         )
       )
     runs-on: 2-gpu-runner
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 2-gpu-runner
     steps:
@@ -1523,6 +1550,7 @@ jobs:
         )
       )
     runs-on: 4-gpu-h100
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 4-gpu-h100
     steps:
@@ -1571,6 +1599,7 @@ jobs:
         )
       )
     runs-on: 8-gpu-h200
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 8-gpu-h200
     steps:
@@ -1619,6 +1648,7 @@ jobs:
         )
       )
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     strategy:
@@ -1672,6 +1702,7 @@ jobs:
         )
       )
     runs-on: 4-gpu-gb200
+    timeout-minutes: 60
     env:
       RUNNER_LABELS: 4-gpu-gb200
     strategy:
@@ -1750,6 +1781,7 @@ jobs:
       ]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check all dependent job statuses
         run: |


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 60` to all 32 jobs in pr-test.yml
- Prevents jobs from hanging indefinitely

## Problem
Jobs can hang waiting for network communication or other issues (e.g., commit e4b2b8f). GitHub Actions has a default 6-hour timeout which is too long to detect hung jobs.

**Example issue:** https://github.com/sgl-project/sglang/commit/e4b2b8f

## Solution
Add a 1-hour job-level timeout to all jobs. This provides:
- Enough time for normal test execution
- Early detection of hung jobs
- Faster feedback when something goes wrong

## Test plan
- [ ] CI passes with the new timeouts
- [ ] No jobs timeout during normal execution