### PR TITLE
Revert "[Perf] fuse q, k norm for Flux2Attention (#17241)"

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -22,7 +22,7 @@ from diffusers.models.normalization import AdaLayerNormContinuous
 
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
-from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
+from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
 from sglang.multimodal_gen.runtime.layers.linear import ColumnParallelLinear
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     NDRotaryEmbedding,
@@ -196,7 +196,8 @@ class Flux2Attention(torch.nn.Module, AttentionModuleMixin):
         key = key.unflatten(-1, (self.heads, -1))
         value = value.unflatten(-1, (self.heads, -1))
 
-        query, key = apply_qk_norm(query, key, self.norm_q, self.norm_k, self.head_dim)
+        query = self.norm_q(query)
+        key = self.norm_k(key)
 
         if self.added_kv_proj_dim is not None:
             encoder_query = encoder_query.unflatten(-1, (self.heads, -1))
@@ -339,7 +340,8 @@ class Flux2ParallelSelfAttention(torch.nn.Module, AttentionModuleMixin):
         key = key.unflatten(-1, (self.heads, -1))
         value = value.unflatten(-1, (self.heads, -1))
 
-        query, key = apply_qk_norm(query, key, self.norm_q, self.norm_k, self.head_dim)
+        query = self.norm_q(query)
+        key = self.norm_k(key)
 
         if freqs_cis is not None:
             cos, sin = freqs_cis


### PR DESCRIPTION
Reverts sgl-project/sglang#17241

First, not implementing a fallback when applying qk_norm will break the [AMD diffusion CI](https://github.com/sgl-project/sglang/actions/runs/21085222138/job/60680696502). Second, the decision to use qknorm should be based on whether `can_use_fused_inplace_qknorm` returns true, rather than being applied directly. Third, converting non-contiguous q and k tensors directly to contiguous here is a performance-sensitive operation and should not be done. Even though this is dead code, it should not be written this way. Finally, a warmup should be add in performace test command.

Please refer to: https://github.com/sgl-project/sglang/pull/17305

And I will refactor diffusion qk_norm apply logic to make it easier to use in the future.

cc @mickqian @yhyang201 @zminglei 