### PR TITLE
feat: Add ModelScope support for multimodal_gen models

### DIFF
--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import filelock
 
-from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import hf_hub_download
 from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
@@ -44,6 +43,8 @@ def _maybe_download_model(
     Returns:
         Local directory path that contains the downloaded config file, or the original local directory.
     """
+
+    from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import hf_hub_download
 
     if os.path.exists(model_name_or_path):
         logger.info("Model already exists locally")

--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -8,8 +8,8 @@ from functools import lru_cache
 from typing import Optional
 
 import filelock
-from huggingface_hub import hf_hub_download
 
+from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import hf_hub_download
 from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
@@ -61,20 +61,11 @@ def _maybe_download_model(
                 source_hub,
                 model_name_or_path,
             )
-            if envs.SGLANG_USE_MODELSCOPE.get():
-                from modelscope import model_file_download
-
-                file_path = model_file_download(
-                    model_id=model_name_or_path,
-                    file_path="model_index.json",
-                    cache_dir=local_dir,
-                )
-            else:
-                file_path = hf_hub_download(
-                    repo_id=model_name_or_path,
-                    filename="model_index.json",
-                    local_dir=local_dir,
-                )
+            file_path = hf_hub_download(
+                repo_id=model_name_or_path,
+                filename="model_index.json",
+                local_dir=local_dir,
+            )
             logger.info("Downloaded to %s", file_path)
             return os.path.dirname(file_path)
         except Exception as e_index:
@@ -87,20 +78,11 @@ def _maybe_download_model(
                 source_hub,
                 model_name_or_path,
             )
-            if envs.SGLANG_USE_MODELSCOPE.get():
-                from modelscope import model_file_download
-
-                file_path = model_file_download(
-                    model_id=model_name_or_path,
-                    file_path="config.json",
-                    cache_dir=local_dir,
-                )
-            else:
-                file_path = hf_hub_download(
-                    repo_id=model_name_or_path,
-                    filename="config.json",
-                    local_dir=local_dir,
-                )
+            file_path = hf_hub_download(
+                repo_id=model_name_or_path,
+                filename="config.json",
+                local_dir=local_dir,
+            )
             logger.info("Downloaded to %s", file_path)
             return os.path.dirname(file_path)
         except Exception as e_config:

--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -10,6 +10,8 @@ from typing import Optional
 import filelock
 from huggingface_hub import hf_hub_download
 
+from sglang.srt.environ import envs
+
 logger = logging.getLogger(__name__)
 
 temp_dir = tempfile.gettempdir()
@@ -51,42 +53,86 @@ def _maybe_download_model(
         return model_name_or_path
 
     with _get_lock(model_name_or_path):
-        # Try `model_index.json` first (diffusers models)
-        try:
-            logger.info(
-                "Downloading model_index.json from HF Hub for %s...",
-                model_name_or_path,
-            )
-            file_path = hf_hub_download(
-                repo_id=model_name_or_path,
-                filename="model_index.json",
-                local_dir=local_dir,
-            )
-            logger.info("Downloaded to %s", file_path)
-            return os.path.dirname(file_path)
-        except Exception as e_index:
-            logger.debug("model_index.json not found or failed: %s", e_index)
+        if envs.SGLANG_USE_MODELSCOPE.get():
+            try:
+                from modelscope import model_file_download
 
-        # Fallback to `config.json`
-        try:
-            logger.info(
-                "Downloading config.json from HF Hub for %s...", model_name_or_path
-            )
-            file_path = hf_hub_download(
-                repo_id=model_name_or_path,
-                filename="config.json",
-                local_dir=local_dir,
-            )
-            logger.info("Downloaded to %s", file_path)
-            return os.path.dirname(file_path)
-        except Exception as e_config:
-            raise ValueError(
-                (
-                    "Could not find model locally at %s and failed to download "
-                    "model_index.json/config.json from HF Hub: %s"
+                logger.info(
+                    "Downloading model_index.json from ModelScope for %s...",
+                    model_name_or_path,
                 )
-                % (model_name_or_path, e_config)
-            ) from e_config
+
+                # Try model_index.json first (diffusers models)
+                file_path = model_file_download(
+                    model_id=model_name_or_path,
+                    file_path="model_index.json",
+                    cache_dir=local_dir,
+                )
+                logger.info("Downloaded to %s", file_path)
+                return os.path.dirname(file_path)
+            except Exception as e_index:
+                logger.debug(
+                    "model_index.json not found or failed on ModelScope: %s", e_index
+                )
+
+                # Fallback to config.json
+                try:
+                    logger.info(
+                        "Downloading config.json from ModelScope for %s...",
+                        model_name_or_path,
+                    )
+                    file_path = model_file_download(
+                        model_id=model_name_or_path,
+                        file_path="config.json",
+                        cache_dir=local_dir,
+                    )
+                    logger.info("Downloaded to %s", file_path)
+                    return os.path.dirname(file_path)
+                except Exception as e_config:
+                    raise ValueError(
+                        (
+                            "Could not find model locally at %s and failed to download "
+                            "model_index.json/config.json from ModelScope: %s"
+                        )
+                        % (model_name_or_path, e_config)
+                    ) from e_config
+        else:
+            # Try `model_index.json` first (diffusers models)
+            try:
+                logger.info(
+                    "Downloading model_index.json from HF Hub for %s...",
+                    model_name_or_path,
+                )
+                file_path = hf_hub_download(
+                    repo_id=model_name_or_path,
+                    filename="model_index.json",
+                    local_dir=local_dir,
+                )
+                logger.info("Downloaded to %s", file_path)
+                return os.path.dirname(file_path)
+            except Exception as e_index:
+                logger.debug("model_index.json not found or failed: %s", e_index)
+
+            # Fallback to `config.json`
+            try:
+                logger.info(
+                    "Downloading config.json from HF Hub for %s...", model_name_or_path
+                )
+                file_path = hf_hub_download(
+                    repo_id=model_name_or_path,
+                    filename="config.json",
+                    local_dir=local_dir,
+                )
+                logger.info("Downloaded to %s", file_path)
+                return os.path.dirname(file_path)
+            except Exception as e_config:
+                raise ValueError(
+                    (
+                        "Could not find model locally at %s and failed to download "
+                        "model_index.json/config.json from HF Hub: %s"
+                    )
+                    % (model_name_or_path, e_config)
+                ) from e_config
 
 
 # Copied and adapted from hf_diffusers_utils.py

--- a/python/sglang/multimodal_gen/apps/webui/main.py
+++ b/python/sglang/multimodal_gen/apps/webui/main.py
@@ -12,6 +12,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 from sglang.multimodal_gen.runtime.scheduler_client import sync_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.environ import envs  # 用于 SGLANG_USE_MODELSCOPE
 
 logger = init_logger(__name__)
 
@@ -27,12 +28,23 @@ def run_sgl_diffusion_webui(server_args: ServerArgs):
     # import gradio in function to avoid CI crash
 
     import gradio as gr
-    from huggingface_hub import model_info
 
-    # init client
-    sync_scheduler_client.initialize(server_args)
+    if envs.SGLANG_USE_MODELSCOPE.get():
+        from modelscope.hub.api import HubApi
 
-    task_name = model_info(server_args.model_path).pipeline_tag
+        api = HubApi()
+        model_info_obj = api.model_info(server_args.model_path)
+        # ModelScope 的 ModelInfo 中 task 字段对应 pipeline_tag
+        task_name = getattr(model_info_obj, "task", None) or getattr(
+            model_info_obj, "pipeline_type", "text-to-image"
+        )
+    else:
+        from huggingface_hub import model_info
+
+        # init client
+        sync_scheduler_client.initialize(server_args)
+
+        task_name = model_info(server_args.model_path).pipeline_tag
 
     if task_name in ("text-to-video", "image-to-video", "video-to-video"):
         task_type = "video"

--- a/python/sglang/multimodal_gen/apps/webui/main.py
+++ b/python/sglang/multimodal_gen/apps/webui/main.py
@@ -12,7 +12,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 from sglang.multimodal_gen.runtime.scheduler_client import sync_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.srt.environ import envs  # 用于 SGLANG_USE_MODELSCOPE
+from sglang.srt.environ import envs
 
 logger = init_logger(__name__)
 
@@ -34,17 +34,14 @@ def run_sgl_diffusion_webui(server_args: ServerArgs):
 
         api = HubApi()
         model_info_obj = api.model_info(server_args.model_path)
-        # ModelScope 的 ModelInfo 中 task 字段对应 pipeline_tag
-        task_name = getattr(model_info_obj, "task", None) or getattr(
-            model_info_obj, "pipeline_type", "text-to-image"
-        )
+        task_name = model_info_obj.tasks[0]["Name"].replace("-synthesis", "")
     else:
         from huggingface_hub import model_info
 
-        # init client
-        sync_scheduler_client.initialize(server_args)
-
         task_name = model_info(server_args.model_path).pipeline_tag
+
+    # init client
+    sync_scheduler_client.initialize(server_args)
 
     if task_name in ("text-to-video", "image-to-video", "video-to-video"):
         task_type = "video"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR adds ModelScope support for diffusion models in SGLang, enabling users in regions with limited Hugging Face access to download and run diffusion models from ModelScope..

## Modifications

- Add support for downloading diffusion models from ModelScope via the SGLANG_USE_MODELSCOPE=True environment variable
- Update hf_diffusers_utils.py, cli/utils.py, and multimodal_gen/apps/webui/main.py to handle ModelScope downloads with the same logic as Hugging Face

## Example
### When set `SGLANG_USE_MODELSCOPE=True`, and use the text-to-image function in the web UI.

(sgl)echo $SGLANG_USE_MODELSCOPE
True
 sglang serve --model-path black-forest-labs/FLUX.1-dev --num-gpus 1 --webui --webui-port 2333
Downloading [model_index.json]: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 536/536 [00:00<00:00, 2.52kB/s]
Downloading [model_index.json]: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 536/536 [00:00<00:00, 2.84kB/s]
[02-09 16:25:59] Disabling some offloading (except dit, text_encoder) for image generation model
[02-09 16:25:59] server_args: {"model_path": "black-forest-labs/FLUX.1-dev", "backend": "auto", "attention_backend": null, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": null, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "vae_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "comfyui_mode": false, "mask_strategy_file_path": null, "STA_mode": "STA_inference", "skip_time_steps": 15, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "disable_autocast": true, "VSA_sparsity": 0.0, "moba_config_path": null, "moba_config": {}, "master_port": 30082, "host": "127.0.0.1", "port": 30000, "webui": true, "webui_port": 2333, "scheduler_port": 5632, "output_path": "outputs/", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true}, "boundary_ratio": null, "log_level": "info"}
[02-09 16:25:59] Starting server...
[02-09 16:26:08] Scheduler bind at endpoint: tcp://127.0.0.1:5632
[02-09 16:26:11] Initializing distributed environment with world_size=1, device=cuda:0
[02-09 16:26:55] No pipeline_class_name specified, using model_index.json
Downloading [model_index.json]: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 536/536 [00:00<00:00, 2.83kB/s]
2026-02-09 16:26:56,885 - modelscope - WARNING - We can not confirm the cached file is for revision: master
Downloading Model from https://www.modelscope.cn to directory: /mnt/workspace/.cache/modelscope/models/black-forest-labs/FLUX.1-dev
2026-02-09 16:26:57,272 - modelscope - INFO - Got 28 files, start to download ...

---------Specific file download information has been omitted/removed here.-----------

2026-02-09 16:31:23,248 - modelscope - INFO - Download model 'black-forest-labs/FLUX.1-dev' successfully.                            | 4.72G/22.2G [01:53<01:22, 226MB/s]
2026-02-09 16:31:23,249 - modelscope - INFO - Creating symbolic link [/mnt/workspace/.cache/modelscope/models/black-forest-labs/FLUX.1-dev]./22.2G [03:12<01:11, 126MB/s]
Loading required modules:  43%|██████████████████████████████████████████████▎                                                             | 3/7 [01:43<02:04, 31.16s/it]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers████████████████████████████████████████████▉| 22.2G/22.2G [04:25<00:00, 124MB/s]
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [03:27<00:00, 29.58s/it]
[02-09 16:34:50] Starting FastAPI server.h_model-00001-of-00003.safetensors]: 100%|█████████████████████████████████████████████████▉| 9.29G/9.30G [03:16<00:00, 125MB/s]
[02-09 16:34:50] Launch FastAPI server in another process because of webui.
[02-09 16:34:52] HTTP Request: GET http://127.0.0.1:2333/gradio_api/startup-events "HTTP/1.1 200 OK"
[02-09 16:34:52] HTTP Request: HEAD http://127.0.0.1:2333/ "HTTP/1.1 200 OK"

================================================================================
SGLang Diffusion WebUI available at: http://127.0.0.1:2333/
================================================================================

[02-09 16:34:53] HTTP Request: GET https://api.gradio.app/pkg-version "HTTP/1.1 200 OK"
INFO:     Started server process [2283185]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:04<00:00,  4.69it/s]
[02-09 16:37:33] Output saved to outputs/A_curious_raccoon_20260209-163719_2d541c82.png

### And after resetting `SGLANG_USE_MODELSCOPE`
the program will download the model from Hugging Face. However, due to network restrictions in mainland China, I haven’t shown this part in detail here.


Traceback (most recent call last):
  File "/root/miniconda3/envs/sgl/bin/sglang", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/mnt/workspace/xxx/sglang/python/sglang/cli/main.py", line 42, in main
    args.func(args, extra_argv)
  File "/mnt/workspace/xxx/sglang/python/sglang/cli/serve.py", line 46, in serve
    is_diffusion_model = get_is_diffusion_model(model_path)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/workspace/xxx/sglang/python/sglang/cli/utils.py", line 163, in get_is_diffusion_model
    model_path = _maybe_download_model(model_path)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/workspace/xxx/sglang/python/sglang/cli/utils.py", line 125, in _maybe_download_model
    raise ValueError(
ValueError: Could not find model locally at black-forest-labs/FLUX.1-dev and failed to download model_index.json/config.json from HF Hub: (MaxRetryError("HTTPSConnectionPool(host='huggingface.co', port=443): Max retries exceeded with url: /black-forest-labs/FLUX.1-dev/resolve/main/config.json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:992)')))"), '(Request ID: 706b8d9d-6368-4570-b2d5-20c1918e0718)')

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
