### PR TITLE
[Feature] add feature mla_ag_after_qlora for dsv3.2

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -7,6 +7,7 @@ import torch
 import torch_npu
 
 from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
     is_fia_nz,
     is_mla_preprocess_enabled,
@@ -14,11 +15,9 @@ from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.nsa.utils import is_nsa_enable_prefill_cp
 from sglang.srt.layers.attention.torch_native_backend import TorchNativeAttnBackend
-from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
-from sglang.srt.environ import envs
 from sglang.srt.utils import get_bool_env_var
 
 if TYPE_CHECKING:
@@ -240,12 +239,17 @@ class AscendAttnBackend(AttentionBackend):
             self.kv_lora_rank = model_runner.model_config.kv_lora_rank
             self.qk_rope_head_dim = model_runner.model_config.qk_rope_head_dim
             self.qk_nope_head_dim = model_runner.model_config.qk_nope_head_dim
-            if hasattr(model_runner.model_config, "not_use_fused_infer_attention_score"):
+            if hasattr(
+                model_runner.model_config, "not_use_fused_infer_attention_score"
+            ):
                 self.not_use_fused_infer_attention_score = True
         else:
             if hasattr(model_runner.model_config, "use_sdpa"):
                 self.use_sdpa = True
-            self.use_alibi = hasattr(model_runner.model_config, "use_alibi") and model_runner.model_config.use_alibi
+            self.use_alibi = (
+                hasattr(model_runner.model_config, "use_alibi")
+                and model_runner.model_config.use_alibi
+            )
         self.native_attn = TorchNativeAttnBackend(model_runner)
         self.graph_metadata = {}
         self.max_context_len = model_runner.model_config.context_len
@@ -306,7 +310,9 @@ class AscendAttnBackend(AttentionBackend):
             seq_lens_list_cumsum = np.cumsum(forward_batch.extend_seq_lens_cpu)
             self.forward_metadata.seq_lens_list_cumsum = seq_lens_list_cumsum
             self.forward_metadata.seq_lens = forward_batch.seq_lens
-            self.forward_metadata.seq_lens_cum_sum = torch.cumsum(forward_batch.deq_lens, dim=0)
+            self.forward_metadata.seq_lens_cum_sum = torch.cumsum(
+                forward_batch.seq_lens, dim=0
+            )
         if forward_batch.forward_mode.is_target_verify():
             self.forward_metadata.seq_lens_cpu_int += self.speculative_num_draft_tokens
 
@@ -433,12 +439,16 @@ class AscendAttnBackend(AttentionBackend):
         slopes: torch.Tensor,
         num_heads: int,
         device: torch.device,
-        dtype: torch.dtype = torch.bfloat16
+        dtype: torch.dtype = torch.bfloat16,
     ) -> torch.Tensor:
         position_point = torch.arange(seq_len) - seq_len + 1
-        position_point = position_point.unsqueeze(0).unsqueeze(0).expand(num_heads, -1, -1)
+        position_point = (
+            position_point.unsqueeze(0).unsqueeze(0).expand(num_heads, -1, -1)
+        )
         diag = torch.diag(position_point[0])
-        position_point = position_point - diag.unsqueeze(0).unsqueeze(0).transpose(-1, -2)
+        position_point = position_point - diag.unsqueeze(0).unsqueeze(0).transpose(
+            -1, -2
+        )
         position_point = position_point.to(device)
         alibi = slopes.unsqueeze(1).unsqueeze(1) * position_point
         alibi_bias = alibi.view(num_heads, 1, seq_len)
@@ -453,32 +463,47 @@ class AscendAttnBackend(AttentionBackend):
         num_heads: int,
         device: torch.device,
         is_extend: bool = True,
-        dtype: torch.dtype = torch.bfloat16
+        dtype: torch.dtype = torch.bfloat16,
     ) -> torch.Tensor:
         if not hasattr(self, "alibi_bias") or self.alibi_bias is None:
-            MAX_LEN_ALB=5000
-            max_seq_len=max(kv_seq_len,q_seq_len)
-            max_seq_len=max(max_seq_len,MAX_LEN_ALB)
-            self.alibi_bias = self._generate_alibi_bias(max_seq_len,slopes,num_heads,device,dtype)
+            MAX_LEN_ALB = 5000
+            max_seq_len = max(kv_seq_len, q_seq_len)
+            max_seq_len = max(max_seq_len, MAX_LEN_ALB)
+            self.alibi_bias = self._generate_alibi_bias(
+                max_seq_len, slopes, num_heads, device, dtype
+            )
 
         if not hasattr(self, "super_mask") or self.super_mask is None:
-            MAX_LEN_ALB=5000
-            max_seq_len=max(kv_seq_len,q_seq_len)
-            max_seq_len=max(max_seq_len,MAX_LEN_ALB)
+            MAX_LEN_ALB = 5000
+            max_seq_len = max(kv_seq_len, q_seq_len)
+            max_seq_len = max(max_seq_len, MAX_LEN_ALB)
             super_mask = torch.ones(size=(1, max_seq_len, max_seq_len), dtype=dtype)
             super_mask = super_mask.float().fill_(float("-inf")).type_as(super_mask)
             super_mask = torch.triu(super_mask, 1).to(device)
             self.super_mask = super_mask
         if is_extend:
-            return self.alibi_bias[:, :q_seq_len, :kv_seq_len] + self.super_mask[:, :q_seq_len, :kv_seq_len]
+            return (
+                self.alibi_bias[:, :q_seq_len, :kv_seq_len]
+                + self.super_mask[:, :q_seq_len, :kv_seq_len]
+            )
         else:
             return self.alibi_bias[:, :q_seq_len, :kv_seq_len]
 
-
-
-    def attn_alibi(self,q,k_cache,v_cache,block_tables,seq_lens,query_lens,scale_value,num_heads,slopes,is_extend):
-        curr=0
-        num_prompts=query_lens.shape[0]
+    def attn_alibi(
+        self,
+        q,
+        k_cache,
+        v_cache,
+        block_tables,
+        seq_lens,
+        query_lens,
+        scale_value,
+        num_heads,
+        slopes,
+        is_extend,
+    ):
+        curr = 0
+        num_prompts = query_lens.shape[0]
         head_size = k_cache.shape[3]
         head_size_v = v_cache.shape[3]
         block_size = k_cache.shape[1]
@@ -487,30 +512,32 @@ class AscendAttnBackend(AttentionBackend):
             seq_len = seq_lens[i].item()
             block_table = block_tables[i]
 
-            j= torch.arange(seq_len,device=block_table.device)
+            j = torch.arange(seq_len, device=block_table.device)
 
             block_number = block_table[j // block_size]
             block_offset = j % block_size
 
-            k = k_cache[block_number,block_offset]
-            v = v_cache[block_number,block_offset]
+            k = k_cache[block_number, block_offset]
+            v = v_cache[block_number, block_offset]
             k = k.view(seq_len, num_heads, head_size)
             v = v.view(seq_len, num_heads, head_size_v)
 
             if is_extend:
                 q_len = query_lens[i].item()
-                querys = q[curr :curr + q_len]
-                assert q_len==seq_len, "Warning: Q sequence length is not consistant with KV sequence length during Prefill phase."
+                queries = q[curr : curr + q_len]
+                assert (
+                    q_len == seq_len
+                ), "Warning: Q sequence length is not consistent with KV sequence length during Prefill phase."
             else:
                 q_len = 1
-                querys = q[curr :curr + 1]
+                queries = q[curr : curr + 1]
 
-            querys = querys.to(torch.float32)
-            querys = querys * scale_value
-            querys = querys.permute(1, 0, 2)
+            queries = queries.to(torch.float32)
+            queries = queries * scale_value
+            queries = queries.permute(1, 0, 2)
             k = k.permute(1, 2, 0)
 
-            score = torch.bmm(querys, k)
+            score = torch.bmm(queries, k)
             score = score.to(torch.float32)
             if slopes is not None:
                 alibi_bias = self.generate_alibi_bias(
@@ -520,14 +547,12 @@ class AscendAttnBackend(AttentionBackend):
                     num_heads=num_heads,
                     device=q.device,
                     is_extend=is_extend,
-                    dtype=querys.dtype
+                    dtype=queries.dtype,
                 )
                 score = score + alibi_bias
-            score = torch.max(
-                score, torch.tensor(torch.finfo(score.dtype).min)
-            )
+            score = torch.max(score, torch.tensor(torch.finfo(score.dtype).min))
             p = torch.nn.functional.softmax(score, dim=-1)
-            v = v.permute(1,0,2)
+            v = v.permute(1, 0, 2)
             out = torch.bmm(p, v)
             out = out.permute(1, 0, 2)
             out = out.reshape(-1, num_heads * head_size_v)
@@ -731,7 +756,7 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
         topk_indices: Optional[torch.Tensor] = None,
-        slopes:  Optional[torch.Tensor] = None,
+        slopes: Optional[torch.Tensor] = None,
     ):
         if topk_indices is not None:
             return self.forward_sparse(
@@ -772,9 +797,7 @@ class AscendAttnBackend(AttentionBackend):
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                forward_batch.token_to_kv_pool.set_kv_buffer(
-                    layer, cache_loc, k, v
-                )
+                forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
 
             k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
             v_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
@@ -823,7 +846,12 @@ class AscendAttnBackend(AttentionBackend):
                 ):
                     causal = False
 
-                if layer.qk_head_dim <= 128 and layer.logit_cap == 0 and causal and forward_batch.encoder_lens is None:
+                if (
+                    layer.qk_head_dim <= 128
+                    and layer.logit_cap == 0
+                    and causal
+                    and forward_batch.encoder_lens is None
+                ):
                     """When logit_cap > 0, use torch native attention backend instead
                     cause Ascend attn ops do not support soft-capping attention currently.
                     """
@@ -882,7 +910,9 @@ class AscendAttnBackend(AttentionBackend):
                         )
                         attn_output = attn_output.transpose(1, 2).contiguous()
                         attn_output = (
-                            attn_output.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)
+                            attn_output.reshape(
+                                -1, layer.tp_q_head_num * layer.v_head_dim
+                            )
                             .contiguous()
                             .squeeze(0)
                         )
@@ -1027,8 +1057,12 @@ class AscendAttnBackend(AttentionBackend):
                     data[: forward_batch.num_token_non_padded_cpu] for data in [q, k, v]
                 ]
 
-                q_nope, q_rope = q.split([layer.v_head_dim, self.qk_rope_head_dim], dim=-1)
-                k_nope, k_rope = k.split([layer.v_head_dim, self.qk_rope_head_dim], dim=-1)
+                q_nope, q_rope = q.split(
+                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+                )
+                k_nope, k_rope = k.split(
+                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+                )
 
                 attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
                     q_nope,
@@ -1046,7 +1080,9 @@ class AscendAttnBackend(AttentionBackend):
                     next_tokens=0,
                 )
 
-                attn_output = attn_output.reshape(-1, layer.tp_q_head_num, layer.v_head_dim)
+                attn_output = attn_output.reshape(
+                    -1, layer.tp_q_head_num, layer.v_head_dim
+                )
                 if num_token_padding != forward_batch.num_token_non_padded_cpu:
                     attn_output = torch.cat(
                         [
@@ -1059,48 +1095,58 @@ class AscendAttnBackend(AttentionBackend):
                         dim=0,
                     )
             else:
-                kv_lora_rank = k.shape[-1]-self.qk_rope_head_dim
+                kv_lora_rank = k.shape[-1] - self.qk_rope_head_dim
                 kv_c, k_rope = k.split([kv_lora_rank, self.qk_rope_head_dim], dim=-1)
                 if save_kv_cache:
-                    forward_batch.token_to_kv_pool.set_kv_buffer(layer, forward_batch.out_cache_loc, kv_c, k_rope)
-                attn_output = q.new_empty((q.shape[0], layer.tp_q_head_num, kv_lora_rank))
-                use_gqa = (layer.tp_q_head_num != layer.tp_k_head_num)
+                    forward_batch.token_to_kv_pool.set_kv_buffer(
+                        layer, forward_batch.out_cache_loc, kv_c, k_rope
+                    )
+                attn_output = q.new_empty(
+                    (q.shape[0], layer.tp_q_head_num, kv_lora_rank)
+                )
+                use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
 
                 q = q.movedim(0, q.dim() - 2)
                 k = k.movedim(0, q.dim() - 2)
                 v = v.movedim(0, q.dim() - 2)
                 k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
-                v_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
+                v_cache = forward_batch.token_to_kv_pool.get_value_buffer(
+                    layer.layer_id
+                )
 
-                curr=0
+                curr = 0
                 head_size = k_cache.shape[3]
                 head_size_v = v_cache.shape[3]
                 block_size = k_cache.shape[1]
                 for i in range(forward_batch.seq_lens_cpu.shape[0]):
                     q_len = forward_batch.extend_seq_lens[i]
-                    q_ = q[:, curr:curr + q_len, :]
+                    q_ = q[:, curr : curr + q_len, :]
 
                     block_table = self.forward_metadata.block_tables[i]
                     j = torch.arange(q_len, device=block_table.device)
                     block_number = block_table[j // block_size]
                     block_offset = j % block_size
 
-                    k_ = k_cache[block_number,block_offset]
-                    v_ = v_cache[block_number,block_offset]
+                    k_ = k_cache[block_number, block_offset]
+                    v_ = v_cache[block_number, block_offset]
                     k_ = k_.view(q_len, layer.tp_k_head_num, head_size)
                     v_ = v_.view(q_len, layer.tp_k_head_num, head_size_v)
 
                     k_kpe = torch.cat([k_, v_], dim=-1).transpose(0, 1)
-                    o_ = torch.nn.functional.scaled_dot_product_attention(
-                        q_.unsqueeze(0),
-                        k_kpe.unsqueeze(0),
-                        v.unsqueeze(0),
-                        enable_gqa=use_gqa,
-                        scale=layer.scaling,
-                        is_causal=True,
-                    ).squeeze(0).movedim(0, q.dim() - 2)
+                    o_ = (
+                        torch.nn.functional.scaled_dot_product_attention(
+                            q_.unsqueeze(0),
+                            k_kpe.unsqueeze(0),
+                            v.unsqueeze(0),
+                            enable_gqa=use_gqa,
+                            scale=layer.scaling,
+                            is_causal=True,
+                        )
+                        .squeeze(0)
+                        .movedim(0, q.dim() - 2)
+                    )
 
-                    attn_output[curr: curr + q_len, :, :] = o_
+                    attn_output[curr : curr + q_len, :, :] = o_
                     curr += q_len
 
         return attn_output
@@ -1376,7 +1422,9 @@ class AscendAttnBackend(AttentionBackend):
                     actual_seq_lengths_kv=actual_seq_len_kv,
                     sparse_mode=0,
                 )
-                return attn_output.view(num_tokens, layer.tp_q_head_num * layer.v_head_dim)
+                return attn_output.view(
+                    num_tokens, layer.tp_q_head_num * layer.v_head_dim
+                )
         else:
             c_kv, k_rope = forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id)
             if is_fia_nz():
@@ -1457,7 +1505,7 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
         topk_indices: Optional[torch.Tensor] = None,
-        slopes:  Optional[torch.Tensor] = None,
+        slopes: Optional[torch.Tensor] = None,
     ):
         if is_mla_preprocess_enabled():
             # MLAPO does saving kv_cache
@@ -1495,9 +1543,7 @@ class AscendAttnBackend(AttentionBackend):
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                forward_batch.token_to_kv_pool.set_kv_buffer(
-                    layer, cache_loc, k, v
-                )
+                forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
             num_tokens = q.shape[0]
             k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
             v_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
@@ -1558,11 +1604,11 @@ class AscendAttnBackend(AttentionBackend):
                         v_cache=v_cache,
                         block_tables=self.forward_metadata.block_tables,
                         seq_lens=self.forward_metadata.seq_lens_cpu_int,
-                        query_lens=torch.ones(num_tokens,dtype=torch.int32),
+                        query_lens=torch.ones(num_tokens, dtype=torch.int32),
                         scale_value=layer.scaling,
                         num_heads=layer.tp_q_head_num,
                         slopes=slopes,
-                        is_extend=False
+                        is_extend=False,
                     )
             else:
                 if layer.qk_head_dim != layer.v_head_dim:

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -12,16 +12,16 @@ from sglang.srt.layers.attention.nsa.utils import (
     cp_split_and_rebuild_position,
     enable_prefill_cp,
 )
-from sglang.srt.layers.communicator import ScatterMode
-from sglang.srt.utils import get_bool_env_var
-from sglang.srt.layers.communicator import get_attn_tp_context
+from sglang.srt.layers.communicator import ScatterMode, get_attn_tp_context
 from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor
+from sglang.srt.utils import get_bool_env_var
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
     from sglang.srt.utils import BumpAllocator
-_use_ag_after_qlora = get_bool_env_var("SGLANG_USER_AG_AFTER_QLORA")
+_use_ag_after_qlora = get_bool_env_var("SGLANG_USE_AG_AFTER_QLORA")
+
 
 # region MHA
 def forward_mha_prepare_npu(
@@ -79,7 +79,9 @@ def forward_mha_prepare_npu(
         )
         q_pe = q_pe.reshape(B, -1, m.qk_rope_head_dim)
 
-        ckv_cache, k_rope_cache = forward_batch.token_to_kv_pool.get_kv_buffer(m.layer_id)
+        ckv_cache, k_rope_cache = forward_batch.token_to_kv_pool.get_kv_buffer(
+            m.layer_id
+        )
         _, _, k_pe, kv_a = torch_npu.npu_kv_rmsnorm_rope_cache(
             latent_cache.view(-1, 1, 1, m.kv_lora_rank + m.qk_rope_head_dim),  # bnsd
             m.kv_a_layernorm.weight,
@@ -100,7 +102,7 @@ def forward_mha_prepare_npu(
         k_pe = k_pe.reshape(B, -1, m.qk_rope_head_dim)
     else:
         kv_a = m.kv_a_layernorm(kv_a)
-        k_pe = latent_cache[:, :, m.kv_lora_rank:]
+        k_pe = latent_cache[:, :, m.kv_lora_rank :]
         if m.rotary_emb is not None:
             q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
         forward_batch.token_to_kv_pool.set_kv_buffer(
@@ -342,7 +344,7 @@ def forward_dsa_prepare_npu(
             q_lora = m.q_a_layernorm(q)
 
     else:
-        fused_qkv_a_proj_out = m.fused_qkv_a_proj_with_mqa(hidden_states)[0]
+        fused_qkv_a_proj_out = get_attn_tp_context().fetch_qkv_latent()
         q, latent_cache = fused_qkv_a_proj_out.split(
             [m.q_lora_rank, m.kv_lora_rank + m.qk_rope_head_dim], dim=-1
         )
@@ -355,9 +357,7 @@ def forward_dsa_prepare_npu(
             and layer_scatter_modes.attn_mode == ScatterMode.TP_ATTN_FULL
         ):
             q = scattered_to_tp_attn_full(q, forward_batch)
-            latent_cache = scattered_to_tp_attn_full(
-                latent_cache, forward_batch
-            )
+            latent_cache = scattered_to_tp_attn_full(latent_cache, forward_batch)
         q_lora = q.clone()  # required for topk_indices
         q_event = None
         if m.alt_stream is not None:
@@ -461,6 +461,7 @@ def forward_dsa_core_npu(
     output, _ = m.o_proj(attn_bmm_output)
     return output
 
+
 def scattered_to_tp_attn_full(
     hidden_states: torch.Tensor,
     forward_batch,
@@ -475,4 +476,6 @@ def scattered_to_tp_attn_full(
     )
     attn_tp_all_gather_into_tensor(hidden_states, local_hidden_states.contiguous())
     return hidden_states
+
+
 # endregion

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -68,6 +68,7 @@ _is_sm100_supported = _is_cuda and is_sm100_supported()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 _is_gfx95_supported = is_gfx95_supported()
 _is_npu = is_npu()
+_use_ag_after_qlora = get_bool_env_var("SGLANG_USE_AG_AFTER_QLORA")
 
 if _use_aiter and _is_gfx95_supported:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
@@ -634,6 +635,8 @@ class CommunicateSimpleFn:
         if (input_mode == ScatterMode.SCATTERED) and (
             output_mode == ScatterMode.TP_ATTN_FULL
         ):
+            if _use_ag_after_qlora:
+                return CommunicateSimpleFn._trivial
             return CommunicateSimpleFn._scattered_to_tp_attn_full
 
         raise NotImplementedError(f"{input_mode=} {output_mode=}")

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -152,7 +152,7 @@ class AttnTpContext:
     def init_context(self, q_lora_rank, is_nsa):
         self.allow_input_scattered = (
             get_global_server_args().enable_attn_tp_input_scattered
-            and _is_cuda
+            and (_is_cuda or _is_npu)
             and q_lora_rank is not None
             and not is_nsa
             and get_tensor_model_parallel_world_size() > 1

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -170,7 +170,7 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _device_sm = get_device_sm()
 _is_gfx95_supported = is_gfx95_supported()
-_use_ag_after_qlora = get_bool_env_var("SGLAGN_USE_AG_AFTER_QLORA")
+_use_ag_after_qlora = get_bool_env_var("SGLANG_USE_AG_AFTER_QLORA")
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 
 if _use_aiter_gfx95:
@@ -1646,7 +1646,12 @@ class DeepseekV2AttentionMLA(nn.Module):
             )
         elif attn_forward_method == AttnForwardMethod.DSA_NPU:
             inner_state = forward_dsa_prepare_npu(
-                self, positions, hidden_states, forward_batch, zero_allocator, layer_scatter_modes
+                self,
+                positions,
+                hidden_states,
+                forward_batch,
+                zero_allocator,
+                layer_scatter_modes,
             )
         else:
             raise NotImplementedError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In DeepSeek-V3.2, due to the large hidden dimension of the model, performing all-gather on hidden_states before attention  introduces a high-dimensional communication operation. The scale of this communication is proportional to hidden_dim × token_num, which can quickly amplify in multi-card TP scenarios, making communication rather than computation the primary performance bottleneck in the attention stage.

## Modifications

allgather_after_q_lora addresses this by removing the pre-attention all-gather of hidden_states and moving the communication before the indexer. It performs all-gather only on low-dimensional tensors such as q_lora, k, and weights just before indexer execution. This reduces high-dimensional communication overhead while maintaining equivalence. Since the all-gather communication occurs after layernorm, it effectively reduces the computational overhead of related operators.

## Accuracy Tests

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [15:25<00:00,  1.43it/s]
Accuracy: 0.959
Invalid: 0.000
Latency: 927.711 s
Output throughput: 154.077 token/s


## Benchmarking and Profiling

Serving Benchmark Result

Backend: sglang
Traffic request rate: 7.0
Max request concurrency: 416
Successful requests: 1664
Benchmark duration (s): 276.95
Total input tokens: 3494400
Total input text tokens: 3494400
Total input vision tokens: 0
Total generated tokens: 1497600
Total generated tokens (retokenized): 1497276
Request throughput (req/s): 6.01
Input token throughput (tok/s): 12617.32
Output token throughput (tok/s): 5407.42
Peak output token throughput (tok/s): 6835.00
Peak concurrent requests: 265
Total token throughput (tok/s): 18024.74
Concurrency: 196.95
Accept length: 3.23
-----------------End-to-End Latency-----------------
Mean E2E Latency (ms): 32779.85
Median E2E Latency (ms): 32644.49
-----------------Time to First Token-----------------
Mean TTFT (ms): 5600.41
Median TTFT (ms): 4935.13
P99 TTFT (ms): 12345.78
-----------------Time per Output Token (excl. 1st token)-----------------
Mean TPOT (ms): 30.23
Median TPOT (ms): 30.64
P99 TPOT (ms): 38.63
-----------------Inter-Token Latency-----------------
Mean ITL (ms): 30.23
Median ITL (ms): 25.18
P95 ITL (ms): 49.39
P99 ITL (ms): 66.04
Max ITL (ms): 521.57

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
