### PR TITLE
[tokenizer] perf: optimize batch output processing to reduce first-token latency

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1528,10 +1528,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             field_name = field.name
             field_value = getattr(recv_obj, field_name, None)
 
-            # Skip None values
-            if field_value is None:
-                continue
-
             # Handle dict with list values (e.g., customized_info)
             if isinstance(field_value, dict):
                 chunk_dict[field_name] = {
@@ -1540,7 +1536,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             # Handle list/tuple types with slicing
             elif isinstance(field_value, (list, tuple)):
                 chunk_dict[field_name] = field_value[start_idx:end_idx]
-            # For other types (e.g., load object), copy as-is
+            # For None and other types (e.g., load object), copy as-is
             else:
                 chunk_dict[field_name] = field_value
 
@@ -1626,11 +1622,11 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                     ]
 
             # Add optional outputs (batch-level checks)
-            if has_hidden_states:
+            if has_hidden_states and recv_obj.output_hidden_states:
                 meta_info["hidden_states"] = recv_obj.output_hidden_states[i]
-            if has_routed_experts:
+            if has_routed_experts and recv_obj.routed_experts:
                 meta_info["routed_experts"] = recv_obj.routed_experts[i]
-            if has_customized_info:
+            if has_customized_info and recv_obj.customized_info:
                 customized_info = recv_obj.customized_info
                 for k in customized_info:
                     meta_info[k] = customized_info[k][i]

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1481,12 +1481,18 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 recv_obj = await self.recv_from_detokenizer.recv_pyobj()
 
             # If batch size limit is set and batch exceeds limit, process in chunks
-            if max_batch_size > 0 and hasattr(recv_obj, 'rids') and len(recv_obj.rids) > max_batch_size:
+            if (
+                max_batch_size > 0
+                and hasattr(recv_obj, "rids")
+                and len(recv_obj.rids) > max_batch_size
+            ):
                 batch_size = len(recv_obj.rids)
                 # Process in chunks to reduce latency for first token
                 for start_idx in range(0, batch_size, max_batch_size):
                     end_idx = min(start_idx + max_batch_size, batch_size)
-                    chunk_recv_obj = self._create_batch_chunk(recv_obj, start_idx, end_idx)
+                    chunk_recv_obj = self._create_batch_chunk(
+                        recv_obj, start_idx, end_idx
+                    )
                     self._result_dispatcher(chunk_recv_obj)
                     # Feed watchdog between chunks to prevent timeout
                     self.soft_watchdog.feed()
@@ -1661,7 +1667,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 }
             elif is_multimodal_output:
                 raise NotImplementedError("BatchMultimodalOut not implemented")
-            
+
             else:
                 assert is_embedding, "Only BatchEmbeddingOutput is supported for now."
                 # BatchEmbeddingOutput

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1621,7 +1621,9 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 meta_info["cached_tokens"] = recv_obj.cached_tokens[i]
                 # Add detailed cache breakdown if available
                 if has_cached_tokens_details:
-                    meta_info["cached_tokens_details"] = recv_obj.cached_tokens_details[i]
+                    meta_info["cached_tokens_details"] = recv_obj.cached_tokens_details[
+                        i
+                    ]
 
             # Add optional outputs (batch-level checks)
             if has_hidden_states:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -338,6 +338,10 @@ class ServerArgs:
     disable_hybrid_swa_memory: bool = False
     radix_eviction_policy: str = "lru"
     enable_prefill_delayer: bool = False
+    # Limit the batch size for detokenizer output processing in tokenizer_manager.
+    # This helps reduce first-token latency under high concurrency by processing
+    # smaller batches more frequently. Set to 0 to disable batching limits.
+    max_detokenizer_batch_size: int = 0
     prefill_delayer_max_delay_passes: int = 30
     prefill_delayer_token_usage_low_watermark: Optional[float] = None
     prefill_delayer_forward_passes_buckets: Optional[List[float]] = None
@@ -3043,6 +3047,14 @@ class ServerArgs:
             type=int,
             default=ServerArgs.max_running_requests,
             help="The maximum number of running requests.",
+        )
+        parser.add_argument(
+            "--max-detokenizer-batch-size",
+            type=int,
+            default=ServerArgs.max_detokenizer_batch_size,
+            help="The maximum batch size for detokenizer output processing in tokenizer_manager. "
+            "This helps reduce first-token latency under high concurrency by processing smaller batches more frequently. "
+            "Set to 0 to disable batching limits (default).",
         )
         parser.add_argument(
             "--max-queued-requests",


### PR DESCRIPTION


  

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  ### Problem

  Under high-concurrency VLM workloads (#17021), we observe abnormally high first-token latency where the LLM has already produced the first token, but the client receives it much later.

  ### Root Cause

  1. `_handle_batch_output` processing time increases with batch size
  2. Many redundant condition checks and attribute lookups in the loop

## Modifications

### Changes

  - Move batch-level condition checks (`enable_metrics`, `isinstance`) outside loop
  - Pre-compute batch-level attributes to avoid repeated `getattr`/`isinstance`
  - Use `dataclasses.fields()` introspection for `_create_batch_chunk` to avoid hardcoded attribute list
  - Add `--max-detokenizer-batch-size` parameter to limit processing batch size

  ### Usage

  To reproduce and verify the fix for issue #17021:

  **Before (high first-token latency):**
  ```bash
  SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
  python -m sglang.launch_server \
    --model-path Qwen/Qwen3-VL-8B-Instruct \
    --host 0.0.0.0 \
    --port 30000 \
    --trust-remote-code \
    --tp-size 1 \
    --enable-cache-report \
    --max-running-requests 128 \
    --mem-fraction-static 0.7 \
    --chunked-prefill-size 8192 \
    --attention-backend fa3 \
    --mm-attention-backend fa3 \
    --log-level debug \
    --log-requests \
    --log-requests-level 1

  After (with reduced first-token latency):
  SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
  python -m sglang.launch_server \
    --model-path Qwen/Qwen3-VL-8B-Instruct \
    --host 0.0.0.0 \
    --port 30000 \
    --trust-remote-code \
    --tp-size 1 \
    --enable-cache-report \
    --max-running-requests 128 \
    --mem-fraction-static 0.7 \
    --chunked-prefill-size 8192 \
    --attention-backend fa3 \
    --mm-attention-backend fa3 \
    --max-detokenizer-batch-size 16 \
    --log-level debug \
    --log-requests \
    --log-requests-level 1

  Related: #17021
  ```


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
