### PR TITLE
Fix missing raise keyword for AssertionError in eic_storage.py

### DIFF
--- a/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
+++ b/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
@@ -170,7 +170,7 @@ class EICStorage(HiCacheStorage):
 
         remote_url = config.get("remote_url", None)
         if remote_url is None:
-            AssertionError("remote_url is None")
+            raise AssertionError("remote_url is None")
 
         endpoint = remote_url[len("eic://") :]
 


### PR DESCRIPTION
## Summary                                                                                                  
- Add missing `raise` keyword for `AssertionError` in `eic_storage.py:173`, which caused the error to be    
silently ignored when `remote_url` is None                                                                  
                                                                                                            
## Test plan                                                                                                
- [ ] Code review