### PR TITLE
[Docs] Explain CUDA attention backend choices and aiter FP8 KV cache support

### DIFF
--- a/docs/advanced_features/attention_backend.md
+++ b/docs/advanced_features/attention_backend.md
@@ -124,26 +124,8 @@ If the `--attention-backend` argument is not specified, SGLang automatically sel
 
 **2. MLA Models (e.g., DeepSeek V3)**
 - **Hopper**: Defaults to `fa3` (requires CUDA 12.3+).
-- **Blackwell**: Defaults to `flashinfer` (though `trtllm_mla` is also an optimized option available for manual selection).
+- **Blackwell**: Defaults to `trtllm_mla`.
 - **Other Architectures**: Defaults to `triton`.
-
-### Constraints & Requirements
-
-When manually selecting a backend, be aware of the following constraints:
-
-- **FlashMLA (`flashmla`)**: Requires `page_size=64`.
-- **Cutlass MLA (`cutlass_mla`)**: Requires `page_size=128`.
-- **TensorRT-LLM MLA (`trtllm_mla`)**:
-    - Only supported on Blackwell (SM100).
-    - Requires `page_size` of 32 or 64.
-    - Supports KV cache dtypes: `fp8_e4m3`, `fp4_e2m1`, `bf16`, or `auto`.
-- **TensorRT-LLM MHA (`trtllm_mha`)**:
-    - Only supported on Blackwell (SM100).
-    - Requires `page_size` of 16, 32, or 64.
-- **FlashAttention 3 (`fa3`)**:
-    - If using FP8 KV cache, only supports `fp8_e4m3`.
-- **FlashAttention 4 (`fa4`)**:
-    - Currently supported for **prefill only**. Use via `--prefill-attention-backend fa4`.
 
 
 ## User Guide

--- a/docs/advanced_features/attention_backend.md
+++ b/docs/advanced_features/attention_backend.md
@@ -25,7 +25,7 @@ The support matrix is split into two parts: MHA (standard attention) and MLA (mu
 | **FlexAttention (PyTorch)**     | ❌                          | ❌               | ✅              | ❌              | ❌              | ❌                 | ❌             |
 | **TRTLLM MHA**                  | 16, 32 or 64                | ✅               | ✅              | ✅              | ❌              | ✅                 | ❌             |
 | **Dual Chunk FlashAttention**   | ✅                          | ❌               | ❌              | ❌              | ❌              | ❌                 | ❌             |
-| **AITER (ROCm)**                | ✅                          | ❌               | ❌              | ✅              | ✅              | ❌                 | ✅             |
+| **AITER (ROCm)**                | ✅                          | ✅               | ❌              | ✅              | ✅              | ❌                 | ✅             |
 | **Wave (ROCm)**                 | ✅                          | ❌               | ❌              | ❌              | ❌              | ❌                 | ❌             |
 | **Ascend (NPU)**                | ✅                          | ❌               | ❌              | ❌              | ❌              | ❌                 | ✅             |
 | **Intel XPU**                   | ✅                          | ❌               | ❌              | ❌              | ❌              | ✅                 | ❌             |
@@ -110,6 +110,41 @@ Constraints when combining hybrid attention with speculative decoding:
 If you set only one of `--prefill-attention-backend` or `--decode-attention-backend`, the unspecified phase inherits `--attention-backend`.
 If both are specified and differ, SGLang automatically enables a hybrid wrapper to dispatch to the chosen backend per phase.
 ```
+
+## Attention Backend Selection Guide (CUDA)
+
+If the `--attention-backend` argument is not specified, SGLang automatically selects the best backend based on the hardware (CUDA) and model architecture.
+
+### Automatic Selection Logic
+
+**1. MHA Models (e.g., Llama, Qwen)**
+- **Hopper (e.g., H100, H200)**: Defaults to `fa3` if using CUDA 12.3+ and the model configuration is supported.
+- **Blackwell (e.g., B200)**: Defaults to `trtllm_mha`, unless using speculative decoding with `topk > 1`.
+- **Other Architectures (Ampere, Ada, etc.)**: Defaults to `flashinfer` if available; otherwise falls back to `triton`.
+
+**2. MLA Models (e.g., DeepSeek V3)**
+- **Hopper**: Defaults to `fa3` (requires CUDA 12.3+).
+- **Blackwell**: Defaults to `flashinfer` (though `trtllm_mla` is also an optimized option available for manual selection).
+- **Other Architectures**: Defaults to `triton`.
+
+### Constraints & Requirements
+
+When manually selecting a backend, be aware of the following constraints:
+
+- **FlashMLA (`flashmla`)**: Requires `page_size=64`.
+- **Cutlass MLA (`cutlass_mla`)**: Requires `page_size=128`.
+- **TensorRT-LLM MLA (`trtllm_mla`)**:
+    - Only supported on Blackwell (SM100).
+    - Requires `page_size` of 32 or 64.
+    - Supports KV cache dtypes: `fp8_e4m3`, `fp4_e2m1`, `bf16`, or `auto`.
+- **TensorRT-LLM MHA (`trtllm_mha`)**:
+    - Only supported on Blackwell (SM100).
+    - Requires `page_size` of 16, 32, or 64.
+- **FlashAttention 3 (`fa3`)**:
+    - If using FP8 KV cache, only supports `fp8_e4m3`.
+- **FlashAttention 4 (`fa4`)**:
+    - Currently supported for **prefill only**. Use via `--prefill-attention-backend fa4`.
+
 
 ## User Guide
 


### PR DESCRIPTION
## Motivation
Update the documentation about attention backend and finish [issue#17371](https://github.com/sgl-project/sglang/issues/17371)
## Modifications
1. Updated the table to reflect that `aiter` support for FP8 KV cache.
2. Added a CUDA-focused selection guide
## Accuracy Tests

## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
