### PR TITLE
feat: add env vars to bias tool token and insert prohibition message …

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -43,6 +43,7 @@ try:
 except:
     StructuralTag = Any
 
+from sglang.srt.environ import envs
 from sglang.utils import convert_json_schema_to_str
 
 logger = logging.getLogger(__name__)
@@ -675,6 +676,21 @@ class ChatCompletionRequest(BaseModel):
             "custom_params": self.custom_params,
             "sampling_seed": self.seed,
         }
+
+        # Apply tool token logit bias when tool_choice is "none" and SGLANG_BIAS_TOOL_WHEN_NONE is enabled
+        if (
+            self.tool_choice == "none"
+            and envs.SGLANG_BIAS_TOOL_WHEN_NONE.get()
+            and envs.SGLANG_TOOL_START_TOKEN.get() is not None
+        ):
+            tool_token_id = envs.SGLANG_TOOL_START_TOKEN.get()
+            existing_bias = sampling_params["logit_bias"] or {}
+            # Use string key for token ID as per OpenAI convention
+            token_key = str(tool_token_id)
+            if token_key not in existing_bias:
+                existing_bias = dict(existing_bias)  # Copy to avoid mutating original
+                existing_bias[token_key] = -100.0
+                sampling_params["logit_bias"] = existing_bias
 
         if self.response_format and self.response_format.type == "json_schema":
             sampling_params["json_schema"] = convert_json_schema_to_str(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -15,6 +15,7 @@ from jsonschema import Draft202012Validator, SchemaError
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import encode_messages
 from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionMessageGenericParam,
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
@@ -39,6 +40,7 @@ from sglang.srt.entrypoints.openai.utils import (
     process_hidden_states_from_ret,
     to_openai_style_logprobs,
 )
+from sglang.srt.environ import envs
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
@@ -263,6 +265,28 @@ class OpenAIServingChat(OpenAIServingBase):
         # GptOss model needs to keep special tokens for harmony parsing
         if self.is_gpt_oss:
             request.skip_special_tokens = False
+
+        # Insert tool prohibition system message when tool_choice is "none"
+        # and SGLANG_INSERT_TOOL_PROHIBIT_WHEN_NONE is set to a non-empty string
+        tool_prohibit_msg = envs.SGLANG_INSERT_TOOL_PROHIBIT_WHEN_NONE.get()
+        if request.tool_choice == "none" and tool_prohibit_msg:
+            # Find the index of the first user message
+            first_user_idx = None
+            for i, msg in enumerate(request.messages):
+                if msg.role == "user":
+                    first_user_idx = i
+                    break
+
+            # Insert a system message right before the first user message
+            if first_user_idx is not None:
+                prohibition_msg = ChatCompletionMessageGenericParam(
+                    role="system",
+                    content=tool_prohibit_msg,
+                )
+                # Create a new messages list with the prohibition message inserted
+                new_messages = list(request.messages)
+                new_messages.insert(first_user_idx, prohibition_msg)
+                request.messages = new_messages
 
         tool_call_constraint = None
 
@@ -950,7 +974,7 @@ class OpenAIServingChat(OpenAIServingBase):
             # Align with Kimi-K2 format: functions.{name}:{index}
             # Kimi-K2 allows multiple tool_calls in one message; SGLang sets call_item.tool_index to the *local* position inside that message.
             # Therefore, the index must be corrected by using `history_tool_calls_cnt + call_item.tool_index` to ensure globally unique and properly ordered.
-            tool_call_id = f"functions.{call_item.name}:{history_tool_calls_cnt+call_item.tool_index}"
+            tool_call_id = f"functions.{call_item.name}:{history_tool_calls_cnt + call_item.tool_index}"
             logger.debug(
                 f"Process tool call idx, parser: {self.tool_call_parser}, tool_call_id: {tool_call_id}, history_cnt: {history_tool_calls_cnt}"
             )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -414,6 +414,12 @@ class Envs:
 
     # Tool-Call behavior
     SGLANG_TOOL_STRICT_LEVEL = EnvInt(ToolStrictLevel.OFF)
+    # Token ID to bias when tool_choice is "none" (e.g., tool start token)
+    SGLANG_TOOL_START_TOKEN = EnvInt(None)
+    # Whether to apply logit bias to SGLANG_TOOL_START_TOKEN when tool_choice is "none"
+    SGLANG_BIAS_TOOL_WHEN_NONE = EnvBool(False)
+    # System message to insert before user query when tool_choice is "none" (empty string disables)
+    SGLANG_INSERT_TOOL_PROHIBIT_WHEN_NONE = EnvStr("")
 
     # Ngram
     SGLANG_NGRAM_FORCE_GREEDY_VERIFY = EnvBool(False)


### PR DESCRIPTION
…when tool_choice is none

Add three new environment variables for controlling tool call behavior:
- SGLANG_TOOL_START_TOKEN: token ID to bias when tool_choice is none
- SGLANG_BIAS_TOOL_WHEN_NONE: enable logit bias (-100) on tool start token
- SGLANG_INSERT_TOOL_PROHIBIT_WHEN_NONE: system message to insert before user query

When SGLANG_BIAS_TOOL_WHEN_NONE is enabled and a request has tool_choice=none, the specified SGLANG_TOOL_START_TOKEN will receive a -100 logit bias to strongly discourage the model from generating tool calls.

When SGLANG_INSERT_TOOL_PROHIBIT_WHEN_NONE is set to a non-empty string and tool_choice=none, that string is inserted as a system message before the first user message to instruct the model not to use tools.
