### PR TITLE
[Diffusion] Apply qknorm to flux2 and apply lightx2v rms_norm_one_pass kernel(without residual)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from sgl_kernel import fused_add_rmsnorm, rmsnorm
+from sgl_kernel import fused_add_rmsnorm
 
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (

--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -21,6 +21,7 @@ from sglang.multimodal_gen.runtime.layers.triton_ops import (
     fuse_scale_shift_kernel,
     norm_infer,
     rms_norm_fn,
+    triton_one_pass_rms_norm,
 )
 from sglang.multimodal_gen.runtime.utils.common import get_bool_env_var
 
@@ -76,7 +77,7 @@ class RMSNorm(CustomOp):
             fused_add_rmsnorm(x, residual, self.weight.data, self.variance_epsilon)
             return x.view(shape), residual.view(residual_shape)
         else:
-            out = rmsnorm(x, self.weight.data, self.variance_epsilon)
+            out = triton_one_pass_rms_norm(x, self.weight.data, self.variance_epsilon)
         out = out.view(shape)
         return out
 

--- a/python/sglang/multimodal_gen/runtime/layers/triton_ops.py
+++ b/python/sglang/multimodal_gen/runtime/layers/triton_ops.py
@@ -1106,3 +1106,59 @@ def rms_norm_fn(
         out,
         residual_out,
     )
+
+# Adapted from https://github.com/ModelTC/LightX2V/blob/main/lightx2v/common/ops/norm/triton_ops.py#L905-L956
+@triton.jit
+def _rms_norm_tiled_onepass(
+    y_ptr,
+    x_ptr,
+    w_ptr,
+    SEQ: tl.constexpr,
+    DIM: tl.constexpr,
+    EPS: tl.constexpr,
+    BLOCK_SIZE_SEQ: tl.constexpr,
+    BLOCK_SIZE_DIM: tl.constexpr,
+):
+    seq_blk_id = tl.program_id(0)
+    seq_id = seq_blk_id * BLOCK_SIZE_SEQ
+
+    seq_offset = seq_id + tl.arange(0, BLOCK_SIZE_SEQ)[:, None]
+    s_mask = seq_offset < SEQ
+    d_offset = tl.arange(0, BLOCK_SIZE_DIM)[None, :]
+    d_mask = d_offset < DIM
+    y_blk = y_ptr + seq_offset * DIM + d_offset
+    x_blk = x_ptr + seq_offset * DIM + d_offset
+    mask = s_mask & d_mask
+
+    x = tl.load(x_blk, mask=mask, other=0.0).to(tl.float32)
+    mean_square = tl.sum(x * x, axis=1, keep_dims=True) / DIM
+    rstd = tl.math.rsqrt(mean_square + EPS)
+    w = tl.load(w_ptr + d_offset, mask=mask)
+    tl.store(y_blk, x * rstd * w, mask=mask)
+
+
+def triton_one_pass_rms_norm(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6):
+    shape = x.shape
+    x = x.contiguous()
+    y = torch.empty_like(x)
+    x_view = x.reshape(-1, shape[-1])
+    y_view = y.reshape(-1, shape[-1])
+    S, D = x_view.shape
+
+    BLOCK_SIZE_SEQ = min(16, triton.next_power_of_2(max(1, S // 512)))
+    grid = triton.cdiv(S, BLOCK_SIZE_SEQ),
+
+    with torch.cuda.device(x.device):
+        torch.library.wrap_triton(
+            _rms_norm_tiled_onepass
+        )[grid](
+            y_view,
+            x_view,
+            w,
+            S,
+            D,
+            eps,
+            BLOCK_SIZE_DIM=triton.next_power_of_2(D),
+            BLOCK_SIZE_SEQ=BLOCK_SIZE_SEQ,
+        )
+    return y

--- a/python/sglang/multimodal_gen/runtime/layers/triton_ops.py
+++ b/python/sglang/multimodal_gen/runtime/layers/triton_ops.py
@@ -1134,7 +1134,7 @@ def _rms_norm_tiled_onepass(
     x = tl.load(x_blk, mask=mask, other=0.0).to(tl.float32)
     mean_square = tl.sum(x * x, axis=1, keep_dims=True) / DIM
     rstd = tl.math.rsqrt(mean_square + EPS)
-    w = tl.load(w_ptr + d_offset, mask=mask)
+    w = tl.load(w_ptr + d_offset, mask=d_mask)
     tl.store(y_blk, x * rstd * w, mask=mask)
 
 

--- a/python/sglang/multimodal_gen/runtime/layers/triton_ops.py
+++ b/python/sglang/multimodal_gen/runtime/layers/triton_ops.py
@@ -1107,6 +1107,7 @@ def rms_norm_fn(
         residual_out,
     )
 
+
 # Adapted from https://github.com/ModelTC/LightX2V/blob/main/lightx2v/common/ops/norm/triton_ops.py#L905-L956
 @triton.jit
 def _rms_norm_tiled_onepass(
@@ -1146,12 +1147,10 @@ def triton_one_pass_rms_norm(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
     S, D = x_view.shape
 
     BLOCK_SIZE_SEQ = min(16, triton.next_power_of_2(max(1, S // 512)))
-    grid = triton.cdiv(S, BLOCK_SIZE_SEQ),
+    grid = (triton.cdiv(S, BLOCK_SIZE_SEQ),)
 
     with torch.cuda.device(x.device):
-        torch.library.wrap_triton(
-            _rms_norm_tiled_onepass
-        )[grid](
+        torch.library.wrap_triton(_rms_norm_tiled_onepass)[grid](
             y_view,
             x_view,
             w,

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -371,23 +371,9 @@ class Flux2ParallelSelfAttention(torch.nn.Module, AttentionModuleMixin):
         query = query.unflatten(-1, (self.heads, -1))
         key = key.unflatten(-1, (self.heads, -1))
         value = value.unflatten(-1, (self.heads, -1))
-
-        if (
-            query.is_cuda
-            and (self.norm_q.variance_epsilon == self.norm_k.variance_epsilon)
-            and can_use_fused_inplace_qknorm(self.head_dim, query.dtype)
-        ):
-            query, key = apply_qk_norm(
-                q=query,
-                k=key,
-                q_norm=self.norm_q,
-                k_norm=self.norm_k,
-                head_dim=self.head_dim,
-                allow_inplace=True,
-            )
-        else:
-            query = self.norm_q(query)
-            key = self.norm_k(key)
+        
+        query = self.norm_q(query)
+        key = self.norm_k(key)
 
         if freqs_cis is not None:
             cos, sin = freqs_cis

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -371,7 +371,7 @@ class Flux2ParallelSelfAttention(torch.nn.Module, AttentionModuleMixin):
         query = query.unflatten(-1, (self.heads, -1))
         key = key.unflatten(-1, (self.heads, -1))
         value = value.unflatten(-1, (self.heads, -1))
-        
+
         query = self.norm_q(query)
         key = self.norm_k(key)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -20,9 +20,10 @@ from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.normalization import AdaLayerNormContinuous
 
+from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
-from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
+from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
 from sglang.multimodal_gen.runtime.layers.linear import ColumnParallelLinear
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     NDRotaryEmbedding,
@@ -196,16 +197,47 @@ class Flux2Attention(torch.nn.Module, AttentionModuleMixin):
         key = key.unflatten(-1, (self.heads, -1))
         value = value.unflatten(-1, (self.heads, -1))
 
-        query = self.norm_q(query)
-        key = self.norm_k(key)
+        if (
+            query.is_cuda
+            and (self.norm_q.variance_epsilon == self.norm_k.variance_epsilon)
+            and can_use_fused_inplace_qknorm(self.head_dim, query.dtype)
+        ):
+            query, key = apply_qk_norm(
+                q=query,
+                k=key,
+                q_norm=self.norm_q,
+                k_norm=self.norm_k,
+                head_dim=self.head_dim,
+                allow_inplace=True,
+            )
+        else:
+            query = self.norm_q(query)
+            key = self.norm_k(key)
 
         if self.added_kv_proj_dim is not None:
             encoder_query = encoder_query.unflatten(-1, (self.heads, -1))
             encoder_key = encoder_key.unflatten(-1, (self.heads, -1))
             encoder_value = encoder_value.unflatten(-1, (self.heads, -1))
 
-            encoder_query = self.norm_added_q(encoder_query)
-            encoder_key = self.norm_added_k(encoder_key)
+            if (
+                encoder_query.is_cuda
+                and (
+                    self.norm_added_q.variance_epsilon
+                    == self.norm_added_k.variance_epsilon
+                )
+                and can_use_fused_inplace_qknorm(self.head_dim, encoder_query.dtype)
+            ):
+                encoder_query, encoder_key = apply_qk_norm(
+                    q=encoder_query,
+                    k=encoder_key,
+                    q_norm=self.norm_added_q,
+                    k_norm=self.norm_added_k,
+                    head_dim=self.head_dim,
+                    allow_inplace=True,
+                )
+            else:
+                encoder_query = self.norm_added_q(encoder_query)
+                encoder_key = self.norm_added_k(encoder_key)
 
             query = torch.cat([encoder_query, query], dim=1)
             key = torch.cat([encoder_key, key], dim=1)
@@ -340,8 +372,22 @@ class Flux2ParallelSelfAttention(torch.nn.Module, AttentionModuleMixin):
         key = key.unflatten(-1, (self.heads, -1))
         value = value.unflatten(-1, (self.heads, -1))
 
-        query = self.norm_q(query)
-        key = self.norm_k(key)
+        if (
+            query.is_cuda
+            and (self.norm_q.variance_epsilon == self.norm_k.variance_epsilon)
+            and can_use_fused_inplace_qknorm(self.head_dim, query.dtype)
+        ):
+            query, key = apply_qk_norm(
+                q=query,
+                k=key,
+                q_norm=self.norm_q,
+                k_norm=self.norm_k,
+                head_dim=self.head_dim,
+                allow_inplace=True,
+            )
+        else:
+            query = self.norm_q(query)
+            key = self.norm_k(key)
 
         if freqs_cis is not None:
             cos, sin = freqs_cis


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->


## Motivation

### FLUX2

sglang generate --model-path black-forest-labs/FLUX.2-dev --prompt "A Logo With Bold Large Text: SGL Diffusion" --width=1024 --height=1024 --dit-layerwise-offload false --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload true --vae-cpu-offload false

main:

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:22<00:00,  2.24it/s]
[01-18 14:19:18] [DenoisingStage] average time per step: 0.4461 seconds
[01-18 14:19:19] [DenoisingStage] finished in 22.7520 seconds

pr:

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:21<00:00,  2.34it/s]
[01-18 14:52:54] [DenoisingStage] average time per step: 0.4280 seconds
[01-18 14:52:55] [DenoisingStage] finished in 21.8318 seconds

About 4.2% end2end performace improve for flux2.

<img width="520" height="458" alt="图片" src="https://github.com/user-attachments/assets/fc07915a-03e4-4e87-b43b-03d0d6a302aa" />

### Qwen-Image-Edit-2511

```shell
sglang generate --model-path Qwen/Qwen-Image-Edit-2511 --prompt "Change the person to a standing position, bending over to hold the dog's front paws." --image-path "/home/lmsys/bbuf/LightX2V/examples/qwen_image/1.png" --warmup --enable-torch-compile
```

- main:

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 40/40 [00:23<00:00,  1.73it/s]
[01-18 15:11:37] [DenoisingStage] average time per step: 0.5769 seconds
[01-18 15:11:37] [DenoisingStage] finished in 23.0815 seconds

- pr:

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 40/40 [00:23<00:00,  1.73it/s]
[01-18 15:13:52] [DenoisingStage] average time per step: 0.5768 seconds
[01-18 15:13:52] [DenoisingStage] finished in 23.0749 seconds

Since in qwen-image there is almost no separate RMSNorm, so performance remains consistent.

## Micro benchmark

Provided by @triple-mu 

```python
import torch
import torch.nn.functional as F

import triton
import triton.language as tl

import flashinfer # flashinfer

@triton.jit
def _rms_norm_tiled_onepass(
    y_ptr,
    x_ptr,
    w_ptr,
    SEQ: tl.constexpr,
    DIM: tl.constexpr,
    EPS: tl.constexpr,
    BLOCK_SIZE_SEQ: tl.constexpr,
    BLOCK_SIZE_DIM: tl.constexpr,
):
    seq_blk_id = tl.program_id(0)
    seq_id = seq_blk_id * BLOCK_SIZE_SEQ

    seq_offset = seq_id + tl.arange(0, BLOCK_SIZE_SEQ)[:, None]
    s_mask = seq_offset < SEQ
    d_offset = tl.arange(0, BLOCK_SIZE_DIM)[None, :]
    d_mask = d_offset < DIM
    y_blk = y_ptr + seq_offset * DIM + d_offset
    x_blk = x_ptr + seq_offset * DIM + d_offset
    mask = s_mask & d_mask

    x = tl.load(x_blk, mask=mask, other=0.0).to(tl.float32)
    mean_square = tl.sum(x * x, axis=1, keep_dims=True) / DIM
    rstd = tl.math.rsqrt(mean_square + EPS)
    w = tl.load(w_ptr + d_offset, mask=d_mask)
    tl.store(y_blk, x * rstd * w, mask=mask)


def rms_norm_kernel(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
    shape = x.shape
    x = x.contiguous()
    y = torch.empty_like(x)
    x_view = x.reshape(-1, shape[-1])
    y_view = y.reshape(-1, shape[-1])
    S, D = x_view.shape

    BLOCK_SIZE_SEQ = min(16, triton.next_power_of_2(max(1, S // 512)))
    grid = (triton.cdiv(S, BLOCK_SIZE_SEQ),)

    with torch.cuda.device(x.device):
        torch.library.wrap_triton(_rms_norm_tiled_onepass)[grid](
            y_view,
            x_view,
            w,
            S,
            D,
            eps,
            BLOCK_SIZE_DIM=triton.next_power_of_2(D),
            BLOCK_SIZE_SEQ=BLOCK_SIZE_SEQ,
        )
    return y


@torch.inference_mode()
def main():

    for head_size in [32, 64, 128]:
        print(f"Testing head_size: {head_size}")

        dtype = torch.bfloat16
        device = torch.device('cuda:0')

        seq_lens = [1 << i for i in range(10, 19)]
        inputs = [
            torch.randn(seq_len, 40, head_size, dtype=dtype, device=device) for seq_len in seq_lens
        ]

        weight = torch.randn(head_size, dtype=dtype, device=device)

        quantiles = [0.5, 0.2, 0.8]

        for i in range(3):
            for input in inputs:
                flashinfer.norm.rmsnorm(input, weight, eps=1e-6)
                rms_norm_kernel(input, weight, eps=1e-6)
                F.rms_norm(input, (head_size, ), weight, eps=1e-6)


        fns = {}
        for input in inputs:
            fn1 = lambda : flashinfer.norm.rmsnorm(input, weight, eps=1e-6)
            fn2 = lambda : rms_norm_kernel(input, weight, eps=1e-6)
            fn3 = lambda : F.rms_norm(input, (head_size, ), weight, eps=1e-6)
            fns[tuple(input.shape)] = (fn1, fn2, fn3)
        
        for shape, all_fns in fns.items():
            for i, fn in enumerate(all_fns):
                ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(fn, quantiles=quantiles)
                print(f'{shape}: fn[{i}] {ms:.5f} ms')
            print('*' * 100)
        
        print('='*50)


if __name__ == '__main__':
    main()

```

Result:

```shell
Testing head_size: 32
(1024, 40, 32): fn[0] 2.76439 ms
(1024, 40, 32): fn[1] 0.45949 ms
(1024, 40, 32): fn[2] 6.36691 ms
****************************************************************************************************
(2048, 40, 32): fn[0] 2.76452 ms
(2048, 40, 32): fn[1] 0.45889 ms
(2048, 40, 32): fn[2] 6.37582 ms
****************************************************************************************************
(4096, 40, 32): fn[0] 2.76442 ms
(4096, 40, 32): fn[1] 0.45948 ms
(4096, 40, 32): fn[2] 6.36517 ms
****************************************************************************************************
(8192, 40, 32): fn[0] 2.76528 ms
(8192, 40, 32): fn[1] 0.45889 ms
(8192, 40, 32): fn[2] 6.37479 ms
****************************************************************************************************
(16384, 40, 32): fn[0] 2.76506 ms
(16384, 40, 32): fn[1] 0.45951 ms
(16384, 40, 32): fn[2] 6.36547 ms
****************************************************************************************************
(32768, 40, 32): fn[0] 2.76439 ms
(32768, 40, 32): fn[1] 0.45890 ms
(32768, 40, 32): fn[2] 6.37488 ms
****************************************************************************************************
(65536, 40, 32): fn[0] 2.76483 ms
(65536, 40, 32): fn[1] 0.45949 ms
(65536, 40, 32): fn[2] 6.36510 ms
****************************************************************************************************
(131072, 40, 32): fn[0] 2.76436 ms
(131072, 40, 32): fn[1] 0.45889 ms
(131072, 40, 32): fn[2] 6.37313 ms
****************************************************************************************************
(262144, 40, 32): fn[0] 2.76399 ms
(262144, 40, 32): fn[1] 0.45950 ms
(262144, 40, 32): fn[2] 6.36560 ms
****************************************************************************************************
==================================================
Testing head_size: 64
(1024, 40, 64): fn[0] 2.75171 ms
(1024, 40, 64): fn[1] 0.87956 ms
(1024, 40, 64): fn[2] 6.37175 ms
****************************************************************************************************
(2048, 40, 64): fn[0] 2.75112 ms
(2048, 40, 64): fn[1] 0.88112 ms
(2048, 40, 64): fn[2] 6.37811 ms
****************************************************************************************************
(4096, 40, 64): fn[0] 2.75024 ms
(4096, 40, 64): fn[1] 0.87958 ms
(4096, 40, 64): fn[2] 6.37240 ms
****************************************************************************************************
(8192, 40, 64): fn[0] 2.75057 ms
(8192, 40, 64): fn[1] 0.88118 ms
(8192, 40, 64): fn[2] 6.37649 ms
****************************************************************************************************
(16384, 40, 64): fn[0] 2.75042 ms
(16384, 40, 64): fn[1] 0.87955 ms
(16384, 40, 64): fn[2] 6.37218 ms
****************************************************************************************************
(32768, 40, 64): fn[0] 2.75036 ms
(32768, 40, 64): fn[1] 0.88116 ms
(32768, 40, 64): fn[2] 6.37589 ms
****************************************************************************************************
(65536, 40, 64): fn[0] 2.75120 ms
(65536, 40, 64): fn[1] 0.87947 ms
(65536, 40, 64): fn[2] 6.37186 ms
****************************************************************************************************
(131072, 40, 64): fn[0] 2.75116 ms
(131072, 40, 64): fn[1] 0.88108 ms
(131072, 40, 64): fn[2] 6.37512 ms
****************************************************************************************************
(262144, 40, 64): fn[0] 2.75039 ms
(262144, 40, 64): fn[1] 0.87956 ms
(262144, 40, 64): fn[2] 6.37167 ms
****************************************************************************************************
==================================================
Testing head_size: 128
(1024, 40, 128): fn[0] 2.77051 ms
(1024, 40, 128): fn[1] 1.76063 ms
(1024, 40, 128): fn[2] 6.38813 ms
****************************************************************************************************
(2048, 40, 128): fn[0] 2.77091 ms
(2048, 40, 128): fn[1] 1.76215 ms
(2048, 40, 128): fn[2] 6.38253 ms
****************************************************************************************************
(4096, 40, 128): fn[0] 2.77168 ms
(4096, 40, 128): fn[1] 1.76031 ms
(4096, 40, 128): fn[2] 6.38663 ms
****************************************************************************************************
(8192, 40, 128): fn[0] 2.76875 ms
(8192, 40, 128): fn[1] 1.76225 ms
(8192, 40, 128): fn[2] 6.38367 ms
****************************************************************************************************
(16384, 40, 128): fn[0] 2.77135 ms
(16384, 40, 128): fn[1] 1.76003 ms
(16384, 40, 128): fn[2] 6.38361 ms
****************************************************************************************************
(32768, 40, 128): fn[0] 2.76964 ms
(32768, 40, 128): fn[1] 1.76233 ms
(32768, 40, 128): fn[2] 6.38564 ms
****************************************************************************************************
(65536, 40, 128): fn[0] 2.77183 ms
(65536, 40, 128): fn[1] 1.76024 ms
(65536, 40, 128): fn[2] 6.38377 ms
****************************************************************************************************
(131072, 40, 128): fn[0] 2.77039 ms
(131072, 40, 128): fn[1] 1.76203 ms
(131072, 40, 128): fn[2] 6.38260 ms
****************************************************************************************************
(262144, 40, 128): fn[0] 2.77206 ms
(262144, 40, 128): fn[1] 1.76016 ms
(262144, 40, 128): fn[2] 6.39005 ms
****************************************************************************************************
==================================================
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
