### PR TITLE
[Diffusion] Fix the bug of output_path not taking effect when generate

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -95,7 +95,7 @@ class SamplingParams:
         "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
     )
     prompt_path: str | None = None
-    output_path: str = "outputs/"
+    output_path: str | None = None
     output_file_name: str | None = None
 
     # Batch info
@@ -318,7 +318,7 @@ class SamplingParams:
 
         self.data_type = server_args.pipeline_config.task_type.data_type()
 
-        if server_args.output_path is not None:
+        if self.output_path is None and server_args.output_path is not None:
             self.output_path = server_args.output_path
             logger.debug(
                 f"Overriding output_path with server configuration: {self.output_path}"


### PR DESCRIPTION
## Motivation

After [#16965](https://github.com/sgl-project/sglang/pull/16965), the default value of`output_path` was set to `None`. When output_path is not explicitly specified, run `generate` would fail.

[#17180](https://github.com/sgl-project/sglang/pull/17180) fix above issue, but the server’s `output_path` will override the one specified in user_sampling_params — meaning outputs will always be saved in the server_args' `output_path`.

## Modifications

Set the default value of `output_path` in SamplingParams to None, and in the `_adjust()`, determine whether to use the `output_path` from server_args based on whether output_path (in SamplingParams) is None. (`python/sglang/multimodal_gen/configs/sample/sampling_params.py`)

## Accuracy Tests

``` bash
sglang generate   --model-path=Tongyi-MAI/Z-Image-Turbo   --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k"   --negative-prompt=" "   --width=1024   --height=1024   --seed=42   --save-output   --enable-torch-compile   --dit-cpu-offload=false   --text-encoder-cpu-offload=false --output-path myoutputs/
# saved to myoutputs/

sglang generate   --model-path=Tongyi-MAI/Z-Image-Turbo   --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k"   --negative-prompt=" "   --width=1024   --height=1024   --seed=42   --save-output   --enable-torch-compile   --dit-cpu-offload=false   --text-encoder-cpu-offload=false
# saved to outputs/

sglang serve --model-path Tongyi-MAI/Z-Image-Turbo --port 3000 --output-path myoutputs/
# call generate
# saved to myoutputs/
sglang serve --model-path Tongyi-MAI/Z-Image-Turbo --port 3000
# call generate
# saved to outputs/
```

## Benchmarking and Profiling


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
