### PR TITLE
[diffusion] fix server cache-dit bug under continuous dynamic requests

### DIFF
--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -522,11 +522,20 @@ def enable_cache_on_dual_transformer(
 def refresh_context_on_transformer(
     transformer: torch.nn.Module,
     num_inference_steps: int,
+    scm_preset: str | None = None,
     verbose: bool = False,
 ) -> None:
     """Refresh cache-dit context for transformer."""
     cache_dit.refresh_context(
-        transformer, num_inference_steps=num_inference_steps, verbose=verbose
+        transformer,
+        cache_config=DBCacheConfig().reset(
+            num_inference_steps=num_inference_steps,
+            steps_computation_mask=cache_dit.steps_mask(
+                mask_policy=scm_preset, total_steps=num_inference_steps
+            ),
+            steps_computation_policy=scm_preset,
+        ),
+        verbose=verbose,
     )
     logger.debug(f"cache-dit refreshed on transformer (steps={num_inference_steps})")
 
@@ -536,14 +545,31 @@ def refresh_context_on_dual_transformer(
     transformer_2: torch.nn.Module,
     num_high_noise_steps: int,
     num_low_noise_steps: int,
+    scm_preset: str | None = None,
     verbose: bool = False,
 ) -> None:
     """Refresh cache-dit context for dual transformers."""
     cache_dit.refresh_context(
-        transformer, num_inference_steps=num_high_noise_steps, verbose=verbose
+        transformer,
+        cache_config=DBCacheConfig().reset(
+            num_inference_steps=num_high_noise_steps,
+            steps_computation_mask=cache_dit.steps_mask(
+                mask_policy=scm_preset, total_steps=num_high_noise_steps
+            ),
+            steps_computation_policy=scm_preset,
+        ),
+        verbose=verbose,
     )
     cache_dit.refresh_context(
-        transformer_2, num_inference_steps=num_low_noise_steps, verbose=verbose
+        transformer_2,
+        cache_config=DBCacheConfig().reset(
+            num_inference_steps=num_low_noise_steps,
+            steps_computation_mask=cache_dit.steps_mask(
+                mask_policy=scm_preset, total_steps=num_low_noise_steps
+            ),
+            steps_computation_policy=scm_preset,
+        ),
+        verbose=verbose,
     )
     logger.debug(
         f"cache-dit refreshed on dual transformers (steps={num_high_noise_steps}, {num_low_noise_steps})"

--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -493,7 +493,7 @@ def enable_cache_on_dual_transformer(
                 blocks=[transformer_blocks, transformer_2_blocks],
                 forward_pattern=[ForwardPattern.Pattern_2, ForwardPattern.Pattern_2],
                 params_modifiers=[primary_modifier, secondary_modifier],
-                has_separate_cfg=False,
+                has_separate_cfg=True,
             ),
             parallelism_config=None,
         )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -136,7 +136,9 @@ class DenoisingStage(PipelineStage):
         # TODO(triple-mu): support customized fullgraph and dynamic in the future
         module.compile(mode=mode, fullgraph=False, dynamic=None)
 
-    def _maybe_enable_cache_dit(self, num_inference_steps: int, batch: Req) -> None:
+    def _maybe_enable_cache_dit(
+        self, num_inference_steps: int | tuple[int, int], batch: Req
+    ) -> None:
         """Enable cache-dit on the transformers if configured (idempotent).
 
         This method should be called after the transformer is fully loaded
@@ -146,16 +148,27 @@ class DenoisingStage(PipelineStage):
         transformers with (potentially) different configurations.
 
         """
+        if isinstance(num_inference_steps, tuple):
+            num_high_noise_steps, num_low_noise_steps = num_inference_steps
+
+        # NOTE: When a new request arrives, we need to refresh the cache-dit context.
         if self._cache_dit_enabled:
-            if self._cached_num_steps != num_inference_steps:
-                logger.warning(
-                    "num_inference_steps changed from %d to %d after cache-dit was enabled. "
-                    "Continuing with initial configuration (steps=%d).",
-                    self._cached_num_steps,
-                    num_inference_steps,
-                    self._cached_num_steps,
+            from sglang.multimodal_gen.runtime.utils.cache_dit_integration import (
+                refresh_context_on_dual_transformer,
+                refresh_context_on_transformer,
+            )
+
+            if isinstance(num_inference_steps, tuple):
+                refresh_context_on_dual_transformer(
+                    self.transformer,
+                    self.transformer_2,
+                    num_high_noise_steps,
+                    num_low_noise_steps,
                 )
+            else:
+                refresh_context_on_transformer(self.transformer, num_inference_steps)
             return
+
         # check if cache-dit is enabled in config
         if not envs.SGLANG_CACHE_DIT_ENABLED or batch.is_warmup:
             return
@@ -229,10 +242,22 @@ class DenoisingStage(PipelineStage):
         # cache-dit handles step count validation and scaling internally
         steps_computation_mask = get_scm_mask(
             preset=scm_preset,
-            num_inference_steps=num_inference_steps,
+            num_inference_steps=(
+                num_inference_steps
+                if isinstance(num_inference_steps, int)
+                else num_high_noise_steps
+            ),
             compute_bins=scm_compute_bins,
             cache_bins=scm_cache_bins,
         )
+
+        if isinstance(num_inference_steps, tuple):
+            steps_computation_mask_2 = get_scm_mask(
+                preset=scm_preset,
+                num_inference_steps=num_low_noise_steps,
+                compute_bins=scm_compute_bins,
+                cache_bins=scm_cache_bins,
+            )
 
         # build config for primary transformer (high-noise expert)
         primary_config = CacheDitConfig(
@@ -244,7 +269,11 @@ class DenoisingStage(PipelineStage):
             max_continuous_cached_steps=envs.SGLANG_CACHE_DIT_MC,
             enable_taylorseer=envs.SGLANG_CACHE_DIT_TAYLORSEER,
             taylorseer_order=envs.SGLANG_CACHE_DIT_TS_ORDER,
-            num_inference_steps=num_inference_steps,
+            num_inference_steps=(
+                num_inference_steps
+                if isinstance(num_inference_steps, int)
+                else num_high_noise_steps
+            ),
             # SCM fields
             steps_computation_mask=steps_computation_mask,
             steps_computation_policy=scm_policy,
@@ -263,9 +292,9 @@ class DenoisingStage(PipelineStage):
                 max_continuous_cached_steps=envs.SGLANG_CACHE_DIT_SECONDARY_MC,
                 enable_taylorseer=envs.SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER,
                 taylorseer_order=envs.SGLANG_CACHE_DIT_SECONDARY_TS_ORDER,
-                num_inference_steps=num_inference_steps,
+                num_inference_steps=num_low_noise_steps,
                 # SCM fields - shared with primary
-                steps_computation_mask=steps_computation_mask,
+                steps_computation_mask=steps_computation_mask_2,
                 steps_computation_policy=scm_policy,
             )
 
@@ -281,8 +310,9 @@ class DenoisingStage(PipelineStage):
                 tp_group=tp_group,
             )
             logger.info(
-                "cache-dit enabled on dual transformers (steps=%d)",
-                num_inference_steps,
+                "cache-dit enabled on dual transformers (steps=%d, %d)",
+                num_high_noise_steps,
+                num_low_noise_steps,
             )
         else:
             # single transformer
@@ -482,12 +512,26 @@ class DenoisingStage(PipelineStage):
         """
         assert self.transformer is not None
         pipeline = self.pipeline() if self.pipeline else None
-        # NOTE: In warmup requests we may override req.num_inference_steps (e.g. set to 1)
-        # for latency amortization, but cache-dit needs the *original* total steps to
-        # initialize/refresh its context correctly.
-        cache_dit_num_inference_steps = batch.extra.get(
-            "cache_dit_num_inference_steps", batch.num_inference_steps
-        )
+
+        boundary_timestep = self._handle_boundary_ratio(server_args, batch)
+        # Get timesteps and calculate warmup steps
+        timesteps = batch.timesteps
+        if timesteps is None:
+            raise ValueError("Timesteps must be provided")
+        num_inference_steps = batch.num_inference_steps
+        num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
+
+        if self.transformer_2 is not None:
+            assert boundary_timestep is not None, "boundary_timestep must be provided"
+            num_high_noise_steps = 0
+            for t in timesteps:
+                if t >= boundary_timestep:
+                    num_high_noise_steps += 1
+            num_low_noise_steps = num_inference_steps - num_high_noise_steps
+            cache_dit_num_inference_steps = (num_high_noise_steps, num_low_noise_steps)
+        else:
+            cache_dit_num_inference_steps = num_inference_steps
+
         if not server_args.model_loaded["transformer"]:
             # FIXME: reuse more code
             loader = TransformerLoader()
@@ -515,13 +559,6 @@ class DenoisingStage(PipelineStage):
             target_dtype != torch.float32
         ) and not server_args.disable_autocast
 
-        # Get timesteps and calculate warmup steps
-        timesteps = batch.timesteps
-        if timesteps is None:
-            raise ValueError("Timesteps must be provided")
-        num_inference_steps = batch.num_inference_steps
-        num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
-
         # Prepare image latents and embeddings for I2V generation
         image_embeds = batch.image_embeds
         if len(image_embeds) > 0:
@@ -542,8 +579,6 @@ class DenoisingStage(PipelineStage):
             neg_prompt_embeds = batch.negative_prompt_embeds
             assert neg_prompt_embeds is not None
             # Removed Tensor truthiness assert to avoid GPU sync
-
-        boundary_timestep = self._handle_boundary_ratio(server_args, batch)
 
         # specifically for Wan2_2_TI2V_5B_Config, not applicable for FastWan2_2_TI2V_5B_Config
         should_preprocess_for_wan_ti2v = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When I used `sglang serve` to test wan2.2 i2v, if two consecutive requests had different target dimensions, a shape mismatch error occurred in cache-dit.

```
Traceback (most recent call last):
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 127, in execute_forward
    result = self.pipeline.forward(req, self.server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py", line 340, in forward
    return self.executor.execute_with_profiling(self.stages, batch, server_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py", line 57, in execute_with_profiling
    batch = self.execute(stages, batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 97, in execute
    batch = self._execute(stages, batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 88, in _execute
    batch = stage(batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 211, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1015, in forward
    noise_pred = self._predict_noise_with_cfg(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1268, in _predict_noise_with_cfg
    noise_pred_cond = self._predict_noise(
                      ^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1214, in _predict_noise
    return current_model(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/cache-dit/src/cache_dit/caching/cache_adapters/cache_adapter.py", line 448, in new_forward_with_hf_hook
    outputs = new_forward(self, *args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/cache-dit/src/cache_dit/caching/cache_adapters/cache_adapter.py", line 436, in new_forward
    outputs = original_forward(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 832, in compile_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py", line 880, in forward
    hidden_states = block(
                    ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/cache-dit/src/cache_dit/caching/cache_blocks/pattern_base.py", line 262, in forward
    can_use_cache = self.context_manager.can_cache(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/cache-dit/src/cache_dit/caching/cache_contexts/cache_manager.py", line 873, in can_cache
    can_cache = prev_states_tensor is not None and self.similarity(
                                                   ^^^^^^^^^^^^^^^^
  File "/nas/wangxingyu/sglang/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py", line 87, in patched_similarity
    mean_diff = (t1 - t2).abs().mean()
                 ~~~^~~~
RuntimeError: The size of tensor a (9180) must match the size of tensor b (9114) at non-singleton dimension 1
```

## Modifications

<!-- Detail the changes made in this pull request. -->

I think there are some issues with the current implementation and have made the following modifications:

* When building separate cache-dit contexts for the two transformers in wan2.2, the `num_inference_steps` should use `num_high_noise_steps` and `num_low_noise_steps` respectively.
* The `has_separate_cfg` parameter passed to cache-dit in wan2.2 should be `False`, because in sglang diffusion, the cfg and non-cfg executions are completed within a single inference step.
* A context reset should be performed when a new request arrives to prevent mixing of cache-dit step counts and buffers between requests.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
