### PR TITLE
Fix streaming logprobs returning empty tokens mid-stream

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -634,11 +634,12 @@ class OpenAIServingChat(OpenAIServingBase):
                     total_output_logprobs = len(
                         content["meta_info"]["output_token_logprobs"]
                     )
-                    # When finish_reason is set and all logprobs have been sent,
-                    # any remaining text is just buffered text being flushed by the
-                    # detokenizer (it holds back text at word boundaries). Return None
-                    # for logprobs since no new tokens were generated for this text.
-                    if n_prev_token < total_output_logprobs or finish_reason is None:
+                    # When all logprobs have been sent, any remaining text is just
+                    # buffered text being flushed by the detokenizer (it holds back
+                    # text at word boundaries). Return None for logprobs since no new
+                    # tokens were generated for this text. This can happen both
+                    # mid-stream and on the final chunk when finish_reason is set.
+                    if n_prev_token < total_output_logprobs:
                         choice_logprobs = self._process_streaming_logprobs(
                             content, n_prev_token
                         )

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -251,33 +251,12 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     output_top_logprobs_slice = content["meta_info"].get(
                         "output_top_logprobs", []
                     )[n_prev_token:]
-                    finish_reason_for_logprobs = content["meta_info"]["finish_reason"]
-
-                    # Debug logging for flaky streaming logprobs test
-                    # See: https://github.com/sgl-project/sglang/pull/17687
-                    delta_text = text[len(stream_buffer) :]
-                    if len(output_logprobs_slice) == 0 and delta_text:
-                        logger.warning(
-                            f"[DEBUG LOGPROBS STREAM] Empty output_logprobs_slice but have delta_text. "
-                            f"index={index}, n_prev_token={n_prev_token}, "
-                            f"total_output_logprobs={total_output_logprobs}, "
-                            f"delta_text={repr(delta_text)}, "
-                            f"finish_reason={finish_reason_for_logprobs}, "
-                            f"stream_buffer_len={len(stream_buffer)}, "
-                            f"text_len={len(text)}, "
-                            f"input_token_logprobs is None={input_token_logprobs is None}, "
-                            f"echo={request.echo}"
-                        )
-
-                    # When finish_reason is set and all logprobs have been sent,
-                    # any remaining text is just buffered text being flushed by the
+                    # When output_logprobs_slice is empty and there are no input logprobs,
+                    # this chunk only contains buffered text being flushed by the
                     # detokenizer (it holds back text at word boundaries). Return None
                     # for logprobs since no new tokens were generated for this text.
-                    if (
-                        len(output_logprobs_slice) == 0
-                        and finish_reason_for_logprobs is not None
-                        and input_token_logprobs is None
-                    ):
+                    # This can happen both mid-stream and on the final chunk.
+                    if len(output_logprobs_slice) == 0 and input_token_logprobs is None:
                         logprobs = None
                     else:
                         logprobs = to_openai_style_logprobs(
@@ -285,14 +264,6 @@ class OpenAIServingCompletion(OpenAIServingBase):
                             input_top_logprobs=input_top_logprobs,
                             output_token_logprobs=output_logprobs_slice,
                             output_top_logprobs=output_top_logprobs_slice,
-                        )
-
-                    # Debug: log when we're about to return logprobs with empty tokens
-                    if logprobs and len(logprobs.tokens) == 0:
-                        logger.warning(
-                            f"[DEBUG LOGPROBS STREAM] Returning logprobs with empty tokens list. "
-                            f"index={index}, delta_text={repr(delta_text)}, "
-                            f"finish_reason={finish_reason_for_logprobs}"
                         )
 
                     n_prev_tokens[index] = total_output_logprobs

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -44,17 +44,6 @@ def to_openai_style_logprobs(
     if output_top_logprobs is not None:
         append_top_logprobs(output_top_logprobs)
 
-    # Debug logging for flaky streaming logprobs test
-    # See: https://github.com/sgl-project/sglang/pull/17687
-    if len(ret_logprobs.tokens) == 0:
-        logger.warning(
-            f"[DEBUG LOGPROBS] to_openai_style_logprobs returning empty tokens list. "
-            f"input_token_logprobs={input_token_logprobs}, "
-            f"output_token_logprobs={output_token_logprobs}, "
-            f"input_top_logprobs is None={input_top_logprobs is None}, "
-            f"output_top_logprobs is None={output_top_logprobs is None}"
-        )
-
     return ret_logprobs
 
 

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -44,6 +44,17 @@ def to_openai_style_logprobs(
     if output_top_logprobs is not None:
         append_top_logprobs(output_top_logprobs)
 
+    # Debug logging for flaky streaming logprobs test
+    # See: https://github.com/sgl-project/sglang/pull/17687
+    if len(ret_logprobs.tokens) == 0:
+        logger.warning(
+            f"[DEBUG LOGPROBS] to_openai_style_logprobs returning empty tokens list. "
+            f"input_token_logprobs={input_token_logprobs}, "
+            f"output_token_logprobs={output_token_logprobs}, "
+            f"input_top_logprobs is None={input_top_logprobs is None}, "
+            f"output_top_logprobs is None={output_top_logprobs is None}"
+        )
+
     return ret_logprobs
 
 

--- a/test/registered/openai_server/basic/test_openai_server.py
+++ b/test/registered/openai_server/basic/test_openai_server.py
@@ -160,9 +160,24 @@ class TestOpenAIServer(CustomTestCase):
                 # only contains buffered text being flushed (no new tokens generated).
                 # The detokenizer holds back text at word boundaries during streaming.
                 if response.choices[0].logprobs is not None:
+                    # Debug logging for flaky streaming logprobs test
+                    # See: https://github.com/sgl-project/sglang/pull/17687
+                    choice_logprobs = response.choices[0].logprobs
+                    if len(choice_logprobs.tokens) == 0:
+                        print(
+                            f"[DEBUG TEST] Empty tokens list in logprobs! "
+                            f"response.id={response.id}, "
+                            f"choice.index={response.choices[0].index}, "
+                            f"choice.text={repr(response.choices[0].text)}, "
+                            f"choice.finish_reason={response.choices[0].finish_reason}, "
+                            f"logprobs.tokens={choice_logprobs.tokens}, "
+                            f"logprobs.token_logprobs={choice_logprobs.token_logprobs}, "
+                            f"logprobs.top_logprobs={choice_logprobs.top_logprobs}, "
+                            f"echo={echo}, is_first={is_first}"
+                        )
                     assert isinstance(
                         response.choices[0].logprobs.tokens[0], str
-                    ), f"{response.choices[0].logprobs.tokens[0]} is not a string"
+                    ), f"{response.choices[0].logprobs.tokens[0]} is not a string, logprobs={response.choices[0].logprobs}, text={repr(response.choices[0].text)}, finish_reason={response.choices[0].finish_reason}"
                     if not (is_first and echo):
                         assert isinstance(
                             response.choices[0].logprobs.top_logprobs[0], dict


### PR DESCRIPTION
## Summary

Fixes the remaining flaky `test_completion_stream` test that PR #17687 didn't fully address.

**Root cause**: PR #17687 fixed the case where empty logprobs were returned on the final chunk (when `finish_reason` was set). However, the detokenizer can also flush buffered text **mid-stream** when `finish_reason` is still `None`, causing the same `IndexError: list index out of range` when the test tries to access `tokens[0]` on an empty list.

**Fix**: Return `logprobs=None` whenever there are no new logprobs to report, regardless of whether `finish_reason` is set.

## Changes

- `serving_completions.py`: Remove the `finish_reason is not None` requirement - return `logprobs=None` when `output_logprobs_slice` is empty
- `serving_chat.py`: Remove the `or finish_reason is None` condition that was causing empty logprobs to be processed mid-stream  
- `utils.py`: Remove debug logging added in previous commit
- `test_openai_server.py`: Remove debug logging and update comments to clarify that `logprobs=None` can happen both mid-stream and on the final chunk

## Comparison

| State | Server Behavior | Test |
|-------|----------------|------|
| Before #17687 | Always returns `Logprobs(tokens=[], ...)` even with empty slice | Assumes logprobs always has tokens → **FLAKY** |
| After #17687 | Returns `None` only when `finish_reason is not None` AND slice is empty | Handles `None` for final chunk only → **STILL FLAKY** |
| This PR | Returns `None` whenever slice is empty (regardless of `finish_reason`) | Handles `None` for any chunk → **CORRECT** |