### PR TITLE
fix: nightly wheel naming for non-post versions

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -49,25 +49,18 @@ jobs:
           cd python
           cp ../README.md ../LICENSE .
 
-          # Get git describe output and force distance=1 if at exact tag
+          # Parse git describe output to detect exact tag builds (distance=0)
           DESC=$(git describe --tags --long --match 'v*' 2>/dev/null || echo 'v0.0.0-0-g0000000')
-          TAG=$(echo "$DESC" | cut -d- -f1)
           DIST=$(echo "$DESC" | cut -d- -f2)
-          HASH=$(echo "$DESC" | cut -d- -f3-)
 
-          echo "=== Git describe output ==="
-          echo "Original: $DESC"
-          echo "Parsed: TAG=$TAG DIST=$DIST HASH=$HASH"
-
-          # If distance is 0 (building at exact tag), force dev0 version
+          # If building at exact tag (distance=0), force dev0 version for unique wheel names
           if [ "$DIST" = "0" ]; then
-            echo "Distance is 0 - using dev0 to ensure unique wheel name"
-            # Override version for setuptools-scm using environment variable
+            TAG=$(echo "$DESC" | cut -d- -f1)
+            HASH=$(echo "$DESC" | cut -d- -f3-)
             FORCE_VERSION="${TAG#v}.dev0+${HASH}"
-            echo "Forcing version to: $FORCE_VERSION"
+            echo "Building at exact tag, forcing version to: $FORCE_VERSION"
             export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"
           fi
-          echo "==========================="
 
           # Build wheel
           python3 -m build --wheel

--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -49,20 +49,27 @@ jobs:
           cd python
           cp ../README.md ../LICENSE .
 
-          # Debug: Show git describe output to diagnose version issues
-          echo "=== Debug: Git describe output ==="
-          git describe --tags --long --match 'v*'
-          echo "=== Debug: Testing custom command ==="
+          # Get git describe output and force distance=1 if at exact tag
           DESC=$(git describe --tags --long --match 'v*' 2>/dev/null || echo 'v0.0.0-0-g0000000')
           TAG=$(echo "$DESC" | cut -d- -f1)
           DIST=$(echo "$DESC" | cut -d- -f2)
           HASH=$(echo "$DESC" | cut -d- -f3-)
-          echo "Parsed: TAG=$TAG DIST=$DIST HASH=$HASH"
-          test "$DIST" = '0' && DIST=1 && echo "Forcing DIST=1 for tag-exact build"
-          echo "Final: ${TAG}-${DIST}-${HASH}"
-          echo "==================================="
 
-          # Build wheel - setuptools-scm automatically generates version from git tags
+          echo "=== Git describe output ==="
+          echo "Original: $DESC"
+          echo "Parsed: TAG=$TAG DIST=$DIST HASH=$HASH"
+
+          # If distance is 0 (building at exact tag), force distance to 1
+          if [ "$DIST" = "0" ]; then
+            echo "Distance is 0 - forcing to 1 to ensure dev version"
+            # Override version for setuptools-scm using environment variable
+            FORCE_VERSION="${TAG#v}.dev1+${HASH}"
+            echo "Forcing version to: $FORCE_VERSION"
+            export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"
+          fi
+          echo "==========================="
+
+          # Build wheel
           python3 -m build --wheel
 
           # Extract version from built wheel filename

--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -49,6 +49,19 @@ jobs:
           cd python
           cp ../README.md ../LICENSE .
 
+          # Debug: Show git describe output to diagnose version issues
+          echo "=== Debug: Git describe output ==="
+          git describe --tags --long --match 'v*'
+          echo "=== Debug: Testing custom command ==="
+          DESC=$(git describe --tags --long --match 'v*' 2>/dev/null || echo 'v0.0.0-0-g0000000')
+          TAG=$(echo "$DESC" | cut -d- -f1)
+          DIST=$(echo "$DESC" | cut -d- -f2)
+          HASH=$(echo "$DESC" | cut -d- -f3-)
+          echo "Parsed: TAG=$TAG DIST=$DIST HASH=$HASH"
+          test "$DIST" = '0' && DIST=1 && echo "Forcing DIST=1 for tag-exact build"
+          echo "Final: ${TAG}-${DIST}-${HASH}"
+          echo "==================================="
+
           # Build wheel - setuptools-scm automatically generates version from git tags
           python3 -m build --wheel
 

--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -59,11 +59,11 @@ jobs:
           echo "Original: $DESC"
           echo "Parsed: TAG=$TAG DIST=$DIST HASH=$HASH"
 
-          # If distance is 0 (building at exact tag), force distance to 1
+          # If distance is 0 (building at exact tag), force dev0 version
           if [ "$DIST" = "0" ]; then
-            echo "Distance is 0 - forcing to 1 to ensure dev version"
+            echo "Distance is 0 - using dev0 to ensure unique wheel name"
             # Override version for setuptools-scm using environment variable
-            FORCE_VERSION="${TAG#v}.dev1+${HASH}"
+            FORCE_VERSION="${TAG#v}.dev0+${HASH}"
             echo "Forcing version to: $FORCE_VERSION"
             export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"
           fi

--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -50,7 +50,8 @@ jobs:
           cp ../README.md ../LICENSE .
 
           # Parse git describe output to detect exact tag builds (distance=0)
-          DESC=$(git describe --tags --long --match 'v*' 2>/dev/null || echo 'v0.0.0-0-g0000000')
+          # Use same command as pyproject.toml to ensure version consistency
+          DESC=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1 | xargs git describe --tags --long 2>/dev/null || echo 'v0.0.0-0-g0000000')
           DIST=$(echo "$DESC" | cut -d- -f2)
 
           # If building at exact tag (distance=0), force dev0 version for unique wheel names

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,10 +172,10 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Force a minimum distance of 1 to ensure dev version is always present
-# This prevents tags at distance=0 from producing plain versions like "0.5.7"
-# Instead we get "0.5.7.dev1" which creates unique wheel names
-git_describe_command = ["bash", "-c", "DESC=$(git describe --tags --long --match 'v*' 2>/dev/null || echo 'v0.0.0-0-g0000000'); TAG=$(echo \"$DESC\" | cut -d- -f1); DIST=$(echo \"$DESC\" | cut -d- -f2); HASH=$(echo \"$DESC\" | cut -d- -f3-); test \"$DIST\" = '0' && DIST=1; echo \"${TAG}-${DIST}-${HASH}\""]
+# Standard setuptools-scm configuration
+# For nightly builds at exact tags, the GitHub Actions workflow uses
+# SETUPTOOLS_SCM_PRETEND_VERSION environment variable to force a dev version
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,11 +172,11 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Custom git command that embeds commit hash in the dev version for unique nightly wheels
-# Generates versions like: 0.5.7.dev701.g1e30903
-# Which creates wheel names like: sglang-0.5.7.dev701.g1e30903-py3-none-any.whl
-# Format breakdown: TAG=v0.5.7, COMMITS=701, HASH=1e30903 -> v0.5.7-701.g1e30903
-git_describe_command = ["bash", "-c", "TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1); COMMITS=$(git rev-list ${TAG}..HEAD --count 2>/dev/null || echo 0); HASH=$(git rev-parse --short=7 HEAD); echo \"${TAG}-${COMMITS}.g${HASH}\""]
+# Use timestamp-based dev versions for unique nightly wheels
+# Format: v0.5.7-20260120143022 where 20260120143022 is YYYYMMDDHHMMSS
+# This creates versions like 0.5.7.dev20260120143022
+# And wheel names like: sglang-0.5.7.dev20260120143022-py3-none-any.whl
+git_describe_command = ["bash", "-c", "TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1); TIMESTAMP=$(date -u +%Y%m%d%H%M%S); echo \"${TAG}-${TIMESTAMP}-g000000\""]
 local_scheme = "no-local-version"
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,11 +172,16 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Use timestamp-based dev versions for unique nightly wheels
-# Format: v0.5.7-20260120143022 where 20260120143022 is YYYYMMDDHHMMSS
-# This creates versions like 0.5.7.dev20260120143022
-# And wheel names like: sglang-0.5.7.dev20260120143022-py3-none-any.whl
-git_describe_command = ["bash", "-c", "TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1); TIMESTAMP=$(date -u +%Y%m%d%H%M%S); echo \"${TAG}-${TIMESTAMP}-g000000\""]
+# Hybrid approach: commit count for post number, timestamp for uniqueness
+# Format: v0.5.7-703-g20260121012243
+#   - Tag: v0.5.7
+#   - Distance: 703 (actual commit count, used for .post703)
+#   - Hash: g20260121012243 (timestamp YYYYMMDDHHMMSS for uniqueness)
+# This creates versions like: 0.5.7.post703.dev20260121012243
+# And wheel names like: sglang-0.5.7.post703.dev20260121012243-py3-none-any.whl
+# The timestamp in dev version ensures each build is unique, preventing overwrites
+git_describe_command = ["bash", "-c", "TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1); COMMITS=$(git rev-list ${TAG}..HEAD --count 2>/dev/null || echo 0); TIMESTAMP=$(date -u +%Y%m%d%H%M%S); echo \"${TAG}-${COMMITS}-g${TIMESTAMP}\""]
+version_scheme = "post-release"
 local_scheme = "no-local-version"
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,7 +172,12 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-git_describe_command = ["bash", "-c", "git tag --list --sort=-version:refname 'v*.*.*' | head -1 | xargs git describe --tags --long"]
+# Custom git command that embeds commit hash in the dev version for unique nightly wheels
+# Generates versions like: 0.5.7.dev701.g1e30903
+# Which creates wheel names like: sglang-0.5.7.dev701.g1e30903-py3-none-any.whl
+# Format breakdown: TAG=v0.5.7, COMMITS=701, HASH=1e30903 -> v0.5.7-701.g1e30903
+git_describe_command = ["bash", "-c", "TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1); COMMITS=$(git rev-list ${TAG}..HEAD --count 2>/dev/null || echo 0); HASH=$(git rev-parse --short=7 HEAD); echo \"${TAG}-${COMMITS}.g${HASH}\""]
+local_scheme = "no-local-version"
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,13 +172,10 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Custom git describe that ensures unique versions even when building at exact tags
-# When distance=0 (at tag), use timestamp as distance to ensure dev number is present
-# Examples:
-#   v0.5.6.post2-1344-ghash → 0.5.6.post2.dev1344+ghash (normal case)
-#   v0.5.7-0-ghash → 0.5.7.dev20260122002631+ghash (at tag, uses timestamp)
-# This ensures wheel names are always unique: sglang-0.5.x.postY.devZ-py3-none-any.whl
-git_describe_command = ["bash", "-c", "DESC=$(git describe --tags --long --match 'v*'); TAG=$(echo $DESC | cut -d- -f1); DIST=$(echo $DESC | cut -d- -f2); HASH=$(echo $DESC | cut -d- -f3); if [ \"$DIST\" = \"0\" ]; then DIST=$(date -u +%Y%m%d%H%M%S); fi; echo \"${TAG}-${DIST}-${HASH}\""]
+# Force a minimum distance of 1 to ensure dev version is always present
+# This prevents tags at distance=0 from producing plain versions like "0.5.7"
+# Instead we get "0.5.7.dev1" which creates unique wheel names
+git_describe_command = ["bash", "-c", "DESC=$(git describe --tags --long --match 'v*' 2>/dev/null || echo 'v0.0.0-0-g0000000'); TAG=$(echo \"$DESC\" | cut -d- -f1); DIST=$(echo \"$DESC\" | cut -d- -f2); HASH=$(echo \"$DESC\" | cut -d- -f3-); test \"$DIST\" = '0' && DIST=1; echo \"${TAG}-${DIST}-${HASH}\""]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,10 +172,7 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Standard setuptools-scm configuration
-# For nightly builds at exact tags, the GitHub Actions workflow uses
-# SETUPTOOLS_SCM_PRETEND_VERSION environment variable to force a dev version
-git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
+git_describe_command = ["bash", "-c", "git tag --list --sort=-version:refname 'v*.*.*' | head -1 | xargs git describe --tags --long"]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,11 +172,13 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Standard git describe with default version scheme
-# This generates versions like: 0.5.6.post3.dev1258+ge486a4dac
-# Wheel names like: sglang-0.5.6.post3.dev1258-py3-none-any.whl
-# The +ge486a4dac part is stripped from wheel names but the dev number ensures uniqueness
-git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
+# Custom git describe that ensures unique versions even when building at exact tags
+# When distance=0 (at tag), use timestamp as distance to ensure dev number is present
+# Examples:
+#   v0.5.6.post2-1344-ghash → 0.5.6.post2.dev1344+ghash (normal case)
+#   v0.5.7-0-ghash → 0.5.7.dev20260122002631+ghash (at tag, uses timestamp)
+# This ensures wheel names are always unique: sglang-0.5.x.postY.devZ-py3-none-any.whl
+git_describe_command = ["bash", "-c", "DESC=$(git describe --tags --long --match 'v*'); TAG=$(echo $DESC | cut -d- -f1); DIST=$(echo $DESC | cut -d- -f2); HASH=$(echo $DESC | cut -d- -f3); if [ \"$DIST\" = \"0\" ]; then DIST=$(date -u +%Y%m%d%H%M%S); fi; echo \"${TAG}-${DIST}-${HASH}\""]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,15 +172,15 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Hybrid approach: commit count for post number, timestamp for uniqueness
-# Format: v0.5.7-703-g20260121012243
-#   - Tag: v0.5.7
-#   - Distance: 703 (actual commit count, used for .post703)
-#   - Hash: g20260121012243 (timestamp YYYYMMDDHHMMSS for uniqueness)
-# This creates versions like: 0.5.7.post703.dev20260121012243
-# And wheel names like: sglang-0.5.7.post703.dev20260121012243-py3-none-any.whl
-# The timestamp in dev version ensures each build is unique, preventing overwrites
-git_describe_command = ["bash", "-c", "TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1); COMMITS=$(git rev-list ${TAG}..HEAD --count 2>/dev/null || echo 0); TIMESTAMP=$(date -u +%Y%m%d%H%M%S); echo \"${TAG}-${COMMITS}-g${TIMESTAMP}\""]
+# Use timestamp in dev version to ensure unique nightly wheels even when rebuilding same commit
+# Format: v0.5.7-704-g20260121020530 (tag-commits-timestamp_as_hash)
+# This becomes: 0.5.7.post704.dev20260121020530
+# Wheel filename: sglang-0.5.7.post704.dev20260121020530-py3-none-any.whl
+# Benefits:
+# - post704 tracks actual commit count from tag
+# - dev20260121020530 is unique timestamp (YYYYMMDDHHMMSS)
+# - Every build is unique, even rebuilding the same commit
+git_describe_command = ["bash", "-c", "TAG=$(git describe --tags --match 'v*' 2>/dev/null || echo 'v0.0.0'); COMMITS=$(echo $TAG | cut -d'-' -f2); if [ \"$COMMITS\" = \"$TAG\" ]; then COMMITS=0; fi; TIMESTAMP=$(date -u +%Y%m%d%H%M%S); echo \"$(echo $TAG | cut -d'-' -f1)-${COMMITS}-g${TIMESTAMP}\""]
 version_scheme = "post-release"
 local_scheme = "no-local-version"
 # Allow editable installs even when .git metadata is not available.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -172,17 +172,11 @@ exclude = [
 [tool.setuptools_scm]
 root = ".."
 version_file = "sglang/_version.py"
-# Use timestamp in dev version to ensure unique nightly wheels even when rebuilding same commit
-# Format: v0.5.7-704-g20260121020530 (tag-commits-timestamp_as_hash)
-# This becomes: 0.5.7.post704.dev20260121020530
-# Wheel filename: sglang-0.5.7.post704.dev20260121020530-py3-none-any.whl
-# Benefits:
-# - post704 tracks actual commit count from tag
-# - dev20260121020530 is unique timestamp (YYYYMMDDHHMMSS)
-# - Every build is unique, even rebuilding the same commit
-git_describe_command = ["bash", "-c", "TAG=$(git describe --tags --match 'v*' 2>/dev/null || echo 'v0.0.0'); COMMITS=$(echo $TAG | cut -d'-' -f2); if [ \"$COMMITS\" = \"$TAG\" ]; then COMMITS=0; fi; TIMESTAMP=$(date -u +%Y%m%d%H%M%S); echo \"$(echo $TAG | cut -d'-' -f1)-${COMMITS}-g${TIMESTAMP}\""]
-version_scheme = "post-release"
-local_scheme = "no-local-version"
+# Standard git describe with default version scheme
+# This generates versions like: 0.5.6.post3.dev1258+ge486a4dac
+# Wheel names like: sglang-0.5.6.post3.dev1258-py3-none-any.whl
+# The +ge486a4dac part is stripped from wheel names but the dev number ensures uniqueness
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
 # Allow editable installs even when .git metadata is not available.
 fallback_version = "0.0.0.dev0"
 


### PR DESCRIPTION
## Motivation

When building nightly wheels at an exact tag commit (Distance=0 from tag), setuptools-scm generates a version without a dev number (eg. 0.5.7 instead of 0.5.7.devN). This results in wheel filenames like sglang-0.5.7-py3-none-any.whl that are not unique, causing new builds to overwrite previous wheels with the same base version.

## Modifications

Modified the nightly wheel build workflow to detect when building at an exact tag (distance=0) and force a dev0 version using the SETUPTOOLS_SCM_PRETEND_VERSION environment variable. This ensures every nightly wheel has a unique filename.

## Accuracy Tests

https://github.com/sgl-project/whl/releases/tag/nightly-2026-01-24-ebafc5cf5

## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
