### PR TITLE
ci(pre-commit): avoids extraneous codespell exclusions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,6 @@ repos:
         args: ['--config', '.codespellrc']
         exclude: |
           (?x)^(
-            docs/advanced_features/vlm_query\.ipynb|
             python/sglang/srt/grpc/.*_pb2\.py|
             python/sglang/srt/grpc/.*_pb2_grpc\.py|
             python/sglang/srt/grpc/.*_pb2\.pyi|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,10 +52,6 @@ repos:
     hooks:
       - id: codespell
         args: ['--config', '.codespellrc']
-        exclude: |
-          (?x)^(
-            sgl-model-gateway/src/tokenizer/chat_template\.rs
-          )$
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,6 @@ repos:
         args: ['--config', '.codespellrc']
         exclude: |
           (?x)^(
-            test/srt/test_reasoning_parser\.py|
             docs/advanced_features/vlm_query\.ipynb|
             python/sglang/srt/grpc/.*_pb2\.py|
             python/sglang/srt/grpc/.*_pb2_grpc\.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,10 +54,6 @@ repos:
         args: ['--config', '.codespellrc']
         exclude: |
           (?x)^(
-            python/sglang/srt/grpc/.*_pb2\.py|
-            python/sglang/srt/grpc/.*_pb2_grpc\.py|
-            python/sglang/srt/grpc/.*_pb2\.pyi|
-            python/sglang/srt/grpc/.*_pb2_grpc\.pyi|
             sgl-model-gateway/src/tokenizer/chat_template\.rs
           )$
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/sgl-model-gateway/src/tokenizer/chat_template.rs
+++ b/sgl-model-gateway/src/tokenizer/chat_template.rs
@@ -17,7 +17,7 @@ use minijinja::{
     Environment, Error as MinijinjaError, ErrorKind, Value,
 };
 use serde::Serialize;
-use serde_json::{self, ser::PrettyFormatter, Value as JsonValue};
+use serde_json::{self, ser::PrettyFormatter, Value as JsonValue}; // codespell:ignore ser
 
 /// Chat template content format
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]


### PR DESCRIPTION
## Motivation

The purpose this pull request is to avoid excluding files from codespell phase in cases where:
- the file is no longer triggering pre-commit failure
- the file only has a single offending line and is eligible for an inline "codespell:ignore" comment

## Modifications

- adds necessary inline comments
- removes `exclude` parameters from `codespell` phase in pre commit config

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
