### PR TITLE
[DeepGEMM] Add DeepGEMM BF16 support

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -57,7 +57,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_DG_CACHE_DIR` | Directory for caching compiled DeepGEMM kernels | `~/.cache/deep_gemm` |
 | `SGL_DG_USE_NVRTC` | Use NVRTC (instead of Triton) for JIT compilation (Experimental) | `"0"` |
 | `SGL_USE_DEEPGEMM_BMM` | Use DeepGEMM for Batched Matrix Multiplication (BMM) operations | `"false"` |
-| `SGLANG_USE_DEEPGEMM_BF16_GEMM` | Use DeepGEMM for BF16 GEMM in unquantized linear layers | `"false"` |
+| `SGLANG_USE_DEEPGEMM_BF16_GEMM` | Use DeepGEMM for BF16 GEMM in unquantized linear layers; also enables BF16 DeepGEMM for MoE when the runner backend resolves to `deep_gemm` (auto may choose other backends) | `"false"` |
 
 ## DeepEP Configuration
 

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -57,7 +57,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_DG_CACHE_DIR` | Directory for caching compiled DeepGEMM kernels | `~/.cache/deep_gemm` |
 | `SGL_DG_USE_NVRTC` | Use NVRTC (instead of Triton) for JIT compilation (Experimental) | `"0"` |
 | `SGL_USE_DEEPGEMM_BMM` | Use DeepGEMM for Batched Matrix Multiplication (BMM) operations | `"false"` |
-| `SGLANG_USE_DEEPGEMM_BF16_GEMM` | Use DeepGEMM for BF16 GEMM in unquantized linear layers; also enables BF16 DeepGEMM for MoE when the runner backend resolves to `deep_gemm` (auto may choose other backends) | `"false"` |
+| `SGLANG_USE_DEEPGEMM_BF16_GEMM` | Use DeepGEMM for BF16 GEMM in unquantized linear layers (MoE requires `--moe-runner-backend deep_gemm`) | `"false"` |
 
 ## DeepEP Configuration
 

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -57,6 +57,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_DG_CACHE_DIR` | Directory for caching compiled DeepGEMM kernels | `~/.cache/deep_gemm` |
 | `SGL_DG_USE_NVRTC` | Use NVRTC (instead of Triton) for JIT compilation (Experimental) | `"0"` |
 | `SGL_USE_DEEPGEMM_BMM` | Use DeepGEMM for Batched Matrix Multiplication (BMM) operations | `"false"` |
+| `SGLANG_USE_DEEPGEMM_BF16_GEMM` | Use DeepGEMM for BF16 GEMM in unquantized linear layers | `"false"` |
 
 ## DeepEP Configuration
 

--- a/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+++ b/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
@@ -13,7 +13,7 @@ from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
 from sglang.srt.utils.common import calc_diff, get_bool_env_var
 
 if ENABLE_JIT_DEEPGEMM:
-    import deep_gemm
+    from sglang.srt.layers import deep_gemm_wrapper
 
 _ENABLE_MM_DEEPGEMM = get_bool_env_var(
     "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM", "1"
@@ -246,7 +246,7 @@ def _matmul_persistent_deepgemm(
     out = torch.empty((M, N), device=a.device, dtype=dtype)
 
     try:
-        deep_gemm.bf16_gemm_nn(a, b, out)
+        deep_gemm_wrapper.gemm_nn_bf16(a, b, out)
     except RuntimeError as e:
         raise RuntimeError(
             f"DeepGEMM failed for matrix shapes M={M}, N={N}, K={K}. "

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -339,6 +339,7 @@ class Envs:
     SGLANG_DG_CACHE_DIR = EnvStr(os.path.expanduser("~/.cache/deep_gemm"))
     SGLANG_DG_USE_NVRTC = EnvBool(False)
     SGLANG_USE_DEEPGEMM_BMM = EnvBool(False)
+    SGLANG_USE_DEEPGEMM_BF16_GEMM = EnvBool(False)
     SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD = EnvInt(8192)
 
     # DeepEP

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -66,6 +66,7 @@ class DeepGemmKernelType(IntEnum):
     GROUPED_GEMM_NT_F8F8BF16_MASKED = auto()
     GROUPED_GEMM_NT_F8F8BF16_CONTIG = auto()
     GEMM_NT_F8F8BF16 = auto()
+    GEMM_NN_BF16 = auto()
 
 
 _INITIALIZATION_DICT: Dict[Tuple[DeepGemmKernelType, int, int, int], bool] = dict()
@@ -186,6 +187,7 @@ class _BaseWarmupExecutor:
             DeepGemmKernelType.GEMM_NT_F8F8BF16: _NormalWarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG: _GroupedContWarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_MASKED: _GroupedMaskedWarmupExecutor,
+            DeepGemmKernelType.GEMM_NN_BF16: _Bf16GemmNnWarmupExecutor,
         }[kernel_type](**kwargs)
 
     @staticmethod
@@ -196,6 +198,8 @@ class _BaseWarmupExecutor:
         _GB = 1 << 30
         if kernel_type == DeepGemmKernelType.GEMM_NT_F8F8BF16:
             return (max_m * k + n * k + max_m * n * 2) / _GB
+        elif kernel_type == DeepGemmKernelType.GEMM_NN_BF16:
+            return (2 * (max_m * k + n * k + max_m * n)) / _GB
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG:
             return (max_m * k + num_groups * n * k + max_m * 4 + max_m * n * 2) / _GB
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_MASKED:
@@ -285,6 +289,16 @@ class _GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
             # DeepGEMM uses `expect_m` instead of input shape for `get_best_config`
             expected_m=m,
         )
+
+
+class _Bf16GemmNnWarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.a = torch.empty((max_m, k), device="cuda", dtype=torch.bfloat16)
+        self.b = torch.empty((k, n), device="cuda", dtype=torch.bfloat16)
+        self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+
+    def execute(self, m):
+        deep_gemm.bf16_gemm_nn(self.a[:m], self.b, self.out[:m])
 
 
 @contextmanager

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -102,6 +102,21 @@ def gemm_nt_f8f8bf16(
         )
 
 
+def gemm_nn_bf16(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    out: torch.Tensor,
+    c: Optional[torch.Tensor] = None,
+):
+    m, k = lhs.shape
+    _, n = rhs.shape
+    num_groups = 1
+    kernel_type = compile_utils.DeepGemmKernelType.GEMM_NN_BF16
+
+    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+        deep_gemm.bf16_gemm_nn(lhs, rhs, out, c)
+
+
 def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
     compile_utils.update_deep_gemm_config(gpu_id, server_args)
 

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -64,6 +64,23 @@ def grouped_gemm_nt_f8f8bf16_masked(
             )
 
 
+def grouped_gemm_nt_bf16_masked(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    out: torch.Tensor,
+    masked_m: torch.Tensor,
+    expected_m: int,
+):
+    num_groups, _, k = lhs.shape
+    _, n, _ = rhs.shape
+    kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED
+
+    with compile_utils.deep_gemm_execution_hook(
+        expected_m, n, k, num_groups, kernel_type
+    ):
+        deep_gemm.m_grouped_bf16_gemm_nt_masked(lhs, rhs, out, masked_m, expected_m)
+
+
 def grouped_gemm_nt_f8f8bf16_contig(
     lhs: Tuple[torch.Tensor, torch.Tensor],
     rhs: Tuple[torch.Tensor, torch.Tensor],
@@ -79,6 +96,20 @@ def grouped_gemm_nt_f8f8bf16_contig(
 
     with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(lhs, rhs, out, m_indices)
+
+
+def grouped_gemm_nt_bf16_contig(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    out: torch.Tensor,
+    m_indices: torch.Tensor,
+):
+    m, k = lhs.shape
+    num_groups, n, _ = rhs.shape
+    kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG
+
+    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(lhs, rhs, out, m_indices)
 
 
 def gemm_nt_f8f8bf16(

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -102,11 +102,24 @@ def gemm_nt_f8f8bf16(
         )
 
 
+def gemm_nt_bf16(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    out: torch.Tensor,
+):
+    m, k = lhs.shape
+    n, _ = rhs.shape
+    num_groups = 1
+    kernel_type = compile_utils.DeepGemmKernelType.GEMM_NT_BF16
+
+    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+        deep_gemm.bf16_gemm_nt(lhs, rhs, out)
+
+
 def gemm_nn_bf16(
     lhs: torch.Tensor,
     rhs: torch.Tensor,
     out: torch.Tensor,
-    c: Optional[torch.Tensor] = None,
 ):
     m, k = lhs.shape
     _, n = rhs.shape
@@ -114,7 +127,7 @@ def gemm_nn_bf16(
     kernel_type = compile_utils.DeepGemmKernelType.GEMM_NN_BF16
 
     with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
-        deep_gemm.bf16_gemm_nn(lhs, rhs, out, c)
+        deep_gemm.bf16_gemm_nn(lhs, rhs, out)
 
 
 def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -361,16 +361,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 if self.use_triton_kernels
                 else MoeRunnerBackend.TRITON
             )
-            if (
-                _use_deepgemm_bf16_gemm
-                and not _is_hip
-                and not _is_npu
-                and moe_runner_config.params_dtype == torch.bfloat16
-            ):
-                from sglang.srt.layers import deep_gemm_wrapper
-
-                if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
-                    backend = MoeRunnerBackend.DEEP_GEMM
         self.runner = MoeRunner(backend, moe_runner_config)
 
     @property

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
@@ -46,6 +47,7 @@ _is_hip = is_hip()
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_deepgemm_bf16_gemm = envs.SGLANG_USE_DEEPGEMM_BF16_GEMM.get()
 
 if _use_aiter:
     from aiter import ActivationType
@@ -147,6 +149,40 @@ class UnquantizedLinearMethod(LinearMethodBase):
             if len(x_shapes) == 3:
                 output = output.view(x_shapes[0], x_shapes[1], -1)
             return output
+
+        if (
+            _use_deepgemm_bf16_gemm
+            and x.is_cuda
+            and not _is_hip
+            and not _is_npu
+            and x.dtype == torch.bfloat16
+            and layer.weight.dtype == torch.bfloat16
+        ):
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
+                weight = layer.weight
+                if weight.stride(-1) == 1 or weight.stride(-2) == 1:
+                    x_shape = x.shape
+                    x_2d = x.reshape(-1, x.shape[-1]) if x.dim() != 2 else x
+                    if x_2d.stride(-1) != 1 and x_2d.stride(-2) != 1:
+                        x_2d = x_2d.contiguous()
+
+                    out_dtype = torch.result_type(x_2d, weight)
+                    if bias is not None:
+                        out_dtype = torch.promote_types(out_dtype, bias.dtype)
+
+                    out_2d = torch.empty(
+                        (x_2d.shape[0], weight.shape[0]),
+                        device=x.device,
+                        dtype=out_dtype,
+                    )
+                    deep_gemm_wrapper.gemm_nt_bf16(x_2d, weight, out_2d)
+                    if bias is not None:
+                        out_2d.add_(bias)
+                    if x.dim() != 2:
+                        return out_2d.view(*x_shape[:-1], weight.shape[0])
+                    return out_2d
 
         return F.linear(x, layer.weight, bias)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

#18028 - add BF16 DeepGEMM support for unquantized linear (and batch‑invariant matmul), plus an opt‑in BF16 DeepGEMM MoE path.

## Modifications

- Add `SGLANG_USE_DEEPGEMM_BF16_GEMM` env and docs (linear only; MoE requires explicit backend).
- Route batch‑invariant BF16 matmul to `deep_gemm_wrapper.gemm_nn_bf16`.
- Add BF16 DeepGEMM kernels + warmup hooks (GEMM_NT/NN and grouped BF16).
- Add BF16 MoE preprocess + grouped BF16 MoE execution in DeepGEMM runner.
- Make BF16 DeepGEMM MoE opt‑in via `--moe-runner-backend deep_gemm` (no auto‑enable).

## Accuracy Tests

### Qwen3‑4B‑Thinking‑2507 (Dense, BF16), GSM8K 20 shots
- cuBLAS:
```
Accuracy: 0.901
Invalid: 0.000
Latency: 41.483 s
Output throughput: 4201.460 token/s
```

- DeepGEMM:
```
Accuracy: 0.901
Invalid: 0.000
Latency: 40.769 s
Output throughput: 4266.452 token/s
```

### Qwen3‑30B‑A3B‑Thinking‑2507 (MoE, BF16), GSM8K 20 shots

- cuBLAS + Triton MoE:
```
Accuracy: 0.931
Invalid: 0.000
Latency: 52.152 s
Output throughput: 3331.034 token/s
```

- DeepGEMM + Triton MoE:
```
Accuracy: 0.932
Invalid: 0.000
Latency: 56.301 s
Output throughput: 3078.020 token/s
```

- cuBLAS + DeepGEMM MoE:
```
Accuracy: 0.921
Invalid: 0.000
Latency: 53.322 s
Output throughput: 3245.123 token/s
```

- DeepGEMM + DeepGEMM:
```
Accuracy: 0.923
Invalid: 0.000
Latency: 50.911 s
Output throughput: 3386.896 token/s
```

## Benchmarking and Profiling

`python -m sglang.bench_one_batch_server --model None --base-url http://127.0.0.1:30000 --batch-size 1 2 4 8 16 32 64 128 256 --input-len 512 --output-len 512`

<img width="5370" height="1759" alt="benchmark_results" src="https://github.com/user-attachments/assets/7bc0a909-228d-42f9-b5f9-bf9ed6d51b56" />

Note: BF16 DeepGEMM MoE is slower than Triton MoE on this workload (expected due to extra reorder/padding, no fused activation/quant, and higher BF16 bandwidth), so it is opt‑in only.

## Review Process

cc @Fridge003 
