### PR TITLE
[MUSA][7/N] Enhance CUDA / PyNccl wrapper to support MTLink connectivity detection

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -111,7 +111,7 @@ srt_musa = [
     "sglang[runtime_common]",
     "torch",
     "torch_musa",
-    "torchada>=0.1.15",
+    "torchada>=0.1.25",
     "mthreads-ml-py",
     "numpy<2.0",
 ]

--- a/python/sglang/srt/distributed/device_communicators/cuda_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/cuda_wrapper.py
@@ -13,6 +13,10 @@ from typing import Any, Dict, List, Optional
 # this line makes it possible to directly load `libcudart.so` using `ctypes`
 import torch  # noqa
 
+from sglang.srt.utils import is_musa
+
+_is_musa = is_musa()
+
 logger = logging.getLogger(__name__)
 
 # === export types and functions from cudart to Python ===
@@ -113,7 +117,7 @@ class CudaRTLibrary:
 
     def __init__(self, so_file: Optional[str] = None):
         if so_file is None:
-            so_file = find_loaded_library("libcudart")
+            so_file = find_loaded_library("libcudart" if not _is_musa else "libmusart")
             assert so_file is not None, "libcudart is not loaded in the current process"
         if so_file not in CudaRTLibrary.path_to_library_cache:
             lib = ctypes.CDLL(so_file)

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -19,10 +19,17 @@ from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import 
 )
 from sglang.srt.distributed.parallel_state import in_the_same_node_as
 from sglang.srt.environ import envs
-from sglang.srt.utils import get_bool_env_var, is_cuda, is_hip, log_info_on_rank0
+from sglang.srt.utils import (
+    get_bool_env_var,
+    is_cuda,
+    is_hip,
+    is_musa,
+    log_info_on_rank0,
+)
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_musa = is_musa()
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +54,9 @@ class CustomAllreduce:
     if _is_hip:
         # crossover is at 16MB buffer size for ROCm
         _MAX_CAR_SIZE = 2 * 8192 * 1024
+    if _is_musa:
+        # crossover is at 128MB buffer size for MUSA
+        _MAX_CAR_SIZE = 16 * 8196 * 1024
 
     # max_size: max supported allreduce size
     def __init__(
@@ -129,7 +139,7 @@ class CustomAllreduce:
         # test nvlink first, this will filter out most of the cases
         # where custom allreduce is not supported
         # this checks hardware and driver support for NVLink
-        if _is_cuda or _is_hip:
+        if _is_cuda or _is_hip or _is_musa:
             full_nvlink = is_full_nvlink(physical_device_ids, world_size)
 
         if world_size > 2 and not full_nvlink:
@@ -210,6 +220,8 @@ class CustomAllreduce:
         """
         lib = CudaRTLibrary()
         pointer = lib.cudaMalloc(size_in_bytes)
+        if _is_musa:
+            lib.cudaMemset(pointer, 0, size_in_bytes)
         handle = lib.cudaIpcGetMemHandle(pointer)
         world_size = dist.get_world_size(group=group)
         rank = dist.get_rank(group=group)
@@ -433,7 +445,7 @@ def dispatch_custom_allreduce():
     On AMD with 1-stage AR enabled, use sglang's CustomAllreduce (has deterministic_all_reduce method).
     Otherwise use AiterCustomAllreduce if available.
     """
-    if _is_cuda:
+    if _is_cuda or _is_musa:
         return CustomAllreduce
 
     assert _is_hip

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py
@@ -4,14 +4,15 @@ from typing import List, Optional, Tuple
 
 import torch
 
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hip, is_musa
 
 logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_musa = is_musa()
 
-IS_CUSTOM_AR_AVAILABLE = _is_cuda or _is_hip
+IS_CUSTOM_AR_AVAILABLE = _is_cuda or _is_hip or _is_musa
 IS_QUICK_AR_AVAILABLE = _is_hip
 # TODO(zyksir): mscclpp is untested on AMD and therefore disabled.
 IS_MSCCLPP_AR_AVAILABLE = _is_cuda
@@ -30,7 +31,7 @@ except ImportError as e:
 if not IS_CUSTOM_AR_AVAILABLE:
     pass
 
-elif _is_cuda:
+elif _is_cuda or _is_musa:
     # CUDA custom allreduce
 
     def init_custom_ar(

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
@@ -18,18 +18,25 @@ import torch.multiprocessing as mp
 from typing_extensions import ParamSpec
 
 from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hip, is_musa
 
 logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_musa = is_musa()
 
 if _is_cuda:
     try:
         import pynvml
     except ImportError as e:
         logger.warning("Failed to import pynvml with %r", e)
+
+if _is_musa:
+    try:
+        import pymtml as pynvml
+    except ImportError as e:
+        logger.warning("Failed to import pymtml with %r", e)
 
 if _is_hip:
     try:

--- a/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
@@ -38,8 +38,8 @@ def find_nccl_library() -> str:
     """
     We either use the library file specified by the `SGLANG_NCCL_SO_PATH`
     environment variable, or we find the library file brought by PyTorch.
-    After importing `torch`, `libnccl.so.2` or `librccl.so.1` can be
-    found by `ctypes` automatically.
+    After importing `torch`, `libnccl.so.2`, `librccl.so.1` or `libmccl.so.2`
+    can be found by `ctypes` automatically.
     """
 
     # so_file can be set to None in sglang
@@ -55,8 +55,10 @@ def find_nccl_library() -> str:
             so_file = "libnccl.so.2"
         elif torch.version.hip is not None:
             so_file = "librccl.so.1"
+        elif hasattr(torch.version, "musa") and torch.version.musa is not None:
+            so_file = "libmccl.so.2"
         else:
-            raise ValueError("NCCL only supports CUDA and ROCm backends.")
+            raise ValueError("NCCL only supports CUDA, ROCm and MUSA backends.")
         logger.debug("Found nccl from library %s", so_file)
     return so_file
 
@@ -341,7 +343,7 @@ class NCCLLibrary:
         except Exception as e:
             logger.error(
                 "Failed to load NCCL library from %s . "
-                "It is expected if you are not running on NVIDIA/AMD GPUs. "
+                "It is expected if you are not running on NVIDIA/AMD/MTHREADS GPUs. "
                 "Otherwise, the nccl library might not exist, be corrupted "
                 "or it does not support the current platform %s. "
                 "If you already have the library, please set the "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is the seventh in a series of pull requests (tracked in https://github.com/sgl-project/sglang/issues/16565) to add full support for [Moore Threads](https://en.mthreads.com/) GPUs, leveraging MUSA (Meta-computing Unified System Architecture) to accelerate LLM inference.

## Modifications

<!-- Detail the changes made in this pull request. -->
This commit updates the runtime wrappers and communication utilities to improve MUSA backend compatibility across SGLang’s distributed execution path.

Key modifications include:
- CUDA wrapper adaptation for MUSA
Introduced backend detection (`is_musa`) and dynamic runtime symbol mapping, enabling CUDA-like APIs to correctly resolve MUSA-prefixed runtime functions.

- Custom AllReduce enhancements
Updated `custom_all_reduce` and related utilities to:
    - Recognize MUSA devices and device strings.
    - Adjust buffer size limits and initialization logic for MUSA environments.
    - Ensure proper resource setup and teardown across CUDA, ROCm, HIP, and MUSA backends.

Overall, this change generalizes several low-level wrappers and communication paths to support MUSA as a first-class backend, improving portability of distributed inference and execution beyond CUDA-only environments.

## Testing Done
Tested in a clean torch_musa container:
`Qwen3-0.6B` without MUSA Graph enabled works fine on `tp=2`, `dp=2`:
```
root@worker3218:/ws/sglang# python -m sglang.launch_server \
> --model-path /home/dist/Qwen3-0.6B/ \
> --host 0.0.0.0 \
> --port 43437 \
> --trust-remote-code \
> --disable-cuda-graph \
> --tp-size 2 \
> --dp-size 2 \
>   
[2026-01-21 19:36:27] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:27 | warnings | 140083125707904 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:27] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:27 | warnings | 140083125707904 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:27] INFO server_args.py:1669: Attention backend not specified. Use triton backend by default.
2026-01-21 19:36:27 | server_args | 140083125707904 | INFO : Attention backend not specified. Use triton backend by default.
[2026-01-21 19:36:28] server_args=ServerArgs(model_path='/home/dist/Qwen3-0.6B/', tokenizer_path='/home/dist/Qwen3-0.6B/', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='0.0.0.0', port=43437, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.834, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=2, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, stream_output=False, random_seed=447709138, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/home/dist/Qwen3-0.6B/', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=2, load_balance_method='round_robin', dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='triton', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend='flashmla_sparse', nsa_decode_backend='fa3', disable_flashinfer_autotune=False, speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype='float32', mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', disable_hicache_numa_detect=False, hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, hierarchical_sparse_attention_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=256, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], disable_cuda_graph=True, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='in-seq-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, disaggregation_decode_enable_fake_auto=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-01-21 19:36:28] Using default HuggingFace chat template with detected content format: string
[2026-01-21 19:36:35] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:35 | warnings | 140497273742464 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:35] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:35 | warnings | 140013278909568 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:36] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:36 | warnings | 140497273742464 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:36] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:36 | warnings | 140013278909568 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:36] Launch DP0 starting at GPU #0.
[2026-01-21 19:36:36] Launch DP1 starting at GPU #2.
[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:44 | warnings | 140103976342656 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:44 | warnings | 140103976342656 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:44 | warnings | 139732156494976 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:44 | warnings | 140031577523328 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:36:44 | warnings | 139981583139968 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:44 | warnings | 139732156494976 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:44 | warnings | 140031577523328 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:44] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:36:44 | warnings | 139981583139968 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:36:45 DP1 TP0] Init torch distributed begin.
[2026-01-21 19:36:45 DP0 TP0] Init torch distributed begin.
[2026-01-21 19:36:45 DP0 TP1] Init torch distributed begin.
[2026-01-21 19:36:45 DP1 TP1] Init torch distributed begin.
[2026-01-21 19:36:45 DP0 TP0] sglang is using nccl==2.11.4
[2026-01-21 19:36:45 DP1 TP0] sglang is using nccl==2.11.4
[2026-01-21 19:36:49 DP1 TP0] Init torch distributed ends. mem usage=0.44 GB
[2026-01-21 19:36:49 DP1 TP1] Init torch distributed ends. mem usage=0.43 GB
[2026-01-21 19:36:49 DP0 TP0] Init torch distributed ends. mem usage=0.41 GB
[2026-01-21 19:36:49 DP0 TP1] Init torch distributed ends. mem usage=0.43 GB
[2026-01-21 19:36:49 DP1 TP0] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-01-21 19:36:49 DP0 TP0] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-01-21 19:36:49 DP1 TP0] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:36:49 DP1 TP1] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:36:49 DP0 TP0] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:36:49 DP0 TP1] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:36:51 DP1 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:36:51 DP1 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:36:51 DP0 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:36:51 DP0 TP0] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP0] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP0] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP0] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP1] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP1] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP1] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP1] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP0] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP0] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP0] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP0] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP0] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP0] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP1] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP1] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:36:51 DP1 TP1] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP1] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP1] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP1] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:36:51 DP0 TP0] Load weight begin. avail mem=78.70 GB
[2026-01-21 19:36:51 DP1 TP0] Load weight begin. avail mem=78.89 GB
[2026-01-21 19:36:51 DP0 TP1] Load weight begin. avail mem=78.90 GB
[2026-01-21 19:36:51 DP1 TP1] Load weight begin. avail mem=78.90 GB
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.94it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.94it/s]

[2026-01-21 19:36:56 DP1 TP0] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=78.04 GB, mem usage=0.85 GB.
[2026-01-21 19:36:56 DP0 TP1] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=78.05 GB, mem usage=0.85 GB.
[2026-01-21 19:36:56 DP1 TP1] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=78.05 GB, mem usage=0.85 GB.
[2026-01-21 19:36:56 DP1 TP0] Using KV cache dtype: torch.bfloat16
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.91it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.91it/s]

[2026-01-21 19:36:57 DP0 TP0] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=77.85 GB, mem usage=0.85 GB.
[2026-01-21 19:36:57 DP0 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-21 19:36:57 DP1 TP0] KV Cache is allocated. #tokens: 1215982, K size: 32.47 GB, V size: 32.47 GB
[2026-01-21 19:36:57 DP1 TP1] KV Cache is allocated. #tokens: 1215982, K size: 32.47 GB, V size: 32.47 GB
[2026-01-21 19:36:57 DP1 TP0] Memory pool end. avail mem=12.29 GB
[2026-01-21 19:36:57 DP1 TP1] Memory pool end. avail mem=12.30 GB
[2026-01-21 19:36:57 DP0 TP1] KV Cache is allocated. #tokens: 1212994, K size: 32.39 GB, V size: 32.39 GB
[2026-01-21 19:36:57 DP0 TP1] Memory pool end. avail mem=12.41 GB
[2026-01-21 19:36:57 DP0 TP0] KV Cache is allocated. #tokens: 1212994, K size: 32.39 GB, V size: 32.39 GB
[2026-01-21 19:36:57 DP0 TP0] Memory pool end. avail mem=12.21 GB
[2026-01-21 19:36:58 DP1 TP0] max_total_num_tokens=1215982, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=12.24 GB
[2026-01-21 19:36:58 DP0 TP0] max_total_num_tokens=1212994, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=12.16 GB
[2026-01-21 19:36:58] INFO:     Started server process [46107]
[2026-01-21 19:36:58] INFO:     Waiting for application startup.
[2026-01-21 19:36:58] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-01-21 19:36:58] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-01-21 19:36:58] INFO:     Application startup complete.
[2026-01-21 19:36:58] INFO:     Uvicorn running on http://0.0.0.0:43437 (Press CTRL+C to quit)
[2026-01-21 19:36:59] INFO:     127.0.0.1:35516 - "GET /model_info HTTP/1.1" 200 OK
[2026-01-21 19:37:00 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:37:00 DP1 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:37:16] INFO:     127.0.0.1:35524 - "POST /generate HTTP/1.1" 200 OK
[2026-01-21 19:37:16] The server is fired up and ready to roll!
[2026-01-21 19:37:26 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 15, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:37:28 DP0 TP0] Decode batch, #running-req: 1, #token: 48, token usage: 0.00, musa graph: False, gen throughput (token/s): 0.93, #queue-req: 0, 
[2026-01-21 19:37:29 DP1 TP0] Prefill batch, #new-seq: 1, #new-token: 15, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:37:30 DP0 TP0] Decode batch, #running-req: 1, #token: 88, token usage: 0.00, musa graph: False, gen throughput (token/s): 18.18, #queue-req: 0, 
[2026-01-21 19:37:31 DP1 TP0] Decode batch, #running-req: 1, #token: 48, token usage: 0.00, musa graph: False, gen throughput (token/s): 0.85, #queue-req: 0, 
[2026-01-21 19:37:32 DP0 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, musa graph: False, gen throughput (token/s): 18.49, #queue-req: 0, 
[2026-01-21 19:37:34 DP1 TP0] Decode batch, #running-req: 1, #token: 88, token usage: 0.00, musa graph: False, gen throughput (token/s): 17.16, #queue-req: 0, 
[2026-01-21 19:37:34 DP0 TP0] Decode batch, #running-req: 1, #token: 168, token usage: 0.00, musa graph: False, gen throughput (token/s): 17.67, #queue-req: 0, 
[2026-01-21 19:37:35] INFO:     127.0.0.1:51430 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-21 19:37:36 DP1 TP0] Decode batch, #running-req: 1, #token: 128, token usage: 0.00, musa graph: False, gen throughput (token/s): 17.59, #queue-req: 0, 
[2026-01-21 19:37:37] INFO:     127.0.0.1:58834 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

`Qwen3-0.6B` with MUSA Graph enabled works fine on `tp=2`, `dp=2`:
```
root@worker3218:/ws/sglang# python -m sglang.launch_server --model-path /home/dist/Qwen3-0.6B/ --host 0.0.0.0 --port 43437 --trust-remote-code  --tp-size 2 --dp-size 2  
[2026-01-21 19:38:48] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:38:48 | warnings | 140229263385728 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:38:48] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:38:48 | warnings | 140229263385728 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:38:48] INFO server_args.py:1669: Attention backend not specified. Use triton backend by default.
2026-01-21 19:38:48 | server_args | 140229263385728 | INFO : Attention backend not specified. Use triton backend by default.
[2026-01-21 19:38:49] server_args=ServerArgs(model_path='/home/dist/Qwen3-0.6B/', tokenizer_path='/home/dist/Qwen3-0.6B/', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=True, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='0.0.0.0', port=43437, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.834, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='musa', tp_size=2, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, stream_output=False, random_seed=587591302, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='/home/dist/Qwen3-0.6B/', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=2, load_balance_method='round_robin', dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='triton', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='pytorch', grammar_backend='xgrammar', mm_attention_backend=None, fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='auto', nsa_prefill_backend='flashmla_sparse', nsa_decode_backend='fa3', disable_flashinfer_autotune=False, speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype='float32', mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', disable_hicache_numa_detect=False, hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, hierarchical_sparse_attention_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=256, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='in-seq-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, disaggregation_decode_enable_fake_auto=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-01-21 19:38:49] Using default HuggingFace chat template with detected content format: string
[2026-01-21 19:38:57] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:38:57 | warnings | 140533695210624 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:38:57] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:38:57 | warnings | 140201758827648 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:38:57] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:38:57 | warnings | 140533695210624 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:38:57] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:38:57 | warnings | 140201758827648 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:38:57] Launch DP0 starting at GPU #0.
[2026-01-21 19:38:57] Launch DP1 starting at GPU #2.
[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:39:05 | warnings | 140479861888128 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:39:05 | warnings | 140324959765632 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:39:05 | warnings | 140065554211968 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-01-21 19:39:05 | warnings | 139952237884544 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/awq.py:76: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:39:05 | warnings | 140479861888128 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:39:05 | warnings | 140324959765632 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:39:05 | warnings | 140065554211968 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:39:05] WARNING warnings.py:109: /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

2026-01-21 19:39:05 | warnings | 139952237884544 | WARNING : /ws/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")

[2026-01-21 19:39:06 DP1 TP0] Init torch distributed begin.
[2026-01-21 19:39:06 DP0 TP0] Init torch distributed begin.
[2026-01-21 19:39:06 DP1 TP1] Init torch distributed begin.
[2026-01-21 19:39:06 DP0 TP1] Init torch distributed begin.
[2026-01-21 19:39:06 DP1 TP0] sglang is using nccl==2.11.4
[2026-01-21 19:39:06 DP0 TP0] sglang is using nccl==2.11.4
[2026-01-21 19:39:10 DP0 TP0] Init torch distributed ends. mem usage=0.41 GB
[2026-01-21 19:39:10 DP0 TP1] Init torch distributed ends. mem usage=0.43 GB
[2026-01-21 19:39:10 DP1 TP1] Init torch distributed ends. mem usage=0.43 GB
[2026-01-21 19:39:10 DP1 TP0] Init torch distributed ends. mem usage=0.44 GB
[2026-01-21 19:39:10 DP0 TP0] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-01-21 19:39:10 DP1 TP0] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-01-21 19:39:10 DP0 TP0] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:39:10 DP0 TP1] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:39:10 DP1 TP0] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:39:10 DP1 TP1] Ignore import error when loading sglang.srt.models.falcon_h1: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:39:12 DP0 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:39:12 DP1 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:39:12 DP0 TP0] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.10/dist-packages/transformers/__init__.py)
[2026-01-21 19:39:12 DP0 TP0] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP1] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP0] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP1] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP0] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP1] Ignore import error when loading sglang.srt.models.jet_nemotron: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP1] Ignore import error when loading sglang.srt.models.jet_vlm: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP0] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP0] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP0] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP1] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP1] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP1] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP0] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP0] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP0] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP1] Ignore import error when loading sglang.srt.models.nano_nemotron_vl: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP1] Ignore import error when loading sglang.srt.models.nemotron_h: No module named 'cuda'
[2026-01-21 19:39:12 DP1 TP1] Ignore import error when loading sglang.srt.models.nemotron_h_mtp: No module named 'cuda'
[2026-01-21 19:39:12 DP0 TP0] Load weight begin. avail mem=78.70 GB
[2026-01-21 19:39:13 DP0 TP1] Load weight begin. avail mem=78.90 GB
[2026-01-21 19:39:13 DP1 TP0] Load weight begin. avail mem=78.89 GB
[2026-01-21 19:39:13 DP1 TP1] Load weight begin. avail mem=78.90 GB
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.26it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.26it/s]

[2026-01-21 19:39:17 DP0 TP0] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=77.85 GB, mem usage=0.85 GB.
[2026-01-21 19:39:18 DP0 TP1] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=78.05 GB, mem usage=0.85 GB.
[2026-01-21 19:39:18 DP0 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-21 19:39:18 DP1 TP1] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=78.05 GB, mem usage=0.85 GB.
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.39it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.39it/s]

[2026-01-21 19:39:18 DP1 TP0] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=78.04 GB, mem usage=0.85 GB.
[2026-01-21 19:39:18 DP1 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-21 19:39:18 DP0 TP1] KV Cache is allocated. #tokens: 1212994, K size: 32.39 GB, V size: 32.39 GB
[2026-01-21 19:39:18 DP0 TP1] Memory pool end. avail mem=12.41 GB
[2026-01-21 19:39:18 DP0 TP0] KV Cache is allocated. #tokens: 1212994, K size: 32.39 GB, V size: 32.39 GB
[2026-01-21 19:39:18 DP0 TP0] Memory pool end. avail mem=12.21 GB
[2026-01-21 19:39:18 DP1 TP0] KV Cache is allocated. #tokens: 1215982, K size: 32.47 GB, V size: 32.47 GB
[2026-01-21 19:39:18 DP1 TP0] Memory pool end. avail mem=12.29 GB
[2026-01-21 19:39:18 DP1 TP1] KV Cache is allocated. #tokens: 1215982, K size: 32.47 GB, V size: 32.47 GB
[2026-01-21 19:39:18 DP1 TP1] Memory pool end. avail mem=12.30 GB
[2026-01-21 19:39:19 DP0 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=12.16 GB
[2026-01-21 19:39:19 DP0 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
[2026-01-21 19:39:19 DP0 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=12.36 GB
[2026-01-21 19:39:19 DP1 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=12.24 GB
[2026-01-21 19:39:19 DP1 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=12.25 GB
[2026-01-21 19:39:19 DP1 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
Capturing batches (bs=1 avail_mem=9.58 GB):  97%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊    | 35/36 [08:58<00:15, 15.20s/it][2026-01-21 19:48:26 DP1 TP1] Capture cuda graph end. Time elapsed: 546.94 s. mem usage=2.59 GB. avail mem=9.66 GB.
Capturing batches (bs=1 avail_mem=9.58 GB): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [09:11<00:00, 15.31s/it]
[2026-01-21 19:48:31 DP1 TP0] Capture cuda graph end. Time elapsed: 551.97 s. mem usage=2.69 GB. avail mem=9.55 GB.
[2026-01-21 19:48:31 DP1 TP0] max_total_num_tokens=1215982, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=9.55 GB
Capturing batches (bs=1 avail_mem=9.50 GB):  97%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊    | 35/36 [09:44<00:13, 13.48s/it][2026-01-21 19:49:10 DP0 TP1] Capture cuda graph end. Time elapsed: 591.91 s. mem usage=2.59 GB. avail mem=9.77 GB.
Capturing batches (bs=1 avail_mem=9.50 GB): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [09:54<00:00, 16.52s/it]
[2026-01-21 19:49:14 DP0 TP0] Capture cuda graph end. Time elapsed: 595.60 s. mem usage=2.69 GB. avail mem=9.47 GB.
[2026-01-21 19:49:14 DP0 TP0] max_total_num_tokens=1212994, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=9.47 GB
[2026-01-21 19:49:15] INFO:     Started server process [59095]
[2026-01-21 19:49:15] INFO:     Waiting for application startup.
[2026-01-21 19:49:15] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-01-21 19:49:15] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2026-01-21 19:49:15] INFO:     Application startup complete.
[2026-01-21 19:49:15] INFO:     Uvicorn running on http://0.0.0.0:43437 (Press CTRL+C to quit)
[2026-01-21 19:49:16] INFO:     127.0.0.1:45016 - "GET /model_info HTTP/1.1" 200 OK
[2026-01-21 19:49:16 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:49:16 DP1 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:49:17] INFO:     127.0.0.1:45024 - "POST /generate HTTP/1.1" 200 OK
[2026-01-21 19:49:17] The server is fired up and ready to roll!
[2026-01-21 19:53:15 DP0 TP0] Prefill batch, #new-seq: 1, #new-token: 15, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:53:16 DP0 TP0] Decode batch, #running-req: 1, #token: 48, token usage: 0.00, musa graph: True, gen throughput (token/s): 0.05, #queue-req: 0, 
[2026-01-21 19:53:17 DP0 TP0] Decode batch, #running-req: 1, #token: 88, token usage: 0.00, musa graph: True, gen throughput (token/s): 44.61, #queue-req: 0, 
[2026-01-21 19:53:17 DP1 TP0] Prefill batch, #new-seq: 1, #new-token: 15, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2026-01-21 19:53:18] INFO:     127.0.0.1:54206 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-21 19:53:18 DP1 TP0] Decode batch, #running-req: 1, #token: 48, token usage: 0.00, musa graph: True, gen throughput (token/s): 0.05, #queue-req: 0, 
[2026-01-21 19:53:19 DP1 TP0] Decode batch, #running-req: 1, #token: 88, token usage: 0.00, musa graph: True, gen throughput (token/s): 45.16, #queue-req: 0, 
[2026-01-21 19:53:19] INFO:     127.0.0.1:54214 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
