### PR TITLE
Disable test_mla_int8_deepseek_v3.py temporarily

### DIFF
--- a/test/registered/mla/test_mla_int8_deepseek_v3.py
+++ b/test/registered/mla/test_mla_int8_deepseek_v3.py
@@ -16,7 +16,11 @@ from sglang.test.test_utils import (
 )
 
 # DeepSeek-V3 INT8 quantization tests (channel and block INT8)
-register_cuda_ci(est_time=341, suite="stage-b-test-large-1-gpu")
+register_cuda_ci(
+    est_time=341,
+    suite="stage-b-test-large-1-gpu",
+    disabled="HF token doesn't have private repository access",
+)
 
 
 class TestMLADeepseekV3ChannelInt8(CustomTestCase):


### PR DESCRIPTION
## Summary
- Temporarily disable `test_mla_int8_deepseek_v3.py` due to HF token not having private repository access
- The test requires access to private model repos `sgl-project/sglang-ci-dsv3-block-int8-test` and `sgl-project/sglang-ci-dsv3-channel-int8-test`

## Failure example
http://shirengithub.com/sgl-project/sglang/actions/runs/21557930062/job/62117515590?pr=17299

## Test plan
- CI should pass without running the disabled test