### PR TITLE
Add cache_config_info metric.

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -586,6 +586,11 @@ class Scheduler(
                 f"{'available_cpu_mem' if self.device == 'cpu' else 'available_gpu_mem'}={avail_mem:.2f} GB"
             )
 
+        if self.enable_metrics and hasattr(self, "metrics_collector"):
+            self.metrics_collector.emit_cache_config_info(
+                self.page_size, self.max_total_num_tokens // self.page_size
+            )
+
     def init_cache_with_memory_pool(self):
         server_args = self.server_args
 

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -849,6 +849,16 @@ class SchedulerMetricsCollector:
             ],
         )
 
+        # This is a work-around Info metric since Info metrics are not supported in Prometheus.
+        # Similar to vLLM, https://github.com/vllm-project/vllm/blob/main/vllm/v1/metrics/loggers.py
+        # If more Info metrics are needed, we can create a common _log_info function.
+        self.cache_config_info = Gauge(
+            name="sglang:cache_config_info",
+            documentation="Cache configuration information.",
+            labelnames=["page_size", "num_pages"],
+            multiprocess_mode="mostrecent",
+        )
+
     def _log_gauge(self, gauge, data: Union[int, float]) -> None:
         # Convenience function for logging to gauge.
         gauge.labels(**self.labels).set(data)
@@ -1065,6 +1075,9 @@ class SchedulerMetricsCollector:
                 grammar_stats.num_timeout
             )
         self.num_grammar_total.labels(**self.labels).inc(1)
+
+    def emit_cache_config_info(self, page_size: int, num_pages: int) -> None:
+        self.cache_config_info.labels(page_size=page_size, num_pages=num_pages).set(1)
 
 
 class TokenizerMetricsCollector:


### PR DESCRIPTION
## Motivation
Kubernetes Gateway API Inference Extension, used by projects like llm-d, would like to use SGLang Cache information for its prefix cache scoring mechanism. For further details check this issue: https://github.com/sgl-project/sglang/issues/17104#issuecomment-3762163094

Similar information is encapsulated by [KvEvents](https://github.com/sgl-project/sglang/blob/53609e5e5b2aa00eb60c9a9a61d9b31b38aa0067/python/sglang/srt/managers/scheduler_metrics_mixin.py#L45-L54) which is consumed by Dynamo. However, consuming `KvEvents` requires setting up a ZMQ channel, which is overkill for this purpose.

Similar information is exported by [vLLM](https://docs.vllm.ai/en/latest/design/metrics/#cache-config-info), this PR adds this metric to SGLang.

## Modifications
Add a `Gauge` metric that emits cache configuration information (page_size and num_pages) once during scheduler initialization.

The `Gauge` functions as a work-around for `Info` metric, since the latter is not supported by Prometheus client in [multiprocessing mode](https://prometheus.github.io/client_python/multiprocess/).

<!-- Detail the changes made in this pull request. -->

## Tests
Launch a server and query the metrics endpoint
```bash
python -m sglang.launch_server \
  --model-path meta-llama/Llama-3.2-1B \
  --port 8000 \
  --enable-metrics \
  --page-size 16 \
  --dp-size 2 \
  --tp-size 2

curl http://0.0.0.0:8000/metrics
```

Result:
```
sglang:cache_config_info{num_pages="148038",page_size="16"} 1.0
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
