### PR TITLE
[FIX] avoid alloc_extend_kernel JIT cost 

### DIFF
--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -250,6 +250,7 @@ def alloc_extend_kernel(
         mask=offset_one_page < num_part3,
     )
 
+
 @triton.jit
 def alloc_extend_kernel_v2(
     pre_lens_ptr,
@@ -311,22 +312,22 @@ def alloc_extend_kernel_v2(
         start_idx = i * step_size
         end_idx = min((i + 1) * step_size, num_part2)
         current_chunk_size = end_idx - start_idx
-        
+
         offset_chunk = tl.arange(0, step_size)
         valid_mask = offset_chunk < current_chunk_size
         global_offset = start_idx + offset_chunk
-        
+
         page_start = tl.load(
             free_page_ptr + new_page_start_loc + global_offset // page_size,
             mask=valid_mask,
         )
-        
+
         tl.store(
             out_indices + output_start_loc + num_part1 + global_offset,
             page_start * page_size + global_offset % page_size,
             mask=valid_mask,
         )
-    
+
     if pre_len + num_part1 + num_part2 == seq_len:
         return
 
@@ -340,7 +341,6 @@ def alloc_extend_kernel_v2(
         start_loc * page_size + offset_one_page,
         mask=offset_one_page < num_part3,
     )
-
 
 
 @triton.jit
@@ -449,7 +449,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
         bs = len(prefix_lens)
-        self.max_bs = next_power_of_2(max(bs,self.max_bs))
+        self.max_bs = next_power_of_2(max(bs, self.max_bs))
         if self.need_sort and extend_num_tokens // self.page_size + bs + 1 > len(
             self.free_pages
         ):
@@ -466,7 +466,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             out_indices,
             self.max_bs,
             self.page_size,
-            self.page_process_step ,
+            self.page_process_step,
         )
 
         if self.debug_mode:

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -178,135 +178,66 @@ def alloc_extend_kernel(
     last_loc_ptr,
     free_page_ptr,
     out_indices,
-    bs_upper: tl.constexpr,
-    page_size: tl.constexpr,
-    max_num_extend_tokens: tl.constexpr,
-):
-    pid = tl.program_id(0)
-
-    load_offset = tl.arange(0, bs_upper)
-    seq_lens = tl.load(seq_lens_ptr + load_offset, mask=load_offset <= pid)
-    pre_lens = tl.load(pre_lens_ptr + load_offset, mask=load_offset <= pid)
-    extend_lens = seq_lens - pre_lens
-
-    seq_len = tl.load(seq_lens_ptr + pid)
-    pre_len = tl.load(pre_lens_ptr + pid)
-    extend_len = seq_len - pre_len
-
-    sum_extend_lens = tl.sum(extend_lens)
-    output_start_loc = sum_extend_lens - extend_len
-
-    num_pages_after = (seq_lens + page_size - 1) // page_size
-    num_pages_before = (pre_lens + page_size - 1) // page_size
-    num_new_pages = num_pages_after - num_pages_before
-
-    num_page_start_loc_self = (seq_len + page_size - 1) // page_size - (
-        pre_len + page_size - 1
-    ) // page_size
-    sum_num_new_pages = tl.sum(num_new_pages)
-    new_page_start_loc = sum_num_new_pages - num_page_start_loc_self
-
-    # Part 1: fill the old partial page
-    last_loc = tl.load(last_loc_ptr + pid)
-    num_part1 = (
-        min(seq_len, (pre_len + page_size - 1) // page_size * page_size) - pre_len
-    )
-    offset_one_page = tl.arange(0, page_size)
-    tl.store(
-        out_indices + output_start_loc + offset_one_page,
-        last_loc + 1 + offset_one_page,
-        mask=offset_one_page < num_part1,
-    )
-    if pre_len + num_part1 == seq_len:
-        return
-
-    # Part 2: fill the new full pages
-    num_part2 = (
-        seq_len // page_size * page_size
-        - (pre_len + page_size - 1) // page_size * page_size
-    )
-
-    offset_many_page = tl.arange(0, max_num_extend_tokens)
-    page_start = tl.load(
-        free_page_ptr + new_page_start_loc + offset_many_page // page_size,
-        mask=offset_many_page < num_part2,
-    )
-    tl.store(
-        out_indices + output_start_loc + num_part1 + offset_many_page,
-        page_start * page_size + offset_many_page % page_size,
-        mask=offset_many_page < num_part2,
-    )
-    if pre_len + num_part1 + num_part2 == seq_len:
-        return
-
-    # Part 3: fill the new partial page
-    num_part3 = seq_len - seq_len // page_size * page_size
-    start_loc = tl.load(
-        free_page_ptr + new_page_start_loc + num_page_start_loc_self - 1
-    )
-    tl.store(
-        out_indices + output_start_loc + num_part1 + num_part2 + offset_one_page,
-        start_loc * page_size + offset_one_page,
-        mask=offset_one_page < num_part3,
-    )
-
-
-@triton.jit
-def alloc_extend_kernel_v2(
-    pre_lens_ptr,
-    seq_lens_ptr,
-    last_loc_ptr,
-    free_page_ptr,
-    out_indices,
-    bs_upper: tl.constexpr,
+    step_size_bs: tl.constexpr,
     page_size: tl.constexpr,
     step_size: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
-    load_offset = tl.arange(0, bs_upper)
-    seq_lens = tl.load(seq_lens_ptr + load_offset, mask=load_offset <= pid)
-    pre_lens = tl.load(pre_lens_ptr + load_offset, mask=load_offset <= pid)
-    extend_lens = seq_lens - pre_lens
+    sum_extend_lens = 0
+    sum_num_new_pages = 0
+    sum_extend_lens = sum_extend_lens.to(tl.int64)
+    sum_num_new_pages = sum_num_new_pages.to(tl.int64)
 
     seq_len = tl.load(seq_lens_ptr + pid)
     pre_len = tl.load(pre_lens_ptr + pid)
     extend_len = seq_len - pre_len
 
-    sum_extend_lens = tl.sum(extend_lens)
+    num_loops_bs = (pid + 1 + step_size_bs - 1) // step_size_bs
+    for i in range(num_loops_bs):
+        start = i * step_size_bs
+        offset = tl.arange(0, step_size_bs)
+        mask = (start + offset) <= pid
+
+        s_lens = tl.load(seq_lens_ptr + start + offset, mask=mask, other=0)
+        p_lens = tl.load(pre_lens_ptr + start + offset, mask=mask, other=0)
+
+        e_lens = s_lens - p_lens
+        sum_extend_lens += tl.sum(e_lens)
+
+        pgs_after = (s_lens + page_size - 1) // page_size
+        pgs_before = (p_lens + page_size - 1) // page_size
+        new_pgs = pgs_after - pgs_before
+        sum_num_new_pages += tl.sum(new_pgs)
+
     output_start_loc = sum_extend_lens - extend_len
 
-    num_pages_after = (seq_lens + page_size - 1) // page_size
-    num_pages_before = (pre_lens + page_size - 1) // page_size
-    num_new_pages = num_pages_after - num_pages_before
+    num_pages_after = (seq_len + page_size - 1) // page_size
+    num_pages_before = (pre_len + page_size - 1) // page_size
+    num_page_start_loc_self = num_pages_after - num_pages_before
 
-    num_page_start_loc_self = (seq_len + page_size - 1) // page_size - (
-        pre_len + page_size - 1
-    ) // page_size
-    sum_num_new_pages = tl.sum(num_new_pages)
     new_page_start_loc = sum_num_new_pages - num_page_start_loc_self
 
     # Part 1: fill the old partial page
     last_loc = tl.load(last_loc_ptr + pid)
-    num_part1 = (
-        min(seq_len, (pre_len + page_size - 1) // page_size * page_size) - pre_len
-    )
+
+    boundary_pre = (pre_len + page_size - 1) // page_size * page_size
+    num_part1 = min(seq_len, boundary_pre) - pre_len
+
     offset_one_page = tl.arange(0, page_size)
     tl.store(
         out_indices + output_start_loc + offset_one_page,
         last_loc + 1 + offset_one_page,
         mask=offset_one_page < num_part1,
     )
+
     if pre_len + num_part1 == seq_len:
         return
 
     # Part 2: fill the new full pages
-    num_part2 = (
-        seq_len // page_size * page_size
-        - (pre_len + page_size - 1) // page_size * page_size
-    )
+    boundary_seq = seq_len // page_size * page_size
+    num_part2 = boundary_seq - boundary_pre
 
-    # handle new page chunk by chunk
     num_loops = (num_part2 + step_size - 1) // step_size
     for i in range(num_loops):
         start_idx = i * step_size
@@ -317,10 +248,9 @@ def alloc_extend_kernel_v2(
         valid_mask = offset_chunk < current_chunk_size
         global_offset = start_idx + offset_chunk
 
-        page_start = tl.load(
-            free_page_ptr + new_page_start_loc + global_offset // page_size,
-            mask=valid_mask,
-        )
+        page_idx_in_free_list = new_page_start_loc + (global_offset // page_size)
+
+        page_start = tl.load(free_page_ptr + page_idx_in_free_list, mask=valid_mask)
 
         tl.store(
             out_indices + output_start_loc + num_part1 + global_offset,
@@ -332,7 +262,7 @@ def alloc_extend_kernel_v2(
         return
 
     # Part 3: fill the new partial page
-    num_part3 = seq_len - seq_len // page_size * page_size
+    num_part3 = seq_len - boundary_seq
     start_loc = tl.load(
         free_page_ptr + new_page_start_loc + num_page_start_loc_self - 1
     )
@@ -402,7 +332,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.num_pages = size // page_size
         self.debug_mode = get_bool_env_var("SGLANG_DEBUG_MEMORY_POOL")
         self.seen_max_num_extend_tokens_next_power_of_2 = 1
-        self.max_bs = next_power_of_2(1024)
+        self.bs_step = next_power_of_2(512)
         self.page_process_step = next_power_of_2(512)
         self.clear()
 
@@ -443,13 +373,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 (last_loc + 1) % self.page_size == prefix_lens % self.page_size
             )
 
-        self.seen_max_num_extend_tokens_next_power_of_2 = max(
-            self.seen_max_num_extend_tokens_next_power_of_2,
-            next_power_of_2(extend_num_tokens),
-        )
-
         bs = len(prefix_lens)
-        self.max_bs = next_power_of_2(max(bs, self.max_bs))
         if self.need_sort and extend_num_tokens // self.page_size + bs + 1 > len(
             self.free_pages
         ):
@@ -458,13 +382,13 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
-        alloc_extend_kernel_v2[(bs,)](
+        alloc_extend_kernel[(bs,)](
             prefix_lens,
             seq_lens,
             last_loc,
             self.free_pages,
             out_indices,
-            self.max_bs,
+            self.bs_step,
             self.page_size,
             self.page_process_step,
         )

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -250,6 +250,100 @@ def alloc_extend_kernel(
         mask=offset_one_page < num_part3,
     )
 
+@triton.jit
+def alloc_extend_kernel_v2(
+    pre_lens_ptr,
+    seq_lens_ptr,
+    last_loc_ptr,
+    free_page_ptr,
+    out_indices,
+    bs_upper: tl.constexpr,
+    page_size: tl.constexpr,
+    step_size: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    load_offset = tl.arange(0, bs_upper)
+    seq_lens = tl.load(seq_lens_ptr + load_offset, mask=load_offset <= pid)
+    pre_lens = tl.load(pre_lens_ptr + load_offset, mask=load_offset <= pid)
+    extend_lens = seq_lens - pre_lens
+
+    seq_len = tl.load(seq_lens_ptr + pid)
+    pre_len = tl.load(pre_lens_ptr + pid)
+    extend_len = seq_len - pre_len
+
+    sum_extend_lens = tl.sum(extend_lens)
+    output_start_loc = sum_extend_lens - extend_len
+
+    num_pages_after = (seq_lens + page_size - 1) // page_size
+    num_pages_before = (pre_lens + page_size - 1) // page_size
+    num_new_pages = num_pages_after - num_pages_before
+
+    num_page_start_loc_self = (seq_len + page_size - 1) // page_size - (
+        pre_len + page_size - 1
+    ) // page_size
+    sum_num_new_pages = tl.sum(num_new_pages)
+    new_page_start_loc = sum_num_new_pages - num_page_start_loc_self
+
+    # Part 1: fill the old partial page
+    last_loc = tl.load(last_loc_ptr + pid)
+    num_part1 = (
+        min(seq_len, (pre_len + page_size - 1) // page_size * page_size) - pre_len
+    )
+    offset_one_page = tl.arange(0, page_size)
+    tl.store(
+        out_indices + output_start_loc + offset_one_page,
+        last_loc + 1 + offset_one_page,
+        mask=offset_one_page < num_part1,
+    )
+    if pre_len + num_part1 == seq_len:
+        return
+
+    # Part 2: fill the new full pages
+    num_part2 = (
+        seq_len // page_size * page_size
+        - (pre_len + page_size - 1) // page_size * page_size
+    )
+
+    # handle new page chunk by chunk
+    num_loops = (num_part2 + step_size - 1) // step_size
+    
+    # 循环处理每个 chunk
+    for i in range(num_loops):
+        start_idx = i * step_size
+        end_idx = min((i + 1) * step_size, num_part2)
+        current_chunk_size = end_idx - start_idx
+        
+        offset_chunk = tl.arange(0, step_size)
+        valid_mask = offset_chunk < current_chunk_size
+        global_offset = start_idx + offset_chunk
+        
+        page_start = tl.load(
+            free_page_ptr + new_page_start_loc + global_offset // page_size,
+            mask=valid_mask,
+        )
+        
+        tl.store(
+            out_indices + output_start_loc + num_part1 + global_offset,
+            page_start * page_size + global_offset % page_size,
+            mask=valid_mask,
+        )
+    
+    if pre_len + num_part1 + num_part2 == seq_len:
+        return
+
+    # Part 3: fill the new partial page
+    num_part3 = seq_len - seq_len // page_size * page_size
+    start_loc = tl.load(
+        free_page_ptr + new_page_start_loc + num_page_start_loc_self - 1
+    )
+    tl.store(
+        out_indices + output_start_loc + num_part1 + num_part2 + offset_one_page,
+        start_loc * page_size + offset_one_page,
+        mask=offset_one_page < num_part3,
+    )
+
+
 
 @triton.jit
 def alloc_decode_kernel(
@@ -310,6 +404,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.num_pages = size // page_size
         self.debug_mode = get_bool_env_var("SGLANG_DEBUG_MEMORY_POOL")
         self.seen_max_num_extend_tokens_next_power_of_2 = 1
+        self.max_bs = next_power_of_2(1024)
+        self.page_process_step = next_power_of_2(512)
         self.clear()
 
     def alloc(self, need_size: int):
@@ -355,6 +451,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
 
         bs = len(prefix_lens)
+        self.max_bs = next_power_of_2(max(bs,self.max_bs))
         if self.need_sort and extend_num_tokens // self.page_size + bs + 1 > len(
             self.free_pages
         ):
@@ -363,15 +460,15 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
-        alloc_extend_kernel[(bs,)](
+        alloc_extend_kernel_v2[(bs,)](
             prefix_lens,
             seq_lens,
             last_loc,
             self.free_pages,
             out_indices,
-            next_power_of_2(bs),
+            self.max_bs,
             self.page_size,
-            self.seen_max_num_extend_tokens_next_power_of_2,
+            self.page_process_step ,
         )
 
         if self.debug_mode:

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -307,8 +307,6 @@ def alloc_extend_kernel_v2(
 
     # handle new page chunk by chunk
     num_loops = (num_part2 + step_size - 1) // step_size
-    
-    # 循环处理每个 chunk
     for i in range(num_loops):
         start_idx = i * step_size
         end_idx = min((i + 1) * step_size, num_part2)

--- a/test/srt/test_triton_page_alloc_extend.py
+++ b/test/srt/test_triton_page_alloc_extend.py
@@ -1,8 +1,10 @@
 import time
 import unittest
+
 import torch
+
 from sglang.srt.mem_cache.allocator import alloc_extend_kernel, alloc_extend_kernel_v2
-from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_2
+from sglang.srt.utils import next_power_of_2
 
 # Test configurations
 BATCH_SIZES = [1, 32, 64]
@@ -17,35 +19,35 @@ def setup_alloc_test(bs, seq_len, prefix_len=0, device="cuda"):
     seq_lens = torch.full((bs,), seq_len, dtype=torch.int64, device=device)
     last_loc = torch.full((bs,), prefix_len - 1, dtype=torch.int64, device=device)
     free_pages = torch.arange(1, NUM_PAGES + 1, dtype=torch.int64, device=device)
-    
+
     extend_num_tokens = (seq_lens - prefix_lens).sum().item()
     out_indices = torch.empty((extend_num_tokens,), dtype=torch.int64, device=device)
-    
+
     return prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens
 
 
 class TestAllocExtend(unittest.TestCase):
     """Test alloc_extend_kernel and alloc_extend_kernel_v2 functions."""
-    
+
     @classmethod
     def setUpClass(cls):
         """Skip tests if CUDA is not available."""
         if not torch.cuda.is_available():
             raise unittest.SkipTest("CUDA not available")
-    
+
     # ==================== Compilation Time Tests ====================
-    
+
     def _test_alloc_extend_compile_time_v1(self, bs, seq_len):
         """Test compilation time for alloc_extend_kernel."""
         prefix_len = 0
-        prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
-            bs, seq_len, prefix_len, "cuda"
+        prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = (
+            setup_alloc_test(bs, seq_len, prefix_len, "cuda")
         )
-        
+
         # Compute required parameters
         max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
         bs_pow2 = next_power_of_2(bs)
-    
+
         # Measure compilation time
         torch.cuda.synchronize()
         compile_times = []
@@ -63,21 +65,23 @@ class TestAllocExtend(unittest.TestCase):
             )
             torch.cuda.synchronize()
             compile_times.append(time.perf_counter() - start)
-        
+
         max_compile_time = max(compile_times) * 1000
         avg_compile_time = sum(compile_times) / len(compile_times) * 1000
-        print(f"V1 - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms")
-    
+        print(
+            f"V1 - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
     def _test_alloc_extend_compile_time_v2(self, bs, seq_len):
         """Test compilation time for alloc_extend_kernel_v2."""
         prefix_len = 0
         step = 512
         max_bs = 128
-        
-        prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
-            bs, seq_len, prefix_len, "cuda"
+
+        prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = (
+            setup_alloc_test(bs, seq_len, prefix_len, "cuda")
         )
-        
+
         # Measure compilation time
         torch.cuda.synchronize()
         compile_times = []
@@ -95,26 +99,33 @@ class TestAllocExtend(unittest.TestCase):
             )
             torch.cuda.synchronize()
             compile_times.append(time.perf_counter() - start)
-        
+
         max_compile_time = max(compile_times) * 1000
         avg_compile_time = sum(compile_times) / len(compile_times) * 1000
-        
-        print(f"V2 - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms")
-    
+
+        print(
+            f"V2 - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
     # ==================== Runtime Performance Tests ====================
-    
+
     def _test_alloc_extend_performance_v1(self, bs, seq_len):
         """Test runtime performance for alloc_extend_kernel."""
         prefix_len = 0
-        
+
         # Warmup
         for _ in range(10):
-            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
-                bs, seq_len, prefix_len, "cuda"
-            )
+            (
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                extend_num_tokens,
+            ) = setup_alloc_test(bs, seq_len, prefix_len, "cuda")
             max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
             bs_pow2 = next_power_of_2(bs)
-            
+
             alloc_extend_kernel[(bs,)](
                 prefix_lens,
                 seq_lens,
@@ -126,21 +137,26 @@ class TestAllocExtend(unittest.TestCase):
                 max_extend_tokens_pow2,
             )
             torch.cuda.synchronize()
-        
+
         # Performance measurement
         start_event = torch.cuda.Event(enable_timing=True)
         end_event = torch.cuda.Event(enable_timing=True)
-        
+
         torch.cuda.synchronize()
         start_event.record()
-        
+
         for _ in range(100):
-            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
-                bs, seq_len, prefix_len, "cuda"
-            )
+            (
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                extend_num_tokens,
+            ) = setup_alloc_test(bs, seq_len, prefix_len, "cuda")
             max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
             bs_pow2 = next_power_of_2(bs)
-            
+
             alloc_extend_kernel[(bs,)](
                 prefix_lens,
                 seq_lens,
@@ -151,28 +167,32 @@ class TestAllocExtend(unittest.TestCase):
                 PAGE_SIZE,
                 max_extend_tokens_pow2,
             )
-        
+
         end_event.record()
         torch.cuda.synchronize()
-        
+
         total_runtime = start_event.elapsed_time(end_event)
         avg_runtime = total_runtime / 100
-        
-        print(f"V1 - bs={bs}, seq_len={seq_len} "
-              f"avg={avg_runtime:.3f}ms")
-    
+
+        print(f"V1 - bs={bs}, seq_len={seq_len} " f"avg={avg_runtime:.3f}ms")
+
     def _test_alloc_extend_performance_v2(self, bs, seq_len):
         """Test runtime performance for alloc_extend_kernel_v2."""
         prefix_len = 0
         step = 512
         max_bs = 128
-        
+
         # Warmup
         for _ in range(10):
-            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
-                bs, seq_len, prefix_len, "cuda"
-            )
-            
+            (
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                extend_num_tokens,
+            ) = setup_alloc_test(bs, seq_len, prefix_len, "cuda")
+
             alloc_extend_kernel_v2[(bs,)](
                 prefix_lens,
                 seq_lens,
@@ -184,19 +204,24 @@ class TestAllocExtend(unittest.TestCase):
                 next_power_of_2(step),
             )
             torch.cuda.synchronize()
-        
+
         # Performance measurement
         start_event = torch.cuda.Event(enable_timing=True)
         end_event = torch.cuda.Event(enable_timing=True)
-        
+
         torch.cuda.synchronize()
         start_event.record()
-        
+
         for _ in range(100):
-            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
-                bs, seq_len, prefix_len, "cuda"
-            )
-            
+            (
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                extend_num_tokens,
+            ) = setup_alloc_test(bs, seq_len, prefix_len, "cuda")
+
             alloc_extend_kernel_v2[(bs,)](
                 prefix_lens,
                 seq_lens,
@@ -207,36 +232,35 @@ class TestAllocExtend(unittest.TestCase):
                 PAGE_SIZE,
                 next_power_of_2(step),
             )
-        
+
         end_event.record()
         torch.cuda.synchronize()
-        
+
         total_runtime = start_event.elapsed_time(end_event)
         avg_runtime = total_runtime / 100
-        
-        print(f"V2 - bs={bs}, seq_len={seq_len} "
-              f"avg={avg_runtime:.3f}ms")
-    
+
+        print(f"V2 - bs={bs}, seq_len={seq_len} " f"avg={avg_runtime:.3f}ms")
+
     # ==================== Correctness Tests ====================
-    
+
     def _test_alloc_extend_correctness(self, bs, seq_len, prefix_len):
         """Test consistency between alloc_extend_kernel and alloc_extend_kernel_v2."""
         step = 512
         max_bs = 128
-        
+
         # Setup for v1
-        prefix_lens, seq_lens, last_loc, free_pages_v1, out_v1, extend_num_tokens = setup_alloc_test(
-            bs, seq_len, prefix_len, "cuda"
+        prefix_lens, seq_lens, last_loc, free_pages_v1, out_v1, extend_num_tokens = (
+            setup_alloc_test(bs, seq_len, prefix_len, "cuda")
         )
-        
+
         # Setup for v2 (need separate free_pages)
         free_pages_v2 = torch.arange(1, NUM_PAGES + 1, dtype=torch.int64, device="cuda")
         out_v2 = torch.empty((extend_num_tokens,), dtype=torch.int64, device="cuda")
-        
+
         # Run v1
         max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
         bs_pow2 = next_power_of_2(bs)
-        
+
         alloc_extend_kernel[(bs,)](
             prefix_lens,
             seq_lens,
@@ -248,7 +272,7 @@ class TestAllocExtend(unittest.TestCase):
             max_extend_tokens_pow2,
         )
         torch.cuda.synchronize()
-        
+
         # Run v2
         alloc_extend_kernel_v2[(bs,)](
             prefix_lens,
@@ -261,53 +285,59 @@ class TestAllocExtend(unittest.TestCase):
             next_power_of_2(step),
         )
         torch.cuda.synchronize()
-        
+
         # Check bounds
         max_valid_index = NUM_PAGES * PAGE_SIZE
-        self.assertTrue(torch.all(out_v1 >= 0) and torch.all(out_v1 < max_valid_index), 
-                       "V1 output out of bounds")
-        self.assertTrue(torch.all(out_v2 >= 0) and torch.all(out_v2 < max_valid_index), 
-                       "V2 output out of bounds")
-        
+        self.assertTrue(
+            torch.all(out_v1 >= 0) and torch.all(out_v1 < max_valid_index),
+            "V1 output out of bounds",
+        )
+        self.assertTrue(
+            torch.all(out_v2 >= 0) and torch.all(out_v2 < max_valid_index),
+            "V2 output out of bounds",
+        )
+
         # Check consistency
-        self.assertTrue(torch.equal(out_v1, out_v2), 
-                       f"Output mismatch for bs={bs}, seq_len={seq_len}, prefix_len={prefix_len}")
-    
+        self.assertTrue(
+            torch.equal(out_v1, out_v2),
+            f"Output mismatch for bs={bs}, seq_len={seq_len}, prefix_len={prefix_len}",
+        )
+
     # ==================== Test Generation Methods ====================
-    
+
     def test_all_compile_time_v1(self):
         """Test compilation time for alloc_extend_kernel with various configurations."""
         for bs in BATCH_SIZES:
             for seq_len in SEQ_LENS:
-                if bs >= 32 and seq_len >= 32000: # skip v1 compile which is too slow 
+                if bs >= 32 and seq_len >= 32000:  # skip v1 compile which is too slow
                     continue
                 with self.subTest(bs=bs, seq_len=seq_len):
                     self._test_alloc_extend_compile_time_v1(bs, seq_len)
                     torch.cuda.empty_cache()
-    
+
     def test_all_compile_time_v2(self):
         """Test compilation time for alloc_extend_kernel_v2 with various configurations."""
         for bs in BATCH_SIZES:
             for seq_len in SEQ_LENS:
                 with self.subTest(bs=bs, seq_len=seq_len):
                     self._test_alloc_extend_compile_time_v2(bs, seq_len)
-    
+
     def test_all_performance_v1(self):
         """Test runtime performance for alloc_extend_kernel with various configurations."""
         for bs in BATCH_SIZES:
             for seq_len in SEQ_LENS:
-                if bs >= 32 and seq_len >= 32000: # skip v1 compile which is too slow 
+                if bs >= 32 and seq_len >= 32000:  # skip v1 compile which is too slow
                     continue
                 with self.subTest(bs=bs, seq_len=seq_len):
                     self._test_alloc_extend_performance_v1(bs, seq_len)
-    
+
     def test_all_performance_v2(self):
         """Test runtime performance for alloc_extend_kernel_v2 with various configurations."""
         for bs in BATCH_SIZES:
             for seq_len in SEQ_LENS:
                 with self.subTest(bs=bs, seq_len=seq_len):
                     self._test_alloc_extend_performance_v2(bs, seq_len)
-    
+
     def test_all_correctness(self):
         """Test correctness with various test cases."""
         test_cases = [
@@ -325,7 +355,7 @@ class TestAllocExtend(unittest.TestCase):
             (4, 30, 10),
             (4, 70, 30),
         ]
-        
+
         for bs, seq_len, prefix_len in test_cases:
             with self.subTest(bs=bs, seq_len=seq_len, prefix_len=prefix_len):
                 self._test_alloc_extend_correctness(bs, seq_len, prefix_len)

--- a/test/srt/test_triton_page_alloc_extend.py
+++ b/test/srt/test_triton_page_alloc_extend.py
@@ -1,0 +1,336 @@
+import time
+import unittest
+import torch
+from sglang.srt.mem_cache.allocator import alloc_extend_kernel, alloc_extend_kernel_v2
+from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_2
+
+# Test configurations
+BATCH_SIZES = [1, 32, 64]
+SEQ_LENS = [1, 1000, 32000, 64000]
+PAGE_SIZE = 64
+NUM_PAGES = 100000
+
+
+def setup_alloc_test(bs, seq_len, prefix_len=0, device="cuda"):
+    """Setup test tensors for allocation test."""
+    prefix_lens = torch.full((bs,), prefix_len, dtype=torch.int64, device=device)
+    seq_lens = torch.full((bs,), seq_len, dtype=torch.int64, device=device)
+    last_loc = torch.full((bs,), prefix_len - 1, dtype=torch.int64, device=device)
+    free_pages = torch.arange(1, NUM_PAGES + 1, dtype=torch.int64, device=device)
+    
+    extend_num_tokens = (seq_lens - prefix_lens).sum().item()
+    out_indices = torch.empty((extend_num_tokens,), dtype=torch.int64, device=device)
+    
+    return prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens
+
+
+class TestAllocExtend(unittest.TestCase):
+    """Test alloc_extend_kernel and alloc_extend_kernel_v2 functions."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Skip tests if CUDA is not available."""
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+    
+    # ==================== Compilation Time Tests ====================
+    
+    def _test_alloc_extend_compile_time_v1(self, bs, seq_len):
+        """Test compilation time for alloc_extend_kernel."""
+        prefix_len = 0
+        prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
+            bs, seq_len, prefix_len, "cuda"
+        )
+        
+        # Compute required parameters
+        max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
+        bs_pow2 = next_power_of_2(bs)
+    
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            alloc_extend_kernel[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_pow2,
+                PAGE_SIZE,
+                max_extend_tokens_pow2,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+        
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(f"V1 - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms")
+    
+    def _test_alloc_extend_compile_time_v2(self, bs, seq_len):
+        """Test compilation time for alloc_extend_kernel_v2."""
+        prefix_len = 0
+        step = 512
+        max_bs = 128
+        
+        prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
+            bs, seq_len, prefix_len, "cuda"
+        )
+        
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            alloc_extend_kernel_v2[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                next_power_of_2(max_bs),
+                PAGE_SIZE,
+                next_power_of_2(step),
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+        
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        
+        print(f"V2 - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms")
+    
+    # ==================== Runtime Performance Tests ====================
+    
+    def _test_alloc_extend_performance_v1(self, bs, seq_len):
+        """Test runtime performance for alloc_extend_kernel."""
+        prefix_len = 0
+        
+        # Warmup
+        for _ in range(10):
+            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
+                bs, seq_len, prefix_len, "cuda"
+            )
+            max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
+            bs_pow2 = next_power_of_2(bs)
+            
+            alloc_extend_kernel[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_pow2,
+                PAGE_SIZE,
+                max_extend_tokens_pow2,
+            )
+            torch.cuda.synchronize()
+        
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        
+        torch.cuda.synchronize()
+        start_event.record()
+        
+        for _ in range(100):
+            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
+                bs, seq_len, prefix_len, "cuda"
+            )
+            max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
+            bs_pow2 = next_power_of_2(bs)
+            
+            alloc_extend_kernel[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_pow2,
+                PAGE_SIZE,
+                max_extend_tokens_pow2,
+            )
+        
+        end_event.record()
+        torch.cuda.synchronize()
+        
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        
+        print(f"V1 - bs={bs}, seq_len={seq_len} "
+              f"avg={avg_runtime:.3f}ms")
+    
+    def _test_alloc_extend_performance_v2(self, bs, seq_len):
+        """Test runtime performance for alloc_extend_kernel_v2."""
+        prefix_len = 0
+        step = 512
+        max_bs = 128
+        
+        # Warmup
+        for _ in range(10):
+            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
+                bs, seq_len, prefix_len, "cuda"
+            )
+            
+            alloc_extend_kernel_v2[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                next_power_of_2(max_bs),
+                PAGE_SIZE,
+                next_power_of_2(step),
+            )
+            torch.cuda.synchronize()
+        
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        
+        torch.cuda.synchronize()
+        start_event.record()
+        
+        for _ in range(100):
+            prefix_lens, seq_lens, last_loc, free_pages, out_indices, extend_num_tokens = setup_alloc_test(
+                bs, seq_len, prefix_len, "cuda"
+            )
+            
+            alloc_extend_kernel_v2[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                next_power_of_2(max_bs),
+                PAGE_SIZE,
+                next_power_of_2(step),
+            )
+        
+        end_event.record()
+        torch.cuda.synchronize()
+        
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        
+        print(f"V2 - bs={bs}, seq_len={seq_len} "
+              f"avg={avg_runtime:.3f}ms")
+    
+    # ==================== Correctness Tests ====================
+    
+    def _test_alloc_extend_correctness(self, bs, seq_len, prefix_len):
+        """Test consistency between alloc_extend_kernel and alloc_extend_kernel_v2."""
+        step = 512
+        max_bs = 128
+        
+        # Setup for v1
+        prefix_lens, seq_lens, last_loc, free_pages_v1, out_v1, extend_num_tokens = setup_alloc_test(
+            bs, seq_len, prefix_len, "cuda"
+        )
+        
+        # Setup for v2 (need separate free_pages)
+        free_pages_v2 = torch.arange(1, NUM_PAGES + 1, dtype=torch.int64, device="cuda")
+        out_v2 = torch.empty((extend_num_tokens,), dtype=torch.int64, device="cuda")
+        
+        # Run v1
+        max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
+        bs_pow2 = next_power_of_2(bs)
+        
+        alloc_extend_kernel[(bs,)](
+            prefix_lens,
+            seq_lens,
+            last_loc,
+            free_pages_v1,
+            out_v1,
+            bs_pow2,
+            PAGE_SIZE,
+            max_extend_tokens_pow2,
+        )
+        torch.cuda.synchronize()
+        
+        # Run v2
+        alloc_extend_kernel_v2[(bs,)](
+            prefix_lens,
+            seq_lens,
+            last_loc,
+            free_pages_v2,
+            out_v2,
+            next_power_of_2(max_bs),
+            PAGE_SIZE,
+            next_power_of_2(step),
+        )
+        torch.cuda.synchronize()
+        
+        # Check bounds
+        max_valid_index = NUM_PAGES * PAGE_SIZE
+        self.assertTrue(torch.all(out_v1 >= 0) and torch.all(out_v1 < max_valid_index), 
+                       "V1 output out of bounds")
+        self.assertTrue(torch.all(out_v2 >= 0) and torch.all(out_v2 < max_valid_index), 
+                       "V2 output out of bounds")
+        
+        # Check consistency
+        self.assertTrue(torch.equal(out_v1, out_v2), 
+                       f"Output mismatch for bs={bs}, seq_len={seq_len}, prefix_len={prefix_len}")
+    
+    # ==================== Test Generation Methods ====================
+    
+    def test_all_compile_time_v1(self):
+        """Test compilation time for alloc_extend_kernel with various configurations."""
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                if bs >= 32 and seq_len >= 32000: # skip v1 compile which is too slow 
+                    continue
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_extend_compile_time_v1(bs, seq_len)
+                    torch.cuda.empty_cache()
+    
+    def test_all_compile_time_v2(self):
+        """Test compilation time for alloc_extend_kernel_v2 with various configurations."""
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_extend_compile_time_v2(bs, seq_len)
+    
+    def test_all_performance_v1(self):
+        """Test runtime performance for alloc_extend_kernel with various configurations."""
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                if bs >= 32 and seq_len >= 32000: # skip v1 compile which is too slow 
+                    continue
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_extend_performance_v1(bs, seq_len)
+    
+    def test_all_performance_v2(self):
+        """Test runtime performance for alloc_extend_kernel_v2 with various configurations."""
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_extend_performance_v2(bs, seq_len)
+    
+    def test_all_correctness(self):
+        """Test correctness with various test cases."""
+        test_cases = [
+            (1, 100, 0),
+            (4, 500, 100),
+            (8, 1000, 200),
+            (16, 2000, 500),
+            (32, 5000, 1000),
+            (1, 63, 0),
+            (1, 64, 0),
+            (1, 65, 0),
+            (1, 511, 0),
+            (1, 513, 0),
+            (1, 1024, 0),
+            (4, 30, 10),
+            (4, 70, 30),
+        ]
+        
+        for bs, seq_len, prefix_len in test_cases:
+            with self.subTest(bs=bs, seq_len=seq_len, prefix_len=prefix_len):
+                self._test_alloc_extend_correctness(bs, seq_len, prefix_len)
+                torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_triton_page_alloc_extend.py
+++ b/test/srt/test_triton_page_alloc_extend.py
@@ -2,8 +2,10 @@ import time
 import unittest
 
 import torch
+import triton
+import triton.language as tl
 
-from sglang.srt.mem_cache.allocator import alloc_extend_kernel, alloc_extend_kernel_v2
+from sglang.srt.mem_cache.allocator import alloc_extend_kernel
 from sglang.srt.utils import next_power_of_2
 
 # Test configurations
@@ -11,6 +13,86 @@ BATCH_SIZES = [1, 32, 64]
 SEQ_LENS = [1, 1000, 32000, 64000]
 PAGE_SIZE = 64
 NUM_PAGES = 100000
+
+
+@triton.jit
+def alloc_extend_kernel_old(
+    pre_lens_ptr,
+    seq_lens_ptr,
+    last_loc_ptr,
+    free_page_ptr,
+    out_indices,
+    bs_upper: tl.constexpr,
+    page_size: tl.constexpr,
+    max_num_extend_tokens: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    load_offset = tl.arange(0, bs_upper)
+    seq_lens = tl.load(seq_lens_ptr + load_offset, mask=load_offset <= pid)
+    pre_lens = tl.load(pre_lens_ptr + load_offset, mask=load_offset <= pid)
+    extend_lens = seq_lens - pre_lens
+
+    seq_len = tl.load(seq_lens_ptr + pid)
+    pre_len = tl.load(pre_lens_ptr + pid)
+    extend_len = seq_len - pre_len
+
+    sum_extend_lens = tl.sum(extend_lens)
+    output_start_loc = sum_extend_lens - extend_len
+
+    num_pages_after = (seq_lens + page_size - 1) // page_size
+    num_pages_before = (pre_lens + page_size - 1) // page_size
+    num_new_pages = num_pages_after - num_pages_before
+
+    num_page_start_loc_self = (seq_len + page_size - 1) // page_size - (
+        pre_len + page_size - 1
+    ) // page_size
+    sum_num_new_pages = tl.sum(num_new_pages)
+    new_page_start_loc = sum_num_new_pages - num_page_start_loc_self
+
+    # Part 1: fill the old partial page
+    last_loc = tl.load(last_loc_ptr + pid)
+    num_part1 = (
+        min(seq_len, (pre_len + page_size - 1) // page_size * page_size) - pre_len
+    )
+    offset_one_page = tl.arange(0, page_size)
+    tl.store(
+        out_indices + output_start_loc + offset_one_page,
+        last_loc + 1 + offset_one_page,
+        mask=offset_one_page < num_part1,
+    )
+    if pre_len + num_part1 == seq_len:
+        return
+
+    # Part 2: fill the new full pages
+    num_part2 = (
+        seq_len // page_size * page_size
+        - (pre_len + page_size - 1) // page_size * page_size
+    )
+
+    offset_many_page = tl.arange(0, max_num_extend_tokens)
+    page_start = tl.load(
+        free_page_ptr + new_page_start_loc + offset_many_page // page_size,
+        mask=offset_many_page < num_part2,
+    )
+    tl.store(
+        out_indices + output_start_loc + num_part1 + offset_many_page,
+        page_start * page_size + offset_many_page % page_size,
+        mask=offset_many_page < num_part2,
+    )
+    if pre_len + num_part1 + num_part2 == seq_len:
+        return
+
+    # Part 3: fill the new partial page
+    num_part3 = seq_len - seq_len // page_size * page_size
+    start_loc = tl.load(
+        free_page_ptr + new_page_start_loc + num_page_start_loc_self - 1
+    )
+    tl.store(
+        out_indices + output_start_loc + num_part1 + num_part2 + offset_one_page,
+        start_loc * page_size + offset_one_page,
+        mask=offset_one_page < num_part3,
+    )
 
 
 def setup_alloc_test(bs, seq_len, prefix_len=0, device="cuda"):
@@ -53,7 +135,7 @@ class TestAllocExtend(unittest.TestCase):
         compile_times = []
         for _ in range(3):
             start = time.perf_counter()
-            alloc_extend_kernel[(bs,)](
+            alloc_extend_kernel_old[(bs,)](
                 prefix_lens,
                 seq_lens,
                 last_loc,
@@ -87,7 +169,7 @@ class TestAllocExtend(unittest.TestCase):
         compile_times = []
         for _ in range(3):
             start = time.perf_counter()
-            alloc_extend_kernel_v2[(bs,)](
+            alloc_extend_kernel[(bs,)](
                 prefix_lens,
                 seq_lens,
                 last_loc,
@@ -126,7 +208,7 @@ class TestAllocExtend(unittest.TestCase):
             max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
             bs_pow2 = next_power_of_2(bs)
 
-            alloc_extend_kernel[(bs,)](
+            alloc_extend_kernel_old[(bs,)](
                 prefix_lens,
                 seq_lens,
                 last_loc,
@@ -157,7 +239,7 @@ class TestAllocExtend(unittest.TestCase):
             max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
             bs_pow2 = next_power_of_2(bs)
 
-            alloc_extend_kernel[(bs,)](
+            alloc_extend_kernel_old[(bs,)](
                 prefix_lens,
                 seq_lens,
                 last_loc,
@@ -193,7 +275,7 @@ class TestAllocExtend(unittest.TestCase):
                 extend_num_tokens,
             ) = setup_alloc_test(bs, seq_len, prefix_len, "cuda")
 
-            alloc_extend_kernel_v2[(bs,)](
+            alloc_extend_kernel[(bs,)](
                 prefix_lens,
                 seq_lens,
                 last_loc,
@@ -222,7 +304,7 @@ class TestAllocExtend(unittest.TestCase):
                 extend_num_tokens,
             ) = setup_alloc_test(bs, seq_len, prefix_len, "cuda")
 
-            alloc_extend_kernel_v2[(bs,)](
+            alloc_extend_kernel[(bs,)](
                 prefix_lens,
                 seq_lens,
                 last_loc,
@@ -261,7 +343,7 @@ class TestAllocExtend(unittest.TestCase):
         max_extend_tokens_pow2 = next_power_of_2(extend_num_tokens)
         bs_pow2 = next_power_of_2(bs)
 
-        alloc_extend_kernel[(bs,)](
+        alloc_extend_kernel_old[(bs,)](
             prefix_lens,
             seq_lens,
             last_loc,
@@ -274,7 +356,7 @@ class TestAllocExtend(unittest.TestCase):
         torch.cuda.synchronize()
 
         # Run v2
-        alloc_extend_kernel_v2[(bs,)](
+        alloc_extend_kernel[(bs,)](
             prefix_lens,
             seq_lens,
             last_loc,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Similar to this issue https://github.com/sgl-project/sglang/issues/17209, our team found that dynamic compilation of alloc_extend_kernel causes severe TPOT issues. Therefore, we decided to modify the implementation of alloc_extend_kernel so that it is not affected by the prefill size and thus avoids triggering JIT compilation.
The new kernel maintains the same performance and accuracy. Additionally, we added a unit test to verify its benefits.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
deepseekv3.2  mmlu=0.88 gsm8k=0.948 . same with old kernel
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
in  NVIDIA H200

alloc_extend_kernel compile cost
```
rm -rf ~/.triton/
python3 -m unittest  test_triton_page_alloc_extend.py -k test_all_compile_time_v1

V1 - bs=1, seq_len=1: max=1067.74ms, avg=355.97ms
V1 - bs=1, seq_len=1000: max=140.57ms, avg=46.90ms
V1 - bs=1, seq_len=32000: max=949.93ms, avg=316.71ms
V1 - bs=1, seq_len=64000: max=2729.79ms, avg=910.01ms
V1 - bs=32, seq_len=1: max=138.81ms, avg=46.31ms
V1 - bs=32, seq_len=1000: max=961.50ms, avg=320.56ms
V1 - bs=64, seq_len=1: max=141.26ms, avg=47.13ms
V1 - bs=64, seq_len=1000: max=2714.51ms, avg=904.91ms
.
----------------------------------------------------------------------
Ran 1 test in 9.089s
```

alloc_extend_kernel_v2 compile cost
```
rm -rf ~/.triton/
python3 -m unittest  test_triton_page_alloc_extend.py -k test_all_compile_time_v2

V2 - bs=1, seq_len=1: max=1123.71ms, avg=374.62ms
V2 - bs=1, seq_len=1000: max=0.06ms, avg=0.05ms
V2 - bs=1, seq_len=32000: max=0.06ms, avg=0.05ms
V2 - bs=1, seq_len=64000: max=0.07ms, avg=0.07ms
V2 - bs=32, seq_len=1: max=0.05ms, avg=0.04ms
V2 - bs=32, seq_len=1000: max=0.06ms, avg=0.04ms
V2 - bs=32, seq_len=32000: max=0.07ms, avg=0.06ms
V2 - bs=32, seq_len=64000: max=0.07ms, avg=0.07ms
V2 - bs=64, seq_len=1: max=0.05ms, avg=0.04ms
V2 - bs=64, seq_len=1000: max=0.04ms, avg=0.04ms
V2 - bs=64, seq_len=32000: max=0.06ms, avg=0.05ms
V2 - bs=64, seq_len=64000: max=0.09ms, avg=0.08ms
.
----------------------------------------------------------------------
Ran 1 test in 1.365s
```

alloc_extend_kernel runtime cost
```
python3 -m unittest  test_triton_page_alloc_extend.py -k test_all_performance_v1

V1 - bs=1, seq_len=1 avg=0.099ms
V1 - bs=1, seq_len=1000 avg=0.097ms
V1 - bs=1, seq_len=32000 avg=0.098ms
V1 - bs=1, seq_len=64000 avg=0.104ms
V1 - bs=32, seq_len=1 avg=0.099ms
V1 - bs=32, seq_len=1000 avg=0.097ms
V1 - bs=64, seq_len=1 avg=0.096ms
V1 - bs=64, seq_len=1000 avg=0.104ms
.
----------------------------------------------------------------------
Ran 1 test in 8.691s
```

alloc_extend_kernel_v2 runtime cost
```
python3 -m unittest  test_triton_page_alloc_extend.py -k test_all_performance_v2

V2 - bs=1, seq_len=1 avg=0.098ms
V2 - bs=1, seq_len=1000 avg=0.096ms
V2 - bs=1, seq_len=32000 avg=0.099ms
V2 - bs=1, seq_len=64000 avg=0.097ms
V2 - bs=32, seq_len=1 avg=0.095ms
V2 - bs=32, seq_len=1000 avg=0.096ms
V2 - bs=32, seq_len=32000 avg=0.096ms
V2 - bs=32, seq_len=64000 avg=0.096ms
V2 - bs=64, seq_len=1 avg=0.095ms
V2 - bs=64, seq_len=1000 avg=0.096ms
V2 - bs=64, seq_len=32000 avg=0.096ms
V2 - bs=64, seq_len=64000 avg=0.097ms
.
----------------------------------------------------------------------
Ran 1 test in 0.848s

OK
```
It can be observed that the compilation overhead of the new kernel has been eliminated, and the runtime performance remains highly stable.

Is anyone interested in taking over this work and merging this optimization into the main branch?

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
