### PR TITLE
[CI] Migrate 5090 tests to registered system

### DIFF
--- a/.github/workflows/test-5090.yml
+++ b/.github/workflows/test-5090.yml
@@ -1,0 +1,139 @@
+name: 5090 GPU Test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-5090.yml'
+  workflow_dispatch:
+  schedule:
+    # Run daily at 2 AM UTC to track 5090 compatibility
+    - cron: '0 2 * * *'
+
+concurrency:
+  group: 5090-test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUNNER_LABELS: 1-gpu-5090
+  SGLANG_IS_IN_CI: "true"
+  LD_LIBRARY_PATH: "/usr/local/cuda-12.4/targets/x86_64-linux/lib:/usr/local/lib/python3.10/dist-packages/nvidia/cudnn/lib:/usr/local/lib/python3.10/dist-packages/nvidia/nvshmem/lib:/usr/local/lib/python3.10/dist-packages/nvidia/cuda_runtime/lib"
+
+jobs:
+  # Run stage-b-test-small-1-gpu-5090 suite (registered tests)
+  stage-b-test-small-1-gpu-5090:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: 1-gpu-5090
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [0, 1, 2, 3]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        timeout-minutes: 15
+        env:
+          IS_BLACKWELL: "1"
+        run: |
+          bash scripts/ci/ci_install_dependency.sh
+
+      - name: Run stage-b-test-small-1-gpu-5090
+        timeout-minutes: 60
+        run: |
+          source /etc/profile.d/sglang-ci.sh
+          cd test/
+          python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu-5090 \
+            --auto-partition-id ${{ matrix.partition }} \
+            --auto-partition-size 4 \
+            --continue-on-error
+
+  # Run 5090-compatible quantization tests (registered)
+  quantization-test-5090:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: 1-gpu-5090
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        timeout-minutes: 15
+        env:
+          IS_BLACKWELL: "1"
+        run: |
+          bash scripts/ci/ci_install_dependency.sh
+
+      - name: Run quantization tests (5090 compatible)
+        timeout-minutes: 30
+        run: |
+          source /etc/profile.d/sglang-ci.sh
+          cd test/
+          python3 run_suite.py --hw cuda --suite quantization-test-5090 --continue-on-error
+
+  # Run accuracy test (registered)
+  accuracy-test-1-gpu:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: 1-gpu-5090
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        timeout-minutes: 15
+        env:
+          IS_BLACKWELL: "1"
+        run: |
+          bash scripts/ci/ci_install_dependency.sh
+          git clone https://github.com/merrymercy/human-eval.git
+          cd human-eval
+          pip install -e .
+
+      - name: Evaluate accuracy
+        timeout-minutes: 25
+        run: |
+          source /etc/profile.d/sglang-ci.sh
+          cd test/
+          python3 run_suite.py --hw cuda --suite accuracy-test-1-gpu-5090 --continue-on-error
+
+  # Run VLM performance benchmarks (registered)
+  performance-test-vlm:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: 1-gpu-5090
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        timeout-minutes: 15
+        env:
+          IS_BLACKWELL: "1"
+        run: |
+          bash scripts/ci/ci_install_dependency.sh
+
+      - name: Benchmark VLM
+        timeout-minutes: 20
+        run: |
+          source /etc/profile.d/sglang-ci.sh
+          cd test/
+          python3 run_suite.py --hw cuda --suite performance-test-vlm-5090 --continue-on-error
+
+  summary:
+    needs: [stage-b-test-small-1-gpu-5090, quantization-test-5090, accuracy-test-1-gpu, performance-test-vlm]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summary
+        run: |
+          echo "## 5090 GPU Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Test Suite | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| stage-b-test-small-1-gpu-5090 | ${{ needs.stage-b-test-small-1-gpu-5090.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| quantization-test-5090 | ${{ needs.quantization-test-5090.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| accuracy-test-1-gpu | ${{ needs.accuracy-test-1-gpu.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| performance-test-vlm | ${{ needs.performance-test-vlm.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/test/srt/quant/test_awq.py
+++ b/test/srt/quant/test_awq.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_AWQ_MOE_MODEL_NAME_FOR_TEST,
@@ -10,6 +11,8 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
+
+register_cuda_ci(est_time=163, suite="quantization-test-5090")
 
 
 class TestAWQ(CustomTestCase):

--- a/test/srt/test_bench_serving.py
+++ b/test/srt/test_bench_serving.py
@@ -4,6 +4,7 @@ import unittest
 
 import requests
 
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE,
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -21,6 +22,8 @@ from sglang.test.test_utils import (
     run_score_benchmark,
     write_github_step_summary,
 )
+
+register_cuda_ci(est_time=300, suite="performance-test-vlm-5090")
 
 
 class TestBenchServing(CustomTestCase):

--- a/test/srt/test_bnb.py
+++ b/test/srt/test_bnb.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import openai
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -20,6 +21,8 @@ from sglang.test.test_utils import (
     is_in_ci,
     popen_launch_server,
 )
+
+register_cuda_ci(est_time=5, suite="quantization-test-5090")
 
 VISION_MODELS = [
     "unsloth/Qwen2.5-VL-7B-Instruct-bnb-4bit",

--- a/test/srt/test_eval_accuracy_large.py
+++ b/test/srt/test_eval_accuracy_large.py
@@ -7,6 +7,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -17,6 +18,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
+
+register_cuda_ci(est_time=300, suite="accuracy-test-1-gpu-5090")
 
 
 class TestEvalAccuracyLarge(CustomTestCase):

--- a/test/srt/test_gguf.py
+++ b/test/srt/test_gguf.py
@@ -3,7 +3,10 @@ import unittest
 from huggingface_hub import hf_hub_download
 
 import sglang as sgl
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=96, suite="quantization-test-5090")
 
 
 class TestGGUF(CustomTestCase):

--- a/test/srt/test_quantization.py
+++ b/test/srt/test_quantization.py
@@ -4,6 +4,7 @@ import warnings
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_QUANT_TP1,
@@ -14,6 +15,8 @@ from sglang.test.test_utils import (
     write_github_step_summary,
     write_results_to_json,
 )
+
+register_cuda_ci(est_time=185, suite="quantization-test-5090")
 
 MODEL_SCORE_THRESHOLDS = {
     "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4": 0.825,


### PR DESCRIPTION
## Summary
- Migrate quantization tests (test_awq.py, test_bnb.py, test_quantization.py, test_gguf.py) to registered suite `quantization-test-5090`
- Migrate accuracy tests (test_eval_accuracy_large.py) to registered suite `accuracy-test-1-gpu-5090`
- Migrate performance tests (test_bench_serving.py) to registered suite `performance-test-vlm-5090`
- Update test-5090.yml workflow to use run_suite.py with registered suites

## Test plan
- [ ] Verify registered tests are discovered by run_suite.py
- [ ] CI runs successfully with new workflow configuration