### PR TITLE
Increase wait-for-stage timeouts to handle long queue times

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -209,7 +209,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const maxWaitMinutes = 60;
+            const maxWaitMinutes = 240;
             const pollIntervalSeconds = 120;  // 2 minutes to reduce GH API calls
             const maxAttempts = (maxWaitMinutes * 60) / pollIntervalSeconds;
 
@@ -270,7 +270,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const maxWaitMinutes = 90;
+            const maxWaitMinutes = 480;
             const pollIntervalSeconds = 120;  // 2 minutes to reduce GH API calls
             const maxAttempts = (maxWaitMinutes * 60) / pollIntervalSeconds;
 


### PR DESCRIPTION
- Increase wait-for-stage-a timeout from 60 min to 240 min (4 hours)
- Increase wait-for-stage-b timeout from 90 min to 480 min (8 hours)

queue times have been very long, causing the wait-for-stage jobs to timeout before all tests complete.