### PR TITLE
[1/N] Integrate Tencent HPC Ops - Support HpcOpsAttention backend for VisionAttention

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "flashinfer_cubin==0.6.2",
   "gguf",
   "hf_transfer",
+  "hpc-ops==0.0.1.dev0+g8e3ea9e",
   "huggingface_hub",
   "interegular",
   "llguidance>=0.7.11,<0.8.0",

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -795,7 +795,7 @@ def _set_envs_and_config(server_args: ServerArgs):
     # Set ulimit
     set_ulimit()
 
-    # Check flashinfer version
+    # Check sgl-kernel version
     if not get_bool_env_var("SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK"):
         if server_args.attention_backend == "flashinfer":
             assert_pkg_version(
@@ -804,6 +804,14 @@ def _set_envs_and_config(server_args: ServerArgs):
                 "Please uninstall the old version and "
                 "reinstall the latest version by following the instructions "
                 "at https://docs.flashinfer.ai/installation.html.",
+            )
+        if server_args.mm_attention_backend == "hpc_ops":
+            assert_pkg_version(
+                "hpc_ops",
+                "0.0.1.dev0+g8e3ea9e",
+                "Please uninstall the current version and "
+                "reinstall the required version by following the instructions "
+                "at https://github.com/Tencent/hpc-ops/blob/main/README.md.",
             )
         if _is_cuda:
             assert_pkg_version(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3615,7 +3615,15 @@ class ServerArgs:
         parser.add_argument(
             "--mm-attention-backend",
             type=str,
-            choices=["sdpa", "fa3", "fa4", "triton_attn", "ascend_attn", "aiter_attn"],
+            choices=[
+                "sdpa",
+                "fa3",
+                "fa4",
+                "triton_attn",
+                "ascend_attn",
+                "aiter_attn",
+                "hpc_ops",
+            ],
             default=ServerArgs.mm_attention_backend,
             help="Set multimodal attention backend.",
         )

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -309,6 +309,17 @@ def is_flashinfer_available():
     return importlib.util.find_spec("flashinfer") is not None and is_cuda()
 
 
+@lru_cache(maxsize=1)
+def is_hpc_ops_available():
+    """
+    Check whether flashinfer is available.
+    As of Jan. 27, 2026, it is only available on NVIDIA SM90 GPUs.
+    """
+    if not get_bool_env_var("SGLANG_IS_HPC_OPS_AVAILABLE", default="true"):
+        return False
+    return importlib.util.find_spec("hpc_ops") is not None and is_sm90_supported
+
+
 def is_nvidia_cublas_cu12_version_ge_12_9():
     """
     temporary fix for issue #11272

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -97,6 +97,15 @@ FetchContent_Declare(
 )
 FetchContent_Populate(repo-flash-attention)
 
+# hpc-ops
+FetchContent_Declare(
+    repo-hpc-ops
+    GIT_REPOSITORY https://github.com/Tencent/hpc-ops
+    GIT_TAG        8e3ea9e359874f6b30a04830b7c2fc4da38d1e08
+    GIT_SHALLOW    OFF
+)
+FetchContent_Populate(repo-hpc-ops)
+
 # mscclpp
 FetchContent_Declare(
     repo-mscclpp


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Integrate HPC Ops Attention into VLM.
Currently the data flow path works but the result is not correct. The reason is because now HPC Ops lib only supports qk head dim = 128, while in VLM case, the qk head dim is 72.
```
[HPC-ATTN] q=(2880, 16, 72) torch.bfloat16 cuda:0 contig=True stride=(1152, 72, 1)
[HPC-ATTN] k=(2880, 16, 72) torch.bfloat16 cuda:0 contig=True stride=(1152, 72, 1)
[HPC-ATTN] v=(2880, 16, 72) torch.bfloat16 cuda:0 contig=True stride=(1152, 72, 1)
[HPC-ATTN] cu_seqlens(len=2): [0, 2880] ... last=2880
[HPC-ATTN] seqlens_q: [2880] ... max_seqlen=2880
[2026-01-27 13:15:08] Decode batch, #running-req: 1, #token: 775, token usage: 0.00, cuda graph: True, gen throughput (token/s): 1.14, #queue-req: 0, 
[2026-01-27 13:15:08] Decode batch, #running-req: 1, #token: 815, token usage: 0.00, cuda graph: True, gen throughput (token/s): 145.84, #queue-req: 0, 
[2026-01-27 13:15:08] Decode batch, #running-req: 1, #token: 855, token usage: 0.00, cuda graph: True, gen throughput (token/s): 145.44, #queue-req: 0, 
[2026-01-27 13:15:09] Decode batch, #running-req: 1, #token: 895, token usage: 0.00, cuda graph: True, gen throughput (token/s): 145.41, #q
```
I confirmed this limitation with Tencent team author offline. From the unit test it also indicates this point.
```
@pytest.mark.parametrize("num_dim_qk", [128])
@pytest.mark.parametrize("num_dim_v", [128])
```
Change these parameters to other value, UT will not pass.
```
root@c7e9bb6a6789:/sgl-workspace/hpc-ops/tests# python -m pytest test_attention_with_kvcache_prefill_bf16.py
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /sgl-workspace/hpc-ops
plugins: anyio-4.12.1, typeguard-4.4.4
collected 32 items                                                                                                                                                                                            

test_attention_with_kvcache_prefill_bf16.py ................................                                                                                                                            [100%]

============================================================================================= 32 passed in 0.87s ==============================================================================================
```

Integrating HPC Ops into LLM attention is non-trivial, will follow up in the next PR.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
