### PR TITLE
fix(ci): recover from corrupted MMMU parquet cache

### DIFF
--- a/python/sglang/test/kits/mmmu_vlm_kit.py
+++ b/python/sglang/test/kits/mmmu_vlm_kit.py
@@ -57,13 +57,18 @@ def _cleanup_mmmu_dataset_cache():
 def _run_lmms_eval_with_retry(cmd: list[str], timeout: int = 3600) -> None:
     """Run lmms_eval command with automatic retry on MMMU parquet corruption."""
     try:
-        subprocess.run(
+        result = subprocess.run(
             cmd,
             check=True,
             timeout=timeout,
             capture_output=True,
             text=True,
         )
+        # Print captured output to maintain visibility of successful runs
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="")
     except subprocess.CalledProcessError as e:
         error_output = e.stderr + e.stdout
         if _is_mmmu_parquet_corruption(error_output):
@@ -76,8 +81,14 @@ def _run_lmms_eval_with_retry(cmd: list[str], timeout: int = 3600) -> None:
                 ):
                     subprocess.run(cmd, check=True, timeout=timeout)
             else:
+                print(
+                    f"Failed to cleanup corrupted MMMU cache. Error from lmms_eval:\nStdout:\n{e.stdout}\nStderr:\n{e.stderr}"
+                )
                 raise
         else:
+            print(
+                f"lmms_eval failed with an unhandled error.\nStdout:\n{e.stdout}\nStderr:\n{e.stderr}"
+            )
             raise
 
 

--- a/python/sglang/test/kits/mmmu_vlm_kit.py
+++ b/python/sglang/test/kits/mmmu_vlm_kit.py
@@ -1,8 +1,10 @@
 import glob
 import json
 import os
+import shutil
 import subprocess
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 
 from sglang.srt.environ import temp_set_env
@@ -16,6 +18,67 @@ from sglang.test.test_utils import (
 
 # Set default mem_fraction_static to 0.8
 DEFAULT_MEM_FRACTION_STATIC = 0.8
+
+
+def _is_mmmu_parquet_corruption(error_output: str) -> bool:
+    """Check if error is due to MMMU parquet file corruption."""
+    return (
+        "ArrowInvalid" in error_output
+        and "Parquet magic bytes not found" in error_output
+        and ("MMMU" in error_output or "lmms-lab--MMMU" in error_output)
+    )
+
+
+def _cleanup_mmmu_dataset_cache():
+    """Clean up corrupted MMMU dataset cache to allow fresh download."""
+    # Priority 1: Check CI convention path /hf_home first (used in Docker containers)
+    ci_hf_home = Path("/hf_home/hub/datasets--lmms-lab--MMMU")
+    if ci_hf_home.exists():
+        mmmu_cache_path = ci_hf_home
+    else:
+        # Priority 2: Use HF_HOME env var or default user cache
+        hf_home = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+        mmmu_cache_path = Path(hf_home) / "hub" / "datasets--lmms-lab--MMMU"
+
+    if mmmu_cache_path.exists():
+        print(f"Detected corrupted MMMU parquet cache. Cleaning up: {mmmu_cache_path}")
+        try:
+            shutil.rmtree(mmmu_cache_path)
+            print(f"Successfully removed corrupted cache: {mmmu_cache_path}")
+            return True
+        except OSError as e:
+            print(f"Warning: Failed to remove cache {mmmu_cache_path}: {e}")
+            return False
+    else:
+        print(f"MMMU cache not found at {mmmu_cache_path}, skipping cleanup")
+        return False
+
+
+def _run_lmms_eval_with_retry(cmd: list[str], timeout: int = 3600) -> None:
+    """Run lmms_eval command with automatic retry on MMMU parquet corruption."""
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        error_output = e.stderr + e.stdout
+        if _is_mmmu_parquet_corruption(error_output):
+            print("Detected MMMU parquet corruption error. Attempting recovery...")
+            if _cleanup_mmmu_dataset_cache():
+                print("Retrying lmms_eval with fresh download...")
+                with temp_set_env(
+                    HF_HUB_OFFLINE="0",
+                    HF_DATASETS_DOWNLOAD_MODE="force_redownload",
+                ):
+                    subprocess.run(cmd, check=True, timeout=timeout)
+            else:
+                raise
+        else:
+            raise
 
 
 class MMMUMixin:
@@ -81,11 +144,7 @@ class MMMUMixin:
             OPENAI_API_KEY=self.api_key,
             OPENAI_API_BASE=f"{self.base_url}/v1",
         ):
-            subprocess.run(
-                cmd,
-                check=True,
-                timeout=3600,
-            )
+            _run_lmms_eval_with_retry(cmd)
 
     def test_mmmu(self: CustomTestCase):
         """Run MMMU evaluation test."""
@@ -209,11 +268,7 @@ class MMMUMultiModelTestBase(CustomTestCase):
             *self.mmmu_args,
         ]
 
-        subprocess.run(
-            cmd,
-            check=True,
-            timeout=3600,
-        )
+        _run_lmms_eval_with_retry(cmd)
 
     def _run_vlm_mmmu_test(
         self,


### PR DESCRIPTION
When MMMU dataset parquet files are corrupted in HuggingFace cache (ArrowInvalid: Parquet magic bytes not found), the lmms_eval process fails without producing JSON results, causing CI test failures.
https://github.com/sgl-project/sglang/actions/runs/21076101101/job/60658633322?pr=16388
https://github.com/sgl-project/sglang/actions/runs/21075841576/job/60653165682?pr=16561 

This fix adds automatic recovery in mmmu_vlm_kit.py:
- Detects parquet corruption errors in lmms_eval subprocess output
- Cleans up the corrupted MMMU dataset cache directory (prioritizes CI path /hf_home, fallback to HF_HOME)
- Retries once with HF_HUB_OFFLINE=0 and force_redownload mode
- Only affects MMMU parquet corruption cases (minimal impact)

Fixes the intermittent CI failures on MMMU evaluation tests.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
