### PR TITLE
[Diffusion] glm-image apply flashinfer rope

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
@@ -391,9 +391,9 @@ class GlmImageAttention(torch.nn.Module):
         if image_rotary_emb is not None:
             cos, sin = image_rotary_emb
 
-            q_img = query[:, text_seq_length:, :, :]
-            k_img = key[:, text_seq_length:, :, :]
             if _is_cuda and cos.dim() == 2:
+                q_img = query[:, text_seq_length:, :, :]
+                k_img = key[:, text_seq_length:, :, :]
                 cos_sin_cache = torch.cat(
                     [
                         cos.to(dtype=torch.float32).contiguous(),
@@ -405,8 +405,12 @@ class GlmImageAttention(torch.nn.Module):
                     q_img, k_img, cos_sin_cache, is_neox=True
                 )
             else:
-                q_img.copy_(_apply_rotary_emb(q_img, cos, sin, is_neox_style=True))
-                k_img.copy_(_apply_rotary_emb(k_img, cos, sin, is_neox_style=True))
+                query[:, text_seq_length:, :, :] = _apply_rotary_emb(
+                    query[:, text_seq_length:, :, :], cos, sin, is_neox_style=True
+                )
+                key[:, text_seq_length:, :, :] = _apply_rotary_emb(
+                    key[:, text_seq_length:, :, :], cos, sin, is_neox_style=True
+                )
 
         if kv_cache is not None:
             if kv_cache.mode == "write":

--- a/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
@@ -401,6 +401,7 @@ class GlmImageAttention(torch.nn.Module):
                     ],
                     dim=-1,
                 )
+                # apply_flashinfer_rope_qk_inplace is inplace kernel and q_img/k_img are views of query/key, so we need not copy back
                 q_out, k_out = apply_flashinfer_rope_qk_inplace(
                     q_img, k_img, cos_sin_cache, is_neox=True
                 )

--- a/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
@@ -401,15 +401,12 @@ class GlmImageAttention(torch.nn.Module):
                     ],
                     dim=-1,
                 )
-                q_img, k_img = apply_flashinfer_rope_qk_inplace(
+                q_out, k_out = apply_flashinfer_rope_qk_inplace(
                     q_img, k_img, cos_sin_cache, is_neox=True
                 )
             else:
-                q_img = _apply_rotary_emb(q_img, cos, sin, is_neox_style=True)
-                k_img = _apply_rotary_emb(k_img, cos, sin, is_neox_style=True)
-
-            query[:, text_seq_length:, :, :] = q_img
-            key[:, text_seq_length:, :, :] = k_img
+                q_img.copy_(_apply_rotary_emb(q_img, cos, sin, is_neox_style=True))
+                k_img.copy_(_apply_rotary_emb(k_img, cos, sin, is_neox_style=True))
 
         if kv_cache is not None:
             if kv_cache.mode == "write":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

### 1xH100

```shell
sglang generate --model-path zai-org/GLM-Image  --prompt "a beautiful girl with glasses." --height 1152 --width 768
sglang generate --model-path=zai-org/GLM-Image \
    --prompt="Convert 2D style to 3D style" --image-path="https://github.com/lm-sys/lm-sys.github.io/releases/download/test/TI2I_Qwen_Image_Edit_Input.jpg" \
    --width=1536 --height=1024 --save-output --warmup
```

main:

```shell
[01-25 01:54:25] [GlmImageBeforeDenoisingStage] started...
[01-25 01:54:57] generate_prior_tokens time: 31.8470778465271
[01-25 01:54:57] [GlmImageBeforeDenoisingStage] finished in 32.4767 seconds
[01-25 01:54:57] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:14<00:00,  2.14it/s]
[01-25 01:55:11] [DenoisingStage] average time per step: 0.4681 seconds
[01-25 01:55:11] [DenoisingStage] finished in 14.0451 seconds
[01-25 01:55:11] [DecodingStage] started...
[01-25 01:55:12] [DecodingStage] finished in 0.1076 seconds
[01-25 01:55:12] Peak GPU memory: 40.53 GB, Remaining GPU memory at peak: 39.12 GB. Components that can stay resident: ['text_encoder', 'transformer']
[01-25 01:55:13] Output saved to outputs/Convert_2D_style_to_3D_style_20260125-015350_cbbb980c.png
```

<img width="936" height="586" alt="图片" src="https://github.com/user-attachments/assets/e2cc73f7-d73d-48e8-a5c0-1f25a9eb0c8d" />


pr:

```shell
[01-25 02:26:07] Running pipeline stages: ['GlmImageBeforeDenoisingStage', 'denoising_stage', 'decoding_stage']
[01-25 02:26:07] [GlmImageBeforeDenoisingStage] started...
[01-25 02:26:40] generate_prior_tokens time: 32.39721345901489
[01-25 02:26:40] [GlmImageBeforeDenoisingStage] finished in 32.9774 seconds
[01-25 02:26:40] [DenoisingStage] started...
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:12<00:00,  2.47it/s]
[01-25 02:26:52] [DenoisingStage] average time per step: 0.4055 seconds
[01-25 02:26:52] [DenoisingStage] finished in 12.1684 seconds
[01-25 02:26:52] [DecodingStage] started...
[01-25 02:26:53] [DecodingStage] finished in 0.1388 seconds
[01-25 02:26:53] Peak GPU memory: 40.53 GB, Remaining GPU memory at peak: 39.12 GB. Components that can stay resident: ['text_encoder', 'transformer']
[01-25 02:26:53] Output saved to outputs/Convert_2D_style_to_3D_style_20260125-022532_b6698b47.png
```

<img width="1182" height="788" alt="图片" src="https://github.com/user-attachments/assets/97905c89-8bcc-48b6-ad16-9fa9a7d9f2d6" />

### benchmark result

- end2end  15.4% improve  : 14.04s->12.16s
- per step 15.4% improve : 2.14it/s->2.47it/s


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
