### PR TITLE
[MUSA][Diffusion][3/N] Support Diffusion Model (single GPU)

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -184,9 +184,9 @@ RUN git clone ${SGL_REPO} \
     && cd .. \
     && rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml \
     && if [ "$BUILD_TYPE" = "srt" ]; then \
-         python -m pip --no-cache-dir install -e "python[srt_hip,diffusion]"; \
+         python -m pip --no-cache-dir install -e "python[srt_hip,diffusion_hip]"; \
        else \
-         python -m pip --no-cache-dir install -e "python[all_hip,diffusion]"; \
+         python -m pip --no-cache-dir install -e "python[all_hip,diffusion_hip]"; \
        fi
 
 RUN python -m pip cache purge

--- a/docs/platforms/amd_gpu.md
+++ b/docs/platforms/amd_gpu.md
@@ -55,7 +55,7 @@ python setup_rocm.py install
 # Install sglang python package along with diffusion support
 cd ..
 rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
-pip install -e "python[all_hip,diffusion]"
+pip install -e "python[all_hip,diffusion_hip]"
 ```
 
 ### Install Using Docker (Recommended)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -91,7 +91,7 @@ diffusion = [
   "moviepy>=2.0.0",
   "opencv-python-headless==4.10.0.84",
   "remote-pdb",
-  "st_attn ==0.0.7",
+  "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer",
   "cache-dit==1.1.8"

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -66,6 +66,7 @@ runtime_common = [
   "grpcio==1.75.1", # keep it align with compile_proto.py
   "grpcio-tools==1.75.1", # keep it align with compile_proto.py
   "grpcio-reflection==1.75.1", # required by srt/entrypoints/grpc_server.py
+  "bidict",
 ]
 
 tracing = [
@@ -84,26 +85,7 @@ srt_hip = [
   "wave-lang==3.8.2",
 ]
 
-# https://docs.sglang.io/platforms/ascend_npu.html
-srt_npu = ["sglang[runtime_common]"]
-
-# For Intel Gaudi(device : hpu) follow the installation guide
-# https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html
-srt_hpu = ["sglang[runtime_common]"]
-
-test = [
-  "accelerate",
-  "expecttest",
-  "gguf",
-  "jsonlines",
-  "matplotlib",
-  "pandas",
-  "peft",
-  "pytest",
-  "sentence_transformers",
-  "tabulate",
-]
-diffusion = [
+diffusion_hip = [
   "diffusers @ git+https://github.com/huggingface/diffusers.git@6290fdfda40610ce7b99920146853614ba529c6e",
   "opencv-python-headless==4.10.0.84",
   "imageio==2.36.0",
@@ -117,13 +99,61 @@ diffusion = [
   "vsa==0.0.4",
   "runai_model_streamer",
 ]
+
+# https://docs.sglang.io/platforms/ascend_npu.html
+srt_npu = ["sglang[runtime_common]"]
+
+# For Intel Gaudi(device : hpu) follow the installation guide
+# https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html
+srt_hpu = ["sglang[runtime_common]"]
+
+# https://docs.sglang.io/platforms/mthreads_gpu.md
+srt_musa = [
+    "sglang[runtime_common]",
+    "torch",
+    "torch_musa",
+    "torchada>=0.1.15",
+    "mthreads-ml-py",
+    "numpy<2.0",
+]
+
+diffusion_musa = [
+  "PyYAML==6.0.1",
+  "cloudpickle",
+  "diffusers==0.36.0",
+  "imageio==2.36.0",
+  "imageio-ffmpeg==0.5.1",
+  "moviepy>=2.0.0",
+  "opencv-python-headless==4.10.0.84",
+  "remote-pdb",
+  "st_attn==0.0.7",
+  "vsa==0.0.4",
+  "runai_model_streamer",
+  "cache-dit==1.1.8"
+]
+
+test = [
+  "accelerate",
+  "expecttest",
+  "gguf",
+  "jsonlines",
+  "matplotlib",
+  "pandas",
+  "peft",
+  "pytest",
+  "sentence_transformers",
+  "tabulate",
+]
+
 all_hip = ["sglang[srt_hip]"]
 all_npu = ["sglang[srt_npu]"]
 all_hpu = ["sglang[srt_hpu]"]
+all_musa = ["sglang[srt_musa]", "sglang[diffusion_musa]"]
 
 dev_hip = ["sglang[all_hip]", "sglang[test]"]
 dev_npu = ["sglang[all_npu]", "sglang[test]"]
 dev_hpu = ["sglang[all_hpu]", "sglang[test]"]
+dev_musa = ["sglang[all_musa]", "sglang[test]"]
 
 [project.urls]
 "Homepage" = "https://github.com/sgl-project/sglang"

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -242,8 +242,12 @@ def init_distributed_environment(
             "distributed environment"
         )
 
-        # For MPS, don't pass device_id as it doesn't support device indices
-        extra_args = {} if current_platform.is_mps() else dict(device_id=device_id)
+        # For MPS and MUSA, don't pass device_id as it doesn't support device indices
+        extra_args = (
+            {}
+            if (current_platform.is_mps() or current_platform.is_musa())
+            else dict(device_id=device_id)
+        )
         torch.distributed.init_process_group(
             backend=backend,
             init_method=distributed_init_method,

--- a/python/sglang/multimodal_gen/runtime/models/dits/causal_wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/causal_wanvideo.py
@@ -633,7 +633,11 @@ class CausalWanTransformer3DModel(BaseDiT, OffloadableDiTMixin):
             self.hidden_size,
             self.num_attention_heads,
             rope_dim_list,
-            dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+            dtype=(
+                torch.float32
+                if current_platform.is_mps() or current_platform.is_musa()
+                else torch.float64
+            ),
             rope_theta=10000,
             start_frame=start_frame,  # Assume that start_frame is 0 when kv_cache is None
         )
@@ -761,7 +765,11 @@ class CausalWanTransformer3DModel(BaseDiT, OffloadableDiTMixin):
             self.hidden_size,
             self.num_attention_heads,
             rope_dim_list,
-            dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+            dtype=(
+                torch.float32
+                if current_platform.is_mps() or current_platform.is_musa()
+                else torch.float64
+            ),
             rope_theta=10000,
             start_frame=start_frame,
         )

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -397,7 +397,11 @@ class FluxPosEmbed(nn.Module):
             rope_theta=theta,
             use_real=False,
             repeat_interleave_real=False,
-            dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+            dtype=(
+                torch.float32
+                if current_platform.is_mps() or current_platform.is_musa()
+                else torch.float64
+            ),
         )
 
     def forward(self, ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -614,7 +614,11 @@ class Flux2PosEmbed(nn.Module):
             rope_theta=theta,
             use_real=False,
             repeat_interleave_real=False,
-            dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+            dtype=(
+                torch.float32
+                if current_platform.is_mps() or current_platform.is_musa()
+                else torch.float64
+            ),
         )
 
     def forward(self, ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -116,7 +116,7 @@ class QwenEmbedRope(nn.Module):
         #     rope_theta=theta,
         #     use_real=False,
         #     repeat_interleave_real=False,
-        #     dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+        #     dtype=torch.float32 if current_platform.is_mps() or current_platform.is_musa() else torch.float64,
         # )
 
         # DO NOT USING REGISTER BUFFER HERE, IT WILL CAUSE COMPLEX NUMBERS LOSE ITS IMAGINARY PART

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -773,7 +773,11 @@ class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
         self.rotary_emb = NDRotaryEmbedding(
             rope_dim_list=self.rope_dim_list,
             rope_theta=10000,
-            dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+            dtype=(
+                torch.float32
+                if current_platform.is_mps() or current_platform.is_musa()
+                else torch.float64
+            ),
         )
 
         self.layer_names = ["blocks"]

--- a/python/sglang/multimodal_gen/runtime/platforms/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/__init__.py
@@ -101,11 +101,31 @@ def rocm_platform_plugin() -> str | None:
     )
 
 
+def musa_platform_plugin() -> str | None:
+    is_musa = False
+
+    try:
+        import pymtml
+
+        pymtml.mtmlLibraryInit()
+        try:
+            is_musa = pymtml.mtmlLibraryCountDevice() > 0
+        finally:
+            pymtml.mtmlLibraryShutDown()
+    except Exception as e:
+        logger.info("MUSA platform is unavailable: %s", e)
+
+    return (
+        "sglang.multimodal_gen.runtime.platforms.musa.MusaPlatform" if is_musa else None
+    )
+
+
 builtin_platform_plugins = {
     "cuda": cuda_platform_plugin,
     "rocm": rocm_platform_plugin,
     "mps": mps_platform_plugin,
     "cpu": cpu_platform_plugin,
+    "musa": musa_platform_plugin,
 }
 
 
@@ -125,6 +145,11 @@ def resolve_current_platform_cls_qualname() -> str:
 
     # Fall back to CUDA
     platform_cls_qualname = cuda_platform_plugin()
+    if platform_cls_qualname is not None:
+        return platform_cls_qualname
+
+    # Fall back to MUSA
+    platform_cls_qualname = musa_platform_plugin()
     if platform_cls_qualname is not None:
         return platform_cls_qualname
 

--- a/python/sglang/multimodal_gen/runtime/platforms/interface.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/interface.py
@@ -45,6 +45,7 @@ class PlatformEnum(enum.Enum):
     TPU = enum.auto()
     CPU = enum.auto()
     MPS = enum.auto()
+    MUSA = enum.auto()
     OOT = enum.auto()
     UNSPECIFIED = enum.auto()
 
@@ -147,7 +148,7 @@ class Platform:
     @lru_cache(maxsize=1)
     def is_cuda_alike(self) -> bool:
         """Stateless version of :func:`torch.cuda.is_available`."""
-        return self._enum in (PlatformEnum.CUDA, PlatformEnum.ROCM)
+        return self._enum in (PlatformEnum.CUDA, PlatformEnum.ROCM, PlatformEnum.MUSA)
 
     @lru_cache(maxsize=1)
     def is_mps(self) -> bool:

--- a/python/sglang/multimodal_gen/runtime/platforms/musa.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/musa.py
@@ -1,0 +1,312 @@
+"""
+This file is a platform abstraction for MThreads (MUSA) GPUs,
+adjusted to match the structure and interface of `cuda.py`.
+"""
+
+import os
+from collections.abc import Callable
+from functools import lru_cache, wraps
+from typing import Any, TypeVar
+
+import psutil
+import pymtml
+
+# isort: off
+import torch
+import torchada  # noqa: F401
+
+# isort: on
+from typing_extensions import ParamSpec
+
+from sglang.multimodal_gen.runtime.platforms.interface import (
+    AttentionBackendEnum,
+    DeviceCapability,
+    Platform,
+    PlatformEnum,
+)
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def device_id_to_physical_device_id(device_id: int) -> int:
+    if "MUSA_VISIBLE_DEVICES" in os.environ:
+        device_ids = os.environ["MUSA_VISIBLE_DEVICES"].split(",")
+        if device_ids == [""]:
+            msg = (
+                "MUSA_VISIBLE_DEVICES is set to empty string, which means"
+                " GPU support is disabled. If you are using ray, please unset"
+                " the environment variable `MUSA_VISIBLE_DEVICES` inside the"
+                " worker/actor. "
+                "Check https://github.com/vllm-project/vllm/issues/8402 for"
+                " more information."
+            )
+            raise RuntimeError(msg)
+        physical_device_id = device_ids[device_id]
+        return int(physical_device_id)
+    else:
+        return device_id
+
+
+def with_mtml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+    @wraps(fn)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        pymtml.nvmlInit()
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            pymtml.nvmlShutdown()
+
+    return wrapper
+
+
+class MusaPlatformBase(Platform):
+    _enum = PlatformEnum.MUSA
+    device_name: str = "musa"
+    device_type: str = "musa"
+    dispatch_key: str = "MUSA"
+    device_control_env_var: str = "MUSA_VISIBLE_DEVICES"
+
+    @classmethod
+    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+        raise NotImplementedError
+
+    @classmethod
+    def get_device_name(cls, device_id: int = 0) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def get_device_total_memory(cls, device_id: int = 0) -> int:
+        raise NotImplementedError
+
+    @classmethod
+    def is_async_output_supported(cls, enforce_eager: bool | None) -> bool:
+        if enforce_eager:
+            logger.warning(
+                "To see benefits of async output processing, enable MUSA "
+                "graph. Since, enforce-eager is enabled, async output "
+                "processor cannot be used"
+            )
+            return False
+        return True
+
+    @classmethod
+    def is_full_mtlink(cls, device_ids: list[int]) -> bool:
+        raise NotImplementedError
+
+    @classmethod
+    def log_warnings(cls) -> None:
+        pass
+
+    @classmethod
+    def get_current_memory_usage(
+        cls, device: torch.types.Device | None = None
+    ) -> float:
+        torch.cuda.reset_peak_memory_stats(device)
+        return float(torch.cuda.max_memory_allocated(device))
+
+    @classmethod
+    def get_available_gpu_memory(
+        cls,
+        device_id: int = 0,
+        distributed: bool = False,
+        empty_cache: bool = True,
+        cpu_group: Any = None,
+    ) -> float:
+        if empty_cache:
+            torch.cuda.empty_cache()
+
+        device_props = torch.cuda.get_device_properties(device_id)
+        if device_props.is_integrated:
+            free_gpu_memory = psutil.virtual_memory().available
+        else:
+            free_gpu_memory, _ = torch.cuda.mem_get_info(device_id)
+
+        if distributed:
+            import torch.distributed as dist
+
+            tensor = torch.tensor(free_gpu_memory, dtype=torch.float32, device="musa")
+            dist.all_reduce(tensor, op=dist.ReduceOp.MIN, group=cpu_group)
+            free_gpu_memory = float(tensor.item())
+
+        return free_gpu_memory / (1 << 30)
+
+    @classmethod
+    def get_attn_backend_cls_str(
+        cls,
+        selected_backend: AttentionBackendEnum | None,
+        head_size: int,
+        dtype: torch.dtype,
+    ) -> str:
+        logger.info("Using Torch SDPA backend.")
+        return (
+            "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
+        )
+
+    @classmethod
+    def get_device_communicator_cls(cls) -> str:
+        return "sglang.multimodal_gen.runtime.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+
+
+# MTML utils
+# Note that MTML is not affected by `MUSA_VISIBLE_DEVICES`,
+# all the related functions work on real physical device ids.
+# the major benefit of using MTML is that it will not initialize MUSA
+class MtmlMusaPlatform(MusaPlatformBase):
+    @classmethod
+    @lru_cache(maxsize=8)
+    @with_mtml_context
+    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+        try:
+            physical_device_id = device_id_to_physical_device_id(device_id)
+            handle = pymtml.nvmlDeviceGetHandleByIndex(physical_device_id)
+            major, minor = pymtml.nvmlDeviceGetCudaComputeCapability(handle)
+            return DeviceCapability(major=major, minor=minor)
+        except RuntimeError:
+            return None
+
+    @classmethod
+    @lru_cache(maxsize=8)
+    @with_mtml_context
+    def has_device_capability(
+        cls,
+        capability: tuple[int, int] | int,
+        device_id: int = 0,
+    ) -> bool:
+        try:
+            return bool(super().has_device_capability(capability, device_id))
+        except RuntimeError:
+            return False
+
+    @classmethod
+    @lru_cache(maxsize=8)
+    @with_mtml_context
+    def get_device_name(cls, device_id: int = 0) -> str:
+        physical_device_id = device_id_to_physical_device_id(device_id)
+        return cls._get_physical_device_name(physical_device_id)
+
+    @classmethod
+    @lru_cache(maxsize=8)
+    @with_mtml_context
+    def get_device_uuid(cls, device_id: int = 0) -> str:
+        physical_device_id = device_id_to_physical_device_id(device_id)
+        handle = pymtml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        return str(pymtml.nvmlDeviceGetUUID(handle))
+
+    @classmethod
+    @lru_cache(maxsize=8)
+    @with_mtml_context
+    def get_device_total_memory(cls, device_id: int = 0) -> int:
+        physical_device_id = device_id_to_physical_device_id(device_id)
+        handle = pymtml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        return int(pymtml.nvmlDeviceGetMemoryInfo(handle).total)
+
+    @classmethod
+    @with_mtml_context
+    def is_full_mtlink(cls, physical_device_ids: list[int]) -> bool:
+        """
+        query if the set of gpus are fully connected by mtlink (1 hop)
+        """
+        handles = [pymtml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids]
+        for i, handle in enumerate(handles):
+            for j, peer_handle in enumerate(handles):
+                if i < j:
+                    try:
+                        p2p_status = pymtml.nvmlDeviceGetP2PStatus(
+                            handle,
+                            peer_handle,
+                            pymtml.NVML_P2P_CAPS_INDEX_NVLINK,
+                        )
+                        if p2p_status != pymtml.NVML_P2P_STATUS_OK:
+                            return False
+                    except pymtml.NVMLError:
+                        logger.exception(
+                            "MTLink detection failed. This is normal if"
+                            " your machine has no MTLink equipped."
+                        )
+                        return False
+        return True
+
+    @classmethod
+    def _get_physical_device_name(cls, device_id: int = 0) -> str:
+        handle = pymtml.nvmlDeviceGetHandleByIndex(device_id)
+        return str(pymtml.nvmlDeviceGetName(handle))
+
+    @classmethod
+    @with_mtml_context
+    def log_warnings(cls) -> None:
+        device_ids: int = pymtml.nvmlDeviceGetCount()
+        if device_ids > 1:
+            device_names = [cls._get_physical_device_name(i) for i in range(device_ids)]
+            if (
+                len(set(device_names)) > 1
+                and os.environ.get("MUSA_DEVICE_ORDER") != "PCI_BUS_ID"
+            ):
+                logger.warning(
+                    "Detected different devices in the system: %s. Please"
+                    " make sure to set `MUSA_DEVICE_ORDER=PCI_BUS_ID` to "
+                    "avoid unexpected behavior.",
+                    ", ".join(device_names),
+                )
+
+
+class NonMtmlMusaPlatform(MusaPlatformBase):
+    @classmethod
+    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
+        major, minor = torch.cuda.get_device_capability(device_id)
+        return DeviceCapability(major=major, minor=minor)
+
+    @classmethod
+    def get_device_name(cls, device_id: int = 0) -> str:
+        return str(torch.cuda.get_device_name(device_id))
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def get_device_total_memory(cls, device_id: int = 0) -> int:
+        device_props = torch.cuda.get_device_properties(device_id)
+        return int(device_props.total_memory)
+
+    @classmethod
+    def is_full_mtlink(cls, physical_device_ids: list[int]) -> bool:
+        logger.error(
+            "MTLink detection not possible, as context support was"
+            " not found. Assuming no MTLink available."
+        )
+        return False
+
+
+# Autodetect either MTML-enabled or non-MTML platform
+# based on whether MTML is available.
+mtml_available = False
+
+if "MUSA_DISABLE_MTML" not in os.environ:
+    try:
+        try:
+            pymtml.nvmlInit()
+            mtml_available = True
+        except Exception:
+            mtml_available = False
+    finally:
+        if mtml_available:
+            pymtml.nvmlShutdown()
+
+MusaPlatform = MtmlMusaPlatform if mtml_available else NonMtmlMusaPlatform
+
+try:
+    from sphinx.ext.autodoc.mock import _MockModule
+
+    if not isinstance(pymtml, _MockModule):
+        MusaPlatform.log_warnings()
+except ModuleNotFoundError:
+    MusaPlatform.log_warnings()
+
+if __name__ == "__main__":
+    print(MusaPlatform.__name__)
+    print(MusaPlatform.get_device_name())
+    print(MusaPlatform.get_device_capability())
+    print(MusaPlatform.get_device_total_memory())
+    print(MusaPlatform.is_full_mtlink([0, 1, 2, 3, 4, 5, 6, 7]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is the third in a series of pull requests (tracked in https://github.com/sgl-project/sglang/issues/16565) to add full support for [Moore Threads](https://en.mthreads.com/) GPUs, leveraging MUSA (Meta-computing Unified System Architecture) to accelerate LLM inference.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. `pyproject_other.toml`: use separate diffusion dependencies for `musa` and `hip` (AMD). The corresponding documentation and Dockerfile are updated accordingly.
2. `musa.py`: added to detect and identify the `musa` platform.
3. RoPE: use `float32`, consistent with `mps`, due to a known bug in our PyTorch implementation (to be fixed in an upcoming release).

### Testing Done

*Tested in a clean torch_musa container.*

Both `MtmlMusaPlatform` and `NonMtmlMusaPlatform` work fine:

```bash
root@worker3218:/ws/python/sglang/multimodal_gen/runtime/platforms# python3 musa.py 
2026-01-15 11:41:01 | __init__ | 139956465951872 | INFO : ROCm platform is unavailable: No module named 'amdsmi'
2026-01-15 11:41:04 | warnings | 139956465951872 | WARNING : /ws/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-15 11:41:04 | warnings | 139956465951872 | WARNING : /ws/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

MtmlMusaPlatform
MTT S5000
DeviceCapability(major=3, minor=1)
85899345920
True
root@worker3218:/ws/python/sglang/multimodal_gen/runtime/platforms# export MUSA_DISABLE_MTML=1
root@worker3218:/ws/python/sglang/multimodal_gen/runtime/platforms# python3 musa.py 
2026-01-15 11:41:18 | __init__ | 139730627499136 | INFO : ROCm platform is unavailable: No module named 'amdsmi'
2026-01-15 11:41:21 | warnings | 139730627499136 | WARNING : /ws/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-15 11:41:21 | warnings | 139730627499136 | WARNING : /ws/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

NonMtmlMusaPlatform
MTT S5000
DeviceCapability(major=3, minor=1)
85813358592
2026-01-15 11:41:21 | musa | 139730627499136 | ERROR : MTLink detection not possible, as context support was not found. Assuming no MTLink available.
False
root@worker3218:/ws/python/sglang/multimodal_gen/runtime/platforms# 
```

`Wan2.1-T2V-1.3B-Diffusers` with prompt `A curious raccoon` works fine:

```bash
root@worker3218:/ws# sglang generate --model-path /home/dist/Wan2.1-T2V-1.3B-Diffusers/ --text-encoder-cpu-offload --pin-cpu-memory --prompt "A curious raccoon" --save-output
2026-01-15 11:51:31 | warnings | 139774343877760 | WARNING : /ws/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-15 11:51:31 | warnings | 139774343877760 | WARNING : /ws/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-15 11:51:32 | hf_diffusers_utils | 139774343877760 | INFO : Diffusers version: 0.33.0.dev0
2026-01-15 11:51:32 | hf_diffusers_utils | 139774343877760 | INFO : Diffusers version: 0.33.0.dev0
2026-01-15 11:51:32 | registry | 139774343877760 | INFO : Using native sglang backend for model '/home/dist/Wan2.1-T2V-1.3B-Diffusers/'
2026-01-15 11:51:32 | registry | 139774343877760 | INFO : Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[01-15 11:51:32] Automatically enable dit_layerwise_offload for Wan for best performance
[01-15 11:51:32] dit_layerwise_offload is enabled, automatically disabling dit_cpu_offload.
[01-15 11:51:32] server_args: {"model_path": "/home/dist/Wan2.1-T2V-1.3B-Diffusers/", "backend": "auto", "attention_backend": null, "diffusers_attention_backend": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": null, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "vae_path": null, "lora_target_modules": null, "dit_cpu_offload": false, "dit_layerwise_offload": true, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": true, "use_fsdp_inference": false, "pin_cpu_memory": true, "comfyui_mode": false, "mask_strategy_file_path": null, "STA_mode": "STA_inference", "skip_time_steps": 15, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "disable_autocast": false, "VSA_sparsity": 0.0, "moba_config_path": null, "moba_config": {}, "master_port": 30086, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5619, "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true}, "boundary_ratio": null, "log_level": "info"}
[01-15 11:51:32] Local mode: True
[01-15 11:51:32] Starting server...
2026-01-15 11:51:40 | warnings | 140425649288320 | WARNING : /ws/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-15 11:51:40 | warnings | 140425649288320 | WARNING : /ws/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[01-15 11:51:40] Scheduler bind at endpoint: tcp://127.0.0.1:5619
[01-15 11:51:40] Initializing distributed environment with world_size=1, device=musa:0
[01-15 11:51:40] No pipeline_class_name specified, using model_index.json
[01-15 11:51:40] Diffusers version: 0.33.0.dev0
[01-15 11:51:40] Diffusers version: 0.33.0.dev0
[01-15 11:51:40] Using native sglang backend for model '/home/dist/Wan2.1-T2V-1.3B-Diffusers/'
[01-15 11:51:40] Found model info: ModelInfo(pipeline_cls=<class 'sglang.multimodal_gen.runtime.pipelines.wan_pipeline.WanPipeline'>, sampling_param_cls=<class 'sglang.multimodal_gen.configs.sample.wan.WanT2V_1_3B_SamplingParams'>, pipeline_config_cls=<class 'sglang.multimodal_gen.configs.pipeline_configs.wan.WanT2V480PConfig'>)
[01-15 11:51:40] Using pipeline from model_index.json: WanPipeline
[01-15 11:51:40] Loading pipeline modules...
[01-15 11:51:40] Model already exists locally and is complete
[01-15 11:51:40] Model path: /home/dist/Wan2.1-T2V-1.3B-Diffusers/
[01-15 11:51:40] Diffusers version: 0.33.0.dev0
[01-15 11:51:40] Loading pipeline modules from config: {'_class_name': 'WanPipeline', '_diffusers_version': '0.33.0.dev0', 'scheduler': ['diffusers', 'UniPCMultistepScheduler'], 'text_encoder': ['transformers', 'UMT5EncoderModel'], 'tokenizer': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'WanTransformer3DModel'], 'vae': ['diffusers', 'AutoencoderKLWan']}
[01-15 11:51:40] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                                                  | 0/5 [00:00<?, ?it/s][01-15 11:51:40] Loading text_encoder from /home/dist/Wan2.1-T2V-1.3B-Diffusers/text_encoder. avail mem: 79.30 GB
[01-15 11:51:40] HF model config: {'architectures': ['UMT5EncoderModel'], 'classifier_dropout': 0.0, 'd_ff': 10240, 'd_kv': 64, 'd_model': 4096, 'decoder_start_token_id': 0, 'dense_act_fn': 'gelu_new', 'dropout_rate': 0.1, 'eos_token_id': 1, 'feed_forward_proj': 'gated-gelu', 'initializer_factor': 1.0, 'is_encoder_decoder': True, 'is_gated_act': True, 'layer_norm_epsilon': 1e-06, 'num_decoder_layers': 24, 'num_heads': 64, 'num_layers': 24, 'output_past': True, 'pad_token_id': 0, 'relative_attention_max_distance': 128, 'relative_attention_num_buckets': 32, 'scalable_attention': True, 'tie_word_embeddings': False, 'use_cache': True, 'vocab_size': 256384}
[01-15 11:51:46] [RunAI Streamer] Overall time to stream 21.2 GiB of all files to cpu: 3.09s, 6.9 GiB/s
[01-15 11:52:07] Loaded text_encoder: FSDPUMT5EncoderModel (sgl-diffusion version). model size: 21.16 GB, avail mem: 78.99 GB
Loading required modules:  20%|███████████████████████████▌                                                                                                              | 1/5 [00:26<01:46, 26.64s/it][01-15 11:52:07] Loading tokenizer from /home/dist/Wan2.1-T2V-1.3B-Diffusers/tokenizer. avail mem: 79.00 GB
[01-15 11:52:07] Loaded tokenizer: T5TokenizerFast (sgl-diffusion version). model size: 0.00 GB, avail mem: 79.00 GB
Loading required modules:  40%|███████████████████████████████████████████████████████▏                                                                                  | 2/5 [00:27<00:33, 11.24s/it][01-15 11:52:07] Loading vae from /home/dist/Wan2.1-T2V-1.3B-Diffusers/vae. avail mem: 79.00 GB
[01-15 11:52:07] HF model config: {'attn_scales': [], 'base_dim': 96, 'dim_mult': [1, 2, 4, 4], 'dropout': 0.0, 'latents_mean': [-0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517, 1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497, 0.2503, -0.2921], 'latents_std': [2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743, 3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.916], 'num_res_blocks': 2, 'temperal_downsample': [False, True, True], 'z_dim': 16}
[01-15 11:52:07] Loaded vae: AutoencoderKLWan (sgl-diffusion version). model size: 0.27 GB, avail mem: 79.00 GB
[01-15 11:52:07] Loading transformer from /home/dist/Wan2.1-T2V-1.3B-Diffusers/transformer. avail mem: 79.00 GB
[01-15 11:52:07] Loading WanTransformer3DModel from 2 safetensors files, default_dtype: torch.bfloat16
[01-15 11:52:07] Using Torch SDPA backend.
[01-15 11:52:08] [RunAI Streamer] Overall time to stream 5.3 GiB of all files to cpu: 0.49s, 10.9 GiB/s
[01-15 11:52:09] Loaded model with 1.42B parameters
[01-15 11:52:09] Loaded transformer: WanTransformer3DModel (sgl-diffusion version). model size: 2.64 GB, avail mem: 76.17 GB
Loading required modules:  80%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████▍                           | 4/5 [00:28<00:04,  4.76s/it][01-15 11:52:09] Loading scheduler from /home/dist/Wan2.1-T2V-1.3B-Diffusers/scheduler. avail mem: 76.17 GB
[01-15 11:52:09] Loaded scheduler: UniPCMultistepScheduler (sgl-diffusion version). model size: 0.00 GB, avail mem: 76.17 GB
Loading required modules: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:28<00:00,  5.78s/it]
[01-15 11:52:09] Creating pipeline stages...
[01-15 11:52:09] Using Torch SDPA backend.
[01-15 11:52:09] Pipeline instantiated
[01-15 11:52:09] Enabled layerwise offload for WanTransformer3DModel on modules: ['blocks']
[01-15 11:52:09] Worker 0: Initialized device, model, and distributed environment.
[01-15 11:52:09] Worker 0: Scheduler loop started.
[01-15 11:52:09] Processing prompt 1/1: A curious raccoon
[01-15 11:52:09] Sampling params:
                       width: 832
                      height: 480
                  num_frames: 81
                      prompt: A curious raccoon
                  neg_prompt: Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 3.0
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: 3.0
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260115-115209_ea9f1040.mp4
        
[01-15 11:52:09] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[01-15 11:52:09] [InputValidationStage] started...
[01-15 11:52:09] [InputValidationStage] finished in 0.0001 seconds
[01-15 11:52:09] [TextEncodingStage] started...
[01-15 11:52:34] [TextEncodingStage] finished in 24.4067 seconds
[01-15 11:52:34] [ConditioningStage] started...
[01-15 11:52:34] [ConditioningStage] finished in 0.0000 seconds
[01-15 11:52:34] [TimestepPreparationStage] started...
[01-15 11:52:34] [TimestepPreparationStage] finished in 0.0005 seconds
[01-15 11:52:34] [LatentPreparationStage] started...
[01-15 11:52:34] [LatentPreparationStage] finished in 0.0042 seconds
[01-15 11:52:34] [DenoisingStage] started...
  0%|                                                                                                                                                                           | 0/50 [00:00<?, ?it/s][01-15 11:52:34] /ws/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py:452: UserWarning: FlashInfer not available, using Triton fallback for RoPE
  query, key = apply_flashinfer_rope_qk_inplace(

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [03:45<00:00,  4.51s/it]
[01-15 11:56:19] [DenoisingStage] average time per step: 4.5086 seconds
[01-15 11:56:19] [DenoisingStage] finished in 225.4316 seconds
[01-15 11:56:19] [DecodingStage] started...
[01-15 11:56:19] /usr/local/lib/python3.10/dist-packages/torch/amp/autocast_mode.py:321: UserWarning: In musa autocast, but the target dtype is not supported. Disabling autocast.
 musa Autocast only supports dtypes of torch.float16, torch.bfloat16 currently.
  warnings.warn(error_message)

[01-15 11:56:19] /ws/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py:533: UserWarning: Unsupported qk_head_dim: 384 v_head_dim: 384 for FlashAttention in MUSA backend (Triggered internally at /home/torch_musa/torch_musa/csrc/aten/ops/attention/mudnn/SDPUtils.h:129.)
  x = F.scaled_dot_product_attention(q, k, v)

[01-15 11:56:26] [DecodingStage] finished in 6.7552 seconds
[01-15 11:56:26] Peak GPU memory: 11.77 GB, Remaining GPU memory at peak: 68.15 GB. Components that can stay resident: ['text_encoder', 'vae', 'transformer']
[01-15 11:56:31] Output saved to outputs/A_curious_raccoon_20260115-115209_ea9f1040.mp4
[01-15 11:56:31] Pixel data generated successfully in 261.41 seconds
[01-15 11:56:31] Completed batch processing. Generated 1 outputs in 261.41 seconds
[01-15 11:56:31] Memory usage - Max peak: 12052.70 MB, Avg peak: 12052.70 MB
[01-15 11:56:31] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
root@worker3218:/ws# /usr/lib/python3.10/multiprocessing/resource_tracker.py:224: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
