### PR TITLE
support nextn>1 for deep_gemm.fp8_paged_mqa_logits and flash_mla_with…

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -374,7 +374,10 @@ class Indexer(MultiPlatformOp):
                 )
 
         assert len(q_fp8.shape) == 3
-        q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
+        num_tokens, num_heads, head_dim = q_fp8.shape
+        batch_size = block_tables.shape[0]
+        assert num_tokens % batch_size == 0
+        q_fp8 = q_fp8.view(batch_size, -1, num_heads, head_dim)
         assert len(kv_cache_fp8.shape) == 2
         block_kv = 1 if _is_hip else 64
         num_heads_kv = 1

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1600,7 +1600,7 @@ class NativeSparseAttnBackend(
             # inefficiently quantize the whole cache
             kv_cache = quantize_k_cache(kv_cache)
 
-        indices = page_table_1.view(batch_size,-1,self.nsa_index_topk)
+        indices = page_table_1.view(batch_size, -1, self.nsa_index_topk)
         assert (
             indices.shape[-1] == self.nsa_index_topk
         )  # requirement of FlashMLA decode kernel


### PR DESCRIPTION
support nextn>1 when use deep_gemm.fp8_paged_mqa_logits and flash_mla_with_kvcache
