### PR TITLE
[VLM] Optimize get_rope_index for GLM4v

### DIFF
--- a/benchmark/bench_rope/benchmark_rope_index.py
+++ b/benchmark/bench_rope/benchmark_rope_index.py
@@ -1,0 +1,425 @@
+# This script benchmarks MRotaryEmbedding.get_rope_index_glm4v (GLM4V mrope index builder).
+# It generates synthetic multimodal input_ids + attention_mask (+ optional image/video grids),
+# runs benchmarks.
+#
+# == Usage Examples ==
+#
+# python3 benchmark_rope_index.py --device cuda --num-tokens 1024 2048 --benchmark-iter 200
+
+import argparse
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import torch
+
+from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
+
+
+# -----------------------------
+# Minimal config objects
+# -----------------------------
+@dataclass
+class DummyVisionConfig:
+    spatial_merge_size: int = 2
+
+
+@dataclass
+class DummyHFConfig:
+    image_token_id: int = 32000
+    video_start_token_id: int = 32001
+    video_end_token_id: int = 32002
+    vision_config: DummyVisionConfig = field(
+        default_factory=lambda: DummyVisionConfig(spatial_merge_size=2)
+    )
+
+
+# -----------------------------
+# Helpers
+# -----------------------------
+def calculate_stats(times: list[float]) -> dict[str, float]:
+    """Calculate statistics from a list of times."""
+    times_array = np.array(times, dtype=np.float64)
+    return {
+        "mean": float(np.mean(times_array)),
+        "median": float(np.median(times_array)),
+        "p99": float(np.percentile(times_array, 99)),
+        "min": float(np.min(times_array)),
+        "max": float(np.max(times_array)),
+    }
+
+
+def _sync(device: torch.device):
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _approx_hw(patches: int, merge: int) -> tuple[int, int]:
+    # want (h/merge)*(w/merge) ~= patches
+    gh = int(math.sqrt(max(1, patches)))
+    gw = max(1, patches // max(1, gh))
+    return gh * merge, gw * merge
+
+
+def generate_test_data(
+    num_tokens: int,
+    batch_size: int,
+    hf_config: DummyHFConfig,
+    dtype: torch.dtype,
+    device: torch.device,
+    pad_ratio: float,
+    num_images_per_sample: int,
+    image_patch_tokens: int,
+    num_videos_per_sample: int,
+    video_patch_tokens: int,
+    seed: int,
+):
+    """
+    Generate synthetic (input_ids, attention_mask, image_grid_thw, video_grid_thw).
+
+    NOTE:
+      - image_grid_thw / video_grid_thw are global lists across the entire batch in encounter order,
+        matching the function's image_index/video_index behavior.
+      - image patches are represented by repeated image_token_id.
+      - video patches are represented by image_token_id wrapped with start/end tokens.
+    """
+    torch.manual_seed(seed)
+
+    forbidden = {
+        0,
+        hf_config.image_token_id,
+        hf_config.video_start_token_id,
+        hf_config.video_end_token_id,
+    }
+    vocab_size = 50000
+
+    def rand_text(n: int) -> torch.Tensor:
+        # generate random ids not in forbidden
+        out = torch.randint(1, vocab_size, (n,), device=device, dtype=torch.long)
+        # fix forbidden by +1 until ok (cheap, deterministic enough for benchmark data)
+        for bad in forbidden:
+            out = torch.where(out == bad, out + 1, out)
+        return out
+
+    image_grids: list[list[int]] = []
+    video_grids: list[list[int]] = []
+
+    input_ids = torch.zeros((batch_size, num_tokens), device=device, dtype=torch.long)
+    attention_mask = torch.zeros(
+        (batch_size, num_tokens), device=device, dtype=torch.long
+    )
+
+    eff_len = int(round(num_tokens * (1.0 - pad_ratio)))
+    eff_len = max(1, min(num_tokens, eff_len))
+
+    min_needed = 1
+    min_needed += num_images_per_sample * image_patch_tokens
+    min_needed += num_videos_per_sample * (2 + video_patch_tokens)
+    if eff_len < min_needed:
+        num_images_per_sample = 0
+        num_videos_per_sample = 0
+
+    for b in range(batch_size):
+        blocks: list[torch.Tensor] = []
+
+        reserved = (
+            num_images_per_sample * image_patch_tokens
+            + num_videos_per_sample * (2 + video_patch_tokens)
+        )
+        reserved = min(reserved, max(0, eff_len - 1))
+        text_budget = max(1, eff_len - reserved)
+
+        n_text_chunks = num_images_per_sample + num_videos_per_sample + 1
+        base = text_budget // n_text_chunks
+        rem = text_budget % n_text_chunks
+        text_chunks = [base + (1 if i < rem else 0) for i in range(n_text_chunks)]
+
+        tci = 0
+        for _ in range(num_images_per_sample):
+            blocks.append(rand_text(text_chunks[tci]))
+            tci += 1
+            blocks.append(
+                torch.full(
+                    (image_patch_tokens,),
+                    hf_config.image_token_id,
+                    device=device,
+                    dtype=torch.long,
+                )
+            )
+
+            h, w = _approx_hw(
+                image_patch_tokens, hf_config.vision_config.spatial_merge_size
+            )
+            image_grids.append([1, h, w])
+
+        for _ in range(num_videos_per_sample):
+            blocks.append(rand_text(text_chunks[tci]))
+            tci += 1
+            blocks.append(
+                torch.tensor(
+                    [hf_config.video_start_token_id], device=device, dtype=torch.long
+                )
+            )
+            blocks.append(
+                torch.full(
+                    (video_patch_tokens,),
+                    hf_config.image_token_id,
+                    device=device,
+                    dtype=torch.long,
+                )
+            )
+            blocks.append(
+                torch.tensor(
+                    [hf_config.video_end_token_id], device=device, dtype=torch.long
+                )
+            )
+
+            h, w = _approx_hw(
+                video_patch_tokens, hf_config.vision_config.spatial_merge_size
+            )
+            # first field = group count used by code; set to 1
+            video_grids.append([1, h, w])
+
+        blocks.append(rand_text(text_chunks[tci]))
+
+        tokens = torch.cat(blocks, dim=0)[:eff_len]
+        pad = torch.zeros(
+            (num_tokens - tokens.numel(),), device=device, dtype=torch.long
+        )
+        ids = torch.cat([tokens, pad], dim=0)
+
+        mask = torch.cat(
+            [
+                torch.ones((tokens.numel(),), device=device, dtype=torch.long),
+                torch.zeros(
+                    (num_tokens - tokens.numel(),), device=device, dtype=torch.long
+                ),
+            ],
+            dim=0,
+        )
+
+        input_ids[b] = ids
+        attention_mask[b] = mask
+
+    image_grid_thw = (
+        torch.tensor(image_grids, device=device, dtype=torch.long)
+        if len(image_grids)
+        else None
+    )
+    video_grid_thw = (
+        torch.tensor(video_grids, device=device, dtype=torch.long)
+        if len(video_grids)
+        else None
+    )
+    return (
+        input_ids.to(dtype=torch.long),
+        attention_mask.to(dtype=torch.long),
+        image_grid_thw,
+        video_grid_thw,
+    )
+
+
+def benchmark_rope_index(
+    model_name: str,
+    tp_size: int,
+    num_tokens: int,
+    batch_size: int,
+    pad_ratio: float,
+    spatial_merge_size: int,
+    num_images: int,
+    image_patch_tokens: int,
+    num_videos: int,
+    video_patch_tokens: int,
+    dtype: torch.dtype,
+    seed: int,
+    warmup_iter: int,
+    benchmark_iter: int,
+    device: torch.device,
+):
+    torch.manual_seed(seed)
+    hf_config = DummyHFConfig(
+        image_token_id=32000,
+        video_start_token_id=32001,
+        video_end_token_id=32002,
+        vision_config=DummyVisionConfig(spatial_merge_size=spatial_merge_size),
+    )
+
+    print(80 * "=")
+    print(
+        f"Evaluating: {model_name} tp_size={tp_size} "
+        f"num_tokens={num_tokens} batch={batch_size} pad_ratio={pad_ratio} "
+        f"images/sample={num_images} image_patch_tokens={image_patch_tokens} "
+        f"videos/sample={num_videos} video_patch_tokens={video_patch_tokens} "
+        f"dtype={dtype} device={device}"
+    )
+
+    input_ids, attention_mask, image_grid_thw, video_grid_thw = generate_test_data(
+        num_tokens=num_tokens,
+        batch_size=batch_size,
+        hf_config=hf_config,
+        dtype=dtype,
+        device=device,
+        pad_ratio=pad_ratio,
+        num_images_per_sample=num_images,
+        image_patch_tokens=image_patch_tokens,
+        num_videos_per_sample=num_videos,
+        video_patch_tokens=video_patch_tokens,
+        seed=seed,
+    )
+
+    # Smoke test
+    has_mm = (image_grid_thw is not None) or (video_grid_thw is not None)
+    if has_mm:
+        pos, delta = MRotaryEmbedding.get_rope_index_glm4v(
+            input_ids=input_ids,
+            hf_config=hf_config,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            attention_mask=attention_mask,
+        )
+        assert pos.shape == (3, batch_size, num_tokens)
+        assert delta.shape == (batch_size, 1)
+
+    # Warm up
+    for _ in range(warmup_iter):
+        if has_mm:
+            MRotaryEmbedding.get_rope_index_glm4v(
+                input_ids=input_ids,
+                hf_config=hf_config,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                attention_mask=attention_mask,
+            )
+        MRotaryEmbedding.get_rope_index_glm4v(
+            input_ids=input_ids,
+            hf_config=hf_config,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            attention_mask=attention_mask,
+        )
+
+    _sync(device)
+
+    # Time multimodal branch
+    multimodal_times = []
+    for _ in range(benchmark_iter):
+        _sync(device)
+        start = time.time()
+        MRotaryEmbedding.get_rope_index_glm4v(
+            input_ids=input_ids,
+            hf_config=hf_config,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            attention_mask=attention_mask,
+        )
+        _sync(device)
+        multimodal_times.append(time.time() - start)
+
+    # Time fallback branch
+    fallback_times = []
+    for _ in range(benchmark_iter):
+        _sync(device)
+        start = time.time()
+        MRotaryEmbedding.get_rope_index_glm4v(
+            input_ids=input_ids,
+            hf_config=hf_config,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            attention_mask=attention_mask,
+        )
+        _sync(device)
+        fallback_times.append(time.time() - start)
+
+    multimodal_stats = calculate_stats(multimodal_times)
+    fallback_stats = calculate_stats(fallback_times)
+
+    print(f"\nPerformance for config (B={batch_size}, T={num_tokens}):")
+    print(
+        f"Multimodal: mean={multimodal_stats['mean']:.8f}s, "
+        f"median={multimodal_stats['median']:.8f}s, "
+        f"p99={multimodal_stats['p99']:.8f}s"
+    )
+    print(
+        f"Fallback:   mean={fallback_stats['mean']:.8f}s, "
+        f"median={fallback_stats['median']:.8f}s, "
+        f"p99={fallback_stats['p99']:.8f}s"
+    )
+
+    if has_mm:
+        speedup = (
+            multimodal_stats["mean"] / fallback_stats["mean"]
+            if fallback_stats["mean"] > 0
+            else float("inf")
+        )
+        print(f"Fallback Speedup over Multimodal: {speedup:.8f}x")
+    else:
+        speedup = float("nan")
+        print(
+            "[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark."
+        )
+
+    print(f"Fallback Speedup over Multimodal: {speedup:.8f}x")
+
+    return multimodal_stats, fallback_stats, speedup
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Benchmark GLM4V get_rope_index_glm4v."
+    )
+    parser.add_argument("--model-name", type=str, default="GLM4V")
+    parser.add_argument("--tp-size", type=int, default=1)
+    parser.add_argument(
+        "--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu"
+    )
+    parser.add_argument("--warmup-iter", type=int, default=10)
+    parser.add_argument("--benchmark-iter", type=int, default=100)
+    parser.add_argument("--dtype", type=str, choices=["int64"], default="int64")
+    parser.add_argument("--seed", type=int, default=0)
+
+    # token length sweep
+    parser.add_argument("--num-tokens", type=int, nargs="+", required=False)
+
+    # data shape knobs
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--pad-ratio", type=float, default=0.0)
+    parser.add_argument("--spatial-merge-size", type=int, default=2)
+    parser.add_argument("--num-images", type=int, default=1)
+    parser.add_argument("--image-patch-tokens", type=int, default=256)
+    parser.add_argument("--num-videos", type=int, default=1)
+    parser.add_argument("--video-patch-tokens", type=int, default=256)
+
+    # output
+    parser.add_argument("--out-dir", type=str, default=".")
+    args = parser.parse_args()
+    print(args)
+
+    device = torch.device(args.device)
+
+    if args.num_tokens is None:
+        num_tokens_list = [2**i for i in range(0, 18)]
+    else:
+        num_tokens_list = args.num_tokens
+
+    rows: list[dict[str, Any]] = []
+
+    for num_tokens in num_tokens_list:
+        multimodal_stats, fallback_stats, speedup = benchmark_rope_index(
+            model_name=args.model_name,
+            tp_size=args.tp_size,
+            num_tokens=num_tokens,
+            batch_size=args.batch_size,
+            pad_ratio=args.pad_ratio,
+            spatial_merge_size=args.spatial_merge_size,
+            num_images=args.num_images,
+            image_patch_tokens=args.image_patch_tokens,
+            num_videos=args.num_videos,
+            video_patch_tokens=args.video_patch_tokens,
+            dtype=getattr(torch, args.dtype),
+            seed=args.seed,
+            warmup_iter=args.warmup_iter,
+            benchmark_iter=args.benchmark_iter,
+            device=device,
+        )

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -2107,13 +2107,17 @@ class MRotaryEmbedding(RotaryEmbedding):
         video_end_token_id = hf_config.video_end_token_id
         spatial_merge_size = hf_config.vision_config.spatial_merge_size
 
+        # Preallocate lists for efficiency
         mrope_position_deltas = []
+
         if input_ids is not None and (
             image_grid_thw is not None or video_grid_thw is not None
         ):
             total_input_ids = input_ids
+
             if attention_mask is None:
                 attention_mask = torch.ones_like(total_input_ids)
+
             position_ids = torch.ones(
                 3,
                 input_ids.shape[0],
@@ -2121,28 +2125,34 @@ class MRotaryEmbedding(RotaryEmbedding):
                 dtype=input_ids.dtype,
                 device=input_ids.device,
             )
-            image_index, video_index = 0, 0
-            video_group_index = 0
-            attention_mask = attention_mask.to(total_input_ids.device)
-            for i, input_ids in enumerate(total_input_ids):
-                input_ids = input_ids[attention_mask[i] == 1]
-                input_tokens = input_ids.tolist()
 
-                input_token_type = []
+            # Move attention mask to device once to avoid repeated transfers
+            attention_mask = attention_mask.to(total_input_ids.device)
+
+            for i, ids in enumerate(total_input_ids):
+                curr_mask = attention_mask[i]
+                ids_masked = ids[curr_mask == 1]
+
+                # Preallocate input_token_type for maximum speed
+                input_tokens = ids_masked.tolist()
+                input_token_type = [""] * len(input_tokens)
+
+                # Single pass through tokens for type assignment, using explicit indices for performance
                 video_check_flg = False
-                for token in input_tokens:
+                for j, token in enumerate(input_tokens):
                     if token == video_start_token_id:
                         video_check_flg = True
                     elif token == video_end_token_id:
                         video_check_flg = False
 
                     if token == image_token_id and not video_check_flg:
-                        input_token_type.append("image")
+                        input_token_type[j] = "image"
                     elif token == image_token_id and video_check_flg:
-                        input_token_type.append("video")
+                        input_token_type[j] = "video"
                     else:
-                        input_token_type.append("text")
+                        input_token_type[j] = "text"
 
+                # Use itertools.groupby for consecutive token type groups (unchanged logic)
                 input_type_group = []
                 for key, group in itertools.groupby(
                     enumerate(input_token_type), lambda x: x[1]
@@ -2154,12 +2164,15 @@ class MRotaryEmbedding(RotaryEmbedding):
 
                 llm_pos_ids_list = []
                 video_frame_num = 1
+                image_index, video_index = 0, 0
+                video_group_index = 0
+
                 for modality_type, start_idx, end_idx in input_type_group:
-                    st_idx = (
-                        llm_pos_ids_list[-1].max() + 1
-                        if len(llm_pos_ids_list) > 0
-                        else 0
-                    )
+                    # st_idx can be computed by torch directly for speed
+                    if llm_pos_ids_list:
+                        st_idx = llm_pos_ids_list[-1].max().item() + 1
+                    else:
+                        st_idx = 0
 
                     if modality_type == "image":
                         t, h, w = (
@@ -2167,103 +2180,103 @@ class MRotaryEmbedding(RotaryEmbedding):
                             image_grid_thw[image_index][1],
                             image_grid_thw[image_index][2],
                         )
-                        llm_grid_t, llm_grid_h, llm_grid_w = (
-                            t.item(),
-                            h.item() // spatial_merge_size,
-                            w.item() // spatial_merge_size,
-                        )
+                        # Avoid .item() lookups in repeated context
+                        t_int, h_int, w_int = int(t), int(h), int(w)
 
+                        llm_grid_t = t_int
+                        llm_grid_h = h_int // spatial_merge_size
+                        llm_grid_w = w_int // spatial_merge_size
+
+                        # Avoid unnecessary views/expands for speed, always flatten at the end
                         t_index = (
-                            torch.arange(llm_grid_t)
+                            torch.arange(llm_grid_t, device=position_ids.device)
                             .view(-1, 1)
-                            .expand(-1, llm_grid_h * llm_grid_w)
-                            .flatten()
+                            .expand(llm_grid_t, llm_grid_h * llm_grid_w)
+                            .reshape(-1)
                         )
                         h_index = (
-                            torch.arange(llm_grid_h)
+                            torch.arange(llm_grid_h, device=position_ids.device)
                             .view(1, -1, 1)
-                            .expand(llm_grid_t, -1, llm_grid_w)
-                            .flatten()
+                            .expand(llm_grid_t, llm_grid_h, llm_grid_w)
+                            .reshape(-1)
                         )
                         w_index = (
-                            torch.arange(llm_grid_w)
+                            torch.arange(llm_grid_w, device=position_ids.device)
                             .view(1, 1, -1)
-                            .expand(llm_grid_t, llm_grid_h, -1)
-                            .flatten()
+                            .expand(llm_grid_t, llm_grid_h, llm_grid_w)
+                            .reshape(-1)
                         )
                         llm_pos_ids_list.append(
                             torch.stack([t_index, h_index, w_index]) + st_idx
                         )
-
                         image_index += 1
                         video_frame_num = 1
 
                     elif modality_type == "video":
-                        t, h, w = (
-                            video_frame_num,
-                            video_grid_thw[video_index][1],
-                            video_grid_thw[video_index][2],
-                        )
+                        t = video_frame_num
+                        h = video_grid_thw[video_index][1]
+                        w = video_grid_thw[video_index][2]
 
-                        llm_grid_t, llm_grid_h, llm_grid_w = (
-                            t,
-                            h.item() // spatial_merge_size,
-                            w.item() // spatial_merge_size,
-                        )
+                        h_int, w_int = int(h), int(w)
+                        llm_grid_h = h_int // spatial_merge_size
+                        llm_grid_w = w_int // spatial_merge_size
 
-                        for t_idx in range(llm_grid_t):
+                        # Only one video frame at a time
+                        for t_idx in range(t):
                             t_index = (
-                                torch.tensor(t_idx)
+                                torch.tensor(t_idx, device=position_ids.device)
                                 .view(-1, 1)
-                                .expand(-1, llm_grid_h * llm_grid_w)
-                                .flatten()
+                                .expand(1, llm_grid_h * llm_grid_w)
+                                .reshape(-1)
                             )
-
                             h_index = (
-                                torch.arange(llm_grid_h)
+                                torch.arange(llm_grid_h, device=position_ids.device)
                                 .view(1, -1, 1)
-                                .expand(1, -1, llm_grid_w)
-                                .flatten()
+                                .expand(1, llm_grid_h, llm_grid_w)
+                                .reshape(-1)
                             )
                             w_index = (
-                                torch.arange(llm_grid_w)
+                                torch.arange(llm_grid_w, device=position_ids.device)
                                 .view(1, 1, -1)
-                                .expand(1, llm_grid_h, -1)
-                                .flatten()
+                                .expand(1, llm_grid_h, llm_grid_w)
+                                .reshape(-1)
                             )
                             llm_pos_ids_list.append(
                                 torch.stack([t_index, h_index, w_index]) + st_idx
                             )
 
                         video_group_index += 1
-
                         if video_group_index >= video_grid_thw[video_index][0]:
                             video_index += 1
                             video_group_index = 0
 
                         video_frame_num += 1
 
-                    else:
+                    else:  # text
                         text_len = end_idx - start_idx
-                        llm_pos_ids_list.append(
-                            torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
-                        )
-
+                        # Use in-place expand for improved performance
+                        text_range = torch.arange(text_len, device=position_ids.device)
+                        text_pos = text_range.view(1, -1).expand(3, text_len) + st_idx
+                        llm_pos_ids_list.append(text_pos)
                         video_frame_num = 1
 
+                # Concatenate once outside for speed
                 llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
-                position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(
-                    position_ids.device
-                )
+                # Use advanced indexing for assignment
+                idx_mask = curr_mask == 1
+                position_ids[..., i, idx_mask] = llm_positions.to(position_ids.device)
+                # Avoid .max() materializing the tensor on CPU; use native device
                 mrope_position_deltas.append(
-                    llm_positions.max() + 1 - len(total_input_ids[i])
+                    llm_positions.max().item() + 1 - len(total_input_ids[i])
                 )
+            # Build tensor in one call at the end
             mrope_position_deltas = torch.tensor(
                 mrope_position_deltas, device=input_ids.device
             ).unsqueeze(1)
             return position_ids, mrope_position_deltas
         else:
             if attention_mask is not None:
+                # Use in-place operations whenever possible
                 position_ids = attention_mask.long().cumsum(-1) - 1
                 position_ids.masked_fill_(attention_mask == 0, 1)
                 position_ids = (
@@ -2271,22 +2284,21 @@ class MRotaryEmbedding(RotaryEmbedding):
                     .expand(3, -1, -1)
                     .to(attention_mask.device)
                 )
-                max_position_ids = position_ids.max(0, keepdim=False)[0].max(
+                max_position_ids = position_ids.amax(dim=0, keepdim=False)
+                mrope_position_deltas = max_position_ids.amax(
                     -1, keepdim=True
-                )[0]
-                mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
+                ) + 1 - attention_mask.shape[-1]
             else:
-                position_ids = (
-                    torch.arange(input_ids.shape[1], device=input_ids.device)
-                    .view(1, 1, -1)
-                    .expand(3, input_ids.shape[0], -1)
-                )
+                length = input_ids.shape[1]
+                batch_size = input_ids.shape[0]
+                # Use torch.arange with in-place expansion
+                arange_ids = torch.arange(length, device=input_ids.device).view(1, 1, -1)
+                position_ids = arange_ids.expand(3, batch_size, length)
                 mrope_position_deltas = torch.zeros(
-                    [input_ids.shape[0], 1],
+                    [batch_size, 1],
                     device=input_ids.device,
                     dtype=input_ids.dtype,
                 )
-
             return position_ids, mrope_position_deltas
 
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Speedup **12%** to **600%**(long token length) for get_rope_index for GLM4v.
Benchmark test added.

<img width="1088" height="642" alt="image" src="https://github.com/user-attachments/assets/eeab5948-e4b1-4265-b09f-e74336d375ae" />


lmms_evals no drop.

PR:
```
root@c7e9bb6a6789:/sgl-workspace/bench_script# python3 benchmark_rope_index.py
[2026-01-20 13:18:27] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-01-20 13:18:27] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-01-20 13:18:27] INFO utils.py:164: NumExpr defaulting to 16 threads.
Namespace(model_name='GLM4V', tp_size=1, device='cuda', warmup_iter=10, benchmark_iter=100, dtype='int64', seed=0, num_tokens=None, batch_size=1, pad_ratio=0.0, spatial_merge_size=2, num_images=1, image_patch_tokens=256, num_videos=1, video_patch_tokens=256, out_dir='.')
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=1 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=1):
Multimodal: mean=0.00006863s, median=0.00006843s, p99=0.00007617s
Fallback:   mean=0.00006712s, median=0.00006628s, p99=0.00007729s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=2 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=2):
Multimodal: mean=0.00006740s, median=0.00006676s, p99=0.00007325s
Fallback:   mean=0.00006693s, median=0.00006676s, p99=0.00007153s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=4 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=4):
Multimodal: mean=0.00006786s, median=0.00006700s, p99=0.00007822s
Fallback:   mean=0.00007262s, median=0.00006831s, p99=0.00009158s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=8 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=8):
Multimodal: mean=0.00006834s, median=0.00006843s, p99=0.00007395s
Fallback:   mean=0.00006839s, median=0.00006819s, p99=0.00007631s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=16 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=16):
Multimodal: mean=0.00006753s, median=0.00006676s, p99=0.00007678s
Fallback:   mean=0.00006691s, median=0.00006628s, p99=0.00007582s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=32 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=32):
Multimodal: mean=0.00006731s, median=0.00006652s, p99=0.00007820s
Fallback:   mean=0.00006707s, median=0.00006652s, p99=0.00007345s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=64 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=64):
Multimodal: mean=0.00006737s, median=0.00006700s, p99=0.00007582s
Fallback:   mean=0.00006725s, median=0.00006676s, p99=0.00007298s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=128 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=128):
Multimodal: mean=0.00006764s, median=0.00006700s, p99=0.00007632s
Fallback:   mean=0.00006750s, median=0.00006700s, p99=0.00007276s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=256 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=256):
Multimodal: mean=0.00006818s, median=0.00006723s, p99=0.00007582s
Fallback:   mean=0.00006721s, median=0.00006676s, p99=0.00007439s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=512 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=512):
Multimodal: mean=0.00006747s, median=0.00006700s, p99=0.00007679s
Fallback:   mean=0.00006716s, median=0.00006676s, p99=0.00007488s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=1024 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=1024):
Multimodal: mean=0.00073278s, median=0.00071609s, p99=0.00114831s
Fallback:   mean=0.00006872s, median=0.00006771s, p99=0.00007756s
Fallback Speedup over Multimodal: 10.66258456x
Fallback Speedup over Multimodal: 10.66258456x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=2048 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=2048):
Multimodal: mean=0.00088511s, median=0.00085711s, p99=0.00097703s
Fallback:   mean=0.00007475s, median=0.00006795s, p99=0.00010307s
Fallback Speedup over Multimodal: 11.84109467x
Fallback Speedup over Multimodal: 11.84109467x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=4096 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=4096):
Multimodal: mean=0.00115255s, median=0.00115132s, p99=0.00118212s
Fallback:   mean=0.00007426s, median=0.00006843s, p99=0.00009696s
Fallback Speedup over Multimodal: 15.52043535x
Fallback Speedup over Multimodal: 15.52043535x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=8192 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=8192):
Multimodal: mean=0.00179818s, median=0.00177395s, p99=0.00249509s
Fallback:   mean=0.00006861s, median=0.00006723s, p99=0.00007953s
Fallback Speedup over Multimodal: 26.20972338x
Fallback Speedup over Multimodal: 26.20972338x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=16384 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=16384):
Multimodal: mean=0.00371805s, median=0.00366211s, p99=0.00525098s
Fallback:   mean=0.00006894s, median=0.00006747s, p99=0.00007742s
Fallback Speedup over Multimodal: 53.93269929x
Fallback Speedup over Multimodal: 53.93269929x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=32768 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=32768):
Multimodal: mean=0.00686914s, median=0.00684130s, p99=0.00718685s
Fallback:   mean=0.00006953s, median=0.00006795s, p99=0.00007931s
Fallback Speedup over Multimodal: 98.79056371x
Fallback Speedup over Multimodal: 98.79056371x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=65536 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=65536):
Multimodal: mean=0.01308443s, median=0.01293290s, p99=0.01568485s
Fallback:   mean=0.00007095s, median=0.00006795s, p99=0.00008220s
Fallback Speedup over Multimodal: 184.41506771x
Fallback Speedup over Multimodal: 184.41506771x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=131072 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=131072):
Multimodal: mean=0.02458367s, median=0.02454710s, p99=0.02778321s
Fallback:   mean=0.00007313s, median=0.00007129s, p99=0.00008432s
Fallback Speedup over Multimodal: 336.15240921x
Fallback Speedup over Multimodal: 336.15240921x
```

Main:
```
root@c7e9bb6a6789:/sgl-workspace/bench_script# python benchmark_rope_index.py 
[2026-01-21 01:21:26] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-01-21 01:21:26] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-01-21 01:21:26] INFO utils.py:164: NumExpr defaulting to 16 threads.
Namespace(model_name='GLM4V', tp_size=1, device='cuda', warmup_iter=10, benchmark_iter=100, dtype='int64', seed=0, num_tokens=None, batch_size=1, pad_ratio=0.0, spatial_merge_size=2, num_images=1, image_patch_tokens=256, num_videos=1, video_patch_tokens=256, out_dir='.')
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=1 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=1):
Multimodal: mean=0.00007301s, median=0.00007248s, p99=0.00008588s
Fallback:   mean=0.00007123s, median=0.00007033s, p99=0.00007727s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=2 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=2):
Multimodal: mean=0.00007161s, median=0.00007105s, p99=0.00007751s
Fallback:   mean=0.00007135s, median=0.00007081s, p99=0.00008059s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=4 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=4):
Multimodal: mean=0.00007182s, median=0.00007105s, p99=0.00008083s
Fallback:   mean=0.00007078s, median=0.00007057s, p99=0.00007510s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=8 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=8):
Multimodal: mean=0.00007123s, median=0.00007057s, p99=0.00008227s
Fallback:   mean=0.00007075s, median=0.00007033s, p99=0.00007750s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=16 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=16):
Multimodal: mean=0.00007248s, median=0.00007153s, p99=0.00008084s
Fallback:   mean=0.00007366s, median=0.00007319s, p99=0.00008538s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=32 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=32):
Multimodal: mean=0.00007210s, median=0.00007129s, p99=0.00007941s
Fallback:   mean=0.00007169s, median=0.00007129s, p99=0.00008083s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=64 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=64):
Multimodal: mean=0.00007199s, median=0.00007129s, p99=0.00007758s
Fallback:   mean=0.00007163s, median=0.00007129s, p99=0.00007610s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=128 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=128):
Multimodal: mean=0.00007338s, median=0.00007153s, p99=0.00009597s
Fallback:   mean=0.00007150s, median=0.00007105s, p99=0.00007868s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=256 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=256):
Multimodal: mean=0.00007224s, median=0.00007153s, p99=0.00008178s
Fallback:   mean=0.00007251s, median=0.00007153s, p99=0.00008560s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=512 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=512):
Multimodal: mean=0.00007182s, median=0.00007129s, p99=0.00007965s
Fallback:   mean=0.00007184s, median=0.00007129s, p99=0.00008036s
[INFO] num_tokens too small for multimodal segments; skip multimodal benchmark.
Fallback Speedup over Multimodal: nanx
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=1024 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=1024):
Multimodal: mean=0.00057760s, median=0.00057685s, p99=0.00059559s
Fallback:   mean=0.00009443s, median=0.00007212s, p99=0.00024320s
Fallback Speedup over Multimodal: 6.11677524x
Fallback Speedup over Multimodal: 6.11677524x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=2048 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=2048):
Multimodal: mean=0.00072351s, median=0.00072169s, p99=0.00077027s
Fallback:   mean=0.00007354s, median=0.00007224s, p99=0.00008548s
Fallback Speedup over Multimodal: 9.83793685x
Fallback Speedup over Multimodal: 9.83793685x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=4096 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=4096):
Multimodal: mean=0.00100719s, median=0.00100577s, p99=0.00103309s
Fallback:   mean=0.00007341s, median=0.00007224s, p99=0.00008432s
Fallback Speedup over Multimodal: 13.72020136x
Fallback Speedup over Multimodal: 13.72020136x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=8192 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=8192):
Multimodal: mean=0.00162929s, median=0.00162792s, p99=0.00166395s
Fallback:   mean=0.00007344s, median=0.00007200s, p99=0.00008435s
Fallback Speedup over Multimodal: 22.18458642x
Fallback Speedup over Multimodal: 22.18458642x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=16384 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=16384):
Multimodal: mean=0.01191243s, median=0.01175499s, p99=0.01465990s
Fallback:   mean=0.00008588s, median=0.00008965s, p99=0.00012821s
Fallback Speedup over Multimodal: 138.71285397x
Fallback Speedup over Multimodal: 138.71285397x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=32768 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=32768):
Multimodal: mean=0.01443047s, median=0.01413357s, p99=0.01946598s
Fallback:   mean=0.00008696s, median=0.00007868s, p99=0.00012399s
Fallback Speedup over Multimodal: 165.93765593x
Fallback Speedup over Multimodal: 165.93765593x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=65536 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=65536):
Multimodal: mean=0.11286658s, median=0.11191475s, p99=0.12707203s
Fallback:   mean=0.00008549s, median=0.00007534s, p99=0.00011458s
Fallback Speedup over Multimodal: 1320.19844944x
Fallback Speedup over Multimodal: 1320.19844944x
================================================================================
Evaluating: GLM4V tp_size=1 num_tokens=131072 batch=1 pad_ratio=0.0 images/sample=1 image_patch_tokens=256 videos/sample=1 video_patch_tokens=256 dtype=torch.int64 device=cuda

Performance for config (B=1, T=131072):
Multimodal: mean=0.16182978s, median=0.16150701s, p99=0.16971291s
Fallback:   mean=0.00008327s, median=0.00007534s, p99=0.00012350s
Fallback Speedup over Multimodal: 1943.48827487x
Fallback Speedup over Multimodal: 1943.48827487x
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

cc: @zRzRzRzRzRzRzR 