### PR TITLE
[Feat] Accelerate by remove uneccessary tokenize when model is multimodel

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -459,10 +459,14 @@ class OpenAIServingChat(OpenAIServingBase):
                 self._handle_last_assistant_message(openai_compatible_messages, request)
             )
 
+            # Optimization: For multimodal, skip tokenization (tokenize=False)
+            # The processor will do tokenization later with proper multimodal placeholders
+            # For non-multimodal, tokenize here (tokenize=True) to avoid redundant tokenization
+            should_tokenize = not is_multimodal
             try:
-                prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
+                result = self.tokenizer_manager.tokenizer.apply_chat_template(
                     openai_compatible_messages,
-                    tokenize=True,
+                    tokenize=should_tokenize,
                     add_generation_prompt=True,
                     tools=tools,
                     reasoning_effort=request.reasoning_effort,
@@ -484,7 +488,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 try:
                     prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
                         openai_compatible_messages,
-                        tokenize=True,
+                        tokenize=should_tokenize,
                         add_generation_prompt=True,
                         tools=tools,
                         reasoning_effort=request.reasoning_effort,
@@ -506,8 +510,15 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_ids, assistant_prefix
                 )
 
+            # Assign to prompt or prompt_ids based on type
             if is_multimodal:
-                prompt = self.tokenizer_manager.tokenizer.decode(prompt_ids)
+                # For multimodal: result is text string
+                prompt = result
+                prompt_ids = []
+            else:
+                # For non-multimodal: result is token IDs list
+                prompt = ""
+                prompt_ids = result
 
         stop = request.stop
         image_data = image_data if image_data else None

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -696,9 +696,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                     "the engine with skip_tokenizer_init=False."
                 )
 
-            # For audio-only requests (e.g., Whisper), text may be empty.
             # The multimodal processor will provide input_ids later.
-            if not input_text and self.mm_processor and obj.contains_mm_input():
+            if self.mm_processor and obj.contains_mm_input():
                 # Use empty placeholder - multimodal processor will override
                 input_ids = []
             else:


### PR DESCRIPTION
# Motivation
In multimodal models such as Qwen3VL, text tokenization is unnecessarily repeated multiple times. This PR eliminates these redundancies, thereby accelerating model inference.

# command
```
export SGLANG_USE_AITER=1
model=/models/nvme3/data/models/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic/
TP=8
EP=1
 
echo "launching ${model}"
echo "TP=${TP}"
echo "EP=${EP}"

python3 -m sglang.launch_server \
    --model-path ${model} \
    --host localhost \
    --port 9000 \
    --tp-size ${TP} \
    --ep-size ${EP} \
    --trust-remote-code \
    --chunked-prefill-size 16384 \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --max-prefill-tokens 16384 \
    --cuda-graph-max-bs 128 \
    --max-running-requests 128 \
    --mm-attention-backend aiter_attn
```