### PR TITLE
[diffusion] feat: add an arg for controlling the number of prefetched layers in Layerwise-offload

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -742,7 +742,10 @@ class DenoisingStage(PipelineStage):
         # reset offload managers with prefetching first layer for next forward
         for dit in filter(None, [self.transformer, self.transformer_2]):
             if isinstance(dit, OffloadableDiTMixin):
-                dit.prepare_for_next_denoise()
+                for manager in dit.layerwise_offload_managers:
+                    manager.release_all()
+                # dit.configure_layerwise_offload()
+                # dit.prepare_for_next_req()
 
     def _preprocess_sp_latents(self, batch: Req, server_args: ServerArgs):
         """Shard latents for Sequence Parallelism if applicable."""

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -742,10 +742,10 @@ class DenoisingStage(PipelineStage):
         # reset offload managers with prefetching first layer for next forward
         for dit in filter(None, [self.transformer, self.transformer_2]):
             if isinstance(dit, OffloadableDiTMixin):
+                # release all weights to avoid peak VRAM usage, while increasing the latency for next req
+                # TODO: should be make this an option?
                 for manager in dit.layerwise_offload_managers:
                     manager.release_all()
-                # dit.configure_layerwise_offload()
-                # dit.prepare_for_next_req()
 
     def _preprocess_sp_latents(self, batch: Req, server_args: ServerArgs):
         """Shard latents for Sequence Parallelism if applicable."""

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -742,7 +742,7 @@ class DenoisingStage(PipelineStage):
         # reset offload managers with prefetching first layer for next forward
         for dit in filter(None, [self.transformer, self.transformer_2]):
             if isinstance(dit, OffloadableDiTMixin):
-                # release all weights to avoid peak VRAM usage, while increasing the latency for next req
+                # release all DiT weights to avoid peak VRAM usage, which may increasing the latency for next req
                 # TODO: should be make this an option?
                 for manager in dit.layerwise_offload_managers:
                     manager.release_all()

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -8,6 +8,7 @@ import argparse
 import dataclasses
 import inspect
 import json
+import math
 import os
 import random
 import sys
@@ -623,7 +624,7 @@ class ServerArgs:
             "--dit-offload-prefetch-size",
             type=float,
             default=ServerArgs.dit_offload_prefetch_size,
-            help="The size of prefetch for dit-layerwise-offload. If the value is between 0.0 and 1.0, it is treated as a ratio of the total number of layers. If the value is >= 1, it is treated as the absolute number of layers. 0.0 means prefetch 1 layer (lowest memory); 1.0 means prefetch all layers (highest memory). Values above 0.5 might have peak memory close to no offload but worse performance.",
+            help="The size of prefetch for dit-layerwise-offload. If the value is between 0.0 and 1.0, it is treated as a ratio of the total number of layers. If the value is >= 1, it is treated as the absolute number of layers. 0.0 means prefetch 1 layer (lowest memory). Values above 0.5 might have peak memory close to no offload but worse performance.",
         )
         parser.add_argument(
             "--use-fsdp-inference",
@@ -956,6 +957,21 @@ class ServerArgs:
         if current_platform.is_mps():
             self.use_fsdp_inference = False
             self.dit_layerwise_offload = False
+
+        if self.dit_offload_prefetch_size > 1 and (
+            isinstance(self.dit_offload_prefetch_size, float)
+            and not self.dit_offload_prefetch_size.is_integer()
+        ):
+            self.dit_offload_prefetch_size = int(
+                math.floor(self.dit_offload_prefetch_size)
+            )
+            logger.info(
+                f"Invalid --dit-offload-prefetch-size value passed, truncated to: {self.dit_offload_prefetch_size}"
+            )
+        if 0.5 <= self.dit_offload_prefetch_size < 1.0:
+            logger.info(
+                f"We do not recommend --dit-offload-prefetch-size to be between 0.5 and 1.0"
+            )
 
         if not envs.SGLANG_CACHE_DIT_ENABLED:
             # TODO: need a better way to tell this

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -286,6 +286,7 @@ class ServerArgs:
     # CPU offload parameters
     dit_cpu_offload: bool | None = None
     dit_layerwise_offload: bool | None = None
+    dit_offload_prefetch_size: int = 1
     text_encoder_cpu_offload: bool | None = None
     image_encoder_cpu_offload: bool | None = None
     vae_cpu_offload: bool | None = None
@@ -617,6 +618,12 @@ class ServerArgs:
             default=ServerArgs.dit_layerwise_offload,
             help="Enable layerwise CPU offload with async H2D prefetch overlap for supported DiT models (e.g., Wan). "
             "Cannot be used together with cache-dit (SGLANG_CACHE_DIT_ENABLED), dit_cpu_offload, or use_fsdp_inference.",
+        )
+        parser.add_argument(
+            "--dit-offload-prefetch-size",
+            type=int,
+            default=ServerArgs.dit_offload_prefetch_size,
+            help="Number of layers to prefetch at once when dit-layerwise-offload is enabled.",
         )
         parser.add_argument(
             "--use-fsdp-inference",

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -623,7 +623,7 @@ class ServerArgs:
             "--dit-offload-prefetch-size",
             type=float,
             default=ServerArgs.dit_offload_prefetch_size,
-            help="The size of prefetch for dit-layerwise-offload. If the value is between 0.0 and 1.0, it is treated as a ratio of the total number of layers. If the value is greater than 1.0, it is treated as the absolute number of layers. 0.0 means prefetch 1 layer (lowest memory); 1.0 means prefetch all layers (highest memory). Values above 0.5 might have peak memory close to no offload but worse performance.",
+            help="The size of prefetch for dit-layerwise-offload. If the value is between 0.0 and 1.0, it is treated as a ratio of the total number of layers. If the value is >= 1, it is treated as the absolute number of layers. 0.0 means prefetch 1 layer (lowest memory); 1.0 means prefetch all layers (highest memory). Values above 0.5 might have peak memory close to no offload but worse performance.",
         )
         parser.add_argument(
             "--use-fsdp-inference",

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -286,7 +286,7 @@ class ServerArgs:
     # CPU offload parameters
     dit_cpu_offload: bool | None = None
     dit_layerwise_offload: bool | None = None
-    dit_offload_prefetch_size: int = 1
+    dit_offload_conservativeness: float = 0.0
     text_encoder_cpu_offload: bool | None = None
     image_encoder_cpu_offload: bool | None = None
     vae_cpu_offload: bool | None = None
@@ -620,10 +620,10 @@ class ServerArgs:
             "Cannot be used together with cache-dit (SGLANG_CACHE_DIT_ENABLED), dit_cpu_offload, or use_fsdp_inference.",
         )
         parser.add_argument(
-            "--dit-offload-prefetch-size",
-            type=int,
-            default=ServerArgs.dit_offload_prefetch_size,
-            help="Number of layers to prefetch at once when dit-layerwise-offload is enabled.",
+            "--dit-offload-conservativeness",
+            type=float,
+            default=ServerArgs.dit_offload_conservativeness,
+            help="Conservativeness of dit-layerwise-offload. 0.0 means prefetch 1 layer (lowest memory, potentially slower); 1.0 means prefetch all layers (highest memory, same as no offload). 0.5 or above might have peak memory close to no offload but worse performance. If you want better performance, consider disabling offload entirely.",
         )
         parser.add_argument(
             "--use-fsdp-inference",
@@ -970,6 +970,9 @@ class ServerArgs:
                 self.dit_layerwise_offload = True
 
         if self.dit_layerwise_offload:
+            assert (
+                0.0 <= self.dit_offload_conservativeness <= 1.0
+            ), "dit_offload_conservativeness must be between 0.0 and 1.0"
             if self.use_fsdp_inference:
                 logger.warning(
                     "dit_layerwise_offload is enabled, automatically disabling use_fsdp_inference."

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -335,7 +335,7 @@ class OffloadableDiTMixin:
                 continue
 
             num_layers = len(module_list)
-            if server_args.dit_offload_prefetch_size <= 1.0:
+            if server_args.dit_offload_prefetch_size < 1.0:
                 prefetch_size = 1 + int(
                     round(server_args.dit_offload_prefetch_size * (num_layers - 1))
                 )

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -113,7 +113,7 @@ class LayerwiseOffloadManager:
                 current_offset = 0
                 for name, weight in weights:
                     numel = weight.numel()
-                    cpu_buffer[current_offset: current_offset + numel].copy_(
+                    cpu_buffer[current_offset : current_offset + numel].copy_(
                         weight.flatten()
                     )
                     self._weight_metadata[layer_idx][name] = {
@@ -189,7 +189,7 @@ class LayerwiseOffloadManager:
             # map the parameter's data to the correct slice of the GPU buffer
             target = self.get_target_with_name(name)
             target.data = gpu_buffer[
-                meta["offset"]: meta["offset"] + meta["numel"]
+                meta["offset"] : meta["offset"] + meta["numel"]
             ].view(meta["shape"])
 
         self._gpu_layers.add(layer_idx)
@@ -260,7 +260,7 @@ class LayerwiseOffloadManager:
             cpu_buffer = self._consolidated_cpu_weights[layer_idx][dtype]
             offset = meta["offset"]
             numel = meta["numel"]
-            cpu_buffer[offset: offset + numel].copy_(gpu_weight)
+            cpu_buffer[offset : offset + numel].copy_(gpu_weight)
 
     @torch.compiler.disable
     def sync_all_layers_to_cpu(self) -> None:

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -138,6 +138,9 @@ class LayerwiseOffloadManager:
         )
 
     def prepare_for_next_req(self, non_blocking=True):
+        """
+        Prepare for the next round of denoising loop with prefetching the necessary layers
+        """
         for i in range(self.prefetch_size):
             self.prefetch_layer(i, non_blocking=non_blocking)
         if not non_blocking and self.copy_stream is not None:

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -40,7 +40,6 @@ class LayerwiseOffloadManager:
         self.num_layers = num_layers
         self.pin_cpu_memory = pin_cpu_memory
         self.prefetch_size = min(max(1, prefetch_size), self.num_layers)
-        print(f"{self.prefetch_size=}")
         self.enabled = bool(enabled and torch.cuda.is_available())
         if not self.enabled:
             return

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -345,9 +345,13 @@ class OffloadableDiTMixin:
                 continue
 
             num_layers = len(module_list)
-            prefetch_size = 1 + int(
-                round(server_args.dit_offload_conservativeness * (num_layers - 1))
-            )
+            if server_args.dit_offload_prefetch_size <= 1.0:
+                prefetch_size = 1 + int(
+                    round(server_args.dit_offload_prefetch_size * (num_layers - 1))
+                )
+            else:
+                prefetch_size = int(server_args.dit_offload_prefetch_size)
+
             manager = LayerwiseOffloadManager(
                 model=self,
                 layers_attr_str=layer_name,

--- a/python/sglang/multimodal_gen/test/scripts/gen_perf_baselines.py
+++ b/python/sglang/multimodal_gen/test/scripts/gen_perf_baselines.py
@@ -53,19 +53,22 @@ def _openai_client(port: int) -> OpenAI:
 
 
 def _build_server_extra_args(case: DiffusionTestCase) -> str:
+    server_args = case.server_args
     a = os.environ.get("SGLANG_TEST_SERVE_ARGS", "")
-    a += f" --num-gpus {case.server_args.num_gpus}"
-    if case.server_args.tp_size is not None:
-        a += f" --tp-size {case.server_args.tp_size}"
-    if case.server_args.ulysses_degree is not None:
-        a += f" --ulysses-degree {case.server_args.ulysses_degree}"
-    if case.server_args.dit_layerwise_offload:
+    a += f" --num-gpus {server_args.num_gpus}"
+    if server_args.tp_size is not None:
+        a += f" --tp-size {server_args.tp_size}"
+    if server_args.ulysses_degree is not None:
+        a += f" --ulysses-degree {server_args.ulysses_degree}"
+    if server_args.dit_layerwise_offload:
         a += " --dit-layerwise-offload true"
-    if case.server_args.ring_degree is not None:
-        a += f" --ring-degree {case.server_args.ring_degree}"
-    if case.server_args.lora_path:
-        a += f" --lora-path {case.server_args.lora_path}"
-    if case.server_args.enable_warmup:
+    if server_args.dit_offload_prefetch_size:
+        a += f" --dit-offload-prefetch-size {server_args.dit_offload_prefetch_size}"
+    if server_args.ring_degree is not None:
+        a += f" --ring-degree {server_args.ring_degree}"
+    if server_args.lora_path:
+        a += f" --lora-path {server_args.lora_path}"
+    if server_args.enable_warmup:
         a += " --enable-warmup"
     return a
 

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -76,6 +76,11 @@ def diffusion_server(case: DiffusionTestCase) -> ServerContext:
     if server_args.dit_layerwise_offload:
         extra_args += f" --dit-layerwise-offload true"
 
+    if server_args.dit_offload_prefetch_size:
+        extra_args += (
+            f" --dit-offload-prefetch-size {server_args.dit_offload_prefetch_size}"
+        )
+
     if server_args.text_encoder_cpu_offload:
         extra_args += f" --text-encoder-cpu-offload"
 

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -164,6 +164,7 @@ class DiffusionServerArgs:
     enable_warmup: bool = False
 
     dit_layerwise_offload: bool = False
+    dit_offload_prefetch_size: int | float | None = None
     enable_cache_dit: bool = False
     text_encoder_cpu_offload: bool = False
 
@@ -369,6 +370,7 @@ ONE_GPU_CASES_A: list[DiffusionTestCase] = [
             model_path="black-forest-labs/FLUX.2-dev",
             modality="image",
             dit_layerwise_offload=True,
+            dit_offload_prefetch_size=2,
         ),
         T2I_sampling_params,
     ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
This PR provides the user with a new argument, for fine-grained controlling how many layers are resident, and in this way controlling the overall speed.

## Motivation

Previously, `--dit-layerwise-offload` is enabled for video models by default. While it allows us to generate high-resolution content with minimum VRAM and delivers decent speedup, for some special video models, turning off this switch could achieve better performance (possibly due to the slower compute stream due to copy stream).

To alleviate the negative effect of copy stream on compute stream, we could reinterpret **Layerwise Offload** and **Vanilla Offload** in a more unified view:
- for Layerwise Offload: 2 layers resident at most. Per layer forward: Prefetch 1 layer , release 1 layer.
- for Vanilla Offload: All layers resident.  Per layer forward:: Prefetch all layers, release 0 layer.

For cases where we have sufficient VRAM for 2 layers ~ all layers, we could batch the prefetch (copy) operations to achieve higher speed.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- arg `--dit-offload-conservativeness`: Conservativeness of dit-layerwise-offload. 0.0 means prefetch 1 layer (lowest memory, potentially slower); 1.0 means prefetch all layers (highest memory, same as no offload). 0.5 or above might have peak memory close to no offload but worse performance. If you want better performance, consider disabling offload entirely
- modify `LayerwiseOffloadManager` to abstract and generalize the concept: prefetch_size 

<!-- Detail the changes made in this pull request. -->

## Benchmarks

```bash
$ sglang generate --model-path=Wan-AI/Wan2.2-T2V-A14B-Diffusers --log-level=info --prompt="A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window." --negative-prompt=" " --720p --num-inference-steps=40 --num-frames=81 --guidance-scale=5.0 --seed=42 --save-output  --num-gpus=8 --enable-cfg-parallel --ulysses-degree=4 --vae-cpu-offload false --text-encoder-cpu-offload true --enable-torch-compile --warmup
```


| Setting                               | Avg time of denoising step (s) | Time of denoising (s) | Peak VRAM (GB) |
|:--------------------------------------|:-------------------------------|-----------------------|----------------|
| main  (--dit-layerwise-offload)       | 1.7765                         | 88.7857               | 10.81          | 
| PR (--dit-offload-prefetch-size=0)    | 1.6496                         | 82.4823               | 10.81          | 
| PR (--dit-offload-prefetch-size=0.05) | 1.4025                         | 70.1278               | 10.81          | 
| PR (--dit-offload-prefetch-size=0.1)  | 1.3419                         | 67.0983               | 10.81          |
| PR (--dit-offload-prefetch-size=0.15) | 1.3482                         | 67.4133               | 12.93          |
| PR (--dit-offload-prefetch-size=0.2)  | 1.3667                         | 68.3390               | 15.94          |
| PR (--dit-offload-prefetch-size=0.3)  | 1.3821                         | 69.1094               | 21.96          |
| PR (--dit-offload-prefetch-size=0.5)  | OOM                            | OOM                   | OOM            |
| PR (--dit-layerwise-offload false)    | 1.3264                         | 66.3258               | 40.22          |



## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
