### PR TITLE
[Docker] Fix CUDA 13 installing wrong `nvidia-nccl-cu13` due to `nixl-cu13` not breaking system package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -310,7 +310,7 @@ RUN --mount=type=cache,target=/root/.cache/pip if [ "${CUDA_VERSION%%.*}" = "12"
 elif [ "${CUDA_VERSION%%.*}" = "13" ]; then \
     python3 -m pip install nvidia-nccl-cu13==2.28.3 --force-reinstall --no-deps ; \
     python3 -m pip install nvidia-cublas==13.1.0.3 --force-reinstall --no-deps ; \
-    python3 -m pip install nixl-cu13 ; \
+    python3 -m pip install nixl-cu13 --no-deps ; \
     python3 -m pip install cuda-python==13.1.1 ; \
 fi
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Noticed in server logs, seems to be using `2.27.7` instead of `2.28.3` like how CUDA 12.x image series can correctly break the dependency tree through Docker.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Use `pipdeptree` which shows it can be the cause (it only has two dependencies, torch and numpy):

```
nixl-cu13==0.8.0
├── torch [required: Any, installed: 2.9.1+cu130]
│   ├── filelock [required: Any, installed: 3.20.3]
│   ├── typing_extensions [required: >=4.10.0, installed: 4.15.0]
│   ├── setuptools [required: Any, installed: 80.9.0]
│   ├── sympy [required: >=1.13.3, installed: 1.14.0]
│   │   └── mpmath [required: >=1.1.0,<1.4, installed: 1.3.0]
│   ├── networkx [required: >=2.5.1, installed: 3.6.1]
│   ├── Jinja2 [required: Any, installed: 3.1.6]
│   │   └── MarkupSafe [required: >=2.0, installed: 3.0.3]
│   ├── fsspec [required: >=0.8.5, installed: 2025.10.0]
│   ├── nvidia-cuda-nvrtc [required: ==13.0.48, installed: 13.0.48]
│   ├── nvidia-cuda-runtime [required: ==13.0.48, installed: 13.0.48]
│   ├── nvidia-cuda-cupti [required: ==13.0.48, installed: 13.0.48]
│   ├── nvidia-cudnn-cu13 [required: ==9.13.0.50, installed: 9.18.0.77]
│   │   └── nvidia-cublas [required: Any, installed: 13.0.0.19]
│   ├── nvidia-cublas [required: ==13.0.0.19, installed: 13.0.0.19]
│   ├── nvidia-cufft [required: ==12.0.0.15, installed: 12.0.0.15]
│   │   └── nvidia-nvjitlink [required: Any, installed: 13.0.39]
│   ├── nvidia-curand [required: ==10.4.0.35, installed: 10.4.0.35]
│   ├── nvidia-cusolver [required: ==12.0.3.29, installed: 12.0.3.29]
│   │   ├── nvidia-cublas [required: Any, installed: 13.0.0.19]
│   │   ├── nvidia-nvjitlink [required: Any, installed: 13.0.39]
│   │   └── nvidia-cusparse [required: Any, installed: 12.6.2.49]
│   │       └── nvidia-nvjitlink [required: Any, installed: 13.0.39]
│   ├── nvidia-cusparse [required: ==12.6.2.49, installed: 12.6.2.49]
│   │   └── nvidia-nvjitlink [required: Any, installed: 13.0.39]
│   ├── nvidia-cusparselt-cu13 [required: ==0.8.0, installed: 0.8.0]
│   ├── nvidia-nccl-cu13 [required: ==2.27.7, installed: 2.27.7]
│   ├── nvidia-nvshmem-cu13 [required: ==3.3.24, installed: 3.3.24]
│   ├── nvidia-nvtx [required: ==13.0.39, installed: 13.0.39]
│   ├── nvidia-nvjitlink [required: ==13.0.39, installed: 13.0.39]
│   ├── nvidia-cufile [required: ==1.15.0.42, installed: 1.15.0.42]
│   └── triton [required: ==3.5.1, installed: 3.5.1]
└── numpy [required: Any, installed: 2.4.1]
```