### PR TITLE
Add Metadata Field for Request ID in MoE Distribution Output

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -390,8 +390,7 @@ class _DetailSinglePassGatherer(_SinglePassGatherer):
     def on_forward_pass_start(self, forward_batch: ForwardBatch):
         assert self._metadata is None
         self._metadata = dict(
-            # TODO pr-chain
-            # rids=forward_batch.rids,
+            rids=forward_batch.req_ids,
             input_ids=forward_batch.input_ids.cpu().tolist(),
             positions=forward_batch.positions.cpu().tolist(),
             extend_seq_lens=forward_batch.extend_seq_lens_cpu,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2207,6 +2207,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             encoder_lens_cpu=self.encoder_lens_cpu,
             encoder_out_cache_loc=self.encoder_out_cache_loc,
             lora_ids=[req.lora_id for req in self.reqs],
+            req_ids=[req.rid for req in self.reqs],
             sampling_info=self.sampling_info,
             input_embeds=self.input_embeds,
             token_type_ids=self.token_type_ids,
@@ -2368,6 +2369,9 @@ class ModelWorkerBatch:
 
     # For LoRA
     lora_ids: Optional[List[str]]
+
+    # For per-chain (per request) loggings
+    req_ids: Optional[List[str]]
 
     # Sampling info
     sampling_info: SamplingBatchInfo

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -675,6 +675,7 @@ class CudaGraphRunner:
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,
             lora_ids=lora_ids,
+            req_ids=None,
         )
         self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -311,6 +311,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For LoRA
     lora_ids: Optional[List[str]] = None
 
+    # For request tracking
+    req_ids: Optional[List[str]] = None
+
     # For input embeddings
     input_embeds: Optional[torch.Tensor] = None
 
@@ -407,6 +410,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             global_forward_mode=batch.global_forward_mode,
             is_prefill_only=batch.is_prefill_only,
             lora_ids=batch.lora_ids,
+            req_ids=batch.req_ids,
             sampling_info=batch.sampling_info,
             req_to_token_pool=model_runner.req_to_token_pool,
             token_to_kv_pool=model_runner.token_to_kv_pool,

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -350,6 +350,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 global_forward_mode=ForwardMode.EXTEND,
                 lora_ids=None,
+                req_ids=None,
             )
 
         # Attention backend
@@ -497,6 +498,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 global_forward_mode=ForwardMode.EXTEND,
                 lora_ids=None,
+                req_ids=None,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 
@@ -660,6 +662,7 @@ class PiecewiseCudaGraphRunner:
             num_token_non_padded=forward_batch.num_token_non_padded,
             global_forward_mode=forward_batch.global_forward_mode,
             lora_ids=forward_batch.lora_ids,
+            req_ids=forward_batch.req_ids,
             sampling_info=forward_batch.sampling_info,
             mm_inputs=forward_batch.mm_inputs,
             temp_scaled_logprobs=forward_batch.temp_scaled_logprobs,


### PR DESCRIPTION
Introducing a request‑ID metadata field, allowing all MoE distribution records belonging to the same request to be grouped cleanly. This significantly improves the utility of the logs for research workflows, reproducibility, and fine‑grained performance analysis.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Right now, MoE distribution logs in SGLang capture expert routing information, but they lack a stable identifier that links recorded distributions back to the originating request. Without this, it becomes difficult to interpret the logs in any request‑centric way.

* It limits per‑request debugging and makes ablation studies on MoE behavior unnecessarily cumbersome.
* It becomes challenging to track allocation patterns across multiple runs, and nearly impossible to reconstruct the full expert‑usage trajectory for a single request.
* For research use cases, several studies rely on analyzing routing consistency between prefill and decode phases to optimize resource usage at the request level.

## Modifications

Add `req_ids` field to forward batch and allowing the expert distribution recorder to dump the request ID while triggered.

## Accuracy Tests

```
Baseline (Qwen/Qwen2-7B-Instruct)
Accuracy: 0.820
Invalid: 0.000
Latency: 13.588 s
Output throughput: 2157.929 token/s

Featured (Qwen/Qwen2-7B-Instruct)
Accuracy: 0.815
Invalid: 0.000
Latency: 12.614 s
Output throughput: 2280.407 token/s
```


## Benchmarking and Profiling

```
Baseline (Qwen/Qwen2-7B-Instruct)
Benchmark ...
Prefill. latency: 0.53206 s, throughput:  15396.64 token/s
Decode 0. Batch size: 32, latency: 0.01760 s, throughput:   1818.04 token/s
Decode 1. Batch size: 32, latency: 0.01566 s, throughput:   2043.89 token/s
Decode 2. Batch size: 32, latency: 0.01510 s, throughput:   2119.13 token/s
Decode 3. Batch size: 32, latency: 0.01497 s, throughput:   2137.68 token/s
Decode 4. Batch size: 32, latency: 0.01554 s, throughput:   2058.91 token/s
Decode.  median latency: 0.01502 s, median throughput:   2130.56 token/s
Total. latency:  1.002 s, throughput:   9200.54 token/s

Featured (Qwen/Qwen2-7B-Instruct)
Benchmark ...
Prefill. latency: 0.53877 s, throughput:  15205.05 token/s
Decode 0. Batch size: 32, latency: 0.01617 s, throughput:   1978.78 token/s
Decode 1. Batch size: 32, latency: 0.01557 s, throughput:   2054.74 token/s
Decode 2. Batch size: 32, latency: 0.01475 s, throughput:   2169.50 token/s
Decode 3. Batch size: 32, latency: 0.01504 s, throughput:   2127.08 token/s
Decode 4. Batch size: 32, latency: 0.01448 s, throughput:   2209.42 token/s
Decode.  median latency: 0.01438 s, median throughput:   2225.39 token/s
Total. latency:  0.991 s, throughput:   9301.22 token/s
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
