### PR TITLE
[BUGFIX] Fix Qwen3 Embedding model weight loading when weights already have model prefix

### DIFF
--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -499,7 +499,9 @@ class Qwen3ForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
-            if "Embedding" in self.config.name_or_path:
+            if "Embedding" in self.config.name_or_path and not name.startswith(
+                "model."
+            ):
                 name = add_prefix(name, "model")
             layer_id = get_layer_id(name)
             if (


### PR DESCRIPTION
## Summary
- Fixes weight loading for fine-tuned Qwen3 Embedding models where checkpoint weights already contain the "model." prefix
- Adds a check to avoid double-prefixing (model.model.xxx) which causes KeyError during weight loading

## Test plan
- Load a Qwen3 Embedding model that was fine-tuned with ms-swift or similar frameworks
- Verify weights load without "Parameter model.model.xxx not found" errors
