### PR TITLE
Add auto-retry for failed jobs in scheduled PR tests on main

### DIFF
--- a/.github/workflows/auto-retry-scheduled.yml
+++ b/.github/workflows/auto-retry-scheduled.yml
@@ -8,11 +8,13 @@ on:
 jobs:
   retry-failed:
     name: Retry Failed Jobs
-    # Only retry for scheduled runs on main that have failures
+    # Only retry for scheduled runs on main that have failures and haven't been retried twice yet
+    # run_attempt starts at 1, so attempt <= 2 means we allow up to 2 retries (attempts 1, 2, 3)
     if: |
       github.event.workflow_run.event == 'schedule' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.conclusion == 'failure'
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt <= 2
     runs-on: ubuntu-latest
     steps:
       - name: Retry failed jobs
@@ -21,9 +23,11 @@ jobs:
           script: |
             const runId = context.payload.workflow_run.id;
             const runUrl = context.payload.workflow_run.html_url;
+            const runAttempt = context.payload.workflow_run.run_attempt;
 
             console.log(`Workflow run ${runId} failed on scheduled main branch run`);
             console.log(`URL: ${runUrl}`);
+            console.log(`Current attempt: ${runAttempt} (max 2 retries allowed)`);
 
             // Get failed jobs
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
@@ -37,7 +41,7 @@ jobs:
             const failedJobs = jobs.filter(job => job.conclusion === 'failure');
 
             if (failedJobs.length === 0) {
-              console.log('No failed jobs found');
+              console.log('No failed jobs found, skipping retry');
               return;
             }
 
@@ -46,16 +50,15 @@ jobs:
               console.log(`  - ${job.name}`);
             }
 
-            // Rerun failed jobs
+            // Rerun failed jobs only
             try {
               await github.rest.actions.reRunWorkflowFailedJobs({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: runId,
               });
-              console.log('Successfully triggered rerun of failed jobs');
+              console.log(`Successfully triggered retry ${runAttempt + 1} of failed jobs`);
             } catch (error) {
               console.log(`Failed to rerun: ${error.message}`);
-              // If rerun fails, it might be because the run is too old or already rerunning
               core.warning(`Could not rerun failed jobs: ${error.message}`);
             }

--- a/.github/workflows/auto-retry-scheduled.yml
+++ b/.github/workflows/auto-retry-scheduled.yml
@@ -1,0 +1,61 @@
+name: Auto Retry Scheduled Failures
+
+on:
+  workflow_run:
+    workflows: ["PR Test"]
+    types: [completed]
+
+jobs:
+  retry-failed:
+    name: Retry Failed Jobs
+    # Only retry for scheduled runs on main that have failures
+    if: |
+      github.event.workflow_run.event == 'schedule' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retry failed jobs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const runUrl = context.payload.workflow_run.html_url;
+
+            console.log(`Workflow run ${runId} failed on scheduled main branch run`);
+            console.log(`URL: ${runUrl}`);
+
+            // Get failed jobs
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              filter: 'latest',
+              per_page: 100,
+            });
+
+            const failedJobs = jobs.filter(job => job.conclusion === 'failure');
+
+            if (failedJobs.length === 0) {
+              console.log('No failed jobs found');
+              return;
+            }
+
+            console.log(`Found ${failedJobs.length} failed job(s):`);
+            for (const job of failedJobs) {
+              console.log(`  - ${job.name}`);
+            }
+
+            // Rerun failed jobs
+            try {
+              await github.rest.actions.reRunWorkflowFailedJobs({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              console.log('Successfully triggered rerun of failed jobs');
+            } catch (error) {
+              console.log(`Failed to rerun: ${error.message}`);
+              // If rerun fails, it might be because the run is too old or already rerunning
+              core.warning(`Could not rerun failed jobs: ${error.message}`);
+            }

--- a/.github/workflows/auto-retry-scheduled.yml
+++ b/.github/workflows/auto-retry-scheduled.yml
@@ -5,27 +5,61 @@ on:
     workflows: ["PR Test"]
     types: [completed]
 
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Workflow run ID to retry (for testing)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run - only list failed jobs without retrying'
+        required: false
+        default: true
+        type: boolean
+
 jobs:
   retry-failed:
     name: Retry Failed Jobs
-    # Only retry for scheduled runs on main that have failures and haven't been retried twice yet
-    # run_attempt starts at 1, so attempt <= 2 means we allow up to 2 retries (attempts 1, 2, 3)
+    # For workflow_run: only retry scheduled main failures with attempt <= 2
+    # For workflow_dispatch: always run (for testing)
     if: |
-      github.event.workflow_run.event == 'schedule' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.run_attempt <= 2
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.event == 'schedule' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.run_attempt <= 2
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Retry failed jobs
         uses: actions/github-script@v7
         with:
           script: |
-            const runId = context.payload.workflow_run.id;
-            const runUrl = context.payload.workflow_run.html_url;
-            const runAttempt = context.payload.workflow_run.run_attempt;
+            // Handle both workflow_run and workflow_dispatch triggers
+            let runId, runAttempt, dryRun;
 
-            console.log(`Workflow run ${runId} failed on scheduled main branch run`);
+            if (context.eventName === 'workflow_dispatch') {
+              runId = parseInt('${{ inputs.run_id }}');
+              dryRun = '${{ inputs.dry_run }}' === 'true';
+              // Fetch run details for workflow_dispatch
+              const run = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              runAttempt = run.data.run_attempt;
+              console.log(`[Manual Test] Run ID: ${runId}, Dry run: ${dryRun}`);
+              console.log(`Run details: event=${run.data.event}, branch=${run.data.head_branch}, conclusion=${run.data.conclusion}`);
+            } else {
+              runId = context.payload.workflow_run.id;
+              runAttempt = context.payload.workflow_run.run_attempt;
+              dryRun = false;
+            }
+
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
+            console.log(`Workflow run ${runId}`);
             console.log(`URL: ${runUrl}`);
             console.log(`Current attempt: ${runAttempt} (max 2 retries allowed)`);
 
@@ -50,7 +84,13 @@ jobs:
               console.log(`  - ${job.name}`);
             }
 
-            // Rerun failed jobs only
+            // Rerun failed jobs only (unless dry run)
+            if (dryRun) {
+              console.log(`[Dry Run] Would retry ${failedJobs.length} failed job(s)`);
+              console.log('[Dry Run] No actual retry triggered');
+              return;
+            }
+
             try {
               await github.rest.actions.reRunWorkflowFailedJobs({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Automatically retry failed jobs when scheduled PR tests on main branch fail
- Only triggers for `schedule` event on `main` branch with `failure` conclusion
- Uses `reRunWorkflowFailedJobs` API to retry only the failed jobs (not the entire workflow)