### PR TITLE
[Fix] GLM 4.7 + NVFP4 + MTP

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -96,6 +96,7 @@ from sglang.srt.model_loader.weight_utils import (
     get_quant_config,
     gguf_quant_weights_iterator,
     initialize_dummy_weights,
+    maybe_add_mtp_safetensors,
     multi_thread_pt_weights_iterator,
     multi_thread_safetensors_weights_iterator,
     np_cache_weights_iterator,
@@ -321,6 +322,9 @@ class DefaultModelLoader(BaseModelLoader):
         fall_back_to_pt: bool = True
         """Whether .pt weights can be used."""
 
+        model_config: Optional["ModelConfig"] = None
+        """The model configuration (for checking architecture, etc)."""
+
         @classmethod
         def init_new(cls, model_config: ModelConfig, model):
             return cls(
@@ -328,6 +332,7 @@ class DefaultModelLoader(BaseModelLoader):
                 model_config.revision,
                 prefix="",
                 fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
+                model_config=model_config,
             )
 
     def __init__(self, load_config: LoadConfig):
@@ -471,6 +476,15 @@ class DefaultModelLoader(BaseModelLoader):
         hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
             source.model_or_path, source.revision, source.fall_back_to_pt
         )
+
+        if use_safetensors and source.model_config is not None:
+            hf_weights_files = maybe_add_mtp_safetensors(
+                hf_weights_files,
+                hf_folder,
+                "model.safetensors.index.json",
+                source.model_config.hf_config,
+            )
+
         if self.load_config.load_format == LoadFormat.NPCACHE:
             # Currently np_cache only support *.bin checkpoints
             assert use_safetensors is False

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -594,6 +594,51 @@ def filter_duplicate_safetensors_files(
     return hf_weights_files
 
 
+def maybe_add_mtp_safetensors(
+    hf_weights_files: List[str], hf_folder: str, index_file: str, hf_config
+) -> List[str]:
+    """
+    Auto-detect and add mtp.safetensors for GLM4Moe MTP/NextN models if:
+    1. mtp.safetensors exists in the model directory
+    2. mtp.safetensors is NOT in the index (checkpoint packaging bug)
+    3. Model architecture is Glm4MoeForCausalLM with num_nextn_predict_layers > 0
+
+    This works around incorrectly packaged FP4 checkpoints like
+    baseten-admin/glm-4.7-fp4 where mtp.safetensors exists but
+    isn't referenced in model.safetensors.index.json.
+    """
+    # Only apply for GLM4Moe architecture
+    arch = getattr(hf_config, "architectures", [None])[0]
+    if arch not in ["Glm4MoeForCausalLM", "Glm4MoeForCausalLMNextN"]:
+        return hf_weights_files
+
+    # Check if model has num_nextn_predict_layers
+    if not hasattr(hf_config, "num_nextn_predict_layers"):
+        return hf_weights_files
+
+    if hf_config.num_nextn_predict_layers <= 0:
+        return hf_weights_files
+
+    # Check if mtp.safetensors exists
+    mtp_path = os.path.join(hf_folder, "mtp.safetensors")
+    if not os.path.isfile(mtp_path):
+        return hf_weights_files
+
+    # Check if it's already in the list (from index)
+    if mtp_path in hf_weights_files:
+        return hf_weights_files
+
+    # mtp.safetensors exists but not in index - this is a bug
+    logger.warning(
+        f"Found mtp.safetensors but it's not referenced in {index_file}. "
+        f"This is a checkpoint packaging bug. Auto-adding it for loading. "
+        f"Please report this to the checkpoint provider."
+    )
+
+    # Add it to the files list
+    return hf_weights_files + [mtp_path]
+
+
 def filter_files_not_needed_for_inference(hf_weights_files: List[str]) -> List[str]:
     """
     Exclude files that are not needed for inference.

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -610,7 +610,10 @@ def maybe_add_mtp_safetensors(
     # Only apply for GLM4Moe architecture with nextn layers
     arch = getattr(hf_config, "architectures", [None])[0]
     num_nextn_layers = getattr(hf_config, "num_nextn_predict_layers", 0)
-    if not (arch in ["Glm4MoeForCausalLM", "Glm4MoeForCausalLMNextN"] and num_nextn_layers > 0):
+    if not (
+        arch in ["Glm4MoeForCausalLM", "Glm4MoeForCausalLMNextN"]
+        and num_nextn_layers > 0
+    ):
         return hf_weights_files
 
     # Check if mtp.safetensors exists and is not already in the file list

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -63,7 +63,10 @@ from sglang.srt.layers.moe import (
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
-from sglang.srt.layers.moe.utils import filter_moe_weight_param_global_expert
+from sglang.srt.layers.moe.utils import (
+    RoutingMethodType,
+    filter_moe_weight_param_global_expert,
+)
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.layers.radix_attention import RadixAttention
@@ -376,6 +379,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             quant_config=quant_config,
             routed_scaling_factor=self.routed_scaling_factor,
+            routing_method_type=RoutingMethodType.DeepSeekV3,
             prefix=add_prefix("experts", prefix),
         )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1531,11 +1531,6 @@ class ServerArgs:
                         logger.info(
                             "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
                         )
-                    else:
-                        logger.warning(
-                            "flashinfer-python version >= 0.6.2 is required for flashinfer_trtllm MoE runner backend. "
-                            "flashinfer_trtllm MoE runner backend is not enabled."
-                        )
 
             # Mamba radix cache v2
             if self.enable_mamba_extra_buffer():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -35,6 +35,7 @@ from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
+    check_pkg_version_at_least,
     configure_ipv6,
     cpu_has_amx_support,
     get_bool_env_var,
@@ -1524,10 +1525,17 @@ class ServerArgs:
                     and self.moe_a2a_backend == "none"
                     and self.moe_runner_backend == "auto"
                 ):
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
-                    )
+                    # Only enable flashinfer_trtllm if flashinfer-python version is >= 0.6.2
+                    if check_pkg_version_at_least("flashinfer-python", "0.6.2"):
+                        self.moe_runner_backend = "flashinfer_trtllm"
+                        logger.info(
+                            "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
+                        )
+                    else:
+                        logger.warning(
+                            "flashinfer-python version >= 0.6.2 is required for flashinfer_trtllm MoE runner backend. "
+                            "flashinfer_trtllm MoE runner backend is not enabled."
+                        )
 
             # Mamba radix cache v2
             if self.enable_mamba_extra_buffer():

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1045,6 +1045,24 @@ def assert_pkg_version(pkg: str, min_version: str, message: str):
         )
 
 
+def check_pkg_version_at_least(pkg: str, min_version: str) -> bool:
+    """
+    Check if a package is installed and meets the minimum version requirement.
+
+    Args:
+        pkg: Package name (distribution name, e.g., "flashinfer-python")
+        min_version: Minimum version required (e.g., "0.6.2")
+
+    Returns:
+        True if package is installed and version >= min_version, False otherwise
+    """
+    try:
+        installed_version = version(pkg)
+        return pkg_version.parse(installed_version) >= pkg_version.parse(min_version)
+    except PackageNotFoundError:
+        return False
+
+
 def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = None):
     """Kill the process and all its child processes."""
     # Remove sigchld handler to avoid spammy logs.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

A few issues reported by @ynwang007 @JustinTong0323

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. We will face an error in loading the draft model with NVFP4 due to some inheritance relationship. Instead of deleting the detection from `modelopt -> modelopt_fp4` in https://github.com/sgl-project/sglang/pull/16581 I think this detection might be a better method.
2. Hardcode a fix for GLM 4.7 FP4 checkpoint + MTP: Essentially, `safetensors.index.json` should be mapping (you can thnkn of it like symlink) the layer 92 weights → `mtp.safetensors` (technically, models like Deepseek store these within the rest of the weights as an additional layer, but I suppose GLM simply decided to do it differently), into a `mtp.safetensors` file seperately, but during the creation with the ModelOpt library it was not added to the index. Instead we can automatically detect this is the case, warn the user about this invalid checkpoint, but still do the remapping online if we have `mtp.safetensors`.
3. Enable `trtllm-gen` automatically, which has much better performance than the CUTLASS backend  (requires Flashinfer 0.6.2 which will be released later) after a small fix in https://github.com/flashinfer-ai/flashinfer/pull/2313.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

```
python3 benchmark/gsm8k/bench_sglang.py --num-questions 1319 --parallel 1319
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 33.7MB/s]                                                                                                                                                                                                                              
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:55<00:00, 23.94it/s]
Accuracy: 0.951
Invalid: 0.000
Latency: 57.876 s
Output throughput: 2323.323 token/s
```

## Benchmarking and Profiling

```
SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server --model-path baseten-admin/glm-4.7-fp8-attn-fp4-mlp --trust-remote-code --tp 8 --quantization modelopt_fp4 --moe-runner-backend flashinfer_trtllm --speculative-algorithm EAGLE --attention-backend trtllm_mha
```

This is an example of a "broken" checkpoint. After our fix, it will run fine automatically:

```
[2026-01-15 18:38:23 TP0] Found mtp.safetensors but it's not referenced in model.safetensors.index.json. This is a checkpoint packaging bug. Auto-adding it for loading. Please report this to the checkpoint provider.
```

```
[2026-01-15 18:40:04 TP0] Decode batch, #running-req: 1, #token: 320, token usage: 0.00, accept len: 3.33, accept rate: 0.83, cuda graph: True, gen throughput (token/s): 323.35, #queue-req: 0, 
[2026-01-15 18:40:05 TP0] Decode batch, #running-req: 1, #token: 448, token usage: 0.00, accept len: 3.62, accept rate: 0.91, cuda graph: True, gen throughput (token/s): 353.81, #queue-req: 0, 
[2026-01-15 18:40:05 TP0] Decode batch, #running-req: 1, #token: 576, token usage: 0.00, accept len: 3.50, accept rate: 0.88, cuda graph: True, gen throughput (token/s): 340.39, #queue-req: 0, 
[2026-01-15 18:40:05 TP0] Decode batch, #running-req: 1, #token: 704, token usage: 0.00, accept len: 3.33, accept rate: 0.83, cuda graph: True, gen throughput (token/s): 328.84, #queue-req: 0, 
```

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    2.449    |  767   |   3.335    |     313.24      |
+-------------+--------+------------+-----------------+
```