### PR TITLE
fix(disaggregation): Support string/dict image_data in native API for EPD mode

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -53,7 +53,11 @@ def _extract_image_url(image_item: Union[str, dict, "ImageData"]) -> str:
         return image_item
     elif isinstance(image_item, dict):
         # Support both {"url": "..."} and {"image_url": "..."} formats
-        return image_item.get("url", image_item.get("image_url", ""))
+        # Support both {"url": "..."} and {"image_url": "..."} formats
+        url = image_item.get("url") or image_item.get("image_url")
+        if url:
+            return url
+        raise ValueError(f"Dictionary image data must contain 'url' or 'image_url' key: {image_item}")
     elif hasattr(image_item, "url"):
         return image_item.url
     else:


### PR DESCRIPTION
## Summary

The native `/generate` endpoint fails with images in EPD (Encoder-Prefill-Decode) disaggregated mode because `encode_receiver.py` assumes `image_data` items are `ImageData` objects with `.url` attribute, but the native API passes raw strings or dicts from JSON.

**Error:**
```
AttributeError: 'str' object has no attribute 'url'
```
or
```
AttributeError: 'dict' object has no attribute 'url'
```

## Root Cause

The OpenAI-compatible `/v1/chat/completions` endpoint works because it goes through `conversation.py` which explicitly creates `ImageData` objects. However, the native `/generate` endpoint passes the raw JSON data directly, which can be:
- `str`: Direct URL or base64 data URI
- `dict`: `{"url": "..."}` format

The problematic code in `encode_receiver.py`:
1. `send_encode_request()` (zmq_to_scheduler backend)
2. `recv_mm_data()` (zmq_to_tokenizer and mooncake backends)

Both methods assumed `.url` attribute access which fails for strings and dicts.

## Solution

Added helper functions `_extract_image_url()` and `_extract_image_urls()` that handle all supported image data formats:
- `str`: Direct URL or base64 data URI (return as-is)
- `dict`: Extract from `{"url": "..."}` or `{"image_url": "..."}` keys
- `ImageData`: Access `.url` attribute (existing behavior)
