### PR TITLE
Remove unused num_experts in CompressedTensorsWNA16TritonMoEMethod

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1396,8 +1396,6 @@ class CompressedTensorsWNA16TritonMoEMethod(CompressedTensorsWNA16MoEMethod):
         if getattr(layer, "is_triton_converted", False):
             return
 
-        num_experts = layer.w13_weight_packed.shape[0]
-
         # Convert w13 weights: [E, K//8, N] int32 -> [E, N, K//2] uint8
         w13 = layer.w13_weight_packed.data
         w13 = w13.transpose(1, 2).contiguous().view(torch.uint8)


### PR DESCRIPTION
## Summary

- Remove unused `num_experts` variable in `CompressedTensorsWNA16TritonMoEMethod.process_weights_after_loading`.

Follow-up from review comment on #17863 by @kkHuang-amd.

## Test plan

- [x] Pre-commit checks pass
- [x] No functional change — the variable was assigned but never referenced