### PR TITLE
fix: add assistant token when last message is not from user/developer

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv32.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv32.py
@@ -327,6 +327,12 @@ def encode_messages(
             idx + len(context), full_messages, thinking_mode=thinking_mode
         )
 
+    if not full_messages or full_messages[-1]["role"] not in ("user", "developer"):
+        prompt += "<｜Assistant｜>"
+        prompt += (
+            thinking_start_token if thinking_mode == "thinking" else thinking_end_token
+        )
+
     return prompt
 
 


### PR DESCRIPTION
## Description
Fixes the case where `encode_messages` does not append the assistant token when the last message role is not "user" or "developer".

## Changes
- Add check for empty messages or non-user/developer last role
- Append `<｜Assistant｜>` + appropriate thinking token

## Checklist
- [x] Code formatted with black
- [x] Pre-commit hooks passed