### PR TITLE
Increase 5090 test parallelism from 4 to 8

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -601,7 +601,7 @@ jobs:
       IS_BLACKWELL: "1"
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         partition: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:


### PR DESCRIPTION
Increase max-parallel from 4 to 8 for stage-b-test-small-1-gpu-5090.

16 runners available but only 4 jobs ran concurrently, causing 2+ hour queue waits. After the flashinfer fix (#16826), 5090 tests are mostly passing (8/8 on runs 21041416426 and 21030712280).