### PR TITLE
[Bug Fix] Use get_local_ip_auto() for remote instance weight loader

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -871,7 +871,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             == RemoteInstanceWeightLoaderBackend.NCCL
         ):
             if self.tp_rank == 0:
-                instance_ip = socket.gethostbyname(socket.gethostname())
+                instance_ip = get_local_ip_auto()
                 t = threading.Thread(
                     target=trigger_init_weights_send_group_for_remote_instance_request,
                     args=(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -107,6 +107,7 @@ from sglang.srt.model_loader.weight_utils import (
 from sglang.srt.utils import (
     get_bool_env_var,
     get_device_capability,
+    get_local_ip_auto,
     is_npu,
     is_pin_memory_available,
     rank0_log,
@@ -2141,7 +2142,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
         self, model, client, model_config: ModelConfig, device_config: DeviceConfig
     ) -> nn.Module:
         load_config = self.load_config
-        instance_ip = socket.gethostbyname(socket.gethostname())
+        instance_ip = get_local_ip_auto()
         start_build_group_tic = time.time()
         client.build_group(
             gpu_id=device_config.gpu_id,


### PR DESCRIPTION
## Summary
- Fix unreliable local IP detection in remote instance weight loader
- Replace `socket.gethostbyname(socket.gethostname())` with existing `get_local_ip_auto()` utility
- This resolves issues in containerized environments (e.g., hostNetwork mode) where the old method may return `127.0.0.1`

## Background
The remote instance weight loader uses local IP to establish NCCL communication with the seed instance. In containerized environments with `hostNetwork: true` or privileged mode, `socket.gethostbyname(socket.gethostname())` may incorrectly return `127.0.0.1`, causing connection failures.

SGLang already has a robust `get_local_ip_auto()` utility that:
1. Checks `SGLANG_HOST_IP` / `HOST_IP` environment variables
2. Detects IP via network interface (`SGLANG_LOCAL_IP_NIC`)
3. Falls back to UDP socket detection

This PR makes the remote instance weight loader consistent with other code (e.g., transfer engine at `model_runner.py:632` already uses `get_local_ip_auto()`).