### PR TITLE
Use attn_tp_group for all reduce in token embedding

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -564,6 +564,10 @@ def attn_tp_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor):
     return get_attention_tp_group().reduce_scatter_tensor(output, input)
 
 
+def attn_tp_all_reduce(input: torch.Tensor):
+    return get_attention_tp_group().all_reduce(input)
+
+
 def attn_tp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):
     return get_attention_tp_group().all_gather_into_tensor(output, input)
 

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -19,7 +19,11 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.layers.amx_utils import PackWeightMethod
 from sglang.srt.layers.communicator import get_attn_tp_context
-from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
+from sglang.srt.layers.dp_attention import (
+    attn_tp_all_reduce,
+    get_attention_tp_rank,
+    get_attention_tp_size,
+)
 from sglang.srt.layers.parameter import BasevLLMParameter
 from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
@@ -210,6 +214,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         self.quant_config = quant_config
 
         self.enable_tp = enable_tp
+        self.use_attn_tp_group = use_attn_tp_group
         if self.enable_tp:
             if use_attn_tp_group:
                 tp_rank = get_attention_tp_rank()
@@ -484,8 +489,11 @@ class VocabParallelEmbedding(torch.nn.Module):
             # Mask the output embedding.
             output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
             if not get_attn_tp_context().input_scattered:
-                # Reduce across all the model parallel GPUs.
-                output_parallel = tensor_model_parallel_all_reduce(output_parallel)
+                if self.use_attn_tp_group:
+                    output_parallel = attn_tp_all_reduce(output_parallel)
+                else:
+                    # Reduce across all the model parallel GPUs.
+                    output_parallel = tensor_model_parallel_all_reduce(output_parallel)
         return output_parallel
 
     def extra_repr(self) -> str:

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -86,7 +86,7 @@ class DeepseekModelNextN(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
-            enable_tp=not is_dp_attention_enabled(),
+            use_attn_tp_group=is_dp_attention_enabled(),
             prefix=add_prefix("embed_tokens", prefix),
         )
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2474,7 +2474,7 @@ class DeepseekV2Model(nn.Module):
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,
-                enable_tp=not is_dp_attention_enabled(),
+                use_attn_tp_group=is_dp_attention_enabled(),
             )
         else:
             self.embed_tokens = PPMissingLayer()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Previously `attn_tp_group` in `VocabParallelEmbedding` is only used for `dp_lm_head`. For token embedding, it will always use full DP. This PR uses `attn_tp_group` for all reduce in embedding layer to support DP/TP combination. 

Compared to full DP, the performance impact is negligible since embedding is a small fraction of the forward pass. While weights memory usage is slightly reduced by using TP embedding (e.g., dsv3 tp=8 dp=2: 82.82GB → 81.53GB per GPU).

## Accuracy Tests

```
python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.1 --tp 8 --dp 2 --enable-dp-attention --trust-remote-code --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'
python3 benchmark/gsm8k/bench_sglang.py --parallel 1400 --num-questions 1400

Accuracy: 0.955
Invalid: 0.000
Latency: 23.974 s
Output throughput: 5272.585 token/s
```

## Benchmarking and Profiling

Before:
```
Input lens: [8192]. Output lens: [1024].
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) | acc length   |   ITL (ms) |   input cost ($/1M) |   output cost ($/1M) | cache hit rate   |
|--------------|-------------|---------------|----------------------------|-----------------------------|--------------|------------|---------------------|----------------------|------------------|
|            1 |        8192 |         16.67 |                    14521.7 |                       63.6  | n/a          |      15.72 |                0.05 |                 8.74 | n/a              |
|            4 |        8192 |         18.88 |                    17333.6 |                      241.08 | n/a          |      16.59 |                0.05 |                 2.3  | n/a              |
|            8 |        8192 |         20.92 |                    20661.6 |                      461.45 | n/a          |      17.34 |                0.04 |                 1.2  | n/a              |
|           16 |        8192 |         28.14 |                    20526.6 |                      753.24 | n/a          |      21.24 |                0.04 |                 0.74 | n/a              |
|           32 |        8192 |         43.5  |                    18134.6 |                     1128.23 | n/a          |      28.36 |                0.04 |                 0.49 | n/a              |
```

After:
```
Input lens: [8192]. Output lens: [1024].
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) | acc length   |   ITL (ms) |   input cost ($/1M) |   output cost ($/1M) | cache hit rate   |
|--------------|-------------|---------------|----------------------------|-----------------------------|--------------|------------|---------------------|----------------------|------------------|
|            1 |        8192 |         16.6  |                    14549.3 |                       63.84 | n/a          |      15.66 |                0.05 |                 8.7  | n/a              |
|            4 |        8192 |         18.67 |                    20980.1 |                      239.49 | n/a          |      16.7  |                0.04 |                 2.32 | n/a              |
|            8 |        8192 |         21.39 |                    17808.6 |                      462.58 | n/a          |      17.29 |                0.04 |                 1.2  | n/a              |
|           16 |        8192 |         29.06 |                    17987.8 |                      752.51 | n/a          |      21.26 |                0.04 |                 0.74 | n/a              |
|           32 |        8192 |         41.64 |                    20587.9 |                     1133.65 | n/a          |      28.23 |                0.04 |                 0.49 | n/a              |
```

## TODO
- [ ] update it for remaining models (update dsv3 first and get stable running and verification for some days, and then update other models)

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
