### PR TITLE
DRAFT: dp routing for heterogeneous p/d

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -342,11 +342,17 @@ class DecodePreallocQueue:
                     self.transfer_backend, KVClassType.RECEIVER
                 )
 
+            explicit_prefill_rank = (
+                req.prefill_dp_rank
+                if req.prefill_dp_rank is not None
+                else req.data_parallel_rank
+            )
+
             kv_receiver = kv_receiver_class(
                 mgr=self.kv_manager,
                 bootstrap_addr=f"{req.bootstrap_host}:{req.bootstrap_port}",
                 bootstrap_room=req.bootstrap_room,
-                prefill_dp_rank=req.data_parallel_rank,
+                prefill_dp_rank=explicit_prefill_rank,
             )
 
             req.add_latency(RequestStage.DECODE_PREPARE)

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -479,6 +479,8 @@ class DataParallelController:
         if req.data_parallel_rank is not None:
             logger.debug(f"Direct routing to DP rank {req.data_parallel_rank}")
             self.workers[req.data_parallel_rank].send_pyobj(req)
+            return True
+        return False
 
     def round_robin_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -476,29 +476,9 @@ class DataParallelController:
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
 
     def maybe_external_dp_rank_routing(self, req: Req):
-        if self.server_args.disaggregation_mode == "prefill":
-            target_rank = req.prefill_dp_rank
-            source_field = "prefill_dp_rank"
-        else:  # "decode" or "null"
-            target_rank = req.decode_dp_rank
-            source_field = "decode_dp_rank"
-
-        if target_rank is None:
-            target_rank = req.data_parallel_rank
-            source_field = "data_parallel_rank"
-
-        if target_rank is not None:
-            # Validate rank is in bounds
-            if target_rank < 0 or target_rank >= len(self.workers):
-                logger.error(
-                    f"Invalid {source_field}={target_rank}, must be in [0, {len(self.workers)})"
-                )
-                return False
-
-            logger.debug(f"Direct routing to DP rank {target_rank}")
-            self.workers[target_rank].send_pyobj(req)
-            return True
-        return False
+        if req.data_parallel_rank is not None:
+            logger.debug(f"Direct routing to DP rank {req.data_parallel_rank}")
+            self.workers[req.data_parallel_rank].send_pyobj(req)
 
     def round_robin_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -233,6 +233,12 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
 
+    # Which decode worker to route to
+    decode_dp_rank: Optional[int] = None
+
+    # Which prefill DP rank holds KV cache
+    prefill_dp_rank: Optional[int] = None
+
     # For background responses (OpenAI responses API)
     background: bool = False
 
@@ -740,6 +746,12 @@ class TokenizedGenerateReqInput(BaseReq):
 
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
+
+    # Which decode worker to route to
+    decode_dp_rank: Optional[int] = None
+
+    # Which prefill DP rank holds KV cache
+    prefill_dp_rank: Optional[int] = None
 
     # Priority for the request
     priority: Optional[int] = None

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -233,9 +233,6 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
 
-    # Which decode worker to route to
-    decode_dp_rank: Optional[int] = None
-
     # Which prefill DP rank holds KV cache
     prefill_dp_rank: Optional[int] = None
 
@@ -746,9 +743,6 @@ class TokenizedGenerateReqInput(BaseReq):
 
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
-
-    # Which decode worker to route to
-    decode_dp_rank: Optional[int] = None
 
     # Which prefill DP rank holds KV cache
     prefill_dp_rank: Optional[int] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -517,6 +517,8 @@ class Req:
         bootstrap_room: Optional[int] = None,
         disagg_mode: Optional[DisaggregationMode] = None,
         data_parallel_rank: Optional[int] = None,
+        decode_dp_rank: Optional[int] = None,
+        prefill_dp_rank: Optional[int] = None,
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
@@ -757,6 +759,10 @@ class Req:
 
         # For data parallel rank routing
         self.data_parallel_rank: Optional[int] = data_parallel_rank
+
+        # Explicit DP rank control
+        self.decode_dp_rank: Optional[int] = decode_dp_rank
+        self.prefill_dp_rank: Optional[int] = prefill_dp_rank
 
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -517,7 +517,6 @@ class Req:
         bootstrap_room: Optional[int] = None,
         disagg_mode: Optional[DisaggregationMode] = None,
         data_parallel_rank: Optional[int] = None,
-        decode_dp_rank: Optional[int] = None,
         prefill_dp_rank: Optional[int] = None,
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
@@ -761,7 +760,6 @@ class Req:
         self.data_parallel_rank: Optional[int] = data_parallel_rank
 
         # Explicit DP rank control
-        self.decode_dp_rank: Optional[int] = decode_dp_rank
         self.prefill_dp_rank: Optional[int] = prefill_dp_rank
 
         # the start index of the sent kv cache

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1460,6 +1460,8 @@ class Scheduler(
                 bootstrap_room=recv_req.bootstrap_room,
                 disagg_mode=self.disaggregation_mode,
                 data_parallel_rank=recv_req.data_parallel_rank,
+                decode_dp_rank=recv_req.decode_dp_rank,
+                prefill_dp_rank=recv_req.prefill_dp_rank,
                 vocab_size=self.model_config.vocab_size,
                 priority=recv_req.priority,
                 metrics_collector=(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1460,7 +1460,6 @@ class Scheduler(
                 bootstrap_room=recv_req.bootstrap_room,
                 disagg_mode=self.disaggregation_mode,
                 data_parallel_rank=recv_req.data_parallel_rank,
-                decode_dp_rank=recv_req.decode_dp_rank,
                 prefill_dp_rank=recv_req.prefill_dp_rank,
                 vocab_size=self.model_config.vocab_size,
                 priority=recv_req.priority,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -938,6 +938,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 return_hidden_states=obj.return_hidden_states,
                 return_routed_experts=obj.return_routed_experts,
                 data_parallel_rank=obj.data_parallel_rank,
+                decode_dp_rank=obj.decode_dp_rank,
+                prefill_dp_rank=obj.prefill_dp_rank,
                 priority=obj.priority,
                 extra_key=obj.extra_key,
                 routing_key=obj.routing_key,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -938,7 +938,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 return_hidden_states=obj.return_hidden_states,
                 return_routed_experts=obj.return_routed_experts,
                 data_parallel_rank=obj.data_parallel_rank,
-                decode_dp_rank=obj.decode_dp_rank,
                 prefill_dp_rank=obj.prefill_dp_rank,
                 priority=obj.priority,
                 extra_key=obj.extra_key,

--- a/test/srt/test_external_dp_ranks_minimal.py
+++ b/test/srt/test_external_dp_ranks_minimal.py
@@ -109,7 +109,7 @@ class TestExternalDPRanks(PDDisaggregationServerBase):
                         "text": f"Test: {desc}",
                         "sampling_params": {"max_new_tokens": 10, "temperature": 0},
                         "data_parallel_rank": decode_rank,  # Routes to decode worker
-                        "prefill_dp_rank": prefill_rank,    # KV source from prefill worker
+                        "prefill_dp_rank": prefill_rank,  # KV source from prefill worker
                     },
                 )
                 self.assertEqual(response.status_code, 200, f"Failed for {desc}")

--- a/test/srt/test_external_dp_ranks_minimal.py
+++ b/test/srt/test_external_dp_ranks_minimal.py
@@ -1,0 +1,151 @@
+"""
+Test explicit decode_dp_rank and prefill_dp_rank routing in disaggregated mode.
+"""
+
+import unittest
+
+import requests
+
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+)
+
+
+class TestExternalDPRanks(PDDisaggregationServerBase):
+    """
+    Test explicit DP rank routing with heterogeneous prefill/decode DP sizes.
+
+    Setup:
+    - Prefill: 2 DP ranks
+    - Decode: 4 DP ranks
+
+    This tests the core functionality: independent control of decode and prefill
+    DP ranks for heterogeneous configurations.
+    """
+
+    PREFILL_DP_SIZE = 2
+    DECODE_DP_SIZE = 4
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+
+        cls.start_prefill()
+        cls.start_decode()
+
+        cls.wait_server_ready(cls.prefill_url + "/health")
+        cls.wait_server_ready(cls.decode_url + "/health")
+
+        cls.launch_lb()
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--tp",
+            "1",
+            "--dp",
+            str(cls.PREFILL_DP_SIZE),
+            "--enable-dp-attention",
+        ]
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--tp",
+            "1",
+            "--dp",
+            str(cls.DECODE_DP_SIZE),
+            "--enable-dp-attention",
+            "--base-gpu-id",
+            str(cls.PREFILL_DP_SIZE),
+        ]
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def test_heterogeneous_dp_ranks(self):
+        """
+        Test heterogeneous DP configuration: 2 prefill workers, 4 decode workers.
+
+        Tests that decode_dp_rank and prefill_dp_rank can be specified independently
+        to route requests across workers with different DP sizes.
+        """
+        test_cases = [
+            # (decode_rank, prefill_rank, description)
+            (0, 0, "Decode#0 <- Prefill#0"),
+            (1, 1, "Decode#1 <- Prefill#1"),
+            (2, 0, "Decode#2 <- Prefill#0"),  # Wrap to prefill worker 0
+            (3, 1, "Decode#3 <- Prefill#1"),  # Wrap to prefill worker 1
+        ]
+
+        for decode_rank, prefill_rank, desc in test_cases:
+            with self.subTest(desc=desc):
+                response = requests.post(
+                    self.lb_url + "/generate",
+                    json={
+                        "text": f"Test: {desc}",
+                        "sampling_params": {"max_new_tokens": 10, "temperature": 0},
+                        "decode_dp_rank": decode_rank,
+                        "prefill_dp_rank": prefill_rank,
+                    },
+                )
+                self.assertEqual(response.status_code, 200, f"Failed for {desc}")
+                result = response.json()
+                self.assertIn("text", result)
+
+    def test_backward_compatibility(self):
+        """Test that old data_parallel_rank field still works."""
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "Backward compatibility test",
+                "sampling_params": {"max_new_tokens": 10, "temperature": 0},
+                "data_parallel_rank": 1,  # Old field should still work
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("text", result)
+
+    def test_new_fields_override_old(self):
+        """Test that new fields take precedence over data_parallel_rank."""
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "Priority test",
+                "sampling_params": {"max_new_tokens": 10, "temperature": 0},
+                "data_parallel_rank": 0,  # Should be ignored
+                "decode_dp_rank": 2,  # Should be used
+                "prefill_dp_rank": 1,  # Should be used
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("text", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_external_dp_ranks_minimal.py
+++ b/test/srt/test_external_dp_ranks_minimal.py
@@ -97,8 +97,8 @@ class TestExternalDPRanks(PDDisaggregationServerBase):
             # (decode_rank, prefill_rank, description)
             (0, 0, "Decode#0 <- Prefill#0"),
             (1, 1, "Decode#1 <- Prefill#1"),
-            (2, 0, "Decode#2 <- Prefill#0"),  # 4 decode workers, 2 prefill workers
-            (3, 1, "Decode#3 <- Prefill#1"),  # 4 decode workers, 2 prefill workers
+            (2, 0, "Decode#2 <- Prefill#0"),  # More decode than prefill workers
+            (3, 1, "Decode#3 <- Prefill#1"),
         ]
 
         for decode_rank, prefill_rank, desc in test_cases:


### PR DESCRIPTION
## Motivation                                                                                                                                                                    
                                                                                                                                                                                   
Support heterogeneous DP configurations in disaggregated prefill/decode mode by decoupling decode routing from prefill KV source identification.                                 
                                                                                                                                                                                   
Currently, `data_parallel_rank` controls both decode routing and prefill KV source, which breaks when prefill and decode have different DP sizes (e.g., 4 prefill workers, 8 decode workers).                                                                                                                                                                 
                                                                                                                                                                                   
  ## Modifications                                                                                                                                                                 
                                                                                                                                                                                   
Add a new optional field:                                                                                                                                                     
  - `prefill_dp_rank` - Which prefill DP rank holds KV cache                                                                                                                   

Falls back to `data_parallel_rank` if not set, maintaining full backward compatibility.                                                                                                                                                                                                        
                                                                                                                                                                                   
  ## Testing                                                                                                                                                                       
                                                                                                                                                                                   
`test_external_dp_ranks_minimal.py` tests with 2 prefill + 4 decode worker configuration.                                                                                                                                                                                                                                    
Backward compatible - existing code using `data_parallel_rank` continues to work.      

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


