### PR TITLE
[Bugfix] fix server hang when enable --mm-enable-dp-encoder & --enable-dp-attention 

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -820,15 +820,15 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         max_images_per_call = get_int_env_var("SGLANG_VLM_MAX_IMAGES_PER_VIT", 0)
 
         if max_patches_per_call == 0 and max_images_per_call == 0:
-            # if self.use_data_parallel:
-            #     return run_dp_sharded_mrope_vision_model(
-            #         self.visual,
-            #         pixel_values,
-            #         image_grid_thw.tolist(),
-            #         rope_type="rope_3d",
-            #     )
-            # else:
-            return self.visual(pixel_values, grid_thw=image_grid_thw)
+            if self.use_data_parallel:
+                return run_dp_sharded_mrope_vision_model(
+                    self.visual,
+                    pixel_values,
+                    image_grid_thw.tolist(),
+                    rope_type="rope_3d",
+                )
+            else:
+                return self.visual(pixel_values, grid_thw=image_grid_thw)
 
         # compute the number of patches per image and the slice positions in pixel_values
         grid_thw_list = (

--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -495,11 +495,18 @@ def run_dp_sharded_mrope_vision_model(
         ```
 
     """
-    tp_size = get_tensor_model_parallel_world_size()
+    from sglang.srt.layers.dp_attention import (
+        get_attention_tp_size,
+        get_attention_tp_group,
+        get_attention_tp_rank
+    )
+    tp_size = get_attention_tp_size()
+    if tp_size == 1:
+        return vision_model(pixel_values, grid_thw=torch.tensor(grid_thw_list))
 
     # GPU_0 tp_rank_local = 0
     # GPU_1 tp_rank_local = 1
-    tp_rank_local = get_tensor_model_parallel_rank()
+    tp_rank_local = get_attention_tp_rank()
 
     # patches_per_image = [1000, 100, 200, 50]
     patches_per_image = [math.prod(grid_thw) for grid_thw in grid_thw_list]
@@ -610,8 +617,8 @@ def run_dp_sharded_mrope_vision_model(
     else:
         image_embeds_local_padded = image_embeds_local
 
-    # Do all_gather to collect embeddings from all ranks
-    gathered_embeds = tensor_model_parallel_all_gather(image_embeds_local_padded, dim=0)
+    # Do all_gather to collect embeddings from all attention ranks
+    gathered_embeds = get_attention_tp_group().all_gather(image_embeds_local_padded, dim=0)
 
     # Remove padding and reconstruct per-rank embeddings
     rank_embeddings = list[torch.Tensor]()


### PR DESCRIPTION
…e-dp-attention parameter

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix server  hang when both --mm-enable-dp-encoder and --enable-dp-attention are enabled.

## ModificationsCollapse file
‎python/sglang/srt/models/qwen3_vl.py
python/sglang/srt/multimodal/mm_utils.py

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

start server command:
```
python -m sglang.launch_server \
    --model-path /***/Qwen3-VL-30B-A3B-Instruct \
    --host *** \
    --port 9596 \
    --tp 2 \
    --max-prefill-tokens 40960 \
    --chunked-prefill-size 40960 \
    --attention-backend ascend \
    --mem-fraction-static 0.8 \
    --mm-attention-backend ascend_attn \
    --max-running-requests 256 \
    --disable-radix-cache \
    --cuda-graph-bs 40 60 80 120 160 200 256 \
    --trust-remote-code \
    --enable-multimodal \
    --sampling-backend ascend \
    --mm-enable-dp-encoder \
    --enable-dp-attention --dp-size 2 2>&1 | tee output.log

```
before this pr
when enable the self.use_data_parallel branch, the server will hang when warm up
```
        if max_patches_per_call == 0 and max_images_per_call == 0:
            # if self.use_data_parallel:
            #     return run_dp_sharded_mrope_vision_model(
            #         self.visual,
            #         pixel_values,
            #         image_grid_thw.tolist(),
            #         rope_type="rope_3d",
            #     )
            # else:
            return self.visual(pixel_values, grid_thw=image_grid_thw)           
```
```
[2026-01-15 13:31:50 DP0 TP0] Load weight begin. avail mem=60.40 GB
[2026-01-15 13:31:50 DP0 TP0] Using ascend_attn as multimodal attention backend.
[2026-01-15 13:31:50 DP1 TP1] Load weight begin. avail mem=60.59 GB
Loading safetensors checkpoint shards:   0% Completed | 0/13 [00:00<?, ?it/s]
[2026-01-15 13:31:50 DP1 TP1] Using ascend_attn as multimodal attention backend.
Loading safetensors checkpoint shards:   8% Completed | 1/13 [00:08<01:40,  8.40s/it]
Loading safetensors checkpoint shards:  15% Completed | 2/13 [00:16<01:32,  8.45s/it]
Loading safetensors checkpoint shards:  23% Completed | 3/13 [00:25<01:24,  8.46s/it]
Loading safetensors checkpoint shards:  31% Completed | 4/13 [00:33<01:16,  8.47s/it]
Loading safetensors checkpoint shards:  38% Completed | 5/13 [00:42<01:07,  8.47s/it]
Loading safetensors checkpoint shards:  46% Completed | 6/13 [00:50<00:59,  8.46s/it]
Loading safetensors checkpoint shards:  54% Completed | 7/13 [00:57<00:47,  7.87s/it]
Loading safetensors checkpoint shards:  62% Completed | 8/13 [01:06<00:41,  8.21s/it]
Loading safetensors checkpoint shards:  69% Completed | 9/13 [01:08<00:25,  6.42s/it]
Loading safetensors checkpoint shards:  77% Completed | 10/13 [01:17<00:21,  7.19s/it]
Loading safetensors checkpoint shards:  85% Completed | 11/13 [01:26<00:15,  7.70s/it]
Loading safetensors checkpoint shards:  92% Completed | 12/13 [01:35<00:08,  8.06s/it]
Loading safetensors checkpoint shards: 100% Completed | 13/13 [01:44<00:00,  8.27s/it]
Loading safetensors checkpoint shards: 100% Completed | 13/13 [01:44<00:00,  8.02s/it]

[2026-01-15 13:33:54 DP0 TP0] Load weight end. type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=29.73 GB, mem usage=30.67 GB.
[2026-01-15 13:33:55 DP1 TP1] Load weight end. type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=29.92 GB, mem usage=30.67 GB.
[2026-01-15 13:33:55 DP0 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-15 13:33:55 DP0 TP0] The available memory for KV cache is 17.57 GB.
[2026-01-15 13:33:55 DP1 TP1] The available memory for KV cache is 17.57 GB.
[2026-01-15 13:33:55 DP1 TP1] KV Cache is allocated. #tokens: 191744, K size: 8.78 GB, V size: 8.78 GB
[2026-01-15 13:33:55 DP0 TP0] KV Cache is allocated. #tokens: 191744, K size: 8.78 GB, V size: 8.78 GB
[2026-01-15 13:33:55 DP1 TP1] Memory pool end. avail mem=12.03 GB
[2026-01-15 13:33:55 DP0 TP0] Memory pool end. avail mem=11.84 GB
[2026-01-15 13:33:55 DP1 TP1] Capture npu graph begin. This can take up to several minutes. avail mem=12.03 GB
[2026-01-15 13:33:55 DP0 TP0] Capture npu graph begin. This can take up to several minutes. avail mem=11.84 GB
[2026-01-15 13:33:55 DP0 TP0] Capture cuda graph bs [40, 60, 80, 120, 160, 200, 256]
Capturing batches (bs=256 avail_mem=11.69 GB):   0%|          | 0/7 [00:00<?, ?it/s][rank1]:[W115 13:33:58.372390820 compiler_depend.ts:207] Warning: Waiting for pending NCCL work to finish before starting graph capture. (function operator())
[rank0]:[W115 13:33:58.372611410 compiler_depend.ts:207] Warning: Waiting for pending NCCL work to finish before starting graph capture. (function operator())
Capturing batches (bs=40 avail_mem=10.67 GB): 100%|??????????| 7/7 [00:08<00:00,  1.20s/it] 
[2026-01-15 13:34:05 DP0 TP0] Capture npu graph end. Time elapsed: 9.33 s. mem usage=1.18 GB. avail mem=10.66 GB.
[2026-01-15 13:34:05 DP1 TP1] Capture npu graph end. Time elapsed: 9.34 s. mem usage=1.18 GB. avail mem=10.85 GB.
/home/luochen/sglang/python/sglang/srt/utils/common.py:1204: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)
  tensor_data = torch.ByteTensor(
[2026-01-15 13:34:06 DP0 TP0] max_total_num_tokens=191744, chunked_prefill_size=20480, max_prefill_tokens=40960, max_running_requests=128, context_len=262144, available_gpu_mem=10.66 GB
[2026-01-15 13:34:06] INFO:     Started server process [510148]
[2026-01-15 13:34:06] INFO:     Waiting for application startup.
[2026-01-15 13:34:06] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
[2026-01-15 13:34:06] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
[2026-01-15 13:34:06] INFO:     Application startup complete.
[2026-01-15 13:34:06] INFO:     Uvicorn running on http://141.61.41.151:9596 (Press CTRL+C to quit)
[2026-01-15 13:34:07] INFO:     141.61.41.151:48468 - "GET /model_info HTTP/1.1" 200 OK
/home/luochen/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py:130: DeprecationWarning: max_tokens is deprecated in favor of the max_completion_tokens field
  max_output_tokens = request.max_completion_tokens or request.max_tokens
/home/luochen/sglang/python/sglang/srt/entrypoints/openai/protocol.py:641: DeprecationWarning: max_tokens is deprecated in favor of the max_completion_tokens field
  "max_new_tokens": self.max_tokens or self.max_completion_tokens,
[2026-01-15 13:34:08 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 

```

after this pr
```
[2026-01-15 13:56:49 DP1 TP1] Load weight end. type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=29.92 GB, mem usage=30.67 GB.
[2026-01-15 13:56:49 DP0 TP0] Load weight end. type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=29.86 GB, mem usage=30.67 GB.
[2026-01-15 13:56:49 DP0 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-15 13:56:49 DP0 TP0] The available memory for KV cache is 17.67 GB.
[2026-01-15 13:56:49 DP1 TP1] The available memory for KV cache is 17.67 GB.
[2026-01-15 13:56:49 DP0 TP0] KV Cache is allocated. #tokens: 192896, K size: 8.84 GB, V size: 8.84 GB
[2026-01-15 13:56:49 DP1 TP1] KV Cache is allocated. #tokens: 192896, K size: 8.84 GB, V size: 8.84 GB
[2026-01-15 13:56:49 DP0 TP0] Memory pool end. avail mem=11.85 GB
[2026-01-15 13:56:49 DP1 TP1] Memory pool end. avail mem=11.91 GB
[2026-01-15 13:56:50 DP1 TP1] Capture npu graph begin. This can take up to several minutes. avail mem=11.91 GB
[2026-01-15 13:56:50 DP0 TP0] Capture npu graph begin. This can take up to several minutes. avail mem=11.85 GB
[2026-01-15 13:56:50 DP0 TP0] Capture cuda graph bs [40, 60, 80, 120, 160, 200, 256]
Capturing batches (bs=200 avail_mem=10.71 GB):  14%|█▍        | 1/7 [00:02<00:13,  2.28s/it][rank1]:[W115 13:56:53.633401730 compiler_depend.ts:207] Warning: Waiting for pending NCCL work to finish before starting graph capture. (function operator())
[rank0]:[W115 13:56:53.636103750 compiler_depend.ts:207] Warning: Waiting for pending NCCL work to finish before starting graph capture. (function operator())
Capturing batches (bs=40 avail_mem=10.68 GB): 100%|██████████| 7/7 [00:08<00:00,  1.18s/it] 
[2026-01-15 13:56:59 DP0 TP0] Capture npu graph end. Time elapsed: 9.14 s. mem usage=1.18 GB. avail mem=10.68 GB.
[2026-01-15 13:56:59 DP1 TP1] Capture npu graph end. Time elapsed: 9.14 s. mem usage=1.18 GB. avail mem=10.74 GB.
/home/luochen/sglang/python/sglang/srt/utils/common.py:1204: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)
  tensor_data = torch.ByteTensor(
[2026-01-15 13:57:00 DP0 TP0] max_total_num_tokens=192896, chunked_prefill_size=20480, max_prefill_tokens=40960, max_running_requests=128, context_len=262144, available_gpu_mem=10.68 GB
[2026-01-15 13:57:01] INFO:     Started server process [518292]
[2026-01-15 13:57:01] INFO:     Waiting for application startup.
[2026-01-15 13:57:01] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
[2026-01-15 13:57:01] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
[2026-01-15 13:57:01] INFO:     Application startup complete.
[2026-01-15 13:57:01] INFO:     Uvicorn running on http://141.61.41.151:9596 (Press CTRL+C to quit)
[2026-01-15 13:57:02] INFO:     141.61.41.151:48478 - "GET /model_info HTTP/1.1" 200 OK
/home/luochen/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py:130: DeprecationWarning: max_tokens is deprecated in favor of the max_completion_tokens field
  max_output_tokens = request.max_completion_tokens or request.max_tokens
/home/luochen/sglang/python/sglang/srt/entrypoints/openai/protocol.py:641: DeprecationWarning: max_tokens is deprecated in favor of the max_completion_tokens field
  "max_new_tokens": self.max_tokens or self.max_completion_tokens,
[2026-01-15 13:57:02 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
.('Warning: torch.save with "_use_new_zipfile_serialization = False" is not recommended for npu tensor, which may bring unexpected errors and hopefully set "_use_new_zipfile_serialization = True"', 'if it is necessary to use this, please convert the npu tensor to cpu tensor for saving')
[2026-01-15 13:57:04] INFO:     141.61.41.151:48480 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-15 13:57:04] The server is fired up and ready to roll!
[2026-01-15 13:57:26] INFO:     141.61.41.151:48482 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-15 13:57:26 DP1 TP1] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
.[2026-01-15 13:57:28 DP1 TP1] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, npu graph: True, gen throughput (token/s): 0.24, #queue-req: 0, 
[2026-01-15 13:57:30 DP1 TP1] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, npu graph: True, gen throughput (token/s): 31.07, #queue-req: 0, 
[2026-01-15 13:57:30] INFO:     141.61.41.151:48482 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-15 13:57:30 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-15 13:57:32 DP0 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, npu graph: True, gen throughput (token/s): 0.24, #queue-req: 0, 
[2026-01-15 13:57:33 DP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, npu graph: True, gen throughput (token/s): 31.17, #queue-req: 0, 
[2026-01-15 13:58:08] INFO:     141.61.41.151:48486 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-15 13:58:09 DP1 TP1] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-15 13:58:09 DP1 TP1] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, npu graph: True, gen throughput (token/s): 1.01, #queue-req: 0, 
[2026-01-15 13:58:11 DP1 TP1] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, npu graph: True, gen throughput (token/s): 31.15, #queue-req: 0, 
[2026-01-15 13:58:12 DP1 TP1] Decode batch, #running-req: 1, #token: 0, token usage: 0.00, npu graph: True, gen throughput (token/s): 31.27, #queue-req: 0, 
[2026-01-15 13:58:12] INFO:     141.61.41.151:48486 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-15 13:58:12 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 128, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-15 13:58:13 DP0 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, npu graph: True, gen throughput (token/s): 1.01, #queue-req: 0, 
[2026-01-15 13:58:14 DP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, npu graph: True, gen throughput (token/s): 31.15, #queue-req: 0, 
[2026-01-15 13:58:15 DP0 TP0] Decode batch, #running-req: 1, #token: 256, token usage: 0.00, npu graph: True, gen throughput (token/s): 31.13, #queue-req: 0, 

```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
