### PR TITLE
hicache: fix EAGLE mode hash inconsistency in storage prefetch

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageConfig,
     HiCacheStorageExtraInfo,
 )
+from sglang.srt.mem_cache.utils import convert_to_bigram_key
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -261,6 +262,7 @@ class HiCacheController:
         storage_backend_extra_config: Optional[dict] = None,
         pp_rank: int = 0,
         pp_size: int = 1,
+        is_eagle: bool = False,
     ):
         self.mem_pool_device_allocator = token_to_kv_pool_allocator
         self.mem_pool_device = token_to_kv_pool_allocator.get_kvcache()
@@ -271,6 +273,7 @@ class HiCacheController:
         self.enable_storage = False
         self.pp_rank = pp_rank
         self.pp_size = pp_size
+        self.is_eagle = is_eagle
 
         if storage_backend is not None:
             self.storage_backend_type = storage_backend
@@ -686,6 +689,11 @@ class HiCacheController:
         last_hash = operation.last_hash
         tokens_to_fetch = operation.token_ids
         prefix_keys = operation.prefix_keys.copy() if operation.prefix_keys else None
+
+        # EAGLE mode: convert tokens to bigram format for hash computation
+        # This ensures consistency with how tokens are stored (using bigram keys)
+        if self.is_eagle:
+            tokens_to_fetch = convert_to_bigram_key(tokens_to_fetch)
 
         storage_query_count = 0
         hash_value = []

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -116,6 +116,7 @@ class HiRadixCache(RadixCache):
             storage_backend_extra_config=extra_config,
             pp_rank=self.pp_rank,
             pp_size=self.pp_size,
+            is_eagle=params.is_eagle,
         )
         if self.enable_storage_metrics:
             # TODO: support pp


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using HiCache with EAGLE speculative decoding and a distributed storage backend (e.g., Mooncake Store), cross-pod KV cache sharing fails because of hash mismatch between write and read operations.

### Root Cause

In EAGLE mode, RadixCache uses **bigram format** `(token1, token2)` tuples as keys (via `convert_to_bigram_key`), and the hash values are computed based on these bigram keys during the write operation. However, when prefetching from storage, the `_storage_hit_query()` method receives raw token IDs and computes hash values using single tokens, causing a hash mismatch.

The write side and the query side use different token formats to calculate the hash value.：

| operation | Token format | Hash |
|------|-----------|-----------|
| BATCH_SET | `(6634, 30181)` bigram tuple | `0186a5d0b1d4e711...` |
| PREFETCH | `[6634]` token | `16fde07b03e14576...` |

### Impact

- Cross-pod KV cache sharing is completely broken in EAGLE mode
- Each pod recomputes all KV cache even when identical prompts were processed by other pods
- Significant waste of GPU computation resources in multi-pod deployments

## Modifications

### 1. `python/sglang/srt/managers/cache_controller.py`

- Added `is_eagle: bool = False` parameter to `HiCacheController.__init__()`
- Added bigram conversion in `_storage_hit_query()` when EAGLE mode is enabled:

```python
def _storage_hit_query(self, operation) -> tuple[list[str], int]:
    last_hash = operation.last_hash
    tokens_to_fetch = operation.token_ids
    prefix_keys = operation.prefix_keys.copy() if operation.prefix_keys else None

    # EAGLE mode: convert tokens to bigram format for hash computation
    # This ensures consistency with how tokens are stored (using bigram keys)
    if self.is_eagle:
        tokens_to_fetch = convert_to_bigram_key(tokens_to_fetch)

    # ... rest of the method unchanged
```

### 2. `python/sglang/srt/mem_cache/hiradix_cache.py`

- Pass `is_eagle=params.is_eagle` to `HiCacheController` constructor

## Verification

After the fix, the prefetch query correctly uses bigram format and successfully retrieves cached data:

```
[PREFETCH_QUERY] EAGLE mode: converted to bigram, original_len=9, bigram_len=8
[PREFETCH_QUERY] first_5_tokens=[(271, 0), (0, 128803), (128803, 2788), (2788, 12201), (12201, 9068)]
[PREFETCH_QUERY] batch_exists result: hit_page_num=8/8
[PREFETCH_QUERY] final result: storage_query_count=8, hash_value_len=8
```

Cross-pod cache sharing now works correctly:
```
Prefetching 1 pages for request 523ec36e23ed454ea01b482d170ac0a8.
Prefetch 523ec36e23ed454ea01b482d170ac0a8 completed with 1 tokens
Prefill batch, #new-seq: 1, #new-token: 2, #cached-token: 8
```

## Test Environment

- Model: DeepSeek-V3 with EAGLE speculative decoding
- Storage Backend: Mooncake Store (RDMA)
- Multi-pod deployment with HiCache enabled
