### PR TITLE
Fix runner utilization workflow to use 24h default

### DIFF
--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -39,5 +39,5 @@ jobs:
         run: |
           python scripts/ci/runner_utilization_report.py \
             --repo ${{ github.repository }} \
-            --hours ${{ inputs.hours || '6' }} \
+            --hours ${{ inputs.hours || '24' }} \
             ${{ inputs.filter && format('--filter {0}', inputs.filter) || '' }}


### PR DESCRIPTION
## Summary
- Fix default time window from 6h to 24h (workflow runs daily, should look at past 24 hours)