### PR TITLE
support model teleflm for npu

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -136,10 +136,15 @@ class ModelConfig:
             **kwargs,
         )
 
-        if getattr(self.hf_config, "architectures", None) is None and getattr(self.hf_config, "auto_map", None) is not None:
+        if (
+            getattr(self.hf_config, "architectures", None) is None
+            and getattr(self.hf_config, "auto_map", None) is not None
+        ):
             if self.hf_config.auto_map.get("AutoModelForCausalLM", None) is not None:
                 pattern = r'.'
-                auto_architecture = self.hf_config.auto_map["AutoModelForCausalLM"].split(pattern)[-1]
+                auto_architecture = self.hf_config.auto_map[
+                    "AutoModelForCausalLM"
+                ].split(pattern)[-1]
                 self.hf_config.architectures = [auto_architecture]
 
         # Set enable_multimodal

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -141,7 +141,7 @@ class ModelConfig:
             and getattr(self.hf_config, "auto_map", None) is not None
         ):
             if self.hf_config.auto_map.get("AutoModelForCausalLM", None) is not None:
-                pattern = r'.'
+                pattern = r"."
                 auto_architecture = self.hf_config.auto_map[
                     "AutoModelForCausalLM"
                 ].split(pattern)[-1]

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -136,6 +136,12 @@ class ModelConfig:
             **kwargs,
         )
 
+        if getattr(self.hf_config, "architectures", None) is None and getattr(self.hf_config, "auto_map", None) is not None:
+            if self.hf_config.auto_map.get("AutoModelForCausalLM", None) is not None:
+                pattern = r'.'
+                auto_architecture = self.hf_config.auto_map["AutoModelForCausalLM"].split(pattern)[-1]
+                self.hf_config.architectures = [auto_architecture]
+
         # Set enable_multimodal
         if enable_multimodal is None:
             mm_disabled_models = [


### PR DESCRIPTION
## Motivation

support model teleflm for npu.
The configuration (config.json) of model teleflm doesn't have the key 'architectures', resulting in failure of entering the model. 

## Modifications

As follows

## Accuracy Tests
<img width="1637" height="123" alt="image" src="https://github.com/user-attachments/assets/722c2215-0aa3-4ee1-ab73-dc26d5fe3a09" />
