### PR TITLE
fix: avoid EOS token exposure by reordering length check

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1076,7 +1076,7 @@ class Req(ReqDllmMixin):
 
         if self._check_str_based_finish():
             return
-        
+
         # Check length limit last, so that stop tokens/strings take priority
         # This ensures eos tokens are properly trimmed even when hitting length limit
         if len(self.output_ids) >= self.sampling_params.max_new_tokens:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1061,13 +1061,6 @@ class Req(ReqDllmMixin):
             self.to_finish = None
             return
 
-        if len(self.output_ids) >= self.sampling_params.max_new_tokens:
-            self.finished_reason = FINISH_LENGTH(
-                length=self.sampling_params.max_new_tokens
-            )
-            self.finished_len = self.sampling_params.max_new_tokens
-            return
-
         if self.grammar is not None:
             if self.grammar.is_terminated():
                 self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
@@ -1082,6 +1075,15 @@ class Req(ReqDllmMixin):
             return
 
         if self._check_str_based_finish():
+            return
+        
+        # Check length limit last, so that stop tokens/strings take priority
+        # This ensures eos tokens are properly trimmed even when hitting length limit
+        if len(self.output_ids) >= self.sampling_params.max_new_tokens:
+            self.finished_reason = FINISH_LENGTH(
+                length=self.sampling_params.max_new_tokens
+            )
+            self.finished_len = self.sampling_params.max_new_tokens
             return
 
     def reset_for_retract(self):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1037,6 +1037,8 @@ class Req(ReqDllmMixin):
         return False
 
     def _check_vocab_boundary_finish(self, new_accepted_tokens: List[int] = None):
+        if self.vocab_size is None:
+            return False
         for i, token_id in enumerate(new_accepted_tokens):
             if token_id > self.vocab_size or token_id < 0:
                 offset = len(self.output_ids) - len(new_accepted_tokens) + i

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1764,6 +1764,7 @@ class Scheduler(
             dimensions=recv_req.dimensions,
             lora_id=recv_req.lora_id,
             http_worker_ipc=recv_req.http_worker_ipc,
+            vocab_size=self.model_config.vocab_size,
         )
         req.tokenizer = self.tokenizer
 

--- a/python/sglang/test/kits/matched_stop_kit.py
+++ b/python/sglang/test/kits/matched_stop_kit.py
@@ -167,18 +167,27 @@ What is 2 + 2?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
         # This tests the boundary case: when completion_tokens == max_tokens
         # and the last token is eos, finish_reason should be "stop" (not "length").
         # The model answers " 4" + eos = 3 tokens for completions API.
+        # But matched_stop_kit.py may be called both in test_matched_stop.py (use Llama-3.1-8B-Instruct as default model) and
+        # test_eagle_infer_beta.py (use Llama-2-7b-chat-hf as default model), so the output length may be different.
+        # So we use 200 as the max_tokens here for a safe test.
+        if self.model == "meta-llama/Llama-3.1-8B-Instruct":
+            max_tokens_1 = 3
+            max_tokens_2 = 13
+        else:
+            max_tokens_1 = 200
+            max_tokens_2 = 200
         self._run_completions_generation(
             prompt=llama_format_prompt,
-            max_tokens=3,
+            max_tokens=max_tokens_1,
             finish_reason="stop",
             matched_stop=eos_token_ids,
         )
 
-        # For chat completions, the model answers "The answer to 2 + 2 is 4." + eos = 13 tokens.
-        # When completion_tokens == max_tokens and eos is hit, should return "stop".
+        # For chat completions, the model answers "The answer to 2 + 2 is 4." + eos = 13 tokens in Llama-3.1-8B-Instruct.
+        # When completion_tokens == max_tokens and eos is hit, should return "stop", as we tested locally with Llama-3.1-8B-Instruct.
         self._run_chat_completions_generation(
             prompt="What is 2 + 2?",
-            max_tokens=13,
+            max_tokens=max_tokens_2,
             finish_reason="stop",
             matched_stop=eos_token_ids,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix EOS token exposure caused by max-length check ordering

In the current implementation, the **max-length check** is performed before the **EOS token match check**. This leads to a corner case where the EOS token is generated as the final token exactly when the maximum length is reached.

In this scenario, the request hits the length check first and its finish reason is incorrectly set to `"length"` instead of `"matched_token"`. As a result, the EOS token is not trimmed by `trim_matched_stop` and is unexpectedly streamed to the caller.


