### PR TITLE
Move test_autoround.py to stage-b-test-large-1-gpu suite

### DIFF
--- a/test/registered/quant/test_autoround.py
+++ b/test/registered/quant/test_autoround.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=77, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=77, suite="stage-b-test-large-1-gpu")
 
 
 class TestAutoRound(CustomTestCase):


### PR DESCRIPTION
## Summary
- Moved test_autoround.py from stage-b-test-small-1-gpu to stage-b-test-large-1-gpu

## Motivation
Test was failing on stage-b-test-small-1-gpu due to resource constraints.

Failure example: https://github.com/sgl-project/sglang/actions/runs/21127557140/job/60752710976