### PR TITLE
feature: adding openai compatible API request to bench_serving

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1041,6 +1041,7 @@ class DatasetRow:
     image_data: Optional[List[str]] = None
     timestamp: Optional[float] = None
     routing_key: Optional[str] = None
+    is_openai_format: bool = False  # True if prompt is pre-formatted OpenAI messages
 
     def __post_init__(self):
         if self.text_prompt_len is None:
@@ -1351,6 +1352,7 @@ def sample_openai_requests(
                 prompt=messages,
                 prompt_len=prompt_len,
                 output_len=output_len,
+                is_openai_format=True,  # Mark as pre-formatted OpenAI messages
             )
         )
 
@@ -2243,7 +2245,9 @@ async def benchmark(
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
-    is_multi_turn = isinstance(input_requests[0].prompt, list)
+    # Check for multi-turn: prompt is a list BUT not pre-formatted OpenAI messages
+    is_openai_format = getattr(input_requests[0], "is_openai_format", False)
+    is_multi_turn = isinstance(input_requests[0].prompt, list) and not is_openai_format
     if is_multi_turn:
         request_func = wrap_multi_turn_request_func(request_func, backend=backend)
 

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -235,12 +235,15 @@ async def async_request_openai_completions(
             "best_of": 1,
             "max_tokens": request_func_input.output_len,
             "stream": not args.disable_stream,
-            "ignore_eos": not args.disable_ignore_eos,
         }
 
         # Add temperature default only if not specified in extra_request_body
         if "temperature" not in request_func_input.extra_request_body:
             payload["temperature"] = 0.0
+
+        # Add ignore_eos default only if not specified in extra_request_body
+        if "ignore_eos" not in request_func_input.extra_request_body:
+            payload["ignore_eos"] = not args.disable_ignore_eos
 
         # Merge in extra parameters - these will override defaults if present
         payload.update(request_func_input.extra_request_body)
@@ -385,12 +388,16 @@ async def async_request_openai_chat_completions(
             "messages": messages,
             "max_completion_tokens": request_func_input.output_len,
             "stream": not args.disable_stream,
-            "ignore_eos": not args.disable_ignore_eos,
         }
 
         # Add temperature default only if not specified in extra_request_body
         if "temperature" not in request_func_input.extra_request_body:
             payload["temperature"] = 0.0
+
+        # Add ignore_eos default only if not specified in extra_request_body
+        # Default to False for more realistic behavior (respect EOS tokens)
+        if "ignore_eos" not in request_func_input.extra_request_body:
+            payload["ignore_eos"] = not args.disable_ignore_eos
 
         # Merge in extra parameters (tools, temperature, top_p, etc.)
         # These will override defaults if present
@@ -1354,7 +1361,9 @@ def sample_openai_requests(
 
     # Fields that should NOT be passed through extra_request_body
     # These are either handled separately or are metadata
-    EXCLUDED_FIELDS = {"messages", "max_tokens", "model"}
+    # max_tokens is excluded because it's handled via output_len -> max_completion_tokens
+    # max_completion_tokens is also excluded to avoid conflicts
+    EXCLUDED_FIELDS = {"messages", "max_tokens", "max_completion_tokens", "model"}
 
     filtered_dataset: List[DatasetRow] = []
     for data in dataset:


### PR DESCRIPTION
## Motivation

Supports jsonl files in OpenAI Compatible API format for bench serving, and also supporting extra params to the payload. Note that default ignore_eos is now False instead of true.

## Modifications

Added openai as a valid dataset type and added conversion to DatasetRow objects for benchmarking.

## Accuracy Tests

Successful benchmarking on nda jsonl data.

## Benchmarking and Profiling

n/a

## Checklist

- [done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
