### PR TITLE
[MUSA][2/N] sgl-kernel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,17 @@ python/sglang/_version.py
 python/sglang/srt/grpc/*_pb2.py
 python/sglang/srt/grpc/*_pb2_grpc.py
 python/sglang/srt/grpc/*_pb2.pyi
+
+# MUSA section
+# Generated source files by torchada
+sgl-kernel/csrc_musa/
+sgl-kernel/include_musa/
+sgl-kernel/csrc/**/*_musa/
+sgl-kernel/third_party/*/csrc_musa/
+sgl-kernel/third_party/*/include_musa/
+
+# Third-party libraries source code
+sgl-kernel/third_party/
+
+# MUSA core dump files
+core_*

--- a/docs/platforms/mthreads_gpu.md
+++ b/docs/platforms/mthreads_gpu.md
@@ -1,0 +1,25 @@
+# Moore Threads GPUs
+
+This document describes how run SGLang on Moore Threads GPUs. If you encounter issues or have questions, please [open an issue](https://github.com/sgl-project/sglang/issues).
+
+## Install SGLang
+
+You can install SGLang using one of the methods below.
+
+### Install from Source
+
+```bash
+# Use the default branch
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+
+# Compile sgl-kernel
+pip install --upgrade pip
+cd sgl-kernel
+python setup_musa.py install
+
+# Install sglang python package
+cd ..
+rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
+pip install -e "python[all_musa]"
+```

--- a/sgl-kernel/csrc/common_extension_musa.cc
+++ b/sgl-kernel/csrc/common_extension_musa.cc
@@ -1,0 +1,51 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+#include "sgl_kernel_ops.h"
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+
+TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
+  /*
+   * From FlashInfer
+   */
+  m.def(
+      "min_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? maybe_min_p_arr, float "
+      "min_p_val, bool deterministic, Generator? gen) -> ()");
+  m.impl("min_p_sampling_from_probs", torch::kMUSA, &min_p_sampling_from_probs);
+
+  m.def("top_k_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_k_arr, int top_k_val) -> ()");
+  m.impl("top_k_renorm_probs", torch::kMUSA, &top_k_renorm_probs);
+
+  m.def("top_p_renorm_probs(Tensor probs, Tensor! renorm_probs, Tensor? maybe_top_p_arr, float top_p_val) -> ()");
+  m.impl("top_p_renorm_probs", torch::kMUSA, &top_p_renorm_probs);
+
+  m.def(
+      "top_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? "
+      "maybe_top_p_arr, float top_p_val, bool deterministic, Generator? gen) -> ()");
+  m.impl("top_p_sampling_from_probs", torch::kMUSA, &top_p_sampling_from_probs);
+
+  m.def(
+      "top_k_top_p_sampling_from_probs(Tensor probs, Tensor output, Tensor? maybe_indices, Tensor? maybe_top_k_arr, "
+      "float top_k_val, Tensor? maybe_top_p_arr, float top_p_val, bool deterministic, Generator? gen) -> ()");
+  m.impl("top_k_top_p_sampling_from_probs", torch::kMUSA, &top_k_top_p_sampling_from_probs);
+
+  m.def("top_k_mask_logits(Tensor logits, Tensor mask_logits, Tensor? maybe_top_k_arr, int top_k_val) -> ()");
+  m.impl("top_k_mask_logits", torch::kMUSA, &top_k_mask_logits);
+}
+
+REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/pyproject_musa.toml
+++ b/sgl-kernel/pyproject_musa.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = [
+  "setuptools>=75.0",
+  "scikit-build-core>=0.10",
+  "torch",
+  "torchada>=0.1.14",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sgl-kernel"
+version = "0.3.20"
+description = "Kernel Library for SGLang"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: Apache Software License",
+  "Environment :: GPU :: MTHREADS MUSA"
+]
+dependencies = []
+
+[project.urls]
+"Homepage" = "https://github.com/sgl-project/sglang/tree/main/sgl-kernel"
+"Bug Tracker" = "https://github.com/sgl-project/sglang/issues"
+
+[tool.wheel]
+exclude = [
+  "dist*",
+  "tests*",
+]

--- a/sgl-kernel/setup_musa.py
+++ b/sgl-kernel/setup_musa.py
@@ -1,0 +1,205 @@
+# Copyright 2025 SGLang Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+# isort: off
+import torch
+import torchada  # noqa: F401
+
+# isort: on
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+root = Path(__file__).parent.resolve()
+third_party = Path("third_party")
+arch = platform.machine().lower()
+
+
+class _RepoInfo:
+    """Configuration for a third-party git repository."""
+
+    def __init__(self, name, git_repository, git_tag, git_shallow=False):
+        self.name = name
+        self.git_repository = git_repository
+        self.git_tag = git_tag
+        self.git_shallow = git_shallow
+        self.source_dir = third_party / name
+
+
+_FLASHINFER_REPO = _RepoInfo(
+    name="flashinfer",
+    git_repository="https://github.com/flashinfer-ai/flashinfer.git",
+    git_tag="bc29697ba20b7e6bdb728ded98f04788e16ee021",
+    git_shallow=False,
+)
+
+_MUTLASS_REPO = _RepoInfo(
+    name="mutlass",
+    git_repository="https://github.com/MooreThreads/mutlass.git",
+    git_tag="3abd6a728aacd190df0d922514aca8a8bc3c46b7",
+    git_shallow=False,
+)
+
+
+def _get_version():
+    with open(root / "pyproject.toml") as f:
+        for line in f:
+            if line.startswith("version"):
+                return line.split("=")[1].strip().strip('"')
+
+
+operator_namespace = "sgl_kernel"
+include_dirs = [
+    root / "include",
+    root / "include" / "impl",
+    root / "csrc",
+    root / _FLASHINFER_REPO.source_dir / "include",
+    root / _FLASHINFER_REPO.source_dir / "csrc",
+    root / _MUTLASS_REPO.source_dir / "include",
+]
+
+sources = [
+    "csrc/common_extension_musa.cc",
+    str(_FLASHINFER_REPO.source_dir / "csrc/norm.cu"),
+    str(_FLASHINFER_REPO.source_dir / "csrc/renorm.cu"),
+    str(_FLASHINFER_REPO.source_dir / "csrc/sampling.cu"),
+]
+
+cxx_flags = ["force_mcc"]
+libraries = ["c10", "torch", "torch_python"]
+extra_link_args = [
+    "-Wl,-rpath,$ORIGIN/../../torch/lib",
+    f"-L/usr/lib/{arch}-linux-gnu",
+    "-lmublasLt",
+]
+
+default_target = "mp_31"
+mtgpu_target = os.environ.get("MTGPU_TARGET", default_target)
+
+if torch.musa.is_available():
+    try:
+        prop = torch.musa.get_device_properties(0)
+        mtgpu_target = f"mp_{prop.major}{prop.minor}"
+    except Exception as e:
+        print(f"Warning: Failed to detect GPU properties: {e}")
+else:
+    print(f"Warning: torch.musa not available. Using default target: {mtgpu_target}")
+
+if mtgpu_target not in ["mp_22", "mp_31"]:
+    print(
+        f"Warning: Unsupported GPU architecture detected '{mtgpu_target}'. Expected 'mp_22' or 'mp_31'."
+    )
+    sys.exit(1)
+
+mcc_flags = [
+    "-DNDEBUG",
+    f"-DOPERATOR_NAMESPACE={operator_namespace}",
+    "-O3",
+    "-fPIC",
+    "-std=c++17",
+    f"--cuda-gpu-arch={mtgpu_target}",
+    "-x",
+    "musa",
+    "-mtgpu",
+    "-Od3",
+    "-ffast-math",
+    "-fmusa-flush-denormals-to-zero",
+    "-fno-strict-aliasing",
+    "-DUSE_MUSA",
+    "-DENABLE_BF16",
+    "-DFLASHINFER_ENABLE_F16",
+    "-DFLASHINFER_ENABLE_BF16",
+]
+
+if mtgpu_target == "mp_31":
+    mcc_flags.extend(
+        [
+            "-DENABLE_FP8",
+            "-DFLASHINFER_ENABLE_FP8",
+            "-DFLASHINFER_ENABLE_FP8_E4M3",
+            "-DFLASHINFER_ENABLE_FP8_E5M2",
+        ]
+    )
+
+ext_modules = [
+    CUDAExtension(
+        name="sgl_kernel.common_ops",
+        sources=sources,
+        include_dirs=include_dirs,
+        extra_compile_args={
+            "mcc": mcc_flags,
+            "cxx": cxx_flags,
+        },
+        libraries=libraries,
+        extra_link_args=extra_link_args,
+        py_limited_api=False,
+    ),
+]
+
+
+class _CustomBuildExt(BuildExtension):
+    """Custom build extension that clones third-party repositories before building."""
+
+    @staticmethod
+    def _clone_and_checkout(repo_path, repo_url, git_tag, git_shallow):
+        """Clone a git repository and checkout a specific tag/commit."""
+        repo_path.parent.mkdir(exist_ok=True)
+        if not repo_path.exists():
+            clone_cmd = ["git", "clone"]
+            if git_shallow:
+                clone_cmd += ["--depth", "1"]
+            clone_cmd += [repo_url, str(repo_path)]
+            subprocess.check_call(clone_cmd)
+            subprocess.check_call(["git", "checkout", git_tag], cwd=repo_path)
+        else:
+            subprocess.check_call(["git", "fetch", "--all"], cwd=repo_path)
+            subprocess.check_call(["git", "checkout", git_tag], cwd=repo_path)
+
+    def run(self):
+        if os.environ.get("SKIP_THIRD_PARTY", "0") == "1":
+            print("Skipping third-party repositories cloning (SKIP_THIRD_PARTY=1)")
+        else:
+            print("Cloning third-party repositories...")
+            self._clone_and_checkout(
+                _MUTLASS_REPO.source_dir,
+                _MUTLASS_REPO.git_repository,
+                _MUTLASS_REPO.git_tag,
+                _MUTLASS_REPO.git_shallow,
+            )
+            self._clone_and_checkout(
+                _FLASHINFER_REPO.source_dir,
+                _FLASHINFER_REPO.git_repository,
+                _FLASHINFER_REPO.git_tag,
+                _FLASHINFER_REPO.git_shallow,
+            )
+            print("Third-party repositories ready.")
+
+        super().run()
+
+
+setup(
+    name="sgl-kernel",
+    version=_get_version(),
+    packages=find_packages(where="python"),
+    package_dir={"": "python"},
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": _CustomBuildExt.with_options(use_ninja=True)},
+    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is the second in a series of pull requests (tracked in https://github.com/sgl-project/sglang/issues/16565) to add full support for [Moore Threads](https://en.mthreads.com/) GPUs, leveraging MUSA (Meta-computing Unified System Architecture) to accelerate LLM inference.

## Modifications

<!-- Detail the changes made in this pull request. -->
Following the AMD approach, we add a small set of MUSA-specific files:

1. `pyproject_musa.toml`: used later during the Docker build.
2. `setup_musa.py`: builds the MUSA extension.
3. `common_extension_musa.cc`: provides Python bindings for the C++ sources.

### Testing Done

Tested in a clean torch_musa container:

```bash
root@worker3218:/ws/sgl-kernel# python setup_musa.py install
2026-01-14 10:33:33 | dist | 140527655466112 | INFO : running install
2026-01-14 10:33:33 | warnings | 140527655466112 | WARNING : /usr/local/lib/python3.10/dist-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()

2026-01-14 10:33:33 | warnings | 140527655466112 | WARNING : /usr/local/lib/python3.10/dist-packages/setuptools/_distutils/cmd.py:66: EasyInstallDeprecationWarning: easy_install command is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` and ``easy_install``.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://github.com/pypa/setuptools/issues/917 for details.
        ********************************************************************************

!!
  self.initialize_options()

2026-01-14 10:33:33 | dist | 140527655466112 | INFO : running bdist_egg
2026-01-14 10:33:33 | dist | 140527655466112 | INFO : running egg_info
2026-01-14 10:33:33 | egg_info | 140527655466112 | INFO : writing python/sgl_kernel.egg-info/PKG-INFO
2026-01-14 10:33:33 | egg_info | 140527655466112 | INFO : writing dependency_links to python/sgl_kernel.egg-info/dependency_links.txt
2026-01-14 10:33:33 | egg_info | 140527655466112 | INFO : writing top-level names to python/sgl_kernel.egg-info/top_level.txt
2026-01-14 10:33:33 | egg_info | 140527655466112 | INFO : adding license file 'LICENSE'
2026-01-14 10:33:33 | util | 140527655466112 | INFO : writing manifest file 'python/sgl_kernel.egg-info/SOURCES.txt'
2026-01-14 10:33:33 | bdist_egg | 140527655466112 | INFO : installing library code to build/bdist.linux-x86_64/egg
2026-01-14 10:33:33 | dist | 140527655466112 | INFO : running install_lib
2026-01-14 10:33:33 | dist | 140527655466112 | INFO : running build_py
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/attention.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/spatial.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/gemm.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/__init__.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/sampling.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/sparse_flash_attn.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/cutlass_moe.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/test_utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/memory.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/fused_moe.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/elementwise.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/flash_mla.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/_fa4_interface.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/expert_specialization.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/marlin.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/flash_attn.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/kvcacheio.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/hadamard.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/version.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/mamba.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/top_k.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/moe.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/allreduce.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/load_utils.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/grammar.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/speculative.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/scalar_type.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/testing/rotary_embedding.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/testing
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/testing/__init__.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/testing
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/quantization/__init__.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/quantization
2026-01-14 10:33:33 | file_util | 140527655466112 | INFO : copying python/sgl_kernel/quantization/gguf.py -> build/lib.linux-x86_64-cpython-310/sgl_kernel/quantization
2026-01-14 10:33:33 | dist | 140527655466112 | INFO : running build_ext
Cloning third-party repositories...
Fetching origin
HEAD is now at 3abd6a72 update minimum compiler version
Fetching origin
HEAD is now at bc29697b ci: collect module status and update flashinfer-cli (#1676)
Third-party repositories ready.
Emitting ninja build file /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/build.ninja...
Compiling objects...
Using envvar MAX_JOBS (128) as the number of workers...
[1/4] /usr/local/musa/bin/mcc -MD -MF /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/third_party/flashinfer/csrc_musa/norm.o.d -I/ws/sgl-kernel/include_musa -I/ws/sgl-kernel/include -I/ws/sgl-kernel/include/impl -I/ws/sgl-kernel/csrc_musa -I/ws/sgl-kernel/csrc -I/ws/sgl-kernel/third_party/flashinfer/include_musa -I/ws/sgl-kernel/third_party/flashinfer/include -I/ws/sgl-kernel/third_party/flashinfer/csrc_musa -I/ws/sgl-kernel/third_party/flashinfer/csrc -I/ws/sgl-kernel/third_party/mutlass/include_musa -I/ws/sgl-kernel/third_party/mutlass/include -I/usr/local/musa/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/aten/src -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/torch_musa_codegen -I/usr/local/lib/python3.10/dist-packages -I/usr/local/musa/include -I/usr/include/python3.10 -c -c /ws/sgl-kernel/third_party/flashinfer/csrc_musa/norm.mu -o /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/third_party/flashinfer/csrc_musa/norm.o -fPIC -DNDEBUG -DOPERATOR_NAMESPACE=sgl_kernel -O3 -fPIC -std=c++17 --cuda-gpu-arch=mp_31 -x musa -mtgpu -Od3 -ffast-math -fmusa-flush-denormals-to-zero -fno-strict-aliasing -DUSE_MUSA -DENABLE_BF16 -DFLASHINFER_ENABLE_F16 -DFLASHINFER_ENABLE_BF16 -DENABLE_FP8 -DFLASHINFER_ENABLE_FP8 -DFLASHINFER_ENABLE_FP8_E4M3 -DFLASHINFER_ENABLE_FP8_E5M2 --offload-arch=mp_31 -march=native -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=common_ops -D_GLIBCXX_USE_CXX11_ABI=1
[2/4] /usr/local/musa/bin/mcc -MD -MF /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/third_party/flashinfer/csrc_musa/renorm.o.d -I/ws/sgl-kernel/include_musa -I/ws/sgl-kernel/include -I/ws/sgl-kernel/include/impl -I/ws/sgl-kernel/csrc_musa -I/ws/sgl-kernel/csrc -I/ws/sgl-kernel/third_party/flashinfer/include_musa -I/ws/sgl-kernel/third_party/flashinfer/include -I/ws/sgl-kernel/third_party/flashinfer/csrc_musa -I/ws/sgl-kernel/third_party/flashinfer/csrc -I/ws/sgl-kernel/third_party/mutlass/include_musa -I/ws/sgl-kernel/third_party/mutlass/include -I/usr/local/musa/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/aten/src -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/torch_musa_codegen -I/usr/local/lib/python3.10/dist-packages -I/usr/local/musa/include -I/usr/include/python3.10 -c -c /ws/sgl-kernel/third_party/flashinfer/csrc_musa/renorm.mu -o /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/third_party/flashinfer/csrc_musa/renorm.o -fPIC -DNDEBUG -DOPERATOR_NAMESPACE=sgl_kernel -O3 -fPIC -std=c++17 --cuda-gpu-arch=mp_31 -x musa -mtgpu -Od3 -ffast-math -fmusa-flush-denormals-to-zero -fno-strict-aliasing -DUSE_MUSA -DENABLE_BF16 -DFLASHINFER_ENABLE_F16 -DFLASHINFER_ENABLE_BF16 -DENABLE_FP8 -DFLASHINFER_ENABLE_FP8 -DFLASHINFER_ENABLE_FP8_E4M3 -DFLASHINFER_ENABLE_FP8_E5M2 --offload-arch=mp_31 -march=native -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=common_ops -D_GLIBCXX_USE_CXX11_ABI=1
[3/4] /usr/local/musa/bin/mcc -x musa -MMD -MF /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/csrc_musa/common_extension_musa.o.d -I/ws/sgl-kernel/include_musa -I/ws/sgl-kernel/include -I/ws/sgl-kernel/include/impl -I/ws/sgl-kernel/csrc_musa -I/ws/sgl-kernel/csrc -I/ws/sgl-kernel/third_party/flashinfer/include_musa -I/ws/sgl-kernel/third_party/flashinfer/include -I/ws/sgl-kernel/third_party/flashinfer/csrc_musa -I/ws/sgl-kernel/third_party/flashinfer/csrc -I/ws/sgl-kernel/third_party/mutlass/include_musa -I/ws/sgl-kernel/third_party/mutlass/include -I/usr/local/musa/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/aten/src -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/torch_musa_codegen -I/usr/local/lib/python3.10/dist-packages -I/usr/local/musa/include -I/usr/include/python3.10 -c -c /ws/sgl-kernel/csrc_musa/common_extension_musa.cc -o /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/csrc_musa/common_extension_musa.o -fPIC -DNDEBUG -DOPERATOR_NAMESPACE=sgl_kernel -O3 -fPIC -std=c++17 --cuda-gpu-arch=mp_31 -x musa -mtgpu -Od3 -ffast-math -fmusa-flush-denormals-to-zero -fno-strict-aliasing -DUSE_MUSA -DENABLE_BF16 -DFLASHINFER_ENABLE_F16 -DFLASHINFER_ENABLE_BF16 -DENABLE_FP8 -DFLASHINFER_ENABLE_FP8 -DFLASHINFER_ENABLE_FP8_E4M3 -DFLASHINFER_ENABLE_FP8_E5M2 --offload-arch=mp_31 -march=native -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=common_ops -D_GLIBCXX_USE_CXX11_ABI=1
[4/4] /usr/local/musa/bin/mcc -MD -MF /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/third_party/flashinfer/csrc_musa/sampling.o.d -I/ws/sgl-kernel/include_musa -I/ws/sgl-kernel/include -I/ws/sgl-kernel/include/impl -I/ws/sgl-kernel/csrc_musa -I/ws/sgl-kernel/csrc -I/ws/sgl-kernel/third_party/flashinfer/include_musa -I/ws/sgl-kernel/third_party/flashinfer/include -I/ws/sgl-kernel/third_party/flashinfer/csrc_musa -I/ws/sgl-kernel/third_party/flashinfer/csrc -I/ws/sgl-kernel/third_party/mutlass/include_musa -I/ws/sgl-kernel/third_party/mutlass/include -I/usr/local/musa/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/aten/src -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/torch_musa_codegen -I/usr/local/lib/python3.10/dist-packages -I/usr/local/musa/include -I/usr/include/python3.10 -c -c /ws/sgl-kernel/third_party/flashinfer/csrc_musa/sampling.mu -o /ws/sgl-kernel/build/temp.linux-x86_64-cpython-310/ws/sgl-kernel/third_party/flashinfer/csrc_musa/sampling.o -fPIC -DNDEBUG -DOPERATOR_NAMESPACE=sgl_kernel -O3 -fPIC -std=c++17 --cuda-gpu-arch=mp_31 -x musa -mtgpu -Od3 -ffast-math -fmusa-flush-denormals-to-zero -fno-strict-aliasing -DUSE_MUSA -DENABLE_BF16 -DFLASHINFER_ENABLE_F16 -DFLASHINFER_ENABLE_BF16 -DENABLE_FP8 -DFLASHINFER_ENABLE_FP8 -DFLASHINFER_ENABLE_FP8_E4M3 -DFLASHINFER_ENABLE_FP8_E5M2 --offload-arch=mp_31 -march=native -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=common_ops -D_GLIBCXX_USE_CXX11_ABI=1
2026-01-14 10:35:12 | easy_install | 140527655466112 | INFO : Adding sgl-kernel 0.3.20 to easy-install.pth file
2026-01-14 10:35:12 | easy_install | 140527655466112 | INFO : 
Installed /usr/local/lib/python3.10/dist-packages/sgl_kernel-0.3.20-py3.10-linux-x86_64.egg
2026-01-14 10:35:12 | easy_install | 140527655466112 | INFO : Processing dependencies for sgl-kernel==0.3.20
2026-01-14 10:35:12 | easy_install | 140527655466112 | INFO : Finished processing dependencies for sgl-kernel==0.3.20
root@worker3218:/ws/sgl-kernel# 
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
