### PR TITLE
add reasoning_tokens usage test for tool call

### DIFF
--- a/test/registered/8-gpu-models/test_deepseek_v32.py
+++ b/test/registered/8-gpu-models/test_deepseek_v32.py
@@ -96,7 +96,9 @@ class TestDeepseekV32(unittest.TestCase):
                 batch_sizes=[1, 8, 16, 64],
                 profile_dir="performance_profiles_deepseek_v32",
             ),
-            tool_call_params=ToolCallTestParams(test_thinking=True),
+            tool_call_params=ToolCallTestParams(
+                test_thinking=True, test_reasoning_usage=True
+            ),
         )
 
     @unittest.skipIf(is_blackwell_system(), "Requires H200 system")


### PR DESCRIPTION
Add a test case to verify usage.reasoning_tokens > 0 when thinking is enabled in tool call scenarios.

related #17933