### PR TITLE
refactor: unify registration through tokenizer_registration workflow

### DIFF
--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -118,6 +118,18 @@ fn default_l1_max_memory() -> usize {
     50 * 1024 * 1024 // 50MB
 }
 
+impl TokenizerCacheConfig {
+    /// Returns Some(self) if any caching is enabled, None otherwise.
+    /// Use this when passing cache config to tokenizer registration workflow.
+    pub fn to_option(&self) -> Option<Self> {
+        if self.enable_l0 || self.enable_l1 {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
+}
+
 impl Default for TokenizerCacheConfig {
     fn default() -> Self {
         Self {

--- a/sgl-model-gateway/src/core/steps/mod.rs
+++ b/sgl-model-gateway/src/core/steps/mod.rs
@@ -83,3 +83,5 @@ pub use workflow_data::{
 };
 // Typed workflow engines
 pub use workflow_engines::WorkflowEngines;
+
+pub use crate::config::TokenizerCacheConfig;

--- a/sgl-model-gateway/src/core/steps/tokenizer_registration.rs
+++ b/sgl-model-gateway/src/core/steps/tokenizer_registration.rs
@@ -17,11 +17,7 @@ use super::workflow_data::TokenizerWorkflowData;
 use crate::{
     app_context::AppContext,
     config::TokenizerCacheConfig,
-    tokenizer::{
-        cache::CachedTokenizer,
-        factory,
-        traits::Tokenizer,
-    },
+    tokenizer::{cache::CachedTokenizer, factory, traits::Tokenizer},
     workflow::{
         BackoffStrategy, FailureAction, RetryPolicy, StepDefinition, StepExecutor, StepId,
         StepResult, WorkflowContext, WorkflowDefinition, WorkflowError, WorkflowResult,

--- a/sgl-model-gateway/src/core/steps/tokenizer_registration.rs
+++ b/sgl-model-gateway/src/core/steps/tokenizer_registration.rs
@@ -2,6 +2,10 @@
 //!
 //! This module provides a workflow for registering tokenizers asynchronously.
 //! Tokenizers can be loaded from local paths or downloaded from HuggingFace.
+//!
+//! This is the **single source of truth** for tokenizer registration. All paths
+//! (startup, worker connection, API) should use this workflow to ensure consistent
+//! behavior (validation, caching, deduplication).
 
 use std::{sync::Arc, time::Duration};
 
@@ -12,7 +16,12 @@ use tracing::{debug, error, info};
 use super::workflow_data::TokenizerWorkflowData;
 use crate::{
     app_context::AppContext,
-    tokenizer::factory,
+    config::TokenizerCacheConfig,
+    tokenizer::{
+        cache::CachedTokenizer,
+        factory,
+        traits::Tokenizer,
+    },
     workflow::{
         BackoffStrategy, FailureAction, RetryPolicy, StepDefinition, StepExecutor, StepId,
         StepResult, WorkflowContext, WorkflowDefinition, WorkflowError, WorkflowResult,
@@ -24,12 +33,15 @@ use crate::{
 pub struct TokenizerConfigRequest {
     /// Pre-generated UUID for this tokenizer
     pub id: String,
-    /// User-provided name
+    /// User-provided name (what to register under in the registry)
     pub name: String,
     /// Source: either a local path or HuggingFace model ID
     pub source: String,
     /// Optional path to chat template file
     pub chat_template_path: Option<String>,
+    /// Optional cache configuration. If provided, wraps tokenizer with CachedTokenizer.
+    #[serde(default)]
+    pub cache_config: Option<TokenizerCacheConfig>,
 }
 
 /// Configuration for removing a tokenizer
@@ -115,8 +127,15 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
             .clone();
 
         info!(
-            "Loading tokenizer '{}' (id: {}) from source: {}",
-            config.name, config.id, config.source
+            "Loading tokenizer '{}' (id: {}) from source: {}{}",
+            config.name,
+            config.id,
+            config.source,
+            if config.cache_config.is_some() {
+                " with caching"
+            } else {
+                ""
+            }
         );
 
         // Clone needed values before async move
@@ -124,6 +143,7 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
         let name = config.name.clone();
         let source = config.source.clone();
         let chat_template = config.chat_template_path.clone();
+        let cache_config = config.cache_config.clone();
 
         // Load the tokenizer using the registry's load method (handles deduplication)
         let result = app_context
@@ -131,13 +151,25 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
             .load(&id, &name, &source, || {
                 let source = source.clone();
                 let chat_template = chat_template.clone();
+                let cache_cfg = cache_config.clone();
                 async move {
-                    factory::create_tokenizer_async_with_chat_template(
+                    // Load base tokenizer
+                    let base_tokenizer = factory::create_tokenizer_async_with_chat_template(
                         &source,
                         chat_template.as_deref(),
                     )
                     .await
-                    .map_err(|e| format!("Failed to load tokenizer: {}", e))
+                    .map_err(|e| format!("Failed to load tokenizer: {}", e))?;
+
+                    // Wrap with caching layer if configured
+                    let tokenizer: Arc<dyn Tokenizer> = match cache_cfg {
+                        Some(cfg) if cfg.enable_l0 || cfg.enable_l1 => {
+                            Arc::new(CachedTokenizer::new(base_tokenizer, cfg.into()))
+                        }
+                        _ => base_tokenizer,
+                    };
+
+                    Ok(tokenizer)
                 }
             })
             .await;
@@ -240,6 +272,7 @@ mod tests {
             name: "test-model".to_string(),
             source: "meta-llama/Llama-2-7b-hf".to_string(),
             chat_template_path: None,
+            cache_config: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -249,6 +282,32 @@ mod tests {
         assert_eq!(parsed.name, "test-model");
         assert_eq!(parsed.source, "meta-llama/Llama-2-7b-hf");
         assert!(parsed.chat_template_path.is_none());
+        assert!(parsed.cache_config.is_none());
+    }
+
+    #[test]
+    fn test_tokenizer_config_request_with_cache() {
+        let config = TokenizerConfigRequest {
+            id: "test-uuid-1234".to_string(),
+            name: "test-model".to_string(),
+            source: "meta-llama/Llama-2-7b-hf".to_string(),
+            chat_template_path: None,
+            cache_config: Some(TokenizerCacheConfig {
+                enable_l0: true,
+                l0_max_entries: 1000,
+                enable_l1: false,
+                l1_max_memory: 0,
+            }),
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: TokenizerConfigRequest = serde_json::from_str(&json).unwrap();
+
+        assert!(parsed.cache_config.is_some());
+        let cache = parsed.cache_config.unwrap();
+        assert!(cache.enable_l0);
+        assert_eq!(cache.l0_max_entries, 1000);
+        assert!(!cache.enable_l1);
     }
 
     #[test]

--- a/sgl-model-gateway/src/core/steps/worker/local/mod.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/mod.rs
@@ -27,7 +27,7 @@ pub use discover_dp::{get_dp_info, DiscoverDPInfoStep, DpInfo};
 pub use discover_metadata::DiscoverMetadataStep;
 pub use find_worker_to_update::FindWorkerToUpdateStep;
 pub use find_workers_to_remove::{FindWorkersToRemoveStep, WorkerRemovalRequest};
-pub use register_tokenizer::RegisterTokenizerStep;
+pub use register_tokenizer::SubmitTokenizerJobStep;
 pub use remove_from_policy_registry::RemoveFromPolicyRegistryStep;
 pub use remove_from_worker_registry::RemoveFromWorkerRegistryStep;
 pub use update_policies_for_worker::UpdatePoliciesForWorkerStep;
@@ -159,15 +159,11 @@ pub fn create_local_worker_workflow(
         )
         .add_step(
             StepDefinition::new(
-                "register_tokenizer",
-                "Register Tokenizer",
-                Arc::new(RegisterTokenizerStep),
+                "submit_tokenizer_job",
+                "Submit Tokenizer Job",
+                Arc::new(SubmitTokenizerJobStep),
             )
-            .with_retry(RetryPolicy {
-                max_attempts: 3,
-                backoff: BackoffStrategy::Fixed(Duration::from_secs(1)),
-            })
-            .with_timeout(Duration::from_secs(10))
+            .with_timeout(Duration::from_secs(5))
             .with_failure_action(FailureAction::ContinueNextStep)
             .depends_on(&["register_workers"]),
         )

--- a/sgl-model-gateway/src/routers/tokenize/handlers.rs
+++ b/sgl-model-gateway/src/routers/tokenize/handlers.rs
@@ -227,11 +227,14 @@ pub async fn add_tokenizer(context: &Arc<AppContext>, request: AddTokenizerReque
     let tokenizer_id = TokenizerRegistry::generate_id();
 
     // Create the job with the pre-generated ID
+    // Note: API-initiated tokenizer loads don't use caching by default
+    // Caching is applied for startup and worker-initiated loads based on router config
     let config = TokenizerConfigRequest {
         id: tokenizer_id.clone(),
         name: request.name.clone(),
         source: request.source.clone(),
         chat_template_path: request.chat_template_path.clone(),
+        cache_config: None,
     };
 
     let job = Job::AddTokenizer {

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -24,7 +24,7 @@ use crate::{
     config::{RouterConfig, RoutingMode},
     core::{
         job_queue::{JobQueue, JobQueueConfig},
-        steps::WorkflowEngines,
+        steps::{TokenizerConfigRequest, WorkflowEngines},
         worker::WorkerType,
         worker_manager::WorkerManager,
         Job,
@@ -60,6 +60,7 @@ use crate::{
     },
     routers::{conversations, parse, router_manager::RouterManager, tokenize, RouterTrait},
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
+    tokenizer::TokenizerRegistry,
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
     workflow::LoggingSubscriber,
 };
@@ -829,6 +830,41 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         "Workflow engines initialized (health check timeout: {}s)",
         config.router_config.health_check.timeout_secs
     );
+
+    // Submit startup tokenizer job if tokenizer path is configured
+    // This runs before worker initialization to ensure tokenizer is available
+    if let Some(tokenizer_source) = config
+        .router_config
+        .tokenizer_path
+        .as_ref()
+        .or(config.router_config.model_path.as_ref())
+    {
+        info!("Loading startup tokenizer from: {}", tokenizer_source);
+
+        let job_queue = app_context
+            .worker_job_queue
+            .get()
+            .expect("JobQueue should be initialized");
+
+        let tokenizer_config = TokenizerConfigRequest {
+            id: TokenizerRegistry::generate_id(),
+            name: tokenizer_source.clone(),
+            source: tokenizer_source.clone(),
+            chat_template_path: config.router_config.chat_template.clone(),
+            cache_config: config.router_config.tokenizer_cache.to_option(),
+        };
+
+        let job = Job::AddTokenizer {
+            config: Box::new(tokenizer_config),
+        };
+
+        job_queue
+            .submit(job)
+            .await
+            .map_err(|e| format!("Failed to submit startup tokenizer job: {}", e))?;
+
+        info!("Startup tokenizer job submitted (will complete in background)");
+    }
 
     info!(
         "Initializing workers for routing mode: {:?}",

--- a/sgl-model-gateway/src/tokenizer/cache/mod.rs
+++ b/sgl-model-gateway/src/tokenizer/cache/mod.rs
@@ -52,6 +52,17 @@ impl Default for CacheConfig {
     }
 }
 
+impl From<crate::config::TokenizerCacheConfig> for CacheConfig {
+    fn from(cfg: crate::config::TokenizerCacheConfig) -> Self {
+        Self {
+            enable_l0: cfg.enable_l0,
+            l0_max_entries: cfg.l0_max_entries,
+            enable_l1: cfg.enable_l1,
+            l1_max_memory: cfg.l1_max_memory,
+        }
+    }
+}
+
 /// A caching wrapper around any tokenizer
 pub struct CachedTokenizer {
     /// The underlying tokenizer

--- a/sgl-model-gateway/src/tokenizer/cache/mod.rs
+++ b/sgl-model-gateway/src/tokenizer/cache/mod.rs
@@ -52,17 +52,6 @@ impl Default for CacheConfig {
     }
 }
 
-impl From<crate::config::TokenizerCacheConfig> for CacheConfig {
-    fn from(cfg: crate::config::TokenizerCacheConfig) -> Self {
-        Self {
-            enable_l0: cfg.enable_l0,
-            l0_max_entries: cfg.l0_max_entries,
-            enable_l1: cfg.enable_l1,
-            l1_max_memory: cfg.l1_max_memory,
-        }
-    }
-}
-
 /// A caching wrapper around any tokenizer
 pub struct CachedTokenizer {
     /// The underlying tokenizer


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The current design of tokenizer registration is quite messy. 

We have three different flows for tokenizer registration:

1. `POST /v1/tokenizers`: this will call the tokenizer_registration workflow.
2. gRPC external worker: this will call the worker_registration workflow, which has a `register_tokenizer` step.
3. App context: it tries to call a tokenizer register by parsing CLI args like `--model-path` and `--tokenizer-path`, and it uses sync operation. (Others use async).

This is merely a high level summary regarding the overall call stack. The actual implementation is way more complex and coupled together. It even introduces issues like duplicated tokenizer maps in `TokenizerRegistry`. And `CachedTokenizer` was not supported either:

| Entry Point | File | Trigger | Registers Under | Caching Applied |
|-------------|------|---------|-----------------|-----------------|
| 1. Startup | `app_context.rs` | Router starts with `--model-path` or `--tokenizer-path` | `source` (the path) | Yes |
| 2. Worker Connection | `worker/local/register_tokenizer.rs` | Worker connects (gRPC or HTTP) | `model_id` | No* |
| 3. Manual API | `tokenizer_registration.rs` | `POST /v1/tokenizers` | User-specified `name` | No |


This PR tries to refactor the whole architecture by introducing a unified tokenizer_registration workflow. 

With this PR, all tokenizer loading now goes through the `tokenizer_registration` workflow via `Job::AddTokenizer`, establishing a single source of truth for tokenizer registration. This replaces the fragmented approach where startup, worker connection, and API each had separate loading logic.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- `app_context.rs`: Simplified to create empty `TokenizerRegistry` only
- `server.rs`: Added `async` startup tokenizer job submission
- `register_tokenizer.rs`: Renamed step to `SubmitTokenizerJobStep`, now submits `Job::AddTokenizer` instead of loading directly
- `tokenizer_registration.rs`: Added caching support via `TokenizerCacheConfig`
- `config/types.rs`: Added `to_option()` helper for `TokenizerCacheConfig`
- `tokenizer/cache/mod.rs`: Added `From<TokenizerCacheConfig>` for `CacheConfig`

Architecture:
- Startup (server.rs) submits job with `name=source`
- Worker connection submits job with `name=model_id`
- Manual API (POST /v1/tokenizers) submits job with `name=request_name`
- All jobs processed by tokenizer_registration workflow with consistent caching behavior


#### Current Architecture (Implemented)

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    IMPLEMENTED: OPTION C                                     │
│              Independent Tokenizer Registration Workflow                     │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  ┌─────────────────────────────────────────────────────────────────────┐    │
│  │             tokenizer_registration workflow                          │    │
│  │                                                                      │    │
│  │  Steps:                                                              │    │
│  │  1. ValidateTokenizerConfigStep (dedup check)                        │    │
│  │  2. LoadTokenizerStep (with caching support)                         │    │
│  │     - Loads from local path or HuggingFace                           │    │
│  │     - Wraps with CachedTokenizer if cache_config provided            │    │
│  │     - Registers in TokenizerRegistry                                 │    │
│  │                                                                      │    │
│  │  Input: TokenizerConfigRequest {                                     │    │
│  │      id: String,                    // Pre-generated UUID            │    │
│  │      name: String,                  // What to register under        │    │
│  │      source: String,                // Where to load from            │    │
│  │      chat_template_path: Option<String>,                             │    │
│  │      cache_config: Option<TokenizerCacheConfig>,                     │    │
│  │  }                                                                   │    │
│  └─────────────────────────────────────────────────────────────────────┘    │
│                              ▲                                               │
│                              │                                               │
│                     Job::AddTokenizer                                        │
│                              │                                               │
│          ┌───────────────────┼───────────────────┐                          │
│          │                   │                   │                          │
│  ┌───────┴────────┐  ┌───────┴────────┐  ┌───────┴───────────┐                │
│  │ Startup        │  │ Worker Workflow│  │ Manual API        │                │
│  │ (server.rs)    │  │ (local_worker) │  │ (POST /v1/tok).   │                │
│  │                │  │                │  │                   │                │
│  │ Submits job:   │  │ Submits job:   │  │ Submits job:      │             │
│  │ name=source    │  │ name=model_id  │  │ name=request_name │             │
│  │ source=source  │  │ source=path    │  │ source=request_src│                │
│  │ cache=config   │  │ cache=config   │  │ cache=None        │                │
│  └────────────────┘  └────────────────┘  └───────────────────┘                │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
