### PR TITLE
fix(benchmark): add missing args for speculative decoding benchmark

### DIFF
--- a/scripts/playground/bench_speculative.py
+++ b/scripts/playground/bench_speculative.py
@@ -83,6 +83,8 @@ def send_one_batch(base_url, num_prompts, batch_size, processor, is_multimodal):
         disable_ignore_eos=False,
         disable_stream=False,
         return_logprob=False,
+        return_routed_experts=False,
+        plot_throughput=False,
         backend=backend,
         dataset_name="custom",
         num_prompts=None,


### PR DESCRIPTION
## Motivation

Fix a runtime `AttributeError` in `bench_speculative.py`. 

Currently, the speculative decoding benchmark fails because the `async_request_sglang_generate` function expects `return_routed_experts` and `plot_throughput` to be present in the `args` object, but these were missing from the `SimpleNamespace` initialization in the benchmark script.

**Error Traceback:**
```text
line 588, in async_request_sglang_generate
    "return_routed_experts": args.return_routed_experts,
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'types.SimpleNamespace' object has no attribute 'return_routed_experts'
```

## Modifications

- Updated `bench_speculative.py` to include `return_routed_experts=False` and `plot_throughput=False` in the `args` initialization.
- These additions ensure the `SimpleNamespace` is compatible with the latest backend expectations.

## Accuracy Tests

N/A (This is a fix for a benchmark script and does not affect model outputs).

## Benchmarking and Profiling

N/A (This fix enables the benchmark script to run; it does not change performance characteristics).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).