### PR TITLE
[OPT] DeepSeekV3.2: optimize indexer weight_proj-mma performance

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -182,7 +182,6 @@ class Indexer(MultiPlatformOp):
             quant_config=quant_config,
             prefix=add_prefix("wk", prefix),
         )
-        # NOTE: weights_proj in the checkpoint is stored in bf16, while the parameters here are stored in fp32 for convenience
         self.weights_proj = ReplicatedLinear(
             self.hidden_size,
             self.n_heads,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -187,7 +187,7 @@ class Indexer(MultiPlatformOp):
             self.hidden_size,
             self.n_heads,
             bias=False,
-            params_dtype=torch.float32,
+            params_dtype=torch.bfloat16,
             prefix=add_prefix("weights_proj", prefix),
         )
         self.k_norm = LayerNorm(self.head_dim, dtype=torch.float32)
@@ -221,13 +221,15 @@ class Indexer(MultiPlatformOp):
 
     @torch.compile(dynamic=True) if not _is_hip else lambda f: f
     def _project_and_scale_head_gates(self, x: torch.Tensor):
-        weights, _ = self.weights_proj(x.float())
+        weights, _ = self.weights_proj(x)
+        weights = weights.float()
         weights = weights * self.n_heads**-0.5
         return weights
 
     @torch.compile(dynamic=True) if not _is_hip else lambda f: f
     def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
-        weights, _ = self.weights_proj(x.float())
+        weights, _ = self.weights_proj(x)
+        weights = weights.float()
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

From these pr[https://github.com/sgl-project/sglang/pull/16637 and https://github.com/sgl-project/sglang/issues/16861 and https://github.com/sgl-project/sglang/pull/13459/files], we know weights_proj is a relatively time-consuming operation.Although weights_proj is stored in BF16 precision in Hugging-Face, it is calculated in FP32 precision in SGLang. The reason for converting weights_proj to FP32 is that in the subsequent scaling calculation, it is necessary to use FP32 precision. To balance performance and accuracy, I still perform the operation on weights_proj with BF16 precision, but then convert its output back to FP32.The accuracy test indicates that with this optimization, the accuracy remains almost unchanged.

## Modifications
1.The input of weights_proj is in BF16 precision, which is the same as wk.
2.Convert weights_proj to BF16 weights
3.Convert the output of weights_proj to FP32

## Accuracy Tests

### test command
python3 -m sglang.compile_deep_gemm --model-path /deepseek-ai/DeepSeek-V3.2 \
    --trust-remote-code --tp-size 8 --dp-size 8 --enable-dp-attention \
    --tool-call-parser deepseekv32 --reasoning-parser deepseek-v3 \
    --host 0.0.0.0 --port 8000 \

#! /bin/bash
export NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK=1

ns prepare_data aime25

PORT=8008
BACKEND=sglang
MODEL="/upfs/models/deepseek-ai/DeepSeek-V3.2" # Should be changed to the model name
MODEL_NAME="dsv32-fp8"

echo "Starting AIME25 evaluation with model $MODEL on port $PORT using backend $BACKEND..."
ns eval \
  --benchmarks=aime25:4 \
  --server_type=$BACKEND \
  --model=$MODEL \
  --server_address=http://192.168.170.100:8008/v1 \
  --output_dir=nemo_skills_aime25_${MODEL_NAME}_output_${BACKEND}_$(date +%Y%m%d_%H%M%S) \
  ++chat_template_kwargs.thinking=true \
  ++inference.temperature=1.0 \
  ++inference.top_p=0.95 \
  ++inference.tokens_to_generate=64000
  #++inference.tokens_to_generate=120000 for Speciale model

before：
<img width="1038" height="463" alt="image" src="https://github.com/user-attachments/assets/093c6b66-27bf-4780-947e-bbf3a1310df7" />

after：
<img width="1024" height="449" alt="image" src="https://github.com/user-attachments/assets/7f1858dc-e22a-407e-b07d-f0f03ee9bba7" />

## Benchmarking and Profiling
before：
<img width="607" height="962" alt="image" src="https://github.com/user-attachments/assets/b0c4bb23-c0ac-4ac5-9fce-f33d069d00d5" />

after：
<img width="583" height="963" alt="image" src="https://github.com/user-attachments/assets/b8501c77-8105-4b78-804b-4310d1b0b961" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
