### PR TITLE
Add AutoSpec to Support Automatic Runtime Speculative Inference Parameter Tuning for Different Batchsizes

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2437,9 +2437,11 @@ class Scheduler(
             self.process_batch_result_idle(batch, result)
 
         if self.auto_spec and batch.forward_mode.is_decode() and self.model_worker.spec_auto_tuner.enable_watch_for_batch(batch.batch_size()):
-            # logger.info(f"[MY LOG] auto_spec enabled, batchsize: {batch.batch_size()}. tune_interval: {self.tune_interval}, interval_counter: {self.interval_counter}")
+            logger.info(f"[MY LOG] auto_spec enabled, batchsize: {batch.batch_size()}")
             accept_length, accept_rate, throughput = self.get_metrics(batch.batch_size(), result.num_accepted_tokens, self.model_worker.speculative_num_draft_tokens)
             self.model_worker.spec_auto_tuner.compute_and_update_best_parameters(batch.batch_size(), accept_length, accept_rate, throughput)
+        elif self.auto_spec and batch.forward_mode.is_decode():
+            logger.info(f"[MY LOG] batchsize {batch.batch_size()}, fix parameter, skip computing.")
 
         self.log_batch_result_stats(batch, result)
         self._maybe_clear_mm_inputs(batch)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2439,8 +2439,8 @@ class Scheduler(
         elif batch.forward_mode.is_idle():
             self.process_batch_result_idle(batch, result)
 
-        if self.auto_spec and (batch.batch_size() <= 6 or batch.batch_size() > 48) and batch.forward_mode.is_decode():
-                # logger.info(f"[MY LOG] auto_spec enabled, batchsize: {batch.batch_size()}. tune_interval: {self.tune_interval}, interval_counter: {self.interval_counter}")
+        if self.auto_spec and batch.forward_mode.is_decode() and self.model_worker.spec_auto_tuner.enable_watch_for_batch(batch.batch_size()):
+            # logger.info(f"[MY LOG] auto_spec enabled, batchsize: {batch.batch_size()}. tune_interval: {self.tune_interval}, interval_counter: {self.interval_counter}")
             if self.tune_interval == 1:
                 # logger.info(f"[MY LOG] auto_spec tune_interval set to 1, tune in every forward pass.")
                 # accept_length, accept_rate, throughput = self.get_metrics()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -312,13 +312,10 @@ class Scheduler(
 
         # auto_spec server args
         self.auto_spec = server_args.auto_spec
-        self.tune_interval = server_args.tune_interval
-        self.interval_counter = 0
         if self.auto_spec:
             self.spec_auto_tuner = AutoTunerEagle(server_args)
             server_args.spec_auto_tuner = self.spec_auto_tuner
         # todo: add idle flag to identify when to start auto tuning
-        self.last_loop_is_idle = True
 
         # Distributed rank info
         self.attn_tp_rank, self.attn_tp_size, self.attn_dp_rank = (
@@ -2441,21 +2438,8 @@ class Scheduler(
 
         if self.auto_spec and batch.forward_mode.is_decode() and self.model_worker.spec_auto_tuner.enable_watch_for_batch(batch.batch_size()):
             # logger.info(f"[MY LOG] auto_spec enabled, batchsize: {batch.batch_size()}. tune_interval: {self.tune_interval}, interval_counter: {self.interval_counter}")
-            if self.tune_interval == 1:
-                # logger.info(f"[MY LOG] auto_spec tune_interval set to 1, tune in every forward pass.")
-                # accept_length, accept_rate, throughput = self.get_metrics()
-                accept_length, accept_rate, throughput = self.get_metrics_v2(batch.batch_size(), result.num_accepted_tokens, self.model_worker.speculative_num_draft_tokens)
-                self.model_worker.spec_auto_tuner.compute_and_update_best_parameters(batch.batch_size(), accept_length, accept_rate, throughput)
-            elif (self.interval_counter + 1) % self.tune_interval != 0:
-                # logger.info(f"[MY LOG] auto_spec, tune_interval: {self.tune_interval}, interval_counter: {self.interval_counter}, only update info.")
-                self.interval_counter += 1
-                self.get_metrics_v3(batch.batch_size(), result.num_accepted_tokens, self.model_worker.speculative_num_draft_tokens)
-            elif (self.interval_counter + 1) % self.tune_interval == 0:
-                # logger.info(f"[MY LOG] auto_spec, tune_interval: {self.tune_interval}, interval_counter: {self.interval_counter}, compute spec info best params.")
-                accept_length, accept_rate, throughput = self.get_metrics_v3(batch.batch_size(), result.num_accepted_tokens, self.model_worker.speculative_num_draft_tokens, True)
-                self.model_worker.spec_auto_tuner.compute_and_update_best_parameters(batch.batch_size(), accept_length,
-                                                                                     accept_rate, throughput)
-                self.interval_counter = 0
+            accept_length, accept_rate, throughput = self.get_metrics(batch.batch_size(), result.num_accepted_tokens, self.model_worker.speculative_num_draft_tokens)
+            self.model_worker.spec_auto_tuner.compute_and_update_best_parameters(batch.batch_size(), accept_length, accept_rate, throughput)
 
         self.log_batch_result_stats(batch, result)
         self._maybe_clear_mm_inputs(batch)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -172,8 +172,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode, PPProxyTen
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
-from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.auto_eagle import AutoTunerEagle
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.tracing.trace import (
     process_tracing_init,
     trace_event_batch,
@@ -1095,8 +1095,12 @@ class Scheduler(
                 self.last_loop_is_idle = False
             else:
                 if not self.last_loop_is_idle and self.server_args.save_tune_results:
-                    with open(self.model_worker.spec_auto_tuner.spec_tune_file, "w") as f:
-                        logger.info(f"[AUTOSPEC] auto tune results saved to file: {self.model_worker.spec_auto_tuner.spec_tune_file}")
+                    with open(
+                        self.model_worker.spec_auto_tuner.spec_tune_file, "w"
+                    ) as f:
+                        logger.info(
+                            f"[AUTOSPEC] auto tune results saved to file: {self.model_worker.spec_auto_tuner.spec_tune_file}"
+                        )
                         json.dump(self.model_worker.spec_auto_tuner.results, f)
                 # When the server is idle, do self-check and re-init some states
                 self.self_check_during_idle()
@@ -2444,9 +2448,21 @@ class Scheduler(
         elif batch.forward_mode.is_idle():
             self.process_batch_result_idle(batch, result)
 
-        if self.auto_spec and batch.forward_mode.is_decode() and self.model_worker.spec_auto_tuner.enable_watch_for_batch(batch.batch_size()):
-            accept_length, accept_rate, throughput = self.get_metrics(batch.batch_size(), result.num_accepted_tokens, self.model_worker.speculative_num_draft_tokens)
-            self.model_worker.spec_auto_tuner.compute_and_update_best_parameters(batch.batch_size(), accept_length, accept_rate, throughput)
+        if (
+            self.auto_spec
+            and batch.forward_mode.is_decode()
+            and self.model_worker.spec_auto_tuner.enable_watch_for_batch(
+                batch.batch_size()
+            )
+        ):
+            accept_length, accept_rate, throughput = self.get_metrics(
+                batch.batch_size(),
+                result.num_accepted_tokens,
+                self.model_worker.speculative_num_draft_tokens,
+            )
+            self.model_worker.spec_auto_tuner.compute_and_update_best_parameters(
+                batch.batch_size(), accept_length, accept_rate, throughput
+            )
 
         self.log_batch_result_stats(batch, result)
         self._maybe_clear_mm_inputs(batch)

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -479,7 +479,9 @@ class SchedulerMetricsMixin:
                 balancedness=m.eplb_balancedness.item(),
             )
 
-    def get_metrics(self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int):
+    def get_metrics(
+        self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int
+    ):
         avg_spec_accept_length = (num_accepted_tokens + bs) / bs
         avg_spec_accept_rate = avg_spec_accept_length / speculative_num_draft_tokens
         return avg_spec_accept_length, avg_spec_accept_rate, 0

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -486,10 +486,8 @@ class SchedulerMetricsMixin:
         return avg_spec_accept_length, avg_spec_accept_rate, 0
 
     def get_metrics_v3(self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int, reset: bool = False):
-        # logger.info(f"[MY LOG] SchedulerMetricsMixin get_metrics_v3, bs={bs}, num_accepted_tokens={num_accepted_tokens}, speculative_num_draft_tokens={speculative_num_draft_tokens}")
         self.interval_accept_length += num_accepted_tokens + bs
         self.interval_forward_count += bs
-        # logger.info(f"[MY LOG] SchedulerMetricsMixin get_metrics_v3, current interval self.interval_accept_length: {self.interval_accept_length}, self.interval_forward_count: {self.interval_forward_count}")
         if reset:
             avg_spec_accept_length = self.interval_accept_length / self.interval_forward_count
             total_draft_tokens = self.interval_forward_count * speculative_num_draft_tokens

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -480,7 +480,6 @@ class SchedulerMetricsMixin:
             )
 
     def get_metrics(self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int):
-        # logger.info(f"[MY LOG] SchedulerMetricsMixin get_metrics_v2, bs={bs}, num_accepted_tokens={num_accepted_tokens}, speculative_num_draft_tokens={speculative_num_draft_tokens}")
         avg_spec_accept_length = (num_accepted_tokens + bs) / bs
         avg_spec_accept_rate = avg_spec_accept_length / speculative_num_draft_tokens
         return avg_spec_accept_length, avg_spec_accept_rate, 0

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -479,31 +479,11 @@ class SchedulerMetricsMixin:
                 balancedness=m.eplb_balancedness.item(),
             )
 
-    def get_metrics_v2(self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int):
+    def get_metrics(self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int):
         # logger.info(f"[MY LOG] SchedulerMetricsMixin get_metrics_v2, bs={bs}, num_accepted_tokens={num_accepted_tokens}, speculative_num_draft_tokens={speculative_num_draft_tokens}")
         avg_spec_accept_length = (num_accepted_tokens + bs) / bs
         avg_spec_accept_rate = avg_spec_accept_length / speculative_num_draft_tokens
         return avg_spec_accept_length, avg_spec_accept_rate, 0
-
-    def get_metrics_v3(self, bs: int, num_accepted_tokens: int, speculative_num_draft_tokens: int, reset: bool = False):
-        self.interval_accept_length += num_accepted_tokens + bs
-        self.interval_forward_count += bs
-        if reset:
-            avg_spec_accept_length = self.interval_accept_length / self.interval_forward_count
-            total_draft_tokens = self.interval_forward_count * speculative_num_draft_tokens
-
-            avg_spec_accept_rate = (
-                self.interval_accept_length / total_draft_tokens
-                if total_draft_tokens > 0
-                else 0
-            )
-            # logger.info(
-            #     f"[MY LOG] SchedulerMetricsMixin get_metrics_v3, return results: avg_spec_accept_length: {avg_spec_accept_length}, avg_spec_accept_rate: {avg_spec_accept_rate}")
-            # reset after finish
-            self.interval_accept_length = 0
-            self.interval_forward_count = 0
-            return avg_spec_accept_length, avg_spec_accept_rate, 0
-        return None, None, 0
 
     def _emit_kv_metrics(self: Scheduler):
         if not self.enable_kv_cache_events:

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -22,7 +22,7 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Optional, Union, List
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import torch
 import tqdm
@@ -218,7 +218,9 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner, num_tokens_per_bs=1):
     return capture_bs, compile_bs
 
 
-def get_batch_sizes_to_capture_for_steps(model_runner: ModelRunner, batchsizes: List[int] = None):
+def get_batch_sizes_to_capture_for_steps(
+    model_runner: ModelRunner, batchsizes: List[int] = None
+):
     # get batchsizes for the given step to capture instead of all cuda graph batchsize
     server_args = model_runner.server_args
     if batchsizes:

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -22,7 +22,7 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union, List
 
 import torch
 import tqdm

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -219,12 +219,10 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner, num_tokens_per_bs=1):
 
 
 def get_batch_sizes_to_capture_for_steps(model_runner: ModelRunner, batchsizes: List[int] = None):
-    # todo autospec: get batchsizes for the given step to capture instead of all cuda graph batchsize
-    # todo this function can be merged with the original function
-    # information can be get from AutoTunerEagle
+    # get batchsizes for the given step to capture instead of all cuda graph batchsize
     server_args = model_runner.server_args
     if batchsizes:
-        capture_bs = batchsizes  # todo if batchsizes given for current step, do not get from server args
+        capture_bs = batchsizes
     else:
         capture_bs = server_args.cuda_graph_bs
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1631,7 +1631,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.server_args.speculative_num_steps = num_steps
                 self.server_args.speculative_num_draft_tokens = 1
                 self.server_args.speculative_num_draft_tokens = num_steps + 1
-                logger.info(f"[AUTOSPEC] init_attention_backend_for_steps: num_steps={num_steps}")
+                logger.info(
+                    f"[AUTOSPEC] init_attention_backend_for_steps: num_steps={num_steps}"
+                )
                 self.attn_backend_for_steps[num_steps] = self._get_attention_backend()
         initial_steps = self.step_range[-1]
         self.server_args.speculative_num_steps = initial_steps

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3752,13 +3752,13 @@ class ServerArgs:
             "--neg-threshold",
             type=float,
             nargs="+",
-            help="Threshold of negative threshold for auto-spec"
+            help="Threshold of negative threshold for auto-spec",
         )
         parser.add_argument(
             "--pos-threshold",
             type=float,
             nargs="+",
-            help="Threshold of positive threshold for auto-spec"
+            help="Threshold of positive threshold for auto-spec",
         )
         parser.add_argument(
             "--speculative-config-file",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -467,7 +467,6 @@ class ServerArgs:
     enable_multi_layer_eagle: bool = False
     # for auto_spec
     auto_spec: bool = False
-    tune_interval: int = 0
     speculative_config_file: Optional[str] = None
     save_tune_results: Optional[str] = None
     neg_threshold: Optional[List[int]] = None
@@ -3760,12 +3759,6 @@ class ServerArgs:
             type=float,
             nargs="+",
             help="Threshold of positive threshold for auto-spec"
-        )
-        parser.add_argument(
-            "--tune-interval",
-            type=int,
-            default=1,
-            help="Dynamic specinfer tuning interval, default to tune in every forward pass.",
         )
         parser.add_argument(
             "--speculative-config-file",

--- a/python/sglang/srt/speculative/auto_eagle.py
+++ b/python/sglang/srt/speculative/auto_eagle.py
@@ -48,6 +48,9 @@ class AutoTunerEagle:
         self.reserve_mem = 4
         self.mem_each_graph = 2
         self.save_tune_results = server_args.save_tune_results
+        if self.save_tune_results is not None:
+            os.makedirs(self.save_tune_results, exist_ok=True)
+            self.spec_tune_file = os.path.join(self.save_tune_results, "spec_tune_results.json")
         self.neg_threshold = None
         self.pos_threshold = None
         if server_args.neg_threshold is not None:

--- a/python/sglang/srt/speculative/auto_eagle.py
+++ b/python/sglang/srt/speculative/auto_eagle.py
@@ -1,0 +1,469 @@
+import math
+
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import get_available_gpu_memory
+from typing import Dict, List, Union
+import bisect
+import json
+import os
+
+import logging
+logger = logging.getLogger(__name__)
+
+STEP_RANGE = [1, 2, 3, 4, 5, 6]
+
+
+class TuningParams:
+    def __init__(self, num_steps: int=5, topk: int=1, num_draft: int=6):
+        """todo add tunable param set for spec infer"""
+        self.num_steps: int = num_steps
+        self.topk: int = topk  # currently do not tune
+        self.num_draft: int = num_draft  # currently do not tune
+        self.interval: int = 5  # define the cumulated number of forward to trigger a forward
+
+
+class AutoTunerEagle:
+    def __init__(
+        self,
+        server_args: ServerArgs,
+    ):
+        """
+        todo
+        initialise
+        """
+        self.cuda_graph_bs = server_args.cuda_graph_bs
+        self.device_id = server_args.device
+        self.model_name = server_args.served_model_name or server_args.model_path
+        self.speculative_config_file = server_args.speculative_config_file
+        self.exp_setting = {
+            1: TuningParams(5, 1, 6),
+            2: TuningParams(5, 1, 6),
+            4: TuningParams(5, 1, 6),
+            8: TuningParams(4, 1, 5),
+            16: TuningParams(3, 1, 4),
+            32: TuningParams(3, 1, 4),
+            64: TuningParams(3, 1, 4),
+            128: TuningParams(1, 1, 2),
+        }
+        self.step_thres = 6
+        self.save_tune_results = server_args.save_tune_results
+        self.last_pos_thres = False
+        self.last_neg_thres = False
+        self.neg_threshold = None
+        self.pos_threshold = None
+        if server_args.neg_threshold is not None:
+            self.neg_threshold = server_args.neg_threshold
+        if server_args.pos_threshold is not None:
+            self.pos_threshold = server_args.pos_threshold
+
+    def initialize(self, gpu_id: int):
+        """must be manually called"""
+        # 1. get remaining memory size, determines how many cuda graphs to capture
+        available_memory = get_available_gpu_memory(self.device_id, gpu_id, empty_cache=False)
+        self.max_num_graphs = int((available_memory - 4) // 2)  # alloc 2GB for each step(verify + draft), 2GB to avoid overflow
+        logger.info(f"AutoTunerEagle, num_graphs to capture for different steps: {self.max_num_graphs}")
+
+        # todo: enable config file
+        self._init_speculative_config()
+
+        # todo: enable bs lookup for all bs
+        self._generate_closest_bs_mapping()
+
+        # 2. calculate the thres_accept_length_growth_rate for each num_steps, need to get the eagle draft model size ratio with respect to target model
+        # todo fill in the calculation
+        self.thres_accept_length_growth_rate = {step: 0.2 for step in self.step_range}  # todo need calculation
+        # self.thres_positive_accept_rate = 0.55
+        # self.thres_negative_accept_rate = 0.5
+
+        # todo increase accept rate for larger batchsize
+        self.thres_positive_accept_rate = {bs: 0.55 for bs in self.bs_steps_mapping.keys()}
+        # self.thres_positive_accept_rate = {bs: 0.6 for bs in self.bs_steps_mapping.keys()}
+        self.thres_negative_accept_rate = {bs: 0.5 for bs in self.bs_steps_mapping.keys()}
+        # self.thres_negative_accept_rate = {bs: 0.55 for bs in self.bs_steps_mapping.keys()}
+        for k in self.thres_positive_accept_rate.keys():
+            # if k >= 8 and k <= 32:
+            if k == 4:
+                self.thres_positive_accept_rate[k] = 0.6
+                self.thres_negative_accept_rate[k] = 0.5
+                if self.pos_threshold is not None:
+                    self.thres_positive_accept_rate[k] = self.pos_threshold[0]
+                if self.neg_threshold is not None:
+                    self.thres_negative_accept_rate[k] = self.neg_threshold[0]
+            if k == 8:
+                self.thres_positive_accept_rate[k] = 0.8
+                self.thres_negative_accept_rate[k] = 0.5
+                if self.pos_threshold is not None:
+                    self.thres_positive_accept_rate[k] = self.pos_threshold[1]
+                if self.neg_threshold is not None:
+                    self.thres_negative_accept_rate[k] = self.neg_threshold[1]
+            elif k == 16:
+                self.thres_positive_accept_rate[k] = 0.95
+                self.thres_negative_accept_rate[k] = 0.6
+                if self.pos_threshold is not None:
+                    self.thres_positive_accept_rate[k] = self.pos_threshold[2]
+                if self.neg_threshold is not None:
+                    self.thres_negative_accept_rate[k] = self.neg_threshold[2]
+            elif k == 32:
+                self.thres_positive_accept_rate[k] = 0.91
+                self.thres_negative_accept_rate[k] = 0.66
+                if self.pos_threshold is not None:
+                    self.thres_positive_accept_rate[k] = self.pos_threshold[3]
+                if self.neg_threshold is not None:
+                    self.thres_negative_accept_rate[k] = self.neg_threshold[3]
+            elif k >= 64:
+                self.thres_positive_accept_rate[k] = 0.95
+                # self.thres_negative_accept_rate[k] = 0.6
+                self.thres_negative_accept_rate[k] = 0.65
+                if self.pos_threshold is not None:
+                    self.thres_positive_accept_rate[k] = self.pos_threshold[4]
+                if self.neg_threshold is not None:
+                    self.thres_negative_accept_rate[k] = self.neg_threshold[4]
+        logger.info(f"[MY LOG] AutoTunerEagle, pos_thresholds: {self.thres_positive_accept_rate}; neg_thresholds: {self.thres_negative_accept_rate}")
+
+        # 3. initialise recorded speculative parameters
+        self.best_speculative_parameters: Dict[int, TuningParams] = {bs: self.exp_setting[bs] for bs in self.cuda_graph_bs}  # todo initialize the best speculative_num_step settings for each bs
+        for bs, params in self.best_speculative_parameters.items():
+            if params.num_steps not in self.bs_steps_mapping[bs]:
+                self.best_speculative_parameters[bs] = TuningParams(self.bs_steps_mapping[bs][-1], 1, self.bs_steps_mapping[bs][-1] + 1)  # if intuitive params not in setting, reset
+        # 4. initialise throughput and speculative_num_step recording
+        self.last_throughput = {bs: 0. for bs in self.cuda_graph_bs}
+        # self.last_accept_length = {bs: 0. for bs in server_args.cuda_graph_bs}
+        # self.last_num_steps = {bs: 0 for bs in server_args.cuda_graph_bs}
+        self.last_accept_length = {step: 0. for step in self.step_range}
+        self.last_time_num_steps_increase_flag = False
+        logger.info(f"[MY LOG] AutoTunerEagle, best_speculative_parameters init: {self._print_params()}")
+        if self.save_tune_results:
+            self.results = {bs: {num_steps: 0 for num_steps in self.bs_steps_mapping[bs]} for bs in self.cuda_graph_bs}
+
+    def _init_speculative_config(self):
+        """Initialize speculative configuration from config file or use defaults."""
+
+        # Default configuration
+        default_bs_steps_mapping = {
+            1: [3, 4, 5, 6],
+            2: [3, 4, 5, 6],
+            4: [3, 4, 5, 6],
+            8: [2, 3, 4],
+            16: [2, 3, 4],
+            32: [2, 3, 4],
+            64: [1, 2, 3, 4],
+            128: [1, 2, 3, 4]
+        }
+
+        # Check if config file is provided
+        if self.speculative_config_file and os.path.exists(self.speculative_config_file):
+            try:
+                with open(self.speculative_config_file, 'r') as f:
+                    config = json.load(f)
+
+                # Get model name from server_args (use model_path as fallback)
+                if self.model_name and self.model_name in config:
+                    # Use model-specific configuration
+                    model_config = config[self.model_name]
+                    self.bs_steps_mapping = {}
+                    for bs_str, steps in model_config.items():
+                        try:
+                            bs = int(bs_str)
+                            self.bs_steps_mapping[bs] = steps
+                        except ValueError:
+                            logger.warning(f"[MY LOG] AutoTunerEagle, config init. Invalid batch size in config: {bs_str}")
+
+                    if self.bs_steps_mapping:
+                        logger.info(f"[MY LOG] AutoTunerEagle, config init. Loaded speculative config for model '{self.model_name}' from {self.speculative_config_file}, parameters: {self.bs_steps_mapping}")
+                    else:
+                        logger.warning(f"[MY LOG] AutoTunerEagle, config init. No valid batch size configuration found for model '{self.model_name}', using defaults: {default_bs_steps_mapping}")
+                        self.bs_steps_mapping = default_bs_steps_mapping
+                else:
+                    logger.info(f"[MY LOG] AutoTunerEagle, config init. Model '{self.model_name}' not found in config file, using defaults: {default_bs_steps_mapping}")
+                    self.bs_steps_mapping = default_bs_steps_mapping
+
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(f"[MY LOG] AutoTunerEagle, config init. Failed to load speculative config from {self.speculative_config_file}: {e}, using defaults: {default_bs_steps_mapping}")
+                self.bs_steps_mapping = default_bs_steps_mapping
+        else:
+            # Use default configuration
+            self.bs_steps_mapping = default_bs_steps_mapping
+            logger.info(f"[MY LOG] AutoTunerEagle, config init. Speculative config file has not been passed, using defaults: {self.bs_steps_mapping}")
+
+        self.step_range = list(set(step for steps in self.bs_steps_mapping.values() for step in steps))
+        self.step_range.sort()
+
+        self.bs_list = list(self.bs_steps_mapping.keys())
+        self.bs_list.sort()
+
+        # Build reverse mapping: steps -> batch sizes
+        self.steps_bs_mapping = {}
+        for bs, steps in self.bs_steps_mapping.items():
+            for step in steps:
+                if step not in self.steps_bs_mapping:
+                    self.steps_bs_mapping[step] = []
+                self.steps_bs_mapping[step].append(bs)
+
+        # Sort batch sizes for each step
+        for step in self.steps_bs_mapping:
+            self.steps_bs_mapping[step].sort()
+
+        # todo: deal with scenes when memory available is not enough for the given number of num_steps
+        # update self.steps_range  eg: self.step_range = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        if self.max_num_graphs < len(self.step_range):
+            logger.info(f"[MY LOG] AutoTunerEagle init, number of speculative steps to capture: {self.step_range} might exceed available memory.")
+            step_range_thres = [step for step in self.step_range if step <= self.step_thres]
+            if len(step_range_thres) <= self.max_num_graphs:  # eg: thres=6, max_num_graph=7, remove 8, 9
+                self.step_range = self.step_range[:self.max_num_graphs]
+            else:  # eg: thres=6, max_num_graph=4
+                self.step_range = step_range_thres  # remove 7, 8, 9 first
+                temp_step_range = []
+                num_even = min(int(math.ceil(len(self.step_range) / 2)), self.max_num_graphs)
+                num_odd = self.max_num_graphs - num_even
+                for i in range(num_even):
+                    temp_step_range.append(self.step_range[2 * i])
+                for i in range(num_odd):
+                    temp_step_range.append(self.step_range[2 * i + 1])
+                self.step_range = temp_step_range
+                self.step_range.sort()
+            logger.info(f"[MY LOG] AutoTunerEagle init, only capture for steps: {self.step_range}")
+
+            # update self.bs_steps_mapping
+            temp_bs_steps_mapping = {}
+            for bs, steps in self.bs_steps_mapping.items():
+                temp_bs_steps_mapping[bs] = [step for step in steps if step in self.step_range]
+                if len(temp_bs_steps_mapping[bs]) == 0:  # if all the steps of given bs is removed, set the bs as the steps_range
+                    temp_bs_steps_mapping[bs] = self.step_range
+            self.bs_steps_mapping = temp_bs_steps_mapping
+            logger.info(f"[MY LOG] AutoTunerEagle init, updated bs_steps_mapping: {self.bs_steps_mapping}")
+
+            # update steps_bs_mapping
+            self.steps_bs_mapping = {}
+            for bs, steps in self.bs_steps_mapping.items():
+                for step in steps:
+                    if step not in self.steps_bs_mapping:
+                        self.steps_bs_mapping[step] = []
+                    self.steps_bs_mapping[step].append(bs)
+            logger.info(f"[MY LOG] AutoTunerEagle init, updated steps_bs_mapping: {self.steps_bs_mapping}")
+
+    def _find_closest_bs(self, target: Union[int, float]) -> Union[int, float, None]:
+        """
+        在有序列表中查找最接近目标值的数
+
+        Args:
+            sorted_list: 已排序的数值列表（升序）
+            target: 目标数值
+
+        Returns:
+            最接近目标值的数，如果列表为空则返回None
+        """
+        # 使用bisect找到插入位置
+        insert_pos = bisect.bisect_left(self.bs_list, target)
+
+        # 处理边界情况
+        if insert_pos == 0:
+            return self.bs_list[0]
+        elif insert_pos == len(self.bs_list):
+            return self.bs_list[-1]
+
+        # 获取左右两个候选值
+        left_val = self.bs_list[insert_pos - 1]
+        right_val = self.bs_list[insert_pos]
+
+        # 计算差值
+        left_diff = abs(target - left_val)
+        right_diff = abs(target - right_val)
+
+        # 根据差值选择结果，差值相同时取较小的数
+        if left_diff < right_diff:
+            return left_val
+        elif right_diff < left_diff:
+            return right_val
+        else:
+            return min(left_val, right_val)
+
+    def _generate_closest_bs_mapping(self) -> dict:
+        """
+        优化的整数到最接近值的映射字典生成函数
+
+        使用更高效的方法生成映射，避免对每个整数都进行二分查找
+
+        Args:
+            sorted_list: 已排序的数值列表（升序）
+
+        Returns:
+            字典，key为范围内的整数，value为最接近的列表中的数
+        """
+
+        start = self.bs_list[0]
+        end = self.bs_list[-1]
+
+        self.raw_bs_to_bs = {}
+
+        # 使用双指针方法优化
+        for i in range(start, end + 1):
+            # 使用二分查找找到最接近的值
+            closest = self._find_closest_bs(i)
+            if closest is not None:
+                self.raw_bs_to_bs[i] = closest
+
+    def _print_params(self, bs: int = None):
+        msg = ""
+        if bs:
+            params = self.best_speculative_parameters[bs]
+            return f"{bs}:{params.num_steps} {params.topk} {params.num_draft}"
+        for bs, params in self.best_speculative_parameters.items():
+            msg += f"{bs}:{params.num_steps} {params.topk} {params.num_draft}\t"
+        return msg
+
+    def _update_speculative_params(self, bs: int, increase: bool = True):
+        # logger.info(f"[MY LOGS] AutoTunerEagle._update_speculative_params, bs={bs}, "
+        #             f"best_speculative_parameters={self.best_speculative_parameters}"
+        #             f"bs_steps_mapping={self.bs_steps_mapping}")
+        if increase:
+            self.best_speculative_parameters[bs].num_steps += 1
+            self.best_speculative_parameters[bs].num_draft += 1
+            while self.best_speculative_parameters[bs].num_steps not in self.bs_steps_mapping[bs]:  # scene when there's no neighbouring num_steps
+                self.best_speculative_parameters[bs].num_steps += 1
+                self.best_speculative_parameters[bs].num_draft += 1
+            # for b in self.best_speculative_parameters.keys():
+            #     if b == bs:
+            #         continue
+            #     if self.best_speculative_parameters[bs].num_steps <= self.bs_steps_mapping[b][-1]:
+            #         self.best_speculative_parameters[b].num_steps = self.best_speculative_parameters[bs].num_steps
+            #         self.best_speculative_parameters[b].num_draft = self.best_speculative_parameters[bs].num_draft
+        else:
+            self.best_speculative_parameters[bs].num_steps -= 1
+            self.best_speculative_parameters[bs].num_draft -= 1
+            while self.best_speculative_parameters[bs].num_steps not in self.bs_steps_mapping[bs]:  # scene when there's no neighbouring num_steps
+                self.best_speculative_parameters[bs].num_steps -= 1
+                self.best_speculative_parameters[bs].num_draft -= 1
+            # for b in self.best_speculative_parameters.keys():
+            #     if b == bs:
+            #         continue
+            #     if self.best_speculative_parameters[bs].num_steps >= self.bs_steps_mapping[b][0]:
+            #         self.best_speculative_parameters[b].num_steps = self.best_speculative_parameters[bs].num_steps
+            #         self.best_speculative_parameters[b].num_draft = self.best_speculative_parameters[bs].num_draft
+
+    def _update_metrics(self, bs: int, num_steps: int, accept_length, throughput):
+        self.last_accept_length[num_steps] = accept_length
+        self.last_throughput[bs] = throughput
+        # logger.info(f"[MY LOG] AutoTunerEagle.update_metrics, num_steps: {num_steps}, self.last_accept_length: {self.last_accept_length[num_steps]:.2f}, "
+        #             f"bs: {bs}, self.last_throughput: {self.last_throughput[bs]:.2f}")
+
+    def compute_batchsize32(self, current_num_steps: int, accept_length: int):
+        if current_num_steps > 3:
+            self.best_speculative_parameters[32].num_steps = 3
+            self.best_speculative_parameters[32].num_draft = 4
+            self.best_speculative_parameters[32].topk = 1
+            return
+        # 参数2
+        if current_num_steps == 3 and accept_length < 2.2:
+            self._update_speculative_params(32, False)
+        elif current_num_steps == 2:
+            if accept_length < 1.9:
+                self._update_speculative_params(32, False)
+            elif accept_length > 2.1:
+                self._update_speculative_params(32, True)
+        elif current_num_steps == 1:
+            if accept_length > 1.7:
+                self._update_speculative_params(32, True)
+        return
+        # # 参数3
+        # self.best_speculative_parameters[32].num_steps = 3
+        # self.best_speculative_parameters[32].num_draft = 4
+        # self.best_speculative_parameters[32].topk = 1
+
+    def compute_and_update_best_parameters(self, bs, accept_length, accept_rate, throughput):
+        """
+        todo special analysis for bs=32
+        calculate best parameters for current batch_size based on negative feedback method and update the
+        settings for self.best_speculative_parameters
+        """
+        # logger.info(f"[MY LOG]AutoTunerEagle compute_and_update_parameters, bs: {bs}, accept_length: {accept_length}, "
+        #             f"accept_rate: {accept_rate}, throughput: {throughput}")
+        raw_bs = bs
+        if bs not in self.raw_bs_to_bs.keys():
+            bs = self.bs_list[-1]  # exceed max bs, set to max bs
+        else:
+            bs = self.raw_bs_to_bs[bs]
+        # logger.info(f"[MY LOG] AutoTunerEagle bs: {raw_bs}, compute_and_update_parameters round to nearest bs: {bs} ")
+        # logger.info(f"[MY LOG]AutoTunerEagle best_speculative_parameters before update: {self._print_params()}")
+        current_num_steps = self.best_speculative_parameters[bs].num_steps  # 假设当前num_steps=2
+        small_compare_num_steps = current_num_steps - 1  # 则应该和num_steps=1是的接受长度比增长率
+        accept_length_flag = 1
+        # todo bs=1/2特殊处理，连续两次才触发决策
+        # todo bs=32的特殊处理，但是对于不同的部署形态不能通用
+        # if bs == 32:
+        #     self.compute_batchsize32(current_num_steps, accept_length)
+        #     return
+        # todo 先取消growth length规则
+        # if self.last_time_num_steps_increase_flag:  # 有上次的记录, 且当前的num_steps相较于上次是增加的, 否则计算这个参数没有意义; last_num_steps>=current_num_steps，都只看accept_rate
+        #     logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, find metric record")
+        #     last_accept_length = self.last_accept_length[small_compare_num_steps]
+        #     accept_length_growth_rate = (accept_length - last_accept_length) / last_accept_length
+        #     accept_length_flag = accept_length_growth_rate >= self.thres_accept_length_growth_rate[small_compare_num_steps]
+        #     logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, bs: {bs}, "
+        #                 f"accept_length_growth_rate: {accept_length_growth_rate} vs threshold: {self.thres_accept_length_growth_rate[current_num_steps - 1]}")
+        accept_rate_pos_flag = accept_rate >= self.thres_positive_accept_rate[bs]
+        accept_rate_neg_flag = accept_rate < self.thres_negative_accept_rate[bs]
+        # if bs == 1 or bs == 2:  # bs=1或2时，连续两次触发阈值才调整参数
+        #     if accept_rate_pos_flag and (not self.last_pos_thres):
+        #         # 第一次触发pos
+        #         # logger.info(f"[MY LOG] bs={bs} 1st exceeds pos thres")
+        #         accept_rate_pos_flag = False
+        #         self.last_pos_thres = True
+        #     elif accept_rate_pos_flag and self.last_pos_thres:
+        #         # 第二次触发pos
+        #         # logger.info(f"[MY LOG] bs={bs} 2nd exceeds pos thres")
+        #         self.last_pos_thres = False
+        #     elif accept_rate_neg_flag and (not self.last_neg_thres):
+        #         # 第一次触发neg
+        #         # logger.info(f"[MY LOG] bs={bs} 1st exceeds neg thres")
+        #         accept_rate_neg_flag = False
+        #         self.last_neg_thres = True
+        #     elif accept_rate_neg_flag and self.last_neg_thres:
+        #         # 第二次触发neg
+        #         # logger.info(f"[MY LOG] bs={bs} 2nd exceeds neg thres")
+        #         self.last_neg_thres = False
+        #     elif self.last_pos_thres:
+        #         # 第一次触发，第二次没触发，置0
+        #         # logger.info(f"[MY LOG] bs={bs} 2nd didn't exceeds pos thres")
+        #         self.last_pos_thres = False
+        #     elif self.last_neg_thres:
+        #         # 第一次触发，第二次没触发，置0
+        #         # logger.info(f"[MY LOG] bs={bs} 2nd didn't exceeds neg thres")
+        #         self.last_neg_thres = False
+        # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, bs: {bs}, accept_rate: {accept_rate} vs threshold_neg: {self.thres_negative_accept_rate} vs threshold_pos: {self.thres_positive_accept_rate}")
+        self._update_metrics(bs, current_num_steps, accept_length, throughput)
+        if accept_length_flag and accept_rate_pos_flag:  # increase parameter
+            # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, should increase")
+            if ((self.best_speculative_parameters[bs].num_steps + 1) in self.bs_steps_mapping[bs]) or ((self.best_speculative_parameters[bs].num_steps + 2) in self.bs_steps_mapping[bs]) or ((self.best_speculative_parameters[bs].num_steps + 3) in self.bs_steps_mapping[bs]):
+                self._update_speculative_params(bs, True)
+                self.last_time_num_steps_increase_flag = True
+                if self.save_tune_results:
+                    self.results[bs][self.best_speculative_parameters[bs].num_steps] += 1
+                return
+            # else:
+            #     logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, increase abandoned because step out of range")
+        elif (not accept_length_flag) or accept_rate_neg_flag:  # decrease parameter, do not update last parameter
+            # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, should decrease")
+            if ((self.best_speculative_parameters[bs].num_steps - 1) in self.bs_steps_mapping[bs]) or ((self.best_speculative_parameters[bs].num_steps - 2) in self.bs_steps_mapping[bs]) or ((self.best_speculative_parameters[bs].num_steps - 3) in self.bs_steps_mapping[bs]):
+                self.last_time_num_steps_increase_flag = False
+                self._update_speculative_params(bs, False)
+                if self.save_tune_results:
+                    self.results[bs][self.best_speculative_parameters[bs].num_steps] += 1
+                return
+            # else:
+            #     logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, decrease abandoned because step out of range")
+        # otherwise, parameters do not change
+        self.last_time_num_steps_increase_flag = False
+        if self.save_tune_results:
+            self.results[bs][self.best_speculative_parameters[bs].num_steps] += 1
+        # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, should remain")
+        # logger.info(f"[MY LOG]AutoTunerEagle best_speculative_parameters after update: {self._print_params()}")
+
+    def get_best_parameters(self, bs):
+        # todo mock for debug
+        if bs not in self.raw_bs_to_bs.keys():
+            bs = self.bs_list[-1]  # exceed max bs, set to max bs
+        else:
+            bs = self.raw_bs_to_bs[bs]
+        # todo mock for debug
+        # logger.info(f"[MY LOG]AutoTunerEagle get_best_parameters for bs {bs}, {self._print_params()}")
+        return self.best_speculative_parameters[bs]

--- a/python/sglang/srt/speculative/auto_eagle.py
+++ b/python/sglang/srt/speculative/auto_eagle.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class TuningParams:
     def __init__(self, num_steps: int=5, topk: int=1, num_draft: int=6):
-        """todo add tunable param set for spec infer"""
+        """Add tunable param set for spec infer"""
         self.num_steps: int = num_steps
         self.topk: int = topk  # fixed for auto_spec
         self.num_draft: int = num_draft  # num_steps+1 for auto_spec
@@ -31,6 +31,8 @@ class AutoTunerEagle:
         self.device_id = server_args.device
         self.model_name = server_args.served_model_name or server_args.model_path
         self.speculative_config_file = server_args.speculative_config_file
+
+        # empirical settings for tuning params and tuning thresholds
         self.exp_setting = {
             1: TuningParams(5, 1, 6),
             2: TuningParams(5, 1, 6),
@@ -43,14 +45,19 @@ class AutoTunerEagle:
         }
         self.exp_pos_threshold = {1: 0.55, 2: 0.55, 4: 0.6, 8: 0.8, 16: 0.95, 32: 0.91, 64: 0.95, 128: 0.95}
         self.exp_neg_threshold = {1: 0.5, 2: 0.5, 4: 0.5, 8: 0.5, 16: 0.6, 32: 0.66, 64: 0.65, 128: 0.65}
+
         # for memory control
         self.step_thres = 6  # control maximum graph number, graph whose num_steps > threshold will be deleted first
         self.reserve_mem = 4
         self.mem_each_graph = 2
+
+        # save auto tune results
         self.save_tune_results = server_args.save_tune_results
         if self.save_tune_results is not None:
             os.makedirs(self.save_tune_results, exist_ok=True)
             self.spec_tune_file = os.path.join(self.save_tune_results, "spec_tune_results.json")
+
+        # auto tune threshold based on server args
         self.neg_threshold = None
         self.pos_threshold = None
         if server_args.neg_threshold is not None:
@@ -63,15 +70,16 @@ class AutoTunerEagle:
         # 1. get remaining memory size, determines how many cuda graphs to capture
         available_memory = get_available_gpu_memory(self.device_id, gpu_id, empty_cache=False)
         self.max_num_graphs = int((available_memory - self.reserve_mem) // self.mem_each_graph)
-        logger.info(f"AutoTunerEagle, max num_graphs to capture for different steps: {self.max_num_graphs}")
+        logger.info(f"[AUTOSPEC] AutoTunerEagle, max num_graphs to capture for different steps: {self.max_num_graphs}")
 
-        # load speculative config file
+        # 2. Load speculative config file
         self._init_speculative_config()
 
-        # init original_bs: bs lookup for all bs, since parameters are only recorded for bs in --cuda-graph-bs
+        # 3. Init original_bs: bs lookup for all bs, since parameters are only recorded for bs in bs_list, other batchsizes
+        # follows their closest recorded bs
         self._generate_closest_bs_mapping()
 
-        # 2. set accept rate to increase or decrease num_steps for different batchsizes
+        # 4. Set accept rate thresholds to increase or decrease num_steps for different batchsizes
         self.thres_positive_accept_rate = {bs: self.exp_pos_threshold[bs] for bs in self.bs_steps_mapping.keys()}
         self.thres_negative_accept_rate = {bs: self.exp_neg_threshold[bs] for bs in self.bs_steps_mapping.keys()}
         if self.pos_threshold is not None:
@@ -82,20 +90,21 @@ class AutoTunerEagle:
             assert len(self.neg_threshold) == len(self.thres_negative_accept_rate)
             for i, bs in enumerate(self.thres_negative_accept_rate.keys()):
                 self.thres_negative_accept_rate[bs] = self.neg_threshold[i]
-        logger.info(f"[MY LOG] AutoTunerEagle, pos_thresholds: {self.thres_positive_accept_rate}; neg_thresholds: {self.thres_negative_accept_rate}")
+        logger.info(f"[AUTOSPEC] AutoTunerEagle, pos_thresholds: {self.thres_positive_accept_rate}; neg_thresholds: {self.thres_negative_accept_rate}")
 
-        # 3. initialise recorded speculative parameters
+        # 5. Initialise recorded speculative parameters
         self.best_speculative_parameters: Dict[int, TuningParams] = {bs: self.exp_setting[bs] for bs in self.bs_list}
         for bs, params in self.best_speculative_parameters.items():
             if params.num_steps not in self.bs_steps_mapping[bs]:
                 self.best_speculative_parameters[bs] = TuningParams(self.bs_steps_mapping[bs][-1], 1, self.bs_steps_mapping[bs][-1] + 1)  # if intuitive params not in setting, reset
-        logger.info(f"[MY LOG] AutoTunerEagle, best_speculative_parameters init: {self._print_params()}")
+        logger.info(f"[AUTOSPEC] AutoTunerEagle, best_speculative_parameters init: {self._print_params()}")
+
+        # 6. Save tune results
         if self.save_tune_results:
             self.results = {bs: {num_steps: 0 for num_steps in self.bs_steps_mapping[bs]} for bs in self.bs_list}
 
     def _init_speculative_config(self):
         """Initialize speculative configuration from config file or use defaults."""
-
         # Default configuration
         default_bs_steps_mapping = {
             1: [3, 4, 5, 6],
@@ -108,7 +117,7 @@ class AutoTunerEagle:
             128: [1, 2, 3, 4]
         }
 
-        # Check if config file is provided
+        # 1. Get bs: [num_steps] mapping from config_file
         if self.speculative_config_file and os.path.exists(self.speculative_config_file):
             try:
                 with open(self.speculative_config_file, 'r') as f:
@@ -125,52 +134,50 @@ class AutoTunerEagle:
                             steps.sort()
                             self.bs_steps_mapping[bs] = steps
                         except ValueError:
-                            logger.warning(f"[MY LOG] AutoTunerEagle, config init. Invalid batch size in config: {bs_str}")
+                            logger.warning(f"[AUTOSPEC] AutoTunerEagle, config init. Invalid batch size in config: {bs_str}")
 
                     if self.bs_steps_mapping:
-                        logger.info(f"[MY LOG] AutoTunerEagle, config init. Loaded speculative config for model '{self.model_name}' from {self.speculative_config_file}, parameters: {self.bs_steps_mapping}")
+                        logger.info(f"[AUTOSPEC] AutoTunerEagle, config init. Loaded speculative config for model '{self.model_name}' from {self.speculative_config_file}, parameters: {self.bs_steps_mapping}")
                     else:
-                        logger.warning(f"[MY LOG] AutoTunerEagle, config init. No valid batch size configuration found for model '{self.model_name}', using defaults: {default_bs_steps_mapping}")
+                        logger.warning(f"[AUTOSPEC] AutoTunerEagle, config init. No valid batch size configuration found for model '{self.model_name}', using defaults: {default_bs_steps_mapping}")
                         self.bs_steps_mapping = default_bs_steps_mapping
                 else:
-                    logger.info(f"[MY LOG] AutoTunerEagle, config init. Model '{self.model_name}' not found in config file, using defaults: {default_bs_steps_mapping}")
+                    logger.info(f"[AUTOSPEC] AutoTunerEagle, config init. Model '{self.model_name}' not found in config file, using defaults: {default_bs_steps_mapping}")
                     self.bs_steps_mapping = default_bs_steps_mapping
 
             except (json.JSONDecodeError, IOError) as e:
-                logger.warning(f"[MY LOG] AutoTunerEagle, config init. Failed to load speculative config from {self.speculative_config_file}: {e}, using defaults: {default_bs_steps_mapping}")
+                logger.warning(f"[AUTOSPEC] AutoTunerEagle, config init. Failed to load speculative config from {self.speculative_config_file}: {e}, using defaults: {default_bs_steps_mapping}")
                 self.bs_steps_mapping = default_bs_steps_mapping
         else:
             # Use default configuration
             self.bs_steps_mapping = default_bs_steps_mapping
-            logger.info(f"[MY LOG] AutoTunerEagle, config init. Speculative config file has not been passed, using defaults: {self.bs_steps_mapping}")
+            logger.info(f"[AUTOSPEC] AutoTunerEagle, config init. Speculative config file has not been passed, using defaults: {self.bs_steps_mapping}")
 
+        # 2. Get step_range, eg: [1, 2, 3, 4, 5, 6], this determines what num_steps' graphs to capture
         self.step_range = list(set(step for steps in self.bs_steps_mapping.values() for step in steps))
         self.step_range.sort()
 
+        # 3. Get batch sizes, eg: [1, 2, 4, 8, 16, 32] and bs_range_dict, this records graphs of bs that will be captured,
+        # and decides the batchsize interval, i.e., batchsize 7 will follow the tuning paradigm of batchsize 8
         self.bs_list = list(self.bs_steps_mapping.keys())
         self.bs_list.sort()
         if self.cuda_graph_bs != self.bs_list:
-            logger.warning(f"AutoTunerEagle, cuda_graph_bs parameter different from speculative config dict, will capture graph according to speculative config.")
+            logger.warning(f"[AUTOSPEC] AutoTunerEagle, cuda_graph_bs parameter different from speculative config dict, will capture graph according to speculative config.")
 
-        self.bs_range_dict = {}
-        for i in range(len(self.bs_list) - 1):
-            self.bs_range_dict[self.bs_list[i]] = int((self.bs_list[i] + self.bs_list[i + 1]) // 2)
-
-        # Build reverse mapping: steps -> batch sizes
+        # 4. Build reverse mapping: steps -> batch sizes
         self.steps_bs_mapping = {}
         for bs, steps in self.bs_steps_mapping.items():
             for step in steps:
                 if step not in self.steps_bs_mapping:
                     self.steps_bs_mapping[step] = []
                 self.steps_bs_mapping[step].append(bs)
-
         # Sort batch sizes for each step
         for step in self.steps_bs_mapping:
             self.steps_bs_mapping[step].sort()
 
-        # deal with scenes when memory available is not enough for the given number of num_steps
+        # 5. Deal with scenes when memory available is not enough for the given number of num_steps
         if self.max_num_graphs < len(self.step_range):
-            logger.info(f"[MY LOG] AutoTunerEagle init, number of speculative steps to capture: {self.step_range} might exceed available memory.")
+            logger.info(f"[AUTOSPEC] AutoTunerEagle init, number of speculative steps to capture: {self.step_range} might exceed available memory.")
             step_range_thres = [step for step in self.step_range if step <= self.step_thres]
             if len(step_range_thres) <= self.max_num_graphs:  # eg: thres=6, max_num_graph=7, remove 8, 9
                 self.step_range = self.step_range[:self.max_num_graphs]
@@ -185,7 +192,7 @@ class AutoTunerEagle:
                     temp_step_range.append(self.step_range[2 * i + 1])
                 self.step_range = temp_step_range
                 self.step_range.sort()
-            logger.info(f"[MY LOG] AutoTunerEagle init, only capture for steps: {self.step_range}")
+            logger.info(f"[AUTOSPEC] AutoTunerEagle init, only capture for steps: {self.step_range}")
 
             # update self.bs_steps_mapping
             temp_bs_steps_mapping = {}
@@ -194,7 +201,7 @@ class AutoTunerEagle:
                 if len(temp_bs_steps_mapping[bs]) == 0:  # if all the steps of given bs is removed, set the bs as the steps_range
                     temp_bs_steps_mapping[bs] = self.step_range
             self.bs_steps_mapping = temp_bs_steps_mapping
-            logger.info(f"[MY LOG] AutoTunerEagle init, updated bs_steps_mapping: {self.bs_steps_mapping}")
+            logger.info(f"[AUTOSPEC] AutoTunerEagle init, updated bs_steps_mapping: {self.bs_steps_mapping}")
 
             # update steps_bs_mapping
             self.steps_bs_mapping = {}
@@ -203,7 +210,7 @@ class AutoTunerEagle:
                     if step not in self.steps_bs_mapping:
                         self.steps_bs_mapping[step] = []
                     self.steps_bs_mapping[step].append(bs)
-            logger.info(f"[MY LOG] AutoTunerEagle init, updated steps_bs_mapping: {self.steps_bs_mapping}")
+            logger.info(f"[AUTOSPEC] AutoTunerEagle init, updated steps_bs_mapping: {self.steps_bs_mapping}")
 
     def _find_closest_bs(self, target: Union[int, float]) -> Union[int, float, None]:
         """
@@ -242,17 +249,18 @@ class AutoTunerEagle:
         generate bs: cuda_graph_bs mapping during initialisation to avoid searching in each forward step
         eg: {1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 8, 8: 8, ..., 48: 32, 49: 64, ...}
         """
-
         start = self.bs_list[0]
         end = self.bs_list[-1]
 
+        # 1. Create bs to recorded bs mapping
         self.raw_bs_to_bs = {}
-
         for i in range(start, end + 1):
             closest = self._find_closest_bs(i)
             if closest is not None:
                 self.raw_bs_to_bs[i] = closest
 
+        # 2. Record if bs has only 1 possible spec params from config, if True, spec params will be fixed for certain
+        # batchsizes to avoid redundant computing
         self.bs_param_fix = {bs: False for bs in self.raw_bs_to_bs.keys()}
         bs_single_param = []
         for bs, num_steps in self.bs_steps_mapping.items():
@@ -272,9 +280,6 @@ class AutoTunerEagle:
         return msg
 
     def _update_speculative_params(self, bs: int, increase: bool = True):
-        # logger.info(f"[MY LOGS] AutoTunerEagle._update_speculative_params, bs={bs}, "
-        #             f"best_speculative_parameters={self.best_speculative_parameters}"
-        #             f"bs_steps_mapping={self.bs_steps_mapping}")
         if increase:
             self.best_speculative_parameters[bs].num_steps += 1
             self.best_speculative_parameters[bs].num_draft += 1
@@ -289,55 +294,46 @@ class AutoTunerEagle:
                 self.best_speculative_parameters[bs].num_draft -= 1
 
     def enable_watch_for_batch(self, bs: int):
+        """
+        Returns if bs only has one possible parameter
+        """
         if bs not in self.bs_param_fix.keys():
             bs = self.bs_list[-1]
-        logger.info(f"[MY LOG] batchsize {bs} enable_watch: {not self.bs_param_fix[bs]}")
         return not self.bs_param_fix[bs]
 
     def compute_and_update_best_parameters(self, bs, accept_length, accept_rate, throughput):
         """
-        calculate best parameters for current batch_size based on negative feedback method and update the
+        Calculate best parameters for current batch_size based on negative feedback method and update the
         settings for self.best_speculative_parameters
         """
-        # logger.info(f"[MY LOG]AutoTunerEagle compute_and_update_parameters, bs: {bs}, accept_length: {accept_length}, "
-        #             f"accept_rate: {accept_rate}, throughput: {throughput}")
         if bs not in self.raw_bs_to_bs.keys():
             bs = self.bs_list[-1]  # exceed max bs, set to max bs
         else:
             bs = self.raw_bs_to_bs[bs]
-        # logger.info(f"[MY LOG] AutoTunerEagle bs: {raw_bs}, compute_and_update_parameters round to nearest bs: {bs} ")
-        # logger.info(f"[MY LOG]AutoTunerEagle best_speculative_parameters before update: {self._print_params()}")
         accept_rate_pos_flag = accept_rate >= self.thres_positive_accept_rate[bs]
         accept_rate_neg_flag = accept_rate < self.thres_negative_accept_rate[bs]
-        # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, bs: {bs}, accept_rate: {accept_rate} vs threshold_neg: {self.thres_negative_accept_rate} vs threshold_pos: {self.thres_positive_accept_rate}")
         if accept_rate_pos_flag:  # increase parameter
-            # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, should increase")
-            if self.best_speculative_parameters[bs].num_steps < self.bs_steps_mapping[bs][-1]:
+            if self.best_speculative_parameters[bs].num_steps < self.bs_steps_mapping[bs][-1]:  # cannot exceed step range
                 self._update_speculative_params(bs, True)
                 if self.save_tune_results:
                     self.results[bs][self.best_speculative_parameters[bs].num_steps] += 1
                 return
-            # else:
-            #     logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, increase abandoned because step out of range")
-        elif accept_rate_neg_flag:  # decrease parameter, do not update last parameter
-            # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, should decrease")
-            if self.best_speculative_parameters[bs].num_steps > self.bs_steps_mapping[bs][0]:
+        elif accept_rate_neg_flag:  # decrease parameter
+            if self.best_speculative_parameters[bs].num_steps > self.bs_steps_mapping[bs][0]:  # cannot exceed step range
                 self._update_speculative_params(bs, False)
                 if self.save_tune_results:
                     self.results[bs][self.best_speculative_parameters[bs].num_steps] += 1
                 return
-            # else:
-            #     logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, decrease abandoned because step out of range")
         # otherwise, parameters do not change
         if self.save_tune_results:
             self.results[bs][self.best_speculative_parameters[bs].num_steps] += 1
-        # logger.info(f"[MY LOG] AutoTunerEagle compute_and_update_parameters, should remain")
-        # logger.info(f"[MY LOG]AutoTunerEagle best_speculative_parameters after update: {self._print_params()}")
 
     def get_best_parameters(self, bs):
+        """
+        Get spec parameters for given batchsize
+        """
         if bs not in self.raw_bs_to_bs.keys():
             bs = self.bs_list[-1]  # exceed max bs, set to max bs
         else:
             bs = self.raw_bs_to_bs[bs]
-        # logger.info(f"[MY LOG]AutoTunerEagle get_best_parameters for bs {bs}, {self._print_params()}")
         return self.best_speculative_parameters[bs]

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -402,8 +402,7 @@ class EAGLEDraftCudaGraphRunner:
 
 class EAGLEDraftCudaGraphRunnerAuto(EAGLEDraftCudaGraphRunner):
     def __init__(self, eagle_worker: EAGLEWorker, speculative_num_steps: int):
-        # super(EAGLEDraftCudaGraphRunnerAuto, self).__init__(eagle_worker)
-        """todo use the parameter for each num_step"""
+        """use the parameter for each num_step"""
         # Parse args
         self.eagle_worker = eagle_worker
         if not hasattr(eagle_worker, "model_runner"):
@@ -504,88 +503,3 @@ class EAGLEDraftCudaGraphRunnerAuto(EAGLEDraftCudaGraphRunner):
                 f"Capture cuda graph failed: {e}\n{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
             )
         logger.info(f"[MY LOG] EAGLEDraftCudaGraphRunnerAuto __init__, num_steps: {self.speculative_num_steps} done")
-        # todo add other init implementations
-
-    # def replay(self, forward_batch: ForwardBatch):
-    #     """todo: replay should be rewritten because the model_runner.draft_attn_backend_for_steps is a dict
-    #     and should be set to current speculative_num_steps"""
-    #     assert forward_batch.out_cache_loc is not None
-    #     self.deepep_adapter.replay()
-    #
-    #     raw_bs = forward_batch.batch_size
-    #     raw_num_token = raw_bs * self.num_tokens_per_bs
-    #
-    #     # Pad
-    #     if self.require_mlp_tp_gather:
-    #         max_num_tokens = max(forward_batch.global_num_tokens_cpu)
-    #         max_batch_size = (
-    #             max_num_tokens // self.num_tokens_per_bs
-    #             if self.model_runner.spec_algorithm.is_eagle()
-    #             else max_num_tokens
-    #         )
-    #         index = bisect.bisect_left(self.capture_bs, max_batch_size)
-    #     else:
-    #         index = bisect.bisect_left(self.capture_bs, raw_bs)
-    #
-    #     bs = self.capture_bs[index]
-    #     if bs != raw_bs:
-    #         self.seq_lens.fill_(self.seq_len_fill_value)
-    #         self.out_cache_loc.zero_()
-    #         self.positions.zero_()
-    #
-    #     num_tokens = bs * self.num_tokens_per_bs
-    #
-    #     # Common inputs
-    #     self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
-    #     self.out_cache_loc[: raw_num_token * self.speculative_num_steps].copy_(
-    #         forward_batch.out_cache_loc
-    #     )
-    #     self.positions[:raw_num_token].copy_(forward_batch.positions)
-    #     self.topk_p[:raw_bs].copy_(forward_batch.spec_info.topk_p)
-    #     self.topk_index[:raw_bs].copy_(forward_batch.spec_info.topk_index)
-    #     self.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
-    #     self.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
-    #
-    #     # TODO(ch-wan): support num_token_non_padded
-    #     if self.require_gathered_buffer:
-    #         self.global_num_tokens_gpu.fill_(bs * self.num_tokens_per_bs)
-    #         self.global_num_tokens_for_logprob_gpu.fill_(bs * self.num_tokens_per_bs)
-    #
-    #     # Attention backend
-    #     if bs != raw_bs:
-    #         forward_batch.batch_size = bs
-    #         forward_batch.seq_lens = self.seq_lens[:bs]
-    #         forward_batch.req_pool_indices = self.req_pool_indices[:bs]
-    #         forward_batch.positions = self.positions[:num_tokens]
-    #
-    #     if forward_batch.seq_lens_cpu is not None:
-    #         if bs != raw_bs:
-    #             self.seq_lens_cpu.fill_(self.seq_len_fill_value)
-    #         self.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
-    #         forward_batch.seq_lens_cpu = self.seq_lens_cpu[:bs]
-    #
-    #     # todo autospec draft_attn_backend should be set to current speculative_num_steps
-    #     self.model_runner.draft_attn_backend = self.model_runner.draft_attn_backend_for_steps[
-    #         self.speculative_num_steps]
-    #
-    #     self.model_runner.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
-    #         forward_batch, bs
-    #     )
-    #     self.raw_bs = raw_bs
-    #     self.bs = bs
-    #     # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph
-    #
-    #     # Replay
-    #     self._replay(forward_batch)
-    #     out = self.output_buffers[bs]
-    #
-    #     if bs != raw_bs:
-    #         out = self._postprocess_output_to_raw_bs(out, raw_bs)
-    #         forward_batch.batch_size = raw_bs
-    #         forward_batch.positions = self.positions[:raw_num_token]
-    #         forward_batch.seq_lens = self.seq_lens[:raw_bs]
-    #         forward_batch.req_pool_indices = self.req_pool_indices[:raw_bs]
-    #         if forward_batch.seq_lens_cpu is not None:
-    #             forward_batch.seq_lens_cpu = self.seq_lens_cpu[:raw_bs]
-    #
-    #     return out

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -506,86 +506,86 @@ class EAGLEDraftCudaGraphRunnerAuto(EAGLEDraftCudaGraphRunner):
         logger.info(f"[MY LOG] EAGLEDraftCudaGraphRunnerAuto __init__, num_steps: {self.speculative_num_steps} done")
         # todo add other init implementations
 
-    def replay(self, forward_batch: ForwardBatch):
-        """todo: replay should be rewritten because the model_runner.draft_attn_backend_for_steps is a dict
-        and should be set to current speculative_num_steps"""
-        assert forward_batch.out_cache_loc is not None
-        self.deepep_adapter.replay()
-
-        raw_bs = forward_batch.batch_size
-        raw_num_token = raw_bs * self.num_tokens_per_bs
-
-        # Pad
-        if self.require_mlp_tp_gather:
-            max_num_tokens = max(forward_batch.global_num_tokens_cpu)
-            max_batch_size = (
-                max_num_tokens // self.num_tokens_per_bs
-                if self.model_runner.spec_algorithm.is_eagle()
-                else max_num_tokens
-            )
-            index = bisect.bisect_left(self.capture_bs, max_batch_size)
-        else:
-            index = bisect.bisect_left(self.capture_bs, raw_bs)
-
-        bs = self.capture_bs[index]
-        if bs != raw_bs:
-            self.seq_lens.fill_(self.seq_len_fill_value)
-            self.out_cache_loc.zero_()
-            self.positions.zero_()
-
-        num_tokens = bs * self.num_tokens_per_bs
-
-        # Common inputs
-        self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
-        self.out_cache_loc[: raw_num_token * self.speculative_num_steps].copy_(
-            forward_batch.out_cache_loc
-        )
-        self.positions[:raw_num_token].copy_(forward_batch.positions)
-        self.topk_p[:raw_bs].copy_(forward_batch.spec_info.topk_p)
-        self.topk_index[:raw_bs].copy_(forward_batch.spec_info.topk_index)
-        self.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
-        self.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
-
-        # TODO(ch-wan): support num_token_non_padded
-        if self.require_gathered_buffer:
-            self.global_num_tokens_gpu.fill_(bs * self.num_tokens_per_bs)
-            self.global_num_tokens_for_logprob_gpu.fill_(bs * self.num_tokens_per_bs)
-
-        # Attention backend
-        if bs != raw_bs:
-            forward_batch.batch_size = bs
-            forward_batch.seq_lens = self.seq_lens[:bs]
-            forward_batch.req_pool_indices = self.req_pool_indices[:bs]
-            forward_batch.positions = self.positions[:num_tokens]
-
-        if forward_batch.seq_lens_cpu is not None:
-            if bs != raw_bs:
-                self.seq_lens_cpu.fill_(self.seq_len_fill_value)
-            self.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
-            forward_batch.seq_lens_cpu = self.seq_lens_cpu[:bs]
-
-        # todo autospec draft_attn_backend should be set to current speculative_num_steps
-        self.model_runner.draft_attn_backend = self.model_runner.draft_attn_backend_for_steps[
-            self.speculative_num_steps]
-
-        self.model_runner.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
-            forward_batch, bs
-        )
-        self.raw_bs = raw_bs
-        self.bs = bs
-        # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph
-
-        # Replay
-        self._replay(forward_batch)
-        out = self.output_buffers[bs]
-
-        if bs != raw_bs:
-            out = self._postprocess_output_to_raw_bs(out, raw_bs)
-            forward_batch.batch_size = raw_bs
-            forward_batch.positions = self.positions[:raw_num_token]
-            forward_batch.seq_lens = self.seq_lens[:raw_bs]
-            forward_batch.req_pool_indices = self.req_pool_indices[:raw_bs]
-            if forward_batch.seq_lens_cpu is not None:
-                forward_batch.seq_lens_cpu = self.seq_lens_cpu[:raw_bs]
-
-        return out
+    # def replay(self, forward_batch: ForwardBatch):
+    #     """todo: replay should be rewritten because the model_runner.draft_attn_backend_for_steps is a dict
+    #     and should be set to current speculative_num_steps"""
+    #     assert forward_batch.out_cache_loc is not None
+    #     self.deepep_adapter.replay()
+    #
+    #     raw_bs = forward_batch.batch_size
+    #     raw_num_token = raw_bs * self.num_tokens_per_bs
+    #
+    #     # Pad
+    #     if self.require_mlp_tp_gather:
+    #         max_num_tokens = max(forward_batch.global_num_tokens_cpu)
+    #         max_batch_size = (
+    #             max_num_tokens // self.num_tokens_per_bs
+    #             if self.model_runner.spec_algorithm.is_eagle()
+    #             else max_num_tokens
+    #         )
+    #         index = bisect.bisect_left(self.capture_bs, max_batch_size)
+    #     else:
+    #         index = bisect.bisect_left(self.capture_bs, raw_bs)
+    #
+    #     bs = self.capture_bs[index]
+    #     if bs != raw_bs:
+    #         self.seq_lens.fill_(self.seq_len_fill_value)
+    #         self.out_cache_loc.zero_()
+    #         self.positions.zero_()
+    #
+    #     num_tokens = bs * self.num_tokens_per_bs
+    #
+    #     # Common inputs
+    #     self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
+    #     self.out_cache_loc[: raw_num_token * self.speculative_num_steps].copy_(
+    #         forward_batch.out_cache_loc
+    #     )
+    #     self.positions[:raw_num_token].copy_(forward_batch.positions)
+    #     self.topk_p[:raw_bs].copy_(forward_batch.spec_info.topk_p)
+    #     self.topk_index[:raw_bs].copy_(forward_batch.spec_info.topk_index)
+    #     self.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
+    #     self.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
+    #
+    #     # TODO(ch-wan): support num_token_non_padded
+    #     if self.require_gathered_buffer:
+    #         self.global_num_tokens_gpu.fill_(bs * self.num_tokens_per_bs)
+    #         self.global_num_tokens_for_logprob_gpu.fill_(bs * self.num_tokens_per_bs)
+    #
+    #     # Attention backend
+    #     if bs != raw_bs:
+    #         forward_batch.batch_size = bs
+    #         forward_batch.seq_lens = self.seq_lens[:bs]
+    #         forward_batch.req_pool_indices = self.req_pool_indices[:bs]
+    #         forward_batch.positions = self.positions[:num_tokens]
+    #
+    #     if forward_batch.seq_lens_cpu is not None:
+    #         if bs != raw_bs:
+    #             self.seq_lens_cpu.fill_(self.seq_len_fill_value)
+    #         self.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
+    #         forward_batch.seq_lens_cpu = self.seq_lens_cpu[:bs]
+    #
+    #     # todo autospec draft_attn_backend should be set to current speculative_num_steps
+    #     self.model_runner.draft_attn_backend = self.model_runner.draft_attn_backend_for_steps[
+    #         self.speculative_num_steps]
+    #
+    #     self.model_runner.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
+    #         forward_batch, bs
+    #     )
+    #     self.raw_bs = raw_bs
+    #     self.bs = bs
+    #     # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph
+    #
+    #     # Replay
+    #     self._replay(forward_batch)
+    #     out = self.output_buffers[bs]
+    #
+    #     if bs != raw_bs:
+    #         out = self._postprocess_output_to_raw_bs(out, raw_bs)
+    #         forward_batch.batch_size = raw_bs
+    #         forward_batch.positions = self.positions[:raw_num_token]
+    #         forward_batch.seq_lens = self.seq_lens[:raw_bs]
+    #         forward_batch.req_pool_indices = self.req_pool_indices[:raw_bs]
+    #         if forward_batch.seq_lens_cpu is not None:
+    #             forward_batch.seq_lens_cpu = self.seq_lens_cpu[:raw_bs]
+    #
+    #     return out

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -524,7 +524,9 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
         self.enable_pdmux = False
         self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
 
-        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture_for_steps(model_runner)  # use batchsizes to be captured for current step
+        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture_for_steps(
+            model_runner
+        )  # use batchsizes to be captured for current step
         self.padded_static_len = -1
 
         # Attention backend

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -516,8 +516,8 @@ class EAGLEDraftExtendCudaGraphRunnerAuto(EAGLEDraftExtendCudaGraphRunner):
         self.require_attn_tp_gather = require_attn_tp_gather(model_runner.server_args)
         self.tp_size = self.model_runner.tp_size
         self.dp_size = self.model_runner.dp_size
-        self.speculative_num_steps = speculative_num_steps  # todo use current num_step for the parameter
-        self.topk = 1  # todo use current topk for the parameter
+        self.speculative_num_steps = speculative_num_steps
+        self.topk = 1
         self.enable_profile_cuda_graph = (
             model_runner.server_args.enable_profile_cuda_graph
         )

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -440,12 +440,14 @@ class EAGLEWorker(TpModelWorker):
             )
         else:
             if self.auto_spec:
-                # logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps before change: {self.speculative_num_steps}")
                 best_params = self.spec_auto_tuner.get_best_parameters(batch.batch_size())
                 if self.speculative_num_steps != best_params.num_steps:  # if same as last step, no need to update
+                    logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps before change: {self.speculative_num_steps}")
                     self.update_member_spec_parameter(best_params)
-                    # logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps after change: {self.speculative_num_steps}")
+                    logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps after change: {self.speculative_num_steps}")
                     self.set_current_graph_and_backend_by_spec_parameter()
+                else:
+                    logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps fixed to {self.speculative_num_steps}")
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -33,9 +33,11 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
+    EAGLEDraftCudaGraphRunnerAuto,
 )
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
+    EAGLEDraftExtendCudaGraphRunnerAuto,
 )
 from sglang.srt.speculative.eagle_info import (
     EagleDraftInput,
@@ -56,6 +58,9 @@ from sglang.srt.speculative.spec_utils import (
     get_last_loc_large_page_size_large_top_k,
     load_token_map,
     select_top_k_tokens,
+)
+from sglang.srt.speculative.auto_eagle import (
+    AutoTunerEagle,
 )
 from sglang.srt.utils import (
     MultiprocessingSerializer,
@@ -100,7 +105,10 @@ class EAGLEWorker(TpModelWorker):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-
+        self.auto_spec = server_args.auto_spec
+        if self.auto_spec:
+            # self.spec_auto_tuner = AutoTunerEagle(server_args, gpu_id)  # todo init eagle AutoTuner
+            self.spec_auto_tuner = server_args.spec_auto_tuner
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
 
@@ -197,8 +205,12 @@ class EAGLEWorker(TpModelWorker):
         with self.draft_tp_context(
             self.draft_model_runner.tp_group
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
-            self.init_attention_backend()
-            self.init_cuda_graphs()
+            if not self.auto_spec:
+                self.init_attention_backend()
+                self.init_cuda_graphs()
+            else:  # init auto spec
+                self.init_attention_backend_for_steps()
+                self.init_cuda_graphs_for_steps()
 
         # Some dummy tensors
         self.num_new_pages_per_topk = torch.empty(
@@ -224,6 +236,40 @@ class EAGLEWorker(TpModelWorker):
         )
 
         self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
+
+    def init_attention_backend_for_steps(self):
+        """auto spec attn_backend init"""
+        self.draft_attn_backend_for_steps = {}
+        self.draft_extend_attn_backend_for_steps = {}
+        self.draft_model_runner.draft_attn_backend_for_steps = {}
+        # Create multi-step attn backends and cuda graph runners
+        for num_steps in self.spec_auto_tuner.step_range:
+            logger.info(f"[MY LOG] EAGLEWorker.init_attention_backend_for_steps, num_steps={num_steps}")
+            draft_backend_factory = DraftBackendFactory(
+                self.server_args,
+                self.draft_model_runner,
+                self.topk,
+                num_steps,
+            )
+
+            # Initialize decode attention backend
+            self.draft_attn_backend_for_steps[num_steps] = draft_backend_factory.create_decode_backend()
+
+            # Initialize draft extend attention backend (respects speculative_attention_mode setting)
+            self.draft_extend_attn_backend_for_steps[num_steps] = (
+                draft_backend_factory.create_draft_extend_backend()
+            )
+
+            self.draft_model_runner.draft_attn_backend_for_steps[num_steps] = self.draft_attn_backend_for_steps[num_steps]
+        # todo set current backend
+        for num_steps, attn_backend in self.draft_model_runner.draft_attn_backend_for_steps.items():
+            logger.info(f"[MY LOG] EAGLEWorker.init_attention_backend_for_steps, step={num_steps}, id attn_backend={id(attn_backend)}")
+        assert len(self.spec_auto_tuner.step_range) > 0  # make sure the step_range has values to avoid index out of range
+        # initial_step = self.spec_auto_tuner.step_range[int(len(self.spec_auto_tuner.step_range) // 2)]  # use the medium value as the start point
+        initial_step = self.spec_auto_tuner.step_range[-1]
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[initial_step]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[initial_step]
+        self.draft_model_runner.draft_attn_backend = self.draft_model_runner.draft_attn_backend_for_steps[initial_step]
 
     def init_cuda_graphs(self):
         """Capture cuda graphs."""
@@ -267,6 +313,101 @@ class EAGLEWorker(TpModelWorker):
                 f"Capture draft extend cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
             )
 
+    def init_cuda_graphs_for_steps(self):
+        """Capture cuda graphs for different num_steps"""
+        self.cuda_graph_runner_for_steps = {}
+        self.cuda_graph_runner_for_draft_extend_for_steps = {}
+        self.cuda_graph_runner = None
+        self.cuda_graph_runner_for_draft_extend = None
+
+        if self.server_args.disable_cuda_graph:
+            return
+
+        Device2DraftCudaGraphRunner = {
+            "npu": EAGLEDraftNpuGraphRunner,
+            "cuda": EAGLEDraftCudaGraphRunnerAuto,
+        }
+        # Capture draft
+        for num_steps in self.spec_auto_tuner.step_range:
+            logger.info(f"[MY LOG] EAGLEWorker.init_cuda_graphs_for_steps, num_steps={num_steps}")
+            # eagle_worker参数
+            self.speculative_num_steps = num_steps
+            self.topk = 1
+            self.speculative_num_draft_tokens = num_steps + 1
+            # model_runner参数
+            self.draft_model_runner.server_args.speculative_num_steps = num_steps  # todo changing server_args here because in CudaGraphRunner, capture function would get_eagle_info from server_args
+            self.draft_model_runner.server_args.speculative_eagle_topk = 1
+            self.draft_model_runner.server_args.speculative_num_draft_tokens = num_steps + 1
+            # self attn_backend
+            self.draft_attn_backend = self.draft_attn_backend_for_steps[num_steps]
+            self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[num_steps]
+            # model_runner attn_backend
+            self.draft_model_runner.draft_attn_backend = self.draft_model_runner.draft_attn_backend_for_steps[num_steps]  # todo will be used in EAGLEDraftCudaGraphRunner.capture_one_batch_size
+            if num_steps > 1:  # num_steps = 1 will not be captured
+                tic = time.perf_counter()
+                before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+                logger.info(
+                    f"Capture draft cuda graph begin. This can take up to several minutes. avail mem={before_mem:.2f} GB"
+                )
+                self.cuda_graph_runner_for_steps[num_steps] = Device2DraftCudaGraphRunner[
+                    self.target_worker.device
+                ](self, num_steps)
+                after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+                logger.info(
+                    f"Capture draft cuda graph end, num_step: {num_steps}. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
+                )
+            else:
+                self.cuda_graph_runner_for_steps[num_steps] = None
+
+            # Capture extend
+            if self.draft_extend_attn_backend and not _is_npu:
+                tic = time.perf_counter()
+                before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+                logger.info(
+                    f"Capture draft extend cuda graph begin. This can take up to several minutes. avail mem={before_mem:.2f} GB"
+                )
+                self.cuda_graph_runner_for_draft_extend_for_steps[num_steps] = EAGLEDraftExtendCudaGraphRunnerAuto(
+                    self, num_steps
+                )
+                after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+                logger.info(
+                    f"Capture draft extend cuda graph end, num_step: {num_steps}. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
+                )
+            logger.info(f"[MY LOG] EAGLEWorker.init_cuda_graphs_for_steps, num_steps={num_steps} capture ends")
+        # todo match the graph_runner step with the attn_backend step
+        assert len(
+            self.spec_auto_tuner.step_range) > 0  # make sure the step_range has values to avoid index out of range
+        # initial_step = self.spec_auto_tuner.step_range[
+        #     int(len(self.spec_auto_tuner.step_range) // 2)]  # use the medium value as the start point
+        initial_step = self.spec_auto_tuner.step_range[-1]
+        # set eagle_worker
+        self.speculative_num_steps = initial_step
+        self.topk = 1
+        self.speculative_num_draft_tokens = initial_step + 1
+        # set draft
+        self.draft_model_runner.server_args.speculative_num_steps = initial_step  # todo changing server_args here because in CudaGraphRunner, capture function would get_eagle_info from server_args
+        self.draft_model_runner.server_args.speculative_eagle_topk = 1
+        self.draft_model_runner.server_args.speculative_num_draft_tokens = initial_step + 1
+        # set draft attn_backend
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[initial_step]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[initial_step]
+        # set draft model_runner attn_backend
+        self.draft_model_runner.draft_attn_backend = self.draft_model_runner.draft_attn_backend_for_steps[initial_step]
+        # set cuda_graph_runer
+        self.cuda_graph_runner = self.cuda_graph_runner_for_steps[initial_step]
+        self.cuda_graph_runner_for_draft_extend = self.cuda_graph_runner_for_draft_extend_for_steps[initial_step]
+
+    def set_current_graph_and_backend_by_spec_parameter(self):
+        # draft
+        self.cuda_graph_runner = self.cuda_graph_runner_for_steps[self.speculative_num_steps]
+        self.cuda_graph_runner_for_draft_extend = self.cuda_graph_runner_for_draft_extend_for_steps[self.speculative_num_steps]
+        self.draft_attn_backend = self.draft_attn_backend_for_steps[self.speculative_num_steps]
+        self.draft_extend_attn_backend = self.draft_extend_attn_backend_for_steps[self.speculative_num_steps]
+        self.draft_model_runner.draft_attn_backend = self.draft_model_runner.draft_attn_backend_for_steps[self.speculative_num_steps]
+        # verify
+        self.target_worker.model_runner.graph_runner = self.target_worker.model_runner.graph_runner_for_steps[self.speculative_num_steps]
+        self.target_worker.model_runner.attn_backend = self.target_worker.model_runner.attn_backend_for_steps[self.speculative_num_steps]
+
     @property
     def draft_model_runner(self):
         return self.model_runner
@@ -300,6 +441,17 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph=False,
             )
         else:
+            # todo get the configured batchsize for current batchsize
+            # todo uncomment these lines to integrate, disable for the bs controlled by bs=32 and bs=64
+            # if self.auto_spec:
+            # if self.auto_spec and (batch.batch_size() <= 12 or (batch.batch_size() > 12 and self.speculative_num_steps != 3)):
+            if self.auto_spec and (batch.batch_size() <= 6 or (batch.batch_size() > 6 and batch.batch_size() <= 12 and self.speculative_num_steps != 4) or (batch.batch_size() > 12 and batch.batch_size() <= 48 and self.speculative_num_steps != 3) or batch.batch_size() > 48):
+                # logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps before change: {self.speculative_num_steps}")
+                best_params = self.spec_auto_tuner.get_best_parameters(batch.batch_size())
+                if self.speculative_num_steps != best_params.num_steps:  # if same as last step, no need to update
+                    self.update_member_spec_parameter(best_params)
+                    # logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps after change: {self.speculative_num_steps}")
+                    self.set_current_graph_and_backend_by_spec_parameter()
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
@@ -597,7 +749,7 @@ class EAGLEWorker(TpModelWorker):
             retrive_cum_len=None,
             spec_steps=self.speculative_num_steps,
             topk=self.topk,
-            draft_token_num=self.server_args.speculative_num_draft_tokens,
+            draft_token_num=self.speculative_num_draft_tokens,
             capture_hidden_mode=CaptureHiddenMode.FULL,
             seq_lens_sum=forward_batch.seq_lens_sum,
             seq_lens_cpu=forward_batch.seq_lens_cpu,
@@ -1001,6 +1153,29 @@ class EAGLEWorker(TpModelWorker):
         )
         return success, message
 
+    def update_member_spec_parameter(self, best_params):
+        """
+        todo: get current best parameter and update all parameters relative to spec_num_steps
+        """
+        # self.cuda_graph_runner.speculative_num_steps = self.speculative_num_steps
+        # self.cuda_graph_runner_for_draft_extend.speculative_num_steps = self.speculative_num_steps
+        # set eagle_worker params
+        self.speculative_num_steps, self.topk, self.speculative_num_draft_tokens = best_params.num_steps, best_params.topk, best_params.num_draft
+        # self.model_runner.speculative_num_steps = self.speculative_num_steps
+        # self.model_runner.attn_backend.speculative_num_steps = self.speculative_num_steps
+        # self.model_runner.attn_backend.speculative_num_draft_tokens = self.speculative_num_draft_tokens
+        # draft: set draft model_runner params
+        self.model_runner.server_args.speculative_num_steps = self.speculative_num_steps
+        self.model_runner.server_args.speculative_eagle_topk = self.topk
+        self.model_runner.server_args.speculative_num_draft_tokens = self.speculative_num_draft_tokens
+
+        # verify: set verify model_runner params
+        self.target_worker.model_runner.server_args.speculative_num_steps = self.speculative_num_steps
+        self.target_worker.model_runner.server_args.speculative_eagle_topk = self.topk
+        self.target_worker.model_runner.server_args.speculative_num_draft_tokens = self.speculative_num_draft_tokens
+        # self.target_worker.model_runner.graph_runner.num_tokens_per_bs = self.speculative_num_draft_tokens
+        # # verify - target_worker
+        # self.target_worker.model_runner.attn_backend.speculative_num_draft_tokens = self.speculative_num_draft_tokens
 
 @torch.compile(dynamic=True, disable=_is_npu)
 def get_last_loc_large_page_size_top_k_1(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -445,7 +445,7 @@ class EAGLEWorker(TpModelWorker):
             # todo uncomment these lines to integrate, disable for the bs controlled by bs=32 and bs=64
             # if self.auto_spec:
             # if self.auto_spec and (batch.batch_size() <= 12 or (batch.batch_size() > 12 and self.speculative_num_steps != 3)):
-            if self.auto_spec and (batch.batch_size() <= 6 or (batch.batch_size() > 6 and batch.batch_size() <= 12 and self.speculative_num_steps != 4) or (batch.batch_size() > 12 and batch.batch_size() <= 48 and self.speculative_num_steps != 3) or batch.batch_size() > 48):
+            if self.auto_spec:
                 # logger.info(f"[MY LOG] bs {batch.batch_size()}, speculative_num_steps before change: {self.speculative_num_steps}")
                 best_params = self.spec_auto_tuner.get_best_parameters(batch.batch_size())
                 if self.speculative_num_steps != best_params.num_steps:  # if same as last step, no need to update


### PR DESCRIPTION
## Motivation

Support Automatic tuning of  speculative decoding parameters for spec v1. Currently, speculative decoding parameters including speculative_num_steps, speculative_topk, speculative_num_draft_tokens have to be manually set. This feature
 supports: (1) setting different speculative decoding parameters get the optimal throughputs across different batchsizes; (2) automatically tune the parameters based on the acceptance rate; (3) user configuration of tuning ranges on different models.

- RFC: https://github.com/sgl-project/sglang/issues/15319

## Modifications

- python/sglang/srt/server_args.py:
1. Basic usage: add `--auto-spec` flag for EAGLE3
2. Support config files: add `--speculative-config-file` to support a given config file
3. Suport saving tuning results：add `--save-tune-results` to save tune results to file

- python/sglang/srt/speculative/auto_eagle.py
1. Init parameter tuner
2. Tune parameters for different batchsizes based on acceptance rate

- python/sglang/srt/speculative/eagle_worker.py
1. Init attention backends for different speculative_num_steps
2. Init cuda graphs for different speculative_num_steps
3. Update speculative decoding parameters and graph in each decoding

- python/sglang/srt/model_executor/model_runner.py
1. Init attention backends for different speculative_num_steps
2. Init cuda graphs for different speculative_num_steps

## Accuracy Test

### Test set up:
- Target Model: Qwen3-32B
- Draft Model: Qwen3-32B-EAGLE3
- Dataset: gsm8k
- TP size: 4
- Hardware: H20
- Static speculative decoding parameter: speculative_num_steps=3, topk=1, num_draft=4
- AutoSpec parameter tuning range: (given by parameter --speculative-config-file)

| batchsize | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 |
| --------- | -- | -- | -- | -- | -- | -- | -- | -- |
| speculative_num_steps range | [3, 4, 5, 6] | [3, 4, 5, 6] | [3, 4, 5, 6] | [4] | [3] | [3] | [1, 2, 3, 4] | [1, 2, 3, 4] |

### Test results:

| Parameter Settings | max parallel | Accuracy | Latency(s) | Output throughput(token/s) | 
| ------------------- | ------------ | --------- | ----------- | ---------------------------- |
| Static (3,1,4) | 64 | 0.839 | 281.781 | 1263.505 |
| AutoSpec | 64 | 0.840 | 270.204 | 1318.292 |

## Benchmarking and Profiling

### Test set up:
- Target Model: Qwen3-32B
- Draft Model: Qwen3-32B-EAGLE3
- Dataset: ShareGPT
- TP size: 4
- Hardware: H20
- AutoSpec tuning range: (given by parameter --speculative-config-file)

| batchsize | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 |
| --------- | -- | -- | -- | -- | -- | -- | -- | -- |
| speculative_num_steps range | [3, 4, 5, 6] | [3, 4, 5, 6] | [3, 4, 5, 6] | [4] | [3] | [3] | [1, 2, 3, 4] | [1, 2, 3, 4] |

### Test results: 

<div align="center"><img width="578" height="362" alt="image" src="https://github.com/user-attachments/assets/7b76508b-1de7-4797-b9bd-dc7d2175c29a" />


<p align="left">The figure plots the improvement ratio of AutoSpec over different dynamic parameters on different batchsizes, which is calculated by: 
$$ratio=(AutoSpec Throughput - Static Parameter Throughput) / Static Parameter Throughput$$</p>

<p align="left">Raw Throughput(token/s):

| parallel | 1 | 2 | 4 | 8 | 16 | 32 | 64 |
| -- | -- | -- | -- | -- | -- | -- | -- |
| Static (1,1,2) | 142.285 | 252.162 | 394.126 | 583.456 | 750.780 | 940.010 | 996.267 |
| Static (2,1,3) | 195.368 | 329.553 | 491.956 | 685.590 | 870.915 | 955.935 | 1037.813 |
| Static (3,1,4) | 236.147 | 368.323 | 543.320 | 694.444 | 882.260 | 990.715 | 1053.897 |
| Static (4,1,5) | 257.460 | 400.305 | 532.184 | 714.250 | 884.910 | 965.675 | 1028.133 |
| Static (5,1,6) | 272.012 | 432.068 | 539.268 | 722.438 | 873.035 | 970.675 | 1025.553 |
| Static (6,1,7) | 282.987 | 446.577 | 534.482 | 714.192 | 850.510 | 926.680 | 990.513| 
| AutoSpec | 292.757 | 459.517 | 561.096 | 722.230 | 886.900 | 987.785 | 1057.613 | 

</p>

