### PR TITLE
[SWA] fix swa radix cache match_len_since_tombstone update when hits swa_tombstone

### DIFF
--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -818,13 +818,12 @@ class SWARadixCache(BasePrefixCache):
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
 
-            # update best_value_len and best_last_node if needed
-            if (
-                child.swa_tombstone
-                and match_len_since_tombstone >= self.sliding_window_size
-            ):
-                best_value_len = len(value)
-                best_last_node = node
+            if child.swa_tombstone:
+                # update best_value_len and best_last_node if needed
+                if match_len_since_tombstone >= self.sliding_window_size:
+                    best_value_len = len(value)
+                    best_last_node = node
+                # reset match_len_since_tombstone if we hit a tombstone node
                 match_len_since_tombstone = 0
 
             prefix_len = self.key_match_fn(child.key, key)


### PR DESCRIPTION
co-author by: @yizhang2077 

## Summary
- always reset `match_len_since_tombstone` when a `swa_tombstone` is hit