### PR TITLE
update urllib3 and gpgv Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -424,6 +424,9 @@ RUN if [ "${CUDA_VERSION%%.*}" = "13" ] && [ -d /usr/local/lib/python3.12/dist-p
         ln -s /usr/local/cuda/bin/ptxas /usr/local/lib/python3.12/dist-packages/triton/backends/nvidia/bin/ptxas; \
     fi
 
+# Security: Upgrade urllib3 to address CVE-2026-21441 (decompression bomb bypass)
+RUN python3 -m pip install --upgrade "urllib3>=2.6.3"
+
 # Set workspace directory
 WORKDIR /sgl-workspace/sglang
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -424,7 +424,6 @@ RUN if [ "${CUDA_VERSION%%.*}" = "13" ] && [ -d /usr/local/lib/python3.12/dist-p
         ln -s /usr/local/cuda/bin/ptxas /usr/local/lib/python3.12/dist-packages/triton/backends/nvidia/bin/ptxas; \
     fi
 
-# Security: Upgrade urllib3 to address CVE-2026-21441 (decompression bomb bypass)
 RUN python3 -m pip install --upgrade "urllib3>=2.6.3"
 
 # Set workspace directory
@@ -508,6 +507,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
     # NCCL packages needed for pynccl_allocator JIT compilation (-lnccl)
     libnccl2 \
     libnccl-dev \
+    # GPG key verification
+    gnupg2 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
     && update-alternatives --set python3 /usr/bin/python3.12 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python \


### PR DESCRIPTION
## Summary
- Upgrade urllib3 to >=2.6.3 
- Upgrade gpgv in runtime stage


## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Verify urllib3 version is >=2.6.3 in the built image
- [ ] Verify gpgv is upgraded in runtime image

🤖 Generated with [Claude Code](https://claude.com/claude-code)