### PR TITLE
Fix grammar sync across TP ranks

### DIFF
--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -125,7 +125,7 @@ class GrammarManager:
                 if i in ready_req_idxs:
                     continue
 
-                if req.finished():  # It is aborted by AbortReq
+                if req.finished() or req.grammar is None:  # It is aborted by AbortReq
                     ready_req_idxs.add(i)
                     continue
 

--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -133,6 +133,9 @@ class GrammarManager:
                 if req.grammar.done():
                     ready_req_idxs.add(i)
 
+            # Sleep a bit to avoid busy waiting
+            time.sleep(self.SGLANG_GRAMMAR_POLL_INTERVAL / 10)
+
         # Check failed requests
         for i, req in enumerate(self.grammar_queue):
             if i not in ready_req_idxs:

--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -104,12 +104,6 @@ class GrammarManager:
 
         return add_to_grammar_queue
 
-    def finalize_grammar(self, req: Req):
-        self.grammar_backend.set_cache(req.grammar_key, req.grammar.copy())
-        if req.grammar is INVALID_GRAMMAR_OBJ:
-            error_msg = f"Invalid grammar request: {req.grammar_key=}"
-            req.set_finish_with_abort(error_msg)
-
     def get_ready_grammar_requests(self) -> List[Req]:
         """
         Move requests whose grammar objects are ready from grammar_queue to waiting_queue.

--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -164,7 +164,7 @@ class GrammarManager:
         for i in synced_ready_req_idxs:
             req = self.grammar_queue[i]
             return_reqs.append(req)
-            if req.finished():
+            if req.finished() or req.grammar is None:  # It is aborted by AbortReq
                 continue
 
             req.grammar = req.grammar.result()

--- a/python/sglang/srt/entrypoints/openai/serving_rerank.py
+++ b/python/sglang/srt/entrypoints/openai/serving_rerank.py
@@ -212,9 +212,6 @@ class OpenAIServingRerank(OpenAIServingBase):
         self._yes_token_id, self._no_token_id = _get_yes_no_token_ids(
             tokenizer_manager.tokenizer
         )
-        logger.info(
-            f"Reranker yes/no token IDs: yes={self._yes_token_id}, no={self._no_token_id}"
-        )
 
     # NOTE: /v1/rerank is not an official OpenAI endpoint. This module may be moved
     # to another module in the future.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -172,8 +172,8 @@ class Envs:
     SGLANG_TEST_MAX_RETRY = EnvInt(None)
 
     # Constrained Decoding (Grammar)
-    SGLANG_GRAMMAR_SIMULATE_TIMEOUT = EnvFloat(-1)
-    SGLANG_GRAMMAR_POLL_INTERVAL = EnvFloat(0.03)
+    SGLANG_GRAMMAR_POLL_INTERVAL = EnvFloat(0.005)
+    SGLANG_GRAMMAR_MAX_POLL_ITERATIONS = EnvInt(10000)
 
     # Test & Debug
     SGLANG_DETECT_SLOW_RANK = EnvBool(False)
@@ -250,10 +250,6 @@ class Envs:
     # Model Parallel
     SGLANG_USE_MESSAGE_QUEUE_BROADCASTER = EnvBool(True)
     SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS = EnvBool(False)
-
-    # Constrained Decoding
-    SGLANG_DISABLE_OUTLINES_DISK_CACHE = EnvBool(True)
-    SGLANG_GRAMMAR_TIMEOUT = EnvFloat(300)
 
     # Tool Calling
     SGLANG_FORWARD_UNKNOWN_TOOLS = EnvBool(False)

--- a/test/registered/distributed/test_dp_attention_large.py
+++ b/test/registered/distributed/test_dp_attention_large.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k

--- a/test/registered/distributed/test_dp_attention_large.py
+++ b/test/registered/distributed/test_dp_attention_large.py
@@ -35,18 +35,17 @@ class TestDPAttentionDP2TP4(
     def setUpClass(cls):
         cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
-        with envs.SGLANG_GRAMMAR_SIMULATE_TIMEOUT.override(0.5):
-            cls.process = popen_launch_server(
-                cls.model,
-                cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-                other_args=[
-                    "--trust-remote-code",
-                    "--tp=4",
-                    "--enable-dp-attention",
-                    "--dp=2",
-                ],
-            )
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp=4",
+                "--enable-dp-attention",
+                "--dp=2",
+            ],
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -91,13 +90,12 @@ class TestDPAttentionDP2TP2DeepseekV3MTP(
         ]
         if not is_in_amd_ci():
             other_args += ["--mem-frac", "0.7"]
-        with envs.SGLANG_GRAMMAR_SIMULATE_TIMEOUT.override(0.5):
-            cls.process = popen_launch_server(
-                cls.model,
-                cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-                other_args=other_args,
-            )
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
```
Rank i returns two sets  ready_reqs_i,  failed_reqs_i
ready_reqs_all = all_gather(ready_reqs_i)
failed_reqs_all = all_gather(failed_reqs_i)

ready_reqs = intersect(ready_reqs_all)
failed_reqs = union(failed_reqs_all)
```