### PR TITLE
[Feat] Accelerate qwen3vl by remove cpu op

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -1005,9 +1005,9 @@ class VisionAttention(nn.Module):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
             # [b, s, embed_dim] --> [b * s, head, head_size]
-            q = q.reshape(bsz * s, head, -1).contiguous()
-            k = k.reshape(bsz * s, kv_head, -1).contiguous()
-            v = v.reshape(bsz * s, kv_head, -1).contiguous()
+            q = q.reshape(bsz * s, head, -1)
+            k = k.reshape(bsz * s, kv_head, -1)
+            v = v.reshape(bsz * s, kv_head, -1)
             if self.qk_normalization_by_head_size:
                 q, k = self._apply_qk_norm_head_size(q, k)
         else:

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1029,18 +1029,36 @@ def embed_mm_inputs(
         other_info["input_deepstack_embeds"] = input_deepstack_embeds
 
     # 4. scatter embeddings into input embedding
+    # Use masked_scatter_ to completely avoid D2D synchronization
     for i, modality, embedding, mask in zip(
         range(len(embeddings)), modalities, embeddings, masks
     ):
         if embedding is None or mask is None:
             continue
-        # in-place update
-        indices = torch.where(mask.squeeze(dim=-1))[0]
-        input_embeds[indices] = embedding.to(input_embeds.device, input_embeds.dtype)
+
+        mask_1d = mask.view(-1)
+
+        # Convert embedding to target device/dtype if needed
+        if (
+            embedding.device != input_embeds.device
+            or embedding.dtype != input_embeds.dtype
+        ):
+            embedding = embedding.to(input_embeds.device, input_embeds.dtype)
+
+        # masked_scatter_ is a pure GPU kernel operation - no D2D
+        # Need to expand mask to match embedding dimensions
+        input_embeds.masked_scatter_(mask_1d.unsqueeze(-1), embedding)
+
         if use_deepstack.get(modality, None):
-            input_deepstack_embeds[indices] = deepstack_embeddings[i].to(
-                input_embeds.device, input_embeds.dtype
-            )
+            deepstack_emb = deepstack_embeddings[i]
+            if (
+                deepstack_emb.device != input_embeds.device
+                or deepstack_emb.dtype != input_embeds.dtype
+            ):
+                deepstack_emb = deepstack_emb.to(
+                    input_embeds.device, input_embeds.dtype
+                )
+            input_deepstack_embeds.masked_scatter_(mask_1d.unsqueeze(-1), deepstack_emb)
 
     return input_embeds, other_info
 


### PR DESCRIPTION
# Motivation
Accelerate qwen3vl by delete contiguous in vision_attention && delete D2D in torch.where and index_put

During the forward pass of the ViT in the Qwen3VL multimodal model, some D2D and H2D operations were observed, which impacted the forward propagation speed of the ViT. This PR eliminates two such instances, as shown below.

# command
```
export SGLANG_USE_AITER=1
model=/models/nvme3/data/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/
TP=8
EP=1
 
echo "launching ${model}"
echo "TP=${TP}"
echo "EP=${EP}"

python3 -m sglang.launch_server \
    --model-path ${model} \
    --host localhost \
    --port 9000 \
    --tp-size ${TP} \
    --ep-size ${EP} \
    --trust-remote-code \
    --chunked-prefill-size 16384 \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --max-prefill-tokens 16384 \
    --cuda-graph-max-bs 128 \
    --max-running-requests 128 \
    --mm-attention-backend aiter_attn
```