### PR TITLE
[Kernel] Fuse Q FP8 cast into KV buffer kernel for TRTLLM MHA backend

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/trtllm_fp8_kv_kernel.py
+++ b/python/sglang/srt/layers/attention/triton_ops/trtllm_fp8_kv_kernel.py
@@ -2,13 +2,14 @@
 Fused FP8 quantization + paged KV cache write kernel for TRTLLM MHA backend.
 
 This kernel fuses the following operations:
-1. FP8 quantization of K and V tensors (from BF16/FP16 to FP8)
+1. FP8 quantization of Q, K and V tensors (from BF16/FP16 to FP8)
 2. Per-token or per-page scale computation
 3. Writing quantized K/V to paged KV cache layout
+4. In-place FP8 conversion of Q tensor (written to pre-allocated output buffer)
 
 Performance benefits:
 - Eliminates intermediate FP8 tensors in memory
-- Reduces kernel launch overhead
+- Reduces kernel launch overhead (single kernel for Q, K, V quantization)
 - Better memory bandwidth utilization
 """
 
@@ -82,6 +83,57 @@ def _process_kv_tensor(
         )
 
         tl.store(cache_ptr + cache_offsets, block_fp8, mask=mask)
+
+
+@triton.jit
+def _process_q_tensor(
+    token_id,
+    head_block_id,
+    q_ptr,
+    q_out_ptr,
+    num_q_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    q_out_stride_token: tl.constexpr,
+    q_out_stride_head: tl.constexpr,
+    q_out_stride_dim: tl.constexpr,
+    BLOCK_HEAD: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """Process a block of heads for Q tensor (cast to FP8, no cache write)."""
+    head_idx = head_block_id * BLOCK_HEAD
+
+    for dim_idx in range(0, head_dim, BLOCK_DIM):
+        head_offsets = head_idx + tl.arange(0, BLOCK_HEAD)
+        dim_offsets = dim_idx + tl.arange(0, BLOCK_DIM)
+
+        # Use real boundaries for masking (avoid Python min() with Triton scalars)
+        head_mask = head_offsets < num_q_heads
+        dim_mask = dim_offsets < head_dim
+        mask = head_mask[:, None] & dim_mask[None, :]
+
+        # Load from Q input
+        q_offsets = (
+            token_id * q_stride_token
+            + head_offsets[:, None] * q_stride_head
+            + dim_offsets[None, :] * q_stride_dim
+        )
+
+        block = tl.load(q_ptr + q_offsets, mask=mask, other=0.0)
+
+        # Cast to FP8 (no scale for Q, equivalent to q.to(fp8))
+        block_fp8 = block.to(tl.float8e4nv)
+
+        # Write to Q output buffer
+        q_out_offsets = (
+            token_id * q_out_stride_token
+            + head_offsets[:, None] * q_out_stride_head
+            + dim_offsets[None, :] * q_out_stride_dim
+        )
+
+        tl.store(q_out_ptr + q_out_offsets, block_fp8, mask=mask)
 
 
 @triton.jit
@@ -196,6 +248,170 @@ def _fused_fp8_set_kv_buffer_kernel(
             v_cache_stride_offset,
             v_cache_stride_head,
             v_cache_stride_dim,
+            BLOCK_HEAD,
+            BLOCK_DIM,
+        )
+
+
+@triton.jit
+def _fused_fp8_set_qkv_buffer_kernel(
+    # Q tensor (input and output)
+    q_ptr,  # [num_tokens, num_q_heads, head_dim] input
+    q_out_ptr,  # [num_tokens, num_q_heads, head_dim] output FP8
+    # K and V tensors
+    k_ptr,  # [num_tokens, num_kv_heads, head_dim]
+    v_ptr,  # [num_tokens, num_kv_heads, head_dim]
+    # Output KV cache buffers (FP8 paged layout)
+    k_cache_ptr,  # [total_slots, num_kv_heads, head_dim]
+    v_cache_ptr,  # [total_slots, num_kv_heads, head_dim]
+    # Cache location indices
+    cache_loc_ptr,  # [num_tokens] -> token to cache location mapping
+    # Pointers to scalar inverse scales (computed on GPU in wrapper)
+    inv_k_scale_ptr,  # pointer to 0-D tensor on GPU
+    inv_v_scale_ptr,  # pointer to 0-D tensor on GPU
+    use_provided_scale: tl.constexpr,  # whether to use provided scale for K/V
+    # Tensor dimensions
+    num_q_heads: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    page_size: tl.constexpr,
+    # Number of head blocks for mapping
+    num_kv_head_blocks: tl.constexpr,  # Bkv = ceil(num_kv_heads / BLOCK_HEAD)
+    num_q_head_blocks: tl.constexpr,  # Bq = ceil(num_q_heads / BLOCK_HEAD)
+    # Strides for Q input [num_tokens, num_q_heads, head_dim]
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    # Strides for Q output [num_tokens, num_q_heads, head_dim]
+    q_out_stride_token: tl.constexpr,
+    q_out_stride_head: tl.constexpr,
+    q_out_stride_dim: tl.constexpr,
+    # Strides for K input [num_tokens, num_kv_heads, head_dim]
+    k_stride_token: tl.constexpr,
+    k_stride_head: tl.constexpr,
+    k_stride_dim: tl.constexpr,
+    # Strides for K cache [total_slots, num_kv_heads, head_dim] (logically paged)
+    k_cache_stride_page: tl.constexpr,
+    k_cache_stride_offset: tl.constexpr,
+    k_cache_stride_head: tl.constexpr,
+    k_cache_stride_dim: tl.constexpr,
+    # Strides for V input [num_tokens, num_kv_heads, head_dim]
+    v_stride_token: tl.constexpr,
+    v_stride_head: tl.constexpr,
+    v_stride_dim: tl.constexpr,
+    # Strides for V cache [total_slots, num_kv_heads, head_dim] (logically paged)
+    v_cache_stride_page: tl.constexpr,
+    v_cache_stride_offset: tl.constexpr,
+    v_cache_stride_head: tl.constexpr,
+    v_cache_stride_dim: tl.constexpr,
+    # Block sizes
+    BLOCK_HEAD: tl.constexpr,  # Number of heads per block
+    BLOCK_DIM: tl.constexpr,  # Head dimension block size
+):
+    """
+    Fused FP8 quantization kernel for Q, K, V tensors.
+
+    - Q: cast to FP8 and write to q_out (no cache)
+    - K, V: cast to FP8 with optional scale and write to paged KV cache
+
+    Grid: (num_tokens, 2 * num_kv_head_blocks + num_q_head_blocks)
+    Block mapping:
+      [0, Bkv)                -> K, head_block = block_id
+      [Bkv, 2*Bkv)            -> V, head_block = block_id - Bkv
+      [2*Bkv, 2*Bkv + Bq)     -> Q, head_block = block_id - 2*Bkv
+    """
+    # Get program IDs
+    token_id = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    # Determine which tensor to process based on block_id
+    if block_id < num_kv_head_blocks:
+        # Process K tensor
+        head_block_id = block_id
+
+        # Get cache location for this token
+        cache_loc = tl.load(cache_loc_ptr + token_id)
+        page_id = cache_loc // page_size
+        page_offset = cache_loc % page_size
+
+        if use_provided_scale:
+            inv_scale = tl.load(inv_k_scale_ptr)
+        else:
+            inv_scale = 1.0
+
+        _process_kv_tensor(
+            token_id,
+            head_block_id,
+            page_id,
+            page_offset,
+            k_ptr,
+            k_cache_ptr,
+            inv_scale,
+            use_provided_scale,
+            num_kv_heads,
+            head_dim,
+            k_stride_token,
+            k_stride_head,
+            k_stride_dim,
+            k_cache_stride_page,
+            k_cache_stride_offset,
+            k_cache_stride_head,
+            k_cache_stride_dim,
+            BLOCK_HEAD,
+            BLOCK_DIM,
+        )
+    elif block_id < 2 * num_kv_head_blocks:
+        # Process V tensor
+        head_block_id = block_id - num_kv_head_blocks
+
+        # Get cache location for this token
+        cache_loc = tl.load(cache_loc_ptr + token_id)
+        page_id = cache_loc // page_size
+        page_offset = cache_loc % page_size
+
+        if use_provided_scale:
+            inv_scale = tl.load(inv_v_scale_ptr)
+        else:
+            inv_scale = 1.0
+
+        _process_kv_tensor(
+            token_id,
+            head_block_id,
+            page_id,
+            page_offset,
+            v_ptr,
+            v_cache_ptr,
+            inv_scale,
+            use_provided_scale,
+            num_kv_heads,
+            head_dim,
+            v_stride_token,
+            v_stride_head,
+            v_stride_dim,
+            v_cache_stride_page,
+            v_cache_stride_offset,
+            v_cache_stride_head,
+            v_cache_stride_dim,
+            BLOCK_HEAD,
+            BLOCK_DIM,
+        )
+    else:
+        # Process Q tensor
+        head_block_id = block_id - 2 * num_kv_head_blocks
+
+        _process_q_tensor(
+            token_id,
+            head_block_id,
+            q_ptr,
+            q_out_ptr,
+            num_q_heads,
+            head_dim,
+            q_stride_token,
+            q_stride_head,
+            q_stride_dim,
+            q_out_stride_token,
+            q_out_stride_head,
+            q_out_stride_dim,
             BLOCK_HEAD,
             BLOCK_DIM,
         )
@@ -502,3 +718,213 @@ def _naive_fp8_set_kv_buffer(
         page_offsets = cache_loc % page_size
         k_cache[page_ids, page_offsets] = k
         v_cache[page_ids, page_offsets] = v
+
+
+def fused_fp8_set_qkv_buffer(
+    q: torch.Tensor,  # [num_tokens, num_q_heads, head_dim] or [num_tokens, num_q_heads * head_dim]
+    k: torch.Tensor,  # [num_tokens, num_kv_heads, head_dim] or [num_tokens, num_kv_heads * head_dim]
+    v: torch.Tensor,  # [num_tokens, num_kv_heads, head_dim] or [num_tokens, num_kv_heads * head_dim]
+    k_cache: torch.Tensor,  # [total_slots, num_kv_heads, head_dim] or [num_pages, page_size, num_kv_heads, head_dim]
+    v_cache: torch.Tensor,  # same as k_cache
+    cache_loc: torch.Tensor,  # [num_tokens], dtype=int32
+    q_out: torch.Tensor,  # [num_tokens, num_q_heads, head_dim] FP8, pre-allocated output buffer
+    inv_k_scale: Optional[torch.Tensor] = None,  # Pre-computed 1/k_scale tensor
+    inv_v_scale: Optional[torch.Tensor] = None,  # Pre-computed 1/v_scale tensor
+    page_size: int = 16,
+) -> None:
+    """
+    Fused FP8 quantization for Q, K, V tensors in a single kernel launch.
+
+    This function performs:
+    1. Q: cast to FP8 and write to q_out (pre-allocated buffer, no cache write)
+    2. K, V: cast to FP8 with optional scale and write to paged KV cache
+
+    Args:
+        q: Query tensor, can be 2D or 3D
+        k: Key tensor after RoPE, can be 2D or 3D
+        v: Value tensor, can be 2D or 3D
+        k_cache: Paged K cache buffer in FP8
+        v_cache: Paged V cache buffer in FP8
+        cache_loc: Cache location for each token, shape [num_tokens]
+        q_out: Pre-allocated FP8 output buffer for Q (MUST be pre-allocated, no allocation here)
+        inv_k_scale: Pre-computed inverse K scale tensor (1/k_scale), or None
+        inv_v_scale: Pre-computed inverse V scale tensor (1/v_scale), or None
+        page_size: Number of tokens per page
+
+    Note:
+        - q_out MUST be pre-allocated by the caller to ensure CUDA graph compatibility.
+        - inv_k_scale/inv_v_scale MUST be pre-computed tensors to avoid allocation during forward.
+        - This function does NOT allocate any memory, making it safe for CUDA graph capture.
+    """
+    num_tokens = k.shape[0]
+
+    if num_tokens == 0:
+        return
+
+    # Step 1: Infer num_kv_heads and head_dim from cache shape
+    if k_cache.ndim == 3:
+        total_slots, num_kv_heads, head_dim = k_cache.shape
+        assert (
+            total_slots % page_size == 0
+        ), f"total_slots ({total_slots}) must be divisible by page_size ({page_size})"
+    elif k_cache.ndim == 4:
+        num_pages, ps, num_kv_heads, head_dim = k_cache.shape
+        assert (
+            ps == page_size
+        ), f"page_size mismatch: cache has {ps}, expected {page_size}"
+    else:
+        raise ValueError(f"Unsupported k_cache.ndim={k_cache.ndim}, expected 3 or 4")
+
+    # Step 2: Infer num_q_heads from q shape
+    if q.ndim == 3:
+        num_q_heads = q.shape[1]
+        assert (
+            q.shape[2] == head_dim
+        ), f"head_dim mismatch: q.shape[2]={q.shape[2]} vs cache={head_dim}"
+        q_3d = q
+    elif q.ndim == 2:
+        # Infer num_q_heads from q_out
+        if q_out.ndim == 3:
+            num_q_heads = q_out.shape[1]
+        else:
+            raise ValueError("Cannot infer num_q_heads from 2D q without 3D q_out")
+        q_3d = q.view(num_tokens, num_q_heads, head_dim)
+    else:
+        raise ValueError(f"Unsupported q.ndim={q.ndim}, expected 2 or 3")
+
+    # Step 3: Normalize k, v to 3D
+    if k.ndim == 3:
+        k_3d = k
+        v_3d = v
+    elif k.ndim == 2:
+        k_3d = k.view(num_tokens, num_kv_heads, head_dim)
+        v_3d = v.view(num_tokens, num_kv_heads, head_dim)
+    else:
+        raise ValueError(f"Unsupported k.ndim={k.ndim}, expected 2 or 3")
+
+    # Step 4: Normalize q_out to 3D
+    if q_out.ndim == 3:
+        q_out_3d = q_out
+    elif q_out.ndim == 2:
+        q_out_3d = q_out.view(num_tokens, num_q_heads, head_dim)
+    else:
+        raise ValueError(f"Unsupported q_out.ndim={q_out.ndim}, expected 2 or 3")
+
+    # Step 5: Compute cache strides
+    if k_cache.ndim == 3:
+        stride_slot = k_cache.stride(0)
+        stride_head = k_cache.stride(1)
+        stride_dim = k_cache.stride(2)
+
+        k_cache_stride_page = stride_slot * page_size
+        k_cache_stride_offset = stride_slot
+        k_cache_stride_head = stride_head
+        k_cache_stride_dim = stride_dim
+
+        v_stride_slot = v_cache.stride(0)
+        v_stride_head = v_cache.stride(1)
+        v_stride_dim = v_cache.stride(2)
+
+        v_cache_stride_page = v_stride_slot * page_size
+        v_cache_stride_offset = v_stride_slot
+        v_cache_stride_head = v_stride_head
+        v_cache_stride_dim = v_stride_dim
+    else:
+        k_cache_stride_page = k_cache.stride(0)
+        k_cache_stride_offset = k_cache.stride(1)
+        k_cache_stride_head = k_cache.stride(2)
+        k_cache_stride_dim = k_cache.stride(3)
+
+        v_cache_stride_page = v_cache.stride(0)
+        v_cache_stride_offset = v_cache.stride(1)
+        v_cache_stride_head = v_cache.stride(2)
+        v_cache_stride_dim = v_cache.stride(3)
+
+    # Step 6: Compute input strides
+    q_stride_token = q_3d.stride(0)
+    q_stride_head = q_3d.stride(1)
+    q_stride_dim = q_3d.stride(2)
+
+    q_out_stride_token = q_out_3d.stride(0)
+    q_out_stride_head = q_out_3d.stride(1)
+    q_out_stride_dim = q_out_3d.stride(2)
+
+    k_stride_token = k_3d.stride(0)
+    k_stride_head = k_3d.stride(1)
+    k_stride_dim = k_3d.stride(2)
+
+    v_stride_token = v_3d.stride(0)
+    v_stride_head = v_3d.stride(1)
+    v_stride_dim = v_3d.stride(2)
+
+    # Step 7: Compute block sizes and grid
+    BLOCK_HEAD = 8  # Fixed for fewer Triton variants
+    BLOCK_DIM = min(head_dim, 128)
+
+    num_kv_head_blocks = (num_kv_heads + BLOCK_HEAD - 1) // BLOCK_HEAD
+    num_q_head_blocks = (num_q_heads + BLOCK_HEAD - 1) // BLOCK_HEAD
+
+    # Grid: (num_tokens, 2 * num_kv_head_blocks + num_q_head_blocks)
+    # Block mapping:
+    #   [0, Bkv)            -> K
+    #   [Bkv, 2*Bkv)        -> V
+    #   [2*Bkv, 2*Bkv + Bq) -> Q
+    total_head_blocks = 2 * num_kv_head_blocks + num_q_head_blocks
+    grid = (num_tokens, total_head_blocks)
+
+    device = q_3d.device
+
+    # Step 8: Handle scales for K/V (Q has no scale)
+    # inv_k_scale/inv_v_scale are pre-computed tensors passed from caller
+    # This avoids any tensor allocation during forward, making it CUDA graph safe
+    use_provided_scale = inv_k_scale is not None and inv_v_scale is not None
+
+    if use_provided_scale:
+        inv_k_scale_ptr = inv_k_scale
+        inv_v_scale_ptr = inv_v_scale
+    else:
+        # Dummy pointers, won't be accessed when use_provided_scale=False
+        inv_k_scale_ptr = k_3d
+        inv_v_scale_ptr = k_3d
+
+    # Step 9: Launch fused kernel
+    _fused_fp8_set_qkv_buffer_kernel[grid](
+        q_3d,
+        q_out_3d,
+        k_3d,
+        v_3d,
+        k_cache,
+        v_cache,
+        cache_loc,
+        inv_k_scale_ptr,
+        inv_v_scale_ptr,
+        use_provided_scale,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        num_kv_head_blocks,
+        num_q_head_blocks,
+        q_stride_token,
+        q_stride_head,
+        q_stride_dim,
+        q_out_stride_token,
+        q_out_stride_head,
+        q_out_stride_dim,
+        k_stride_token,
+        k_stride_head,
+        k_stride_dim,
+        k_cache_stride_page,
+        k_cache_stride_offset,
+        k_cache_stride_head,
+        k_cache_stride_dim,
+        v_stride_token,
+        v_stride_head,
+        v_stride_dim,
+        v_cache_stride_page,
+        v_cache_stride_offset,
+        v_cache_stride_head,
+        v_cache_stride_dim,
+        BLOCK_HEAD=BLOCK_HEAD,
+        BLOCK_DIM=BLOCK_DIM,
+    )


### PR DESCRIPTION
## Summary                                                                              
  - Fuse the FP8 cast operation for Q tensor into the existing KV buffer kernel for TRTLLM
   MHA backend                                                                            
  - This eliminates a separate `q.to(fp8)` kernel launch, reducing kernel launch overhead 
  and improving memory bandwidth utilization                                              
                                
                                                                                          
  ## Motivation                                                                           
  In the original implementation, FP8 attention requires two separate operations:         
  1. `_fused_fp8_set_kv_buffer_kernel`: quantize K/V to FP8 and write to paged KV cache   
  2. `q.to(torch.float8_e4m3fn)`: cast Q to FP8 (via PyTorch elementwise kernel)          
                                                                                          
  This PR fuses both operations into a single Triton kernel, eliminating the extra kernel 
  launch overhead.                                                                        
                                                                                          
  ## Changes                                                                              
                                                                                          
  ### Kernel Design (`trtllm_fp8_kv_kernel.py`)                                           
  - Added `_fused_fp8_set_qkv_buffer_kernel` with precise block mapping to avoid empty    
  thread blocks in GQA models:                                                            
    - Grid: `(num_tokens, 2 * Bkv + Bq)` where `Bkv = ceil(num_kv_heads / BLOCK_HEAD)`,   
  `Bq = ceil(num_q_heads / BLOCK_HEAD)`                                                   
    - Block mapping: `[0, Bkv)` → K, `[Bkv, 2*Bkv)` → V, `[2*Bkv, 2*Bkv+Bq)` → Q          
  - Added `_process_q_tensor` helper for Q FP8 cast (equivalent to `q.to(fp8)`)           
  - Q cast produces bitwise-identical results to `q.to(torch.float8_e4m3fn)`              
                                                                                          
  ### Backend Changes (`trtllm_mha_backend.py`)                                           
  - Added `q_fp8_buffer` for pre-allocated Q output buffer                                
  - Added `_inv_scale_cache` to cache pre-computed inverse scale tensors per layer        
  - Added `_ensure_q_fp8_buffer()` for lazy allocation in non-CUDA-graph mode             
  - Added `_get_inv_scale_tensors()` to avoid tensor allocation during CUDA graph capture 
  - Modified `forward_decode` and `forward_extend` to use fused QKV path when FP8         
  attention is enabled                                                                    
                                                                                          
  ### CUDA Graph Compatibility                                                            
  - `q_fp8_buffer` is pre-allocated in `init_cuda_graph_state()`                          
  - Inverse scale tensors are computed once and cached in `_inv_scale_cache`              
  - No tensor allocation occurs during forward pass, ensuring CUDA graph capture works    
  correctly                                                                               
                                                                                          
  ## Performance                                                                          
  Tested on GLM-4.7 with 4xB300, FP8 attention, TP=4:                                     
                                                                                          
  | Metric | Before | After | Improvement |                                               
  |--------|--------|-------|-------------|                                               
  | Output throughput | 990 tok/s | 1019 tok/s | +2.9% |                                  
  | Q+KV kernel time | 4262 us | 1483 us | -65% |                                         
                                                                                          
  Profile comparison (920 calls per decode step on TP0):                                  
  - **Before**: `_fused_fp8_set_kv_buffer_kernel` (1432us) + `q.to(fp8)` elementwise      
  (2830us) = 4262us                                                                       
  - **After**: `_fused_fp8_set_qkv_buffer_kernel` (1483us)                                
                                                                                          
  ### Before                                                                              
  <img width="1096" height="755" alt="beforechange" src="https://github.com/user-attachments/assets/b986639a-b081-450e-aed9-a29d64357478" />                                                        
                                                                                          
  ### After                                                                               
   <img width="1397" height="864" alt="afterchange" src="https://github.com/user-attachments/assets/da65c0cb-ed7c-4d3f-bdce-8ad27a9994d2" />