### PR TITLE
[Diffusion] Fix the LoRA weights mismatch caused by weights packing

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/zimage.py
@@ -38,6 +38,16 @@ class ZImageArchConfig(DiTArchConfig):
         default_factory=lambda: {
             r"(.*)\.feed_forward\.w1\.weight$": (r"\1.feed_forward.w13.weight", 0, 2),
             r"(.*)\.feed_forward\.w3\.weight$": (r"\1.feed_forward.w13.weight", 1, 2),
+            r"(.*)\.feed_forward\.w1\.(lora_A|lora_B)$": (
+                r"\1.feed_forward.w13.\2",
+                0,
+                2,
+            ),
+            r"(.*)\.feed_forward\.w3\.(lora_A|lora_B)$": (
+                r"\1.feed_forward.w13.\2",
+                1,
+                2,
+            ),
         }
     )
 

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -90,6 +90,8 @@ class BaseLayerWithLoRA(nn.Module):
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
             delta = delta * self.strength
+            if delta.dim() > 2:
+                delta = delta.reshape(-1, delta.shape[-1])
             out, output_bias = self.base_layer(x)
             return out + delta, output_bias
         else:
@@ -171,6 +173,8 @@ class BaseLayerWithLoRA(nn.Module):
             if self.lora_alpha is not None and self.lora_rank is not None:
                 if self.lora_alpha != self.lora_rank:
                     lora_delta = lora_delta * (self.lora_alpha / self.lora_rank)
+            if lora_delta.dim() > 2:
+                lora_delta = lora_delta.reshape(-1, lora_delta.shape[-1])
             data += lora_strength * lora_delta
 
     @torch.no_grad()
@@ -468,6 +472,8 @@ class LinearWithLoRA(BaseLayerWithLoRA):
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
             delta = delta * self.strength
+            if delta.dim() > 2:
+                delta = delta.reshape(-1, delta.shape[-1])
             # nn.Linear.forward() returns a single tensor, not a tuple
             out = self.base_layer(x)
             return out + delta

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -560,17 +560,17 @@ class LoRAPipeline(ComposedPipelineBase):
             name, _, _ = lora_param_names_mapping_fn(name)
             # HF-format (LoRA) -> SGLang-dit-format
             target_name, merge_index, num_params_to_merge = param_names_mapping_fn(name)
-            # for (in_dim, r) @ (r, out_dim), we only merge (r, out_dim * n) where n is the number of linear layers to fuse
+            # for multiple B(out_dim, r) @ A(r, in_dim) -> (N, out_dim, r) @ (N, out_dim, r)
             # see param mapping in HunyuanVideoArchConfig
-            if merge_index is not None and "lora_B" in name:
+            if merge_index is not None:
                 to_merge_params[target_name][merge_index] = weight
                 if len(to_merge_params[target_name]) == num_params_to_merge:
-                    # cat at output dim according to the merge_index order
                     sorted_tensors = [
                         to_merge_params[target_name][i]
                         for i in range(num_params_to_merge)
                     ]
-                    weight = torch.cat(sorted_tensors, dim=1)
+                    # Use stack instead of cat because it needs to be compatible with TP.
+                    weight = torch.stack(sorted_tensors, dim=0)
                     del to_merge_params[target_name]
                 else:
                     continue

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -560,7 +560,7 @@ class LoRAPipeline(ComposedPipelineBase):
             name, _, _ = lora_param_names_mapping_fn(name)
             # HF-format (LoRA) -> SGLang-dit-format
             target_name, merge_index, num_params_to_merge = param_names_mapping_fn(name)
-            # for multiple B(out_dim, r) @ A(r, in_dim) -> (N, out_dim, r) @ (N, out_dim, r)
+            # for fuse B(out_dim, r) @ A(r, in_dim) -> (N, out_dim, r) @ (N, r, in_dim)
             # see param mapping in HunyuanVideoArchConfig
             if merge_index is not None:
                 to_merge_params[target_name][merge_index] = weight


### PR DESCRIPTION
## Motivation

#15201 pack gate and up proj, fuse `layers.0.feed_forward.w1 (n, m)`, `layers.0.feed_forward.w3 (n, m)` to `layers.0.feed_forward.w13 (n * 2, m)`. 

Due to the modification of parameter names, the LoRA parameters cannot be matched, so the LoRA parameters also need to be fused and adjusted.

## Modifications

- add lora param_names_mapping at (`sglang/multimodal_gen/configs/models/dits/zimage.py`)

- stack the lora weights at ('sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py')

- Adapt the LoRA product for the case of weights stacking at ('sglang/multimodal_gen/runtime/layers/lora/linear.py')
## Accuracy Tests

```
sglang generate   --model-path=Tongyi-MAI/Z-Image-Turbo   --prompt="elusarca anime style.  A female demon sitting on a thrown chair.  Fire burns around her"   --negative-prompt=" "   --width=1024   --height=1024   --seed=42   --save-output   --lora-path=reverentelusarca/elusarca-anime-style-lora-z-image-turbo --enable-torch-compile   --dit-cpu-offload=false   --text-encoder-cpu-offload=false --output-path myoutputs
```

- version before PR#15201
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/e0ae1a1e-6f60-49d3-bc1c-e6579c9db760" />

- version now (before this PR)
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/47e25214-1800-4091-9845-6d631d1afad9" />

- version after this PR
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/3bc4305c-2d47-42db-b508-a43bdb2df99c" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
