### PR TITLE
[CI] Fix AMD CI by inlining dummy_grok config

### DIFF
--- a/python/sglang/multimodal_gen/__init__.py
+++ b/python/sglang/multimodal_gen/__init__.py
@@ -4,3 +4,5 @@ from sglang.multimodal_gen.configs.sample import SamplingParams
 from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator
 
 __all__ = ["DiffGenerator", "PipelineConfig", "SamplingParams"]
+
+# Trigger multimodal CI tests

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -124,7 +124,31 @@ docker cp human-eval ci_sglang:/
 install_with_retry docker exec -w /human-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
 
 docker exec -w / ci_sglang mkdir -p /dummy-grok
-mkdir -p dummy-grok && wget https://sharkpublic.blob.core.windows.net/sharkpublic/sglang/dummy_grok.json -O dummy-grok/config.json
+# Create dummy grok config inline (bypasses Azure blob storage which may have auth issues)
+mkdir -p dummy-grok
+cat > dummy-grok/config.json << 'EOF'
+{
+  "architectures": [
+    "Grok1ModelForCausalLM"
+  ],
+  "embedding_multiplier_scale": 78.38367176906169,
+  "output_multiplier_scale": 0.5773502691896257,
+  "vocab_size": 131072,
+  "hidden_size": 6144,
+  "intermediate_size": 32768,
+  "max_position_embeddings": 8192,
+  "num_experts_per_tok": 2,
+  "num_local_experts": 8,
+  "num_attention_heads": 48,
+  "num_hidden_layers": 64,
+  "num_key_value_heads": 8,
+  "head_dim": 128,
+  "rms_norm_eps": 1e-05,
+  "rope_theta": 10000.0,
+  "model_type": "mixtral",
+  "torch_dtype": "bfloat16"
+}
+EOF
 docker cp ./dummy-grok ci_sglang:/
 
 docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache huggingface_hub[hf_xet]


### PR DESCRIPTION
## Motivation

The Azure blob storage endpoint (`sharkpublic.blob.core.windows.net`) is returning **403 Forbidden** errors, causing all AMD CI jobs to fail at the "Install dependencies" step:

```
--2026-01-31 10:11:33--  https://sharkpublic.blob.core.windows.net/sharkpublic/sglang/dummy_grok.json
HTTP request sent, awaiting response... 403 This request is not authorized to perform this operation.
```

This is affecting multiple PRs including #18026.

## Modifications

- Remove the `wget` download from Azure blob storage
- Create the `config.json` inline using a heredoc
- Config content sourced from existing documentation (`3rdparty/amd/profiling/PROFILING.md`)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).


Made with [Cursor](https://cursor.com)