### PR TITLE
[Bugfix] Wrong Answer in PD disaggregation [P w/o SPS | D w/ SPS]

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -164,7 +164,7 @@ class CommonKVManager(BaseKVManager):
         if num_kv_layers == dst_num_total_layers:
             dst_k_ptrs = dst_kv_ptrs[:dst_num_total_layers]
             dst_v_ptrs = dst_kv_ptrs[dst_num_total_layers:]
-        elif num_kv_layers < dst_num_total_layers:
+        elif num_kv_layers < dst_num_total_layers and dst_num_total_layers % num_kv_layers != 0:
             # Case: Decode has more layers than Prefill (e.g., Decode has draft model KV while Prefill is deployed without speculative decoding)
             # To prevent empty Value Cache, which leads to wrong response
             # dst_kv_ptrs layout: [K_main..., V_main..., draft_K..., draft_V...]

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -164,7 +164,10 @@ class CommonKVManager(BaseKVManager):
         if num_kv_layers == dst_num_total_layers:
             dst_k_ptrs = dst_kv_ptrs[:dst_num_total_layers]
             dst_v_ptrs = dst_kv_ptrs[dst_num_total_layers:]
-        elif num_kv_layers < dst_num_total_layers and dst_num_total_layers % num_kv_layers != 0:
+        elif (
+            num_kv_layers < dst_num_total_layers
+            and dst_num_total_layers % num_kv_layers != 0
+        ):
             # Case: Decode has more layers than Prefill (e.g., Decode has draft model KV while Prefill is deployed without speculative decoding)
             # To prevent empty Value Cache, which leads to wrong response
             # dst_kv_ptrs layout: [K_main..., V_main..., draft_K..., draft_V...]

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -164,6 +164,14 @@ class CommonKVManager(BaseKVManager):
         if num_kv_layers == dst_num_total_layers:
             dst_k_ptrs = dst_kv_ptrs[:dst_num_total_layers]
             dst_v_ptrs = dst_kv_ptrs[dst_num_total_layers:]
+        elif num_kv_layers < dst_num_total_layers:
+            # Case: Decode has more layers than Prefill (e.g., Decode has draft model KV while Prefill is deployed without speculative decoding)
+            # To prevent empty Value Cache, which leads to wrong response
+            # dst_kv_ptrs layout: [K_main..., V_main..., draft_K..., draft_V...]
+            dst_k_ptrs = dst_kv_ptrs[start_layer:end_layer]
+            dst_v_ptrs = dst_kv_ptrs[
+                num_kv_layers + start_layer : num_kv_layers + end_layer
+            ]
         else:
             # Decode pp size should be equal to prefill pp size or 1
             dst_k_ptrs = dst_kv_ptrs[start_layer:end_layer]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

After SGLang v0.5.2, when deploying a PD-disaggregated MHA model (e.g., GLM4.5 Air FP8), if speculative decoding parameters are not configured on the Prefill node but are configured on the Decode node, the service may return incorrect responses.

## Modifications

Investigation showed that KV transfer caused incorrect Value cache on the Decode (D) node, so we updated the corresponding logic accordingly.

## Accuracy Tests

Deploy Scripts:
```
# prefill
python3 -m sglang.launch_server \
    --model-path /dev/shm/GLM-4.5-Air-FP8 \
    --disaggregation-mode prefill \
    --tp-size 4 \
    --mem-fraction-static 0.8 \
    --kv-cache-dtype fp8_e4m3 \
    --host 0.0.0.0 \
    --attention-backend fa3 \
    --port 30001 \
    --chunked-prefill-size $((16384 * 4)) \
    # --speculative-algo EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3
# decode
python3 -m sglang.launch_server \
    --model-path /dev/shm/GLM-4.5-Air-FP8 \
    --disaggregation-mode decode \
    --tp-size 4 \
    --mem-fraction-static 0.8 \
    --kv-cache-dtype fp8_e4m3 \
    --host 0.0.0.0 \
    --attention-backend fa3 \
    --port 30011 \
    --speculative-algo EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3

```

Running evaluation with
```
python benchmark/gsm8k/bench_sglang.py     --host http://127.0.0.1     --port 30000     --num-questions 1319     --parallel 256
```

Results
```
# P with Speculative Decoding
100%|████████████████████████████████████████████████████████████| 1319/1319 [00:56<00:00, 23.24it/s]
Accuracy: 0.920
Invalid: 0.000
Latency: 57.106 s
Output throughput: 2379.669 token/s

# P without Speculative Decoding without this PR
100%|████████████████████████████████████████████████████████████| 1319/1319 [04:54<00:00,  4.48it/s]
Accuracy: 0.011
Invalid: 0.313
Latency: 294.957 s
Output throughput: 2248.717 token/s

# P without Speculative Decoding with this PR
100%|████████████████████████████████████████████████████████████| 1319/1319 [01:02<00:00, 21.20it/s]
Accuracy: 0.916
Invalid: 0.000
Latency: 62.603 s
Output throughput: 2246.093 token/s
```


## Benchmarking and Profiling
The bench serving results for the multi-turn chat are as follows. We first use the first 10,000 samples for KV-cache warmup, and then benchmark the remaining 10,000 samples. The results are shown below.

* Device = H200 * 8
* P = 2xTP2
* D = 2xTP2

```
# Prefill with speculative decoding: 
# Round1 --> Sample ID [0, 10000)

============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    40.0      
Max request concurrency:                 not set   
Successful requests:                     10000     
Benchmark duration (s):                  282.80    
Total input tokens:                      25873815  
Total generated tokens:                  1876513   
Total generated tokens (retokenized):    1869016   
Request throughput (req/s):              35.36     
Input token throughput (tok/s):          91490.07  
Output token throughput (tok/s):         6635.37   
Total token throughput (tok/s):          98125.43  
Concurrency:                             784.53    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   22186.77  
Median E2E Latency (ms):                 23569.19  
---------------Time to First Token----------------
Mean TTFT (ms):                          19182.07  
Median TTFT (ms):                        20462.93  
P99 TTFT (ms):                           26864.65  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           34.28     
Median ITL (ms):                         33.80     
P95 ITL (ms):                            43.10     
P99 ITL (ms):                            62.13     
Max ITL (ms):                            992.52    
Mean TPOT (ms):                          16.09     
Median TPOT (ms):                        16.28     
P95 TPOT (ms):                           18.65     
P99 TPOT (ms):                           21.74     
Max TPOT (ms):                           34.69     
==================================================

# Round2 --> Sample ID [10000, 20000)

============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    40.0      
Max request concurrency:                 not set   
Successful requests:                     10000     
Benchmark duration (s):                  275.27    
Total input tokens:                      25997995  
Total generated tokens:                  1876513   
Total generated tokens (retokenized):    1868842   
Request throughput (req/s):              36.33     
Input token throughput (tok/s):          94446.92  
Output token throughput (tok/s):         6817.10   
Total token throughput (tok/s):          101264.02 
Concurrency:                             195.73    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5387.78   
Median E2E Latency (ms):                 5333.12   
---------------Time to First Token----------------
Mean TTFT (ms):                          2439.15   
Median TTFT (ms):                        2320.33   
P99 TTFT (ms):                           4927.51   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           33.58     
Median ITL (ms):                         33.55     
P95 ITL (ms):                            41.72     
P99 ITL (ms):                            53.83     
Max ITL (ms):                            481.44    
Mean TPOT (ms):                          15.79     
Median TPOT (ms):                        16.04     
P95 TPOT (ms):                           17.97     
P99 TPOT (ms):                           18.68     
Max TPOT (ms):                           20.51     
==================================================
```


```
# with this PR, Prefill without speculative decoding: 
# Round1 --> Sample ID [0, 10000)

============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    40.0      
Max request concurrency:                 not set   
Successful requests:                     10000     
Benchmark duration (s):                  272.63    
Total input tokens:                      25873815  
Total generated tokens:                  1876533   
Total generated tokens (retokenized):    1845595   
Request throughput (req/s):              36.68     
Input token throughput (tok/s):          94905.18  
Output token throughput (tok/s):         6883.12   
Total token throughput (tok/s):          101788.30 
Concurrency:                             235.95    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6432.56   
Median E2E Latency (ms):                 4249.37   
---------------Time to First Token----------------
Mean TTFT (ms):                          3562.08   
Median TTFT (ms):                        1218.30   
P99 TTFT (ms):                           15838.37  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           35.46     
Median ITL (ms):                         34.48     
P95 ITL (ms):                            45.19     
P99 ITL (ms):                            71.50     
Max ITL (ms):                            3195.92   
Mean TPOT (ms):                          15.47     
Median TPOT (ms):                        15.12     
P95 TPOT (ms):                           20.75     
P99 TPOT (ms):                           24.14     
Max TPOT (ms):                           37.20     
==================================================

# Round2 --> Sample ID [10000, 20000)

============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    40.0      
Max request concurrency:                 not set   
Successful requests:                     10000     
Benchmark duration (s):                  271.78    
Total input tokens:                      25997995  
Total generated tokens:                  1876323   
Total generated tokens (retokenized):    1664673   
Request throughput (req/s):              36.79     
Input token throughput (tok/s):          95658.17  
Output token throughput (tok/s):         6903.83   
Total token throughput (tok/s):          102561.99 
Concurrency:                             131.76    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3580.96   
Median E2E Latency (ms):                 3495.13   
---------------Time to First Token----------------
Mean TTFT (ms):                          448.86    
Median TTFT (ms):                        423.63    
P99 TTFT (ms):                           940.30    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           36.30     
Median ITL (ms):                         34.45     
P95 ITL (ms):                            49.14     
P99 ITL (ms):                            77.42     
Max ITL (ms):                            3771.21   
Mean TPOT (ms):                          16.94     
Median TPOT (ms):                        16.28     
P95 TPOT (ms):                           23.44     
P99 TPOT (ms):                           28.65     
Max TPOT (ms):                           41.04     
==================================================


```

|  deploy |  TTFT-R1 |  TPOT-R1 | TTFT-R2 |  TPOT-R2 |
|---|---|---|---|---|
|  P with SPS |  19182.07 |  16.09 | 2439.15 | 15.79 |
|  P without SPS | 3562.08 |  15.47 | 448.86 | 16.94 |



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
