### PR TITLE
Fix/compatible responses api #17853

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -355,7 +355,7 @@ class CompletionStreamResponse(BaseModel):
 
 
 class ChatCompletionMessageContentTextPart(BaseModel):
-    type: Literal["text"]
+    type: Literal["text", "input_text"]
     text: str
 
 
@@ -377,9 +377,11 @@ class ChatCompletionMessageContentAudioURL(BaseModel):
 
 
 class ChatCompletionMessageContentImagePart(BaseModel):
-    type: Literal["image_url"]
+    type: Literal["image_url", "input_image"]
     image_url: ChatCompletionMessageContentImageURL
     modalities: Optional[Literal["image", "multi-images", "video"]] = "image"
+    detail: Optional[Literal["high", "low", "auto"]] = "auto"
+    file_id: Optional[str] = None
 
 
 class ChatCompletionMessageContentVideoPart(BaseModel):

--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -153,7 +153,7 @@ def process_content_for_template_format(
             if isinstance(chunk, dict):
                 chunk_type = chunk.get("type")
 
-                if chunk_type == "image_url":
+                if chunk_type in ("image_url", "input_image"):
                     image_obj = chunk.get("image_url") or {}
                     mdp = image_obj.get("max_dynamic_patch", None)
                     # Also allow flat style: chunk["max_dynamic_patch"]
@@ -204,7 +204,7 @@ def process_content_for_template_format(
         # String format: flatten to text only (for templates like DeepSeek)
         text_parts = []
         for chunk in msg_dict["content"]:
-            if isinstance(chunk, dict) and chunk.get("type") == "text":
+            if isinstance(chunk, dict) and chunk.get("type") in ("text", "input_text"):
                 text_parts.append(chunk["text"])
             # Note: For string format, we ignore images/audio since the template
             # doesn't expect structured content - multimodal placeholders would

--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -154,13 +154,23 @@ def process_content_for_template_format(
                 chunk_type = chunk.get("type")
 
                 if chunk_type in ("image_url", "input_image"):
-                    image_obj = chunk.get("image_url") or {}
-                    mdp = image_obj.get("max_dynamic_patch", None)
-                    # Also allow flat style: chunk["max_dynamic_patch"]
+                    if chunk_type == "image_url":
+                        image_obj = chunk.get("image_url") or {}
+                        mdp = image_obj.get("max_dynamic_patch", None)
+                        # Also allow flat style: chunk["max_dynamic_patch"]
+                        image_url = image_obj["url"]
+                        image_detail = image_obj.get("detail", "auto")
+                    else:
+                        # image_url Optional
+                        image_url = chunk.get("image_url", "")
+                        # detail Required
+                        image_detail = chunk["detail"]
+                        mdp = None
+
                     image_data.append(
                         ImageData(
-                            url=image_obj["url"],
-                            detail=image_obj.get("detail", "auto"),
+                            url=image_url,
+                            detail=image_detail,
                             max_dynamic_patch=mdp,
                         )
                     )


### PR DESCRIPTION
Fixes #17853 

## Motivation

The current /v1/responses API has limited compatibility with the OpenAI Responses API when message content is provided as structured parts.

When input is provided as an array, SGLang may fail request validation and drop the textual prompt during message processing.
In addition, input_image handling was adjusted as part of this change, although it has not been extensively validated yet.

## Modifications

- Fix request validation failures when input is provided as an array of message objects.
- Normalize input_text content so textual prompts are correctly extracted and passed to the model.
- Fix extraction logic for url and detail fields in input_image content.
- Improve robustness of the /v1/responses request adaptation logic.

## Accuracy Tests

- No changes to model computation or kernels.
- input_text behavior was manually verified.
- input_image changes were not fully validated and may require additional testing.

## Benchmarking and Profiling

No impact on inference performance.

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).