### PR TITLE
[Diffusion] [Rocm] Add env for controling Aiter FA round mode

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -12,6 +12,7 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
     AttentionMetadataBuilder,
 )
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.srt.environ import envs
 
 
 class AITerBackend(AttentionBackend):
@@ -81,6 +82,14 @@ class AITerImpl(AttentionImpl):
         """
         # aiter.flash_attn_func expects tensors in [B, H, S, D] layout,
         # which is what ring_attn provides.
+
+        # 0: rtne, 1: rtna, 2: rtz
+        if envs.SGLANG_USE_AITER_FA_ROUND_MODE.get() == True:
+            # use Aiter FA round mode
+            how_v3_bf16_cvt = 2
+        else:
+            # default value is 1
+            how_v3_bf16_cvt = 1
         output, _ = aiter.flash_attn_func(
             query,
             key,
@@ -89,5 +98,6 @@ class AITerImpl(AttentionImpl):
             causal=self.causal,
             return_attn_probs=False,
             return_lse=True,
+            how_v3_bf16_cvt=how_v3_bf16_cvt,
         )
         return output

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -284,6 +284,7 @@ class Envs:
     SGLANG_USE_AITER = EnvBool(False)
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
+    SGLANG_USE_AITER_FA_ROUND_MODE = EnvBool(False)
 
     # NPU
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)


### PR DESCRIPTION
## Motivation
Enable a controllable switch for ROCm AITer FlashAttention BF16 rounding mode.
## Modifications
`environ.py`
- registered SGLANG_USE_AITER_FA_ROUND_MODE in Envs as a boolean environment variable

`aiter.py`
- used the env flag in AITerImpl.forward to set how_v3_bf16_cvt (default 1, enabled 2) before calling aiter.flash_attn_func

## Accuracy Tests
Here is my script:
```
from sglang.multimodal_gen import DiffGenerator
def main():
    # Create a diff generator from a pre-trained model
    generator = DiffGenerator.from_pretrained(
        model_path="/data/models/Qwen-Image-Edit",
        lora_path="/data/models/lightx2v/Qwen-Image-Edit-2511-Lightning/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
        num_gpus=2,
        ulysses_degree=2,
        enable_torch_compile=True,
        dit_cpu_offload=False,
        text_encoder_cpu_offload=False,
        vae_cpu_offload=False,
        image_encoder_cpu_offload=False,
        image_encoder_precision="bf16",
        vae_precision="bf16",
    )

    # warm up
      image = generator.generate(
          sampling_params_kwargs=dict(
              prompt="make the clothes to red",
              image_path="/data/sglang/evaluation/768x1024.png", 
              output_path="qwen_image_edit/",
              save_output=False,
              height=1024,
              width=768,
              num_inference_steps=8,
              seed=42,
              guidance_scale=1,
          )
      )
      # Generate the image
      image = generator.generate(
          sampling_params_kwargs=dict(
              prompt="make the clothes to red",
              image_path="/data/sglang/evaluation/768x1024.png", 
              output_path="qwen_image_edit/",
              save_output=True,
              height=1024,
              width=768,
              num_inference_steps=8,
              seed=42,
              guidance_scale=1,
          )
      )

if __name__ == "__main__":
    main()
```
the input image is:
https://raw.githubusercontent.com/modelscope/DiffSynth-Engine/dev/qz/qwen_app_amd/examples/input/768x1024.png
<img width="768" height="1024" alt="768x1024" src="https://github.com/user-attachments/assets/d10bd7a8-34d5-4e04-a5dc-aad046c3e891" />

after use this pr:
<img width="768" height="1024" alt="image" src="https://github.com/user-attachments/assets/85a7e1d9-c0f8-4b8a-9083-2b45659ba008" />

## Benchmarking and Profiling
use Aiter FA round mode, uplift: 4.2% (13.02s -> 12.47s)
before:
<img width="592" height="35" alt="image" src="https://github.com/user-attachments/assets/04e4cd3c-a373-4afa-ad2e-4afd47670a6b" />

after:
<img width="591" height="35" alt="image" src="https://github.com/user-attachments/assets/6101a2f9-4a43-4126-94b8-c0b10fc57fcf" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).