### PR TITLE
Fix test_tensor_dump_forward_hook.py to use unittest.TestCase

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -494,7 +494,11 @@ async def health_generate(request: Request) -> Response:
             gri.bootstrap_room = 0
     else:
         gri = EmbeddingReqInput(
-            rid=rid, input_ids=[0], sampling_params=sampling_params, log_metrics=False
+            rid=rid,
+            input_ids=[0],
+            token_type_ids=[0],
+            sampling_params=sampling_params,
+            log_metrics=False,
         )
 
     async def gen():


### PR DESCRIPTION
## Summary
- Convert pytest-style test function to proper unittest.TestCase class
- Use tempfile.TemporaryDirectory() instead of pytest's tmp_path
- Convert assert statements to self.assertX methods
- Remove disabled parameter from CI registrations to re-enable the test

## Related Issue
Fixes #17145

## Test Plan
- The test now properly runs with unittest.main() instead of silently passing with 0 tests
- Pre-commit checks pass