### PR TITLE
Fix /tag-and-rerun-ci to do full rerun when PR has sgl-kernel changes

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -124,6 +124,24 @@ def load_permissions(user_login):
         sys.exit(1)
 
 
+def has_sgl_kernel_changes(pr):
+    """
+    Check if the PR has changes to the sgl-kernel directory.
+    This is used to determine if we need a full workflow rerun
+    (to rebuild the kernel) vs just rerunning failed jobs.
+    """
+    try:
+        files = pr.get_files()
+        for f in files:
+            if f.filename.startswith("sgl-kernel/"):
+                return True
+        return False
+    except Exception as e:
+        print(f"Warning: Could not check PR files for sgl-kernel changes: {e}")
+        # Default to False to avoid unnecessary full reruns
+        return False
+
+
 def handle_tag_run_ci(gh_repo, pr, comment, user_perms, react_on_success=True):
     """
     Handles the /tag-run-ci-label command.
@@ -157,6 +175,12 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
 
     print("Permission granted. Triggering rerun of failed or skipped workflows.")
 
+    # Check if PR has sgl-kernel changes - if so, we need full reruns
+    # to ensure sgl-kernel-build-wheels runs and produces fresh artifacts
+    sgl_kernel_changes = has_sgl_kernel_changes(pr)
+    if sgl_kernel_changes:
+        print("PR has sgl-kernel changes - will use full rerun to rebuild kernel")
+
     # Get the SHA of the latest commit in the PR
     head_sha = pr.head.sha
     print(f"Checking workflows for commit: {head_sha}")
@@ -170,11 +194,15 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
             continue
 
         if run.conclusion == "failure":
-            # DEBUG
             print(f"Rerunning failed workflow: {run.name} (ID: {run.id})")
             try:
-                # Use rerun_failed_jobs for efficiency on failures
-                run.rerun_failed_jobs()
+                if sgl_kernel_changes:
+                    # Full rerun to ensure sgl-kernel-build-wheels runs
+                    # and produces fresh artifacts for dependent jobs
+                    run.rerun()
+                else:
+                    # Use rerun_failed_jobs for efficiency on failures
+                    run.rerun_failed_jobs()
                 rerun_count += 1
             except Exception as e:
                 print(f"Failed to rerun workflow {run.id}: {e}")


### PR DESCRIPTION
## Summary
- Fix `/tag-and-rerun-ci` and `/rerun-failed-ci` to use full workflow rerun when PR has sgl-kernel changes
- This ensures `sgl-kernel-build-wheels` runs again and produces fresh artifacts

## Problem
When a PR modifies sgl-kernel and tests fail:
1. User runs `/tag-and-rerun-ci`
2. `rerun_failed_jobs()` only reruns the failed test jobs, NOT the `sgl-kernel-build-wheels` job
3. Test jobs try to download artifacts, but artifacts are scoped to the original workflow run
4. Test jobs fail with "Found 0 artifact(s)"

Example failure: https://github.com/sgl-project/sglang/actions/runs/21241650161

## Solution
Detect if the PR has sgl-kernel changes (`sgl-kernel/` directory), and if so, use `run.rerun()` instead of `run.rerun_failed_jobs()` to ensure the kernel build job runs again.

## Test plan
- [ ] Verify rerun works correctly for PRs without sgl-kernel changes (should use efficient `rerun_failed_jobs`)
- [ ] Verify rerun works correctly for PRs with sgl-kernel changes (should use full `rerun`)