### PR TITLE
fix(sgl-kernel): Add SM121 support for NVFP4 MoE kernels

### DIFF
--- a/sgl-kernel/csrc/moe/nvfp4_blockwise_moe.cu
+++ b/sgl-kernel/csrc/moe/nvfp4_blockwise_moe.cu
@@ -665,7 +665,7 @@ void cutlass_fp4_group_mm(
           N,
           K);
     }
-  } else if (sm_version == 120) {
+  } else if (sm_version == 120 || sm_version == 121) {
     if (output.scalar_type() == torch::kBFloat16) {
       run_fp4_blockwise_scaled_group_mm_sm120(
           output,


### PR DESCRIPTION
## Summary
- Add SM121 (Blackwell GB10/DGX Spark) to the runtime SM version check for CUTLASS FP4 group GEMM kernel dispatch
- SM121 uses the same Blackwell architecture as SM120, so it can share the SM120 kernel implementation

## Test plan
Tested on NVIDIA DGX Spark (GB10, SM121) with NVFP4-quantized Qwen3-30B-A3B:
- [x] Model loads successfully with `--quantization modelopt_fp4`
- [x] Single request inference: ~37 tok/s
- [x] Batch inference (4 concurrent): ~110 tok/s total throughput
- [x] No runtime errors from `cutlass_fp4_group_mm`

## Hardware
- **GPU**: NVIDIA GB10 (DGX Spark)
- **SM Version**: 121 (compute_121a)
- **CUDA**: 13.0

## Changes
One-line change in `sgl-kernel/csrc/moe/nvfp4_blockwise_moe.cu`:
```cpp
// Before
} else if (sm_version == 120) {

// After
} else if (sm_version == 120 || sm_version == 121) {
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)