### PR TITLE
fix: updating pypi workflow with new base version formatting in pyproject.toml

### DIFF
--- a/.github/workflows/release-pypi-pr.yml
+++ b/.github/workflows/release-pypi-pr.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Generate PR wheel version
         id: gen_version
         run: |
-          # Get base version from version.py
-          BASE_VERSION=$(cat python/sglang/version.py | cut -d'"' -f2)
+          # Get base version from setuptools_scm
+          cd python
+          pip install setuptools-scm
+          BASE_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version(root='..'))" | cut -d'+' -f1)
+          cd ..
 
           # Get commit info
           COMMIT_HASH=$(git rev-parse --short HEAD)
@@ -68,15 +71,17 @@ jobs:
       - name: Update pyproject.toml with PR wheel version
         run: |
           cd python
-          BASE_VERSION=$(cat sglang/version.py | cut -d'"' -f2)
           WHEEL_VERSION="${{ steps.gen_version.outputs.wheel_version }}"
 
-          # Update version (temporary, not committed)
-          sed -i "s/version = \"${BASE_VERSION}\"/version = \"${WHEEL_VERSION}\"/" pyproject.toml
+          # Update pyproject.toml to use static version instead of dynamic
+          # Remove 'version' from dynamic list and add static version
+          sed -i 's/dynamic = \["version"\]/dynamic = []/' pyproject.toml
+          sed -i "/^name = \"sglang\"/a version = \"${WHEEL_VERSION}\"" pyproject.toml
 
           # Verify update
           echo "Updated version in pyproject.toml:"
           grep "^version" pyproject.toml
+          grep "^dynamic" pyproject.toml
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
## Motivation

Updating pr pypi workflow to extract base version from import from pyproject.toml (a new change introduced since the workflow was added)

Reference of issue: https://github.com/sgl-project/sglang/actions/workflows/release-pypi-pr.yml

## Modifications

Updated BASE_VERSION handling in pr pypi workflow.

## Accuracy Tests

n/a

## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
