### PR TITLE
[Diffusion] Fix FLUX.1-schnell time embedding argument mismatch

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -541,11 +541,11 @@ class FluxTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             )
         hidden_states, _ = self.x_embedder(hidden_states)
 
-        temb = (
-            self.time_text_embed(timestep, pooled_projections)
-            if guidance is None
-            else self.time_text_embed(timestep, guidance, pooled_projections)
-        )
+        # Only pass guidance to time_text_embed if the model supports it
+        if self.config.guidance_embeds and guidance is not None:
+            temb = self.time_text_embed(timestep, guidance, pooled_projections)
+        else:
+            temb = self.time_text_embed(timestep, pooled_projections)
 
         encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In main:

Server:

```shell
#!/bin/bash
# export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so.1:$LD_PRELOAD
# export FLASHINFER_DISABLE_VERSION_CHECK=1

# Set default values
MODEL_PATH="/nas/shared/models/FLUX.1-schnell"

PORT=30000
HOST="0.0.0.0"
NUM_GPUS=1
TP_SIZE=1
USP_SIZE=1
RING_SIZE=1

# Launch the multimodal_gen server with optimizations enabled
python3 -m sglang.multimodal_gen.runtime.launch_server \
  --model-path "$MODEL_PATH" \
  --port "$PORT" \
  --host "$HOST" \
  --num-gpus "$NUM_GPUS" \
  --tp-size "$TP_SIZE" \
  --ulysses-degree "$USP_SIZE" \
  --ring-degree "$RING_SIZE" \
  --attention-backend fa3 \
  --pin-cpu-memory \
  --warmup \
  --enable-torch-compile
```

Client:

```shell
import argparse
import base64
import requests
import time

def main():
    parser = argparse.ArgumentParser(description="Test SGLang FLUX.1-schnell image generation")
    parser.add_argument("--host", type=str, default="127.0.0.1", help="Server host")
    parser.add_argument("--port", type=int, default=30000, help="Server port")
    parser.add_argument("--prompt", type=str, default="A cat holding a sign that says hello world", help="Generation prompt")
    parser.add_argument("--steps", type=int, default=4, help="Number of inference steps (schnell uses 4)")
    parser.add_argument("--guidance", type=float, default=0.0, help="Guidance scale (schnell uses 0.0)")
    parser.add_argument("--seed", type=int, default=0, help="Random seed")
    parser.add_argument("--max-sequence-length", type=int, default=256, help="Max sequence length")
    parser.add_argument("--output", type=str, default="flux-schnell.png", help="Output filename")
    args = parser.parse_args()

    # Prepare request
    url = f"http://{args.host}:{args.port}/v1/images/generations"
    data = {
        "prompt": args.prompt,
        "size": "1024x1024",
        "num_inference_steps": args.steps,
        "guidance_scale": args.guidance,
        #"max_sequence_length": args.max_sequence_length,
        "seed": args.seed,
        "response_format": "b64_json",
        "n": 1
    }

    # Generate image
    print(f"🎨 FLUX.1-schnell: Generating image with {args.steps} steps (guidance={args.guidance})...")
    print(f"📝 Prompt: {args.prompt}")
    print(f"🔢 Seed: {args.seed}, Max seq length: {args.max_sequence_length}")
    start_time = time.time()
    response = requests.post(url, json=data, timeout=600)
    response.raise_for_status()
    elapsed = time.time() - start_time

    # Save image
    result = response.json()
    image_data = base64.b64decode(result["data"][0]["b64_json"])
    with open(args.output, "wb") as f:
        f.write(image_data)
    
    print(f"✅ Success! Image saved to: {args.output}")
    print(f"⏱️  Time: {elapsed:.2f}s")

if __name__ == "__main__":
    main()
```

I got the error:

```shell
[01-30 09:08:25] [DenoisingStage] Error during execution after 4.0582 ms: CombinedTimestepTextProjEmbeddings.forward() takes 3 positional arguments but 4 were given
Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 200, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1021, in forward
    noise_pred = self._predict_noise_with_cfg(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1266, in _predict_noise_with_cfg
    noise_pred_cond = self._predict_noise(
                      ^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1212, in _predict_noise
    return current_model(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 832, in compile_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/multimodal_gen/runtime/models/dits/flux.py", line 531, in forward
    else self.time_text_embed(timestep, guidance, pooled_projections)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CombinedTimestepTextProjEmbeddings.forward() takes 3 positional arguments but 4 were given
```


## Root Cause
- FLUX.1-schnell uses `guidance_embeds=False`(https://huggingface.co/black-forest-labs/FLUX.1-schnell/blob/main/transformer/config.json#L5), which means it uses `CombinedTimestepTextProjEmbeddings` (accepts 2 args: timestep, pooled_projections)
- The original code only checked `if guidance is None` but didn't verify if the model actually supports guidance embeddings
- When guidance was passed (even 0.0), it tried to call with 3 arguments, causing the error

## Solution
Changed the logic to check both conditions:
- Only pass guidance to `time_text_embed` when **both** `self.config.guidance_embeds=True` AND `guidance is not None`
- Otherwise, call with just timestep and pooled_projections

With the fix:

<img width="1386" height="614" alt="图片" src="https://github.com/user-attachments/assets/977eb21a-1079-4b2a-abc0-f3fb7629e01f" />

<img width="1028" height="790" alt="图片" src="https://github.com/user-attachments/assets/da5fe837-69cf-444b-b9c5-3a8e528ae972" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
