### PR TITLE
[MUSA] Update 3rd party dir to build/_deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,11 +272,6 @@ python/sglang/srt/grpc/*_pb2.pyi
 sgl-kernel/csrc_musa/
 sgl-kernel/include_musa/
 sgl-kernel/csrc/**/*_musa/
-sgl-kernel/third_party/*/csrc_musa/
-sgl-kernel/third_party/*/include_musa/
-
-# Third-party libraries source code
-sgl-kernel/third_party/
 
 # MUSA core dump files
 *.mudmp

--- a/sgl-kernel/setup_musa.py
+++ b/sgl-kernel/setup_musa.py
@@ -28,7 +28,7 @@ from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 root = Path(__file__).parent.resolve()
-third_party = Path("third_party")
+third_party = Path(os.environ.get("SGLANG_MUSA_THIRD_PARTY_DIR", "build/_deps"))
 arch = platform.machine().lower()
 
 
@@ -160,7 +160,7 @@ class _CustomBuildExt(BuildExtension):
     @staticmethod
     def _clone_and_checkout(repo_path, repo_url, git_tag, git_shallow):
         """Clone a git repository and checkout a specific tag/commit."""
-        repo_path.parent.mkdir(exist_ok=True)
+        repo_path.parent.mkdir(parents=True, exist_ok=True)
         if not repo_path.exists():
             clone_cmd = ["git", "clone"]
             if git_shallow:
@@ -173,8 +173,10 @@ class _CustomBuildExt(BuildExtension):
             subprocess.check_call(["git", "checkout", git_tag], cwd=repo_path)
 
     def run(self):
-        if os.environ.get("SKIP_THIRD_PARTY", "0") == "1":
-            print("Skipping third-party repositories cloning (SKIP_THIRD_PARTY=1)")
+        if os.environ.get("SGLANG_MUSA_SKIP_THIRD_PARTY", "0") == "1":
+            print(
+                "Skipping third-party repositories cloning (SGLANG_MUSA_SKIP_THIRD_PARTY=1)"
+            )
         else:
             print("Cloning third-party repositories...")
             self._clone_and_checkout(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The MUSA build previously cloned third-party repositories (mutlass, flashinfer) into `sgl-kernel/third_party/`, which polluted the source tree and required explicit `.gitignore` entries. This was inconsistent with the CUDA CMake build, which uses `FetchContent` to clone dependencies into `build/_deps/` - a directory already ignored by the existing `**/build/` pattern in `.gitignore`.

## Modifications

<!-- Detail the changes made in this pull request. -->
- **`sgl-kernel/setup_musa.py`**:
  - Change default third-party directory from `third_party` to `build/_deps` to match CMake's `FetchContent` behavior
  - Add `SGLANG_MUSA_THIRD_PARTY_DIR` environment variable for custom override
  - Rename `SKIP_THIRD_PARTY` to `SGLANG_MUSA_SKIP_THIRD_PARTY` for consistent naming convention
  - Add `parents=True` to `mkdir()` to create full directory hierarchy

- **`.gitignore`**:
  - Remove `sgl-kernel/third_party/` entries (no longer needed since `build/_deps/` is covered by `**/build/`)

### Testing Done

sgl-kernel build on MUSA passed.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
