### PR TITLE
[Bugfix] Fix 500 error under high-concurrency streaming requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1106,7 +1106,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 )
             except asyncio.TimeoutError:
                 if (
-                    request is not None
+                    not is_stream
+                    and request is not None
                     and not obj.background
                     and await request.is_disconnected()
                 ):


### PR DESCRIPTION
## Summary

Fixes #17031

- Under high concurrency, streaming requests could receive 500 errors with "Request is disconnected from the client side (type 1)" even when the client hadn't disconnected
- The root cause was that the disconnection check during timeout in `_wait_one_response` was applied to both streaming and non-streaming requests, despite the comment saying "non-streaming, waiting queue"
- For streaming requests, when `request.is_disconnected()` returns True (possibly a false positive under high load), raising a ValueError causes "Task exception was never retrieved" warnings and 500 errors

## Changes

- Added `not is_stream` to the timeout disconnection check condition (type 1), matching the behavior of the second disconnection check (type 3) which is already properly gated by `is_stream`
- For streaming requests, the background abort task will still clean up disconnected requests after the stream completes

## Test Plan

- Run the server with high-concurrency streaming requests
- Verify that 500 errors no longer occur spuriously
- Verify that genuinely disconnected streaming requests are still cleaned up via the background abort task