### PR TITLE
fix(ollama): preserve content in stream=true when max_new_tokens is tiny

### DIFF
--- a/python/sglang/srt/entrypoints/ollama/serving.py
+++ b/python/sglang/srt/entrypoints/ollama/serving.py
@@ -146,8 +146,18 @@ class OllamaServing:
                 delta = text[len(previous_text) :]
                 previous_text = text
 
+                # Send content chunk if there's new content
+                if delta:
+                    response = OllamaChatStreamResponse(
+                        model=model_name,
+                        created_at=self._get_timestamp(),
+                        message=OllamaMessage(role="assistant", content=delta),
+                        done=False,
+                    )
+                    yield orjson.dumps(response.model_dump()) + b"\n"
+
+                # Send final chunk if done
                 if is_done:
-                    # Final chunk
                     response = OllamaChatStreamResponse(
                         model=model_name,
                         created_at=self._get_timestamp(),
@@ -155,15 +165,7 @@ class OllamaServing:
                         done=True,
                         done_reason="stop",
                     )
-                else:
-                    response = OllamaChatStreamResponse(
-                        model=model_name,
-                        created_at=self._get_timestamp(),
-                        message=OllamaMessage(role="assistant", content=delta),
-                        done=False,
-                    )
-
-                yield orjson.dumps(response.model_dump()) + b"\n"
+                    yield orjson.dumps(response.model_dump()) + b"\n"
 
         return StreamingResponse(
             generate_stream(),
@@ -263,6 +265,17 @@ class OllamaServing:
                 delta = text[len(previous_text) :]
                 previous_text = text
 
+                # Send content chunk if there's new content
+                if delta:
+                    response = OllamaGenerateStreamResponse(
+                        model=model_name,
+                        created_at=self._get_timestamp(),
+                        response=delta,
+                        done=False,
+                    )
+                    yield orjson.dumps(response.model_dump()) + b"\n"
+
+                # Send final chunk if done
                 if is_done:
                     response = OllamaGenerateStreamResponse(
                         model=model_name,
@@ -271,15 +284,7 @@ class OllamaServing:
                         done=True,
                         done_reason="stop",
                     )
-                else:
-                    response = OllamaGenerateStreamResponse(
-                        model=model_name,
-                        created_at=self._get_timestamp(),
-                        response=delta,
-                        done=False,
-                    )
-
-                yield orjson.dumps(response.model_dump()) + b"\n"
+                    yield orjson.dumps(response.model_dump()) + b"\n"
 
         return StreamingResponse(
             generate_stream(),


### PR DESCRIPTION
Hi all,

I was doing some experiments with the ollama api (thank you so much for providing an ollama api btw, I am a big fan!). I noticed that when I tried streaming with `max_new_tokens=1` (from the ollama api setting the num_tokens to 1), the generation completed on the very first chunk. This is OK. The *issue* (i think) is that the previous code used an if/else structure that would send either the content OR the done chunk, but not both.

When `is_done=True`, it would skip the content and only send:
```json
{"message": {"content": ""}, "done": true}
```

This caused the actual generated content to be lost for the case where we wanted a single token in streaming mode.

I added a fix. Please double check it.

My fix changes the logic to send the content chunk *first* if delta is non-empty and *then* send the final `done=true` chunk if `is_done` is true. This ensures no content is lost even when the generation completes immediately.

Thank you and I appreciate your time!

Here is a screenshot of the issue:

<img width="753" height="351" alt="image" src="https://github.com/user-attachments/assets/2e682b7d-f4f2-4922-96c8-3633289c055f" />

