### PR TITLE
[model-gateway] fix: support multiple MCP servers in responses

### DIFF
--- a/sgl-model-gateway/e2e_test/responses/test_tools_call.py
+++ b/sgl-model-gateway/e2e_test/responses/test_tools_call.py
@@ -364,6 +364,66 @@ class TestToolCallingCloud:
         final_text = text_done_events[0].text
         assert len(final_text) > 0, "Final text should not be empty"
 
+    def test_mcp_multi_server_tool_call(self, setup_backend):
+        """Test MCP tool call with multiple servers (non-streaming)."""
+        _, model, client, gateway = setup_backend
+
+        time.sleep(2)  # Avoid rate limiting
+
+        resp = client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=False,
+            reasoning={"effort": "low"},
+        )
+
+        assert resp.error is None
+        assert resp.id is not None
+        assert resp.status == "completed"
+        assert resp.output is not None
+
+        list_tools_items = [
+            item for item in resp.output if item.type == "mcp_list_tools"
+        ]
+        assert len(list_tools_items) == 2
+        labels = {item.server_label for item in list_tools_items}
+        assert labels == {"brave", "deepwiki"}
+
+        mcp_calls = [item for item in resp.output if item.type == "mcp_call"]
+        assert len(mcp_calls) > 0
+
+    def test_mcp_multi_server_tool_call_streaming(self, setup_backend):
+        """Test MCP tool call with multiple servers (streaming)."""
+        _, model, client, gateway = setup_backend
+
+        time.sleep(2)  # Avoid rate limiting
+
+        resp = client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=True,
+            reasoning={"effort": "low"},
+        )
+
+        events = list(resp)
+        assert len(events) > 0
+
+        completed_events = [e for e in events if e.type == "response.completed"]
+        assert len(completed_events) == 1
+
+        final_output = completed_events[0].response.output
+        list_tools_items = [
+            item for item in final_output if item.type == "mcp_list_tools"
+        ]
+        assert len(list_tools_items) == 2
+        labels = {item.server_label for item in list_tools_items}
+        assert labels == {"brave", "deepwiki"}
+
+        mcp_calls = [item for item in final_output if item.type == "mcp_call"]
+        assert len(mcp_calls) > 0
+
 
 # =============================================================================
 # Local Backend Tests (gRPC with Harmony model) - Tool Choice
@@ -498,6 +558,66 @@ class TestToolChoiceHarmony:
         output = resp.output
         mcp_calls = [item for item in output if item.type == "mcp_call"]
         assert len(mcp_calls) > 0, "tool_choice='auto' should allow MCP tool calls"
+
+    def test_mcp_multi_server_tool_call(self, setup_backend):
+        """Test MCP tool call with multiple servers (non-streaming)."""
+        _, model, client, gateway = setup_backend
+
+        time.sleep(2)
+
+        resp = client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=False,
+            reasoning={"effort": "low"},
+        )
+
+        assert resp.error is None
+        assert resp.id is not None
+        assert resp.status == "completed"
+        assert resp.output is not None
+
+        list_tools_items = [
+            item for item in resp.output if item.type == "mcp_list_tools"
+        ]
+        assert len(list_tools_items) == 2
+        labels = {item.server_label for item in list_tools_items}
+        assert labels == {"brave", "deepwiki"}
+
+        mcp_calls = [item for item in resp.output if item.type == "mcp_call"]
+        assert len(mcp_calls) > 0
+
+    def test_mcp_multi_server_tool_call_streaming(self, setup_backend):
+        """Test MCP tool call with multiple servers (streaming)."""
+        _, model, client, gateway = setup_backend
+
+        time.sleep(2)
+
+        resp = client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=True,
+            reasoning={"effort": "low"},
+        )
+
+        events = list(resp)
+        assert len(events) > 0
+
+        completed_events = [e for e in events if e.type == "response.completed"]
+        assert len(completed_events) == 1
+
+        final_output = completed_events[0].response.output
+        list_tools_items = [
+            item for item in final_output if item.type == "mcp_list_tools"
+        ]
+        assert len(list_tools_items) == 2
+        labels = {item.server_label for item in list_tools_items}
+        assert labels == {"brave", "deepwiki"}
+
+        mcp_calls = [item for item in final_output if item.type == "mcp_call"]
+        assert len(mcp_calls) > 0
 
     def test_tool_choice_mixed_function_and_mcp(self, setup_backend):
         """Test tool_choice with mixed function and MCP tools."""
@@ -794,6 +914,66 @@ class TestToolChoiceLocal:
         event_types = [event.type for event in events]
         assert "response.created" in event_types
         assert "response.completed" in event_types
+
+    def test_mcp_multi_server_tool_call(self, setup_backend):
+        """Test MCP tool call with multiple servers (non-streaming)."""
+        _, model, client, gateway = setup_backend
+
+        time.sleep(2)
+
+        resp = client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=False,
+            reasoning={"effort": "low"},
+        )
+
+        assert resp.error is None
+        assert resp.id is not None
+        assert resp.status == "completed"
+        assert resp.output is not None
+
+        list_tools_items = [
+            item for item in resp.output if item.type == "mcp_list_tools"
+        ]
+        assert len(list_tools_items) == 2
+        labels = {item.server_label for item in list_tools_items}
+        assert labels == {"brave", "deepwiki"}
+
+        mcp_calls = [item for item in resp.output if item.type == "mcp_call"]
+        assert len(mcp_calls) > 0
+
+    def test_mcp_multi_server_tool_call_streaming(self, setup_backend):
+        """Test MCP tool call with multiple servers (streaming)."""
+        _, model, client, gateway = setup_backend
+
+        time.sleep(2)
+
+        resp = client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=True,
+            reasoning={"effort": "low"},
+        )
+
+        events = list(resp)
+        assert len(events) > 0
+
+        completed_events = [e for e in events if e.type == "response.completed"]
+        assert len(completed_events) == 1
+
+        final_output = completed_events[0].response.output
+        list_tools_items = [
+            item for item in final_output if item.type == "mcp_list_tools"
+        ]
+        assert len(list_tools_items) == 2
+        labels = {item.server_label for item in list_tools_items}
+        assert labels == {"brave", "deepwiki"}
+
+        mcp_calls = [item for item in final_output if item.type == "mcp_call"]
+        assert len(mcp_calls) > 0
 
     def test_tool_choice_with_mcp_tools(self, setup_backend):
         """Test tool_choice parameter works with MCP tools."""

--- a/sgl-model-gateway/src/mcp/connection_pool.rs
+++ b/sgl-model-gateway/src/mcp/connection_pool.rs
@@ -230,6 +230,7 @@ mod tests {
             transport: McpTransport::Streamable {
                 url: url.to_string(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,

--- a/sgl-model-gateway/src/mcp/proxy.rs
+++ b/sgl-model-gateway/src/mcp/proxy.rs
@@ -124,6 +124,7 @@ mod tests {
             transport: McpTransport::Sse {
                 url: "http://localhost:3000/sse".to_string(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -143,6 +144,7 @@ mod tests {
             transport: McpTransport::Sse {
                 url: "http://localhost:3000/sse".to_string(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -179,6 +181,7 @@ mod tests {
             transport: McpTransport::Sse {
                 url: "http://localhost:3000/sse".to_string(),
                 token: None,
+                headers: None,
             },
             proxy: Some(server_proxy),
             required: false,

--- a/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/responses/streaming.rs
@@ -80,7 +80,7 @@ pub(crate) struct ResponseStreamEventEmitter {
     has_emitted_content_part_added: bool,
     // MCP call tracking
     mcp_call_accumulated_args: HashMap<String, String>,
-    pub(crate) mcp_server_label: Option<String>, // Server label for MCP tools
+    pub(crate) mcp_tool_labels: Option<HashMap<String, String>>,
     // Output item tracking
     output_items: Vec<OutputItemState>,
     next_output_index: usize,
@@ -105,7 +105,7 @@ impl ResponseStreamEventEmitter {
             has_emitted_output_item_added: false,
             has_emitted_content_part_added: false,
             mcp_call_accumulated_args: HashMap::new(),
-            mcp_server_label: None,
+            mcp_tool_labels: None,
             output_items: Vec::new(),
             next_output_index: 0,
             current_message_output_index: None,
@@ -119,9 +119,9 @@ impl ResponseStreamEventEmitter {
         self.original_request = Some(request);
     }
 
-    /// Set the MCP server label for MCP tool calls
-    pub fn set_mcp_server_label(&mut self, server_label: String) {
-        self.mcp_server_label = Some(server_label);
+    /// Set MCP tool labels for per-tool server labeling
+    pub fn set_mcp_tool_labels(&mut self, tool_labels: HashMap<String, String>) {
+        self.mcp_tool_labels = Some(tool_labels);
     }
 
     /// Update mcp_call output items with tool execution results

--- a/sgl-model-gateway/src/routers/grpc/harmony/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/streaming.rs
@@ -866,9 +866,12 @@ impl HarmonyStreamingProcessor {
 
                                 // Add server_label for MCP calls
                                 if tool_mode.emits_status_events() {
-                                    if let Some(ref server_label) = emitter.mcp_server_label {
-                                        item["server_label"] = json!(server_label);
-                                    }
+                                    let server_label = emitter
+                                        .mcp_tool_labels
+                                        .as_ref()
+                                        .and_then(|labels| labels.get(tool_name).cloned())
+                                        .unwrap_or_else(|| "mcp".to_string());
+                                    item["server_label"] = json!(server_label);
                                 }
 
                                 let event = emitter.emit_output_item_added(output_index, &item);
@@ -980,10 +983,12 @@ impl HarmonyStreamingProcessor {
 
                                 // Add server_label for MCP calls
                                 if tool_mode.emits_status_events() {
-                                    // MCP mode - include server_label
-                                    if let Some(ref server_label) = emitter.mcp_server_label {
-                                        item["server_label"] = json!(server_label);
-                                    }
+                                    let server_label = emitter
+                                        .mcp_tool_labels
+                                        .as_ref()
+                                        .and_then(|labels| labels.get(tool_name).cloned())
+                                        .unwrap_or_else(|| "mcp".to_string());
+                                    item["server_label"] = json!(server_label);
                                 }
 
                                 let event = emitter.emit_output_item_done(*output_index, &item);
@@ -1101,9 +1106,12 @@ impl HarmonyStreamingProcessor {
 
                         // Add server_label for MCP calls
                         if tool_mode.emits_status_events() {
-                            if let Some(ref server_label) = emitter.mcp_server_label {
-                                item["server_label"] = json!(server_label);
-                            }
+                            let server_label = emitter
+                                .mcp_tool_labels
+                                .as_ref()
+                                .and_then(|labels| labels.get(tool_name).cloned())
+                                .unwrap_or_else(|| "mcp".to_string());
+                            item["server_label"] = json!(server_label);
                         }
 
                         let event = emitter.emit_output_item_done(*output_index, &item);

--- a/sgl-model-gateway/src/routers/mcp_utils.rs
+++ b/sgl-model-gateway/src/routers/mcp_utils.rs
@@ -3,12 +3,16 @@
 //! This module provides shared MCP-related functionality that can be
 //! used across different router implementations (OpenAI, gRPC regular, gRPC harmony).
 
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
+use serde_json::Value;
 use tracing::warn;
 
 use crate::{
-    mcp::{McpManager, McpServerConfig, McpTransport},
+    mcp::{self, McpManager, McpServerConfig, McpTransport},
     protocols::responses::{ResponseTool, ResponseToolType},
 };
 
@@ -52,22 +56,242 @@ impl Default for McpLoopConfig {
 // Helper Functions
 // ============================================================================
 
-/// Extract MCP server label from request tools.
-///
-/// Searches for the first MCP tool in the tools array and returns its server_label.
-/// Falls back to a default value if no MCP tool with server_label is found.
-pub fn extract_server_label(tools: Option<&[ResponseTool]>, default_label: &str) -> String {
-    tools
-        .and_then(|tools| {
-            tools.iter().find_map(|tool| {
-                if matches!(tool.r#type, ResponseToolType::Mcp) {
-                    tool.server_label.clone()
-                } else {
-                    None
+/// Build a mapping of server_key -> server_label for request-scoped MCP tools.
+pub fn build_server_label_map(tools: Option<&[ResponseTool]>) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+
+    if let Some(tools) = tools {
+        for tool in tools {
+            if tool.r#type != ResponseToolType::Mcp {
+                continue;
+            }
+
+            let Some(server_url) = tool.server_url.as_ref().map(|s| s.trim().to_string()) else {
+                continue;
+            };
+
+            // Validate URL scheme
+            if !(server_url.starts_with("http://") || server_url.starts_with("https://")) {
+                continue;
+            }
+
+            let label = tool
+                .server_label
+                .as_ref()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| server_url.clone());
+
+            let transport = if server_url.contains("/sse") {
+                McpTransport::Sse {
+                    url: server_url.clone(),
+                    token: tool.authorization.clone(),
+                    headers: tool.headers.clone(),
                 }
-            })
-        })
-        .unwrap_or_else(|| default_label.to_string())
+            } else {
+                McpTransport::Streamable {
+                    url: server_url.clone(),
+                    token: tool.authorization.clone(),
+                    headers: tool.headers.clone(),
+                }
+            };
+
+            let server_config = McpServerConfig {
+                name: label.clone(),
+                transport,
+                proxy: None,
+                required: false,
+            };
+
+            let server_key = McpManager::server_key(&server_config);
+            labels.insert(server_key, label);
+        }
+    }
+
+    labels
+}
+
+/// Build a mapping of server_label -> allowed tool names (None means no filter).
+pub fn build_allowed_tools_map(
+    tools: Option<&[ResponseTool]>,
+) -> HashMap<String, Option<HashSet<String>>> {
+    let mut allowed = HashMap::new();
+
+    if let Some(tools) = tools {
+        for tool in tools {
+            if tool.r#type != ResponseToolType::Mcp {
+                continue;
+            }
+
+            let Some(label) = tool
+                .server_label
+                .as_ref()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+            else {
+                continue;
+            };
+
+            let value = tool.allowed_tools.as_ref().map(|names| {
+                names
+                    .iter()
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .collect::<HashSet<String>>()
+            });
+
+            allowed.insert(label.to_string(), value);
+        }
+    }
+
+    allowed
+}
+
+pub fn resolve_server_label(server_key: &str, server_labels: &HashMap<String, String>) -> String {
+    if let Some(label) = server_labels.get(server_key) {
+        return label.clone();
+    }
+
+    if let Some((url, _)) = server_key.split_once('#') {
+        return url.to_string();
+    }
+
+    server_key.to_string()
+}
+
+pub fn filter_tools_for_server(
+    tools: &[mcp::Tool],
+    server_label: &str,
+    allowed_tools: &HashMap<String, Option<HashSet<String>>>,
+) -> Vec<mcp::Tool> {
+    let allow_set = allowed_tools.get(server_label);
+
+    if allow_set.is_some_and(|set| set.as_ref().is_some_and(|s| s.is_empty())) {
+        return Vec::new();
+    }
+
+    if let Some(Some(allowed)) = allow_set {
+        tools
+            .iter()
+            .filter(|tool| allowed.contains(tool.name.as_ref()))
+            .cloned()
+            .collect()
+    } else {
+        tools.to_vec()
+    }
+}
+
+// ============================================================================
+// MCP Tool Name Encoding
+// ============================================================================
+
+/// Encode an MCP function name with server label prefix.
+///
+/// Format: `mcp__{server_label}__{tool_name}`
+///
+/// This encoding allows distinguishing tools from different MCP servers
+/// that may have the same tool name.
+pub fn encode_mcp_function_name(server_label: &str, tool_name: &str) -> String {
+    format!("mcp__{}__{}", server_label, tool_name)
+}
+
+/// Decode an MCP function name to extract server label and tool name.
+///
+/// Returns `Some((server_label, tool_name))` if the name matches the encoding format,
+/// `None` otherwise.
+pub fn decode_mcp_function_name(name: &str) -> Option<(String, String)> {
+    let rest = name.strip_prefix("mcp__")?;
+    let (label, tool_name) = rest.split_once("__")?;
+    if label.is_empty() || tool_name.is_empty() {
+        return None;
+    }
+    Some((label.to_string(), tool_name.to_string()))
+}
+
+// ============================================================================
+// MCP Tool Lookup
+// ============================================================================
+
+/// Lookup structure for MCP tool routing.
+///
+/// Maps encoded tool names to their server keys and schemas,
+/// enabling correct routing of tool calls to the right MCP server.
+#[derive(Debug, Clone, Default)]
+pub struct McpToolLookup {
+    /// Maps encoded tool name -> server key
+    pub tool_servers: HashMap<String, String>,
+    /// Maps encoded tool name -> original tool name
+    pub tool_names: HashMap<String, String>,
+    /// Maps encoded tool name -> input schema
+    pub tool_schemas: HashMap<String, Value>,
+}
+
+/// List tools grouped by server.
+///
+/// Returns a vector of (server_key, tools) pairs, maintaining the order
+/// of server_keys where possible.
+pub fn list_tools_by_server(
+    mcp: &McpManager,
+    server_keys: &[String],
+) -> Vec<(String, Vec<mcp::Tool>)> {
+    let mut tools_by_server: HashMap<String, Vec<mcp::Tool>> = HashMap::new();
+    let server_key_set: HashSet<&str> = server_keys.iter().map(|s| s.as_str()).collect();
+
+    for (_tool_name, server_key, tool) in mcp.inventory().list_tools() {
+        if mcp.is_static_server(&server_key) || server_key_set.contains(server_key.as_str()) {
+            tools_by_server.entry(server_key).or_default().push(tool);
+        }
+    }
+
+    // Maintain order: first the requested server_keys, then any remaining
+    let mut ordered = Vec::new();
+    for server_key in server_keys {
+        if let Some(tools) = tools_by_server.remove(server_key) {
+            ordered.push((server_key.clone(), tools));
+        }
+    }
+
+    // Add any remaining servers (static servers not in server_keys)
+    if !tools_by_server.is_empty() {
+        let mut remaining: Vec<(String, Vec<mcp::Tool>)> = tools_by_server.into_iter().collect();
+        remaining.sort_by(|a, b| a.0.cmp(&b.0));
+        ordered.extend(remaining);
+    }
+
+    ordered
+}
+
+/// Build McpToolLookup from MCP manager and server configuration.
+pub fn build_mcp_tool_lookup(
+    mcp: &McpManager,
+    server_keys: &[String],
+    server_labels: &HashMap<String, String>,
+    allowed_tools: &HashMap<String, Option<HashSet<String>>>,
+) -> McpToolLookup {
+    let mut lookup = McpToolLookup::default();
+
+    for (server_key, tools) in list_tools_by_server(mcp, server_keys) {
+        let server_label = resolve_server_label(&server_key, server_labels);
+        let filtered_tools = filter_tools_for_server(&tools, &server_label, allowed_tools);
+
+        for tool in filtered_tools {
+            let tool_name = tool.name.as_ref();
+            let encoded_name = encode_mcp_function_name(&server_label, tool_name);
+            lookup
+                .tool_servers
+                .insert(encoded_name.clone(), server_key.clone());
+            lookup
+                .tool_names
+                .insert(encoded_name.clone(), tool_name.to_string());
+            lookup
+                .tool_schemas
+                .insert(encoded_name, Value::Object((*tool.input_schema).clone()));
+        }
+    }
+
+    lookup
 }
 
 // ============================================================================
@@ -111,17 +335,20 @@ pub async fn ensure_request_mcp_client(
                 .clone()
                 .unwrap_or_else(|| "request-mcp".to_string());
             let token = tool.authorization.clone();
+            let headers = tool.headers.clone();
 
             // Determine transport type based on URL pattern
             let transport = if server_url.contains("/sse") {
                 McpTransport::Sse {
                     url: server_url.clone(),
                     token,
+                    headers,
                 }
             } else {
                 McpTransport::Streamable {
                     url: server_url.clone(),
                     token,
+                    headers,
                 }
             };
 

--- a/sgl-model-gateway/src/routers/openai/responses/non_streaming.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/non_streaming.rs
@@ -71,7 +71,12 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             server_keys: server_keys.clone(),
             ..McpLoopConfig::default()
         };
-        prepare_mcp_tools_as_functions(&mut payload, mcp, &server_keys);
+        prepare_mcp_tools_as_functions(
+            &mut payload,
+            mcp,
+            &server_keys,
+            original_body.tools.as_deref(),
+        );
 
         match execute_tool_loop(
             ctx.components.client(),

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -693,7 +693,7 @@ async fn responses_handler(
                         "item": {
                             "id": call_id.clone(),
                             "type": "function_tool_call",
-                            "name": "brave_web_search",
+                            "name": "mcp__mock__brave_web_search",
                             "arguments": "",
                             "status": "in_progress"
                         }
@@ -764,7 +764,7 @@ async fn responses_handler(
                         "item": {
                             "id": call_id.clone(),
                             "type": "function_tool_call",
-                            "name": "brave_web_search",
+                            "name": "mcp__mock__brave_web_search",
                             "arguments": "{\"query\":\"SGLang router MCP integration\"}",
                             "status": "completed"
                         }
@@ -1017,7 +1017,7 @@ async fn responses_handler(
                 "output": [{
                     "type": "function_tool_call",
                     "id": "call_1",
-                    "name": "brave_web_search",
+                    "name": "mcp__mock__brave_web_search",
                     "arguments": "{\"query\":\"SGLang router MCP integration\"}",
                     "status": "in_progress"
                 }],

--- a/sgl-model-gateway/tests/mcp_test.rs
+++ b/sgl-model-gateway/tests/mcp_test.rs
@@ -13,7 +13,15 @@ use std::collections::HashMap;
 
 use common::mock_mcp_server::MockMCPServer;
 use serde_json::json;
-use smg::mcp::{error::McpError, McpConfig, McpManager, McpServerConfig, McpTransport};
+use smg::{
+    mcp::{error::McpError, McpConfig, McpManager, McpServerConfig, McpTransport},
+    protocols::responses::{ResponseTool, ResponseToolType},
+    routers::mcp_utils::{
+        build_allowed_tools_map, build_mcp_tool_lookup, build_server_label_map,
+        decode_mcp_function_name, encode_mcp_function_name, filter_tools_for_server,
+        resolve_server_label,
+    },
+};
 
 /// Create a new mock server for testing (each test gets its own)
 async fn create_mock_server() -> MockMCPServer {
@@ -49,16 +57,19 @@ async fn test_mcp_server_initialization() {
 async fn test_server_connection_with_mock() {
     let mock_server = create_mock_server().await;
 
+    let server_config = McpServerConfig {
+        name: "mock_server".to_string(),
+        transport: McpTransport::Streamable {
+            url: mock_server.url(),
+            token: None,
+            headers: None,
+        },
+        proxy: None,
+        required: false,
+    };
+
     let config = McpConfig {
-        servers: vec![McpServerConfig {
-            name: "mock_server".to_string(),
-            transport: McpTransport::Streamable {
-                url: mock_server.url(),
-                token: None,
-            },
-            proxy: None,
-            required: false,
-        }],
+        servers: vec![server_config.clone()],
         pool: Default::default(),
         proxy: None,
         warmup: Vec::new(),
@@ -72,7 +83,8 @@ async fn test_server_connection_with_mock() {
 
     let servers = manager.list_servers();
     assert_eq!(servers.len(), 1);
-    assert!(servers.contains(&"mock_server".to_string()));
+    let server_key = McpManager::server_key(&server_config);
+    assert!(servers.contains(&server_key));
 
     let tools = manager.list_tools();
     assert_eq!(tools.len(), 2, "Should have 2 tools from mock server");
@@ -93,6 +105,7 @@ async fn test_tool_availability_checking() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -142,6 +155,7 @@ async fn test_multi_server_connection() {
                 transport: McpTransport::Streamable {
                     url: mock_server1.url(),
                     token: None,
+                    headers: None,
                 },
                 proxy: None,
                 required: false,
@@ -151,6 +165,7 @@ async fn test_multi_server_connection() {
                 transport: McpTransport::Streamable {
                     url: mock_server2.url(),
                     token: None,
+                    headers: None,
                 },
                 proxy: None,
                 required: false,
@@ -187,6 +202,7 @@ async fn test_tool_execution_with_mock() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -235,6 +251,203 @@ async fn test_tool_execution_with_mock() {
 }
 
 #[tokio::test]
+async fn test_call_tool_on_specific_server() {
+    let mock_server = create_mock_server().await;
+
+    let server_config = McpServerConfig {
+        name: "mock_server".to_string(),
+        transport: McpTransport::Streamable {
+            url: mock_server.url(),
+            token: None,
+            headers: None,
+        },
+        proxy: None,
+        required: false,
+    };
+    let server_key = McpManager::server_key(&server_config);
+
+    let config = McpConfig {
+        servers: vec![server_config],
+        pool: Default::default(),
+        proxy: None,
+        warmup: Vec::new(),
+        inventory: Default::default(),
+    };
+
+    let manager = McpManager::with_defaults(config).await.unwrap();
+
+    let result = manager
+        .call_tool_on_server(
+            &server_key,
+            "brave_web_search",
+            Some(
+                json!({
+                    "query": "specific server",
+                    "count": 1
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await;
+
+    assert!(result.is_ok(), "Tool execution should succeed");
+    let response = result.unwrap();
+    assert!(!response.content.is_empty(), "Should have content");
+
+    manager.shutdown().await;
+}
+
+#[test]
+fn test_mcp_function_name_encoding_roundtrip() {
+    let encoded = encode_mcp_function_name("server-1", "tool");
+    assert_eq!(encoded, "mcp__server-1__tool");
+
+    let decoded = decode_mcp_function_name(&encoded).expect("Should decode");
+    assert_eq!(decoded.0, "server-1");
+    assert_eq!(decoded.1, "tool");
+
+    assert!(decode_mcp_function_name("invalid").is_none());
+    assert!(decode_mcp_function_name("mcp__server").is_none());
+    assert!(decode_mcp_function_name("mcp__server__").is_none());
+}
+
+#[tokio::test]
+async fn test_mcp_tool_label_and_allowed_filtering() {
+    let mock_server = create_mock_server().await;
+
+    let mut headers = HashMap::new();
+    headers.insert("X-Request-ID".to_string(), "abc123".to_string());
+
+    let request_tools = vec![ResponseTool {
+        r#type: ResponseToolType::Mcp,
+        function: None,
+        server_url: Some(mock_server.url()),
+        authorization: Some("token".to_string()),
+        headers: Some(headers.clone()),
+        server_label: Some("mock".to_string()),
+        server_description: None,
+        require_approval: None,
+        allowed_tools: Some(vec![
+            " brave_web_search ".to_string(),
+            "brave_local_search".to_string(),
+            " ".to_string(),
+        ]),
+    }];
+
+    let server_config = McpServerConfig {
+        name: "mock".to_string(),
+        transport: McpTransport::Streamable {
+            url: mock_server.url(),
+            token: Some("token".to_string()),
+            headers: Some(headers),
+        },
+        proxy: None,
+        required: false,
+    };
+    let server_key = McpManager::server_key(&server_config);
+
+    let server_labels = build_server_label_map(Some(&request_tools));
+    assert_eq!(server_labels.get(&server_key).unwrap(), "mock");
+    assert_eq!(resolve_server_label(&server_key, &server_labels), "mock");
+
+    let allowed_tools = build_allowed_tools_map(Some(&request_tools));
+    let allow_set = allowed_tools
+        .get("mock")
+        .and_then(|set| set.as_ref())
+        .expect("Expected allowed tools");
+    assert!(allow_set.contains("brave_web_search"));
+    assert!(allow_set.contains("brave_local_search"));
+
+    let config = McpConfig {
+        servers: vec![server_config],
+        pool: Default::default(),
+        proxy: None,
+        warmup: Vec::new(),
+        inventory: Default::default(),
+    };
+    let manager = McpManager::with_defaults(config).await.unwrap();
+
+    let tools = manager.list_tools();
+    let filtered = filter_tools_for_server(&tools, "mock", &allowed_tools);
+    assert_eq!(filtered.len(), 2);
+
+    let empty_allowed = build_allowed_tools_map(Some(&[ResponseTool {
+        r#type: ResponseToolType::Mcp,
+        function: None,
+        server_url: Some("http://localhost:9999".to_string()),
+        authorization: None,
+        headers: None,
+        server_label: Some("empty".to_string()),
+        server_description: None,
+        require_approval: None,
+        allowed_tools: Some(vec![]),
+    }]));
+    let empty_filtered = filter_tools_for_server(&tools, "empty", &empty_allowed);
+    assert!(empty_filtered.is_empty());
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_build_mcp_tool_lookup() {
+    let mock_server = create_mock_server().await;
+
+    let request_tools = vec![ResponseTool {
+        r#type: ResponseToolType::Mcp,
+        function: None,
+        server_url: Some(mock_server.url()),
+        authorization: None,
+        headers: None,
+        server_label: Some("mock".to_string()),
+        server_description: None,
+        require_approval: None,
+        allowed_tools: None,
+    }];
+
+    let server_config = McpServerConfig {
+        name: "mock".to_string(),
+        transport: McpTransport::Streamable {
+            url: mock_server.url(),
+            token: None,
+            headers: None,
+        },
+        proxy: None,
+        required: false,
+    };
+    let server_key = McpManager::server_key(&server_config);
+
+    let config = McpConfig {
+        servers: vec![server_config],
+        pool: Default::default(),
+        proxy: None,
+        warmup: Vec::new(),
+        inventory: Default::default(),
+    };
+    let manager = McpManager::with_defaults(config).await.unwrap();
+
+    let server_labels = build_server_label_map(Some(&request_tools));
+    let allowed_tools = build_allowed_tools_map(Some(&request_tools));
+    let lookup = build_mcp_tool_lookup(
+        &manager,
+        std::slice::from_ref(&server_key),
+        &server_labels,
+        &allowed_tools,
+    );
+
+    let encoded = encode_mcp_function_name("mock", "brave_web_search");
+    assert_eq!(lookup.tool_servers.get(&encoded), Some(&server_key));
+    assert_eq!(
+        lookup.tool_names.get(&encoded),
+        Some(&"brave_web_search".to_string())
+    );
+    assert!(lookup.tool_schemas.contains_key(&encoded));
+
+    manager.shutdown().await;
+}
+
+#[tokio::test]
 async fn test_concurrent_tool_execution() {
     let mock_server = create_mock_server().await;
 
@@ -244,6 +457,7 @@ async fn test_concurrent_tool_execution() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -287,6 +501,7 @@ async fn test_tool_execution_errors() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -358,6 +573,7 @@ async fn test_tool_info_structure() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: None,
             },
             proxy: None,
             required: false,
@@ -423,6 +639,53 @@ async fn test_sse_connection() {
 
 // Connection Type Tests
 
+#[test]
+fn test_server_key_hash_includes_token_and_headers() {
+    let mut headers_a = HashMap::new();
+    headers_a.insert("X-Request-ID".to_string(), "abc123".to_string());
+    headers_a.insert("X-Custom".to_string(), "value".to_string());
+
+    let mut headers_b = HashMap::new();
+    headers_b.insert("X-Custom".to_string(), "value".to_string());
+    headers_b.insert("X-Request-ID".to_string(), "abc123".to_string());
+
+    let base_config = |token: Option<&str>, headers: HashMap<String, String>| McpServerConfig {
+        name: "http_server".to_string(),
+        transport: McpTransport::Streamable {
+            url: "http://localhost:8080/mcp".to_string(),
+            token: token.map(|t| t.to_string()),
+            headers: Some(headers),
+        },
+        proxy: None,
+        required: false,
+    };
+
+    let config_a = base_config(Some("auth_token"), headers_a);
+    let config_b = base_config(Some("auth_token"), headers_b);
+
+    let key_a = McpManager::server_key(&config_a);
+    let key_b = McpManager::server_key(&config_b);
+    assert_eq!(key_a, key_b, "Header order should not affect key");
+
+    let config_c = base_config(Some("other_token"), {
+        let mut headers = HashMap::new();
+        headers.insert("X-Request-ID".to_string(), "abc123".to_string());
+        headers.insert("X-Custom".to_string(), "value".to_string());
+        headers
+    });
+    let key_c = McpManager::server_key(&config_c);
+    assert_ne!(key_a, key_c, "Token should affect key");
+
+    let config_d = base_config(Some("auth_token"), {
+        let mut headers = HashMap::new();
+        headers.insert("X-Request-ID".to_string(), "abc123".to_string());
+        headers.insert("X-Custom".to_string(), "value2".to_string());
+        headers
+    });
+    let key_d = McpManager::server_key(&config_d);
+    assert_ne!(key_a, key_d, "Header values should affect key");
+}
+
 #[tokio::test]
 async fn test_transport_types() {
     // HTTP/Streamable transport
@@ -431,6 +694,7 @@ async fn test_transport_types() {
         transport: McpTransport::Streamable {
             url: "http://localhost:8080/mcp".to_string(),
             token: Some("auth_token".to_string()),
+            headers: None,
         },
         proxy: None,
         required: false,
@@ -443,6 +707,7 @@ async fn test_transport_types() {
         transport: McpTransport::Sse {
             url: "http://localhost:8081/sse".to_string(),
             token: None,
+            headers: None,
         },
         proxy: None,
         required: false,
@@ -470,16 +735,19 @@ async fn test_complete_workflow() {
     let mock_server = create_mock_server().await;
 
     // 1. Initialize configuration
+    let server_config = McpServerConfig {
+        name: "integration_test".to_string(),
+        transport: McpTransport::Streamable {
+            url: mock_server.url(),
+            token: None,
+            headers: None,
+        },
+        proxy: None,
+        required: false,
+    };
+
     let config = McpConfig {
-        servers: vec![McpServerConfig {
-            name: "integration_test".to_string(),
-            transport: McpTransport::Streamable {
-                url: mock_server.url(),
-                token: None,
-            },
-            proxy: None,
-            required: false,
-        }],
+        servers: vec![server_config.clone()],
         pool: Default::default(),
         proxy: None,
         warmup: Vec::new(),
@@ -494,7 +762,8 @@ async fn test_complete_workflow() {
     // 3. Verify server connection
     let servers = manager.list_servers();
     assert_eq!(servers.len(), 1);
-    assert_eq!(servers[0], "integration_test");
+    let server_key = McpManager::server_key(&server_config);
+    assert_eq!(servers[0], server_key);
 
     // 4. Check available tools
     let tools = manager.list_tools();

--- a/sgl-model-gateway/tests/spec/responses.rs
+++ b/sgl-model-gateway/tests/spec/responses.rs
@@ -638,6 +638,7 @@ fn test_validate_tools_function_missing() {
             function: None, // Missing function definition
             server_url: None,
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,
@@ -662,6 +663,7 @@ fn test_validate_tools_mcp_missing_url() {
             function: None,
             server_url: None, // Missing server_url
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,
@@ -673,6 +675,94 @@ fn test_validate_tools_mcp_missing_url() {
     assert!(
         result.is_err(),
         "MCP tool without server_url should be invalid"
+    );
+}
+
+/// Test MCP tool requires server_label when server_url provided
+#[test]
+fn test_validate_tools_mcp_missing_label() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool {
+            r#type: ResponseToolType::Mcp,
+            function: None,
+            server_url: Some("http://localhost:3000".to_string()),
+            authorization: None,
+            headers: None,
+            server_label: None,
+            server_description: None,
+            require_approval: None,
+            allowed_tools: None,
+        }]),
+        ..Default::default()
+    };
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "MCP tool without server_label should be invalid"
+    );
+}
+
+/// Test MCP tool server_label must not include '__'
+#[test]
+fn test_validate_tools_mcp_invalid_label() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool {
+            r#type: ResponseToolType::Mcp,
+            function: None,
+            server_url: Some("http://localhost:3000".to_string()),
+            authorization: None,
+            headers: None,
+            server_label: Some("bad__label".to_string()),
+            server_description: None,
+            require_approval: None,
+            allowed_tools: None,
+        }]),
+        ..Default::default()
+    };
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "MCP tool with invalid server_label should be invalid"
+    );
+}
+
+/// Test MCP tool server_label must be unique
+#[test]
+fn test_validate_tools_mcp_duplicate_label() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![
+            ResponseTool {
+                r#type: ResponseToolType::Mcp,
+                function: None,
+                server_url: Some("http://localhost:3000".to_string()),
+                authorization: None,
+                headers: None,
+                server_label: Some("dup".to_string()),
+                server_description: None,
+                require_approval: None,
+                allowed_tools: None,
+            },
+            ResponseTool {
+                r#type: ResponseToolType::Mcp,
+                function: None,
+                server_url: Some("http://localhost:4000".to_string()),
+                authorization: None,
+                headers: None,
+                server_label: Some("dup".to_string()),
+                server_description: None,
+                require_approval: None,
+                allowed_tools: None,
+            },
+        ]),
+        ..Default::default()
+    };
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "MCP tools with duplicate server_label should be invalid"
     );
 }
 
@@ -718,6 +808,7 @@ fn test_validate_tool_choice_requires_tools() {
             }),
             server_url: None,
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,
@@ -977,6 +1068,7 @@ fn test_normalize_tool_choice_auto() {
             }),
             server_url: None,
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,
@@ -1045,6 +1137,7 @@ fn test_normalize_tool_choice_no_override() {
             }),
             server_url: None,
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,
@@ -1082,6 +1175,7 @@ fn test_normalize_parallel_tool_calls() {
             }),
             server_url: None,
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,
@@ -1141,6 +1235,7 @@ fn test_normalize_parallel_tool_calls_no_override() {
             }),
             server_url: None,
             authorization: None,
+            headers: None,
             server_label: None,
             server_description: None,
             require_approval: None,


### PR DESCRIPTION
## Motivation

This PR fixes the following issues:

1. The model-gateway merges multiple MCP tool definitions into a single returned tool set/metadata and use the first server_label, which is not compatible with the OpenAI spec and makes tool discovery and the outputs of mcp_list_tools / mcp_call ambiguous when more than one MCP server is provided.

1. The connection pool caches connections by server_url (using the first auth/header), which can cause potential credential leakage across Responses requests.

1. The allowed_tools config is not used to filter mcp tools before sending to the LLM.


## Modifications

- Make MCP server identity unique for HTTP transports (SSE/Streamable) by computing a stable server_key derived from url + token + headers (hashed), and use it consistently for registration, inventory loading, and client lookup.
- Prevent potential credential leak across requests by incorporating token/headers into the computed MCP server_key, so the connection pool does not reuse a cached client across different auth/header contexts even when server_url matches.
- Add optional custom headers support for MCP SSE/Streamable transport configs and Responses tools; build default headers safely (including bearer token handling without overriding user-provided Authorization).
- Fix tool inventory to support multiple servers exporting the same tool name by keying tools by (server_key, tool_name) rather than only tool_name.
- Introduce shared MCP routing helpers (sgl-model-gateway/src/routers/mcp_utils.rs) to:
  - Encode/decode MCP tool function names with per-server labeling (e.g. mcp__{server_label}__{tool_name}) to avoid collisions.
  - Build lookup maps from encoded tool name → server key, enabling correct server routing at execution time.
  - List and filter tools per server, and build per-server mcp_list_tools.
- Update gRPC (regular + harmony) and OpenAI Responses implementations to:
  - Emit/inject mcp_list_tools per server (multiple items) instead of assuming a single MCP server.
  - Ensure each mcp_call item/event uses the correct server_label for the tool’s server in both streaming and non-streaming flows.
- Tighten Responses API validation for MCP tools:
  - MCP tool must have non-empty server_url.
  - When server_url is provided, server_label must be non-empty and unique.
  - server_label must not contain __ to avoid ambiguity with encoded tool naming.
- Tests:
  - Add multi-server MCP e2e coverage in sgl-model-gateway/e2e_test/responses/test_tools_call.py (streaming + non-streaming).
  - Add Responses API integration tests sgl-model-gateway/tests/api/responses_api_test.rs for multi-server MCP (streaming + non-streaming).
  - Add/extend unit/spec tests for header parsing, duplicate tool names across servers, name encoding/decoding, tool lookup building, and validation (sgl-model-gateway/src/mcp/config.rs, sgl-model-gateway/src/mcp/inventory.rs, sgl-model-gateway/tests/mcp_test.rs, sgl-model-gateway/tests/spec/responses.rs).

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
