### PR TITLE
Temporarily disable flaky test_gpt_oss_4gpu.py on B200

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -34,7 +34,6 @@ suites = {
     "per-commit-4-gpu-b200": [
         TestFile("test_deepseek_v3_fp4_4gpu.py", 1500),
         TestFile("test_fp8_blockwise_gemm.py", 280),
-        TestFile("test_gpt_oss_4gpu.py", 700),
         TestFile("test_nvfp4_gemm.py", 360),
     ],
     # "per-commit-8-gpu-b200": [
@@ -66,6 +65,7 @@ suites = {
             "models/test_qwen3_next_models_pcg.py"
         ),  # Disabled: intermittent failures, see #17039
         TestFile("ep/test_deepep_large.py", 563),  # Disabled: see #17175
+        TestFile("test_gpt_oss_4gpu.py", 700),  # Disabled: flaky on B200, see #17527
     ],
 }
 


### PR DESCRIPTION
## Summary
- Disable `test_gpt_oss_4gpu.py` due to flaky failures on B200 runners

## Problem
Same test on same runner (b200-novita-2) can pass or fail within minutes:

**Failed**: https://github.com/sgl-project/sglang/actions/runs/21172906875/job/61056442699
- Scores: 0.379, 0.399 (expected ≥0.6)
- Output: ~4000-4600 chars

**Passed**: https://github.com/sgl-project/sglang/actions/runs/21220673438/job/61074323719
- Scores: 0.636, 0.631
- Output: ~1700-1800 chars

## Root Cause
Under investigation. See #17527 for details.

## Test plan
- CI validation