### PR TITLE
support model teleflm for npu

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -138,6 +138,17 @@ class ModelConfig:
             **kwargs,
         )
 
+        if (
+            getattr(self.hf_config, "architectures", None) is None
+            and getattr(self.hf_config, "auto_map", None) is not None
+        ):
+            if self.hf_config.auto_map.get("AutoModelForCausalLM", None) is not None:
+                pattern = r"."
+                auto_architecture = self.hf_config.auto_map[
+                    "AutoModelForCausalLM"
+                ].split(pattern)[-1]
+                self.hf_config.architectures = [auto_architecture]
+
         # Set enable_multimodal
         if enable_multimodal is None:
             mm_disabled_models = [


### PR DESCRIPTION
## Motivation

support model teleflm for npu.
The configuration (config.json) of model teleflm doesn't have the key 'architectures', resulting in failure of entering the model.

## Modifications

As follows. the same as pr:https://github.com/sgl-project/sglang/pull/17285

## Accuracy Tests

<img width="1637" height="123" alt="image" src="https://github.com/user-attachments/assets/5d172d14-3876-4cd6-8437-2dc2e3b81c95" />
