### PR TITLE
[diffusion]: Fix ZImage SP sharding for caption and latent

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -1,8 +1,10 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
+import math
 from dataclasses import dataclass, field
 from typing import Callable
 
 import torch
+import torch.nn.functional as F
 
 from sglang.multimodal_gen.configs.models import DiTConfig, EncoderConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.zimage import ZImageDitConfig
@@ -15,6 +17,13 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ImagePipelineConfig,
     ModelTaskType,
     PipelineConfig,
+)
+from sglang.multimodal_gen.runtime.distributed.communication_op import (
+    sequence_model_parallel_all_gather,
+)
+from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+    get_sp_parallel_rank,
+    get_sp_world_size,
 )
 
 
@@ -70,19 +79,133 @@ class ZImagePipelineConfig(ImagePipelineConfig):
         )
         return inputs
 
+    @staticmethod
+    def _ceil_to_multiple(x: int, m: int) -> int:
+        if m <= 0:
+            return x
+        return int(math.ceil(x / m) * m)
+
+    def _build_zimage_sp_plan(self, batch) -> dict:
+        """Build a minimal SP plan on batch for zimage (spatial sharding + cap sharding)."""
+        sp_size = get_sp_world_size()
+        rank = get_sp_parallel_rank()
+
+        raw_latent_shape = getattr(batch, "raw_latent_shape", None)
+        if raw_latent_shape is not None and len(raw_latent_shape) >= 5:
+            H = int(raw_latent_shape[3])
+            W = int(raw_latent_shape[4])
+        else:
+            H = int(batch.height // self.vae_config.arch_config.spatial_compression_ratio)
+            W = int(batch.width // self.vae_config.arch_config.spatial_compression_ratio)
+
+        # Rule: shard along the larger spatial dimension (W/H), implemented via optional H/W transpose.
+        # 目的：选择 H 和 W 较大的 进行 shard，所以 H_eff = max(H, W)
+        swap_hw = W > H
+        H_eff = W if swap_hw else H
+        W_eff = H if swap_hw else W
+
+        # ZImage uses PATCH_SIZE=2 for spatial patchify; shard in token space and convert back to latent rows.
+        PATCH_SIZE = 2
+        H_tok = H_eff // PATCH_SIZE
+        W_tok = W_eff // PATCH_SIZE
+        H_tok_pad = self._ceil_to_multiple(H_tok, sp_size)
+        H_tok_local = H_tok_pad // sp_size
+        h0_tok = rank * H_tok_local
+
+        # Cap/text sharding: avoid duplicating cap tokens across ranks.
+        cap_len = int(batch.prompt_embeds[0].size(0)) if getattr(batch, "prompt_embeds", None) else 0
+        cap_total = self._ceil_to_multiple(cap_len, 32 * sp_size)
+        cap_local = cap_total // sp_size
+        cap_start = rank * cap_local
+
+        plan = {
+            "sp_size": sp_size,
+            "rank": rank,
+            "swap_hw": swap_hw,
+            "H": H,
+            "W": W,
+            "H_eff": H_eff,
+            "W_eff": W_eff,
+            "H_tok": H_tok,
+            "W_tok": W_tok,
+            "H_tok_pad": H_tok_pad,
+            "H_tok_local": H_tok_local,
+            "h0_tok": h0_tok,
+            "cap_total": cap_total,
+            "cap_local": cap_local,
+            "cap_start": cap_start,
+        }
+        batch._zimage_sp_plan = plan
+        return plan
+
+    def _get_zimage_sp_plan(self, batch) -> dict:
+        plan = getattr(batch, "_zimage_sp_plan", None)
+        sp_size = get_sp_world_size()
+        if plan is None or plan.get("sp_size") != sp_size:
+            plan = self._build_zimage_sp_plan(batch)
+        return plan
+
+    def _shard_cap(self, cap: torch.Tensor, plan: dict) -> torch.Tensor:
+        """cap: [L, D] -> [cap_local, D], padded by repeating last token."""
+        if plan["sp_size"] <= 1:
+            return cap
+        # print(f"cap shape: {cap.shape}")  # [L, 2560] for zimage-turbo
+        L = cap.size(0)
+        cap_total = plan["cap_total"]
+        if cap_total > L:
+            cap = torch.cat([cap, cap[-1:].repeat(cap_total - L, 1)], dim=0)
+        start = plan["cap_start"]
+        local = plan["cap_local"]
+        return cap[start : start + local]
+
+    def get_pos_prompt_embeds(self, batch):
+        # Keep ZImage model signature: encoder_hidden_states is List[Tensor]
+        if get_sp_world_size() <= 1:
+            return batch.prompt_embeds
+        plan = self._get_zimage_sp_plan(batch)
+        return [self._shard_cap(batch.prompt_embeds[0], plan)]
+
     def shard_latents_for_sp(self, batch, latents):
-        if latents.dim() == 5:
-            return PipelineConfig.shard_latents_for_sp(self, batch, latents)
-        return super().shard_latents_for_sp(batch, latents)
+        sp_size = get_sp_world_size()
+        if sp_size <= 1 or latents.dim() != 5:
+            return latents, False
+
+        plan = self._get_zimage_sp_plan(batch)
+
+        # Layout: [B, C, T, H, W]. Always shard on dim=3 by optionally swapping H/W.
+        if plan["swap_hw"]:
+            latents = latents.transpose(3, 4).contiguous()
+
+        # Pad on effective-H so that H_tok is divisible by sp.
+        H_eff = latents.size(3)
+        H_tok = H_eff // 2
+        pad_tok = plan["H_tok_pad"] - H_tok
+        pad_lat = pad_tok * 2
+        if pad_lat > 0:
+            pad = latents[:, :, :, -1:, :].repeat(1, 1, 1, pad_lat, 1)
+            latents = torch.cat([latents, pad], dim=3)
+
+        h0 = plan["h0_tok"] * 2
+        h1 = (plan["h0_tok"] + plan["H_tok_local"]) * 2
+        latents = latents[:, :, :, h0:h1, :]
+        batch._zimage_sp_swap_hw = plan["swap_hw"]
+        return latents, True
 
     def gather_latents_for_sp(self, latents):
-        if latents.dim() == 5:
-            return PipelineConfig.gather_latents_for_sp(self, latents)
-        return super().gather_latents_for_sp(latents)
+        # Gather on effective-H dim=3 (matches shard_latents_for_sp); swap-back is handled in post_denoising_loop.
+        if get_sp_world_size() <= 1 or latents.dim() != 5:
+            return latents
+        return sequence_model_parallel_all_gather(latents, dim=3)
 
     def post_denoising_loop(self, latents, batch):
-        bs, channels, num_frames, height, width = latents.shape
+        # Restore swapped H/W and crop padded spatial dims before final reshape.
+        if latents.dim() == 5 and getattr(batch, "_zimage_sp_swap_hw", False):
+            latents = latents.transpose(3, 4).contiguous()
         raw_latent_shape = getattr(batch, "raw_latent_shape", None)
+        if raw_latent_shape is not None and latents.dim() == 5:
+            latents = latents[:, :, :, : raw_latent_shape[3], : raw_latent_shape[4]]
+
+        bs, channels, num_frames, height, width = latents.shape
         if raw_latent_shape is not None and num_frames > raw_latent_shape[2]:
             latents = latents[:, :, : raw_latent_shape[2], :, :]
             num_frames = raw_latent_shape[2]
@@ -105,6 +228,37 @@ class ZImagePipelineConfig(ImagePipelineConfig):
         PATCH_SIZE = 2
         F_PATCH_SIZE = 1
         SEQ_MULTI_OF = 32
+
+        sp_size = get_sp_world_size()
+        if sp_size > 1:
+            # SP path: build local-only freqs_cis matching local cap/x.
+            plan = self._get_zimage_sp_plan(batch)
+
+            # cap (local)
+            cap_pos_ids = create_coordinate_grid(
+                size=(plan["cap_local"], 1, 1),
+                start=(1 + plan["cap_start"], 0, 0),
+                device=device,
+            ).flatten(0, 2)
+            cap_freqs_cis = rotary_emb(cap_pos_ids)
+
+            # image (local, effective H-shard). Use cap_total for a stable offset across ranks/passes.
+            F_tokens = 1
+            H_tokens_local = plan["H_tok_local"]
+            W_tokens = plan["W_tok"]
+            img_pos_ids = create_coordinate_grid(
+                size=(F_tokens, H_tokens_local, W_tokens),
+                start=(plan["cap_total"] + 1, plan["h0_tok"], 0),
+                device=device,
+            ).flatten(0, 2)
+            img_pad_len = (-img_pos_ids.shape[0]) % SEQ_MULTI_OF
+            if img_pad_len:
+                pad_ids = create_coordinate_grid(
+                    size=(1, 1, 1), start=(0, 0, 0), device=device
+                ).flatten(0, 2)
+                img_pos_ids = torch.cat([img_pos_ids, pad_ids.repeat(img_pad_len, 1)], dim=0)
+            x_freqs_cis = rotary_emb(img_pos_ids)
+            return (cap_freqs_cis, x_freqs_cis)
 
         cap_ori_len = prompt_embeds.size(0)
         cap_padding_len = (-cap_ori_len) % SEQ_MULTI_OF

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1017,9 +1017,6 @@ class DenoisingStage(PipelineStage):
 
                         # Predict noise residual
                         attn_metadata = self._build_attn_metadata(i, batch, server_args)
-                        # print(f"latent_model_input shape: {latent_model_input.shape}")
-                        # # [B, C, T, H/sp_size, W] for zimage-turbo
-                        # [B, H*C / sp_size,C] for FLUX.1-dev
                         noise_pred = self._predict_noise_with_cfg(
                             current_model=current_model,
                             latent_model_input=latent_model_input,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1017,6 +1017,9 @@ class DenoisingStage(PipelineStage):
 
                         # Predict noise residual
                         attn_metadata = self._build_attn_metadata(i, batch, server_args)
+                        # print(f"latent_model_input shape: {latent_model_input.shape}")  
+                        # # [B, C, T, H/sp_size, W] for zimage-turbo
+                        # [B, H*C / sp_size,C] for FLUX.1-dev
                         noise_pred = self._predict_noise_with_cfg(
                             current_model=current_model,
                             latent_model_input=latent_model_input,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1017,7 +1017,7 @@ class DenoisingStage(PipelineStage):
 
                         # Predict noise residual
                         attn_metadata = self._build_attn_metadata(i, batch, server_args)
-                        # print(f"latent_model_input shape: {latent_model_input.shape}")  
+                        # print(f"latent_model_input shape: {latent_model_input.shape}")
                         # # [B, C, T, H/sp_size, W] for zimage-turbo
                         # [B, H*C / sp_size,C] for FLUX.1-dev
                         noise_pred = self._predict_noise_with_cfg(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The parallel implementation of the zimage model sequence is relatively inefficient because the current implementation pads the frame dimension of the 5D tensor, and the frame dimension of the Zimage model is always 1. Padding leads to increased computation. 
#16407 
#16418 

The optimization strategy for this pull request is to select the maximum of H and W as the effective splitting dimension in the 5-dimensional tensor [B, C, T, H, W], and simultaneously split the caption and input latents across multiple GPUs to achieve sequence-parallel splitting.


## Modifications

- The `shard_latents_for_sp`, `gather_latents_for_sp`, and `post_denoising_loop` methods in the `ZImagePipelineConfig` class have been rewritten to split the larger dimension between H and W.
- Utility functions required by these methods were also added.
- In denoising.py, print the shape of `latent_model_input` to verify the splitting logic.(commented)

## Accuracy Tests

After the modifications, the image generation is now correct and complete compared to before.  

## Benchmarking and Profiling

Generating 1024*1024 size images with 9 denoising steps and H20, the denoising stage P50 latency decreased from **3450ms** on a single card to **1953ms**, resulting in a **1.77x** speedup.

**test environment**: H20, 1024x1024 resolution, 9 denoising steps

| Configuration | P50 Latency (ms) | P90 Latency (ms) | P99 Latency (ms) | Speedup |
| :--- | :---: | :---: | :---: | :---: |
| H20 (Baseline) | 3450 | 3477 | 3527 | 1.0x |
| **2 x H20** | **1953** | **1954** | **2022** |**1.74x-1.77x** |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
