### PR TITLE
Use monotonic clock for request timing stats (#17482)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -16,6 +16,7 @@ from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingR
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.server_args import ServerArgs
 
+from sglang.srt.tracing.clock import now_mono_s, now_wall_s
 if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
@@ -89,14 +90,14 @@ class OpenAIServingBase(ABC):
         """Handle the specific request type with common pattern
         If you want to override this method, you should be careful to record the validation time.
         """
-        received_time = time.time()
-        received_time_perf = time.perf_counter()
+        received_time = now_wall_s()
+        received_time_perf = now_mono_s()
 
         try:
             # Validate request
-            validation_start = time.perf_counter()
+            validation_start = now_mono_s()
             error_msg = self._validate_request(request)
-            validation_time = time.perf_counter() - validation_start
+            validation_time = now_mono_s() - validation_start
             if error_msg:
                 return self.create_error_response(error_msg)
 

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
@@ -15,8 +14,8 @@ from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.server_args import ServerArgs
-
 from sglang.srt.tracing.clock import now_mono_s, now_wall_s
+
 if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1,3 +1,4 @@
+from sglang.srt.tracing.clock import now_mono_s, now_wall_s
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -488,7 +489,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
     ):
-        created_time = obj.received_time if obj.received_time else time.time()
+        created_time = obj.received_time if obj.received_time else now_wall_s()
         self.auto_create_handle_loop()
 
         # Normalize the request
@@ -1062,7 +1063,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         state = self.req_state_class(
             [], False, asyncio.Event(), obj, created_time=created_time
         )
-        state.request_sent_to_scheduler_ts = time.time()
+        state.request_sent_to_scheduler_ts = now_wall_s()
         self.rid_to_state[obj.rid] = state
         trace_slice_end(
             RequestStage.TOKENIZER_DISPATCH, obj.rid, thread_finish_flag=True
@@ -1127,7 +1128,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 # For non-streaming cases, response has not been sent yet (`response_sent_to_client_ts` has not been set yet).
                 # Record response sent time right before we log finished results and metrics.
                 if not state.response_sent_to_client_ts:
-                    state.response_sent_to_client_ts = time.time()
+                    state.response_sent_to_client_ts = now_wall_s()
                     out["meta_info"][
                         "response_sent_to_client_ts"
                     ] = state.response_sent_to_client_ts
@@ -1188,7 +1189,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             if is_stream:
                 # Record response sent time right before we send response.
                 if not state.response_sent_to_client_ts:
-                    state.response_sent_to_client_ts = time.time()
+                    state.response_sent_to_client_ts = now_wall_s()
                     out["meta_info"][
                         "response_sent_to_client_ts"
                     ] = state.response_sent_to_client_ts
@@ -1471,7 +1472,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             with self.soft_watchdog.disable():
                 recv_obj = await self.recv_from_detokenizer.recv_pyobj()
             self._result_dispatcher(recv_obj)
-            self.last_receive_tstamp = time.time()
+            self.last_receive_tstamp = now_wall_s()
             self.soft_watchdog.feed()
 
     def _handle_batch_output(
@@ -1583,8 +1584,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
             state.finished = recv_obj.finished_reasons[i] is not None
             if state.finished:
-                state.finished_time = time.time()
-                state.finished_time_perf = time.perf_counter()
+                state.finished_time = now_wall_s()
+                state.finished_time_perf = now_mono_s()
                 meta_info["e2e_latency"] = state.finished_time - state.created_time
 
                 if self.server_args.speculative_algorithm:
@@ -1938,8 +1939,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             state.first_token_time == 0.0
             and self.disaggregation_mode != DisaggregationMode.PREFILL
         ):
-            state.first_token_time = state.last_time = time.time()
-            state.first_token_time_perf = time.perf_counter()
+            state.first_token_time = state.last_time = now_wall_s()
+            state.first_token_time_perf = now_mono_s()
             state.last_completion_tokens = completion_tokens
             self.metrics_collector.observe_time_to_first_token(
                 labels, state.first_token_time - state.created_time
@@ -1947,7 +1948,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         else:
             num_new_tokens = completion_tokens - state.last_completion_tokens
             if num_new_tokens:
-                new_time = time.time()
+                new_time = now_wall_s()
                 interval = new_time - state.last_time
                 self.metrics_collector.observe_inter_token_latency(
                     labels,
@@ -1977,7 +1978,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
     def dump_requests(self, state: ReqState, out_dict: dict):
         self.dump_request_list.append(
-            (state.obj, out_dict, state.created_time, time.time())
+            (state.obj, out_dict, state.created_time, now_wall_s())
         )
 
         if len(self.dump_request_list) >= self.dump_requests_threshold:
@@ -1993,7 +1994,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             self.dump_request_list = []
 
     def record_request_for_crash_dump(self, state: ReqState, out_dict: dict):
-        current_time = time.time()
+        current_time = now_wall_s()
         self.crash_dump_request_list.append(
             (state.obj, out_dict, state.created_time, current_time)
         )
@@ -2050,7 +2051,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                         state.obj,
                         state.out_list[-1] if state.out_list else {},
                         state.created_time,
-                        time.time(),
+                        now_wall_s(),
                     )
                 )
         if unfinished_requests:

--- a/python/sglang/srt/tracing/clock.py
+++ b/python/sglang/srt/tracing/clock.py
@@ -1,0 +1,10 @@
+import time
+
+def now_wall_s() -> float:
+    return time.time()
+
+def now_mono_s() -> float:
+    return time.perf_counter()
+
+def now_wall_ns() -> int:
+    return int(time.time() * 1_000_000_000)

--- a/python/sglang/srt/tracing/clock.py
+++ b/python/sglang/srt/tracing/clock.py
@@ -1,10 +1,13 @@
 import time
 
+
 def now_wall_s() -> float:
     return time.time()
 
+
 def now_mono_s() -> float:
     return time.perf_counter()
+
 
 def now_wall_ns() -> int:
     return int(time.time() * 1_000_000_000)

--- a/python/sglang/srt/tracing/req_time_stats.py
+++ b/python/sglang/srt/tracing/req_time_stats.py
@@ -34,8 +34,17 @@ class ReqTimeStatsBase:
             return
         self.ts_mono_s[i] = now_mono_s()
 
+
+    def mark_at(self, point: ReqTimePoint, ts_mono_s: float) -> None:
+        i = int(point)
+        cur = self.ts_mono_s[i]
+        if cur == cur:
+            return
+        self.ts_mono_s[i] = ts_mono_s
+
+
     def duration_s(self, start: ReqTimePoint, end: ReqTimePoint) -> float:
         return self.ts_mono_s[int(end)] - self.ts_mono_s[int(start)]
 
     def to_log_record(self) -> dict:
-        return {"req_time_ts_mono_s": self.ts_mono_s}
+        return {"req_time_ts_mono_s": list(self.ts_mono_s)}

--- a/python/sglang/srt/tracing/req_time_stats.py
+++ b/python/sglang/srt/tracing/req_time_stats.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import List
+
+from sglang.srt.tracing.clock import now_mono_s
+
+class ReqTimePoint(IntEnum):
+    received = 0
+    request_sent_to_scheduler = 1
+    scheduled = 2
+    first_token = 3
+    response_sent = 4
+    finished = 5
+
+@dataclass
+class ReqTimeStatsBase:
+    """
+    Per request time stats are stored as a fixed list of monotonic timestamps in seconds.
+    Each entry corresponds to a milestone in ReqTimePoint.
+    Durations are computed as ts[end] minus ts[start].
+    """
+    ts_mono_s: List[float]
+
+    @classmethod
+    def create(cls) -> "ReqTimeStatsBase":
+        return cls(ts_mono_s=[float("nan")] * len(ReqTimePoint))
+
+    def mark(self, point: ReqTimePoint) -> None:
+        i = int(point)
+        cur = self.ts_mono_s[i]
+        if cur == cur:
+            return
+        self.ts_mono_s[i] = now_mono_s()
+
+    def duration_s(self, start: ReqTimePoint, end: ReqTimePoint) -> float:
+        return self.ts_mono_s[int(end)] - self.ts_mono_s[int(start)]
+
+    def to_log_record(self) -> dict:
+        return {"req_time_ts_mono_s": self.ts_mono_s}

--- a/python/sglang/srt/tracing/req_time_stats.py
+++ b/python/sglang/srt/tracing/req_time_stats.py
@@ -6,6 +6,7 @@ from typing import List
 
 from sglang.srt.tracing.clock import now_mono_s
 
+
 class ReqTimePoint(IntEnum):
     received = 0
     request_sent_to_scheduler = 1
@@ -14,6 +15,7 @@ class ReqTimePoint(IntEnum):
     response_sent = 4
     finished = 5
 
+
 @dataclass
 class ReqTimeStatsBase:
     """
@@ -21,6 +23,7 @@ class ReqTimeStatsBase:
     Each entry corresponds to a milestone in ReqTimePoint.
     Durations are computed as ts[end] minus ts[start].
     """
+
     ts_mono_s: List[float]
 
     @classmethod
@@ -34,14 +37,12 @@ class ReqTimeStatsBase:
             return
         self.ts_mono_s[i] = now_mono_s()
 
-
     def mark_at(self, point: ReqTimePoint, ts_mono_s: float) -> None:
         i = int(point)
         cur = self.ts_mono_s[i]
         if cur == cur:
             return
         self.ts_mono_s[i] = ts_mono_s
-
 
     def duration_s(self, start: ReqTimePoint, end: ReqTimePoint) -> float:
         return self.ts_mono_s[int(end)] - self.ts_mono_s[int(start)]

--- a/python/tests/test_req_time_stats.py
+++ b/python/tests/test_req_time_stats.py
@@ -1,10 +1,15 @@
 from sglang.srt.tracing.req_time_stats import ReqTimePoint, ReqTimeStatsBase
 
+
 def test_req_time_stats_mark_and_duration_non_negative():
     s = ReqTimeStatsBase.create()
     s.mark(ReqTimePoint.received)
     s.mark(ReqTimePoint.request_sent_to_scheduler)
-    assert s.duration_s(ReqTimePoint.received, ReqTimePoint.request_sent_to_scheduler) >= 0.0
+    assert (
+        s.duration_s(ReqTimePoint.received, ReqTimePoint.request_sent_to_scheduler)
+        >= 0.0
+    )
+
 
 def test_req_time_stats_mark_is_idempotent():
     s = ReqTimeStatsBase.create()
@@ -14,11 +19,13 @@ def test_req_time_stats_mark_is_idempotent():
     t2 = s.ts_mono_s[int(ReqTimePoint.received)]
     assert t1 == t2
 
+
 def test_req_time_stats_mark_at_is_idempotent():
     s = ReqTimeStatsBase.create()
     s.mark_at(ReqTimePoint.received, 123.0)
     s.mark_at(ReqTimePoint.received, 456.0)
     assert s.ts_mono_s[int(ReqTimePoint.received)] == 123.0
+
 
 def test_req_time_stats_to_log_record_is_copy():
     s = ReqTimeStatsBase.create()

--- a/python/tests/test_req_time_stats.py
+++ b/python/tests/test_req_time_stats.py
@@ -1,0 +1,15 @@
+from sglang.srt.tracing.req_time_stats import ReqTimePoint, ReqTimeStatsBase
+
+def test_req_time_stats_mark_and_duration_non_negative():
+    s = ReqTimeStatsBase.create()
+    s.mark(ReqTimePoint.received)
+    s.mark(ReqTimePoint.request_sent_to_scheduler)
+    assert s.duration_s(ReqTimePoint.received, ReqTimePoint.request_sent_to_scheduler) >= 0.0
+
+def test_req_time_stats_mark_is_idempotent():
+    s = ReqTimeStatsBase.create()
+    s.mark(ReqTimePoint.received)
+    t1 = s.ts_mono_s[int(ReqTimePoint.received)]
+    s.mark(ReqTimePoint.received)
+    t2 = s.ts_mono_s[int(ReqTimePoint.received)]
+    assert t1 == t2

--- a/python/tests/test_req_time_stats.py
+++ b/python/tests/test_req_time_stats.py
@@ -13,3 +13,16 @@ def test_req_time_stats_mark_is_idempotent():
     s.mark(ReqTimePoint.received)
     t2 = s.ts_mono_s[int(ReqTimePoint.received)]
     assert t1 == t2
+
+def test_req_time_stats_mark_at_is_idempotent():
+    s = ReqTimeStatsBase.create()
+    s.mark_at(ReqTimePoint.received, 123.0)
+    s.mark_at(ReqTimePoint.received, 456.0)
+    assert s.ts_mono_s[int(ReqTimePoint.received)] == 123.0
+
+def test_req_time_stats_to_log_record_is_copy():
+    s = ReqTimeStatsBase.create()
+    s.mark_at(ReqTimePoint.received, 1.0)
+    rec = s.to_log_record()
+    rec["req_time_ts_mono_s"][int(ReqTimePoint.received)] = 999.0
+    assert s.ts_mono_s[int(ReqTimePoint.received)] == 1.0


### PR DESCRIPTION
Switch request timing stats to monotonic clock to avoid wall-clock adjustments impacting latency measurements. Also adds small unit tests and keeps.