### PR TITLE
[CI] Add human-eval nightly evaluation with model thresholds

### DIFF
--- a/test/registered/eval/test_text_models_humaneval_eval.py
+++ b/test/registered/eval/test_text_models_humaneval_eval.py
@@ -1,0 +1,140 @@
+import json
+import unittest
+import warnings
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_FP8_TP1,
+    DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_FP8_TP2,
+    DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_TP1,
+    DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_TP2,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    ModelLaunchSettings,
+    check_evaluation_test_results,
+    parse_models,
+    popen_launch_server,
+    write_results_to_json,
+)
+
+register_cuda_ci(est_time=3600, suite="nightly-eval-text-2-gpu", nightly=True)
+
+MODEL_SCORE_THRESHOLDS = {
+    # TP1 models
+    "meta-llama/Llama-3.1-8B-Instruct": 0.64,
+    "mistralai/Mistral-7B-Instruct-v0.3": 0.30,
+    "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct": 0.70,
+    "google/gemma-2-27b-it": 0.55,
+    # TP2 models
+    "meta-llama/Llama-3.1-70B-Instruct": 0.70,
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": 0.40,
+    "Qwen/Qwen2-57B-A14B-Instruct": 0.60,
+    # FP8 TP1 models
+    "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8": 0.63,
+    "neuralmagic/Mistral-7B-Instruct-v0.3-FP8": 0.28,
+    "neuralmagic/DeepSeek-Coder-V2-Lite-Instruct-FP8": 0.68,
+    "neuralmagic/gemma-2-2b-it-FP8": 0.25,
+    # FP8 TP2 models
+    "neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8": 0.68,
+    "neuralmagic/Mixtral-8x7B-Instruct-v0.1-FP8": 0.38,
+    "neuralmagic/Qwen2-72B-Instruct-FP8": 0.60,
+    "neuralmagic/Qwen2-57B-A14B-Instruct-FP8": 0.58,
+    "zai-org/GLM-4.5-Air-FP8": 0.40,
+}
+
+
+# Do not use `CustomTestCase` since `test_humaneval_all_models` does not want retry
+class TestNightlyHumanEval(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.models = []
+        models_tp1 = parse_models(
+            DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_TP1
+        ) + parse_models(DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_FP8_TP1)
+        for model_path in models_tp1:
+            cls.models.append(ModelLaunchSettings(model_path, tp_size=1))
+
+        models_tp2 = parse_models(
+            DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_TP2
+        ) + parse_models(DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_FP8_TP2)
+        for model_path in models_tp2:
+            cls.models.append(ModelLaunchSettings(model_path, tp_size=2))
+
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+    def test_humaneval_all_models(self):
+        warnings.filterwarnings(
+            "ignore", category=ResourceWarning, message="unclosed.*socket"
+        )
+        is_first = True
+        all_results = []
+        for model_setup in self.models:
+            with self.subTest(model=model_setup.model_path):
+                other_args = list(model_setup.extra_args)
+                error_message = None
+
+                if model_setup.model_path == "meta-llama/Llama-3.1-70B-Instruct":
+                    other_args.extend(["--mem-fraction-static", "0.9"])
+
+                process = popen_launch_server(
+                    model=model_setup.model_path,
+                    other_args=other_args,
+                    base_url=self.base_url,
+                    timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                )
+
+                try:
+                    args = SimpleNamespace(
+                        base_url=self.base_url,
+                        model=model_setup.model_path,
+                        eval_name="humaneval",
+                        num_examples=None,
+                        num_threads=1024,
+                    )
+
+                    metrics = run_eval(args)
+                    print(
+                        f"{'=' * 42}\n{model_setup.model_path} - metrics={metrics} score={metrics['score']}\n{'=' * 42}\n"
+                    )
+
+                    write_results_to_json(
+                        model_setup.model_path, metrics, "w" if is_first else "a"
+                    )
+                    is_first = False
+
+                    # 0.0 for empty latency, None for no error
+                    all_results.append(
+                        (model_setup.model_path, metrics["score"], 0.0, error_message)
+                    )
+                except Exception as e:
+                    # Capture error message for the summary table
+                    error_message = str(e)
+                    # Still append result with error info (use None for N/A metrics to match else clause)
+                    all_results.append(
+                        (model_setup.model_path, None, None, error_message)
+                    )
+                    print(f"Error evaluating {model_setup.model_path}: {error_message}")
+                finally:
+                    kill_process_tree(process.pid)
+
+        try:
+            with open("results.json", "r") as f:
+                print("\nFinal Results from results.json:")
+                print(json.dumps(json.load(f), indent=2))
+        except Exception as e:
+            print(f"Error reading results.json: {e}")
+
+        # Check all scores after collecting all results
+        check_evaluation_test_results(
+            all_results,
+            self.__class__.__name__,
+            model_accuracy_thresholds=MODEL_SCORE_THRESHOLDS,
+            model_count=len(self.models),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add nightly human-eval evaluation test similar to the existing gsm8k evaluation
- Define per-model score thresholds for human-eval benchmark
- Print evaluation results as a markdown table to `GITHUB_STEP_SUMMARY` using `check_evaluation_test_results()`

This addresses the request in #2275 to:
1. Print nightly evaluation results to `GITHUB_STEP_SUMMARY`
2. Add thresholds for human-eval similar to gsm8k

The new test file follows the same structure as `test_text_models_gsm8k_eval.py` and is registered with the `nightly-eval-text-2-gpu` suite.

Fixes #2275

## Test plan
- [ ] Verify the test file is correctly registered with the `nightly-eval-text-2-gpu` suite
- [ ] Run the test locally to verify it works: `python -m unittest test.registered.eval.test_text_models_humaneval_eval`
- [ ] Verify results are printed to `GITHUB_STEP_SUMMARY` in CI environment