### PR TITLE
Remove test_gpt_oss_4gpu.py from __not_in_ci__ (keep in per-commit-4-gpu)

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -65,7 +65,6 @@ suites = {
             "models/test_qwen3_next_models_pcg.py"
         ),  # Disabled: intermittent failures, see #17039
         TestFile("ep/test_deepep_large.py", 563),  # Disabled: see #17175
-        TestFile("test_gpt_oss_4gpu.py", 700),  # Disabled: flaky on B200, see #17527
     ],
 }
 


### PR DESCRIPTION
## Summary

PR #17528 incorrectly added test_gpt_oss_4gpu.py to `__not_in_ci__` to disable it on B200, but the test was never in the B200 suite - it only runs in `per-commit-4-gpu` (H100). This caused a sanity check failure due to duplicate entries.

Fix: Remove from `__not_in_ci__` and keep in `per-commit-4-gpu` where it should continue to run on H100 machines.

Failure: https://github.com/sgl-project/sglang/actions/runs/21242413614/job/61128168621

## Test plan

- CI sanity check should pass
- test_gpt_oss_4gpu.py continues to run on H100 (per-commit-4-gpu)