### PR TITLE
Support regional compile

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -675,28 +675,6 @@ class WanTransformerBlock_VSA(nn.Module):
         return hidden_states
 
 
-class WanPreTransformerLayers(nn.Module):
-    def __init__(self, config: WanVideoConfig, hf_config: dict[str, Any]) -> None:
-        super().__init__(config=config, hf_config=hf_config)
-        inner_dim = config.num_attention_heads * config.attention_head_dim
-
-        # 1. Patch & position embedding
-        self.patch_embedding = PatchEmbed(
-            in_chans=config.in_channels,
-            embed_dim=inner_dim,
-            patch_size=config.patch_size,
-            flatten=False,
-        )
-
-        # 2. Condition embeddings
-        self.condition_embedder = WanTimeTextImageEmbedding(
-            dim=inner_dim,
-            time_freq_dim=config.freq_dim,
-            text_embed_dim=config.text_dim,
-            image_embed_dim=config.image_dim,
-        )
-
-
 class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
     _fsdp_shard_conditions = WanVideoConfig()._fsdp_shard_conditions
     _compile_conditions = WanVideoConfig()._compile_conditions

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -683,7 +683,6 @@ class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
     reverse_param_names_mapping = WanVideoConfig().reverse_param_names_mapping
     lora_param_names_mapping = WanVideoConfig().lora_param_names_mapping
 
-
     def __init__(self, config: WanVideoConfig, hf_config: dict[str, Any]) -> None:
         super().__init__(config=config, hf_config=hf_config)
 
@@ -697,7 +696,7 @@ class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
         self.text_len = config.text_len
 
         # Could have been class attribute, but the type of block is decide based on
-        # attn_backend, therfore we put it here.
+        # attn_backend, therefore we put it here.
         self._repeated_blocks = []
 
         # 1. Patch & position embedding

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -116,7 +116,7 @@ class DenoisingStage(PipelineStage):
         self._cached_num_steps = None
         self._is_warmed_up = False
 
-    def _maybe_enable_torch_compile(self, module: object, regional: bool = False) -> None:
+    def _maybe_enable_torch_compile(self, module: object) -> None:
         """
         Compile a module with torch.compile, and enable inductor overlap tweak if available.
         No-op if torch compile is disabled or the object is not a nn.Module.
@@ -135,6 +135,7 @@ class DenoisingStage(PipelineStage):
         logger.info(f"Compiling transformer with mode: {mode}, regional: {regional}")
         fullgraph = False
         dynamic = None
+        regional = self.server_args.regional_compile
         if regional:
             self.regionally_compile(module, mode=mode, fullgraph=fullgraph, dynamic=dynamic)
         else:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -135,9 +135,13 @@ class DenoisingStage(PipelineStage):
         fullgraph = False
         dynamic = None
         regional = self.server_args.regional_compile
-        logger.info(f"Compiling transformer with mode: {mode}, fullgraph: {fullgraph}, dynamic: {dynamic}, regional: {regional}")
+        logger.info(
+            f"Compiling transformer with mode: {mode}, fullgraph: {fullgraph}, dynamic: {dynamic}, regional: {regional}"
+        )
         if regional:
-            self.regionally_compile(module, mode=mode, fullgraph=fullgraph, dynamic=dynamic)
+            self.regionally_compile(
+                module, mode=mode, fullgraph=fullgraph, dynamic=dynamic
+            )
         else:
             # TODO(triple-mu): support customized fullgraph and dynamic in the future
             module.compile(mode=mode, fullgraph=fullgraph, dynamic=dynamic)
@@ -159,7 +163,9 @@ class DenoisingStage(PipelineStage):
                 has_compiled_region = True
 
         if not has_compiled_region:
-            logger.warning(f"Regional compilation failed because {repeated_blocks} classes are not found in the model.")
+            logger.warning(
+                f"Regional compilation failed because {repeated_blocks} classes are not found in the model."
+            )
 
     def _maybe_enable_cache_dit(self, num_inference_steps: int, batch: Req) -> None:
         """Enable cache-dit on the transformers if configured (idempotent).

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -132,10 +132,10 @@ class DenoisingStage(PipelineStage):
         except ImportError:
             pass
         mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs")
-        logger.info(f"Compiling transformer with mode: {mode}, regional: {regional}")
         fullgraph = False
         dynamic = None
         regional = self.server_args.regional_compile
+        logger.info(f"Compiling transformer with mode: {mode}, fullgraph: {fullgraph}, dynamic: {dynamic}, regional: {regional}")
         if regional:
             self.regionally_compile(module, mode=mode, fullgraph=fullgraph, dynamic=dynamic)
         else:

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -302,6 +302,7 @@ class ServerArgs:
 
     # Compilation
     enable_torch_compile: bool = False
+    regional_compile: bool = False
 
     # warmup
     warmup: bool = False
@@ -587,6 +588,12 @@ class ServerArgs:
             default=ServerArgs.enable_torch_compile,
             help="Use torch.compile to speed up DiT inference."
             + "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
+        )
+        parser.add_argument(
+            "--regional-compile",
+            action=StoreBoolean,
+            default=ServerArgs.regional_compile,
+            help="Apply regional compile on repeated blocks to reduce compile time."
         )
 
         # warmup

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -593,7 +593,7 @@ class ServerArgs:
             "--regional-compile",
             action=StoreBoolean,
             default=ServerArgs.regional_compile,
-            help="Apply regional compile on repeated blocks to reduce compile time."
+            help="Apply regional compile on repeated blocks to reduce compile time.",
         )
 
         # warmup


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Currently the compile integration in diffusions only support compiling the whole model. The graph trace will include all repeated layers like transformer block, which leads to potential long compile time.

To address the issue, other frameworks like vllm/transformers leverages [regional compile](https://docs.pytorch.org/tutorials/recipes/regional_compilation.html) to only compile the repeated blocks(you can of course manually add other non-repeated blocks as well), so that you need to only compile once and reuse the code cache for the same blocks.


## Modifications

A new server arg is added to control whether using regional compile.

## Accuracy Tests


## Benchmarking and Profiling

I only have A100 at hand, and I use a smaller model `Wan2.2-TI2V-5B-Diffusers` just to illustrate how it works.

```shell
SGLANG_DIFFUSION_ATTENTION_CONFIG=./mask_strategy_wan.json \
sglang generate   \
  --model-path Wan-AI/Wan2.2-TI2V-5B-Diffusers/   \
  --pin-cpu-memory   \
  --num-gpus 8   \
  --ulysses-degree 8 \
  --attention-backend sage_attn  \
  --enable-torch-compile \
  --regional-compile \
  --prompt "A cat walks on the grass, realistic" \
  --num-frames 81 \
  --height 480 \
  --width 832 \
  --num-inference-steps 27 \
  --guidance-scale 3.5 \
  --guidance-scale-2 4.0 \
  --perf-dump-path ./dump/wan_step_profile_cp8_main.json
```

| Option      | Stage | Time(s) | 
| ----------- | ----------- | ----------- |
| Full      | denoising       | 27.3190 |
| Full      | decoding       | 33.2832 |
| Full      |   TOTAL    | 68.32 |
| Regional   | denoising        | 43.6123 |
| Regional   | decoding        | 9.6507 |
| Regional   |  TOTAL      | 61.46 |

The denoising step-wise duration is
| Denoise Step | Full(ms) | Regional | 
| ----------- | ----------- | ----------- |
| 0       | 13365.79 | 4963.19 |
| 1       | 466.87 | 1488.04 |
| 2       | 1568.19 | 1474.05 |
| 3       | 1559.44 | 1472.11 |
| 4       | 384.02 | 1496.27 |
| ...       |  |  |
| 26       | 924.59 | 1472.33 |

### Observations
There are a few interesting observations from the statistics
1. The first-step compile time reduces about 8.41s (13.37s -> 4.96s)
2. The total end-to-end time decreases about 6.86s (68.32s -> 61.46s), which means region compile indeed introduces some kind of overhead for non-regional components, but I think the overhead also partially comes from the graph breaks, if we mitigate such breaks, the performance difference should be more minor, as per the [benchmark by diffusers](https://pytorch.org/blog/torch-compile-and-diffusers-a-hands-on-guide-to-peak-performance/)
3. The step-wise time has mismatch between full and regional, which could be due to synchronization in stage perf, e.g., non-regional part might contains some unnecessary sync operations, or there might be some bugs in stage perf, but I don't time to dived deep into the perf part yet.

For now I only add transformer blocks into repeated blocks, and have not tested adding other non-repeated layers, which should help improve performance as well.

Also, there are many graph breaks inside the model right now, which could lead to unexpected time change too.

###  Plan for mitigating graph breaks and a more general compilation mechanism
From the dynamo logs, there are many graph breaks in the compile procedure. Due to the massive graph breaks, the performance has definitely not reached the peak of compiled artifacts, regardless of full or regional compile.

I have already figured out a few graph break points from the dynamo logs, and plan to mitigate such breaks in future PRs.

Also, I think the diffusion model layers are not quite compile-friendly at the moment, and it would be great to have a more structured and flexible compilation mechanism, which could introduces more optimization opportunities.

There is already an on-going work #11830 trying to integrate the compilation mechanism, which would be really helpful to fully utilize the torch.compile benefits. Is there any plan to proceed the work?

I am glad to help and contribute to the compile mechanism if possible.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
