### PR TITLE
[Diffusion] Revise Diffusion FA backend to support blackwell

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -1,5 +1,4 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
-
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 from functools import lru_cache
@@ -21,11 +20,18 @@ except ImportError as e:
     raise e
 
 
-def maybe_contiguous(x):
+def maybe_contiguous(x: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
 
-def flash_attn_varlen_func_fake(
+# -----------------------------
+# Fake implementations for schema / tracing
+# custom op schema requires FIXED return structure.
+# We provide TWO ops:
+# 1) out-only op: always returns Tensor
+# 2) out+lse op: always returns Tuple[Tensor, Tensor]
+# -----------------------------
+def flash_attn_varlen_func_fake_out(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -51,6 +57,66 @@ def flash_attn_varlen_func_fake(
     return_softmax_lse: bool = False,
     sinks: Optional[torch.Tensor] = None,
     ver: int = 4,
+) -> torch.Tensor:
+    assert ver == 4, "only support flash attention v4"
+    q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
+    num_head, head_dim = q.shape[-2:]
+    if cu_seqlens_q is None:
+        batch_size, seqlen_q = q.shape[:2]
+    else:
+        batch_size = cu_seqlens_q.shape[0] - 1
+        seqlen_q = None
+    head_dim_v = v.shape[-1]
+
+    if cu_seqlens_q is not None:
+        assert cu_seqlens_q.shape == (
+            batch_size + 1,
+        ), "cu_seqlens_q must have shape (batch_size + 1,)"
+        assert cu_seqlens_q.dtype == torch.int32, "cu_seqlens_q must be int32"
+        assert cu_seqlens_q.stride(0) == 1, "cu_seqlens_q must be contiguous"
+
+    assert q.dtype in [
+        torch.float16,
+        torch.bfloat16,
+    ], "inputs must be float16 or bfloat16"
+    assert q.dtype == k.dtype == v.dtype, "inputs must have the same dtype"
+    assert head_dim <= 256, "head_dim must be less than or equal to 256"
+    alignment = 16 // q.element_size()
+    assert head_dim_v % alignment == 0, f"head_dim_v must be divisible by {alignment}"
+
+    q_batch_seqlen_shape = (
+        (batch_size, seqlen_q) if cu_seqlens_q is None else (q.shape[0],)
+    )
+    out = q.new_empty(*q_batch_seqlen_shape, num_head, head_dim_v)
+    return out
+
+
+def flash_attn_varlen_func_fake_out_lse(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    qv: Optional[torch.Tensor] = None,
+    q_descale: Optional[torch.Tensor] = None,
+    k_descale: Optional[torch.Tensor] = None,
+    v_descale: Optional[torch.Tensor] = None,
+    window_size: Optional[List[int]] = None,
+    attention_chunk: int = 0,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    sm_margin: int = 0,
+    return_softmax_lse: bool = True,
+    sinks: Optional[torch.Tensor] = None,
+    ver: int = 4,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert ver == 4, "only support flash attention v4"
     q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
@@ -63,12 +129,14 @@ def flash_attn_varlen_func_fake(
         seqlen_q = None
         total_q = q.shape[0]
     head_dim_v = v.shape[-1]
+
     if cu_seqlens_q is not None:
         assert cu_seqlens_q.shape == (
             batch_size + 1,
         ), "cu_seqlens_q must have shape (batch_size + 1,)"
         assert cu_seqlens_q.dtype == torch.int32, "cu_seqlens_q must be int32"
         assert cu_seqlens_q.stride(0) == 1, "cu_seqlens_q must be contiguous"
+
     assert q.dtype in [
         torch.float16,
         torch.bfloat16,
@@ -86,12 +154,18 @@ def flash_attn_varlen_func_fake(
         if cu_seqlens_q is None
         else (num_head, total_q)
     )
+
     out = q.new_empty(*q_batch_seqlen_shape, num_head, head_dim_v)
-    lse = q.new_empty(lse_shape, dtype=torch.float32) if return_softmax_lse else None
-    return (out, lse) if return_softmax_lse else out
+    lse = q.new_empty(lse_shape, dtype=torch.float32)
+    return out, lse
 
 
-@register_custom_op(fake_impl=flash_attn_varlen_func_fake)
+# -----------------------------
+# Registered custom ops
+# NOTE: fixed return schemas to avoid:
+# "Object of type 'Tensor' is not an instance of 'sequence'"
+# -----------------------------
+@register_custom_op(fake_impl=flash_attn_varlen_func_fake_out)
 def flash_attn_varlen_func_op(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -118,9 +192,14 @@ def flash_attn_varlen_func_op(
     return_softmax_lse: bool = False,
     sinks: Optional[torch.Tensor] = None,
     ver: int = 4,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     if window_size is None:
         window_size = [-1, -1]
+    if return_softmax_lse:
+        raise ValueError(
+            "flash_attn_varlen_func_op is out-only op; return_softmax_lse must be False. "
+            "Use flash_attn_varlen_func_op_lse for (out, lse)."
+        )
     return flash_attn_func(
         q,
         k,
@@ -144,7 +223,71 @@ def flash_attn_varlen_func_op(
         num_splits=num_splits,
         pack_gqa=pack_gqa,
         sm_margin=sm_margin,
-        return_softmax_lse=return_softmax_lse,
+        return_softmax_lse=False,
+        sinks=sinks,
+        ver=ver,
+    )
+
+
+@register_custom_op(fake_impl=flash_attn_varlen_func_fake_out_lse)
+def flash_attn_varlen_func_op_lse(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    qv: Optional[torch.Tensor] = None,
+    q_descale: Optional[torch.Tensor] = None,
+    k_descale: Optional[torch.Tensor] = None,
+    v_descale: Optional[torch.Tensor] = None,
+    window_size: Optional[List[int]] = None,
+    attention_chunk: int = 0,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    sm_margin: int = 0,
+    return_softmax_lse: bool = True,
+    sinks: Optional[torch.Tensor] = None,
+    ver: int = 4,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if window_size is None:
+        window_size = [-1, -1]
+    if not return_softmax_lse:
+        raise ValueError(
+            "flash_attn_varlen_func_op_lse is out+lse op; return_softmax_lse must be True. "
+            "Use flash_attn_varlen_func_op for out-only."
+        )
+    return flash_attn_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        seqused_q=seqused_q,
+        seqused_k=seqused_k,
+        page_table=page_table,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        qv=qv,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        window_size=tuple(window_size),
+        attention_chunk=attention_chunk,
+        softcap=softcap,
+        num_splits=num_splits,
+        pack_gqa=pack_gqa,
+        sm_margin=sm_margin,
+        return_softmax_lse=True,
         sinks=sinks,
         ver=ver,
     )
@@ -215,7 +358,7 @@ def _should_use_upstream_flash_attention(
     return True
 
 
-def set_fa_ver(ver: int):
+def set_fa_ver(ver: int) -> None:
     global fa_ver
     fa_ver = ver
 
@@ -234,11 +377,10 @@ class FlashAttentionMetadata:
 
 
 class FlashAttentionMetadataBuilder(AttentionMetadataBuilder):
-
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def prepare(self):
+    def prepare(self) -> None:
         pass
 
     def build(  # type: ignore
@@ -275,7 +417,6 @@ class FlashAttentionBackend(AttentionBackend):
 
 
 class FlashAttentionImpl(AttentionImpl):
-
     def __init__(
         self,
         num_heads: int,
@@ -318,9 +459,11 @@ class FlashAttentionImpl(AttentionImpl):
         else:
             max_seqlen_q = query.shape[1]
             max_seqlen_k = key.shape[1]
+
         q_shape = tuple(query.shape)
         k_shape = tuple(key.shape)
         v_shape = tuple(value.shape)
+
         use_upstream = _should_use_upstream_flash_attention(
             flash_attn_varlen_func_upstream is not None,
             self._upstream_heads_ok,
@@ -347,28 +490,59 @@ class FlashAttentionImpl(AttentionImpl):
                 return_attn_probs=return_softmax_lse,
             )
             if return_softmax_lse:
-                out, softmax_lse = out
-                return out.reshape(bsz, seqlen, nheads_q, -1), softmax_lse
+                out_tensor, softmax_lse = out
+                return out_tensor.reshape(bsz, seqlen, nheads_q, -1), softmax_lse
             return out.reshape(bsz, seqlen, nheads_q, d)
 
+        # FA version selection:
+        # - fa_ver == 3: call python function (can return Tensor or (Tensor, Tensor) depending on flag)
+        # - fa_ver == 4: call custom ops with FIXED return schema
         if fa_ver == 3:
             flash_attn_op = flash_attn_func
-        elif fa_ver == 4:
-            flash_attn_op = flash_attn_varlen_func_op
-        else:
-            raise ValueError(f"flash attention version {fa_ver} is not supported.")
+            output = flash_attn_op(
+                q=query,
+                k=key,
+                v=value,
+                cu_seqlens_q=None,
+                cu_seqlens_k=None,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=self.softmax_scale,
+                causal=self.causal,
+                return_softmax_lse=return_softmax_lse,
+                ver=fa_ver,
+            )
+            return output
 
-        output = flash_attn_op(
-            q=query,  # type: ignore[no-untyped-call]
-            k=key,
-            v=value,
-            cu_seqlens_q=None,
-            cu_seqlens_k=None,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_k=max_seqlen_k,
-            softmax_scale=self.softmax_scale,
-            causal=self.causal,
-            return_softmax_lse=return_softmax_lse,
-            ver=fa_ver,
-        )
-        return output
+        if fa_ver == 4:
+            if return_softmax_lse:
+                out_tensor, softmax_lse = flash_attn_varlen_func_op_lse(
+                    q=query,
+                    k=key,
+                    v=value,
+                    cu_seqlens_q=None,
+                    cu_seqlens_k=None,
+                    max_seqlen_q=max_seqlen_q,
+                    max_seqlen_k=max_seqlen_k,
+                    softmax_scale=self.softmax_scale,
+                    causal=self.causal,
+                    return_softmax_lse=True,
+                    ver=fa_ver,
+                )
+                return out_tensor, softmax_lse
+            out_tensor = flash_attn_varlen_func_op(
+                q=query,
+                k=key,
+                v=value,
+                cu_seqlens_q=None,
+                cu_seqlens_k=None,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=self.softmax_scale,
+                causal=self.causal,
+                return_softmax_lse=False,
+                ver=fa_ver,
+            )
+            return out_tensor
+
+        raise ValueError(f"flash attention version {fa_ver} is not supported.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Inspired by @mickqian 

Diffusion FA backend was broken due to https://github.com/sgl-project/sglang/pull/16790/. 
The reason is `register_custom_op` (implemented in the torch.library.custom_op system) uses a Python function’s type annotations to generate a fixed op schema: the input types are fixed, and the number of return values is fixed as well.

In the code, the return type is annotated as Tuple[Tensor, Tensor], so the schema for this op becomes "it always returns two Tensors." We need to split it into two custom ops (one that returns only out, and another that returns (out, lse)), because a custom op’s number of return values can’t change dynamically based on a flag (the schema is fixed).

This PR is to refactor the diffusion fa4 backend to support in blackwell.

Before fix there's error:
```
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/multimodal_gen/runtime/models/dits/wanvideo.py", line 880, in forward
    hidden_states = block(
                    ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/multimodal_gen/runtime/models/dits/wanvideo.py", line 459, in forward
    attn_output = self.attn1(query, key, value)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/multimodal_gen/runtime/layers/attention/layer.py", line 364, in forward
    out = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py", line 361, in forward
    output = flash_attn_op(
             ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1255, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Object of type 'Tensor' is not an instance of 'sequence'
[01-14 09:17:04] Failed to generate output for prompt 1: Error executing request 5b8e6ae0-c2c7-4aa3-a689-355ad8547901: Object of type 'Tensor' is not an instance of 'sequence'
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/sglang/multimodal_gen/runtime/utils/logging_utils.py", line 466, in log_generation_timer
    yield timer
  File "/usr/local/lib/python3.12/dist-packages/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 226, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 5b8e6ae0-c2c7-4aa3-a689-355ad8547901: Object of type 'Tensor' is not an instance of 'sequence'
[01-14 09:17:04] Completed batch processing. Generated 0 outputs in 72.11 seconds
[01-14 09:17:04] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
/usr/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```

After fix:
```
➜  python git:(main) sglang generate --model-path Wan-AI/Wan2.2-TI2V-5B-Diffusers \
  --log-level info \
  --dit-layerwise-offload false \
  --dit-cpu-offload false \
  --vae-cpu-offload false \
  --text-encoder-cpu-offload false \
  --prompt "An astronaut hatching from an egg, on the surface of the moon, the darkness and depth of space realised in the background. High quality, ultrarealistic detail and breath-taking movie-like camera shot." \
  --negative-prompt "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards" \
  --image-path "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/astronaut.jpg" \
  --num-frames 81 \
  --720p \
  --num-inference-steps 50 \
  --guidance-scale 5.0 \
  --seed 42 \
  --save-output
[01-14 11:24:49] server_args: {"model_path": "Wan-AI/Wan2.2-TI2V-5B-Diffusers", "backend": "auto", "attention_backend": null, "diffusers_attention_backend": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": null, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "vae_path": null, "lora_target_modules": null, "dit_cpu_offload": false, "dit_layerwise_offload": false, "text_encoder_cpu_offload": false, "image_encoder_cpu_offload": true, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "comfyui_mode": false, "mask_strategy_file_path": null, "STA_mode": "STA_inference", "skip_time_steps": 15, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "disable_autocast": false, "VSA_sparsity": 0.0, "moba_config_path": null, "moba_config": {}, "master_port": 30048, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5609, "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true}, "boundary_ratio": null, "log_level": "info"}
[01-14 11:24:49] Local mode: True
[01-14 11:24:49] Starting server...
[01-14 11:24:57] Scheduler bind at endpoint: tcp://127.0.0.1:5609
[01-14 11:24:57] Initializing distributed environment with world_size=1, device=cuda:0
[rank0]:[W114 11:24:58.152371205 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[01-14 11:24:59] No pipeline_class_name specified, using model_index.json
[01-14 11:25:00] Downloaded model_index.json for Wan-AI/Wan2.2-TI2V-5B-Diffusers, pipeline: WanPipeline
[01-14 11:25:00] Using native sglang backend for model 'Wan-AI/Wan2.2-TI2V-5B-Diffusers'
[01-14 11:25:00] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.Wan2_2_TI2V_5B_SamplingParam'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.Wan2_2_TI2V_5B_Config'>)
[01-14 11:25:00] Using pipeline from model_index.json: WanPipeline
[01-14 11:25:00] Loading pipeline modules...
[01-14 11:25:00] Checking for cached model in HF Hub cache for Wan-AI/Wan2.2-TI2V-5B-Diffusers...
[01-14 11:25:00] Found complete model in cache at /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635
[01-14 11:25:00] Model path: /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635
[01-14 11:25:00] Diffusers version: 0.35.0.dev0
[01-14 11:25:00] Loading pipeline modules from config: {'_class_name': 'WanPipeline', '_diffusers_version': '0.35.0.dev0', 'boundary_ratio': None, 'expand_timesteps': True, 'scheduler': ['diffusers', 'UniPCMultistepScheduler'], 'text_encoder': ['transformers', 'UMT5EncoderModel'], 'tokenizer': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'WanTransformer3DModel'], 'transformer_2': [None, None], 'vae': ['diffusers', 'AutoencoderKLWan']}
[01-14 11:25:00] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                                                                                              | 0/5 [00:00<?, ?it/s][01-14 11:25:00] Loading text_encoder from /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635/text_encoder. avail mem: 172.93 GB
[01-14 11:25:00] HF model config: {'architectures': ['UMT5EncoderModel'], 'classifier_dropout': 0.0, 'd_ff': 10240, 'd_kv': 64, 'd_model': 4096, 'decoder_start_token_id': 0, 'dense_act_fn': 'gelu_new', 'dropout_rate': 0.1, 'eos_token_id': 1, 'feed_forward_proj': 'gated-gelu', 'initializer_factor': 1.0, 'is_encoder_decoder': True, 'is_gated_act': True, 'layer_norm_epsilon': 1e-06, 'num_decoder_layers': 24, 'num_heads': 64, 'num_layers': 24, 'output_past': True, 'pad_token_id': 0, 'relative_attention_max_distance': 128, 'relative_attention_num_buckets': 32, 'scalable_attention': True, 'tie_word_embeddings': False, 'use_cache': True, 'vocab_size': 256384}

Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  33% Completed | 1/3 [00:01<00:02,  1.43s/it]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:01<00:00,  1.21it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:03<00:00,  1.15s/it]

[01-14 11:25:03] Loaded text_encoder: UMT5EncoderModel (sgl-diffusion version). model size: 21.16 GB, avail mem: 151.76 GB
Loading required modules:  20%|████████████████████████████████████▍                                                                                                                                                 | 1/5 [00:03<00:14,  3.59s/it][01-14 11:25:03] Loading tokenizer from /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635/tokenizer. avail mem: 151.76 GB
[01-14 11:25:04] Loaded tokenizer: T5TokenizerFast (sgl-diffusion version). model size: 0.00 GB, avail mem: 151.76 GB
Loading required modules:  40%|████████████████████████████████████████████████████████████████████████▊                                                                                                             | 2/5 [00:04<00:05,  1.86s/it][01-14 11:25:04] Loading vae from /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635/vae. avail mem: 151.76 GB
[01-14 11:25:04] HF model config: {'attn_scales': [], 'base_dim': 160, 'clip_output': False, 'decoder_base_dim': 256, 'dim_mult': [1, 2, 4, 4], 'dropout': 0.0, 'in_channels': 12, 'is_residual': True, 'latents_mean': [-0.2289, -0.0052, -0.1323, -0.2339, -0.2799, 0.0174, 0.1838, 0.1557, -0.1382, 0.0542, 0.2813, 0.0891, 0.157, -0.0098, 0.0375, -0.1825, -0.2246, -0.1207, -0.0698, 0.5109, 0.2665, -0.2108, -0.2158, 0.2502, -0.2055, -0.0322, 0.1109, 0.1567, -0.0729, 0.0899, -0.2799, -0.123, -0.0313, -0.1649, 0.0117, 0.0723, -0.2839, -0.2083, -0.052, 0.3748, 0.0152, 0.1957, 0.1433, -0.2944, 0.3573, -0.0548, -0.1681, -0.0667], 'latents_std': [0.4765, 1.0364, 0.4514, 1.1677, 0.5313, 0.499, 0.4818, 0.5013, 0.8158, 1.0344, 0.5894, 1.0901, 0.6885, 0.6165, 0.8454, 0.4978, 0.5759, 0.3523, 0.7135, 0.6804, 0.5833, 1.4146, 0.8986, 0.5659, 0.7069, 0.5338, 0.4889, 0.4917, 0.4069, 0.4999, 0.6866, 0.4093, 0.5709, 0.6065, 0.6415, 0.4944, 0.5726, 1.2042, 0.5458, 1.6887, 0.3971, 1.06, 0.3943, 0.5537, 0.5444, 0.4089, 0.7468, 0.7744], 'num_res_blocks': 2, 'out_channels': 12, 'patch_size': 2, 'scale_factor_spatial': 16, 'scale_factor_temporal': 4, 'temperal_downsample': [False, True, True], 'z_dim': 48}
[01-14 11:25:06] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 2.63 GB, avail mem: 149.09 GB
Loading required modules:  60%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████▏                                                                        | 3/5 [00:06<00:03,  1.92s/it][01-14 11:25:06] Loading transformer from /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635/transformer. avail mem: 149.09 GB
[01-14 11:25:06] Loading WanTransformer3DModel from 5 safetensors files, default_dtype: torch.bfloat16
[01-14 11:25:06] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend

Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:00<00:00, 236.97it/s]

[01-14 11:25:14] Loaded model with 5.00B parameters
[01-14 11:25:14] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 9.31 GB, avail mem: 139.44 GB
Loading required modules:  80%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                    | 4/5 [00:14<00:04,  4.48s/it][01-14 11:25:14] Loading scheduler from /root/.cache/huggingface/hub/models--Wan-AI--Wan2.2-TI2V-5B-Diffusers/snapshots/b8fff7315c768468a5333511427288870b2e9635/scheduler. avail mem: 139.44 GB
[01-14 11:25:14] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: 0.00 GB, avail mem: 139.44 GB
Loading required modules: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:14<00:00,  2.93s/it]
[01-14 11:25:14] Creating pipeline stages...
[01-14 11:25:14] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[01-14 11:25:14] Pipeline instantiated
[01-14 11:25:14] Worker 0: Initialized device, model, and distributed environment.
[01-14 11:25:14] Worker 0: Scheduler loop started.
[01-14 11:25:14] Unsupported resolution: 1280x720, output quality may suffer. Supported resolutions: 1280x704, 704x1280
[01-14 11:25:14] Processing prompt 1/1: An astronaut hatching from an egg, on the surface of the moon, the darkness and depth of space reali
[01-14 11:25:14] Sampling params:
                       width: 1280
                      height: 720
                  num_frames: 81
                      prompt: An astronaut hatching from an egg, on the surface of the moon, the darkness and depth of space realised in the background. High quality, ultrarealistic detail and breath-taking movie-like camera shot.
                  neg_prompt: 色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 5.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: 5.0
                  image_path: ['https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/astronaut.jpg']
                 save_output: True
            output_file_path: outputs/An_astronaut_hatching_from_an_egg_on_the_surface_of_the_moon_the_darkness_and_depth_of_space_reali_20260114-112514_1ce2ddea.mp4

[01-14 11:25:14] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[01-14 11:25:14] [InputValidationStage] started...
[01-14 11:25:15] resized img height: 809, img width: 1088
[01-14 11:25:15] [InputValidationStage] finished in 0.7601 seconds
[01-14 11:25:15] [TextEncodingStage] started...
[01-14 11:25:17] [TextEncodingStage] finished in 1.6331 seconds
[01-14 11:25:17] [ConditioningStage] started...
[01-14 11:25:17] [ConditioningStage] finished in 0.0000 seconds
[01-14 11:25:17] [TimestepPreparationStage] started...
[01-14 11:25:17] [TimestepPreparationStage] finished in 0.0004 seconds
[01-14 11:25:17] [LatentPreparationStage] started...
[01-14 11:25:17] [LatentPreparationStage] finished in 0.0015 seconds
[01-14 11:25:17] [DenoisingStage] started...
  0%|                                                                                                                                                                                                                       | 0/50 [00:00<?, ?it/s][01-14 11:25:17] Running FA4 warmup (global/causal/local, LSE on/off, optional GQA pack)...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:07<00:00,  1.35s/it]
[01-14 11:26:25] [DenoisingStage] average time per step: 1.3487 seconds
[01-14 11:26:25] [DenoisingStage] finished in 67.7815 seconds
[01-14 11:26:25] [DecodingStage] started...
[01-14 11:26:28] [DecodingStage] finished in 3.2186 seconds
[01-14 11:26:28] Peak GPU memory: 51.50 GB, Remaining GPU memory at peak: 127.56 GB. Components that can stay resident: []
[01-14 11:26:40] Output saved to outputs/An_astronaut_hatching_from_an_egg_on_the_surface_of_the_moon_the_darkness_and_depth_of_space_reali_20260114-112514_1ce2ddea.mp4
[01-14 11:26:40] Pixel data generated successfully in 85.17 seconds
[01-14 11:26:40] Completed batch processing. Generated 1 outputs in 85.17 seconds
[01-14 11:26:40] Memory usage - Max peak: 52739.80 MB, Avg peak: 52739.80 MB
[01-14 11:26:40] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
/usr/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
