### PR TITLE
[Feature][ROCM] Fuse aiter allreduce with residual_rmsnorm and quantization (fp8)

### DIFF
--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -28,6 +28,19 @@ def tensor_model_parallel_fused_allreduce_rmsnorm(
     return get_tp_group().fused_allreduce_rmsnorm(input_, residual_inp_, weight_, eps)
 
 
+def tensor_model_parallel_fused_allreduce_rmsnorm_quant(
+    input_: torch.Tensor,
+    residual_inp_: torch.Tensor,
+    weight_: torch.Tensor,
+    eps: float,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Fused TP all-reduce + RMSNorm + FP8 per-token quant.
+
+    Returns (out_fp8, residual_out, scale_out) or None if unavailable.
+    """
+    return get_tp_group().fused_allreduce_rmsnorm_quant(input_, residual_inp_, weight_, eps)
+
+
 def tensor_model_parallel_all_gather(
     input_: torch.Tensor, dim: int = -1
 ) -> torch.Tensor:

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -698,6 +698,31 @@ class GroupCoordinator:
         )
         return fused_outputs
 
+    def fused_allreduce_rmsnorm_quant(
+        self,
+        input_: torch.Tensor,
+        residual_inp_: torch.Tensor,
+        weight_: torch.Tensor,
+        eps: float,
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        """Attempt fused all-reduce + RMSNorm + FP8 per-token quant.
+
+        Returns (out_fp8, residual_out, scale_out) or None if unavailable.
+        """
+        ca_comm = self.ca_comm
+        if ca_comm is None or getattr(ca_comm, "disabled", True):
+            return None
+
+        if hasattr(ca_comm, "fused_allreduce_rmsnorm_quant"):
+            try:
+                return ca_comm.fused_allreduce_rmsnorm_quant(
+                    input_, residual_inp_, weight_, eps
+                )
+            except Exception:
+                pass
+
+        return None
+
     def _all_reduce_out_place(
         self, input_: torch.Tensor, outplace_all_reduce_method: str
     ) -> torch.Tensor:

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -406,11 +406,13 @@ class LayerCommunicator:
         forward_batch: ForwardBatch,
         captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
+        quant_format: str = "",
     ):
         hidden_states, residual = self.prepare_attn(
             hidden_states,
             residual,
             forward_batch,
+            quant_format=quant_format,
             post_residual_addition=post_residual_addition,
         )
         if captured_last_layer_outputs is not None:
@@ -450,11 +452,15 @@ class LayerCommunicator:
                     apply_aiter_all_reduce_fusion(hidden_states)
                     or apply_flashinfer_allreduce_fusion(hidden_states.shape[0])
                 ) and hasattr(self.input_layernorm, "forward_with_allreduce_fusion"):
-                    hidden_states, residual = (
+                    fused_result = (
                         self.input_layernorm.forward_with_allreduce_fusion(
-                            hidden_states, residual
+                            hidden_states, residual, quant_format=quant_format,
                         )
                     )
+                    if len(fused_result) == 3:
+                        hidden_states, residual, _ = fused_result
+                    else:
+                        hidden_states, residual = fused_result
                 else:
                     hidden_states = tensor_model_parallel_all_reduce(hidden_states)
                     hidden_states, residual = self.input_layernorm(

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -302,15 +302,18 @@ class RMSNorm(MultiPlatformOp):
         x: torch.Tensor,
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
+        quant_format: str = "",
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         """
-        Forward method with allreduce fusion, prioritizing flashinfer fused operations
+        Forward method with allreduce fusion, prioritizing flashinfer fused operations.
+        When quant_format contains "fp8", attempts fused AR+RMSNorm+FP8 quant.
         """
         if residual is not None:
             from sglang.srt.distributed import (
                 get_tensor_model_parallel_world_size,
                 tensor_model_parallel_all_reduce,
                 tensor_model_parallel_fused_allreduce_rmsnorm,
+                tensor_model_parallel_fused_allreduce_rmsnorm_quant,
             )
             from sglang.srt.layers.flashinfer_comm_fusion import (
                 flashinfer_allreduce_residual_rmsnorm,
@@ -320,8 +323,19 @@ class RMSNorm(MultiPlatformOp):
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
 
-                # Prefer AITER fused AR+RMSNorm when enabled on AMD.
+                # Prefer AITER fused AR+RMSNorm+(fp8 quant) when enabled on AMD.
+                fp8_out = "fp8_e4m3fnuz" in quant_format
+
                 if _use_aiter:
+                    if fp8_out:
+                        fused_result = (
+                            tensor_model_parallel_fused_allreduce_rmsnorm_quant(
+                                x, residual, self.weight, self.variance_epsilon
+                            )
+                        )
+                        if fused_result is not None:
+                            return fused_result
+
                     fused_result = tensor_model_parallel_fused_allreduce_rmsnorm(
                         x, residual, self.weight, self.variance_epsilon
                     )

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -73,10 +73,12 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    get_bool_env_var,
     is_cuda,
     is_flashinfer_available,
     is_non_idle_and_non_empty,
     is_npu,
+    is_hip,
 )
 
 _is_cuda = is_cuda()
@@ -93,6 +95,8 @@ _is_flashinfer_available = is_flashinfer_available()
 logger = logging.getLogger(__name__)
 _is_cuda = is_cuda()
 _is_npu = is_npu()
+_is_hip = is_hip()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_npu:
     from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
@@ -768,6 +772,12 @@ class Qwen3MoeDecoderLayer(nn.Module):
         captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if _use_aiter and self.self_attn.qkv_proj.weight.dtype == getattr(
+            torch, "float8_e4m3fnuz", None
+        ):
+            quant_format = "fp8_e4m3fnuz"
+        else:
+            quant_format = ""
 
         hidden_states, residual = (
             self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
@@ -775,6 +785,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
                 residual,
                 forward_batch,
                 captured_last_layer_outputs=captured_last_layer_outputs,
+                quant_format=quant_format,
                 **kwargs,
             )
         )


### PR DESCRIPTION
## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
