### PR TITLE
fix: move nightly whl to cuda version folder

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -14,6 +14,11 @@ on:
         description: 'Specific commit SHA to build (leave empty for latest)'
         required: false
         type: string
+      cuda_version:
+        description: 'CUDA version (e.g., 129 or 130)'
+        required: false
+        default: '129'
+        type: string
 
 concurrency:
   group: release-pypi-nightly-${{ github.ref }}
@@ -142,6 +147,7 @@ jobs:
           python3 scripts/update_nightly_whl_index.py \
             --commit-hash ${{ needs.build-nightly-wheel.outputs.commit_hash }} \
             --nightly-version ${{ needs.build-nightly-wheel.outputs.nightly_version }} \
+            --cuda-version ${{ inputs.cuda_version || '129' }} \
             --build-date ${{ needs.build-nightly-wheel.outputs.build_date }}
 
       - name: Push wheel index

--- a/scripts/update_nightly_whl_index.py
+++ b/scripts/update_nightly_whl_index.py
@@ -14,7 +14,6 @@ import argparse
 import hashlib
 import pathlib
 import re
-import tomllib
 
 
 def compute_sha256(file_path: pathlib.Path) -> str:
@@ -33,15 +32,13 @@ def detect_cuda_version() -> str:
         CUDA version string like "cu129" or "cu130"
     """
     pyproject_path = pathlib.Path("python/pyproject.toml")
-    with open(pyproject_path, "rb") as f:
-        config = tomllib.load(f)
+    content = pyproject_path.read_text()
 
-    for dep in config["project"]["dependencies"]:
-        # Match cuda-python==12.9 or cuda-python==13.0, etc.
-        match = re.match(r"cuda-python==(\d+)\.(\d+)", dep)
-        if match:
-            major, minor = match.groups()
-            return f"cu{major}{minor}"  # "cu129" or "cu130"
+    # Match cuda-python==12.9 or cuda-python==13.0, etc.
+    match = re.search(r'"cuda-python==(\d+)\.(\d+)"', content)
+    if match:
+        major, minor = match.groups()
+        return f"cu{major}{minor}"  # "cu129" or "cu130"
 
     raise ValueError("cuda-python dependency not found in pyproject.toml")
 


### PR DESCRIPTION
## Motivation

For better organization, nightly whl files are added to the respective cuda version folder instead of the current generic nightly folder in the whl repo. Now, the folder structure is as follows:

cu129/
- index.html (sglang, sgl-kernel)
- /sglang (nightly whl)
- /sgl-kernel (sgl kernel)

The workflow now accepts a cuda python version as a parameter (defaults to cu129)

## Modifications

Updated update_nightly_whl_index.py to place whl in the correct position, and auto detect the cuda python version (ie. if cuda-python=13.0, then whls will be placed in cu130)

## Accuracy Tests

https://github.com/sgl-project/whl/tree/gh-pages/cu129

Installation of nightly whl works with: pip install sglang==0.5.8.dev0+g0189f41c3 --extra-index-url https://sgl-project.github.io/whl/cu129/

> However, there is a hash mismatch for kernel 0.3.21 for x86_64 - 
<a href="https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl#sha256=57dfb3a2a3cd759f499c32e2bad5f6489b7c58f7f9a84ee00c53ec92d303aaab">sgl_kernel-0.3.21-cp310-abi3-manylinux2014_x86_64.whl</a><br> is outdated or out of sync, and the newest hash is e7f66eb6a149ae2d1ea5a5bc29bc14cbb4322a23952d8d861eedbb253850c90f. This is unrelated to this code change, and someone likely created a new sgl-kernel whl and didn't update the index accordingly.

## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
