### PR TITLE
fix: Fixed the issue where "finish_reason":"stop" appeared when calling the tool and the tool was in the content.

### DIFF
--- a/examples/chat_template/tool_chat_template_deepseekv32.jinja
+++ b/examples/chat_template/tool_chat_template_deepseekv32.jinja
@@ -22,7 +22,7 @@
   {% for tool in tools %}
     {% set tool_ns.text = tool_ns.text + '\n### ' + tool.function.name + '\nDescription: ' + tool.function.description + '\n\nParameters: ' + (tool.function.parameters | tojson) + '\n' %}
   {% endfor %}
-  {% set tool_ns.text = tool_ns.text + "\nIMPORTANT: ALWAYS adhere to this exact format for tool use:\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>tool_call_name<｜tool▁sep｜>tool_call_arguments<｜tool▁call▁end｜>{{additional_tool_calls}}<｜tool▁calls▁end｜>\n\nWhere:\n\n- `tool_call_name` must be an exact match to one of the available tools\n- `tool_call_arguments` must be valid JSON that strictly follows the tool's Parameters Schema\n- For multiple tool calls, chain them directly without separators or spaces\n" %}
+  {% set tool_ns.text = tool_ns.text + "\nIMPORTANT: ALWAYS adhere to this exact format for tool use:\n<｜DSML｜function_calls>\n<｜DSML｜invoke name=\"tool_call_name\">\n<｜DSML｜parameter name=\"param_name\" string=\"true\">param_value</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n</｜DSML｜function_calls>\n\nWhere:\n- `tool_call_name` must be an exact match to one of the available tools\n- For multiple tool calls, nest multiple <｜DSML｜invoke> blocks inside <｜DSML｜function_calls>\n- Parameters should be passed as JSON object inside the invoke block, e.g.: {\"param_name\": \"param_value\"}\n" %}
   {% set ns.system_prompt = ns.system_prompt + '\n\n' + tool_ns.text %}
 {% endif %}
 
@@ -41,20 +41,14 @@
     {%- set ns.is_last_user = false -%}
     {%- set ns.is_first = false %}
     {%- set ns.is_tool = false -%}
+    {{'<｜DSML｜function_calls>'}}
     {%- for tool in message['tool_calls'] %}
       {%- set formatted_args = tool['function']['arguments'] if tool['function']['arguments'] is string else tool['function']['arguments']|tojson %}
-      {%- if not ns.is_first %}
-        {%- if message['content'] is none %}
-          {{'<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>'+ tool['function']['name'] + '<｜tool▁sep｜>' + formatted_args + '<｜tool▁call▁end｜>'}}
-        {%- else %}
-          {{message['content'] + '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['function']['name'] + '<｜tool▁sep｜>' + formatted_args + '<｜tool▁call▁end｜>'}}
-        {%- endif %}
-        {%- set ns.is_first = true -%}
-      {%- else %}
-        {{'<｜tool▁call▁begin｜>'+ tool['function']['name'] + '<｜tool▁sep｜>' + formatted_args + '<｜tool▁call▁end｜>'}}
-      {%- endif %}
+      {{'<｜DSML｜invoke name=\"' + tool['function']['name'] + '\">'}}
+      {{formatted_args}}
+      {{'</｜DSML｜invoke>'}}
     {%- endfor %}
-    {{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}
+    {{'</｜DSML｜function_calls><｜end▁of▁sentence｜>'}}
   {%- endif %}
   {%- if message['role'] == 'assistant' and (message['tool_calls'] is not defined or message['tool_calls'] is none) %}
     {%- if ns.is_last_user %}

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -195,12 +195,16 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 self.invoke_regex, function_calls_content, re.DOTALL
             )
 
-            for func_name, invoke_content, _ in invoke_matches:
+            for i, (func_name, invoke_content, _) in enumerate(invoke_matches):
                 # Parse parameters from XML format
                 func_args = self._parse_parameters_from_xml(invoke_content)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": func_args}
-                calls.extend(self.parse_base_json(match_result, tools))
+                calls.append(
+                    ToolCallItem(
+                        tool_index=i,
+                        name=func_name,
+                        parameters=json.dumps(func_args, ensure_ascii=False),
+                    )
+                )
 
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:


### PR DESCRIPTION
Motivation
The DeepSeek-V3.2 model exhibits an issue with tool call parsing: tool call information is always output as plain text in the content field instead of being correctly parsed into the tool_calls field, and the response’s finish_reason is "stop" rather than "tool_calls".

This occurs because the tool_chat_template_deepseekv32.jinja template uses the older V3.1 format tokens (<｜tool▁calls▁begin｜>), while the --tool-call-parser deepseekv32 option expects the newer V3.2 DSML format (<｜DSML｜function_calls>). The mismatch between the template’s token format and the parser’s expected format prevents proper detection and extraction of tool calls, causing them to be treated as regular message content.

Example request:

curl "http://127.0.0.1:9001/v1/chat/completions" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer sk-XXXXX" \
    -d '{
      "model": "DeepSeek-V3.2",
      "messages": [
        {
          "role": "system",
          "content": "You are a helpful assistant. Use function calling when you need to answer questions that require external tools."
        },
        {
          "role": "user",
          "content": "What is the weather like in Beijing today?"
        }
      ],
      "tools": [
        {
          "type": "function",
          "function": {
            "name": "query_weather",
            "description": "Input a city name in English and get today's weather forecast",
            "parameters": {
              "type": "object",
              "properties": {
                "city": {
                  "type": "string",
                  "description": "City name (must be in English)"
                }
              },
              "required": ["city"]
            }
          }
        }
      ],
      "tool_choice": "auto"
    }'
Error response (before fix):

{
    "id": "6ccd8fcaa546470c9d1bb1be07ddcdff",
    "object": "chat.completion",
    "created": 1768470805,
    "model": "DeepSeek-V3.2",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "query_weather\n{\"city\":\"beijing\"}",
                "reasoning_content": null,
                "tool_calls": null
            },
            "logprobs": null,
            "finish_reason": "stop",
            "matched_stop": 1
        }
    ],
    "usage": {
        "prompt_tokens": 194,
        "total_tokens": 206,
        "completion_tokens": 12,
        "prompt_tokens_details": {
            "cached_tokens": 192
        },
        "reasoning_tokens": 0
    },
    "metadata": {
        "weight_version": "default"
    }
}
Expected response (after fix):

{
    "id": "b29795a4595b4504a4c6b07c09cbcb51",
    "object": "chat.completion",
    "created": 1768474829,
    "model": "DeepSeek-V3.2",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "我来帮你查询北京的天气情况。",
                "reasoning_content": null,
                "tool_calls": [
                    {
                        "id": "call_44fea397f6994cf3b5be44cb",
                        "index": 0,
                        "type": "function",
                        "function": {
                            "name": "query_weather",
                            "arguments": "{\"city\":\"Beijing\"}"
                        }
                    }
                ]
            },
            "logprobs": null,
            "finish_reason": "tool_calls",
            "matched_stop": null
        }
    ],
    "usage": {
        "prompt_tokens": 230,
        "total_tokens": 281,
        "completion_tokens": 51,
        "prompt_tokens_details": {
            "cached_tokens": 192
        },
        "reasoning_tokens": 0
    },
    "metadata": {
        "weight_version": "default"
    }
}
Modifications
examples/chat_template/tool_chat_template_deepseekv32.jinja:

Updated the tool description in the system prompt to use DSML format for tool calls
Modified the tool_calls rendering logic to output <｜DSML｜function_calls>...</｜DSML｜function_calls> format
python/sglang/srt/function_call/deepseekv32_detector.py:

Modified the detect_and_parse method to directly use the enumeration index i as tool_index, instead of relying on parse_base_json to look up indices from the tools list
Accuracy Tests
Validation results after the fix:

Before fix: "content": "query_weather\n{\"city\": \"beijing\"}", "tool_calls": null, "finish_reason": "stop"
After fix: "tool_calls": [{"id": "...", "index": 0, "function": {"name": "query_weather", "arguments": "{\"city\": \"beijing\"}"}}], "finish_reason": "tool_calls"