### PR TITLE
[AMD] Support symmetric memory with pynccl for AMD GPUs

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -556,7 +556,11 @@ class GroupCoordinator:
         if self.npu_communicator is not None and not self.npu_communicator.disabled:
             return self.npu_communicator.all_reduce(input_)
 
-        if self.pynccl_comm is not None and self.is_symmetric_memory_enabled():
+        if (
+            self.pynccl_comm is not None
+            and self.is_symmetric_memory_enabled()
+            and not is_hip()
+        ):
             with self.pynccl_comm.change_state(
                 enable=True, stream=get_current_device_stream_fast()
             ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR supports symmetric memory with pynccl for AMD GPUs.

## Modifications

Since the `self.pynccl_comm.all_reduce()` is slower than other out-of-place all-reduce alternatives, we only register allgather and reducescatter buffers with symm memory when `--enable-symm-mem` is specified.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

```
# Current
python3 -m sglang.launch_server --model-path /data2/deepseek-ai/DeepSeek-R1-MXFP4-Preview/ --tensor-parallel-size 8  --trust-remote-code --mem-fraction-static 0.95 --attention-backend aiter --kv-cache-dtype fp8_e4m3

python3 benchmark/gsm8k/bench_sglang.py --parallel 1319 --num-questions 1319
	Accuracy: 0.941
	Invalid: 0.000


# This PR
python3 -m sglang.launch_server --model-path /data2/deepseek-ai/DeepSeek-R1-MXFP4-Preview/ --tensor-parallel-size 8  --trust-remote-code --mem-fraction-static 0.95 --attention-backend aiter --kv-cache-dtype fp8_e4m3 --enable-symm-mem

python3 benchmark/gsm8k/bench_sglang.py --parallel 1319 --num-questions 1319
	Accuracy: 0.941
	Invalid: 0.000
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

CC: @HaiShaw @kkHuang-amd 