### PR TITLE
[Fix] Remove unused Type import in gpt_j.py

### DIFF
--- a/python/sglang/srt/models/gpt_j.py
+++ b/python/sglang/srt/models/gpt_j.py
@@ -16,7 +16,7 @@
 # https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gpt_j.py
 """Inference-only GPT-J model compatible with HuggingFace weights."""
 
-from typing import Iterable, Optional, Tuple, Type
+from typing import Iterable, Optional, Tuple
 
 import torch
 from torch import nn


### PR DESCRIPTION
## Summary
- Fix ruff lint error F401 (unused import) by removing the unused `Type` import from the typing module in `gpt_j.py`

## Test plan
- [x] pre-commit checks pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)