### PR TITLE
[diffusion] feat: support generating videos with specified resolution and aspect ratio in I2V

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -205,7 +205,7 @@ class FastWan2_2_TI2V_5B_Config(Wan2_2_TI2V_5B_Config):
 
 
 @dataclass
-class Wan2_2_T2V_A14B_Config(WanT2V480PConfig):
+class Wan2_2_T2V_A14B_Config(WanT2V720PConfig):
     flow_shift: float | None = 12.0
     boundary_ratio: float | None = 0.875
 
@@ -214,7 +214,7 @@ class Wan2_2_T2V_A14B_Config(WanT2V480PConfig):
 
 
 @dataclass
-class Wan2_2_I2V_A14B_Config(WanI2V480PConfig):
+class Wan2_2_I2V_A14B_Config(WanI2V720PConfig):
     flow_shift: float | None = 5.0
     boundary_ratio: float | None = 0.900
 

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -150,6 +150,10 @@ class SamplingParams:
     # whether to adjust num_frames for multi-GPU friendly splitting (default: True)
     adjust_frames: bool = True
 
+    # Resolution and aspect ratio for I2V/T2V
+    resolution: str | None = None
+    aspect_ratio: str | None = None
+
     def _set_output_file_ext(self):
         # add extension if needed
         if not any(
@@ -333,7 +337,11 @@ class SamplingParams:
 
         # Validate resolution against pipeline-specific supported resolutions
         if self.height is None and self.width is None:
-            if self.supported_resolutions is not None:
+            if self.resolution is not None and self.aspect_ratio is not None:
+                logger.info(
+                    f"Resolution and aspect ratio specified, height and width will be calculated based on them"
+                )
+            elif self.supported_resolutions is not None:
                 self.width, self.height = self.supported_resolutions[0]
                 logger.info(
                     f"Resolution unspecified, using default: {self.supported_resolutions[0]}"
@@ -717,6 +725,20 @@ class SamplingParams:
                 "and satisfy model temporal constraints. If disabled, tokens might be padded for SP."
                 "Default: true. Examples: --adjust-frames, --adjust-frames true, --adjust-frames false."
             ),
+        )
+        parser.add_argument(
+            "--resolution",
+            type=str,
+            default=SamplingParams.resolution,
+            choices=["480p", "580p", "720p"],
+            help="Target resolution for video generation. Options: 480p, 580p, 720p",
+        )
+        parser.add_argument(
+            "--aspect-ratio",
+            type=str,
+            default=SamplingParams.aspect_ratio,
+            choices=["auto", "16:9", "9:16", "1:1"],
+            help="Target aspect ratio for video generation. Options: auto, 16:9, 9:16, 1:1",
         )
         return parser
 

--- a/python/sglang/multimodal_gen/configs/sample/wan.py
+++ b/python/sglang/multimodal_gen/configs/sample/wan.py
@@ -247,6 +247,8 @@ class Wan2_2_T2V_A14B_SamplingParam(Wan2_2_Base_SamplingParams):
         default_factory=lambda: [
             (1280, 720),  # 16:9
             (720, 1280),  # 9:16
+            (960, 512),  # 16:9
+            (512, 960),  # 9:16
             (832, 480),  # 16:9
             (480, 832),  # 9:16
         ]
@@ -267,6 +269,8 @@ class Wan2_2_I2V_A14B_SamplingParam(Wan2_2_Base_SamplingParams):
         default_factory=lambda: [
             (1280, 720),  # 16:9
             (720, 1280),  # 9:16
+            (960, 512),  # 16:9
+            (512, 960),  # 9:16
             (832, 480),  # 16:9
             (480, 832),  # 9:16
         ]

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -68,6 +68,8 @@ class VideoGenerationsRequest(BaseModel):
     model: Optional[str] = None
     seconds: Optional[int] = 4
     size: Optional[str] = ""
+    resolution: Optional[str] = None
+    aspect_ratio: Optional[str] = None
     fps: Optional[int] = None
     num_frames: Optional[int] = None
     seed: Optional[int] = 1024

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -87,6 +87,10 @@ def _build_sampling_params_from_request(
         sampling_kwargs["enable_teacache"] = request.enable_teacache
     if request.output_path is not None:
         sampling_kwargs["output_path"] = request.output_path
+    if request.resolution is not None:
+        sampling_kwargs["resolution"] = request.resolution
+    if request.aspect_ratio is not None:
+        sampling_kwargs["aspect_ratio"] = request.aspect_ratio
     sampling_params = SamplingParams.from_user_sampling_params_args(
         model_path=server_args.model_path,
         server_args=server_args,
@@ -156,6 +160,8 @@ async def create_video(
     model: Optional[str] = Form(None),
     seconds: Optional[int] = Form(None),
     size: Optional[str] = Form(None),
+    resolution: Optional[str] = Form(None),
+    aspect_ratio: Optional[str] = Form(None),
     fps: Optional[int] = Form(None),
     num_frames: Optional[int] = Form(None),
     seed: Optional[int] = Form(1024),
@@ -210,6 +216,8 @@ async def create_video(
             model=model,
             seconds=seconds if seconds is not None else 4,
             size=size,
+            resolution=resolution,
+            aspect_ratio=aspect_ratio,
             fps=fps_val,
             num_frames=num_frames_val,
             seed=seed,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -286,6 +286,8 @@ class Req:
                   image_path: {self.image_path}
                  save_output: {self.save_output}
             output_file_path: {self.output_file_path()}
+                  resolution: {self.resolution}
+                aspect_ratio: {self.aspect_ratio}
         """  # type: ignore[attr-defined]
         logger.info(debug_str)
 

--- a/python/sglang/multimodal_gen/runtime/utils/resolution_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/resolution_utils.py
@@ -1,0 +1,86 @@
+from PIL import Image
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+RESOLUTION_PRESETS = {
+    "16:9": {
+        "480p": (832, 480),
+        "580p": (960, 512),
+        "720p": (1280, 720),
+    },
+    "9:16": {
+        "480p": (480, 832),
+        "580p": (512, 960),
+        "720p": (720, 1280),
+    },
+    "1:1": {
+        "480p": (480, 480),
+        "580p": (512, 512),
+        "720p": (720, 720),
+    },
+}
+
+ASPECT_RATIO_MAP = {16 / 9: "16:9", 9 / 16: "9:16", 1.0: "1:1"}
+
+
+def isotropic_crop_resize_pil(
+    image: Image.Image, target_size: tuple[int, int]
+) -> Image.Image:
+    target_width, target_height = target_size
+    orig_width, orig_height = image.size
+    target_ratio = target_height / target_width
+    orig_ratio = orig_height / orig_width
+
+    if abs(orig_ratio - target_ratio) < 0.01:
+        return image.resize((target_width, target_height), Image.LANCZOS)
+
+    if orig_ratio > target_ratio:
+        # Image is taller, crop height
+        crop_height = int(target_ratio * orig_width)
+        crop_width = orig_width
+        y0 = (orig_height - crop_height) // 2
+        y1 = y0 + crop_height
+        x0, x1 = 0, orig_width
+    else:
+        # Image is wider, crop width
+        crop_width = int(orig_height / target_ratio)
+        crop_height = orig_height
+        x0 = (orig_width - crop_width) // 2
+        x1 = x0 + crop_width
+        y0, y1 = 0, orig_height
+
+    cropped_image = image.crop((x0, y0, x1, y1))
+    resized_image = cropped_image.resize((target_width, target_height), Image.LANCZOS)
+
+    return resized_image
+
+
+def parse_resolution_and_aspect_ratio(
+    original_aspect_ratio: float, resolution: str | None, aspect_ratio: str | None
+) -> tuple[int, int] | None:
+    if resolution is None or aspect_ratio is None:
+        return None
+
+    if aspect_ratio == "auto":
+        # according to the original aspect ratio of the image, select the closest resolution
+        closest_aspect_ratio = min(
+            ASPECT_RATIO_MAP.keys(), key=lambda x: abs(x - original_aspect_ratio)
+        )
+        aspect_ratio = ASPECT_RATIO_MAP[closest_aspect_ratio]
+        logger.info(
+            f"Based on the original aspect ratio {original_aspect_ratio}, the closest aspect ratio is {aspect_ratio}"
+        )
+
+    if aspect_ratio not in RESOLUTION_PRESETS:
+        logger.warning(f"Invalid aspect_ratio: {aspect_ratio}, using default logic")
+        return None
+
+    if resolution not in RESOLUTION_PRESETS[aspect_ratio]:
+        logger.warning(
+            f"Resolution {resolution} not found for aspect_ratio {aspect_ratio}, using default logic"
+        )
+        return None
+
+    return RESOLUTION_PRESETS[aspect_ratio][resolution]  # (width, height)

--- a/python/sglang/multimodal_gen/runtime/utils/resolution_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/resolution_utils.py
@@ -23,6 +23,7 @@ RESOLUTION_PRESETS = {
 }
 
 ASPECT_RATIO_MAP = {16 / 9: "16:9", 9 / 16: "9:16", 1.0: "1:1"}
+ASPECT_RATIO_TOLERANCE = 0.01
 
 
 def isotropic_crop_resize_pil(
@@ -33,7 +34,7 @@ def isotropic_crop_resize_pil(
     target_ratio = target_height / target_width
     orig_ratio = orig_height / orig_width
 
-    if abs(orig_ratio - target_ratio) < 0.01:
+    if abs(orig_ratio - target_ratio) < ASPECT_RATIO_TOLERANCE:
         return image.resize((target_width, target_height), Image.LANCZOS)
 
     if orig_ratio > target_ratio:


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently in wan2.2 i2v, the input validation stage determines the video size based on the image size, using a core logic that relies on max_area and maintains the original aspect ratio through direct resizing. This approach has two issues:

1. **User-specified width/height are ignored**—the video size is determined by the image, not the user.  
2. **When the input image size changes, the tensor shape in the denoising stage becomes dynamic**, causing frequent recompilation when torch compile is enabled.

## Modifications

<!-- Detail the changes made in this pull request. -->

I have added a new configuration method to generate videos with specified resolution and aspect ratio. The key features are:

1. By **cropping and resizing** the original image, video distortion is avoided.  
2. When resolution and aspect ratio are configured as a fixed set of options (frame changes are not considered for now), we obtain a set of **static tensor shapes**, fully leveraging the benefits of torch compile.  
3. This method **coexists in isolation** with the original logic without causing conflicts.

Note: Setting aspect_ratio to "auto" will automatically choose the nearest preset (16:9/9:16/1:1) according to the image's original aspect ratio.

### Example
**[Old Method]** Using [832x1104](https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true) as the input image, regardless of the size setting, the video generated by wan2.2 is shown below, with dimensions **544x720**:

https://github.com/user-attachments/assets/5e391412-5c5b-4ec7-8156-464d75d2ad3f

**[New Method]** When resolution is set to 720p and aspect ratio to 9:16, wan2.2 generates the following video with dimensions **720x1280**:

https://github.com/user-attachments/assets/395f3975-3589-44f1-938e-9bc4b9c76958

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
