### PR TITLE
[DeepSeek V3.2] [Bugfix] slice indexer and padding fa3 when can not run cuda graph

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -86,6 +86,11 @@ class BaseIndexerMetadata(ABC):
         Return: seq lens for each batch.
         """
 
+    def get_nsa_extend_len_cpu(self) -> List[int]:
+        """
+        Return: extend seq lens for each batch.
+        """
+
     def get_token_to_batch_idx(self) -> torch.Tensor:
         """
         Return: batch idx for each token.
@@ -390,6 +395,7 @@ class Indexer(MultiPlatformOp):
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
 
+        q_offset = sum(metadata.get_nsa_extend_len_cpu())
         if _is_hip:
             from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
 
@@ -416,9 +422,9 @@ class Indexer(MultiPlatformOp):
             )
         else:
             logits = deep_gemm.fp8_paged_mqa_logits(
-                q_fp8,
+                q_fp8[:q_offset],
                 kv_cache_fp8,
-                weights,
+                weights[:q_offset],
                 seqlens_32,
                 block_tables,
                 schedule_metadata,
@@ -428,6 +434,15 @@ class Indexer(MultiPlatformOp):
 
         # NOTE(dark): logits should be cleaned in topk_transform
         topk_result = metadata.topk_transform(logits, self.index_topk)
+        if not _is_hip and q_offset < q_fp8.shape[0]:
+            pad_len = q_fp8.shape[0] - q_offset
+            padding = torch.full(
+                (pad_len, topk_result.shape[1]),
+                -1,
+                dtype=topk_result.dtype,
+                device=topk_result.device,
+            )
+            topk_result = torch.cat([topk_result, padding], dim=0)
         return topk_result
 
     def _should_chunk_mqa_logits(

--- a/python/sglang/srt/layers/attention/nsa/utils.py
+++ b/python/sglang/srt/layers/attention/nsa/utils.py
@@ -9,12 +9,15 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.dp_attention import (
+    DpPaddingMode,
     attn_tp_all_gather_into_tensor,
+    get_attention_dp_rank,
     get_attention_tp_group,
     get_attention_tp_rank,
     get_attention_tp_size,
 )
 from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils.common import ceil_align, ceil_div
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -82,11 +85,28 @@ def nsa_cp_round_robin_split_data(input_: Union[torch.Tensor, List]):
 
 
 def pad_nsa_cache_seqlens(forward_batch: "ForwardBatch", nsa_cache_seqlens):
-    attn_tp_size = get_attention_tp_size()
-    if attn_tp_size == 1 or not can_nsa_prefill_cp_round_robin_split(forward_batch):
+    if forward_batch.global_num_tokens_cpu is None:
         return nsa_cache_seqlens
-    tokens = sum(forward_batch.extend_seq_lens_cpu)
-    pad_len = (tokens - 1) // attn_tp_size + 1 - nsa_cache_seqlens.shape[0]
+
+    global_num_tokens = forward_batch.global_num_tokens_cpu.copy()
+    # same with ForwardBatch.prepare_mlp_sync_batch
+    sync_group_size = len(global_num_tokens)
+    attn_tp_size = get_attention_tp_size()
+    for i in range(sync_group_size):
+        global_num_tokens[i] = ceil_align(global_num_tokens[i], attn_tp_size)
+    dp_padding_mode = DpPaddingMode.get_dp_padding_mode(
+        forward_batch.is_extend_in_batch, global_num_tokens
+    )
+    if dp_padding_mode.is_max_len():
+        tokens = max(forward_batch.global_num_tokens_cpu)
+    elif len(global_num_tokens) > 1:
+        tokens = global_num_tokens[get_attention_dp_rank()]
+    else:
+        tokens = global_num_tokens[0]
+
+    if can_nsa_prefill_cp_round_robin_split(forward_batch):
+        tokens = ceil_div(tokens, attn_tp_size)
+    pad_len = tokens - nsa_cache_seqlens.shape[0]
     if pad_len > 0:
         nsa_cache_seqlens = torch.cat(
             [

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -189,6 +189,9 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
     def get_indexer_seq_len_cpu(self) -> torch.Tensor:
         return self.attn_metadata.indexer_seq_lens_cpu
 
+    def get_nsa_extend_len_cpu(self) -> List[int]:
+        return self.attn_metadata.nsa_extend_seq_lens_list
+
     def get_token_to_batch_idx(self) -> torch.Tensor:
         return self.attn_metadata.token_to_batch_idx
 

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -290,7 +290,7 @@ class CudaGraphRunner:
 
         # Batch sizes to capture
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(
-            model_runner, self.num_tokens_per_bs
+            model_runner, self.num_tokens_per_bs if self.nsa_enable_prefill_cp else 1
         )
         log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
         if KTRANSFORMERS_AVAILABLE:

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -290,7 +290,7 @@ class CudaGraphRunner:
 
         # Batch sizes to capture
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(
-            model_runner, self.num_tokens_per_bs if self.nsa_enable_prefill_cp else 1
+            model_runner, self.num_tokens_per_bs
         )
         log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
         if KTRANSFORMERS_AVAILABLE:

--- a/test/registered/kernels/test_nsa_indexer.py
+++ b/test/registered/kernels/test_nsa_indexer.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -131,6 +131,12 @@ class MockIndexerMetadata(BaseIndexerMetadata):
     def get_indexer_seq_len_cpu(self) -> torch.Tensor:
         """Return: seq lens for each batch."""
         return torch.tensor(self.seq_lens, dtype=torch.int32, device="cpu")
+
+    def get_nsa_extend_len_cpu(self) -> List[int]:
+        """
+        Return: extend seq lens for each batch.
+        """
+        return list(self.seq_lens)
 
     def get_token_to_batch_idx(self) -> torch.Tensor:
         """Return: batch idx for each token."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR #15227 only resolves the issue occurring during `forward_idle`.  If running in Eagle mode (MTP Spec2, batch size exceeding the CUDA maximum batch size, or with `disable-cuda-graph` enabled), the DP padding mode is set to `MAX_LEN`, or the `attn_tp_size` > 1, padding may be applied to tokens or batch sizes. In such cases, a batch size misalignment issue will occur, leading to errors in both the indexer and FA3.

1、Fixed the issue where in ds3.2 cp, decode and draft extend does not support eagle. The reason is that 
- The input is padded  via `prepare_mlp_sync_batch`, and `nsa_cache_seqlens_int32` also needs to be padded; otherwise, the fa3 implementation will report a mismatch in input batch size.
- The input `q_fp8` and `weights` in `deep_gemm.fp8_paged_mqa_logits` have been padded , while the batch sizes of other inputs such as `block_tables` remain the actual batch size. There is a need to retrieve `q_fp8` and `weights` corresponding to the actual batch.

~~2、Added support for ds3.2 spec v2 draft extend cuda graph mode.~~

~~3、Optimized the calculation of `seqlens_expanded` in `draft_extend_v2` and `target_verify` scenarios by replacing multiple batches of `arange+cat` operations with a single `add`.~~

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
export SGLANG_ENABLE_SPEC_V2=1
MODEL_PATH=/home/models/DeepSeek-V3.2/

python3 -m sglang.launch_server --model-path $MODEL_PATH --trust-remote-code \
--port 8000 --host 0.0.0.0 --attention-backend  nsa \
--enable-metrics --mem-fraction-static 0.8 --max-running-requests 128 --enable-cache-report --page-size 64 \
--tp-size 8 --moe-dense-tp-size 1 \
--tool-call-parser deepseekv32 \
--reasoning-parser deepseek-v3 \
--moe-dense-tp-size 1 \
--chunked-prefill-size 16384 \
--nsa-decode-backend fa3 \
--enable-nsa-prefill-context-parallel \
--nsa-prefill-cp-mode round-robin-split \
--speculative-algorithm EAGLE \
--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4
```

```
# gsm8k
Accuracy: 0.947
Invalid: 0.000
Latency: 207.892 s
Output throughput: 596.477 token/s
```

```
# mmlu
subject: abstract_algebra, #q:100, acc: 0.820
subject: anatomy, #q:135, acc: 0.867
subject: astronomy, #q:152, acc: 0.954
subject: business_ethics, #q:100, acc: 0.870
subject: clinical_knowledge, #q:265, acc: 0.917
subject: college_biology, #q:144, acc: 0.965
subject: college_chemistry, #q:100, acc: 0.640
subject: college_computer_science, #q:100, acc: 0.910
subject: college_mathematics, #q:100, acc: 0.860
subject: college_medicine, #q:173, acc: 0.867
subject: college_physics, #q:102, acc: 0.902
subject: computer_security, #q:100, acc: 0.900
subject: conceptual_physics, #q:235, acc: 0.932
subject: econometrics, #q:114, acc: 0.781
subject: electrical_engineering, #q:145, acc: 0.897
subject: elementary_mathematics, #q:378, acc: 0.952
subject: formal_logic, #q:126, acc: 0.841
subject: global_facts, #q:100, acc: 0.720
subject: high_school_biology, #q:310, acc: 0.961
subject: high_school_chemistry, #q:203, acc: 0.897
subject: high_school_computer_science, #q:100, acc: 0.950
subject: high_school_european_history, #q:165, acc: 0.891
subject: high_school_geography, #q:198, acc: 0.965
subject: high_school_government_and_politics, #q:193, acc: 0.979
subject: high_school_macroeconomics, #q:390, acc: 0.923
subject: high_school_mathematics, #q:270, acc: 0.789
subject: high_school_microeconomics, #q:238, acc: 0.966
subject: high_school_physics, #q:151, acc: 0.841
subject: high_school_psychology, #q:545, acc: 0.971
subject: high_school_statistics, #q:216, acc: 0.861
subject: high_school_us_history, #q:204, acc: 0.961
subject: high_school_world_history, #q:237, acc: 0.954
subject: human_aging, #q:223, acc: 0.848
subject: human_sexuality, #q:131, acc: 0.931
subject: international_law, #q:121, acc: 0.950
subject: jurisprudence, #q:108, acc: 0.898
subject: logical_fallacies, #q:163, acc: 0.926
subject: machine_learning, #q:112, acc: 0.804
subject: management, #q:103, acc: 0.922
subject: marketing, #q:234, acc: 0.949
subject: medical_genetics, #q:100, acc: 0.940
subject: miscellaneous, #q:783, acc: 0.960
subject: moral_disputes, #q:346, acc: 0.870
subject: moral_scenarios, #q:895, acc: 0.794
subject: nutrition, #q:306, acc: 0.935
subject: philosophy, #q:311, acc: 0.907
subject: prehistory, #q:324, acc: 0.941
subject: professional_accounting, #q:282, acc: 0.872
subject: professional_law, #q:1534, acc: 0.726
subject: professional_medicine, #q:272, acc: 0.945
subject: professional_psychology, #q:612, acc: 0.907
subject: public_relations, #q:110, acc: 0.818
subject: security_studies, #q:245, acc: 0.873
subject: sociology, #q:201, acc: 0.970
subject: us_foreign_policy, #q:100, acc: 0.950
subject: virology, #q:166, acc: 0.584
subject: world_religions, #q:171, acc: 0.936
Total latency: 708.301
Average accuracy: 0.881
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Replace multiple batches of `arange+cat` operations with a single `add`:
<img width="1494" height="872" alt="image" src="https://github.com/user-attachments/assets/d43972ab-6bcd-4f70-a8ef-ef220f23e350" />
<img width="2348" height="976" alt="image" src="https://github.com/user-attachments/assets/2b9df2fc-ef79-42f2-8dd6-a93cdd0478e5" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
