### PR TITLE
Attempt to fix flaky test_completion_stream IndexError

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -237,16 +237,23 @@ class OpenAIServingCompletion(OpenAIServingBase):
                         input_top_logprobs = None
 
                     n_prev_token = n_prev_tokens.get(index, 0)
-                    logprobs = to_openai_style_logprobs(
-                        input_token_logprobs=input_token_logprobs,
-                        input_top_logprobs=input_top_logprobs,
-                        output_token_logprobs=content["meta_info"][
-                            "output_token_logprobs"
-                        ][n_prev_token:],
-                        output_top_logprobs=content["meta_info"].get(
-                            "output_top_logprobs", []
-                        )[n_prev_token:],
-                    )
+                    output_token_logprobs = content["meta_info"][
+                        "output_token_logprobs"
+                    ][n_prev_token:]
+                    output_top_logprobs = content["meta_info"].get(
+                        "output_top_logprobs", []
+                    )[n_prev_token:]
+
+                    # Only build logprobs if there are actual tokens to report.
+                    # This prevents sending empty logprobs.tokens which causes
+                    # IndexError when clients access tokens[0].
+                    if output_token_logprobs or input_token_logprobs:
+                        logprobs = to_openai_style_logprobs(
+                            input_token_logprobs=input_token_logprobs,
+                            input_top_logprobs=input_top_logprobs,
+                            output_token_logprobs=output_token_logprobs,
+                            output_top_logprobs=output_top_logprobs,
+                        )
                     n_prev_tokens[index] = len(
                         content["meta_info"]["output_token_logprobs"]
                     )

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -254,6 +254,12 @@ class OpenAIServingCompletion(OpenAIServingBase):
                             output_token_logprobs=output_token_logprobs,
                             output_top_logprobs=output_top_logprobs,
                         )
+                    else:
+                        logger.debug(
+                            "Skipping logprobs for streaming chunk %d: "
+                            "no tokens available yet (race condition)",
+                            index,
+                        )
                     n_prev_tokens[index] = len(
                         content["meta_info"]["output_token_logprobs"]
                     )

--- a/test/registered/openai_server/basic/test_openai_server.py
+++ b/test/registered/openai_server/basic/test_openai_server.py
@@ -153,7 +153,9 @@ class TestOpenAIServer(CustomTestCase):
             index = response.choices[0].index
             is_first = is_firsts.get(index, True)
 
-            if logprobs:
+            # Only check logprobs when chunk has text delta (tokens were decoded).
+            # Race condition: first chunk may arrive before decode, with no tokens.
+            if logprobs and response.choices[0].text:
                 assert response.choices[0].logprobs, f"no logprobs in response"
                 assert isinstance(
                     response.choices[0].logprobs.tokens[0], str


### PR DESCRIPTION
## Summary

This PR fixes a race condition in streaming completions where logprobs.tokens could be empty, causing IndexError when clients access tokens[0]. The issue occurs when a streaming chunk is sent after prefill but before any decode batch runs, resulting in an empty output_token_logprobs list. The fix checks if there are actual tokens before building the logprobs object, setting it to None instead of an object with empty tokens when no tokens exist.

Example failure: https://github.com/sgl-project/sglang/actions/runs/21192446524/job/60962023626
https://github.com/sgl-project/sglang/actions/runs/21227973811/job/61080255000?pr=17533
https://github.com/sgl-project/sglang/actions/runs/21230758516/job/61088501185

## Test plan

CI should pass test_completion_stream consistently.