### PR TITLE
Add job-level timeout for weekly test workflow

### DIFF
--- a/.github/workflows/weekly-test-nvidia.yml
+++ b/.github/workflows/weekly-test-nvidia.yml
@@ -28,6 +28,7 @@ jobs:
   weekly-test-8-gpu-h200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'weekly-test-8-gpu-h200')
     runs-on: 8-gpu-h200
+    timeout-minutes: 120
     env:
       RUNNER_LABELS: 8-gpu-h200
     steps:
@@ -45,4 +46,4 @@ jobs:
           IS_H200: "1"
         run: |
           cd test
-          python3 run_suite.py --hw cuda --suite weekly-8-gpu-h200 --nightly --continue-on-error
+          python3 run_suite.py --hw cuda --suite weekly-8-gpu-h200 --nightly --continue-on-error --timeout-per-file 7200


### PR DESCRIPTION
Add 120 minute job-level timeout for weekly-test-8-gpu-h200 job.

The step timeout was already set but the job-level timeout was missing, causing the job to timeout prematurely at ~20 minutes.