### PR TITLE
[Diffusion] Support select fa2 backend in hopper

### DIFF
--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -246,6 +246,13 @@ class CudaPlatformBase(Platform):
         elif selected_backend == AttentionBackendEnum.SAGE_SLA_ATTN:
             logger.info("Using Sage Sparse Linear Attention backend")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sparse_linear_attn.SageSparseLinearAttentionBackend"
+        elif selected_backend == AttentionBackendEnum.FA2:
+            from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
+                FlashAttention2Backend,
+            )
+
+            logger.info("Using FlashAttention2 backend")
+            return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
         elif selected_backend in [
             AttentionBackendEnum.FA,
         ]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

```shell
sglang generate --model-path=Qwen/Qwen-Image-Edit-2511 --prompt="remain the dog in the image and create a beautiful girl in the image and the background is a beautiful garden" --negative-prompt=" " --image-path=https://modelscope.oss-cn-beijing.aliyuncs.com/Dog.png --width=1024 --height=1024 --num-inference-steps=28  --guidance-scale=4.0 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false  --attention-backend fa2
```

main:

```shell
[01-21 15:08:04] Loading text_encoder from /root/.cache/huggingface/hub/models--Qwen--Qwen-Image-Edit-2511/snapshots/6f3ccc0b56e431dc6a0c2b2039706d7d26f22cb9/text_encoder. avail mem: 73.84 GB
[01-21 15:08:04] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[01-21 15:08:06] [RunAI Streamer] Overall time to stream 15.4 GiB of all files to cpu: 1.94s, 8.0 GiB/s
[01-21 15:08:06] Loaded text_encoder: Qwen2_5_VLForConditionalGeneration (sgl-diffusion version). model size: 15.45 GB, avail mem: 58.12 GB
Loading required modules:  50%|█████████████████████████████████████████▌                                         | 3/6 [00:02<00:03,  1.02s/it][01-21 15:08:06] Loading tokenizer from /root/.cache/huggingface/hub/models--Qwen--Qwen-Image-Edit-2511/snapshots/6f3ccc0b56e431dc6a0c2b2039706d7d26f22cb9/tokenizer. avail mem: 58.12 GB
[01-21 15:08:06] Loaded tokenizer: Qwen2TokenizerFast (sgl-diffusion version). model size: 0.00 GB, avail mem: 58.12 GB
Loading required modules:  67%|███████████████████████████████████████████████████████▎                           | 4/6 [00:03<00:01,  1.32it/s][01-21 15:08:06] Loading transformer from /root/.cache/huggingface/hub/models--Qwen--Qwen-Image-Edit-2511/snapshots/6f3ccc0b56e431dc6a0c2b2039706d7d26f22cb9/transformer. avail mem: 58.12 GB
[01-21 15:08:06] Loading QwenImageTransformer2DModel from 5 safetensors files, default_dtype: torch.bfloat16
[01-21 15:08:06] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[01-21 15:08:10] [RunAI Streamer] Overall time to stream 38.1 GiB of all files to cpu: 3.22s, 11.8 GiB/s
[01-21 15:08:19] Loaded model with 20.43B parameters
[01-21 15:08:19] Loaded transformer: QwenImageTransformer2DModel (sgl-diffusion version). model size: 38.05 GB, avail mem: 20.12 GB
Loading required modules:  83%|█████████████████████████████████████████████████████████████████████▏             | 5/6 [00:15<00:04,  4.66s/it][01-21 15:08:19] Loading vae from /root/.cache/huggingface/hub/models--Qwen--Qwen-Image-Edit-2511/snapshots/6f3ccc0b56e431dc6a0c2b2039706d7d26f22cb9/vae. avail mem: 20.12 GB
[01-21 15:08:19] Loaded vae: AutoencoderKLQwenImage (sgl-diffusion version). model size: 0.47 GB, avail mem: 19.64 GB
Loading required modules: 100%|███████████████████████████████████████████████████████████████████████████████████| 6/6 [00:15<00:00,  2.66s/it]
[01-21 15:08:19] Creating pipeline stages...
[01-21 15:08:19] Compiling transformer with mode: max-autotune-no-cudagraphs
[01-21 15:08:19] Worker 0: Shutdown complete.
Process sglang-diffusionWorker-0:
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 315, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/managers/scheduler.py", line 71, in __init__
    worker = GPUWorker(
             ^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 61, in __init__
    self.init_device_and_model()
```

pr:

```shell
01-21 15:41:11] Compiling transformer with mode: max-autotune-no-cudagraphs
[01-21 15:41:11] Using FlashAttention2 backend
[01-21 15:41:11] Pipeline instantiated
[01-21 15:41:11] Worker 0: Initialized device, model, and distributed environment.
[01-21 15:41:11] Worker 0: Scheduler loop started.
[01-21 15:41:11] Processing prompt 1/1: remain the dog in the image and create a beautiful girl in the image and the background is a beautif
[01-21 15:41:11] Processing warmup req... (1/1)

[01-21 15:41:31] [ConditioningStage] started...
[01-21 15:41:31] [ConditioningStage] finished in 0.0000 seconds
[01-21 15:41:31] [DenoisingStage] started...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:16<00:00,  1.68it/s]
[01-21 15:41:47] [DenoisingStage] average time per step: 0.5960 seconds
[01-21 15:41:47] [DenoisingStage] finished in 16.6929 seconds
[01-21 15:41:47] [DecodingStage] started...
[01-21 15:41:47] [DecodingStage] finished in 0.1272 seconds
[01-21 15:41:47] Peak GPU memory: 62.37 GB, Remaining GPU memory at peak: 17.27 GB. Components that can stay resident: []
[01-21 15:41:48] Output saved to outputs/remain_the_dog_in_the_image_and_create_a_beautiful_girl_in_the_image_and_the_background_is_a_beautif_20260121-154111_9b3bebb0.png
[01-21 15:41:48] Pixel data generated successfully in 37.02 seconds
[01-21 15:41:48] Completed batch processing. Generated 1 outputs in 37.02 seconds
[01-21 15:41:48] Warmed-up request processed in 19.72 seconds (with warmup excluded)
[01-21 15:41:48] Memory usage - Max peak: 63870.40 MB, Avg peak: 63870.40 MB
```

<img width="1400" height="1184" alt="图片" src="https://github.com/user-attachments/assets/8c1a6b22-0d9c-4faf-824d-a647aff6a5a2" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
