### PR TITLE
[Diffusion] Fix lora default lora_scale bug

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -98,7 +98,7 @@ class LoRAPipeline(ComposedPipelineBase):
         if self.lora_path is not None:
             self.convert_to_lora_layers()
             self.set_lora(
-                self.lora_nickname, self.lora_path  # type: ignore
+                self.lora_nickname, self.lora_path, strength=self.server_args.lora_scale  # type: ignore
             )  # type: ignore
 
     def is_target_layer(self, module_name: str) -> bool:

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -276,6 +276,7 @@ class ServerArgs:
     # (Wenxuan) prefer to keep it here instead of in pipeline config to not make it complicated.
     lora_path: str | None = None
     lora_nickname: str = "default"  # for swapping adapters in the pipeline
+    lora_scale: float = 1.0  # LoRA scale for merging (e.g., 0.125 for Hyper-SD)
 
     # VAE parameters
     vae_path: str | None = None  # Custom VAE path (e.g., for distilled autoencoder)
@@ -727,6 +728,12 @@ class ServerArgs:
             type=str,
             default=ServerArgs.lora_nickname,
             help="The nickname for the LoRA adapter to launch with",
+        )
+        parser.add_argument(
+            "--lora-scale",
+            type=float,
+            default=ServerArgs.lora_scale,
+            help="LoRA scale for merging (e.g., 0.125 for Hyper-SD). Same as lora_scale in Diffusers",
         )
         # Add pipeline configuration arguments
         PipelineConfig.add_cli_args(parser)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

For https://huggingface.co/ByteDance/Hyper-SD

Client:

```python
import argparse
import base64
import requests
import time
from datetime import datetime


def main():
    parser = argparse.ArgumentParser(description="Test SGLang FLUX image generation")
    parser.add_argument("--host", type=str, default="127.0.0.1", help="Server host")
    parser.add_argument("--port", type=int, default=30000, help="Server port")
    parser.add_argument("--prompt", type=str, default="a lovely cat is drinking water from a glass", help="Generation prompt")
    parser.add_argument("--negative-prompt", type=str, default="", help="Negative prompt")
    parser.add_argument("--steps", type=int, default=16, help="Number of inference steps")
    parser.add_argument("--guidance", type=float, default=3.5, help="Guidance scale")
    parser.add_argument("--seed", type=int, default=None, help="Random seed")
    parser.add_argument("--output", type=str, default="output.png", help="Output filename")
    args = parser.parse_args()

    # Prepare request
    url = f"http://{args.host}:{args.port}/v1/images/generations"
    data = {
        "prompt": args.prompt,
        "size": "1024x1024",
        "num_inference_steps": args.steps,
        "guidance_scale": args.guidance,
        "response_format": "b64_json",
        "n": 1
    }
    if args.negative_prompt:
        data["negative_prompt"] = args.negative_prompt
    if args.seed is not None:
        data["seed"] = args.seed

    # Generate image
    print(f"🎨 Generating image with {args.steps} steps...")
    print(f"📝 Prompt: {args.prompt}")
    start_time = time.time()
    response = requests.post(url, json=data, timeout=600)
    response.raise_for_status()
    elapsed = time.time() - start_time

    # Save image
    result = response.json()
    image_data = base64.b64decode(result["data"][0]["b64_json"])
    with open(args.output, "wb") as f:
        f.write(image_data)
    
    print(f"✅ Success! Image saved to: {args.output}")
    print(f"⏱️  Time: {elapsed:.2f}s")


if __name__ == "__main__":
    main()

```

### main

```shell
#!/bin/bash
# export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so.1:$LD_PRELOAD
# export FLASHINFER_DISABLE_VERSION_CHECK=1

# Set default values
MODEL_PATH="/nas/shared/models/FLUX.1-dev"

PORT=30000
HOST="0.0.0.0"
NUM_GPUS=1
TP_SIZE=1
USP_SIZE=1
RING_SIZE=1

# Launch the multimodal_gen server with optimizations enabled
python3 -m sglang.multimodal_gen.runtime.launch_server \
  --model-path "$MODEL_PATH" \
  --port "$PORT" \
  --host "$HOST" \
  --num-gpus "$NUM_GPUS" \
  --tp-size "$TP_SIZE" \
  --ulysses-degree "$USP_SIZE" \
  --ring-degree "$RING_SIZE" \
  --attention-backend fa3 \
  --pin-cpu-memory \
  --warmup \
  --enable-torch-compile \
  --lora-path /nas/shared/models/ByteDance/Hyper-SD/Hyper-FLUX.1-dev-16steps-lora.safetensors 

```
<img width="1068" height="1002" alt="图片" src="https://github.com/user-attachments/assets/03467744-25ef-4290-b845-8c5c12cb979c" />


### pr

```shell
#!/bin/bash
# export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so.1:$LD_PRELOAD
# export FLASHINFER_DISABLE_VERSION_CHECK=1

# Set default values
MODEL_PATH="/nas/shared/models/FLUX.1-dev"

PORT=30000
HOST="0.0.0.0"
NUM_GPUS=1
TP_SIZE=1
USP_SIZE=1
RING_SIZE=1

# Launch the multimodal_gen server with optimizations enabled
python3 -m sglang.multimodal_gen.runtime.launch_server \
  --model-path "$MODEL_PATH" \
  --port "$PORT" \
  --host "$HOST" \
  --num-gpus "$NUM_GPUS" \
  --tp-size "$TP_SIZE" \
  --ulysses-degree "$USP_SIZE" \
  --ring-degree "$RING_SIZE" \
  --attention-backend fa3 \
  --pin-cpu-memory \
  --warmup \
  --enable-torch-compile \
  --lora-path /nas/shared/models/ByteDance/Hyper-SD/Hyper-FLUX.1-dev-16steps-lora.safetensors \
  --lora-scale 0.125
```

<img width="908" height="926" alt="图片" src="https://github.com/user-attachments/assets/8687dbef-cde2-4a97-b5ef-b817e07dbce2" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
