### PR TITLE
Fix health check crash for rerank models by adding token_type_ids

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -494,7 +494,11 @@ async def health_generate(request: Request) -> Response:
             gri.bootstrap_room = 0
     else:
         gri = EmbeddingReqInput(
-            rid=rid, input_ids=[0], sampling_params=sampling_params, log_metrics=False
+            rid=rid,
+            input_ids=[0],
+            token_type_ids=[0],
+            sampling_params=sampling_params,
+            log_metrics=False,
         )
 
     async def gen():


### PR DESCRIPTION
## Motivation

Fixes #17491

When deploying rerank models like `BAAI/bge-reranker-v2-m3`, the health check endpoint causes a crash with the following error:

```
RuntimeError: The size of tensor a (8013) must match the size of tensor b (8008) at non-singleton dimension 0
```

This happens because the `EmbeddingReqInput` in the health check is created with `input_ids=[0]` but `token_type_ids=None`. For RoBERTa-based models, the embeddings layer requires both tensors to have matching dimensions.

## Modifications

Added `token_type_ids=[0]` to the `EmbeddingReqInput` in the health check endpoint (`/health` and `/health_generate`) for embedding/rerank models.

## Checklist

- [x] Format your code according to the [Contribution Guide](https://docs.sglang.ai/contributor_guide/contribution_guide.html).
- [x] Add unit tests as appropriate.
- [x] Update documentation as appropriate.