### PR TITLE
Fix pr-test-finish to fail when wait-for-stage jobs fail

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1812,6 +1812,9 @@ jobs:
         sgl-kernel-benchmark-test,
         sgl-kernel-b200-test,
 
+        wait-for-stage-a,
+        wait-for-stage-b,
+
         jit-kernel-unit-test,
 
         multimodal-gen-test-1-gpu,


### PR DESCRIPTION
## Summary
- Add `wait-for-stage-a` and `wait-for-stage-b` to `pr-test-finish` job's needs list

## Problem
The `pr-test-finish` job did not depend on `wait-for-stage-a` or `wait-for-stage-b`. When a wait-for-stage job failed (e.g., due to timeout), `pr-test-finish` would still succeed because it only checks the jobs in its `needs` list.

## Fix
Add both wait-for-stage jobs to the `pr-test-finish` needs list so their failure/cancellation will cause `pr-test-finish` to fail.

## Test plan
- CI will validate the workflow syntax
- After merge, `pr-test-finish` will correctly fail if any wait-for-stage job fails

Example of the bug: https://github.com/sgl-project/sglang/actions/runs/21162775050/job/60860609736 (wait-for-stage-a timeout → pr-test-finish still succeeded)