### PR TITLE
[fix] Fix wrong input mode using deepep with PP

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -149,7 +149,9 @@ from sglang.srt.utils import (
     LazyValue,
     add_prefix,
     get_bool_env_var,
+    get_layer_id_within_pp_stage,
     is_non_idle_and_non_empty,
+    is_pp_last_layer,
     log_info_on_rank0,
     make_layers,
     use_intel_amx_backend,
@@ -2256,9 +2258,19 @@ class DeepseekV2DecoderLayer(nn.Module):
         is_previous_layer_sparse = self._is_layer_sparse(layer_id - 1, is_nextn=False)
         is_next_layer_sparse = self._is_layer_sparse(layer_id + 1, is_nextn=False)
 
+        # Use PP-aware layer_id and num_layers for LayerScatterModes computation
+        # This ensures PP boundary layers have correct layer_output_mode (TP_ATTN_FULL)
+        pp_group = get_pp_group()
+        relative_layer_id, num_layers_in_stage = get_layer_id_within_pp_stage(
+            layer_id,
+            config.num_hidden_layers,
+            pp_group.rank_in_group,
+            pp_group.world_size,
+        )
+
         self.layer_scatter_modes = LayerScatterModes.init_new(
-            layer_id=layer_id,
-            num_layers=1 if is_nextn else config.num_hidden_layers,
+            layer_id=relative_layer_id,
+            num_layers=1 if is_nextn else num_layers_in_stage,
             is_layer_sparse=self.is_layer_sparse,
             is_previous_layer_sparse=is_previous_layer_sparse,
             is_next_layer_sparse=is_next_layer_sparse,
@@ -2293,15 +2305,21 @@ class DeepseekV2DecoderLayer(nn.Module):
             config.hidden_size, eps=config.rms_norm_eps
         )
 
+        # Use PP-aware is_last_layer to ensure correct layer_output_mode at PP boundaries
+        pp_is_last_layer = is_nextn or is_pp_last_layer(
+            self.layer_id,
+            self.config.num_hidden_layers,
+            pp_group.rank_in_group,
+            pp_group.world_size,
+        )
+
         if self.nsa_enable_prefill_cp:
             self.layer_communicator = NSACPLayerCommunicator(
                 layer_scatter_modes=self.layer_scatter_modes,
                 input_layernorm=self.input_layernorm,
                 post_attention_layernorm=self.post_attention_layernorm,
                 allow_reduce_scatter=True,
-                is_last_layer=(
-                    is_nextn or (self.layer_id == self.config.num_hidden_layers - 1)
-                ),
+                is_last_layer=pp_is_last_layer,
                 qkv_latent_func=self.self_attn.prepare_qkv_latent,
             )
         else:
@@ -2310,9 +2328,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 input_layernorm=self.input_layernorm,
                 post_attention_layernorm=self.post_attention_layernorm,
                 allow_reduce_scatter=True,
-                is_last_layer=(
-                    is_nextn or (self.layer_id == self.config.num_hidden_layers - 1)
-                ),
+                is_last_layer=pp_is_last_layer,
                 qkv_latent_func=self.self_attn.prepare_qkv_latent,
             )
 


### PR DESCRIPTION
## Motivation

When using Pipeline Parallelism with DeepEP MoE backend (`--moe-a2a-backend deepep --pp-size 2`), hidden states at PP boundaries were corrupted.

**Root Cause:** MoE layers output in `SCATTERED` mode, but `LayerScatterModes` used global `layer_id` instead of PP stage-relative `layer_id`. This caused PP boundary layers (e.g., layer 45 in PP0 of a 92-layer model) to output `SCATTERED` mode instead of `TP_ATTN_FULL`, breaking PP tensor transfer assumptions.
### Why It Failed (DeepSeek 61-layer model, PP=2, TP=8)
**Before Fix:**

| PP Stage 0 (layers 0-30) | → PP Transfer → | PP Stage 1 (layers 31-60) |
|:-------------------------|:---------------:|:--------------------------|
| Layer 30 (boundary) | | Layer 31 (boundary) |
| `layer_id = 30` | | |
| `num_layers = 61` | | |
| `is_last_layer? 30 == 60?` ❌ **FALSE** | | |
| `output_mode = SCATTERED` ❌ | **EXPECT FULL TOKENS BUT ONLY TRANSFERRED 1/8** | `input_mode = SCATTERED` but expect 'TP_ATTN_FULL' |


**After Fix:**

| PP Stage 0 (layers 0-30) | → PP Transfer → | PP Stage 1 (layers 31-60) |
|:-------------------------|:---------------:|:--------------------------|
| Layer 30 (boundary) | | Layer 31 (boundary) |
| `relative_layer_id = 30` | | `relative_layer_id = 0` |
| `num_layers_in_stage = 31` | | `num_layers_in_stage = 30` |
| `is_last_layer? 30 == 30?` ✅ **TRUE** | | `is_first_layer? 0 == 0?` ✅ **TRUE** |
| `output_mode = TP_ATTN_FULL` ✅ | **SUCCESS!** | `input_mode = TP_ATTN_FULL` ✅ |
## Modifications

1. Added two utility functions in `common.py`:
   - `is_pp_last_layer()`: Check if layer is last in current PP stage
   - `get_layer_id_within_pp_stage()`: Convert global layer_id to PP stage-relative layer_id

2. Updated models.py:
   - Use PP-aware `relative_layer_id` for `LayerScatterModes.init_new()`
   - Use `is_pp_last_layer()` for `LayerCommunicator`'s `is_last_layer`

This ensures PP boundary layers correctly use `TP_ATTN_FULL` mode for proper tensor transfer.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
