### PR TITLE
[NPU] [Bug Fix] Fix typo in npu device check in gpt_oss.py

### DIFF
--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -492,7 +492,7 @@ class GptOssModel(nn.Module):
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
 
-        if is_npu:
+        if _is_npu:
             config.hidden_act = "npu_swiglu_oai"
 
         if self.pp_group.is_first_rank:


### PR DESCRIPTION
## Motivation
NPU support for gpt-oss enabled through the following PR https://github.com/sgl-project/sglang/pull/14197 has a small typo in npu device check for activation. That needs to be fixed otherwise the default activation function will be set as per NPU backend irrespective on whichever device the model is executed. 


## Modifications
Fix typo in npu device check in gpt_oss.py

