### PR TITLE
[NPU] support dsv32 radixcache on ascend

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -505,7 +505,7 @@ class AscendAttnBackend(AttentionBackend):
             if self.forward_metadata.actual_seq_lengths_q is not None:
                 actual_seq_qlen = self.forward_metadata.actual_seq_lengths_q
             else:
-                actual_seq_qlen = torch.cumsum(forward_batch.seq_lens, dim=0)
+                actual_seq_qlen = torch.cumsum(forward_batch.extend_seq_lens, dim=0)
         else:
             if self.forward_metadata.actual_seq_lengths_q is None:
                 if (

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -1222,7 +1222,7 @@ class Indexer(MultiPlatformOp):
                 )
             else:
                 actual_seq_lengths_kv = forward_batch.seq_lens
-                actual_seq_lengths_q = forward_batch.seq_lens.cumsum(dim=0)
+                actual_seq_lengths_q = forward_batch.extend_seq_lens.cumsum(dim=0)
         else:
             if forward_batch.attn_backend.forward_metadata.actual_seq_lengths_q is None:
                 if (

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -769,6 +769,14 @@ class MLATokenToKVPoolHost(HostKVCache):
                 pin_memory=self.pin_memory,
                 allocator=self.allocator,
             )
+            if self.device_pool.index_head_dim is not None:
+                self.index_k_buffer = alloc_func(
+                    (*base_dims, self.device_pool.index_head_dim),
+                    dtype=self.dtype,
+                    device=self.device,
+                    pin_memory=self.pin_memory,
+                    allocator=self.allocator,
+                )
             # Return k_buffer to preserve original kv_buffer and data_refs init logic,
             # though Ascend doesn't use these parameters.
             return self.k_buffer
@@ -844,6 +852,16 @@ class MLATokenToKVPoolHost(HostKVCache):
                         host_k=self.k_buffer,
                         device_v=device_pool.v_buffer,
                         host_v=self.v_buffer,
+                        device_index_k=(
+                            device_pool.index_k_buffer
+                            if device_pool.index_head_dim is not None
+                            else None
+                        ),
+                        host_index_k=(
+                            self.index_k_buffer
+                            if device_pool.index_head_dim is not None
+                            else None
+                        ),
                         page_size=self.page_size,
                         direction=TransferDirection.H2D,
                     )
@@ -905,6 +923,16 @@ class MLATokenToKVPoolHost(HostKVCache):
                     host_k=self.k_buffer,
                     device_v=device_pool.v_buffer,
                     host_v=self.v_buffer,
+                    device_index_k=(
+                        device_pool.index_k_buffer
+                        if device_pool.index_head_dim is not None
+                        else None
+                    ),
+                    host_index_k=(
+                        self.index_k_buffer
+                        if device_pool.index_head_dim is not None
+                        else None
+                    ),
                     page_size=self.page_size,
                     direction=TransferDirection.D2H,
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Ascend currently does not support the radixcache feature on the DeepSeek-3.2 model

## Modifications

<!-- Detail the changes made in this pull request. -->
1. We have modified the inputs of `npu_sparse_flash_attention` and `npu_lightning_indexer` to `extend_seq_lens`. This change ensures correct input in the radixcache scenario without affecting the original functionality.
2. We have added the transfer of `index_k_buffer` in `memory_pool_host.py`.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```sh
export MODEL_PATH=/home/weights/DeepSeek-3.2-w8a8
python -m sglang.launch_server \
    --model-path $MODEL_PATH --quantization modelslim \
    --host 0.0.0.0 --port 8100 \
    --trust-remote-code --attention-backend ascend --device npu \
    --tp-size 16 --mem-fraction-static 0.8 \
    --chunked-prefill-size -1 \
	--disable-cuda-graph
```


<img width="585" height="161" alt="image" src="https://github.com/user-attachments/assets/957d3dfa-b422-42fd-b948-f74fd63068ed" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
