### PR TITLE
[WIP][VLM] Support Eagle2_5_VL

### DIFF
--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -523,6 +523,21 @@ register_chat_template(
     )
 )
 
+# Reference: https://huggingface.co/nvidia/Eagle2.5-8B/blob/main/chat_template.json
+register_chat_template(
+    ChatTemplate(
+        name="eagle25-vl",
+        default_system_prompt="You are a helpful assistant.",
+        role_prefix_and_suffix={
+            "system": ("<|im_start|>system\n", "<|im_end|>\n"),
+            "user": ("<|user|>\n", "\n"),
+            "assistant": ("<|assistant|>\n", "\n"),
+        },
+        stop_str=["<|im_end|>"],
+        image_token="<|image|>",
+    )
+)
+
 
 @register_chat_template_matching_function
 def match_deepseek(model_path: str):
@@ -598,6 +613,12 @@ def match_chat_ml(model_path: str):
         re.IGNORECASE,
     ):
         return "chatml-llava"
+    if re.search(
+        r"eagle2\.5",
+        model_path,
+        re.IGNORECASE,
+    ):
+        return "eagle25-vl"
 
 
 @register_chat_template_matching_function

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -5,6 +5,7 @@ from sglang.srt.configs.dbrx import DbrxConfig
 from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
 from sglang.srt.configs.dots_ocr import DotsOCRConfig
 from sglang.srt.configs.dots_vlm import DotsVLMConfig
+from sglang.srt.configs.eagle2_5_vl import Eagle2_5_VLConfig
 from sglang.srt.configs.exaone import ExaoneConfig
 from sglang.srt.configs.falcon_h1 import FalconH1Config
 from sglang.srt.configs.granitemoehybrid import GraniteMoeHybridConfig
@@ -40,6 +41,7 @@ __all__ = [
     "DeepseekVL2Config",
     "LongcatFlashConfig",
     "MultiModalityConfig",
+    "Eagle2_5_VLConfig",
     "KimiVLConfig",
     "MoonViTConfig",
     "Step3VLConfig",

--- a/python/sglang/srt/configs/eagle2_5_vl.py
+++ b/python/sglang/srt/configs/eagle2_5_vl.py
@@ -1,0 +1,115 @@
+import copy
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+class Eagle2_5_VLConfig(PretrainedConfig):
+    model_type = "eagle_2_5_vl"
+    is_composition = True
+    sub_configs = {"vision_config": SiglipVisionConfig, "text_config": Qwen2Config}
+
+    def __init__(
+        self,
+        vision_config=None,
+        text_config=None,
+        use_backbone_lora=0,
+        use_llm_lora=0,
+        pad2square=False,
+        select_layer=-4,
+        force_image_size=None,
+        downsample_ratio=0.5,
+        template=None,
+        dynamic_image_size=False,
+        use_thumbnail=False,
+        loss_version="v1",
+        min_dynamic_tiles=1,
+        max_dynamic_tiles=6,
+        mlp_checkpoint=False,
+        image_token_index=151667,
+        use_pixel_shuffle=True,
+        mlp_connector_layers=2,
+        llm_config=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        if vision_config is None:
+            vision_config = {"model_type": "siglip_vision_model"}
+            logger.info(
+                "vision_config is None. Initializing the SiglipVisionConfig with default values."
+            )
+
+        if llm_config is not None:
+            text_config = llm_config
+            logger.info("Using llm_config as text_config for Eagle2.5-VL.")
+
+        if text_config is None:
+            text_config = {"architectures": ["Qwen2ForCausalLM"]}
+            logger.info(
+                "text_config is None. Initializing the Qwen2Config with default values."
+            )
+
+        if vision_config["model_type"] != "siglip_vision_model":
+            raise ValueError(f"Unsupported model_type: {vision_config['model_type']}")
+        self.vision_config = SiglipVisionConfig(**vision_config)
+
+        arch = text_config["architectures"][0]
+        if arch == "Qwen2ForCausalLM":
+            self.text_config = Qwen2Config(**text_config)
+        elif arch == "Qwen3ForCausalLM":
+            self.text_config = Qwen3Config(**text_config)
+        else:
+            raise ValueError(f"Unsupported architecture: {arch}")
+
+        self.use_backbone_lora = use_backbone_lora
+        self.use_llm_lora = use_llm_lora
+        self.mlp_checkpoint = mlp_checkpoint
+        self.pad2square = pad2square
+        self.select_layer = select_layer
+        self.force_image_size = force_image_size
+        self.downsample_ratio = downsample_ratio
+        self.template = template
+        self.dynamic_image_size = dynamic_image_size
+        self.use_thumbnail = use_thumbnail
+        self.loss_version = loss_version
+        self.min_dynamic_tiles = min_dynamic_tiles
+        self.max_dynamic_tiles = max_dynamic_tiles
+        self.tie_word_embeddings = self.text_config.tie_word_embeddings
+        self.image_token_index = image_token_index
+        self.use_pixel_shuffle = use_pixel_shuffle
+        self.mlp_connector_layers = mlp_connector_layers
+
+        logger.info("min_dynamic_tiles: %s", self.min_dynamic_tiles)
+        logger.info("max_dynamic_tiles: %s", self.max_dynamic_tiles)
+
+    def to_dict(self):
+        output = copy.deepcopy(self.__dict__)
+        output["vision_config"] = self.vision_config.to_dict()
+        output["text_config"] = self.text_config.to_dict()
+        output["model_type"] = self.__class__.model_type
+        output["use_backbone_lora"] = self.use_backbone_lora
+        output["use_llm_lora"] = self.use_llm_lora
+        output["pad2square"] = self.pad2square
+        output["select_layer"] = self.select_layer
+        output["force_image_size"] = self.force_image_size
+        output["downsample_ratio"] = self.downsample_ratio
+        output["template"] = self.template
+        output["dynamic_image_size"] = self.dynamic_image_size
+        output["use_thumbnail"] = self.use_thumbnail
+        output["min_dynamic_tiles"] = self.min_dynamic_tiles
+        output["max_dynamic_tiles"] = self.max_dynamic_tiles
+        output["tie_word_embeddings"] = self.tie_word_embeddings
+        output["image_token_index"] = self.image_token_index
+        if hasattr(self, "_attn_implementation"):
+            output["_attn_implementation"] = self._attn_implementation
+        if hasattr(self, "_attn_implementation_autoset"):
+            output["_attn_implementation_autoset"] = self._attn_implementation_autoset
+        output["use_pixel_shuffle"] = self.use_pixel_shuffle
+        output["mlp_connector_layers"] = self.mlp_connector_layers
+        return output

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1340,6 +1340,7 @@ multimodal_model_archs = [
     "DotsVLMForCausalLM",
     "DotsOCRForCausalLM",
     "Sarashina2VisionForCausalLM",
+    "Eagle2_5_VLForConditionalGeneration",
     "NVILAForConditionalGeneration",
     "NVILALiteForConditionalGeneration",
     "DeepseekOCRForCausalLM",

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2518,6 +2518,19 @@ def _get_processor_wrapper(server_args):
             revision=server_args.revision,
             use_fast=not server_args.disable_fast_image_processor,
         )
+    except ImportError:
+        # Some models (e.g. Eagle2.5-VL) lack a fast image processor.
+        logger.info(
+            f"Fast image processor for {server_args.tokenizer_path} failed to import. "
+            f"Falling back to slow version"
+        )
+        processor = get_processor(
+            server_args.tokenizer_path,
+            tokenizer_mode=server_args.tokenizer_mode,
+            trust_remote_code=server_args.trust_remote_code,
+            revision=server_args.revision,
+            use_fast=False,
+        )
     except ValueError as e:
         error_message = str(e)
         if "does not have a slow version" in error_message:

--- a/python/sglang/srt/models/eagle2_5_vl.py
+++ b/python/sglang/srt/models/eagle2_5_vl.py
@@ -1,0 +1,430 @@
+# Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Portions of this file are derived from the following projects:
+#   - LLaVA-OneVision, part of the Hugging Face Transformers project
+#     (https://github.com/huggingface/transformers),
+#     licensed under the Apache License, Version 2.0.
+#   - InternVL (https://github.com/OpenGVLab/InternVL),
+#     licensed under the MIT License.
+#
+# Modifications © 2025 NVIDIA CORPORATION & AFFILIATES, licensed under
+# the Apache License, Version 2.0.
+#
+# --------------------------------------------------------
+# InternVL
+# Copyright (c) 2023 OpenGVLab
+# Licensed under The MIT License
+#
+# Hugging Face Transformers / LLaVA-OneVision
+# Copyright (c) 2024 Hugging Face Inc.
+# Licensed under the Apache License, Version 2.0
+# --------------------------------------------------------
+
+import copy
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternTokenPairs,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.internlm2 import InternLM2ForCausalLM
+from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.qwen3_moe import Qwen3MoeForCausalLM
+from sglang.srt.models.siglip import SiglipVisionModel
+from sglang.srt.server_args import get_global_server_args
+from sglang.utils import logger
+
+try:
+    from sglang.srt.layers.attention import vision_utils
+except ImportError:
+    vision_utils = None
+
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+
+
+class Eagle2_5_VLForConditionalGeneration(nn.Module):
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        use_flash_attn: bool = True,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+        # TODO: Wire use_data_parallel to SigLIP encoder layers.
+        # InternVL passes this through InternVisionModel → InternVisionEncoder →
+        # InternVisionEncoderLayer → InternAttention/InternMLP. SigLIP's
+        # VisionAttention needs similar plumbing to enable DP encoder sharding.
+        self.use_data_parallel = get_global_server_args().mm_enable_dp_encoder
+
+        if not hasattr(config, "llm_config") and hasattr(config, "text_config"):
+            config.llm_config = config.text_config  # type: ignore[attr-defined]
+
+        if vision_utils is not None:
+            vision_utils.update_vit_attn_dummy_heads_config(self.config)
+
+        image_size = (
+            getattr(config, "force_image_size", None) or config.vision_config.image_size
+        )
+        patch_size = config.vision_config.patch_size
+        self.patch_size = patch_size
+
+        self.downsample_ratio = getattr(config, "downsample_ratio", 0.5)
+        self.num_image_token = int(
+            (image_size // patch_size) ** 2 * (self.downsample_ratio**2)
+        )
+
+        self.select_layer = getattr(config, "select_layer", -1)
+        self._init_vision_model()
+
+        # LLM side
+        llm_arch = config.llm_config.architectures[0]
+        if llm_arch == "Qwen2ForCausalLM":
+            self.language_model = Qwen2ForCausalLM(
+                config=config.llm_config, quant_config=quant_config
+            )
+        elif llm_arch == "InternLM2ForCausalLM":
+            self.language_model = InternLM2ForCausalLM(
+                config=config.llm_config, quant_config=quant_config
+            )
+        elif llm_arch == "Qwen3MoeForCausalLM":
+            self.language_model = Qwen3MoeForCausalLM(
+                config=config.llm_config, quant_config=quant_config
+            )
+        elif llm_arch == "Qwen3ForCausalLM":
+            self.language_model = Qwen3ForCausalLM(
+                config=config.llm_config, quant_config=quant_config
+            )
+        else:
+            raise NotImplementedError(
+                f"{llm_arch} is not implemented in Eagle2_5_VLChatModel."
+            )
+
+        # Connector MLP
+        vit_hidden_size = config.vision_config.hidden_size
+        llm_hidden_size = config.llm_config.hidden_size
+        mult = int(1 / self.downsample_ratio) ** 2
+
+        self.mlp1 = nn.Sequential(
+            nn.LayerNorm(vit_hidden_size * mult),
+            nn.Linear(vit_hidden_size * mult, llm_hidden_size),
+            nn.GELU(),
+            nn.Linear(llm_hidden_size, llm_hidden_size),
+        )
+
+        self.external_mm_data_embedding_funcs = {
+            Modality.IMAGE: self.get_image_feature,
+            Modality.VIDEO: self.get_video_feature,
+        }
+
+        self.model = self.language_model.model
+
+        logger.info(
+            f"[Eagle2.5-VL] num_image_token: {self.num_image_token}, downsample_ratio: {self.downsample_ratio}"
+        )
+        logger.info(
+            f"[Eagle2.5-VL] select_layer(original): {getattr(config, 'select_layer', -1)}"
+        )
+
+    def _init_vision_model(self) -> None:
+        """
+        Truncate SigLIP num_hidden_layers based on select_laye,
+        so we can always use last_hidden_state without output_hidden_states.
+        """
+        vision_cfg = copy.deepcopy(self.config.vision_config)
+
+        # Determine number of hidden layers based on select_layer
+        vision_feature_layer = self.select_layer
+        if vision_feature_layer < 0:
+            num_hidden_layers = vision_cfg.num_hidden_layers + vision_feature_layer + 1
+        else:
+            num_hidden_layers = vision_feature_layer + 1
+
+        if hasattr(vision_cfg, "vision_use_head"):
+            vision_cfg.vision_use_head = False
+
+        self.vision_model = SiglipVisionModel(
+            vision_cfg,
+            quant_config=self.quant_config,
+            num_hidden_layers_override=num_hidden_layers,
+        )
+
+    def _vision_device_dtype(self):
+        try:
+            p = next(self.vision_model.parameters())
+            return p.device, p.dtype
+        except StopIteration:
+            p = next(self.mlp1.parameters())
+            return p.device, p.dtype
+
+    def pixel_shuffle(self, x: torch.Tensor, scale_factor: float = 0.5) -> torch.Tensor:
+        """
+        Pixel shuffle downsample:
+          x: (n, w, h, c) -> (n, w*scale, h*scale, c/(scale^2))
+        """
+        n, w, h, c = x.size()
+        x = x.view(n, w, int(h * scale_factor), int(c / scale_factor))
+        x = x.permute(0, 2, 1, 3).contiguous()
+        x = x.view(
+            n,
+            int(h * scale_factor),
+            int(w * scale_factor),
+            int(c / (scale_factor * scale_factor)),
+        )
+        x = x.permute(0, 2, 1, 3).contiguous()
+        return x
+
+    def extract_feature(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        """
+        SigLIP -> patch features -> pixel shuffle -> MLP to LLM hidden space.
+        Returns: (B, L_img, hidden_size_llm)
+        """
+        vit_embeds = self.vision_model(pixel_values=pixel_values)
+
+        h = w = int(vit_embeds.shape[1] ** 0.5)
+        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], h, w, -1)
+        vit_embeds = self.pixel_shuffle(vit_embeds, scale_factor=self.downsample_ratio)
+        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1, vit_embeds.shape[-1])
+        vit_embeds = self.mlp1(vit_embeds)
+        L = int(self.num_image_token)
+        if vit_embeds.size(1) > L:
+            logger.warning(
+                "[Eagle2.5-VL] extract_feature: truncating %d -> %d tokens. "
+                "This may indicate a num_image_token formula mismatch.",
+                vit_embeds.size(1),
+                L,
+            )
+            vit_embeds = vit_embeds[:, :L, :]
+        elif vit_embeds.size(1) < L:
+            logger.warning(
+                "[Eagle2.5-VL] extract_feature: padding %d -> %d tokens with zeros. "
+                "This may indicate a num_image_token formula mismatch.",
+                vit_embeds.size(1),
+                L,
+            )
+            vit_embeds = torch.cat(
+                [
+                    vit_embeds,
+                    vit_embeds.new_zeros(
+                        vit_embeds.shape[0], L - vit_embeds.size(1), vit_embeds.size(2)
+                    ),
+                ],
+                dim=1,
+            )
+        return vit_embeds
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        """
+        items: one item per image (or per tile).
+        item.feature: [1, 3, H, W] (or [num_tiles, 3, H, W]) depending on preprocessing.
+        Return: [num_images_or_tiles, img_len, hidden]
+        """
+        pixel_values = torch.cat([item.feature for item in items], dim=0)
+        # Precomputed embeddings are 2D or 3D; raw pixel_values are 4D [N, C, H, W]
+        if pixel_values.dim() != 4:
+            return pixel_values
+        return self.extract_feature(pixel_values)
+
+    def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        """
+        Treat video frames as a batch of images.
+        item.feature: [num_frames, 3, H, W]
+        Return: [num_frames_total, img_len, hidden]
+        """
+        pixel_values = torch.cat([item.feature for item in items], dim=0)
+        # Precomputed embeddings are 2D or 3D; raw pixel_values are 4D [N, C, H, W]
+        if pixel_values.dim() != 4:
+            return pixel_values
+        return self.extract_feature(pixel_values)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+    ) -> torch.Tensor:
+        hidden_states = general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            multimodal_model=self,
+            data_embedding_funcs=self.external_mm_data_embedding_funcs,
+            positions=positions,
+        )
+        return hidden_states
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        media_token_pairs = [(mm_inputs.im_start_id, mm_inputs.im_end_id)]
+        pattern = MultiModalityDataPaddingPatternTokenPairs(media_token_pairs)
+        return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        arch = self.config.llm_config.architectures[0]
+
+        # Dispatch stacked_params_mapping per LLM architecture
+        expert_params_mapping = []
+        if arch == "InternLM2ForCausalLM":
+            stacked_params_mapping = [
+                ("gate_up_proj", "w1", 0),
+                ("gate_up_proj", "w3", 1),
+            ]
+        else:
+            # Qwen2ForCausalLM, Qwen3ForCausalLM, Qwen3MoeForCausalLM
+            stacked_params_mapping = [
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "k_proj", "k"),
+                ("qkv_proj", "v_proj", "v"),
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+            ]
+            if arch == "Qwen3MoeForCausalLM":
+                expert_params_mapping = FusedMoE.make_expert_params_mapping(
+                    ckpt_gate_proj_name="gate_proj",
+                    ckpt_down_proj_name="down_proj",
+                    ckpt_up_proj_name="up_proj",
+                    num_experts=self.config.llm_config.num_experts,
+                )
+
+        params_dict = dict(self.named_parameters())
+        has_vision_head = any(
+            k.startswith("vision_model.") and ".head." in k for k in params_dict
+        )
+
+        def _pick_existing(cands: List[str]) -> Optional[str]:
+            for c in cands:
+                if c in params_dict:
+                    return c
+            return None
+
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            # Stacked params (skip MoE experts — handled separately below)
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if "mlp.experts" in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name in params_dict:
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.startswith("vision_model."):
+                    if ".head." in name and not has_vision_head:
+                        continue
+                    cands = [
+                        name,
+                        name.replace(".attention.", ".self_attn."),
+                        name.replace(".attn.", ".self_attn."),
+                        name.replace(
+                            ".attention.in_proj_weight",
+                            ".self_attn.qkv_proj.weight",
+                        ),
+                        name.replace(
+                            ".attention.in_proj_bias", ".self_attn.qkv_proj.bias"
+                        ),
+                        name.replace(".attention.out_proj.", ".self_attn.proj."),
+                        name.replace(".attention.qkv_proj.", ".self_attn.qkv_proj."),
+                        name.replace(".attention.proj.", ".self_attn.proj."),
+                        name.replace("attn.qkv.", "attn.qkv_proj."),
+                        name.replace(".self_attn.out_proj.", ".self_attn.proj."),
+                    ]
+                    picked = _pick_existing(cands)
+                    if picked is None:
+                        continue
+                    name = picked
+
+                # MoE expert params (Qwen3Moe)
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(
+                        param,
+                        loaded_weight,
+                        name,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                    )
+                    break
+                else:
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+
+                    param = params_dict.get(name, None)
+                    if param is None:
+                        continue
+
+                    # InternLM2 fused QKV split
+                    if "wqkv" in name:
+                        config = self.config.llm_config
+                        kv_groups = (
+                            config.num_attention_heads // config.num_key_value_heads
+                        )
+                        head_dim = config.hidden_size // config.num_attention_heads
+                        loaded_weight = loaded_weight.view(
+                            -1,
+                            2 + kv_groups,
+                            head_dim,
+                            loaded_weight.shape[-1],
+                        )
+                        wq, wk, wv = torch.split(
+                            loaded_weight, [kv_groups, 1, 1], dim=1
+                        )
+                        wq = wq.reshape(-1, wq.shape[-1])
+                        wk = wk.reshape(-1, wk.shape[-1])
+                        wv = wv.reshape(-1, wv.shape[-1])
+                        weight_loader = param.weight_loader
+                        weight_loader(param, wq, "q")
+                        weight_loader(param, wk, "k")
+                        weight_loader(param, wv, "v")
+                    else:
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
+                        if "vision_model" in name and vision_utils is not None:
+                            loaded_weight = vision_utils.pad_vit_attn_dummy_heads(
+                                self.config, name, loaded_weight
+                            )
+                        weight_loader(param, loaded_weight)
+
+
+EntryClass = [Eagle2_5_VLForConditionalGeneration]

--- a/python/sglang/srt/models/siglip.py
+++ b/python/sglang/srt/models/siglip.py
@@ -2,18 +2,23 @@
 # https://github.com/huggingface/transformers/blob/af9b2eaa54c150741f298d6db939af6328e1dc38/src/transformers/models/siglip/modeling_siglip.py
 
 from functools import partial
-from typing import Optional, Type, Union
+from typing import Iterable, Optional, Type, Union
 
 import torch
 import torch.nn as nn
 from transformers import SiglipVisionConfig
 
+from sglang.srt.distributed import get_tensor_model_parallel_world_size
 from sglang.srt.layers.activation import QuickGELU
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.conv import Conv2dLayer
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
 from sglang.srt.utils import add_prefix
 
 
@@ -166,13 +171,17 @@ class SiglipEncoder(nn.Module):
         self,
         config: SiglipVisionConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        num_hidden_layers_override: Optional[int] = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
 
         self.config = config
 
-        num_hidden_layers = config.num_hidden_layers
+        if num_hidden_layers_override is None:
+            num_hidden_layers = config.num_hidden_layers
+        else:
+            num_hidden_layers = num_hidden_layers_override
         norm_layer = partial(nn.LayerNorm, eps=config.layer_norm_eps)
         self.layers = nn.ModuleList(
             [
@@ -214,6 +223,7 @@ class SiglipVisionTransformer(nn.Module):
         self,
         config: SiglipVisionConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        num_hidden_layers_override: Optional[int] = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -226,6 +236,7 @@ class SiglipVisionTransformer(nn.Module):
         self.encoder = SiglipEncoder(
             config=config,
             quant_config=quant_config,
+            num_hidden_layers_override=num_hidden_layers_override,
             prefix=add_prefix("encoder", prefix),
         )
 
@@ -237,7 +248,13 @@ class SiglipVisionTransformer(nn.Module):
             )
 
         # VisionAttention in SiglipEncoderLayer is multihead attention
-        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        # If possible, skip post_layernorm to conserve memory
+        require_post_norm = len(self.encoder.layers) == num_hidden_layers
+
+        if require_post_norm:
+            self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        else:
+            self.post_layernorm = None
 
     @property
     def device(self) -> torch.device:
@@ -267,11 +284,17 @@ class SiglipVisionModel(nn.Module):
         self,
         config: SiglipVisionConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        num_hidden_layers_override: Optional[int] = None,
         prefix: str = "",
     ):
         super().__init__()
+
+        self.quant_config = quant_config
         self.vision_model = SiglipVisionTransformer(
-            config, quant_config, prefix=add_prefix("vision_model", prefix)
+            config,
+            quant_config,
+            num_hidden_layers_override=num_hidden_layers_override,
+            prefix=add_prefix("vision_model", prefix),
         )
 
     @property
@@ -280,3 +303,85 @@ class SiglipVisionModel(nn.Module):
 
     def forward(self, pixel_values: torch.Tensor):
         return self.vision_model(pixel_values)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        layer_count = len(self.vision_model.encoder.layers)
+
+        for name, loaded_weight in weights:
+            # post_layernorm is optional in SiglipVisionModel
+            if (
+                name.startswith("vision_model.post_layernorm")
+                and self.vision_model.post_layernorm is None
+            ):
+                continue
+
+            # omit layers when num_hidden_layers_override is set
+            if name.startswith("vision_model.encoder.layers"):
+                layer_idx = int(name.split(".")[3])
+                if layer_idx >= layer_count:
+                    continue
+
+            # Check if this is a scale parameter that needs remapping first
+            if name.endswith((".k_scale", ".v_scale", ".q_scale", ".prob_scale")):
+                # Try to remap the scale name first
+                remapped_name = maybe_remap_kv_scale_name(name, params_dict)
+                if remapped_name is not None and remapped_name in params_dict:
+                    # Successfully remapped, use the remapped name
+                    param = params_dict[remapped_name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    loaded_params.add(remapped_name)
+                    continue
+                # If remapping failed, continue with normal processing
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                param = maybe_swap_ffn_param(
+                    name, param, loaded_weight, params_dict, self.quant_config
+                )
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+def maybe_swap_ffn_param(
+    name: str,
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    params_dict: dict[str, torch.Tensor],
+    quant_config: QuantizationConfig,
+) -> torch.Tensor:
+    if not (quant_config and quant_config.get_name() == "gguf") or ".fc" not in name:
+        return param
+    # Some GGUF models have fc1 and fc2 weights swapped
+    tp_size = get_tensor_model_parallel_world_size()
+    output_dim = getattr(param, "output_dim", 0)
+    output_size = param.size(output_dim) * tp_size
+    weight_out_size = loaded_weight.size(output_dim)
+    if ".fc1." in name and output_size != weight_out_size:
+        new_name = name.replace(".fc1.", ".fc2.")
+        param = params_dict[new_name]
+    elif ".fc2." in name and output_size != weight_out_size:
+        new_name = name.replace(".fc2.", ".fc1.")
+        param = params_dict[new_name]
+    return param

--- a/python/sglang/srt/multimodal/processors/eagle2_5_vl.py
+++ b/python/sglang/srt/multimodal/processors/eagle2_5_vl.py
@@ -1,0 +1,145 @@
+import re
+from typing import List, Union
+
+from sglang.srt.models.eagle2_5_vl import Eagle2_5_VLForConditionalGeneration
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+from sglang.utils import logger
+
+
+class Eagle2_5_VLProcessor(BaseMultimodalProcessor):
+    models = [Eagle2_5_VLForConditionalGeneration]
+
+    IMG_START = "<img>"
+    IMG_END = "</img>"
+    IMG_PLACEHOLDER = "image"
+    VIDEO_PLACEHOLDER = "video"
+    IMG_CONTEXT = "<IMG_CONTEXT>"
+
+    # HF chat_template placeholders
+    HF_IMAGE_PLACEHOLDER_RE = re.compile(r"<image-\d+>")
+    HF_VIDEO_PLACEHOLDER_RE = re.compile(r"<video-\d+>")
+
+    # add_vision_id might add "<image 1>" (not actual placeholder)
+    HF_IMAGE_VISION_ID_RE = re.compile(r"<image\s+\d+>")
+    HF_VIDEO_VISION_ID_RE = re.compile(r"<video\s+\d+>")
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+
+        self.config = hf_config
+        self.hf_config = hf_config
+
+        tokenizer = (
+            self._processor.tokenizer
+            if hasattr(self._processor, "tokenizer")
+            else self._processor
+        )
+        self.tokenizer = tokenizer
+
+        img_ctx_id = tokenizer.convert_tokens_to_ids(self.IMG_CONTEXT)
+        if img_ctx_id is None or img_ctx_id < 0:
+            raise RuntimeError("Token <IMG_CONTEXT> not found in tokenizer vocab.")
+
+        self.image_token_id = img_ctx_id
+        self.video_token_id = img_ctx_id
+
+        self.img_start_token_id = tokenizer.convert_tokens_to_ids(self.IMG_START)
+        self.img_end_token_id = tokenizer.convert_tokens_to_ids(self.IMG_END)
+
+        # canonical placeholder text for SGLang
+        self._img_placeholder_text = (
+            f"{self.IMG_START}{self.IMG_PLACEHOLDER}{self.IMG_END}"
+        )
+        self._video_placeholder_text = (
+            f"{self.IMG_START}{self.VIDEO_PLACEHOLDER}{self.IMG_END}"
+        )
+
+        # IMPORTANT: combined regex should match both formats,
+        # but we will REWRITE HF format into canonical format before load_mm_data
+        self._img_placeholder_re = re.compile(r"(?:<img>\s*image\s*</img>|<image-\d+>)")
+        self._video_placeholder_re = re.compile(
+            r"(?:<img>\s*video\s*</img>|<video-\d+>)"
+        )
+
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token=self._img_placeholder_text,
+            image_token_id=self.image_token_id,
+            image_token_regex=self._img_placeholder_re,
+            video_token=self._video_placeholder_text,
+            video_token_id=self.video_token_id,
+            video_token_regex=self._video_placeholder_re,
+        ).build(_processor)
+
+    def _rewrite_mm_placeholders(self, input_text: str) -> str:
+        if not isinstance(input_text, str):
+            return input_text
+
+        # remove vision-id tags if present
+        input_text = self.HF_IMAGE_VISION_ID_RE.sub("", input_text)
+        input_text = self.HF_VIDEO_VISION_ID_RE.sub("", input_text)
+
+        # rewrite <image-1> -> <img>image</img>
+        input_text = self.HF_IMAGE_PLACEHOLDER_RE.sub(
+            self._img_placeholder_text, input_text
+        )
+        input_text = self.HF_VIDEO_PLACEHOLDER_RE.sub(
+            self._video_placeholder_text, input_text
+        )
+
+        return input_text
+
+    async def process_mm_data_async(
+        self,
+        image_data: List[Union[str, bytes]],
+        input_text,
+        request_obj,
+        *args,
+        **kwargs,
+    ):
+
+        input_text = self._rewrite_mm_placeholders(input_text)
+
+        base_output = self.load_mm_data(
+            prompt=input_text,
+            image_data=image_data,
+            video_data=request_obj.video_data,
+            audio_data=request_obj.audio_data,
+            multimodal_tokens=self.mm_tokens,
+        )
+
+        mm_items, input_ids, ret = self.process_and_combine_mm_data(
+            base_output, self.mm_tokens
+        )
+
+        # ret should NOT be None if raw images were processed
+        if ret is None:
+            logger.warning(
+                "Processor ret is None. This usually means raw images were not processed by HF processor. "
+                "Check that image_data is non-empty and load_mm_data aligned tokens with data."
+            )
+
+        if (
+            (image_data or request_obj.video_data)
+            and mm_items
+            and all((not it.offsets) for it in mm_items)
+        ):
+            keys = list(ret.keys()) if isinstance(ret, dict) else None
+            logger.warning(
+                "Multimodal inputs exist but all mm_items.offsets are empty. "
+                "Usually means processor didn't insert <IMG_CONTEXT> into input_ids. "
+                "processor_ret_keys=%s, image_token_id=%s",
+                keys,
+                self.image_token_id,
+            )
+
+        return {
+            "input_ids": input_ids.tolist(),
+            "mm_items": mm_items,
+            "im_start_id": self.img_start_token_id,
+            "im_end_id": self.img_end_token_id,
+            "im_token_id": self.image_token_id,
+            "video_token_id": self.video_token_id,
+        }

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2696,6 +2696,7 @@ def is_fa3_default_architecture(hf_config):
         "Step3VLForConditionalGeneration",
         "StepVLForConditionalGeneration",
         "MiMoV2FlashForCausalLM",
+        "Eagle2_5_VLForConditionalGeneration",
     }
     return architectures[0] in default_archs
 

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -21,13 +21,13 @@ import tempfile
 import warnings
 from functools import lru_cache
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Type, Union
 
 import torch
 from huggingface_hub import snapshot_download
 
 from sglang.srt.utils import get_bool_env_var
-from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
 # Compatibility shim: flash-attn-4 registers a bare ``flash_attn`` namespace
 # that makes ``is_flash_attn_2_available()`` return True, but lacks the v2 API
@@ -71,6 +71,7 @@ from sglang.srt.configs import (
     DeepseekVL2Config,
     DotsOCRConfig,
     DotsVLMConfig,
+    Eagle2_5_VLConfig,
     ExaoneConfig,
     FalconH1Config,
     GraniteMoeHybridConfig,
@@ -104,6 +105,7 @@ _CONFIG_REGISTRY: List[Type[PretrainedConfig]] = [
     DbrxConfig,
     ExaoneConfig,
     DeepseekVL2Config,
+    Eagle2_5_VLConfig,
     MultiModalityConfig,
     KimiVLConfig,
     InternVLChatConfig,
@@ -489,9 +491,6 @@ def get_config(
         kwargs["gguf_file"] = model
         model = Path(model).parent
 
-    if is_runai_obj_uri(model):
-        model = ObjectStorageModel.get_path(model)
-
     if is_remote_url(model):
         # BaseConnector implements __del__() to clean up the local dir.
         # Since config files need to exist all the time, so we DO NOT use
@@ -716,57 +715,6 @@ class TokenizerWarningsFilter(logging.Filter):
         return "Calling super().encode with" not in record.getMessage()
 
 
-_is_base_mistral_patched = False
-
-# transformers version where _patch_mistral_regex calls model_info() on every tokenizer load
-_TRANSFORMERS_PATCHED_VERSION = "5.3.0"
-
-
-def _patch_is_base_mistral_in_ci():
-    """Patch transformers' _patch_mistral_regex to avoid HF API calls in CI.
-
-    transformers defines is_base_mistral as a local function inside
-    _patch_mistral_regex, so it cannot be patched via module attribute.
-    Instead we replace the entire _patch_mistral_regex classmethod with a
-    version that simply returns the tokenizer unchanged.
-
-    In CI this prevents exhausting the 3000 req/5min HF API rate limit.
-    """
-    global _is_base_mistral_patched
-    if _is_base_mistral_patched:
-        return
-
-    from sglang.srt.environ import envs
-
-    if not envs.SGLANG_IS_IN_CI.get():
-        return
-
-    import transformers
-
-    if transformers.__version__ != _TRANSFORMERS_PATCHED_VERSION:
-        logger.warning(
-            "transformers version changed to %s (expected %s), "
-            "_patch_mistral_regex patch skipped — may need update if 429 errors recur",
-            transformers.__version__,
-            _TRANSFORMERS_PATCHED_VERSION,
-        )
-        _is_base_mistral_patched = True  # don't warn repeatedly
-        return
-
-    from transformers import PreTrainedTokenizerFast
-
-    if hasattr(PreTrainedTokenizerFast, "_patch_mistral_regex"):
-
-        @classmethod
-        def _noop_patch_mistral_regex(cls, tokenizer, *args, **kwargs):
-            return tokenizer
-
-        PreTrainedTokenizerFast._patch_mistral_regex = _noop_patch_mistral_regex
-        logger.info("CI: patched _patch_mistral_regex to skip HF API calls")
-
-    _is_base_mistral_patched = True
-
-
 def get_tokenizer(
     tokenizer_name: str,
     *args,
@@ -802,9 +750,6 @@ def get_tokenizer(
         kwargs["gguf_file"] = tokenizer_name
         tokenizer_name = Path(tokenizer_name).parent
 
-    if is_runai_obj_uri(tokenizer_name):
-        tokenizer_name = ObjectStorageModel.get_path(tokenizer_name)
-
     if is_remote_url(tokenizer_name):
         # BaseConnector implements __del__() to clean up the local dir.
         # Since config files need to exist all the time, so we DO NOT use
@@ -812,8 +757,6 @@ def get_tokenizer(
         client = create_remote_connector(tokenizer_name)
         client.pull_files(ignore_pattern=["*.pt", "*.safetensors", "*.bin"])
         tokenizer_name = client.get_local_dir()
-
-    _patch_is_base_mistral_in_ci()
 
     try:
         tokenizer = AutoTokenizer.from_pretrained(
@@ -837,25 +780,9 @@ def get_tokenizer(
         )
         raise RuntimeError(err_msg) from e
     except ValueError as e:
-        # MistralCommon tokenizers reject standard HF kwargs like
-        # trust_remote_code, use_fast etc. Retry without them.
-        if "are not supported by" in str(e) and "MistralCommon" in str(e):
-            for k in (
-                "trust_remote_code",
-                "tokenizer_revision",
-                "use_fast",
-                "_from_auto",
-                "clean_up_tokenization_spaces",
-            ):
-                kwargs.pop(k, None)
-            tokenizer = AutoTokenizer.from_pretrained(
-                tokenizer_name,
-                *args,
-                **kwargs,
-            )
         # If the error pertains to the tokenizer class not existing or not
         # currently being imported, suggest using the --trust-remote-code flag.
-        elif not trust_remote_code and (
+        if not trust_remote_code and (
             "does not exist or is not currently imported." in str(e)
             or "requires you to execute the tokenizer file" in str(e)
         ):
@@ -873,6 +800,11 @@ def get_tokenizer(
     # when trust_remote_code=False and the model requires a custom tokenizer.
     # Detect this and auto-retry with trust_remote_code=True.
     if not trust_remote_code and type(tokenizer).__name__ == "TokenizersBackend":
+        logger.info(
+            "Detected generic TokenizersBackend for %s, "
+            "retrying with trust_remote_code=True",
+            tokenizer_name,
+        )
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name,
             *args,
@@ -891,7 +823,6 @@ def get_tokenizer(
             "slowdown. Consider using a fast tokenizer instead."
         )
 
-    _patch_mistral_common_tokenizer(tokenizer)
     _fix_special_tokens_pattern(tokenizer)
     attach_additional_stop_token_ids(tokenizer)
     tokenizer = patch_tokenizer(tokenizer)
@@ -1025,15 +956,6 @@ def _fix_v5_add_bos_eos_token(tokenizer, model_name_or_path, revision=None):
         if config_val is None:
             # Key missing or null → use v4 default for this tokenizer class
             config_val = _V4_DEFAULTS.get(attr, False)
-        # Fast tokenizers in v4 used tokenizer.json post-processor for EOS —
-        # the add_eos_token Python attribute was set but the post-processor
-        # came from tokenizer.json, not from the attribute. In v5, the flag is
-        # stripped and both sglang and HF reference end up with add_eos_token=False.
-        # Restoring add_eos_token for fast tokenizers makes sglang diverge from
-        # the HF reference (which doesn't restore it), breaking embedding models
-        # like intfloat/e5-mistral-7b-instruct (cosine similarity drops to ~0.33).
-        if attr == "add_eos_token" and isinstance(tokenizer, PreTrainedTokenizerFast):
-            config_val = _V4_DEFAULTS["add_eos_token"]  # False
         current_val = getattr(tokenizer, attr, None)
         if current_val != config_val:
             logger.info(
@@ -1197,6 +1119,48 @@ def _build_processor_manually(
     return proc_cls(**init_kwargs)
 
 
+def _should_build_local_eagle2_5_processor(config, exc: Exception) -> bool:
+    if getattr(config, "model_type", None) != "eagle_2_5_vl":
+        return False
+
+    message = str(exc)
+    return any(
+        marker in message
+        for marker in (
+            "DefaultFastImageProcessorKwargs",
+            "image_processing_eagle2_5_vl_fast",
+            "does not have a slow version",
+        )
+    )
+
+
+def _build_local_eagle2_5_processor(
+    model_path: str,
+    *,
+    tokenizer_mode: str,
+    trust_remote_code: bool,
+    revision: Optional[str],
+    use_fast: Optional[bool],
+    config,
+):
+    # Eagle2.5-VL uses SGLang's local multimodal processor path. The remote HF
+    # image processor only supplies config-like defaults, so a light shim is
+    # sufficient when the dynamic module is incompatible with local transformers.
+    tokenizer = get_tokenizer(
+        model_path,
+        tokenizer_mode=tokenizer_mode,
+        trust_remote_code=trust_remote_code,
+        tokenizer_revision=revision,
+        use_fast=use_fast,
+    )
+    image_processor = SimpleNamespace(
+        min_dynamic_tiles=getattr(config, "min_dynamic_tiles", 1),
+        max_dynamic_tiles=getattr(config, "max_dynamic_tiles", 6),
+        use_thumbnail=bool(getattr(config, "use_thumbnail", False)),
+    )
+    return SimpleNamespace(tokenizer=tokenizer, image_processor=image_processor)
+
+
 def get_processor(
     tokenizer_name: str,
     *args,
@@ -1272,34 +1236,52 @@ def get_processor(
 
     except ValueError as e:
         error_message = str(e)
-        if "does not have a slow version" in error_message:
+        if _should_build_local_eagle2_5_processor(config, e):
+            logger.warning(
+                "Falling back to local Eagle2.5-VL processor for %s due to "
+                "transformers/HF processor incompatibility: %s",
+                tokenizer_name,
+                error_message,
+            )
+            processor = _build_local_eagle2_5_processor(
+                tokenizer_name,
+                tokenizer_mode=tokenizer_mode,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                use_fast=use_fast,
+                config=config,
+            )
+        elif "does not have a slow version" in error_message:
             logger.info(
                 f"Processor {tokenizer_name} does not have a slow version. Automatically use fast version"
             )
             kwargs["use_fast"] = True
-            processor = AutoProcessor.from_pretrained(
-                tokenizer_name,
-                *args,
-                trust_remote_code=trust_remote_code,
-                revision=revision,
-                **kwargs,
-            )
-        elif (
-            "are not supported by" in error_message and "MistralCommon" in error_message
-        ):
-            logger.info(
-                "AutoProcessor for %s rejected standard kwargs, "
-                "retrying without trust_remote_code/use_fast",
-                tokenizer_name,
-            )
-            kwargs.pop("use_fast", None)
-            kwargs.pop("_from_auto", None)
-            processor = AutoProcessor.from_pretrained(
-                tokenizer_name,
-                *args,
-                revision=revision,
-                **kwargs,
-            )
+            try:
+                processor = AutoProcessor.from_pretrained(
+                    tokenizer_name,
+                    *args,
+                    trust_remote_code=trust_remote_code,
+                    revision=revision,
+                    **kwargs,
+                )
+            except Exception as retry_error:
+                if _should_build_local_eagle2_5_processor(config, retry_error):
+                    logger.warning(
+                        "Falling back to local Eagle2.5-VL processor for %s after "
+                        "fast retry failed: %s",
+                        tokenizer_name,
+                        retry_error,
+                    )
+                    processor = _build_local_eagle2_5_processor(
+                        tokenizer_name,
+                        tokenizer_mode=tokenizer_mode,
+                        trust_remote_code=trust_remote_code,
+                        revision=revision,
+                        use_fast=True,
+                        config=config,
+                    )
+                else:
+                    raise
         elif "Unrecognized feature extractor" in error_message:
             logger.info(
                 "AutoProcessor failed on feature extractor for %s, "
@@ -1315,6 +1297,24 @@ def get_processor(
             )
         else:
             raise e
+    except ImportError as e:
+        if _should_build_local_eagle2_5_processor(config, e):
+            logger.warning(
+                "Falling back to local Eagle2.5-VL processor for %s due to "
+                "remote import failure: %s",
+                tokenizer_name,
+                e,
+            )
+            processor = _build_local_eagle2_5_processor(
+                tokenizer_name,
+                tokenizer_mode=tokenizer_mode,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                use_fast=use_fast,
+                config=config,
+            )
+        else:
+            raise
     # If processor is a bare tokenizer (e.g. Mistral-Small-4 has no processor_config.json)
     # and the model is a vision model (pixtral), wrap it in a proper PixtralProcessor
     # so that image data is actually processed through the image processor.
@@ -1348,7 +1348,6 @@ def get_processor(
         )
 
     tokenizer = get_tokenizer_from_processor(processor)
-    _patch_mistral_common_tokenizer(tokenizer)
 
     if tokenizer.chat_template is None:
         local_path = download_from_hf(
@@ -1373,86 +1372,6 @@ def attach_additional_stop_token_ids(tokenizer):
         )
     else:
         tokenizer.additional_stop_token_ids = None
-
-
-def _patch_mistral_common_tokenizer(tokenizer):
-    """Patch MistralCommonTokenizer/Backend to be compatible with HF tokenizer API.
-
-    MistralCommon tokenizers (used by Voxtral, Pixtral, etc.) reject several
-    standard kwargs and lack some attributes that sglang expects.  We wrap the
-    offending methods once at load time so that the rest of the codebase does
-    not need any special-casing.
-    """
-    cls_name = type(tokenizer).__name__
-    if "MistralCommon" not in cls_name:
-        return tokenizer
-    if getattr(tokenizer, "_mistral_common_patched", False):
-        return tokenizer
-    tokenizer._mistral_common_patched = True
-
-    # Missing attributes
-    if not hasattr(tokenizer, "get_added_vocab"):
-        tokenizer.get_added_vocab = lambda: {}
-
-    # Set a chat_template containing "audio" so that sglang's content format
-    # detector returns "openai" (which preserves audio_url extraction).
-    # The actual template rendering is done by MistralCommon's apply_chat_template.
-    if not hasattr(tokenizer, "chat_template") or tokenizer.chat_template is None:
-        tokenizer.chat_template = "<!-- audio/image multimodal -->"
-
-    # convert_tokens_to_ids asserts on multi-token strings
-    _orig_convert = tokenizer.convert_tokens_to_ids
-
-    def _safe_convert(val):
-        try:
-            return _orig_convert(val)
-        except AssertionError:
-            return getattr(tokenizer, "unk_token_id", None)
-
-    tokenizer.convert_tokens_to_ids = _safe_convert
-
-    # Wrap methods that reject certain kwargs
-    def _drop_kwargs(fn, keys):
-        def wrapper(*args, **kwargs):
-            for k in keys:
-                kwargs.pop(k, None)
-            return fn(*args, **kwargs)
-
-        return wrapper
-
-    tokenizer.decode = _drop_kwargs(tokenizer.decode, ["spaces_between_special_tokens"])
-    tokenizer.batch_decode = _drop_kwargs(
-        tokenizer.batch_decode, ["spaces_between_special_tokens"]
-    )
-
-    # Save original apply_chat_template for processors that need it (e.g. Voxtral)
-    tokenizer._orig_apply_chat_template = tokenizer.apply_chat_template
-
-    def _safe_apply_chat_template(messages, **kwargs):
-        """Wrapper that strips unsupported kwargs and non-text content parts.
-
-        When sglang extracts audio/image URLs, it replaces content blocks with
-        {"type": "audio"} or {"type": "image"} (no URL).  MistralCommon fails
-        on these stripped blocks.  We convert them to text-only messages.
-        """
-        kwargs.pop("add_generation_prompt", None)
-        cleaned = []
-        for msg in messages:
-            if isinstance(msg, dict):
-                content = msg.get("content", "")
-                if isinstance(content, list):
-                    text_parts = [
-                        p.get("text", "")
-                        for p in content
-                        if isinstance(p, dict) and p.get("type") == "text"
-                    ]
-                    msg = {**msg, "content": " ".join(text_parts) if text_parts else ""}
-                cleaned.append(msg)
-            else:
-                cleaned.append(msg)
-        return tokenizer._orig_apply_chat_template(cleaned, **kwargs)
-
-    tokenizer.apply_chat_template = _safe_apply_chat_template
 
 
 def check_gguf_file(model: Union[str, os.PathLike]) -> bool:

--- a/test/registered/eval/test_vlms_mmmu_eval.py
+++ b/test/registered/eval/test_vlms_mmmu_eval.py
@@ -41,6 +41,7 @@ MODEL_THRESHOLDS = {
     ModelLaunchSettings("moonshotai/Kimi-VL-A3B-Instruct"): ModelEvalMetrics(
         0.330, 23.5
     ),
+    ModelLaunchSettings("nvidia/Eagle2.5-8B"): ModelEvalMetrics(0.300, 40.0),
     ModelLaunchSettings("openbmb/MiniCPM-o-2_6"): ModelEvalMetrics(0.330, 29.5),
     ModelLaunchSettings("openbmb/MiniCPM-v-2_6"): ModelEvalMetrics(0.259, 36.3),
     ModelLaunchSettings("OpenGVLab/InternVL2_5-2B"): ModelEvalMetrics(0.300, 18.0),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

E2E passed.

```
root@c7e9bb6a6789:/sgl-workspace/bench_script# bash bench_n_image2.sh 
{"id":"12b324bbd2aa40e5acd25987e5be414a","object":"chat.completion","created":1769084679,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"The image shows a close-up of a small, round, white ceramic plate. On the plate, there are two fried eggs, one on the left and one on the right. The eggs are cooked sunny-side up, with bright yellow yolks intact. The plate is sitting on a white tablecloth, and the background is blurred, focusing attention on the plate of eggs.","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":26,"total_tokens":102,"completion_tokens":76,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m0.470s
user    0m0.002s
sys     0m0.005s
```

```
root@c7e9bb6a6789:/# SGLANG_VLM_CACHE_SIZE_MB=2048 python -m sglang.launch_server --model-path nvidia/Eagle2.5-8B --host 0.0.0.0 --port 30000 --trust-remote-code --tp-size 1 --max-running-requests 8 --mem-fraction-static 0.65 --attention-backend flashinfer --mm-attention-backend fa3
[2026-01-19 13:30:12] INFO configuration_eagle2_5_vl.py:84: min_dynamic_tiles: 1
[2026-01-19 13:30:12] INFO configuration_eagle2_5_vl.py:85: max_dynamic_tiles: 12
[2026-01-19 13:30:12] INFO configuration_eagle2_5_vl.py:48: vision_config is None. Initializing the InternVisionConfig with default values.
[2026-01-19 13:30:12] INFO configuration_eagle2_5_vl.py:52: text_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`).
[2026-01-19 13:30:12] INFO configuration_eagle2_5_vl.py:84: min_dynamic_tiles: 1
[2026-01-19 13:30:12] INFO configuration_eagle2_5_vl.py:85: max_dynamic_tiles: 6
[2026-01-19 13:30:13] server_args=ServerArgs(model_path='nvidia/Eagle2.5-8B', tokenizer_path='nvidia/Eagle2.5-8B', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='0.0.0.0', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.65, max_running_requests=8, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='cuda', tp_size=1, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, stream_output=False, random_seed=1038714734, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='nvidia/Eagle2.5-8B', weight_version='default', chat_template=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='flashinfer', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend='fa3', fp8_gemm_runner_backend='auto', nsa_prefill_backend='flashmla_sparse', nsa_decode_backend='fa3', disable_flashinfer_autotune=False, speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype='float32', mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, hierarchical_sparse_attention_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=256, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='in-seq-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, disaggregation_decode_enable_fake_auto=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-01-19 13:30:14] Ignore import error when loading sglang.srt.multimodal.processors.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-01-19 13:30:15] min_dynamic_tiles: 1
[2026-01-19 13:30:15] max_dynamic_tiles: 12
[2026-01-19 13:30:15] vision_config is None. Initializing the InternVisionConfig with default values.
[2026-01-19 13:30:15] text_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`).
[2026-01-19 13:30:15] min_dynamic_tiles: 1
[2026-01-19 13:30:15] max_dynamic_tiles: 6
`use_fast` is set to `True` but the image processor class does not have a fast version.  Falling back to the slow version.
[2026-01-19 13:30:20] min_dynamic_tiles: 1
[2026-01-19 13:30:20] max_dynamic_tiles: 12
[2026-01-19 13:30:20] vision_config is None. Initializing the InternVisionConfig with default values.
[2026-01-19 13:30:20] text_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`).
[2026-01-19 13:30:20] min_dynamic_tiles: 1
[2026-01-19 13:30:20] max_dynamic_tiles: 6
[2026-01-19 13:30:20] Processor Eagle2_5_VLProcessor:
- image_processor: Eagle2_5_VLImageProcessorFast {
  "auto_map": {
    "AutoImageProcessor": "image_processing_eagle2_5_vl_fast.Eagle2_5_VLImageProcessorFast",
    "AutoProcessor": "processing_eagle2_5_vl.Eagle2_5_VLProcessor"
  },
  "crop_size": null,
  "data_format": "channels_first",
  "default_to_square": false,
  "device": null,
  "disable_grouping": null,
  "do_center_crop": null,
  "do_convert_rgb": true,
  "do_normalize": true,
  "do_pad": false,
  "do_rescale": true,
  "do_resize": false,
  "image_mean": [
    0.5,
    0.5,
    0.5
  ],
  "image_processor_type": "Eagle2_5_VLImageProcessorFast",
  "image_std": [
    0.5,
    0.5,
    0.5
  ],
  "input_data_format": null,
  "max_dynamic_tiles": 12,
  "min_dynamic_tiles": 1,
  "pad_during_tiling": false,
  "pad_size": null,
  "processor_class": "Eagle2_5_VLProcessor",
  "resample": 3,
  "rescale_factor": 0.00392156862745098,
  "return_tensors": null,
  "size": {
    "height": 448,
    "width": 448
  },
  "tokens_per_tile": 256,
  "use_thumbnail": true
}

- tokenizer: Qwen2TokenizerFast(name_or_path='nvidia/Eagle2.5-8B', vocab_size=151643, model_max_length=131072, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'eos_token': '<|im_end|>', 'pad_token': '<|endoftext|>', 'additional_special_tokens': ['<|im_start|>', '<|im_end|>', '<|object_ref_start|>', '<|object_ref_end|>', '<|box_start|>', '<|box_end|>', '<|quad_start|>', '<|quad_end|>', '<|vision_start|>', '<|vision_end|>', '<|vision_pad|>', '<|image_pad|>', '<|video_pad|>', '<img>', '</img>', '<IMG_CONTEXT>', '<quad>', '</quad>', '<ref>', '</ref>', '<box>', '</box>', '<interval>', '</interval>']}, clean_up_tokenization_spaces=False, added_tokens_decoder={
        151643: AddedToken("<|endoftext|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151644: AddedToken("<|im_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151645: AddedToken("<|im_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151646: AddedToken("<|object_ref_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151647: AddedToken("<|object_ref_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151648: AddedToken("<|box_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151649: AddedToken("<|box_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151650: AddedToken("<|quad_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151651: AddedToken("<|quad_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151652: AddedToken("<|vision_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151653: AddedToken("<|vision_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151654: AddedToken("<|vision_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151655: AddedToken("<|image_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151656: AddedToken("<|video_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151657: AddedToken("<tool_call>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151658: AddedToken("</tool_call>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151659: AddedToken("<|fim_prefix|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151660: AddedToken("<|fim_middle|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151661: AddedToken("<|fim_suffix|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151662: AddedToken("<|fim_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151663: AddedToken("<|repo_name|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151664: AddedToken("<|file_sep|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151665: AddedToken("<img>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151666: AddedToken("</img>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151667: AddedToken("<IMG_CONTEXT>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151668: AddedToken("<quad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151669: AddedToken("</quad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151670: AddedToken("<ref>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151671: AddedToken("</ref>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151672: AddedToken("<box>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151673: AddedToken("</box>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151674: AddedToken("<interval>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151675: AddedToken("</interval>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
)

{
  "auto_map": {
    "AutoImageProcessor": "image_processing_eagle2_5_vl_fast.Eagle2_5_VLImageProcessorFast",
    "AutoProcessor": "processing_eagle2_5_vl.Eagle2_5_VLProcessor"
  },
  "image_end_token": "</img>",
  "image_placeholder": "image",
  "image_start_token": "<img>",
  "image_token": "<IMG_CONTEXT>",
  "processor_class": "Eagle2_5_VLProcessor",
  "tokens_per_tile": 256,
  "video_placeholder": "video",
  "video_token": "<IMG_CONTEXT>",
  "vision_feature_select_strategy": null
}

[2026-01-19 13:30:20] Using default HuggingFace chat template with detected content format: openai
[2026-01-19 13:30:21] min_dynamic_tiles: 1
[2026-01-19 13:30:21] max_dynamic_tiles: 12
[2026-01-19 13:30:21] vision_config is None. Initializing the InternVisionConfig with default values.
[2026-01-19 13:30:21] text_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`).
[2026-01-19 13:30:21] min_dynamic_tiles: 1
[2026-01-19 13:30:21] max_dynamic_tiles: 6
`use_fast` is set to `True` but the image processor class does not have a fast version.  Falling back to the slow version.
[2026-01-19 13:30:26] Processor Eagle2_5_VLProcessor:
- image_processor: Eagle2_5_VLImageProcessorFast {
  "auto_map": {
    "AutoImageProcessor": "image_processing_eagle2_5_vl_fast.Eagle2_5_VLImageProcessorFast",
    "AutoProcessor": "processing_eagle2_5_vl.Eagle2_5_VLProcessor"
  },
  "crop_size": null,
  "data_format": "channels_first",
  "default_to_square": false,
  "device": null,
  "disable_grouping": null,
  "do_center_crop": null,
  "do_convert_rgb": true,
  "do_normalize": true,
  "do_pad": false,
  "do_rescale": true,
  "do_resize": false,
  "image_mean": [
    0.5,
    0.5,
    0.5
  ],
  "image_processor_type": "Eagle2_5_VLImageProcessorFast",
  "image_std": [
    0.5,
    0.5,
    0.5
  ],
  "input_data_format": null,
  "max_dynamic_tiles": 12,
  "min_dynamic_tiles": 1,
  "pad_during_tiling": false,
  "pad_size": null,
  "processor_class": "Eagle2_5_VLProcessor",
  "resample": 3,
  "rescale_factor": 0.00392156862745098,
  "return_tensors": null,
  "size": {
    "height": 448,
    "width": 448
  },
  "tokens_per_tile": 256,
  "use_thumbnail": true
}

- tokenizer: Qwen2TokenizerFast(name_or_path='nvidia/Eagle2.5-8B', vocab_size=151643, model_max_length=131072, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'eos_token': '<|im_end|>', 'pad_token': '<|endoftext|>', 'additional_special_tokens': ['<|im_start|>', '<|im_end|>', '<|object_ref_start|>', '<|object_ref_end|>', '<|box_start|>', '<|box_end|>', '<|quad_start|>', '<|quad_end|>', '<|vision_start|>', '<|vision_end|>', '<|vision_pad|>', '<|image_pad|>', '<|video_pad|>', '<img>', '</img>', '<IMG_CONTEXT>', '<quad>', '</quad>', '<ref>', '</ref>', '<box>', '</box>', '<interval>', '</interval>']}, clean_up_tokenization_spaces=False, added_tokens_decoder={
        151643: AddedToken("<|endoftext|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151644: AddedToken("<|im_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151645: AddedToken("<|im_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151646: AddedToken("<|object_ref_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151647: AddedToken("<|object_ref_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151648: AddedToken("<|box_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151649: AddedToken("<|box_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151650: AddedToken("<|quad_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151651: AddedToken("<|quad_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151652: AddedToken("<|vision_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151653: AddedToken("<|vision_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151654: AddedToken("<|vision_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151655: AddedToken("<|image_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151656: AddedToken("<|video_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151657: AddedToken("<tool_call>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151658: AddedToken("</tool_call>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151659: AddedToken("<|fim_prefix|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151660: AddedToken("<|fim_middle|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151661: AddedToken("<|fim_suffix|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151662: AddedToken("<|fim_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151663: AddedToken("<|repo_name|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151664: AddedToken("<|file_sep|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151665: AddedToken("<img>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151666: AddedToken("</img>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151667: AddedToken("<IMG_CONTEXT>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151668: AddedToken("<quad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151669: AddedToken("</quad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151670: AddedToken("<ref>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151671: AddedToken("</ref>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151672: AddedToken("<box>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151673: AddedToken("</box>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151674: AddedToken("<interval>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151675: AddedToken("</interval>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
)

{
  "auto_map": {
    "AutoImageProcessor": "image_processing_eagle2_5_vl_fast.Eagle2_5_VLImageProcessorFast",
    "AutoProcessor": "processing_eagle2_5_vl.Eagle2_5_VLProcessor"
  },
  "image_end_token": "</img>",
  "image_placeholder": "image",
  "image_start_token": "<img>",
  "image_token": "<IMG_CONTEXT>",
  "processor_class": "Eagle2_5_VLProcessor",
  "tokens_per_tile": 256,
  "video_placeholder": "video",
  "video_token": "<IMG_CONTEXT>",
  "vision_feature_select_strategy": null
}

[2026-01-19 13:30:27] Init torch distributed begin.
[rank0]:[W119 13:30:27.383623499 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-01-19 13:30:27] Init torch distributed ends. mem usage=0.00 GB
[2026-01-19 13:30:27] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-01-19 13:30:27] Ignore import error when loading sglang.srt.models.eagle_2_5_vl: cannot import name 'Eagle2_5_VLConfig' from 'sglang.srt.configs' (/usr/local/lib/python3.12/dist-packages/sglang/srt/configs/__init__.py)
[2026-01-19 13:30:28] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-01-19 13:30:28] Load weight begin. avail mem=78.81 GB
[2026-01-19 13:30:28] Using fa3 as multimodal attention backend.
[2026-01-19 13:30:28] [Eagle2.5-VL] num_image_token: 256, downsample_ratio: 0.5
[2026-01-19 13:30:28] [Eagle2.5-VL] select_layer(original): -1
[2026-01-19 13:30:28] Found local HF snapshot for nvidia/Eagle2.5-8B at /root/.cache/huggingface/hub/models--nvidia--Eagle2.5-8B/snapshots/61e45235a1e4a35222b86383479b3b004f4809d7; skipping download.
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:00<00:00, 154.48it/s]

[2026-01-19 13:30:31] Load weight end. type=Eagle2_5_VLForConditionalGeneration, dtype=torch.bfloat16, avail mem=63.44 GB, mem usage=15.37 GB.
[2026-01-19 13:30:31] Using KV cache dtype: torch.bfloat16
[2026-01-19 13:30:31] KV Cache is allocated. #tokens: 671362, K size: 17.93 GB, V size: 17.93 GB
[2026-01-19 13:30:31] Memory pool end. avail mem=27.47 GB
[2026-01-19 13:30:32] Capture cuda graph begin. This can take up to several minutes. avail mem=26.92 GB
[2026-01-19 13:30:32] Capture cuda graph bs [1, 2, 4, 8]
Capturing batches (bs=8 avail_mem=26.90 GB):   0%|                                                                                                                                       | 0/4 [00:00<?, ?it/s][2026-01-19 13:30:33] Failed to load JIT KV-Cache kernel with row_bytes=1024: ninja exited with status 1
stdout:
[1/2] /usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output cuda_0.o.d -Xcompiler -fPIC -std=c++17 -O2 -gencode=arch=compute_89,code=sm_89 -std=c++20 -O3 --expt-relaxed-constexpr -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/sglang/jit_kernel/include -c /root/.cache/tvm-ffi/sgl_kernel_jit_kvcache_1024_true_7b6120e8a560c3f3/cuda.cu -o cuda_0.o
FAILED: [code=1] cuda_0.o 
/usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output cuda_0.o.d -Xcompiler -fPIC -std=c++17 -O2 -gencode=arch=compute_89,code=sm_89 -std=c++20 -O3 --expt-relaxed-constexpr -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/tvm_ffi/include -I/usr/local/lib/python3.12/dist-packages/sglang/jit_kernel/include -c /root/.cache/tvm-ffi/sgl_kernel_jit_kvcache_1024_true_7b6120e8a560c3f3/cuda.cu -o cuda_0.o
nvcc warning : incompatible redefinition for option 'std', the last value of this option was used
nvcc warning : incompatible redefinition for option 'optimize', the last value of this option was used
/root/.cache/tvm-ffi/sgl_kernel_jit_kvcache_1024_true_7b6120e8a560c3f3/cuda.cu:7:10: fatal error: /usr/local/lib/python3.12/dist-packages/sglang/jit_kernel/csrc/elementwise/kvcache.cuh: No such file or directory
    7 | #include "/usr/local/lib/python3.12/dist-packages/sglang/jit_kernel/csrc/elementwise/kvcache.cuh"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.

Capturing batches (bs=1 avail_mem=26.79 GB): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  4.32it/s]
[2026-01-19 13:30:33] Capture cuda graph end. Time elapsed: 1.46 s. mem usage=0.13 GB. avail mem=26.79 GB.
[2026-01-19 13:30:34] min_dynamic_tiles: 1
[2026-01-19 13:30:34] max_dynamic_tiles: 12
[2026-01-19 13:30:34] vision_config is None. Initializing the InternVisionConfig with default values.
[2026-01-19 13:30:34] text_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`).
[2026-01-19 13:30:34] min_dynamic_tiles: 1
[2026-01-19 13:30:34] max_dynamic_tiles: 6
[2026-01-19 13:30:39] Processor Eagle2_5_VLProcessor:
- image_processor: Eagle2_5_VLImageProcessorFast {
  "auto_map": {
    "AutoImageProcessor": "image_processing_eagle2_5_vl_fast.Eagle2_5_VLImageProcessorFast",
    "AutoProcessor": "processing_eagle2_5_vl.Eagle2_5_VLProcessor"
  },
  "crop_size": null,
  "data_format": "channels_first",
  "default_to_square": false,
  "device": null,
  "disable_grouping": null,
  "do_center_crop": null,
  "do_convert_rgb": true,
  "do_normalize": true,
  "do_pad": false,
  "do_rescale": true,
  "do_resize": false,
  "image_mean": [
    0.5,
    0.5,
    0.5
  ],
  "image_processor_type": "Eagle2_5_VLImageProcessorFast",
  "image_std": [
    0.5,
    0.5,
    0.5
  ],
  "input_data_format": null,
  "max_dynamic_tiles": 12,
  "min_dynamic_tiles": 1,
  "pad_during_tiling": false,
  "pad_size": null,
  "processor_class": "Eagle2_5_VLProcessor",
  "resample": 3,
  "rescale_factor": 0.00392156862745098,
  "return_tensors": null,
  "size": {
    "height": 448,
    "width": 448
  },
  "tokens_per_tile": 256,
  "use_thumbnail": true
}

- tokenizer: Qwen2TokenizerFast(name_or_path='nvidia/Eagle2.5-8B', vocab_size=151643, model_max_length=131072, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'eos_token': '<|im_end|>', 'pad_token': '<|endoftext|>', 'additional_special_tokens': ['<|im_start|>', '<|im_end|>', '<|object_ref_start|>', '<|object_ref_end|>', '<|box_start|>', '<|box_end|>', '<|quad_start|>', '<|quad_end|>', '<|vision_start|>', '<|vision_end|>', '<|vision_pad|>', '<|image_pad|>', '<|video_pad|>', '<img>', '</img>', '<IMG_CONTEXT>', '<quad>', '</quad>', '<ref>', '</ref>', '<box>', '</box>', '<interval>', '</interval>']}, clean_up_tokenization_spaces=False, added_tokens_decoder={
        151643: AddedToken("<|endoftext|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151644: AddedToken("<|im_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151645: AddedToken("<|im_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151646: AddedToken("<|object_ref_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151647: AddedToken("<|object_ref_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151648: AddedToken("<|box_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151649: AddedToken("<|box_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151650: AddedToken("<|quad_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151651: AddedToken("<|quad_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151652: AddedToken("<|vision_start|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151653: AddedToken("<|vision_end|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151654: AddedToken("<|vision_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151655: AddedToken("<|image_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151656: AddedToken("<|video_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151657: AddedToken("<tool_call>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151658: AddedToken("</tool_call>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151659: AddedToken("<|fim_prefix|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151660: AddedToken("<|fim_middle|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151661: AddedToken("<|fim_suffix|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151662: AddedToken("<|fim_pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151663: AddedToken("<|repo_name|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151664: AddedToken("<|file_sep|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=False),
        151665: AddedToken("<img>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151666: AddedToken("</img>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151667: AddedToken("<IMG_CONTEXT>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151668: AddedToken("<quad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151669: AddedToken("</quad>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151670: AddedToken("<ref>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151671: AddedToken("</ref>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151672: AddedToken("<box>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151673: AddedToken("</box>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151674: AddedToken("<interval>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        151675: AddedToken("</interval>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
)

{
  "auto_map": {
    "AutoImageProcessor": "image_processing_eagle2_5_vl_fast.Eagle2_5_VLImageProcessorFast",
    "AutoProcessor": "processing_eagle2_5_vl.Eagle2_5_VLProcessor"
  },
  "image_end_token": "</img>",
  "image_placeholder": "image",
  "image_start_token": "<img>",
  "image_token": "<IMG_CONTEXT>",
  "processor_class": "Eagle2_5_VLProcessor",
  "tokens_per_tile": 256,
  "video_placeholder": "video",
  "video_token": "<IMG_CONTEXT>",
  "vision_feature_select_strategy": null
}

[2026-01-19 13:30:39] max_total_num_tokens=671362, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=8, context_len=262144, available_gpu_mem=26.79 GB
[2026-01-19 13:30:39] INFO:     Started server process [469557]
[2026-01-19 13:30:39] INFO:     Waiting for application startup.
[2026-01-19 13:30:39] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 1.0, 'top_k': 50, 'top_p': 1.0}
[2026-01-19 13:30:39] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 1.0, 'top_k': 50, 'top_p': 1.0}
[2026-01-19 13:30:39] INFO:     Application startup complete.
[2026-01-19 13:30:39] INFO:     Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)
[2026-01-19 13:30:40] INFO:     127.0.0.1:53386 - "GET /model_info HTTP/1.1" 200 OK
[2026-01-19 13:30:40] Warning: More image data items provided than corresponding tokens found in the prompt.
[2026-01-19 13:30:40] Multimodal inputs exist but all mm_items.offsets are empty. This usually means HF processor did not insert <IMG_CONTEXT> tokens.
[2026-01-19 13:30:40] Prefill batch, #new-seq: 1, #new-token: 28, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-19 13:30:41] INFO:     127.0.0.1:53402 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-19 13:30:41] The server is fired up and ready to roll!


[2026-01-19 13:30:52] Warning: More image data items provided than corresponding tokens found in the prompt.
[2026-01-19 13:30:52] Multimodal inputs exist but all mm_items.offsets are empty. This usually means HF processor did not insert <IMG_CONTEXT> tokens.
[2026-01-19 13:30:52] Prefill batch, #new-seq: 1, #new-token: 17, #cached-token: 19, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-19 13:30:52] INFO:     127.0.0.1:60184 - "POST /v1/chat/completions HTTP/1.1" 200 OK


[2026-01-19 13:31:22] Prefill batch, #new-seq: 1, #new-token: 26, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-19 13:31:22] Decode batch, #running-req: 1, #token: 42, token usage: 0.00, cuda graph: True, gen throughput (token/s): 0.65, #queue-req: 0, 
[2026-01-19 13:31:22] Decode batch, #running-req: 1, #token: 82, token usage: 0.00, cuda graph: True, gen throughput (token/s): 168.93, #queue-req: 0, 
[2026-01-19 13:31:22] INFO:     127.0.0.1:45726 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
