### PR TITLE
[diffusion] fix TeaCache parameter initialize fail

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
@@ -36,6 +36,16 @@ def prepare_request(
     if diffusers_kwargs:
         req.extra["diffusers_kwargs"] = diffusers_kwargs
 
+    enable_teacache = getattr(sampling_params, "enable_teacache", False)
+    if enable_teacache:
+        teacache_params = getattr(sampling_params, "teacache_params", None)
+        if teacache_params is not None:
+            req.teacache_params = teacache_params
+            logger.debug(
+                f"TeaCache enabled: cache_type={teacache_params.cache_type}, "
+                f"teacache_thresh={teacache_params.teacache_thresh}"
+            )
+
     req.adjust_size(server_args)
 
     if (req.width is not None and req.width <= 0) or (


### PR DESCRIPTION

## Motivation

```
curl -sS -X POST "http://localhost:30010/v1/videos"   -H "Content-Type: application/json"   -H "Authorization: Bearer sk-proj-1234567890"   -d '{
    "prompt": "A beautiful sunset over the mountains",
    "size": "480x832",
    "num_frames": 81,
    "enable_teacache": true
  }'   --max-time 600
```

`[01-16 11:36:47] [DenoisingStage] Error during execution after 218.5121 ms: teacache_params is not initialized                                                              
Traceback (most recent call last):   `

## Modifications
Copy teacache_params to req.teacache_params

## Accuracy Tests
```
curl -sS -X POST "http://localhost:30010/v1/videos"   -H "Content-Type: application/json"   -H "Authorization: Bearer sk-proj-1234567890"   -d '{
    "prompt": "A beautiful sunset over the mountains",
    "size": "480x832",
    "num_frames": 81,
    "enable_teacache": true
  }'   --max-time 600
```

https://github.com/user-attachments/assets/eeb97861-5623-4a50-bdf4-3d42a3bca6fd



Per-Step Denoising Time：1.38x
Total Generation Time：1.30x
