### PR TITLE
Add BF16 support to EP-MoE for DeepGEMM

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -97,6 +97,8 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
 class DeepGemmKernelType(IntEnum):
     GROUPED_GEMM_NT_F8F8BF16_MASKED = auto()
     GROUPED_GEMM_NT_F8F8BF16_CONTIG = auto()
+    GROUPED_GEMM_NT_BF16_MASKED = auto()
+    GROUPED_GEMM_NT_BF16_CONTIG = auto()
     GEMM_NT_F8F8BF16 = auto()
     GEMM_NT_BF16BF16F32 = auto()
 
@@ -164,6 +166,9 @@ def _compile_deep_gemm_one_type_all(
         if kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG:
             m_alignment = deep_gemm.get_mk_alignment_for_contiguous_layout()
             m_list = sorted(list(set(m for m in m_list if m % m_alignment == 0)))
+        elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG:
+            m_alignment = deep_gemm.get_mk_alignment_for_contiguous_layout()
+            m_list = sorted(list(set(m for m in m_list if m % m_alignment == 0)))
 
         # Here the precompilation is only run on the first rank, so gpu_id should be 0
         memory_budget = get_available_gpu_memory(device="cuda", gpu_id=0)
@@ -226,6 +231,8 @@ class _BaseWarmupExecutor:
             DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG: _GroupedContWarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_MASKED: _GroupedMaskedWarmupExecutor,
             DeepGemmKernelType.GEMM_NT_BF16BF16F32: _BF16F32WarmupExecutor,
+            DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG: _BF16GroupedContWarmupExecutor,
+            DeepGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED: _BF16GroupedMaskedWarmupExecutor,
         }[kernel_type](**kwargs)
 
     @staticmethod
@@ -238,6 +245,10 @@ class _BaseWarmupExecutor:
             return (max_m * k + n * k + max_m * n * 2) / _GB
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG:
             return (max_m * k + num_groups * n * k + max_m * 4 + max_m * n * 2) / _GB
+        elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG:
+            return (
+                max_m * k * 2 + num_groups * n * k * 2 + max_m * 4 + max_m * n * 2
+            ) / _GB
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_MASKED:
             return (
                 num_groups * max_m * k
@@ -248,6 +259,13 @@ class _BaseWarmupExecutor:
         elif kernel_type == DeepGemmKernelType.GEMM_NT_BF16BF16F32:
             # bf16 lhs + bf16 rhs + fp32 out
             return (max_m * k * 2 + n * k * 2 + max_m * n * 4) / _GB
+        elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED:
+            return (
+                num_groups * max_m * k * 2
+                + num_groups * n * k * 2
+                + num_groups * 4
+                + num_groups * max_m * n * 2
+            ) / _GB
         else:
             raise ValueError(f"Invalid kernel type: {kernel_type}")
 
@@ -310,6 +328,22 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
         )
 
 
+class _BF16GroupedContWarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.a = torch.empty((max_m, k), device="cuda", dtype=torch.bfloat16)
+        self.b = torch.empty((num_groups, n, k), device="cuda", dtype=torch.bfloat16)
+        self.m_indices = torch.zeros((max_m,), device="cuda", dtype=torch.int32)
+        self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+
+    def execute(self, m):
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
+            self.a[:m],
+            self.b,
+            self.out[:m],
+            m_indices=self.m_indices[:m],
+        )
+
+
 class _GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
     def __init__(self, max_m: int, n: int, k: int, num_groups: int):
         self.lhs_q, self.lhs_s = _empty_token_fp8((num_groups, max_m, k))
@@ -338,6 +372,28 @@ class _BF16F32WarmupExecutor(_BaseWarmupExecutor):
 
     def execute(self, m):
         deep_gemm.bf16_gemm_nt(self.lhs[:m], self.rhs, self.out[:m])
+
+
+class _BF16GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.a = torch.empty(
+            (num_groups, max_m, k), device="cuda", dtype=torch.bfloat16
+        )
+        self.b = torch.empty((num_groups, n, k), device="cuda", dtype=torch.bfloat16)
+        self.masked_m = torch.zeros((num_groups,), device="cuda", dtype=torch.int32)
+        self.out = torch.empty(
+            (num_groups, max_m, n), device="cuda", dtype=torch.bfloat16
+        )
+
+    def execute(self, m):
+        deep_gemm.m_grouped_bf16_gemm_nt_masked(
+            self.a,
+            self.b,
+            self.out,
+            masked_m=self.masked_m,
+            # DeepGEMM uses `expect_m` instead of input shape for `get_best_config`
+            expected_m=m,
+        )
 
 
 def deep_gemm_execution_hook(

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -86,6 +86,29 @@ def _ensure_cuda(
     )
 
 
+def grouped_gemm_nt_bf16_masked(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    d: torch.Tensor,
+    masked_m: torch.Tensor,
+    expected_m: int,
+):
+    num_groups, _, k = a.shape
+    _, n, _ = b.shape
+    kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED
+
+    with compile_utils.deep_gemm_execution_hook(
+        expected_m, n, k, num_groups, kernel_type
+    ):
+        return deep_gemm.m_grouped_bf16_gemm_nt_masked(
+            a,
+            b,
+            d,
+            masked_m,
+            expected_m,
+        )
+
+
 def grouped_gemm_nt_f8f8bf16_contig(
     lhs: Tuple[torch.Tensor, torch.Tensor],
     rhs: Tuple[torch.Tensor, torch.Tensor],
@@ -114,6 +137,17 @@ def grouped_gemm_nt_f8f8bf16_contig(
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
             lhs, rhs, out, m_indices, **fp4_kwargs
         )
+
+
+def grouped_gemm_nt_bf16_contig(
+    a: torch.Tensor, b: torch.Tensor, d: torch.Tensor, m_indices: torch.Tensor
+):
+    m, k = a.shape
+    num_groups, n, _ = b.shape
+    kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG
+
+    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(a, b, d, m_indices)
 
 
 def gemm_nt_f8f8bf16(

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -432,6 +432,114 @@ def silu_and_mul_masked_post_quant_fwd(
 
 
 @triton.jit
+def _silu_and_mul_kernel(
+    input_ptr,
+    stride_input_0,
+    stride_input_1,
+    stride_input_2,
+    output_ptr,
+    stride_output_0,
+    stride_output_1,
+    stride_output_2,
+    masked_m_ptr,
+    size_n,
+    BLOCK_N: tl.constexpr,
+    NUM_STAGE: tl.constexpr,
+):
+    expert_id = tl.program_id(2)
+    token_id = tl.program_id(1)
+    hidden_dim_block_index = tl.program_id(0)
+
+    block_num_per_expert = tl.num_programs(1)
+
+    token_num_cur_expert = tl.load(masked_m_ptr + expert_id)
+
+    stride_input_0 = tl.cast(stride_input_0, dtype=tl.int64)
+    stride_output_0 = tl.cast(stride_output_0, dtype=tl.int64)
+    stride_input_1 = tl.cast(stride_input_1, dtype=tl.int64)
+    stride_output_1 = tl.cast(stride_output_1, dtype=tl.int64)
+
+    offs_in_d = hidden_dim_block_index * BLOCK_N + tl.arange(0, BLOCK_N)
+    input_ptr_offs = input_ptr + expert_id * stride_input_0 + offs_in_d
+    output_ptr_offs = output_ptr + expert_id * stride_output_0 + offs_in_d
+
+    for token_index in tl.range(
+        token_id, token_num_cur_expert, block_num_per_expert, num_stages=NUM_STAGE
+    ):
+        gate = tl.load(
+            input_ptr_offs + token_index * stride_input_1,
+            mask=offs_in_d < size_n,
+            other=0.0,
+        ).to(tl.float32)
+        up = tl.load(
+            input_ptr_offs + token_index * stride_input_1 + size_n,
+            mask=offs_in_d < size_n,
+            other=0.0,
+        )
+        gate = gate / (1 + tl.exp(-gate))
+        gate = gate.to(input_ptr.dtype.element_ty)
+        gate_up = up * gate
+        tl.store(
+            output_ptr_offs + token_index * stride_output_1,
+            gate_up,
+            mask=offs_in_d < size_n,
+        )
+
+
+def silu_and_mul_masked_fwd(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    masked_m: torch.Tensor,
+):
+    """
+    input shape [expert_num, token_num_padded, hidden_dim], dtype bf16
+    output shape [expert_num, token_num_padded, hidden_dim // 2], dtype bf16
+    masked_m shape [expert_num]
+    """
+
+    assert input.is_contiguous()
+    assert output.dtype == torch.bfloat16
+    assert input.dtype == torch.bfloat16
+    assert output.is_contiguous()
+    assert len(input.shape) == 3
+    assert input.shape[0] == masked_m.shape[0]
+    assert input.shape[-1] % 2 == 0
+
+    size_n = input.shape[-1] // 2
+    expert_num = len(masked_m)
+
+    if expert_num < 4:
+        BLOCK_NUM_PER_EXPERT = 64
+    else:
+        BLOCK_NUM_PER_EXPERT = 32
+
+    BLOCK_N = 128
+    num_warps = 4
+    NUM_STAGES = 4
+
+    hidden_dim_split_block_num = triton.cdiv(size_n, BLOCK_N)
+
+    grid = (
+        hidden_dim_split_block_num,
+        BLOCK_NUM_PER_EXPERT,
+        expert_num,
+    )
+
+    _silu_and_mul_kernel[grid](
+        input,
+        *input.stride(),
+        output,
+        *output.stride(),
+        masked_m,
+        size_n,
+        BLOCK_N=BLOCK_N,
+        NUM_STAGE=NUM_STAGES,
+        num_warps=num_warps,
+    )
+    return output
+
+
+@triton.jit
 def silu_mul_static_tensorwise_quant_triton_kernel_for_cutlass_moe(
     input_ptr,
     output_ptr,
@@ -669,6 +777,7 @@ def _fwd_kernel_ep_scatter_2(
     SCALE_HIDDEN_SIZE_PAD: tl.constexpr,
     # Platform-specific semaphore for atomic_add performance tuning
     ATOMIC_ADD_SEM: tl.constexpr,
+    IS_FP8: tl.constexpr,
 ):
     start_token_id = tl.program_id(0)
     grid_num = tl.num_programs(0)
@@ -682,12 +791,13 @@ def _fwd_kernel_ep_scatter_2(
     for token_id_int32 in range(start_token_id, total_token_num, grid_num):
         token_id = token_id_int32.to(tl.int64)
         to_copy = tl.load(recv_x + token_id * recv_x_stride0 + offset_in, mask=mask)
-        to_copy_s = tl.load(
-            recv_x_scale
-            + token_id * recv_x_scale_stride0
-            + index_in_s * recv_x_scale_stride1,
-            mask=mask_s,
-        )
+        if IS_FP8:
+            to_copy_s = tl.load(
+                recv_x_scale
+                + token_id * recv_x_scale_stride0
+                + index_in_s * recv_x_scale_stride1,
+                mask=mask_s,
+            )
 
         for topk_idx_int32 in tl.range(0, topk_num, 1, num_stages=4):
             topk_index = topk_idx_int32.to(tl.int64)
@@ -705,15 +815,18 @@ def _fwd_kernel_ep_scatter_2(
                 output_tensor_ptr = (
                     output_tensor + dest_token_index * output_tensor_stride0
                 )
-                output_tensor_scale_ptr = (
-                    output_tensor_scale + dest_token_index * output_tensor_scale_stride0
-                )
                 tl.store(output_tensor_ptr + offset_in, to_copy, mask=mask)
-                tl.store(
-                    output_tensor_scale_ptr + index_in_s * output_tensor_scale_stride1,
-                    to_copy_s,
-                    mask=mask_s,
-                )
+                if IS_FP8:
+                    output_tensor_scale_ptr = (
+                        output_tensor_scale
+                        + dest_token_index * output_tensor_scale_stride0
+                    )
+                    tl.store(
+                        output_tensor_scale_ptr
+                        + index_in_s * output_tensor_scale_stride1,
+                        to_copy_s,
+                        mask=mask_s,
+                    )
 
 
 # copy from https://github.com/ModelTC/lightllm/blob/main/lightllm/common/fused_moe/deepep_scatter_gather.py
@@ -745,10 +858,15 @@ def ep_scatter(
         scale_hidden_size = ceil_div(scale_hidden_size, 4)
 
     assert m_indices.shape[0] % BLOCK_E == 0
-    assert (
-        recv_x_scale.dtype == output_tensor_scale.dtype
-    ), f"recv_x_scale.dtype: {recv_x_scale.dtype}, output_tensor_scale.dtype: {output_tensor_scale.dtype}"
-    assert recv_x_scale.shape[1] == output_tensor_scale.shape[1] == scale_hidden_size
+
+    is_fp8 = recv_x_scale is not None and recv_x.dtype != torch.bfloat16
+    if is_fp8:
+        assert (
+            recv_x_scale.dtype == output_tensor_scale.dtype
+        ), f"recv_x_scale.dtype: {recv_x_scale.dtype}, output_tensor_scale.dtype: {output_tensor_scale.dtype}"
+        assert (
+            recv_x_scale.shape[1] == output_tensor_scale.shape[1] == scale_hidden_size
+        )
 
     _fwd_kernel_ep_scatter_1[(grid,)](
         num_recv_tokens_per_expert,
@@ -769,8 +887,8 @@ def ep_scatter(
         recv_x.stride(0),
         recv_x.stride(1),
         recv_x_scale,
-        recv_x_scale.stride(0),
-        recv_x_scale.stride(1),
+        recv_x_scale.stride(0) if is_fp8 else 0,
+        recv_x_scale.stride(1) if is_fp8 else 0,
         recv_topk,
         recv_topk.stride(0),
         recv_topk.stride(1),
@@ -778,8 +896,8 @@ def ep_scatter(
         output_tensor.stride(0),
         output_tensor.stride(1),
         output_tensor_scale,
-        output_tensor_scale.stride(0),
-        output_tensor_scale.stride(1),
+        output_tensor_scale.stride(0) if is_fp8 else 0,
+        output_tensor_scale.stride(1) if is_fp8 else 0,
         output_index,
         output_index.stride(0),
         output_index.stride(1),
@@ -791,6 +909,7 @@ def ep_scatter(
         SCALE_HIDDEN_SIZE_PAD=triton.next_power_of_2(scale_hidden_size),
         # XXX (MUSA): Atomic add with "relaxed" semaphore on musa backend for better performance
         ATOMIC_ADD_SEM=None if not _is_musa else "relaxed",
+        IS_FP8=is_fp8,
     )
     return
 

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -110,6 +110,11 @@ class DeepEPMoE(FusedMoE):
             quant_config, Fp8Config
         ):
             self.deprecate_flag = True
+        elif (
+            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            and envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+        ):
+            self.deprecate_flag = True
         else:
             self.deprecate_flag = False
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -225,6 +225,7 @@ class FusedMoE(torch.nn.Module):
             get_moe_runner_backend().is_flashinfer_trtllm()
             or get_moe_runner_backend().is_flashinfer_trtllm_routed()
         )
+        self.use_deep_gemm = get_moe_runner_backend().is_deep_gemm()
 
         # flashinfer_trtllm kernel requires intermediate_size to be a multiple of 128
         # Pad the intermediate_size_per_partition if necessary
@@ -282,7 +283,9 @@ class FusedMoE(torch.nn.Module):
                 self.quant_method = quant_config.get_quant_method(self, prefix)
             if self.quant_method is None:
                 self.quant_method = UnquantizedFusedMoEMethod(
-                    self.use_triton_kernels, self.use_flashinfer_trtllm_moe
+                    self.use_triton_kernels,
+                    self.use_flashinfer_trtllm_moe,
+                    self.use_deep_gemm,
                 )
 
         self.quant_method.create_weights(

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -51,6 +51,8 @@ _is_musa = is_musa()
 # Imported only for the SGLANG_OPT_FIX_MEGA_MOE_MEMORY=False fallback path.
 if not (_is_npu or _is_hip) and _is_cuda:
     from sglang.jit_kernel.activation import silu_and_mul as _legacy_silu_and_mul
+elif _is_musa:
+    _silu_and_mul_musa = torch.nn.SwishGLU()
 else:
     _legacy_silu_and_mul = None
 
@@ -139,14 +141,25 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         running_state: dict,
         hooks: Optional[Any] = None,
     ) -> DeepGemmRunnerOutput:
+        weight_dtype = quant_info.w13_weight.dtype
         if not runner_input.use_masked_gemm:
-            hidden_states = self._run_contiguous_gemm(
-                runner_input, quant_info, running_state
-            )
+            if weight_dtype == torch.bfloat16:
+                hidden_states = self._run_bf16_contiguous_gemm(
+                    runner_input, quant_info, running_state
+                )
+            else:
+                hidden_states = self._run_contiguous_gemm(
+                    runner_input, quant_info, running_state
+                )
         else:
-            hidden_states = self._run_masked_gemm(
-                runner_input, quant_info, running_state
-            )
+            if weight_dtype == torch.bfloat16:
+                hidden_states = self._run_masked_bf16_gemm(
+                    runner_input, quant_info, running_state
+                )
+            else:
+                hidden_states = self._run_masked_gemm(
+                    runner_input, quant_info, running_state
+                )
         return DeepGemmRunnerOutput(hidden_states=hidden_states)
 
     def _run_contiguous_gemm(
@@ -243,12 +256,15 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                     gateup_output, swiglu_limit=self.swiglu_limit
                 )
 
-            down_input = torch.empty(
-                (all_tokens, N // 2),
-                device=gateup_output.device,
-                dtype=torch.bfloat16,
-            )
-            _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
+            if not _is_musa:
+                down_input = torch.empty(
+                    (all_tokens, N // 2),
+                    device=gateup_output.device,
+                    dtype=torch.bfloat16,
+                )
+                _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
+            else:
+                down_input = _silu_and_mul_musa(gateup_output.view(-1, N))
             del gateup_output
 
             down_input_fp8, down_input_scale = sglang_per_token_group_quant_fp8(
@@ -275,6 +291,71 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             m_indices,
             recipe_a=recipe_a,
             recipe_b=recipe_b,
+        )
+
+        return down_output
+
+    def _run_bf16_contiguous_gemm(
+        self,
+        runner_input: DeepGemmRunnerInput,
+        quant_info: DeepGemmMoeQuantInfo,
+        running_state: dict,
+    ) -> torch.Tensor:
+
+        hidden_states = runner_input.hidden_states
+        all_tokens = running_state["all_tokens"]
+        hidden_states_device = running_state["hidden_states_device"]
+        hidden_states_shape = running_state["hidden_states_shape"]
+        m_indices = runner_input.m_indices
+
+        N = quant_info.w13_weight.size(1)
+        K = hidden_states_shape[1]
+
+        w13_weight = quant_info.w13_weight
+        w2_weight = quant_info.w2_weight
+
+        # GroupGemm-1: (M, K) (E, N, K) -> (M, N)
+        gateup_output = torch.empty(
+            (all_tokens, N),
+            device=hidden_states_device,
+            dtype=torch.bfloat16,
+        )
+
+        deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
+            hidden_states,
+            w13_weight,
+            gateup_output,
+            m_indices,
+        )
+
+        dispose_tensor(hidden_states)
+
+        # Act: (M, N) -> (M, N/2)
+        if not _is_musa:
+            down_input = torch.empty(
+                (
+                    all_tokens,
+                    N // 2,
+                ),
+                device=gateup_output.device,
+                dtype=torch.bfloat16,
+            )
+            _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
+        else:
+            down_input = _silu_and_mul_musa(gateup_output.view(-1, N))
+        del gateup_output
+
+        # GroupGemm-2: (M, N/2) (E, K, N/2) -> (M, K)
+        down_output = torch.empty(
+            (all_tokens, K),
+            device=hidden_states_device,
+            dtype=torch.bfloat16,
+        )
+        deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
+            down_input,
+            w2_weight,
+            down_output,
+            m_indices,
         )
 
         return down_output
@@ -410,6 +491,70 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             block_m, threshold = deep_gemm_return_value
             meta_overlap_args["block_m"] = block_m
             meta_overlap_args["threshold"] = threshold
+
+        return down_output
+
+    def _run_masked_bf16_gemm(
+        self,
+        runner_input: DeepGemmRunnerInput,
+        quant_info: DeepGemmMoeQuantInfo,
+        running_state: dict,
+    ) -> torch.Tensor:
+        from sglang.srt.layers import deep_gemm_wrapper
+        from sglang.srt.layers.moe.ep_moe.kernels import silu_and_mul_masked_fwd
+
+        hidden_states = runner_input.hidden_states
+        masked_m = runner_input.masked_m
+        expected_m = runner_input.expected_m
+
+        w13_weight = quant_info.w13_weight
+        w2_weight = quant_info.w2_weight
+
+        hidden_states_device = running_state["hidden_states_device"]
+
+        # GroupGemm-0
+        num_groups, m, k = hidden_states.shape
+        n = w13_weight.size(1)
+        gateup_output = torch.empty(
+            (num_groups, m, n), device=hidden_states_device, dtype=torch.bfloat16
+        )
+        deep_gemm_wrapper.grouped_gemm_nt_bf16_masked(
+            hidden_states,
+            w13_weight,
+            gateup_output,
+            masked_m,
+            expected_m,
+        )
+        dispose_tensor(hidden_states)
+
+        down_input = torch.empty(
+            (
+                gateup_output.shape[0],
+                gateup_output.shape[1],
+                gateup_output.shape[2] // 2,
+            ),
+            device=hidden_states_device,
+            dtype=torch.bfloat16,
+        )
+
+        # Act
+        silu_and_mul_masked_fwd(gateup_output, down_input, masked_m)
+        del gateup_output
+
+        # GroupGemm-1
+        n = w2_weight.shape[1]
+
+        down_output = torch.empty(
+            (num_groups, m, n), device=hidden_states_device, dtype=torch.bfloat16
+        )
+        deep_gemm_wrapper.grouped_gemm_nt_bf16_masked(
+            down_input,
+            w2_weight,
+            down_output,
+            masked_m,
+            expected_m,
+        )
+        # Note: BF16 masked gemm doesn't support overlap_args, so no return value unpack
 
         return down_output
 
@@ -632,7 +777,8 @@ def pre_permute_deepep_normal_to_deep_gemm(
         scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
     )
     dispose_tensor(hidden_states)
-    dispose_tensor(hidden_states_scale)
+    if hidden_states_scale is not None:
+        dispose_tensor(hidden_states_scale)
 
     running_state["output_index"] = output_index
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -393,11 +393,14 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
     ):
         topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
         topk_ids = topk_ids.to(torch.int64)
-        if (
-            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-            and not get_moe_runner_backend().is_cutlass()
-            and not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
-        ):
+        backend = get_moe_runner_backend()
+        # BF16 dispatch is needed when:
+        #   - cutlass backend (uses different kernel)
+        #   - deep_gemm backend with SGLANG_DEEPEP_BF16_DISPATCH enabled
+        need_bf16_dispatch = backend.is_cutlass() or (
+            backend.is_deep_gemm() and envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+        )
+        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and not need_bf16_dispatch:
             # TODO hard code 128 block quant,use fp8 communication
             hidden_states = sglang_per_token_group_quant_fp8(
                 hidden_states,
@@ -620,14 +623,19 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         input_global_scale = self.quant_config.get("input_global_scale", None)
         if input_global_scale is not None:
             use_nvfp4 = True
-        elif not get_moe_runner_backend().is_flashinfer_cutedsl() and (
-            not _is_npu or not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
-        ):
-            # flashinfer_cutedsl expects BF16 dispatch when NVFP4 dispatch is
-            # off; its kernel quantizes to NVFP4 internally.
-            # SGLANG_DEEPEP_BF16_DISPATCH forces BF16 dispatch for NPU
-            # where INT8 input + BF16 weight GMM is not supported.
-            use_fp8 = True
+        else:
+            backend = get_moe_runner_backend()
+            # BF16 dispatch is needed when:
+            #   - flashinfer_cutedsl: kernel quantizes to NVFP4 internally
+            #   - NPU with SGLANG_DEEPEP_BF16_DISPATCH: INT8 input + BF16 weight GMM not supported
+            #   - deep_gemm with SGLANG_DEEPEP_BF16_DISPATCH: user requests BF16 dispatch
+            need_bf16_dispatch = (
+                backend.is_flashinfer_cutedsl()
+                or (_is_npu and envs.SGLANG_DEEPEP_BF16_DISPATCH.get())
+                or (backend.is_deep_gemm() and envs.SGLANG_DEEPEP_BF16_DISPATCH.get())
+            )
+            if not need_bf16_dispatch:
+                use_fp8 = True
 
         # round_scale / use_ue8m0 are FP8-DeepGEMM specific; they cause DeepEP
         # to return int32-packed UE8M0 scales that don't feed the flashinfer

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -182,8 +182,9 @@ class CompressedTensorsConfig(QuantizationConfig):
                 use_flashinfer_trtllm_moe = (
                     get_moe_runner_backend().is_flashinfer_trtllm()
                 )
+                use_deep_gemm = get_moe_runner_backend().is_deep_gemm()
                 return UnquantizedFusedMoEMethod(
-                    use_triton_kernels, use_flashinfer_trtllm_moe
+                    use_triton_kernels, use_flashinfer_trtllm_moe, use_deep_gemm
                 )
             return CompressedTensorsFusedMoEMethod(self)
         return None

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
@@ -163,13 +164,17 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
     """MoE method without quantization."""
 
     def __init__(
-        self, use_triton_kernels: bool = False, use_flashinfer_trtllm_moe: bool = False
+        self,
+        use_triton_kernels: bool = False,
+        use_flashinfer_trtllm_moe: bool = False,
+        use_deep_gemm: bool = False,
     ):
         super().__init__()
         self.use_flashinfer_cutlass = get_moe_runner_backend().is_flashinfer_cutlass()
         self.use_triton_kernels = use_triton_kernels
         self.with_bias = False
         self.use_flashinfer_trtllm_moe = use_flashinfer_trtllm_moe
+        self.use_deep_gemm = use_deep_gemm
         self._cache_permute_indices = dict({})
 
     def create_weights(
@@ -375,6 +380,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 if get_moe_runner_backend().is_flashinfer_trtllm_routed()
                 else MoeRunnerBackend.FLASHINFER_TRTLLM
             )
+        elif self.use_deep_gemm:
+            backend = MoeRunnerBackend.DEEP_GEMM
         elif self.use_triton_kernels:
             backend = MoeRunnerBackend.TRITON_KERNELS
         else:
@@ -416,7 +423,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
         x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
 
         moe_runner_config = self.moe_runner_config
 
@@ -433,7 +439,22 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 w2_bias=getattr(layer, "w2_weight_bias", None),
             )
             return self.runner.run(dispatch_output, quant_info)
+        elif self.runner.runner_backend.is_deep_gemm():
+            w13_weight = layer.w13_weight
+            w2_weight = layer.w2_weight
+            from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+
+            # Only use_fp8=False when SGLANG_DEEPEP_BF16_DISPATCH is true,
+            # otherwise use_fp8=True for FP8 dispatch path
+            use_fp8 = not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+            quant_info = DeepGemmMoeQuantInfo(
+                w13_weight=w13_weight,
+                w2_weight=w2_weight,
+                use_fp8=use_fp8,
+            )
+            return self.runner.run(dispatch_output, quant_info)
         elif self.use_flashinfer_cutlass:
+            topk_output = dispatch_output.topk_output
             output = flashinfer_cutlass_fused_moe(
                 input=x,
                 token_selected_experts=topk_output.topk_ids,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2033,6 +2033,11 @@ class ServerArgs:
                     logger.warning(
                         "Detected ROCm with SGLANG_USE_AITER for GPT-OSS bf16 model, using triton MOE kernel."
                     )
+                elif is_musa() and envs.SGLANG_DEEPEP_BF16_DISPATCH.get():
+                    self.moe_runner_backend = "deep_gemm"
+                    logger.warning(
+                        "Detected MUSA with SGLANG_DEEPEP_BF16_DISPATCH for bf16 model, using deep_gemm kernel."
+                    )
                 elif (
                     self.ep_size == 1
                     and is_triton_kernels_available()


### PR DESCRIPTION
## Motivation
We attempted to enable EP-MoE on BF16 models and found that BF16 data type was not supported in the DeepGEMM backend. This PR implements BF16 EP-MoE support using DeepGEMM's grouped BF16 GEMM kernels.

## Modifications
Following the same computational paradigm as FP8, we have implemented EP-MoE for BF16 using `deep_gemm.m_grouped_bf16_gemm_nt_contiguous` and `deep_gemm.m_grouped_bf16_gemm_nt_masked` from DeepGEMM.

The changes include:

1. **BF16 DeepGEMM interface** (`entrypoint.py`): Added `grouped_gemm_nt_bf16_masked` and `grouped_gemm_nt_bf16_contig` functions
2. **BF16 DeepGEMM warmup** (`compile_utils.py`): Added `DeepGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED` and `GROUPED_GEMM_NT_BF16_CONTIG` kernel types with corresponding warmup executors
3. **New Triton kernel** (`ep_moe/kernels.py`): Introduced `silu_and_mul_masked_fwd` kernel for BF16 activation, and extended `ep_scatter` to support BF16 data type (FP8 scale handling is now conditional)
4. **BF16 GEMM runners** (`moe_runner/deep_gemm.py`): Added `_run_bf16_contiguous_gemm` and `_run_masked_bf16_gemm` functions
5. **Server args** (`server_args.py`): Auto-select `deep_gemm` runner backend on MUSA platform when `SGLANG_DEEPEP_BF16_DISPATCH` is enabled

## Platform Support
- **MUSA platform**: Uses DeepGEMM as the BF16 EP-MoE backend (set `SGLANG_DEEPEP_BF16_DISPATCH=1` to enable)
- **CUDA platform**: Functionally available with the same configuration

## Benchmarking and Accuracy Tests
### MUSA Platform(S5000)
#### Run prefill server
```
export SGLANG_OPT_USE_JIT_EP_ACTIVATION=0
SGLANG_DEEPEP_BF16_DISPATCH=1 python3 -m sglang.launch_server \
    --model /home/dist/Qwen3.5-35B-A3B \
    --trust-remote-code \
    --tp-size 4 \
    --ep-size 4 \
    --dp-size 4 \
    --moe-runner-backend deep_gemm \
    --enable-dp-lm-head \
    --moe-dense-tp-size 1 \
    --enable-dp-attention \
    --moe-a2a-backend deepep \
    --deepep-config /home/dist/config.json \
    --deepep-mode normal \
    --mem-fraction-static 0.8 \
    --attention-backend fa3 \
    --max-running-requests 64 \
    --port 30033 \
    --disable-radix-cache \
    --disaggregation-mode prefill \
    --disaggregation-ib-device mlx5_2,mlx5_3,mlx5_4,mlx5_5
```

<details>

```
2026-05-07 06:15:41 | warnings | 140586425304896 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/launch_server.py:54: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(

INFO 05-07 06:15:41 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:41 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:41 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:41 [__init__.py:232] Platform plugin musa is activated
[2026-05-07 06:15:41] /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-05-07 06:15:42] DP attention is enabled. The chunked prefill size is adjusted to 2048 to avoid MoE kernel issues. 
[2026-05-07 06:15:42] Cuda graph is disabled because deepep_mode=`normal`
[2026-05-07 06:15:42] DeepEP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[4].
[2026-05-07 06:15:43] server_args=ServerArgs(model_path='/home/dist/qzg/0506/Qwen3.5-35B-A3B', tokenizer_path='/home/dist/qzg/0506/Qwen3.5-35B-A3B', tokenizer_mode='auto', tokenizer_backend='huggingface', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30033, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.8, max_running_requests=64, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=2048, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=0.3, page_size=64, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=4, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, batch_notify_size=16, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=641349217, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, grpc_http_sidecar_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/home/dist/qzg/0506/Qwen3.5-35B-A3B', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, strip_thinking_cache=False, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=4, load_balance_method='follow_bootstrap_room', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, lora_drain_wait_threshold=0.0, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='deep_gemm', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_adaptive=False, speculative_adaptive_config=None, speculative_skip_dp_mlp_sync=False, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=4, moe_a2a_backend='deepep', moe_runner_backend='deep_gemm', record_nolora_graph=True, flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='normal', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config='/home/dist/qzg/0506/config.json', moe_dense_tp_size=1, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, elastic_ep_rejoin=False, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', enable_mis=False, disable_radix_cache=True, cuda_graph_max_bs=512, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], disable_cuda_graph=True, disable_cuda_graph_padding=False, enable_breakable_cuda_graph=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=True, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=True, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, enable_return_indexer_topk=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='prefill', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device='mlx5_2,mlx5_3,mlx5_4,mlx5_5', disaggregation_decode_enable_radix_cache=False, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None, enable_quant_communications=False, msprobe_dump_config=None)
[2026-05-07 06:15:43] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 06:15:43] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[2026-05-07 06:15:44] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 06:15:44] CommonKVBootstrapServer started successfully on 127.0.0.1:8998
[2026-05-07 06:15:44] Using default HuggingFace chat template with detected content format: openai
INFO 05-07 06:15:50 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:50 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:50 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:50 [__init__.py:232] Platform plugin musa is activated
2026-05-07 06:15:50 | warnings | 140060799350592 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 06:15:50 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:50 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:50 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:50 [__init__.py:232] Platform plugin musa is activated
2026-05-07 06:15:50 | warnings | 140617009502016 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 06:15:57 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:57 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:57 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:57 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:57 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:57 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:57 [__init__.py:232] Platform plugin musa is activated
INFO 05-07 06:15:57 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:57 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:57 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:57 [__init__.py:232] Platform plugin musa is activated
INFO 05-07 06:15:57 [__init__.py:232] Platform plugin musa is activated
2026-05-07 06:15:57 | warnings | 140547905496896 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-05-07 06:15:57 | warnings | 140053788620608 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-05-07 06:15:57 | warnings | 140672597317440 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 06:15:58 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 06:15:58 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 06:15:58 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 06:15:58 [__init__.py:232] Platform plugin musa is activated
2026-05-07 06:15:58 | warnings | 140411563685696 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[2026-05-07 06:16:00 DP3 TP3 EP3] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:00 DP1 TP1 EP1] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:00 DP0 TP0 EP0] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:00 DP3 TP3 EP3] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 06:16:00 DP1 TP1 EP1] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 06:16:00 DP0 TP0 EP0] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 06:16:00 DP3 TP3 EP3] Init torch distributed begin.
[2026-05-07 06:16:00 DP1 TP1 EP1] Init torch distributed begin.
[2026-05-07 06:16:00 DP0 TP0 EP0] Init torch distributed begin.
[2026-05-07 06:16:00 DP2 TP2 EP2] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:00 DP2 TP2 EP2] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 06:16:00 DP2 TP2 EP2] Init torch distributed begin.
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-05-07 06:16:02 DP0 TP0 EP0] Init torch distributed ends. elapsed=2.12 s, mem usage=0.49 GB
[2026-05-07 06:16:02 DP3 TP3 EP3] Init torch distributed ends. elapsed=2.17 s, mem usage=0.49 GB
[2026-05-07 06:16:02 DP2 TP2 EP2] Init torch distributed ends. elapsed=1.86 s, mem usage=0.49 GB
[2026-05-07 06:16:02 DP1 TP1 EP1] Init torch distributed ends. elapsed=2.15 s, mem usage=0.49 GB
WARNING: Logging before InitGoogleLogging() is written to STDERR
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0507 06:16:02.458165 3417845 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0507 06:16:02.458468 3417845 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 06:16:02.458186 3417843 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 06:16:02.458165 3417842 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0507 06:16:02.458487 3417843 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 06:16:02.458489 3417842 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 06:16:02.458263 3417844 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 06:16:02.458498 3417845 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:15316
I0507 06:16:02.458508 3417844 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 06:16:02.458514 3417843 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:16681
I0507 06:16:02.458520 3417842 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:16513
I0507 06:16:02.458529 3417844 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:16935
I0507 06:16:02.458563 3417845 transfer_engine.cpp:185] Auto-discovering topology...
I0507 06:16:02.458578 3417843 transfer_engine.cpp:185] Auto-discovering topology...
I0507 06:16:02.458586 3417842 transfer_engine.cpp:185] Auto-discovering topology...
I0507 06:16:02.458590 3417844 transfer_engine.cpp:185] Auto-discovering topology...
I0507 06:16:02.461980 3417845 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 06:16:02.462020 3417842 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 06:16:02.462037 3417843 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 06:16:02.462045 3417844 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 06:16:02.483167 3417842 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 06:16:02.483201 3417845 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 06:16:02.484064 3417845 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 06:16:02.484089 3417842 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 06:16:02.486672 3417843 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 06:16:02.486752 3417844 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 06:16:02.487237 3417843 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 06:16:02.487375 3417844 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 06:16:02.488315 3417842 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 06:16:02.489162 3417842 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 06:16:02.491101 3417844 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 06:16:02.491659 3417844 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 06:16:02.510668 3417843 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 06:16:02.510736 3417845 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 06:16:02.510908 3417842 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 06:16:02.511210 3417843 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 06:16:02.511526 3417845 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 06:16:02.511891 3417842 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 06:16:02.514492 3417844 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 06:16:02.515054 3417844 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 06:16:02.515647 3417845 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 06:16:02.516295 3417845 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 06:16:02.534513 3417843 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 06:16:02.535043 3417843 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 06:16:02.538962 3417845 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 06:16:02.539007 3417842 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 06:16:02.539880 3417845 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
I0507 06:16:02.539923 3417842 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
I0507 06:16:02.543592 3417844 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 06:16:02.544178 3417844 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
I0507 06:16:02.559825 3417843 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 06:16:02.560451 3417843 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
[2026-05-07 06:16:03 DP0 TP0 EP0] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:03 DP3 TP3 EP3] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:03 DP2 TP2 EP2] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:03 DP1 TP1 EP1] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 06:16:05 DP0 TP0 EP0] Load weight begin. avail mem=78.15 GB
[2026-05-07 06:16:05 DP3 TP3 EP3] Load weight begin. avail mem=78.64 GB
[2026-05-07 06:16:05 DP1 TP1 EP1] Load weight begin. avail mem=78.64 GB
[2026-05-07 06:16:05 DP2 TP2 EP2] Load weight begin. avail mem=78.64 GB
[2026-05-07 06:16:07 DP0 TP0 EP0] Multimodal attention backend not set. Use fa3.
[2026-05-07 06:16:07 DP0 TP0 EP0] Using fa3 as multimodal attention backend.
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 06:16:07 DP0 TP0 EP0] using attn output gate!
[2026-05-07 06:16:07 DP3 TP3 EP3] Multimodal attention backend not set. Use fa3.
[2026-05-07 06:16:07 DP3 TP3 EP3] Using fa3 as multimodal attention backend.
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 06:16:07 DP3 TP3 EP3] using attn output gate!

Multi-thread loading shards:   0% Completed | 0/14 [00:00<?, ?it/s][2026-05-07 06:16:07 DP2 TP2 EP2] Multimodal attention backend not set. Use fa3.
[2026-05-07 06:16:07 DP2 TP2 EP2] Using fa3 as multimodal attention backend.
[2026-05-07 06:16:07 DP1 TP1 EP1] Multimodal attention backend not set. Use fa3.
[2026-05-07 06:16:07 DP1 TP1 EP1] Using fa3 as multimodal attention backend.
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 06:16:07 DP2 TP2 EP2] using attn output gate!
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 06:16:07 DP1 TP1 EP1] using attn output gate!

Multi-thread loading shards:   7% Completed | 1/14 [00:00<00:10,  1.30it/s]
Multi-thread loading shards:  14% Completed | 2/14 [00:01<00:09,  1.23it/s]
Multi-thread loading shards:  21% Completed | 3/14 [00:02<00:09,  1.20it/s]
Multi-thread loading shards:  29% Completed | 4/14 [00:03<00:08,  1.17it/s]
Multi-thread loading shards:  36% Completed | 5/14 [00:04<00:07,  1.18it/s]
Multi-thread loading shards:  43% Completed | 6/14 [00:05<00:06,  1.19it/s]
Multi-thread loading shards:  50% Completed | 7/14 [00:05<00:05,  1.19it/s]
Multi-thread loading shards:  57% Completed | 8/14 [00:06<00:05,  1.18it/s]
Multi-thread loading shards:  64% Completed | 9/14 [00:08<00:05,  1.02s/it]
Multi-thread loading shards:  71% Completed | 10/14 [00:09<00:03,  1.01it/s]
Multi-thread loading shards:  79% Completed | 11/14 [00:09<00:02,  1.06it/s]
Multi-thread loading shards:  86% Completed | 12/14 [00:10<00:01,  1.09it/s]
Multi-thread loading shards:  93% Completed | 13/14 [00:12<00:01,  1.23s/it]
Multi-thread loading shards: 100% Completed | 14/14 [00:13<00:00,  1.02s/it]
Multi-thread loading shards: 100% Completed | 14/14 [00:13<00:00,  1.06it/s]
[2026-05-07 06:16:20 DP1 TP1 EP1] Load weight end. elapsed=15.61 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.
[2026-05-07 06:16:20 DP0 TP0 EP0] Load weight end. elapsed=15.79 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=57.52 GB, mem usage=20.63 GB.
[2026-05-07 06:16:21 DP3 TP3 EP3] Load weight end. elapsed=15.88 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.
[2026-05-07 06:16:21 DP2 TP2 EP2] Load weight end. elapsed=15.95 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.
[2026-05-07 06:16:21 DP0 TP0 EP0] Using KV cache dtype: torch.bfloat16
[2026-05-07 06:16:21 DP2 TP2 EP2] Mamba Cache is allocated. max_mamba_cache_size: 16, conv_state size: 0.02GB, ssm_state size: 1.00GB 
[2026-05-07 06:16:21 DP1 TP1 EP1] Mamba Cache is allocated. max_mamba_cache_size: 16, conv_state size: 0.02GB, ssm_state size: 1.00GB 
[2026-05-07 06:16:21 DP0 TP0 EP0] Mamba Cache is allocated. max_mamba_cache_size: 16, conv_state size: 0.02GB, ssm_state size: 1.00GB 
[2026-05-07 06:16:21 DP3 TP3 EP3] Mamba Cache is allocated. max_mamba_cache_size: 16, conv_state size: 0.02GB, ssm_state size: 1.00GB 
[2026-05-07 06:16:21 DP2 TP2 EP2] KV Cache is allocated. #tokens: 2142080, K size: 20.43 GB, V size: 20.43 GB
[2026-05-07 06:16:21 DP2 TP2 EP2] Memory pool end. avail mem=16.02 GB
[2026-05-07 06:16:21 DP0 TP0 EP0] KV Cache is allocated. #tokens: 2142080, K size: 20.43 GB, V size: 20.43 GB
[2026-05-07 06:16:21 DP1 TP1 EP1] KV Cache is allocated. #tokens: 2142080, K size: 20.43 GB, V size: 20.43 GB
[2026-05-07 06:16:21 DP0 TP0 EP0] Memory pool end. avail mem=15.52 GB
[2026-05-07 06:16:21 DP1 TP1 EP1] Memory pool end. avail mem=16.02 GB
[2026-05-07 06:16:21 DP3 TP3 EP3] KV Cache is allocated. #tokens: 2142080, K size: 20.43 GB, V size: 20.43 GB
[2026-05-07 06:16:21 DP3 TP3 EP3] Memory pool end. avail mem=16.02 GB
[2026-05-07 06:16:22 DP1 TP1 EP1] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 06:16:22 DP0 TP0 EP0] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 06:16:22 DP1 TP1 EP1] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 06:16:22 DP2 TP2 EP2] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 06:16:22 DP0 TP0 EP0] Linear attention kernel backend: decode=triton, prefill=triton
[2026-05-07 06:16:22 DP2 TP2 EP2] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 06:16:22 DP0 TP0 EP0] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 06:16:22 DP0 TP0 EP0] GDN kernel dispatcher: decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True
[2026-05-07 06:16:22 DP1 TP1 EP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 06:16:22 DP2 TP2 EP2] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 06:16:22 DP0 TP0 EP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 06:16:22 DP3 TP3 EP3] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 06:16:22 DP3 TP3 EP3] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 06:16:22 DP3 TP3 EP3] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 06:16:23 DP0 TP0 EP0] max_total_num_tokens=2142080, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=16, context_len=262144, available_gpu_mem=15.47 GB
[2026-05-07 06:16:24] INFO:     Started server process [3415446]
[2026-05-07 06:16:24] INFO:     Waiting for application startup.
[2026-05-07 06:16:24] Using default chat sampling params from model generation config: {'temperature': 1.0, 'top_k': 20, 'top_p': 0.95}
[2026-05-07 06:16:24] INFO:     Application startup complete.
[2026-05-07 06:16:24] INFO:     Uvicorn running on http://127.0.0.1:30033 (Press CTRL+C to quit)
[2026-05-07 06:16:25] INFO:     127.0.0.1:37156 - "GET /model_info HTTP/1.1" 200 OK
[2026-05-07 06:16:25] Start of pd disaggregation warmup ...
[2026-05-07 06:16:25] /root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/starlette/_exception_handler.py:59: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
  response = await handler(conn, exc)

[2026-05-07 06:16:25] INFO:     127.0.0.1:37168 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
[2026-05-07 06:16:25] Prefill disaggregation mode warm Up Failed, status code: 400
[2026-05-07 06:16:25] The server is fired up and ready to roll!
[2026-05-07 06:17:02] Endpoint '/get_model_info' is deprecated and will be removed in a future version. Please use '/model_info' instead.
[2026-05-07 06:17:02] INFO:     127.0.0.1:43406 - "GET /get_model_info HTTP/1.1" 200 OK
[2026-05-07 06:17:03 DP0 TP0 EP0] Use DeepEP Config: {'normal_dispatch': {'num_sms': 60, 'num_max_nvl_chunked_send_tokens': 26}, 'normal_combine': {'num_sms': 60, 'num_max_nvl_chunked_send_tokens': 16}}
[2026-05-07 06:17:16 DP1 TP1 EP1] Prefill batch, #new-seq: 1, #new-token: 832, #cached-token: 0, full token usage: 0.00, mamba usage: 0.06, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 10.61
[2026-05-07 06:17:16] INFO:     127.0.0.1:43422 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 06:17:22 DP2 TP2 EP2] Prefill batch, #new-seq: 1, #new-token: 896, #cached-token: 0, full token usage: 0.00, mamba usage: 0.25, #running-req: 0, #queue-req: 28, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 10.69
[2026-05-07 06:17:29 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, full token usage: 0.00, mamba usage: 0.31, #running-req: 0, #queue-req: 27, #pending-token: 25535, #bootstrap-req: 0, #inflight-req: 2, cuda graph: False, input throughput (token/s): 22.50
[2026-05-07 06:17:29 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, full token usage: 0.00, mamba usage: 0.31, #running-req: 0, #queue-req: 27, #pending-token: 25703, #bootstrap-req: 0, #inflight-req: 2, cuda graph: False, input throughput (token/s): 22.51
[2026-05-07 06:17:29 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, full token usage: 0.00, mamba usage: 0.38, #running-req: 0, #queue-req: 26, #pending-token: 24817, #bootstrap-req: 0, #inflight-req: 3, cuda graph: False, input throughput (token/s): 297.98
[2026-05-07 06:17:29 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, full token usage: 0.00, mamba usage: 0.31, #running-req: 0, #queue-req: 27, #pending-token: 25647, #bootstrap-req: 0, #inflight-req: 2, cuda graph: False, input throughput (token/s): 162.48
```
</details>


#### Run decode server
```
export SGLANG_OPT_USE_JIT_EP_ACTIVATION=0
SGLANG_DEEPEP_BF16_DISPATCH=1 python3 -m sglang.launch_server \
    --model /home/dist/Qwen3.5-35B-A3B \
    --trust-remote-code \
    --tp-size 4 \
    --ep-size 4 \
    --dp-size 4 \
    --base-gpu-id 4 \
    --moe-runner-backend deep_gemm \
    --enable-dp-lm-head \
    --moe-dense-tp-size 1 \
    --enable-dp-attention \
    --moe-a2a-backend deepep \
    --deepep-mode low_latency \
    --mem-fraction-static 0.8 \
    --attention-backend fa3 \
    --disable-radix-cache \
    --port 30044 \
    --max-running-requests 64 \
    --disaggregation-mode decode \
    --disaggregation-ib-device mlx5_2,mlx5_3,mlx5_4,mlx5_5
```

<details>

```
2026-05-07 05:55:49 | warnings | 139636726466368 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/launch_server.py:54: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(

[2026-05-07 05:55:49] KV cache is forced as chunk cache for decode server
INFO 05-07 05:55:50 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:55:50 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:55:50 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:55:50 [__init__.py:232] Platform plugin musa is activated
[2026-05-07 05:55:50] /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-05-07 05:55:50] DP attention is enabled. The chunked prefill size is adjusted to 2048 to avoid MoE kernel issues. 
[2026-05-07 05:55:50] DeepEP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[4].
[2026-05-07 05:55:51] server_args=ServerArgs(model_path='/home/dist/qzg/0506/Qwen3.5-35B-A3B', tokenizer_path='/home/dist/qzg/0506/Qwen3.5-35B-A3B', tokenizer_mode='auto', tokenizer_backend='huggingface', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30044, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.8, max_running_requests=64, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=2048, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=0.3, page_size=64, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=4, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, batch_notify_size=16, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=831549355, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=4, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, grpc_http_sidecar_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/home/dist/qzg/0506/Qwen3.5-35B-A3B', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, strip_thinking_cache=False, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=4, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, lora_drain_wait_threshold=0.0, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='deep_gemm', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_adaptive=False, speculative_adaptive_config=None, speculative_skip_dp_mlp_sync=False, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=4, moe_a2a_backend='deepep', moe_runner_backend='deep_gemm', record_nolora_graph=True, flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='low_latency', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=1, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, elastic_ep_rejoin=False, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', enable_mis=False, disable_radix_cache=True, cuda_graph_max_bs=512, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_breakable_cuda_graph=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=True, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=True, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, enable_return_indexer_topk=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='decode', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device='mlx5_2,mlx5_3,mlx5_4,mlx5_5', disaggregation_decode_enable_radix_cache=False, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None, enable_quant_communications=False, msprobe_dump_config=None)
[2026-05-07 05:55:52] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 05:55:52] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[2026-05-07 05:55:53] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 05:55:53] Using default HuggingFace chat template with detected content format: openai
INFO 05-07 05:55:58 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:55:58 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:55:58 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:55:58 [__init__.py:232] Platform plugin musa is activated
INFO 05-07 05:55:58 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:55:58 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:55:58 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:55:58 [__init__.py:232] Platform plugin musa is activated
2026-05-07 05:55:58 | warnings | 140626328340288 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-05-07 05:55:58 | warnings | 139961956017984 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 05:56:06 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:56:06 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:56:06 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:56:06 [__init__.py:232] Platform plugin musa is activated
2026-05-07 05:56:06 | warnings | 140123626260288 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 05:56:06 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:56:06 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:56:06 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:56:06 [__init__.py:232] Platform plugin musa is activated
2026-05-07 05:56:06 | warnings | 139805723473728 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 05:56:06 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:56:06 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:56:06 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:56:06 [__init__.py:232] Platform plugin musa is activated
2026-05-07 05:56:06 | warnings | 140556402652992 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO 05-07 05:56:06 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 05-07 05:56:06 [__init__.py:38] - musa -> vllm_musa:register
INFO 05-07 05:56:06 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 05-07 05:56:06 [__init__.py:232] Platform plugin musa is activated
2026-05-07 05:56:06 | warnings | 139808253400896 | WARNING : /home/dist/qzg/0506/sglang/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
[2026-05-07 05:56:09 DP3 TP3 EP3] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:09 DP0 TP0 EP0] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:09 DP1 TP1 EP1] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:09 DP2 TP2 EP2] Ignore import error when loading sglang.srt.multimodal.processors.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:09 DP3 TP3 EP3] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 05:56:09 DP0 TP0 EP0] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 05:56:09 DP1 TP1 EP1] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 05:56:09 DP3 TP3 EP3] Init torch distributed begin.
[2026-05-07 05:56:09 DP2 TP2 EP2] Ignore import error when loading sglang.srt.multimodal.processors.mimo_v2: No module named 'torchcodec'
[2026-05-07 05:56:09 DP0 TP0 EP0] Init torch distributed begin.
[2026-05-07 05:56:09 DP1 TP1 EP1] Init torch distributed begin.
[2026-05-07 05:56:09 DP2 TP2 EP2] Init torch distributed begin.
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-05-07 05:56:11 DP3 TP3 EP3] Init torch distributed ends. elapsed=2.59 s, mem usage=0.49 GB
[2026-05-07 05:56:11 DP1 TP1 EP1] Init torch distributed ends. elapsed=2.53 s, mem usage=0.49 GB
[2026-05-07 05:56:11 DP0 TP0 EP0] Init torch distributed ends. elapsed=2.56 s, mem usage=0.49 GB
[2026-05-07 05:56:11 DP2 TP2 EP2] Init torch distributed ends. elapsed=2.47 s, mem usage=0.49 GB
WARNING: Logging before InitGoogleLogging() is written to STDERR
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0507 05:56:11.874027 3305431 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 05:56:11.874034 3305433 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 05:56:11.874234 3305431 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 05:56:11.874238 3305433 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 05:56:11.874258 3305431 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:15308
I0507 05:56:11.874262 3305433 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:16409
WARNING: Logging before InitGoogleLogging() is written to STDERR
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0507 05:56:11.874274 3305430 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 05:56:11.874286 3305432 transfer_engine.cpp:486] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 05:56:11.874313 3305430 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 05:56:11.874315 3305432 transfer_engine.cpp:91] Transfer Engine parseHostNameWithPort. server_name: 10.18.32.99 port: 12001
I0507 05:56:11.874325 3305433 transfer_engine.cpp:185] Auto-discovering topology...
I0507 05:56:11.874334 3305431 transfer_engine.cpp:185] Auto-discovering topology...
I0507 05:56:11.874336 3305432 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:15468
I0507 05:56:11.874336 3305430 transfer_engine.cpp:146] Transfer Engine RPC using P2P handshake, listening on 10.18.32.99:16038
I0507 05:56:11.874420 3305432 transfer_engine.cpp:185] Auto-discovering topology...
I0507 05:56:11.874423 3305430 transfer_engine.cpp:185] Auto-discovering topology...
I0507 05:56:11.880373 3305433 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 05:56:11.880431 3305431 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 05:56:11.880921 3305432 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 05:56:11.880921 3305430 transfer_engine.cpp:200] Topology discovery complete. Found 4 HCAs.
I0507 05:56:11.909554 3305430 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 05:56:11.909642 3305431 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 05:56:11.909646 3305432 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 05:56:11.909655 3305433 rdma_context.cpp:540] Find best gid index: 0 on mlx5_2/
I0507 05:56:11.910903 3305433 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 05:56:11.910907 3305430 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 05:56:11.910926 3305432 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 05:56:11.910928 3305431 rdma_context.cpp:133] RDMA device: mlx5_2, LID: 13, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a5:c0
I0507 05:56:11.917819 3305432 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 05:56:11.917888 3305433 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 05:56:11.919091 3305432 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 05:56:11.919094 3305433 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 05:56:11.925662 3305432 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 05:56:11.926848 3305432 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 05:56:11.934618 3305430 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 05:56:11.935256 3305430 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 05:56:11.938603 3305431 rdma_context.cpp:540] Find best gid index: 0 on mlx5_3/
I0507 05:56:11.939278 3305431 rdma_context.cpp:133] RDMA device: mlx5_3, LID: 14, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:a1:50
I0507 05:56:11.943686 3305433 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 05:56:11.944350 3305433 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 05:56:11.956789 3305432 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 05:56:11.958016 3305432 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
I0507 05:56:11.958590 3305430 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 05:56:11.959203 3305430 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 05:56:11.966576 3305431 rdma_context.cpp:540] Find best gid index: 0 on mlx5_4/
I0507 05:56:11.967231 3305431 rdma_context.cpp:133] RDMA device: mlx5_4, LID: 15, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:c3:48
I0507 05:56:11.970600 3305433 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 05:56:11.971210 3305433 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
I0507 05:56:11.986694 3305430 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 05:56:11.987339 3305430 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
I0507 05:56:11.994493 3305431 rdma_context.cpp:540] Find best gid index: 0 on mlx5_5/
I0507 05:56:11.995065 3305431 rdma_context.cpp:133] RDMA device: mlx5_5, LID: 19, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:a0:88:c2:03:00:04:9d:a8
[2026-05-07 05:56:12 DP2 TP2 EP2] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:12 DP3 TP3 EP3] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:12 DP0 TP0 EP0] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:12 DP1 TP1 EP1] Ignore import error when loading sglang.srt.models.midashenglm: No module named 'torchaudio'
[2026-05-07 05:56:14 DP2 TP2 EP2] Load weight begin. avail mem=78.65 GB
[2026-05-07 05:56:14 DP0 TP0 EP0] Load weight begin. avail mem=78.65 GB
[2026-05-07 05:56:14 DP1 TP1 EP1] Load weight begin. avail mem=78.65 GB
[2026-05-07 05:56:14 DP3 TP3 EP3] Load weight begin. avail mem=78.65 GB
[2026-05-07 05:56:17 DP0 TP0 EP0] Multimodal attention backend not set. Use fa3.
[2026-05-07 05:56:17 DP0 TP0 EP0] Using fa3 as multimodal attention backend.
[2026-05-07 05:56:17 DP2 TP2 EP2] Multimodal attention backend not set. Use fa3.
[2026-05-07 05:56:17 DP2 TP2 EP2] Using fa3 as multimodal attention backend.
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 05:56:17 DP1 TP1 EP1] Multimodal attention backend not set. Use fa3.
[2026-05-07 05:56:17 DP1 TP1 EP1] Using fa3 as multimodal attention backend.
[2026-05-07 05:56:17 DP0 TP0 EP0] using attn output gate!
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 05:56:17 DP2 TP2 EP2] using attn output gate!
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 05:56:17 DP3 TP3 EP3] Multimodal attention backend not set. Use fa3.
[2026-05-07 05:56:17 DP3 TP3 EP3] Using fa3 as multimodal attention backend.
[2026-05-07 05:56:17 DP1 TP1 EP1] using attn output gate!
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
[2026-05-07 05:56:17 DP3 TP3 EP3] using attn output gate!

Multi-thread loading shards:   0% Completed | 0/14 [00:00<?, ?it/s]
Multi-thread loading shards:   7% Completed | 1/14 [00:00<00:09,  1.32it/s]
Multi-thread loading shards:  14% Completed | 2/14 [00:01<00:09,  1.24it/s]
Multi-thread loading shards:  21% Completed | 3/14 [00:02<00:09,  1.21it/s]
Multi-thread loading shards:  29% Completed | 4/14 [00:03<00:08,  1.20it/s]
Multi-thread loading shards:  36% Completed | 5/14 [00:04<00:07,  1.17it/s]
Multi-thread loading shards:  43% Completed | 6/14 [00:05<00:06,  1.15it/s]
Multi-thread loading shards:  50% Completed | 7/14 [00:05<00:06,  1.15it/s]
Multi-thread loading shards:  57% Completed | 8/14 [00:06<00:05,  1.15it/s]
Multi-thread loading shards:  64% Completed | 9/14 [00:08<00:05,  1.04s/it]
Multi-thread loading shards:  71% Completed | 10/14 [00:09<00:04,  1.00s/it]
Multi-thread loading shards:  79% Completed | 11/14 [00:10<00:02,  1.05it/s]
Multi-thread loading shards:  86% Completed | 12/14 [00:10<00:01,  1.08it/s]
Multi-thread loading shards:  93% Completed | 13/14 [00:12<00:01,  1.21s/it][2026-05-07 05:56:30 DP2 TP2 EP2] Load weight end. elapsed=15.80 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.

Multi-thread loading shards: 100% Completed | 14/14 [00:13<00:00,  1.00it/s]
Multi-thread loading shards: 100% Completed | 14/14 [00:13<00:00,  1.06it/s]
[2026-05-07 05:56:30 DP0 TP0 EP0] Load weight end. elapsed=15.84 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.
[2026-05-07 05:56:30 DP3 TP3 EP3] Load weight end. elapsed=15.75 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.
[2026-05-07 05:56:31 DP1 TP1 EP1] Load weight end. elapsed=16.49 s, type=Qwen3_5MoeForConditionalGeneration, avail mem=58.02 GB, mem usage=20.63 GB.
[2026-05-07 05:56:31 DP0 TP0 EP0] Using KV cache dtype: torch.bfloat16
[2026-05-07 05:56:31 DP0 TP0 EP0] mamba_size (16) is less than decode side's max_slots_needed (48 = 48 reqs * 1 slots/req), raising effective_mamba_size to 48
[2026-05-07 05:56:31 DP1 TP1 EP1] mamba_size (16) is less than decode side's max_slots_needed (48 = 48 reqs * 1 slots/req), raising effective_mamba_size to 48
[2026-05-07 05:56:31 DP2 TP2 EP2] mamba_size (16) is less than decode side's max_slots_needed (48 = 48 reqs * 1 slots/req), raising effective_mamba_size to 48
[2026-05-07 05:56:31 DP3 TP3 EP3] mamba_size (16) is less than decode side's max_slots_needed (48 = 48 reqs * 1 slots/req), raising effective_mamba_size to 48
[2026-05-07 05:56:31 DP0 TP0 EP0] Mamba Cache is allocated. max_mamba_cache_size: 48, conv_state size: 0.07GB, ssm_state size: 2.87GB 
[2026-05-07 05:56:31 DP1 TP1 EP1] Mamba Cache is allocated. max_mamba_cache_size: 48, conv_state size: 0.07GB, ssm_state size: 2.87GB 
[2026-05-07 05:56:31 DP2 TP2 EP2] Mamba Cache is allocated. max_mamba_cache_size: 48, conv_state size: 0.07GB, ssm_state size: 2.87GB 
[2026-05-07 05:56:31 DP3 TP3 EP3] Mamba Cache is allocated. max_mamba_cache_size: 48, conv_state size: 0.07GB, ssm_state size: 2.87GB 
[2026-05-07 05:56:31 DP0 TP0 EP0] KV Cache is allocated. #tokens: 2163072, K size: 20.63 GB, V size: 20.63 GB
[2026-05-07 05:56:31 DP0 TP0 EP0] Memory pool end. avail mem=13.62 GB
[2026-05-07 05:56:31 DP1 TP1 EP1] KV Cache is allocated. #tokens: 2163072, K size: 20.63 GB, V size: 20.63 GB
[2026-05-07 05:56:31 DP1 TP1 EP1] Memory pool end. avail mem=13.62 GB
[2026-05-07 05:56:31 DP2 TP2 EP2] KV Cache is allocated. #tokens: 2163072, K size: 20.63 GB, V size: 20.63 GB
[2026-05-07 05:56:31 DP2 TP2 EP2] Memory pool end. avail mem=13.62 GB
[2026-05-07 05:56:31 DP3 TP3 EP3] KV Cache is allocated. #tokens: 2163072, K size: 20.63 GB, V size: 20.63 GB
[2026-05-07 05:56:31 DP3 TP3 EP3] Memory pool end. avail mem=13.62 GB
[2026-05-07 05:56:32 DP1 TP1 EP1] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 05:56:32 DP1 TP1 EP1] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 05:56:32 DP1 TP1 EP1] Capture cuda graph begin. This can take up to several minutes. avail mem=13.56 GB
[2026-05-07 05:56:32 DP0 TP0 EP0] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 05:56:32 DP0 TP0 EP0] Linear attention kernel backend: decode=triton, prefill=triton
[2026-05-07 05:56:32 DP0 TP0 EP0] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 05:56:32 DP0 TP0 EP0] GDN kernel dispatcher: decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True
[2026-05-07 05:56:32 DP0 TP0 EP0] Capture cuda graph begin. This can take up to several minutes. avail mem=13.56 GB
[2026-05-07 05:56:32 DP0 TP0 EP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16]
[2026-05-07 05:56:32 DP2 TP2 EP2] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 05:56:32 DP2 TP2 EP2] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 05:56:32 DP3 TP3 EP3] Current Python version 3.10 is below the recommended 3.11 version. It is recommended to upgrade to Python 3.11 or higher for the best experience.
[2026-05-07 05:56:32 DP3 TP3 EP3] Using hybrid linear attention backend for hybrid GDN models.
[2026-05-07 05:56:32 DP2 TP2 EP2] Capture cuda graph begin. This can take up to several minutes. avail mem=13.56 GB
[2026-05-07 05:56:32 DP3 TP3 EP3] Capture cuda graph begin. This can take up to several minutes. avail mem=13.56 GB

  0%|          | 0/6 [00:00<?, ?it/s]
Capturing batches (bs=16 avail_mem=13.56 GB):   0%|          | 0/6 [00:00<?, ?it/s]
Capturing batches (bs=16 avail_mem=13.56 GB):  17%|█▋        | 1/6 [00:16<01:22, 16.57s/it]
Capturing batches (bs=12 avail_mem=10.19 GB):  17%|█▋        | 1/6 [00:16<01:22, 16.57s/it]
Capturing batches (bs=12 avail_mem=10.19 GB):  33%|███▎      | 2/6 [00:23<00:43, 10.95s/it]
Capturing batches (bs=8 avail_mem=10.19 GB):  33%|███▎      | 2/6 [00:23<00:43, 10.95s/it] 
Capturing batches (bs=8 avail_mem=10.19 GB):  50%|█████     | 3/6 [00:32<00:30, 10.19s/it]
Capturing batches (bs=4 avail_mem=10.18 GB):  50%|█████     | 3/6 [00:32<00:30, 10.19s/it]
Capturing batches (bs=4 avail_mem=10.18 GB):  67%|██████▋   | 4/6 [00:41<00:19,  9.59s/it]
Capturing batches (bs=2 avail_mem=10.18 GB):  67%|██████▋   | 4/6 [00:41<00:19,  9.59s/it]
Capturing batches (bs=2 avail_mem=10.18 GB):  83%|████████▎ | 5/6 [00:50<00:09,  9.29s/it]
Capturing batches (bs=1 avail_mem=10.17 GB):  83%|████████▎ | 5/6 [00:50<00:09,  9.29s/it]
Capturing batches (bs=1 avail_mem=10.17 GB): 100%|██████████| 6/6 [00:59<00:00,  9.12s/it]
Capturing batches (bs=1 avail_mem=10.17 GB): 100%|██████████| 6/6 [00:59<00:00,  9.85s/it]
[2026-05-07 05:57:31 DP0 TP0 EP0] Registering 0 cuda graph addresses
[2026-05-07 05:57:35 DP0 TP0 EP0] Capture cuda graph end. Time elapsed: 63.41 s. mem usage=3.40 GB. avail mem=10.17 GB.
[2026-05-07 05:57:35 DP0 TP0 EP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 05:57:35 DP2 TP2 EP2] Capture cuda graph end. Time elapsed: 63.41 s. mem usage=3.40 GB. avail mem=10.17 GB.
[2026-05-07 05:57:35 DP2 TP2 EP2] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 05:57:35 DP3 TP3 EP3] Capture cuda graph end. Time elapsed: 63.60 s. mem usage=3.40 GB. avail mem=10.17 GB.
[2026-05-07 05:57:35 DP3 TP3 EP3] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 05:57:35 DP1 TP1 EP1] Capture cuda graph end. Time elapsed: 63.63 s. mem usage=3.40 GB. avail mem=10.17 GB.
[2026-05-07 05:57:35 DP1 TP1 EP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 05:57:36 DP0 TP0 EP0] max_total_num_tokens=2163072, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=16, context_len=262144, available_gpu_mem=10.17 GB
[2026-05-07 05:57:37] INFO:     Started server process [3301094]
[2026-05-07 05:57:37] INFO:     Waiting for application startup.
[2026-05-07 05:57:37] Using default chat sampling params from model generation config: {'temperature': 1.0, 'top_k': 20, 'top_p': 0.95}
[2026-05-07 05:57:37] INFO:     Application startup complete.
[2026-05-07 05:57:37] INFO:     Uvicorn running on http://127.0.0.1:30044 (Press CTRL+C to quit)
[2026-05-07 05:57:38] INFO:     127.0.0.1:38108 - "GET /model_info HTTP/1.1" 200 OK
[2026-05-07 05:57:38] Start of pd disaggregation warmup ...
[2026-05-07 05:57:38] /root/.virtualenvs/sglang-0.5.6/lib/python3.10/site-packages/starlette/_exception_handler.py:59: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
  response = await handler(conn, exc)

[2026-05-07 05:57:38] INFO:     127.0.0.1:38110 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
[2026-05-07 05:57:38] Prefill disaggregation mode warm Up Failed, status code: 400
[2026-05-07 05:57:38] The server is fired up and ready to roll!
[2026-05-07 06:11:13] INFO:     127.0.0.1:35396 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 06:11:20 DP1 TP1 EP1] Decode batch, #running-req: 1, #full token: 28992, full token usage: 0.01, mamba num: 32, mamba usage: 0.67, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 31, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 0.04, #queue-req: 0
[2026-05-07 06:11:21] INFO:     127.0.0.1:47902 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 06:11:26 DP1 TP1 EP1] Decode batch, #running-req: 2, #full token: 28928, full token usage: 0.01, mamba num: 32, mamba usage: 0.67, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 30, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 8.20, #queue-req: 0
[2026-05-07 06:11:27 DP0 TP0 EP0] Decode batch, #running-req: 2, #full token: 28800, full token usage: 0.01, mamba num: 32, mamba usage: 0.67, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 30, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 0.09, #queue-req: 0
[2026-05-07 06:11:27 DP2 TP2 EP2] Decode batch, #running-req: 2, #full token: 28800, full token usage: 0.01, mamba num: 32, mamba usage: 0.67, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 30, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 0.09, #queue-req: 0
[2026-05-07 06:11:27 DP3 TP3 EP3] Decode batch, #running-req: 2, #full token: 28800, full token usage: 0.01, mamba num: 32, mamba usage: 0.67, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 30, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 0.09, #queue-req: 0
[2026-05-07 06:11:28 DP1 TP1 EP1] Decode batch, #running-req: 2, #full token: 28992, full token usage: 0.01, mamba num: 32, mamba usage: 0.67, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 30, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 70.23, #queue-req: 0
```
</details>

#### Run router
```
python -m sglang_router.launch_router \
    --pd-disaggregation \
    --mini-lb \
    --prefill http://127.0.0.1:30033 \
    --decode http://127.0.0.1:30044 \
    --host 0.0.0.0 \
    --request-timeout-secs 7200 \
    --port 30000
```

#### Test gsm8k
```
python3 sglang/python/sglang/test/few_shot_gsm8k.py 
100%|███████████████████████████████████████████████████████████████████████████| 200/200 [02:07<00:00,  1.57it/s]
Accuracy: 0.845
Invalid: 0.000
Latency: 142.123 s
Output throughput: 248.525 token/s
```


### CUDA Platform(H20)
#### Run prefill server
```
export SGLANG_OPT_USE_JIT_EP_ACTIVATION=0
SGLANG_DEEPEP_BF16_DISPATCH=1 python3 -m sglang.launch_server \
    --model $MODEL \
    --trust-remote-code \
    --tp-size 4 \
    --ep-size 4 \
    --dp-size 4 \
    --moe-runner-backend deep_gemm \
    --deepep-config /home/dist/config.json \
    --enable-dp-lm-head \
    --moe-dense-tp-size 1 \
    --enable-dp-attention \
    --moe-a2a-backend deepep \
    --deepep-mode normal \
    --mem-fraction-static 0.8 \
    --max-running-requests 64 \
    --port 30033 \
    --disable-radix-cache \
    --disaggregation-mode prefill \
    --disaggregation-ib-device mlx5_2,mlx5_3,mlx5_4,mlx5_5
```

<details>

```
/home/dist/qzg/sglang/python/sglang/launch_server.py:54: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(
[2026-05-07 13:38:45] Attention backend not specified. Use fa3 backend by default.
[2026-05-07 13:38:45] DP attention is enabled. The chunked prefill size is adjusted to 2048 to avoid MoE kernel issues. 
[2026-05-07 13:38:45] Cuda graph is disabled because deepep_mode=`normal`
[2026-05-07 13:38:45] DeepEP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[4].
[2026-05-07 13:38:46] server_args=ServerArgs(model_path='/home/dist/models/Qwen3-30B-A3B/', tokenizer_path='/home/dist/models/Qwen3-30B-A3B/', tokenizer_mode='auto', tokenizer_backend='huggingface', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30033, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.8, max_running_requests=64, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=2048, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=0.3, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='cuda', tp_size=4, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, batch_notify_size=16, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=768544959, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, grpc_http_sidecar_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/home/dist/models/Qwen3-30B-A3B/', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, strip_thinking_cache=False, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=4, load_balance_method='follow_bootstrap_room', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, lora_drain_wait_threshold=0.0, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='deep_gemm', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_adaptive=False, speculative_adaptive_config=None, speculative_skip_dp_mlp_sync=False, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=4, moe_a2a_backend='deepep', moe_runner_backend='deep_gemm', record_nolora_graph=True, flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='normal', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config='/home/dist/qzg/config.json', moe_dense_tp_size=1, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, elastic_ep_rejoin=False, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', enable_mis=False, disable_radix_cache=True, cuda_graph_max_bs=512, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], disable_cuda_graph=True, disable_cuda_graph_padding=False, enable_breakable_cuda_graph=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=True, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=True, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, enable_return_indexer_topk=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='prefill', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device='mlx5_2,mlx5_3,mlx5_4,mlx5_5', disaggregation_decode_enable_radix_cache=False, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None, enable_quant_communications=False, msprobe_dump_config=None)
[2026-05-07 13:38:47] CommonKVBootstrapServer started successfully on 127.0.0.1:8998
[2026-05-07 13:38:47] Using default HuggingFace chat template with detected content format: string
[2026-05-07 13:39:05 DP3 TP3 EP3] Init torch distributed begin.
[2026-05-07 13:39:05 DP2 TP2 EP2] Init torch distributed begin.
[2026-05-07 13:39:05 DP0 TP0 EP0] Init torch distributed begin.
[2026-05-07 13:39:06 DP1 TP1 EP1] Init torch distributed begin.
[2026-05-07 13:39:07 DP0 TP0 EP0] sglang is using nccl==2.28.9
[2026-05-07 13:39:08 DP0 TP0 EP0] Init torch distributed ends. elapsed=2.73 s, mem usage=1.13 GB
[2026-05-07 13:39:08 DP1 TP1 EP1] Init torch distributed ends. elapsed=2.44 s, mem usage=1.18 GB
[2026-05-07 13:39:08 DP3 TP3 EP3] Init torch distributed ends. elapsed=3.51 s, mem usage=0.95 GB
[2026-05-07 13:39:08 DP2 TP2 EP2] Init torch distributed ends. elapsed=3.45 s, mem usage=1.18 GB
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:08.529709 90699 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:08.529786 90699 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:08.529803 90699 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:08.529831 90699 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:15109
I0507 13:39:08.529935 90699 transfer_engine_impl.cpp:229] Auto-discovering topology...
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:08.534137 90701 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:08.534266 90701 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:08.534291 90701 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:08.534337 90701 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:16564
I0507 13:39:08.534485 90701 transfer_engine_impl.cpp:229] Auto-discovering topology...
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:08.535908 90700 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:08.536048 90700 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:08.536074 90700 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:08.536119 90700 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:15656
I0507 13:39:08.536269 90700 transfer_engine_impl.cpp:229] Auto-discovering topology...
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:08.537256 90698 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:08.537380 90698 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:08.537402 90698 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:08.537449 90698 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:15653
I0507 13:39:08.537596 90698 transfer_engine_impl.cpp:229] Auto-discovering topology...
I0507 13:39:08.553267 90699 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:08.560199 90701 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:08.564602 90698 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:08.566078 90700 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:08.567693 90701 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:08.574996 90701 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:08.580994 90699 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:08.582204 90701 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:08.584052 90701 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:08.584082 90701 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:08.584108 90701 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.591823 90701 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:08.592954 90701 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:08.592999 90701 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.594167 90698 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:08.594238 90700 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:08.600997 90701 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:08.602056 90701 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:08.602084 90701 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.603988 90700 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:08.609151 90699 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:08.618757 90699 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:08.619724 90698 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:08.621269 90699 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:08.621308 90699 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:08.621340 90699 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.625435 90698 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:08.626780 90698 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:08.626803 90698 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:08.626819 90698 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.627628 90701 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:08.628566 90701 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:08.628592 90701 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.630061 90700 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:08.631456 90699 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:08.632496 90698 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:08.632723 90700 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:08.632730 90699 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:08.632748 90700 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:08.632784 90699 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.632797 90700 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.633284 90698 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:08.633306 90698 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.635596 90701 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:08.636513 90701 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:08.636554 90701 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:08.636617 90701 transfer_engine_impl.cpp:319] installTransport, type=rdma
I0507 13:39:08.638290 90698 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:08.639025 90698 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:08.639043 90698 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.641979 90699 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:08.643085 90699 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:08.643127 90699 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.649245 90698 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:08.650629 90698 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:08.650676 90698 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.651816 90699 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:08.652940 90699 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:08.652980 90699 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.661531 90699 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:08.662639 90700 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:08.662655 90699 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:08.662688 90699 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:08.662763 90699 transfer_engine_impl.cpp:319] installTransport, type=rdma
I0507 13:39:08.664156 90700 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:08.664201 90700 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.678613 90698 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:08.680001 90698 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:08.680047 90698 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:08.680136 90698 transfer_engine_impl.cpp:319] installTransport, type=rdma
I0507 13:39:08.694679 90700 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:08.696080 90700 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:08.696122 90700 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.722611 90700 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:08.724057 90700 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:08.724103 90700 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:08.750686 90700 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:08.752100 90700 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:08.752148 90700 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:08.752252 90700 transfer_engine_impl.cpp:319] installTransport, type=rdma
[2026-05-07 13:39:09 DP3 TP3 EP3] Load weight begin. avail mem=138.53 GB
[2026-05-07 13:39:09 DP0 TP0 EP0] Load weight begin. avail mem=138.34 GB
[2026-05-07 13:39:09 DP1 TP1 EP1] Load weight begin. avail mem=138.29 GB
[2026-05-07 13:39:09 DP2 TP2 EP2] Load weight begin. avail mem=138.29 GB

Multi-thread loading shards:   0% Completed | 0/16 [00:00<?, ?it/s]
Multi-thread loading shards:   6% Completed | 1/16 [00:01<00:15,  1.02s/it]
Multi-thread loading shards:  12% Completed | 2/16 [00:01<00:08,  1.68it/s]
Multi-thread loading shards:  19% Completed | 3/16 [00:01<00:05,  2.18it/s]
Multi-thread loading shards:  25% Completed | 4/16 [00:01<00:04,  2.46it/s]
Multi-thread loading shards:  31% Completed | 5/16 [00:02<00:03,  2.80it/s]
Multi-thread loading shards:  38% Completed | 6/16 [00:02<00:03,  3.08it/s]
Multi-thread loading shards:  44% Completed | 7/16 [00:02<00:02,  3.32it/s]
Multi-thread loading shards:  50% Completed | 8/16 [00:03<00:02,  3.38it/s]
Multi-thread loading shards:  56% Completed | 9/16 [00:03<00:02,  3.47it/s]
Multi-thread loading shards:  62% Completed | 10/16 [00:03<00:01,  3.63it/s]
Multi-thread loading shards:  69% Completed | 11/16 [00:03<00:01,  3.78it/s]
Multi-thread loading shards:  75% Completed | 12/16 [00:04<00:01,  3.90it/s]
Multi-thread loading shards:  81% Completed | 13/16 [00:04<00:00,  3.77it/s]
Multi-thread loading shards:  88% Completed | 14/16 [00:04<00:00,  3.80it/s]
Multi-thread loading shards:  94% Completed | 15/16 [00:04<00:00,  3.89it/s][2026-05-07 13:39:14 DP1 TP1 EP1] Load weight end. elapsed=5.05 s, type=Qwen3MoeForCausalLM, avail mem=121.90 GB, mem usage=16.39 GB.

Multi-thread loading shards: 100% Completed | 16/16 [00:04<00:00,  4.62it/s]
Multi-thread loading shards: 100% Completed | 16/16 [00:04<00:00,  3.26it/s]
[2026-05-07 13:39:14 DP0 TP0 EP0] Load weight end. elapsed=5.19 s, type=Qwen3MoeForCausalLM, avail mem=121.95 GB, mem usage=16.39 GB.
[2026-05-07 13:39:14 DP3 TP3 EP3] Load weight end. elapsed=5.37 s, type=Qwen3MoeForCausalLM, avail mem=122.14 GB, mem usage=16.39 GB.
[2026-05-07 13:39:14 DP2 TP2 EP2] Load weight end. elapsed=5.11 s, type=Qwen3MoeForCausalLM, avail mem=121.90 GB, mem usage=16.39 GB.
[2026-05-07 13:39:14 DP0 TP0 EP0] Using KV cache dtype: torch.bfloat16
[2026-05-07 13:39:15 DP0 TP0 EP0] KV Cache is allocated. #tokens: 1029388, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:15 DP0 TP0 EP0] Memory pool end. avail mem=27.62 GB
[2026-05-07 13:39:15 DP2 TP2 EP2] KV Cache is allocated. #tokens: 1029388, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:15 DP2 TP2 EP2] Memory pool end. avail mem=27.57 GB
[2026-05-07 13:39:15 DP1 TP1 EP1] KV Cache is allocated. #tokens: 1029388, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:15 DP1 TP1 EP1] Memory pool end. avail mem=27.57 GB
[2026-05-07 13:39:15 DP3 TP3 EP3] KV Cache is allocated. #tokens: 1029388, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:15 DP3 TP3 EP3] Memory pool end. avail mem=27.80 GB
[2026-05-07 13:39:15 DP1 TP1 EP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:15 DP0 TP0 EP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:15 DP2 TP2 EP2] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:15 DP3 TP3 EP3] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:16 DP0 TP0 EP0] max_total_num_tokens=1029388, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=16, context_len=40960, available_gpu_mem=27.52 GB
[2026-05-07 13:39:30] INFO:     Started server process [89490]
[2026-05-07 13:39:30] INFO:     Waiting for application startup.
[2026-05-07 13:39:30] Using default chat sampling params from model generation config: {'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-05-07 13:39:30] INFO:     Application startup complete.
[2026-05-07 13:39:30] INFO:     Uvicorn running on http://127.0.0.1:30033 (Press CTRL+C to quit)
[2026-05-07 13:39:31] INFO:     127.0.0.1:59032 - "GET /model_info HTTP/1.1" 200 OK
[2026-05-07 13:39:31] Start of pd disaggregation warmup ...
[2026-05-07 13:39:33 DP0 TP0 EP0] Use DeepEP Config: {'normal_dispatch': {'num_sms': 60, 'num_max_nvl_chunked_send_tokens': 26}, 'normal_combine': {'num_sms': 60, 'num_max_nvl_chunked_send_tokens': 16}}
[2026-05-07 13:39:34 DP2 TP2 EP2] Prefill batch, #new-seq: 1, #new-token: 4, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 0.13
[2026-05-07 13:39:34 DP3 TP3 EP3] Prefill batch, #new-seq: 1, #new-token: 4, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 0.13
[2026-05-07 13:39:34 DP0 TP0 EP0] Prefill batch, #new-seq: 1, #new-token: 4, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 0.14
[2026-05-07 13:39:34 DP1 TP1 EP1] Prefill batch, #new-seq: 1, #new-token: 4, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 0.14
[2026-05-07 13:39:34] INFO:     127.0.0.1:59036 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:39:34] Disaggregation warmup request completed with status 200, resp: [{'text': ' ', 'output_ids': [220], 'meta_info': {'id': '867b3456ed3c4d3db58ef001255d9759', 'finish_reason': {'type': 'length', 'length': 0}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 1, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 0, 'e2e_latency': 2.7772847621235996, 'response_sent_to_client_ts': 1778161174.3082063}}, {'text': ' ', 'output_ids': [220], 'meta_info': {'id': '09d77d638f78494b97cf54c658ac45a1', 'finish_reason': {'type': 'length', 'length': 0}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 1, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 1, 'e2e_latency': 2.7787546899635345, 'response_sent_to_client_ts': 1778161174.3094625}}, {'text': ' ', 'output_ids': [220], 'meta_info': {'id': '931eac7f50d54a5ca5834e6a6e7542f0', 'finish_reason': {'type': 'length', 'length': 0}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 1, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 2, 'e2e_latency': 2.7779208049178123, 'response_sent_to_client_ts': 1778161174.308716}}, {'text': ' ', 'output_ids': [220], 'meta_info': {'id': '2c1ff58c01cb496cb1a035aa3845db62', 'finish_reason': {'type': 'length', 'length': 0}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 1, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 3, 'e2e_latency': 2.778366065118462, 'response_sent_to_client_ts': 1778161174.3091042}}]
[2026-05-07 13:39:34] End of disaggregation warmup
[2026-05-07 13:39:34] The server is fired up and ready to roll!
[2026-05-07 13:40:36] INFO:     127.0.0.1:35518 - "GET /model_info HTTP/1.1" 200 OK
[2026-05-07 13:40:36 DP3 TP3 EP3] Prefill batch, #new-seq: 1, #new-token: 789, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 1, cuda graph: False, input throughput (token/s): 12.62
[2026-05-07 13:40:36] INFO:     127.0.0.1:35530 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37 DP0 TP0 EP0] Prefill batch, #new-seq: 1, #new-token: 857, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 5, #pending-token: 0, #bootstrap-req: 2, #inflight-req: 1, cuda graph: False, input throughput (token/s): 13.61
[2026-05-07 13:40:37 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 14, #pending-token: 4799, #bootstrap-req: 0, #inflight-req: 3, cuda graph: False, input throughput (token/s): 10327.28
[2026-05-07 13:40:37 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 23, #pending-token: 5593, #bootstrap-req: 0, #inflight-req: 2, cuda graph: False, input throughput (token/s): 3273.39
[2026-05-07 13:40:37] INFO:     127.0.0.1:35534 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 18, #pending-token: 7307, #bootstrap-req: 0, #inflight-req: 2, cuda graph: False, input throughput (token/s): 32.42
[2026-05-07 13:40:37 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 13, #pending-token: 3839, #bootstrap-req: 0, #inflight-req: 2, cuda graph: False, input throughput (token/s): 32.42
[2026-05-07 13:40:37 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 24, #pending-token: 19731, #bootstrap-req: 6, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12092.93
[2026-05-07 13:40:37 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 18, #pending-token: 12105, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12039.89
[2026-05-07 13:40:37 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 22, #pending-token: 11303, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12289.78
[2026-05-07 13:40:37 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 24, #pending-token: 15425, #bootstrap-req: 1, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12148.28
[2026-05-07 13:40:37] INFO:     127.0.0.1:35608 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35618 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35542 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35562 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35564 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35612 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35552 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35568 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37 DP2 TP2 EP2] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 23, #pending-token: 21097, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11954.93
[2026-05-07 13:40:37 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 24, #pending-token: 21091, #bootstrap-req: 4, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11848.82
[2026-05-07 13:40:37 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 20, #pending-token: 19570, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11825.52
[2026-05-07 13:40:37 DP0 TP0 EP0] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 16, #pending-token: 15999, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11805.37
[2026-05-07 13:40:37] INFO:     127.0.0.1:35624 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35702 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35584 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35598 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35640 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35670 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35660 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35684 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 13, #pending-token: 13951, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13010.84
[2026-05-07 13:40:37 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 23, #pending-token: 20758, #bootstrap-req: 2, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12939.63
[2026-05-07 13:40:37 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 17, #pending-token: 17522, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12959.78
[2026-05-07 13:40:37 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 20, #pending-token: 19896, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12862.07
[2026-05-07 13:40:37] INFO:     127.0.0.1:35686 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35696 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35698 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35786 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35794 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35808 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35734 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35740 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35798 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35606 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35648 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37] INFO:     127.0.0.1:35714 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 15, #pending-token: 15474, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13144.28
[2026-05-07 13:40:38 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 24, #pending-token: 20459, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13102.65
[2026-05-07 13:40:38 DP0 TP0 EP0] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 11, #pending-token: 11903, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13080.28
[2026-05-07 13:40:38 DP2 TP2 EP2] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 18, #pending-token: 17848, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13109.80
[2026-05-07 13:40:38] INFO:     127.0.0.1:35862 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35906 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35760 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35850 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35824 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35836 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35728 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35730 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 9, #pending-token: 9855, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11960.98
[2026-05-07 13:40:38 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 14, #pending-token: 13426, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11906.19
[2026-05-07 13:40:38 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 16, #pending-token: 15800, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11951.44
[2026-05-07 13:40:38 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 23, #pending-token: 20980, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11887.61
[2026-05-07 13:40:38] INFO:     127.0.0.1:35876 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35930 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35986 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35910 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35916 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35962 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35750 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35776 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35892 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35924 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35948 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35976 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 11, #pending-token: 12234, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 13289.61
[2026-05-07 13:40:38 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 13, #pending-token: 13752, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 13297.28
[2026-05-07 13:40:38 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 20, #pending-token: 19779, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 13313.42
[2026-05-07 13:40:38 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 7, #pending-token: 7807, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 13231.14
[2026-05-07 13:40:38] INFO:     127.0.0.1:35978 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36002 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36014 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36036 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35938 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:35944 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36112 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36128 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP2 TP2 EP2] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 11, #pending-token: 11704, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13253.97
[2026-05-07 13:40:38 DP0 TP0 EP0] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 5, #pending-token: 6586, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13266.27
[2026-05-07 13:40:38 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 18, #pending-token: 17731, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13246.40
[2026-05-07 13:40:38 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 9, #pending-token: 10186, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13214.51
[2026-05-07 13:40:38] INFO:     127.0.0.1:35994 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36022 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36190 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36202 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36054 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36198 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36044 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36072 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 15, #pending-token: 15683, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13089.55
[2026-05-07 13:40:38 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 7, #pending-token: 8138, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13087.38
[2026-05-07 13:40:38 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 2, #pending-token: 4538, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13026.16
[2026-05-07 13:40:38 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 8, #pending-token: 9656, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13008.96
[2026-05-07 13:40:38] INFO:     127.0.0.1:36208 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36340 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36388 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36084 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36106 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36114 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36060 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36100 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36104 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36234 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36238 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36290 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 6, #pending-token: 6090, #bootstrap-req: 1, #inflight-req: 4, cuda graph: False, input throughput (token/s): 11733.71
[2026-05-07 13:40:38 DP0 TP0 EP0] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 1, #pending-token: 2490, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11757.64
[2026-05-07 13:40:38 DP2 TP2 EP2] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 10, #pending-token: 7608, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11748.53
[2026-05-07 13:40:38 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 14, #pending-token: 13635, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11663.57
[2026-05-07 13:40:38] INFO:     127.0.0.1:36408 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36530 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36394 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36468 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36116 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36156 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36140 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:36258 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 1, #pending-token: 1308, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13190.41
[2026-05-07 13:40:39 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 15, #pending-token: 12426, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13211.09
[2026-05-07 13:40:39 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 8, #pending-token: 8909, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13168.17
[2026-05-07 13:40:39 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 6, #pending-token: 5746, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13113.08
[2026-05-07 13:40:39] INFO:     127.0.0.1:36166 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36174 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36220 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36554 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36570 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36656 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36518 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36544 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36306 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36322 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36370 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 5, #pending-token: 6861, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12571.48
[2026-05-07 13:40:39 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 12, #pending-token: 12900, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12546.49
[2026-05-07 13:40:39 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 5, #pending-token: 5456, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12557.94
[2026-05-07 13:40:39 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0, #pending-token: 976, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12480.68
[2026-05-07 13:40:39] INFO:     127.0.0.1:36372 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36424 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36254 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36274 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36666 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36688 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36576 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36590 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36622 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 1894, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 3, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12249.39
[2026-05-07 13:40:39 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 10, #pending-token: 10852, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13216.48
[2026-05-07 13:40:39 DP2 TP2 EP2] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 4, #pending-token: 4813, #bootstrap-req: 1, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13161.05
[2026-05-07 13:40:39 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 6, #pending-token: 5100, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13179.43
[2026-05-07 13:40:39] INFO:     127.0.0.1:36648 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36680 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36338 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36352 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36442 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36484 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36784 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36842 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 5, #pending-token: 5677, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13121.11
[2026-05-07 13:40:39 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 4, #pending-token: 3616, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13075.98
[2026-05-07 13:40:39 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 1, #pending-token: 3163, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13019.96
[2026-05-07 13:40:39 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 8, #pending-token: 8804, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12993.67
[2026-05-07 13:40:39] INFO:     127.0.0.1:36702 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36706 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36768 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36506 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36606 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36638 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36908 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36920 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36928 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36354 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36402 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36430 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 2, #pending-token: 1115, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12100.76
[2026-05-07 13:40:39 DP2 TP2 EP2] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 2, #pending-token: 4141, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12055.60
[2026-05-07 13:40:39 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 2, #pending-token: 4464, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12028.20
[2026-05-07 13:40:39 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 7, #pending-token: 7605, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12029.90
[2026-05-07 13:40:39] INFO:     127.0.0.1:36828 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36838 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36954 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36956 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36454 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36482 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36672 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36738 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 3, #pending-token: 2416, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11969.26
[2026-05-07 13:40:39 DP0 TP0 EP0] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 2, #pending-token: 2386, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11936.45
[2026-05-07 13:40:39 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0, #pending-token: 2093, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11947.82
[2026-05-07 13:40:39 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 8, #pending-token: 6467, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 12003.46
[2026-05-07 13:40:39] INFO:     127.0.0.1:36858 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36894 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36976 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36990 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36788 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36790 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36800 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36500 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36634 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:36670 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 4, #pending-token: 2079, #bootstrap-req: 1, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13022.44
[2026-05-07 13:40:40 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 3, #pending-token: 2957, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13004.78
[2026-05-07 13:40:40 DP2 TP2 EP2] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 45, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 13014.66
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 8, #pending-token: 6986, #bootstrap-req: 1, #inflight-req: 4, cuda graph: False, input throughput (token/s): 13029.27
[2026-05-07 13:40:40] INFO:     127.0.0.1:36814 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37036 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37002 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37008 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37096 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36934 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36944 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36948 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36722 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36752 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 1, #pending-token: 2744, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12040.37
[2026-05-07 13:40:40 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 3, #pending-token: 3427, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 12018.72
[2026-05-07 13:40:40 DP2 TP2 EP2] Prefill batch, #new-seq: 2, #new-token: 880, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 5170.10
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 7, #pending-token: 7434, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 11968.99
[2026-05-07 13:40:40] INFO:     127.0.0.1:37108 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37124 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37044 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37052 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36966 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37024 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36760 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36772 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 8, #pending-token: 6247, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13953.23
[2026-05-07 13:40:40 DP0 TP0 EP0] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 2, #pending-token: 3089, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13839.36
[2026-05-07 13:40:40 DP2 TP2 EP2] Prefill batch, #new-seq: 2, #new-token: 1742, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 11779.98
[2026-05-07 13:40:40 DP1 TP1 EP1] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0, #pending-token: 1518, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 13792.81
[2026-05-07 13:40:40] INFO:     127.0.0.1:36848 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36866 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36878 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37138 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37172 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37216 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37080 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37226 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37064 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37150 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37166 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP2 TP2 EP2] Prefill batch, #new-seq: 1, #new-token: 871, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 3, cuda graph: False, input throughput (token/s): 6719.07
[2026-05-07 13:40:40 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0, #pending-token: 1909, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 15731.46
[2026-05-07 13:40:40 DP1 TP1 EP1] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 305, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 15750.75
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 5, #pending-token: 6710, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 15668.89
[2026-05-07 13:40:40] INFO:     127.0.0.1:37240 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37246 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37186 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37284 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37346 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37364 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:36882 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37066 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP1 TP1 EP1] Prefill batch, #new-seq: 1, #new-token: 305, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 3, cuda graph: False, input throughput (token/s): 2289.59
[2026-05-07 13:40:40 DP0 TP0 EP0] Prefill batch, #new-seq: 3, #new-token: 1909, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 14274.54
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 3, #pending-token: 4662, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 15202.89
[2026-05-07 13:40:40] INFO:     127.0.0.1:37262 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37298 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37414 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37300 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37340 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37094 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37178 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37202 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37380 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 3, #new-token: 2048, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0, #pending-token: 2614, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 20204.58
[2026-05-07 13:40:40] INFO:     127.0.0.1:37324 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37352 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37402 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37208 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37272 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 4, #new-token: 2048, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 566, #bootstrap-req: 0, #inflight-req: 5, cuda graph: False, input throughput (token/s): 18853.02
[2026-05-07 13:40:40] INFO:     127.0.0.1:37294 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37310 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP3 TP3 EP3] Prefill batch, #new-seq: 1, #new-token: 566, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, #bootstrap-req: 0, #inflight-req: 4, cuda graph: False, input throughput (token/s): 162183.32
[2026-05-07 13:40:40] INFO:     127.0.0.1:37332 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37376 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37378 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:37394 - "POST /generate HTTP/1.1" 200 OK

```
</details>


#### Run decode server
```
export SGLANG_OPT_USE_JIT_EP_ACTIVATION=0
SGLANG_DEEPEP_BF16_DISPATCH=1 python3 -m sglang.launch_server \
    --model $MODEL \
    --trust-remote-code \
    --tp-size 4 \
    --ep-size 4 \
    --dp-size 4 \
    --base-gpu-id 4 \
    --moe-runner-backend deep_gemm \
    --enable-dp-lm-head \
    --moe-dense-tp-size 1 \
    --enable-dp-attention \
    --moe-a2a-backend deepep \
    --deepep-mode low_latency \
    --mem-fraction-static 0.8 \
    --disable-radix-cache \
    --port 30044 \
    --max-running-requests 128 \
    --disaggregation-mode decode \
    --disaggregation-ib-device mlx5_2,mlx5_3,mlx5_4,mlx5_5
```

<details>

```
/home/dist/qzg/sglang/python/sglang/launch_server.py:54: UserWarning: 'python -m sglang.launch_server' is still supported, but 'sglang serve' is the recommended entrypoint.
  Example: sglang serve --model-path <model> [options]
  warnings.warn(
[2026-05-07 13:38:44] KV cache is forced as chunk cache for decode server
[2026-05-07 13:38:45] Attention backend not specified. Use fa3 backend by default.
[2026-05-07 13:38:45] DP attention is enabled. The chunked prefill size is adjusted to 2048 to avoid MoE kernel issues. 
[2026-05-07 13:38:45] DeepEP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[4].
[2026-05-07 13:38:46] server_args=ServerArgs(model_path='/home/dist/models/Qwen3-30B-A3B/', tokenizer_path='/home/dist/models/Qwen3-30B-A3B/', tokenizer_mode='auto', tokenizer_backend='huggingface', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30044, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_keyfile_password=None, enable_ssl_refresh=False, enable_http2=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.8, max_running_requests=128, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=2048, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, disable_priority_preemption=False, default_priority_value=None, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=0.3, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='cuda', tp_size=4, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, batch_notify_size=16, stream_response_default_include_usage=False, incremental_streaming_output=False, enable_streaming_session=False, random_seed=574838647, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=4, gpu_id_step=1, sleep_on_idle=False, use_ray=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, grpc_http_sidecar_port=None, enable_mfu_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/home/dist/models/Qwen3-30B-A3B/', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, strip_thinking_cache=False, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=4, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, experts_shared_outer_loras=None, lora_use_virtual_experts=False, lora_strict_loading=False, lora_drain_wait_threshold=0.0, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, mamba_backend='triton', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_dflash_block_size=None, speculative_dflash_draft_window_size=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='deep_gemm', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_adaptive=False, speculative_adaptive_config=None, speculative_skip_dp_mlp_sync=False, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_max_trie_depth=18, speculative_ngram_capacity=10000000, speculative_ngram_external_corpus_path=None, speculative_ngram_external_sam_budget=0, speculative_ngram_external_corpus_max_tokens=10000000, enable_multi_layer_eagle=False, ep_size=4, moe_a2a_backend='deepep', moe_runner_backend='deep_gemm', record_nolora_graph=True, flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, enforce_disable_flashinfer_allreduce_fusion=False, enable_aiter_allreduce_fusion=False, deepep_mode='low_latency', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=1, elastic_ep_backend=None, enable_elastic_expert_backup=False, mooncake_ib_device=None, elastic_ep_rejoin=False, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, linear_attn_backend='triton', linear_attn_decode_backend=None, linear_attn_prefill_backend=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_hisparse=False, hisparse_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', enable_mis=False, disable_radix_cache=True, cuda_graph_max_bs=512, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_breakable_cuda_graph=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, debug_cuda_graph=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, pre_warm_nccl=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=True, enable_dp_attention_local_control_broadcast=False, enable_dp_lm_head=True, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, disable_piecewise_cuda_graph=True, enforce_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, enforce_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, enable_return_indexer_topk=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, gc_threshold=None, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_fused_moe_sum_all_reduce=False, enable_prefill_context_parallel=False, prefill_cp_mode='in-seq-split', enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='decode', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_ib_device='mlx5_2,mlx5_3,mlx5_4,mlx5_5', disaggregation_decode_enable_radix_cache=False, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], enable_adaptive_dispatch_to_encoder=False, custom_weight_loader=[], weight_loader_disable_mmap=False, weight_loader_prefetch_checkpoints=False, weight_loader_prefetch_num_threads=4, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, engine_info_bootstrap_port=6789, modelexpress_config=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, enable_mm_global_cache=False, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None, enable_quant_communications=False, msprobe_dump_config=None)
[2026-05-07 13:38:47] Using default HuggingFace chat template with detected content format: string
[2026-05-07 13:39:03 DP1 TP1 EP1] Init torch distributed begin.
[2026-05-07 13:39:03 DP0 TP0 EP0] Init torch distributed begin.
[2026-05-07 13:39:04 DP3 TP3 EP3] Init torch distributed begin.
[2026-05-07 13:39:04 DP2 TP2 EP2] Init torch distributed begin.
[2026-05-07 13:39:05 DP0 TP0 EP0] sglang is using nccl==2.28.9
[2026-05-07 13:39:06 DP1 TP1 EP1] Init torch distributed ends. elapsed=3.65 s, mem usage=1.18 GB
[2026-05-07 13:39:06 DP3 TP3 EP3] Init torch distributed ends. elapsed=2.73 s, mem usage=0.95 GB
[2026-05-07 13:39:06 DP0 TP0 EP0] Init torch distributed ends. elapsed=2.99 s, mem usage=1.13 GB
[2026-05-07 13:39:06 DP2 TP2 EP2] Init torch distributed ends. elapsed=2.58 s, mem usage=1.18 GB
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:06.933516 90427 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:06.933594 90427 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:06.933614 90427 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:06.933646 90427 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:16177
I0507 13:39:06.933760 90427 transfer_engine_impl.cpp:229] Auto-discovering topology...
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:06.935034 90429 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:06.935112 90429 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:06.935128 90429 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:06.935158 90429 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:16065
I0507 13:39:06.935242 90429 transfer_engine_impl.cpp:229] Auto-discovering topology...
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:06.940162 90426 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:06.940284 90426 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:06.940306 90426 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:06.940357 90426 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:16579
I0507 13:39:06.940502 90426 transfer_engine_impl.cpp:229] Auto-discovering topology...
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0507 13:39:06.945129 90428 transfer_engine_py.cpp:92] Using default malloc/free for protocol: rdma
I0507 13:39:06.945335 90428 transfer_engine_impl.cpp:757] Metrics reporting is disabled (set MC_TE_METRIC=1 to enable)
I0507 13:39:06.945361 90428 transfer_engine_impl.cpp:107] Transfer Engine parseHostNameWithPort. server_name: 10.10.142.201 port: 12001
I0507 13:39:06.945416 90428 transfer_engine_impl.cpp:174] Transfer Engine RPC using P2P handshake, listening on 10.10.142.201:15069
I0507 13:39:06.945648 90428 transfer_engine_impl.cpp:229] Auto-discovering topology...
I0507 13:39:06.957267 90427 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:06.961915 90429 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:06.964658 90426 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:06.967242 90429 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:06.968525 90426 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:06.972378 90426 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:06.972424 90429 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:06.974089 90428 topology.cpp:124] Device mlx5_2 port 1 is available
I0507 13:39:06.977505 90429 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:06.978760 90429 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:06.978783 90429 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:06.978803 90429 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:06.983098 90428 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:06.984031 90427 topology.cpp:124] Device mlx5_3 port 1 is available
I0507 13:39:06.984154 90429 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:06.985409 90429 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:06.985433 90429 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:06.990952 90429 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:06.991509 90427 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:06.991515 90428 topology.cpp:124] Device mlx5_4 port 1 is available
I0507 13:39:06.992125 90429 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:06.992144 90429 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:06.997673 90429 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:06.997941 90426 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:06.998736 90429 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:06.998759 90429 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:06.999281 90428 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:07.000875 90426 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:07.000919 90426 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:07.000950 90426 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.001669 90428 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:07.001703 90428 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:07.001725 90428 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.009840 90428 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:07.011022 90428 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:07.011060 90428 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.016363 90427 topology.cpp:124] Device mlx5_5 port 1 is available
I0507 13:39:07.018373 90427 transfer_engine_impl.cpp:244] Topology discovery complete. Found 4 HCAs.
I0507 13:39:07.018405 90427 rdma_transport.cpp:63] [RDMA] Relaxed ordering disabled via MC_IB_PCI_RELAXED_ORDERING=0. Falling back to strict ordering.
I0507 13:39:07.018430 90427 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.022392 90429 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:07.023514 90429 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:07.023537 90429 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:07.023592 90429 transfer_engine_impl.cpp:319] installTransport, type=rdma
I0507 13:39:07.026944 90427 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:07.028151 90427 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:07.028198 90427 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.030475 90426 rdma_context.cpp:610] Find best gid index: 0 on mlx5_4/ (network state: without network device)
I0507 13:39:07.031817 90426 rdma_context.cpp:140] RDMA device: mlx5_4, LID: 5, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:81:0c
I0507 13:39:07.031857 90426 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.036335 90428 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:07.037436 90428 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:07.037464 90428 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.057142 90427 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:07.058341 90427 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:07.058373 90427 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.058521 90426 rdma_context.cpp:610] Find best gid index: 0 on mlx5_5/ (network state: without network device)
I0507 13:39:07.059850 90426 rdma_context.cpp:140] RDMA device: mlx5_5, LID: 18, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:38:82:fc
I0507 13:39:07.059890 90426 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.070412 90428 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:07.071664 90428 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:07.071699 90428 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.081043 90428 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:07.082203 90428 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:07.082242 90428 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:07.082331 90428 transfer_engine_impl.cpp:319] installTransport, type=rdma
I0507 13:39:07.086997 90427 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:07.087024 90426 rdma_context.cpp:610] Find best gid index: 0 on mlx5_2/ (network state: without network device)
I0507 13:39:07.088375 90426 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:07.088413 90426 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.088516 90427 rdma_context.cpp:140] RDMA device: mlx5_2, LID: 17, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:86:fa
I0507 13:39:07.088562 90427 rdma_context.cpp:77] Using SIEVE endpoint store
I0507 13:39:07.099005 90427 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:07.100443 90427 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:07.100497 90427 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:07.100593 90427 transfer_engine_impl.cpp:319] installTransport, type=rdma
I0507 13:39:07.118577 90426 rdma_context.cpp:610] Find best gid index: 0 on mlx5_3/ (network state: without network device)
I0507 13:39:07.119750 90426 rdma_context.cpp:140] RDMA device: mlx5_3, LID: 11, GID: (GID_Index 0) fe:80:00:00:00:00:00:00:b8:3f:d2:03:00:56:82:a2
E0507 13:39:07.119771 90426 transfer_metadata.cpp:863] Local segment descriptor not found
I0507 13:39:07.119810 90426 transfer_engine_impl.cpp:319] installTransport, type=rdma
[2026-05-07 13:39:07 DP0 TP0 EP0] Load weight begin. avail mem=138.34 GB
[2026-05-07 13:39:07 DP2 TP2 EP2] Load weight begin. avail mem=138.29 GB
[2026-05-07 13:39:07 DP3 TP3 EP3] Load weight begin. avail mem=138.53 GB
[2026-05-07 13:39:07 DP1 TP1 EP1] Load weight begin. avail mem=138.29 GB

Multi-thread loading shards:   0% Completed | 0/16 [00:00<?, ?it/s]
Multi-thread loading shards:   6% Completed | 1/16 [00:00<00:14,  1.04it/s]
Multi-thread loading shards:  12% Completed | 2/16 [00:01<00:07,  1.82it/s]
Multi-thread loading shards:  19% Completed | 3/16 [00:01<00:05,  2.34it/s]
Multi-thread loading shards:  25% Completed | 4/16 [00:01<00:04,  2.67it/s]
Multi-thread loading shards:  31% Completed | 5/16 [00:02<00:03,  3.00it/s]
Multi-thread loading shards:  38% Completed | 6/16 [00:02<00:03,  3.20it/s]
Multi-thread loading shards:  44% Completed | 7/16 [00:02<00:02,  3.43it/s]
Multi-thread loading shards:  50% Completed | 8/16 [00:02<00:02,  3.45it/s]
Multi-thread loading shards:  56% Completed | 9/16 [00:03<00:01,  3.52it/s]
Multi-thread loading shards:  62% Completed | 10/16 [00:03<00:01,  3.67it/s]
Multi-thread loading shards:  69% Completed | 11/16 [00:03<00:01,  3.79it/s]
Multi-thread loading shards:  75% Completed | 12/16 [00:03<00:01,  3.88it/s]
Multi-thread loading shards:  81% Completed | 13/16 [00:04<00:00,  3.72it/s]
Multi-thread loading shards:  88% Completed | 14/16 [00:04<00:00,  3.86it/s]
Multi-thread loading shards:  94% Completed | 15/16 [00:04<00:00,  4.04it/s]
Multi-thread loading shards: 100% Completed | 16/16 [00:04<00:00,  4.84it/s]
Multi-thread loading shards: 100% Completed | 16/16 [00:04<00:00,  3.38it/s]
[2026-05-07 13:39:13 DP0 TP0 EP0] Load weight end. elapsed=5.38 s, type=Qwen3MoeForCausalLM, avail mem=121.95 GB, mem usage=16.39 GB.
[2026-05-07 13:39:13 DP2 TP2 EP2] Load weight end. elapsed=5.55 s, type=Qwen3MoeForCausalLM, avail mem=121.90 GB, mem usage=16.39 GB.
[2026-05-07 13:39:13 DP3 TP3 EP3] Load weight end. elapsed=5.57 s, type=Qwen3MoeForCausalLM, avail mem=122.14 GB, mem usage=16.39 GB.
[2026-05-07 13:39:13 DP1 TP1 EP1] Load weight end. elapsed=5.69 s, type=Qwen3MoeForCausalLM, avail mem=121.90 GB, mem usage=16.39 GB.
[2026-05-07 13:39:13 DP0 TP0 EP0] Using KV cache dtype: torch.bfloat16
[2026-05-07 13:39:13 DP0 TP0 EP0] KV Cache is allocated. #tokens: 1029389, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:13 DP0 TP0 EP0] Memory pool end. avail mem=27.60 GB
[2026-05-07 13:39:13 DP1 TP1 EP1] KV Cache is allocated. #tokens: 1029389, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:13 DP1 TP1 EP1] Memory pool end. avail mem=27.55 GB
[2026-05-07 13:39:13 DP3 TP3 EP3] KV Cache is allocated. #tokens: 1029389, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:13 DP3 TP3 EP3] Memory pool end. avail mem=27.79 GB
[2026-05-07 13:39:13 DP2 TP2 EP2] KV Cache is allocated. #tokens: 1029389, K size: 47.12 GB, V size: 47.12 GB
[2026-05-07 13:39:13 DP2 TP2 EP2] Memory pool end. avail mem=27.55 GB
[2026-05-07 13:39:13 DP2 TP2 EP2] Capture cuda graph begin. This can take up to several minutes. avail mem=27.46 GB
[2026-05-07 13:39:13 DP3 TP3 EP3] Capture cuda graph begin. This can take up to several minutes. avail mem=27.70 GB
[2026-05-07 13:39:13 DP1 TP1 EP1] Capture cuda graph begin. This can take up to several minutes. avail mem=27.46 GB
[2026-05-07 13:39:13 DP0 TP0 EP0] Capture cuda graph begin. This can take up to several minutes. avail mem=27.51 GB
[2026-05-07 13:39:13 DP0 TP0 EP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32]

  0%|          | 0/8 [00:00<?, ?it/s]
Capturing batches (bs=32 avail_mem=27.49 GB):   0%|          | 0/8 [00:00<?, ?it/s]
Capturing batches (bs=32 avail_mem=27.49 GB):  12%|█▎        | 1/8 [00:05<00:39,  5.62s/it]
Capturing batches (bs=24 avail_mem=21.80 GB):  12%|█▎        | 1/8 [00:05<00:39,  5.62s/it]
Capturing batches (bs=24 avail_mem=21.80 GB):  25%|██▌       | 2/8 [00:05<00:15,  2.50s/it]
Capturing batches (bs=16 avail_mem=21.80 GB):  25%|██▌       | 2/8 [00:05<00:15,  2.50s/it]
Capturing batches (bs=16 avail_mem=21.80 GB):  38%|███▊      | 3/8 [00:06<00:07,  1.47s/it]
Capturing batches (bs=12 avail_mem=21.80 GB):  38%|███▊      | 3/8 [00:06<00:07,  1.47s/it]
Capturing batches (bs=12 avail_mem=21.80 GB):  50%|█████     | 4/8 [00:06<00:03,  1.04it/s]
Capturing batches (bs=8 avail_mem=21.79 GB):  50%|█████     | 4/8 [00:06<00:03,  1.04it/s] 
Capturing batches (bs=8 avail_mem=21.79 GB):  62%|██████▎   | 5/8 [00:06<00:02,  1.47it/s]
Capturing batches (bs=4 avail_mem=21.79 GB):  62%|██████▎   | 5/8 [00:06<00:02,  1.47it/s]
Capturing batches (bs=4 avail_mem=21.79 GB):  75%|███████▌  | 6/8 [00:06<00:01,  1.95it/s]
Capturing batches (bs=2 avail_mem=21.79 GB):  75%|███████▌  | 6/8 [00:06<00:01,  1.95it/s]
Capturing batches (bs=2 avail_mem=21.79 GB):  88%|████████▊ | 7/8 [00:07<00:00,  2.27it/s]
Capturing batches (bs=1 avail_mem=21.78 GB):  88%|████████▊ | 7/8 [00:07<00:00,  2.27it/s]
Capturing batches (bs=1 avail_mem=21.78 GB): 100%|██████████| 8/8 [00:07<00:00,  2.63it/s]
Capturing batches (bs=1 avail_mem=21.78 GB): 100%|██████████| 8/8 [00:07<00:00,  1.10it/s]
[2026-05-07 13:39:21 DP0 TP0 EP0] Registering 0 cuda graph addresses
[2026-05-07 13:39:21 DP3 TP3 EP3] Capture cuda graph end. Time elapsed: 7.93 s. mem usage=4.79 GB. avail mem=22.91 GB.
[2026-05-07 13:39:21 DP3 TP3 EP3] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:21 DP0 TP0 EP0] Capture cuda graph end. Time elapsed: 7.92 s. mem usage=5.73 GB. avail mem=21.78 GB.
[2026-05-07 13:39:21 DP0 TP0 EP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:21 DP2 TP2 EP2] Capture cuda graph end. Time elapsed: 7.94 s. mem usage=5.96 GB. avail mem=21.50 GB.
[2026-05-07 13:39:21 DP2 TP2 EP2] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:21 DP1 TP1 EP1] Capture cuda graph end. Time elapsed: 7.95 s. mem usage=5.96 GB. avail mem=21.50 GB.
[2026-05-07 13:39:21 DP1 TP1 EP1] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
[2026-05-07 13:39:22 DP0 TP0 EP0] max_total_num_tokens=1029389, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=32, context_len=40960, available_gpu_mem=21.78 GB
[2026-05-07 13:39:31] INFO:     Started server process [89491]
[2026-05-07 13:39:31] INFO:     Waiting for application startup.
[2026-05-07 13:39:31] Using default chat sampling params from model generation config: {'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-05-07 13:39:31] INFO:     Application startup complete.
[2026-05-07 13:39:31] INFO:     Uvicorn running on http://127.0.0.1:30044 (Press CTRL+C to quit)
[2026-05-07 13:39:32] INFO:     127.0.0.1:36798 - "GET /model_info HTTP/1.1" 200 OK
[2026-05-07 13:39:32] Start of pd disaggregation warmup ...
[2026-05-07 13:39:33] INFO:     127.0.0.1:36806 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:39:33] Disaggregation warmup request completed with status 200, resp: [{'text': '![](http://www.81', 'output_ids': [0, 50994, 1254, 1110, 2136, 13, 23, 16], 'meta_info': {'id': '2905544cbf404669b683e213eb66148d', 'finish_reason': {'type': 'length', 'length': 8}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 8, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 0, 'e2e_latency': 1.1065701129846275, 'response_sent_to_client_ts': 1778161173.8817852}}, {'text': '![](http://www.81', 'output_ids': [0, 50994, 1254, 1110, 2136, 13, 23, 16], 'meta_info': {'id': 'f52ef84b6f4742f1b9668cd8132815f6', 'finish_reason': {'type': 'length', 'length': 8}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 8, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 1, 'e2e_latency': 1.113453104859218, 'response_sent_to_client_ts': 1778161173.8886678}}, {'text': '![](http://www.81', 'output_ids': [0, 50994, 1254, 1110, 2136, 13, 23, 16], 'meta_info': {'id': '0c8c962823914daca01dd94b3f04d742', 'finish_reason': {'type': 'length', 'length': 8}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 8, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 2, 'e2e_latency': 1.1127808559685946, 'response_sent_to_client_ts': 1778161173.8880205}}, {'text': '![](http://www.81', 'output_ids': [0, 50994, 1254, 1110, 2136, 13, 23, 16], 'meta_info': {'id': '2635cab1daca4f7ca8fe03bb4dc02c19', 'finish_reason': {'type': 'length', 'length': 8}, 'prompt_tokens': 4, 'weight_version': 'default', 'total_retractions': 0, 'reasoning_tokens': 0, 'completion_tokens': 8, 'cached_tokens': 0, 'cached_tokens_details': None, 'dp_rank': 3, 'e2e_latency': 1.1131154131144285, 'response_sent_to_client_ts': 1778161173.8883526}}]
[2026-05-07 13:39:33] End of disaggregation warmup
[2026-05-07 13:39:33] The server is fired up and ready to roll!
[2026-05-07 13:40:36] INFO:     127.0.0.1:45660 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:37 DP1 TP1 EP1] Decode batch, #running-req: 2, #token: 27308, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 30, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 0.56, #queue-req: 0
[2026-05-07 13:40:37 DP0 TP0 EP0] Decode batch, #running-req: 4, #token: 27375, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 28, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 0.91, #queue-req: 0
[2026-05-07 13:40:37 DP3 TP3 EP3] Decode batch, #running-req: 5, #token: 27406, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 27, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1.00, #queue-req: 0
[2026-05-07 13:40:37 DP2 TP2 EP2] Decode batch, #running-req: 8, #token: 27481, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 24, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1.66, #queue-req: 0
[2026-05-07 13:40:37] INFO:     127.0.0.1:45662 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP1 TP1 EP1] Decode batch, #running-req: 10, #token: 27454, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 22, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 426.68, #queue-req: 0
[2026-05-07 13:40:38] INFO:     127.0.0.1:45680 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45674 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45830 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP0 TP0 EP0] Decode batch, #running-req: 13, #token: 28536, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 20, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 708.64, #queue-req: 0
[2026-05-07 13:40:38 DP3 TP3 EP3] Decode batch, #running-req: 10, #token: 27732, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 22, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 748.59, #queue-req: 0
[2026-05-07 13:40:38 DP2 TP2 EP2] Decode batch, #running-req: 11, #token: 27842, token usage: 0.03, pre-allocated usage: 0.02, #prealloc-req: 0, #transfer-req: 21, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 789.14, #queue-req: 0
[2026-05-07 13:40:38 DP1 TP1 EP1] Decode batch, #running-req: 15, #token: 27023, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 16, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 930.19, #queue-req: 0
[2026-05-07 13:40:38] INFO:     127.0.0.1:45948 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45758 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45708 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45724 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45884 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45964 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45694 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45996 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45764 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:46066 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45840 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45864 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP0 TP0 EP0] Decode batch, #running-req: 17, #token: 28146, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 15, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1165.10, #queue-req: 0
[2026-05-07 13:40:38] INFO:     127.0.0.1:45930 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45872 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38 DP2 TP2 EP2] Decode batch, #running-req: 17, #token: 28994, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 16, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1149.61, #queue-req: 0
[2026-05-07 13:40:38 DP3 TP3 EP3] Decode batch, #running-req: 16, #token: 27166, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 15, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1137.76, #queue-req: 0
[2026-05-07 13:40:38] INFO:     127.0.0.1:45954 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:45988 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:38] INFO:     127.0.0.1:46012 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP1 TP1 EP1] Decode batch, #running-req: 18, #token: 28249, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 14, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1184.31, #queue-req: 0
[2026-05-07 13:40:39] INFO:     127.0.0.1:46146 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45940 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45888 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45974 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46102 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46142 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45914 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45932 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45812 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45788 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45776 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45942 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46128 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46182 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46406 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP0 TP0 EP0] Decode batch, #running-req: 17, #token: 26851, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 13, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1459.41, #queue-req: 0
[2026-05-07 13:40:39] INFO:     127.0.0.1:46080 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP3 TP3 EP3] Decode batch, #running-req: 20, #token: 27442, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 11, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1263.52, #queue-req: 0
[2026-05-07 13:40:39 DP2 TP2 EP2] Decode batch, #running-req: 21, #token: 30511, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 13, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1481.16, #queue-req: 0
[2026-05-07 13:40:39] INFO:     127.0.0.1:46010 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46096 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45858 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46368 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46270 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46454 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45820 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP1 TP1 EP1] Decode batch, #running-req: 19, #token: 27593, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 12, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1320.75, #queue-req: 0
[2026-05-07 13:40:39] INFO:     127.0.0.1:46054 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46184 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46572 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46240 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46162 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46226 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46290 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46266 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46204 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46490 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46034 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45960 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46044 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:45898 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46022 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46410 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP0 TP0 EP0] Decode batch, #running-req: 20, #token: 27977, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 11, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1371.39, #queue-req: 0
[2026-05-07 13:40:39] INFO:     127.0.0.1:45894 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46636 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46300 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39 DP3 TP3 EP3] Decode batch, #running-req: 22, #token: 29648, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 9, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1566.88, #queue-req: 0
[2026-05-07 13:40:39 DP2 TP2 EP2] Decode batch, #running-req: 19, #token: 28960, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 10, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1617.19, #queue-req: 0
[2026-05-07 13:40:39] INFO:     127.0.0.1:46246 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:39] INFO:     127.0.0.1:46668 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:45834 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:45738 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:45798 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46388 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46178 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP1 TP1 EP1] Decode batch, #running-req: 24, #token: 27778, token usage: 0.03, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 8, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1480.51, #queue-req: 0
[2026-05-07 13:40:40] INFO:     127.0.0.1:46104 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46190 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46666 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46576 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46462 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46046 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46432 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:45690 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46254 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46006 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46308 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46408 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46818 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46536 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46314 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46390 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46598 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46594 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:45842 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46422 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46712 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP0 TP0 EP0] Decode batch, #running-req: 26, #token: 27223, token usage: 0.03, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 4, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1558.92, #queue-req: 0
[2026-05-07 13:40:40] INFO:     127.0.0.1:46114 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46630 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46764 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46874 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP3 TP3 EP3] Decode batch, #running-req: 23, #token: 25465, token usage: 0.02, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 5, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1650.40, #queue-req: 0
[2026-05-07 13:40:40 DP2 TP2 EP2] Decode batch, #running-req: 17, #token: 20763, token usage: 0.02, pre-allocated usage: 0.01, #prealloc-req: 0, #transfer-req: 6, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1333.82, #queue-req: 0
[2026-05-07 13:40:40] INFO:     127.0.0.1:46998 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46702 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46380 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46428 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46848 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46278 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46344 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46332 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46684 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46560 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40 DP1 TP1 EP1] Decode batch, #running-req: 19, #token: 18154, token usage: 0.02, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 1, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1412.64, #queue-req: 0
[2026-05-07 13:40:40] INFO:     127.0.0.1:46478 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46566 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46864 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46916 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46438 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46776 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46746 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46212 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46732 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:45748 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46446 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46984 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:47152 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46622 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46838 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46324 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:47108 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:40] INFO:     127.0.0.1:46966 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41 DP0 TP0 EP0] Decode batch, #running-req: 21, #token: 19574, token usage: 0.02, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1774.38, #queue-req: 0
[2026-05-07 13:40:41] INFO:     127.0.0.1:47106 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41 DP2 TP2 EP2] Decode batch, #running-req: 20, #token: 18788, token usage: 0.02, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1392.52, #queue-req: 0
[2026-05-07 13:40:41 DP3 TP3 EP3] Decode batch, #running-req: 21, #token: 19646, token usage: 0.02, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1612.16, #queue-req: 0
[2026-05-07 13:40:41] INFO:     127.0.0.1:46912 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46608 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47036 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46544 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47084 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47104 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46906 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46568 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46814 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46828 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46506 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47134 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47262 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41 DP1 TP1 EP1] Decode batch, #running-req: 9, #token: 8250, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1141.82, #queue-req: 0
[2026-05-07 13:40:41] INFO:     127.0.0.1:46934 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46952 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47302 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46716 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46762 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46586 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46642 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46520 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47168 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47158 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47240 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46354 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41 DP0 TP0 EP0] Decode batch, #running-req: 17, #token: 15497, token usage: 0.02, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1416.30, #queue-req: 0
[2026-05-07 13:40:41] INFO:     127.0.0.1:46498 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47356 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47348 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47426 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41 DP2 TP2 EP2] Decode batch, #running-req: 14, #token: 13768, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1299.19, #queue-req: 0
[2026-05-07 13:40:41 DP3 TP3 EP3] Decode batch, #running-req: 10, #token: 9566, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1145.17, #queue-req: 0
[2026-05-07 13:40:41] INFO:     127.0.0.1:47254 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47232 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47394 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47194 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46424 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:46926 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41 DP1 TP1 EP1] Decode batch, #running-req: 5, #token: 4862, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 602.45, #queue-req: 0
[2026-05-07 13:40:41] INFO:     127.0.0.1:47014 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47172 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47030 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47126 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47156 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47294 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47410 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47070 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:41] INFO:     127.0.0.1:47182 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47318 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47146 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP0 TP0 EP0] Decode batch, #running-req: 8, #token: 7198, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1082.11, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:47120 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47440 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP3 TP3 EP3] Decode batch, #running-req: 6, #token: 6037, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 653.92, #queue-req: 0
[2026-05-07 13:40:42 DP2 TP2 EP2] Decode batch, #running-req: 11, #token: 10385, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 1111.11, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:47266 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46808 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47282 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47442 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP1 TP1 EP1] Decode batch, #running-req: 4, #token: 3126, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 374.32, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:47330 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47212 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46938 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47042 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47380 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47210 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46470 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47280 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46890 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP0 TP0 EP0] Decode batch, #running-req: 5, #token: 5376, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 563.94, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:47366 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP3 TP3 EP3] Decode batch, #running-req: 2, #token: 2142, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 406.40, #queue-req: 0
[2026-05-07 13:40:42 DP2 TP2 EP2] Decode batch, #running-req: 5, #token: 5407, token usage: 0.01, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 728.08, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:46792 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47058 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46940 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46650 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:46982 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP0 TP0 EP0] Decode batch, #running-req: 3, #token: 3230, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 447.45, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:47116 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42] INFO:     127.0.0.1:47334 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:42 DP3 TP3 EP3] Decode batch, #running-req: 1, #token: 1105, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 113.22, #queue-req: 0
[2026-05-07 13:40:42 DP2 TP2 EP2] Decode batch, #running-req: 3, #token: 3477, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 501.78, #queue-req: 0
[2026-05-07 13:40:42] INFO:     127.0.0.1:47090 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:43] INFO:     127.0.0.1:47220 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:43] INFO:     127.0.0.1:46688 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:43 DP0 TP0 EP0] Decode batch, #running-req: 1, #token: 1103, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 255.78, #queue-req: 0
[2026-05-07 13:40:43] INFO:     127.0.0.1:47236 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:43 DP3 TP3 EP3] Decode batch, #running-req: 1, #token: 1145, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 126.54, #queue-req: 0
[2026-05-07 13:40:43 DP2 TP2 EP2] Decode batch, #running-req: 1, #token: 1285, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 268.95, #queue-req: 0
[2026-05-07 13:40:43] INFO:     127.0.0.1:47458 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:43] INFO:     127.0.0.1:47316 - "POST /generate HTTP/1.1" 200 OK
[2026-05-07 13:40:43 DP2 TP2 EP2] Decode batch, #running-req: 1, #token: 1325, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 144.18, #queue-req: 0
[2026-05-07 13:40:43 DP2 TP2 EP2] Decode batch, #running-req: 1, #token: 1365, token usage: 0.00, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 147.85, #queue-req: 0
[2026-05-07 13:40:43] INFO:     127.0.0.1:45984 - "POST /generate HTTP/1.1" 200 OK
```
</details>

#### Run router
```
python -m sglang_router.launch_router \
    --pd-disaggregation \
    --mini-lb \
    --prefill http://127.0.0.1:30033 \
    --decode http://127.0.0.1:30044 \
    --host 0.0.0.0 \
    --request-timeout-secs 7200 \
    --port 30000
```

#### Test gsm8k
```
python sglang/python/sglang/test/few_shot_gsm8k.py 
100%|██████████████████████████████████████████████████████████████████████████████████| 200/200 [00:07<00:00, 27.04it/s]
Accuracy: 0.925
Invalid: 0.000
Latency: 47.310 s
Output throughput: 482.225 token/s
```
#### Benchmark
```
python3 -m sglang.bench_serving \
    --dataset-name random \
    --model /home/dist/models/Qwen3-30B-A3B/ \
    --dataset-path /home/dist/ShareGPT_V3_unfiltered_cleaned_split.json \
    --random-range-ratio 1 \
    --num-prompt 64 \
    --random-input 4096 \
    --random-output 1536 \
    --port 30000 \
    --host 127.0.0.1 \
    --request-rate 1


============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    1.0       
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  70.61     
Total input tokens:                      262144    
Total input text tokens:                 262144    
Total generated tokens:                  98304     
Total generated tokens (retokenized):    96653     
Request throughput (req/s):              0.91      
Input token throughput (tok/s):          3712.80   
Output token throughput (tok/s):         1392.30   
Peak output token throughput (tok/s):    1909.00   
Peak concurrent requests:                24        
Total token throughput (tok/s):          5105.10   
Concurrency:                             16.11     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   17774.30  
Median E2E Latency (ms):                 18026.49  
P90 E2E Latency (ms):                    18447.80  
P99 E2E Latency (ms):                    18650.77  
---------------Time to First Token----------------
Mean TTFT (ms):                          397.02    
Median TTFT (ms):                        392.86    
P99 TTFT (ms):                           652.87    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.32     
Median TPOT (ms):                        11.47     
P99 TPOT (ms):                           11.83     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           11.32     
Median ITL (ms):                         11.35     
P95 ITL (ms):                            14.34     
P99 ITL (ms):                            17.94     
Max ITL (ms):                            52.49     
==================================================
```


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
6. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
7. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
8. After green CI and required approvals, ask Merge Oncalls to merge.
