### PR TITLE
[Feat][Rocm] Accelerate mutimodal hash func

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1358,8 +1358,7 @@ def tensor_hash(tensor_list) -> int:
                 x.flatten() if isinstance(x, torch.Tensor) else x for x in tensor_list
             ]
             tensor = torch.concat(tensor_list)
-        tensor = torch.concat(tensor_list)
-    if is_cuda_alike(tensor):
+    if is_cuda_alike():
         return gpu_tensor_hash(tensor.cuda())
     tensor = tensor.detach().contiguous()
 

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -3,13 +3,13 @@ Multi-modality utils
 """
 
 import copy
-import hashlib
 import pickle
 from abc import abstractmethod
 from collections import defaultdict
 from multiprocessing import shared_memory
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
+import blake3
 import numpy as np
 import torch
 from torch import nn
@@ -26,7 +26,12 @@ from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalSta
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.multimodal.evs import EVSEmbeddingResult
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import flatten_nested_list, is_npu, print_warning_once
+from sglang.srt.utils import (
+    flatten_nested_list,
+    is_cuda_alike,
+    is_npu,
+    print_warning_once,
+)
 from sglang.utils import logger
 
 _is_npu = is_npu()
@@ -1335,7 +1340,7 @@ def get_multimodal_data_bounds(
 
 
 def data_hash(data) -> int:
-    hash_bytes = hashlib.sha256(data).digest()[:8]
+    hash_bytes = blake3.blake3(data).digest()[:8]
     return int.from_bytes(hash_bytes, byteorder="big", signed=False)
 
 
@@ -1346,11 +1351,15 @@ def tensor_hash(tensor_list) -> int:
     tensor = tensor_list
     if isinstance(tensor_list, list):
         tensor_list = flatten_nested_list(tensor_list)
-        tensor_list = [
-            x.flatten() if isinstance(x, torch.Tensor) else x for x in tensor_list
-        ]
+        if len(tensor_list) == 1:
+            tensor = tensor_list[0]
+        else:
+            tensor_list = [
+                x.flatten() if isinstance(x, torch.Tensor) else x for x in tensor_list
+            ]
+            tensor = torch.concat(tensor_list)
         tensor = torch.concat(tensor_list)
-    if tensor.is_cuda:
+    if is_cuda_alike(tensor):
         return gpu_tensor_hash(tensor.cuda())
     tensor = tensor.detach().contiguous()
 

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -28,7 +28,6 @@ from sglang.srt.multimodal.evs import EVSEmbeddingResult
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     flatten_nested_list,
-    is_cuda_alike,
     is_npu,
     print_warning_once,
 )
@@ -1358,7 +1357,7 @@ def tensor_hash(tensor_list) -> int:
                 x.flatten() if isinstance(x, torch.Tensor) else x for x in tensor_list
             ]
             tensor = torch.concat(tensor_list)
-    if is_cuda_alike():
+    if tensor.is_cuda:
         return gpu_tensor_hash(tensor.cuda())
     tensor = tensor.detach().contiguous()
 


### PR DESCRIPTION
## Motivation
In Qwen3VL, there are numerous CPU operations, with multimodal hash encoding being one of them. This PR eliminates the concat CPU operations in the hash encoding. For CPU-based hash encoding, a faster algorithm library (consistent with vLLM) is employed. Additionally, for AMD GPUs, the hash encoding is moved to the GPU for computation to accelerate performance.
## command
```
export SGLANG_USE_AITER=1
model=/models/nvme3/data/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/
TP=8
EP=1
 
echo "launching ${model}"
echo "TP=${TP}"
echo "EP=${EP}"

python3 -m sglang.launch_server \
    --model-path ${model} \
    --host localhost \
    --port 9000 \
    --tp-size ${TP} \
    --ep-size ${EP} \
    --trust-remote-code \
    --chunked-prefill-size 16384 \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --max-prefill-tokens 16384 \
    --cuda-graph-max-bs 128 \
    --max-running-requests 128 \
    --mm-attention-backend aiter_attn
```
