### PR TITLE
fix(ci): apply MMMU retry logic to all affected test files

### DIFF
--- a/test/manual/nightly/test_vlms_piecewise_cuda_graph.py
+++ b/test/manual/nightly/test_vlms_piecewise_cuda_graph.py
@@ -3,12 +3,12 @@ import glob
 import json
 import os
 import random
-import subprocess
 import sys
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -85,11 +85,7 @@ class TestVLMPiecewiseCudaGraph(CustomTestCase):
             str(output_path),
         ]
 
-        subprocess.run(
-            cmd,
-            check=True,
-            timeout=3600,
-        )
+        _run_lmms_eval_with_retry(cmd, timeout=3600)
 
     def _run_vlm_mmmu_test(
         self,

--- a/test/manual/nightly/test_vlms_vit_cuda_graph.py
+++ b/test/manual/nightly/test_vlms_vit_cuda_graph.py
@@ -3,12 +3,12 @@ import glob
 import json
 import os
 import random
-import subprocess
 import sys
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -88,11 +88,7 @@ class TestVLMViTCudaGraph(CustomTestCase):
             str(output_path),
         ]
 
-        subprocess.run(
-            cmd,
-            check=True,
-            timeout=3600,
-        )
+        _run_lmms_eval_with_retry(cmd, timeout=3600)
 
     def _run_vlm_mmmu_test(
         self,

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -3,13 +3,13 @@ import glob
 import json
 import os
 import random
-import subprocess
 import sys
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -94,11 +94,7 @@ class TestVLMEncoderDP(CustomTestCase):
             str(output_path),
         ]
 
-        subprocess.run(
-            cmd,
-            check=True,
-            timeout=3600,
-        )
+        _run_lmms_eval_with_retry(cmd, timeout=3600)
 
     def _run_vlm_mmmu_test(
         self,

--- a/test/srt/test_epd_disaggregation.py
+++ b/test/srt/test_epd_disaggregation.py
@@ -1,9 +1,9 @@
 import os
-import subprocess
 import threading
 import unittest
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
 )
@@ -177,7 +177,7 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
             limit,
         ]
 
-        subprocess.run(cmd, check=True, timeout=3600)
+        _run_lmms_eval_with_retry(cmd, timeout=3600)
 
     def test_mmmu(self):
         """Test MMMU evaluation with EPD disaggregation"""
@@ -393,7 +393,7 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
             limit,
         ]
 
-        subprocess.run(cmd, check=True, timeout=3600)
+        _run_lmms_eval_with_retry(cmd, timeout=3600)
 
     def test_mmmu(self):
         """Test MMMU evaluation with EPD disaggregation (multiple encoders)"""


### PR DESCRIPTION
The MMMU parquet corruption retry logic was not being used by several test files that had their own run_mmmu_eval methods directly calling subprocess.run(). This caused these tests to fail when encountering corrupted parquet files.

Changes:
- Import _run_lmms_eval_with_retry from mmmu_vlm_kit in:
  - test/srt/test_epd_disaggregation.py (2 classes)
  - test/registered/vlm/test_encoder_dp.py
  - test/manual/nightly/test_vlms_vit_cuda_graph.py
  - test/manual/nightly/test_vlms_piecewise_cuda_graph.py
- Replace subprocess.run() with _run_lmms_eval_with_retry()

This ensures all MMMU tests will automatically clean up corrupted cache and retry with fresh downloads.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
