### PR TITLE
fix: improve transformers 5.0 compatibility

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -940,9 +940,11 @@ class ModelConfig:
         needs_tf_v5 = is_glm_46vmoe
 
         tf_version = version.parse(tf_version_str)
-        required_version = version.parse("5.0.0dev0")
+        # Accept any version >= 5.0.0 (including dev, rc, and release versions)
+        required_major_minor = (5, 0)
+        tf_major_minor = (tf_version.major, tf_version.minor)
 
-        if tf_version < required_version:
+        if tf_major_minor < required_major_minor:
             if needs_tf_v5:
                 raise ValueError(
                     f"Transformers version {tf_version_str} is not supported for model {self.model_path} "

--- a/python/sglang/srt/configs/utils.py
+++ b/python/sglang/srt/configs/utils.py
@@ -15,13 +15,32 @@ def register_image_processor(
     """
     register customized hf image processor while removing hf impl
     """
-    AutoImageProcessor.register(
-        config, slow_image_processor_class=image_processor, exist_ok=True
-    )
+    try:
+        # Attempt to register with named parameter for transformers >= 5.0
+        AutoImageProcessor.register(
+            config, 
+            slow_image_processor_class=image_processor, 
+            exist_ok=True
+        )
+    except TypeError:
+        # Fallback: use only positional args without exist_ok conflict
+        try:
+            AutoImageProcessor.register(config, image_processor, None, exist_ok=True)
+        except TypeError:
+            # Last resort: register without exist_ok
+            AutoImageProcessor.register(config, image_processor, None)
 
 
 def register_processor(config: Type[PretrainedConfig], processor: Type[ProcessorMixin]):
     """
     register customized hf processor while removing hf impl
     """
-    AutoProcessor.register(config, processor, exist_ok=True)
+    try:
+        AutoProcessor.register(config, processor, exist_ok=True)
+    except TypeError:
+        # Fallback: try alternative signature
+        try:
+            AutoProcessor.register(config, None, processor, exist_ok=True)
+        except TypeError:
+            # Last resort: register without exist_ok
+            AutoProcessor.register(config, None, processor)


### PR DESCRIPTION
## Motivation

Fix compatibility issues with transformers 5.0.0rc3 in SGLang. When deploying multimodal models like GLM-4.6V-FP8, two critical errors occur:

1. `AutoImageProcessor.register()` method call fails with parameter conflict: `TypeError: got multiple values for argument 'exist_ok'`
2. Pre-release versions of transformers (e.g., 5.0.0rc3) are incorrectly identified as unsupported, causing: `ValueError: Transformers version 5.0.0rc3 is not supported`

These issues prevent the GLM-4.6V model service from starting properly.

## Modifications

### 1. `python/sglang/srt/configs/utils.py`
- Add multi-level fallback mechanism for `register_image_processor()` and `register_processor()`
- First attempt: use named parameters (compatible with transformers >= 5.0)
- Second attempt: adjust positional argument order to avoid `exist_ok` conflicts
- Final fallback: register without `exist_ok` parameter
- Ensures compatibility with different transformers API signatures

### 2. `python/sglang/srt/configs/model_config.py`
- Modify `_verify_transformers_version()` version checking logic
- Change from comparing full version string (`5.0.0dev0`) to comparing only major.minor versions
- Now correctly accepts all 5.0.x series versions, including:
  - Development versions (5.0.0dev0)
  - Release candidate versions (5.0.0rc1, 5.0.0rc3)
  - Stable releases (5.0.0)

## Accuracy Tests

This PR does not affect model outputs - it only fixes API compatibility and version checking logic. No additional accuracy tests are required.

## Benchmarking and Profiling

This PR does not impact inference speed. No performance impact.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A - no impact on accuracy or speed)
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

---

## Test Environment

- transformers: 5.0.0rc3
- Model: GLM-4.6V-FP8
- Launch args: `--model-path /workspace/model --tp-size 4 --mm-enable-dp-encoder --reasoning-parser glm45`

## Before fix
python -m sglang.launch_server --model-path /workspace/model(ZhipuAI/GLM-4.6V-FP8) --host 0.0.0.0 --port 8000 --context-length 131072 --tp-size 4 --mm-enable-dp-encoder --reasoning-parser glm45 --tool-call-parser glm --mem-fraction-static 0.9 --tp 4

```
[TypeError: AutoImageProcessor.register() got multiple values for argument 'exist_ok'
ValueError: Transformers version 5.0.0rc3 is not supported](https://github.com/zai-org/GLM-V/issues/246)
```

## After fix

Service starts successfully ✅
