### PR TITLE
[Diffusion] Fix Ring Parallel bug with FA4

### DIFF
--- a/python/sglang/jit_kernel/flash_attention/cute/interface.py
+++ b/python/sglang/jit_kernel/flash_attention/cute/interface.py
@@ -1364,6 +1364,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             pack_gqa=pack_gqa,
             score_mod=score_mod,
             aux_tensors=aux_tensors,
+            return_lse=True,
         )
         ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k)
         ctx.softmax_scale = softmax_scale


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

```shell
CUDA_VISIBLE_DEVICES=4,5,6,7 sglang generate \
  --model-path OpenMOSS-Team/MOVA-720p \
  --prompt “A man in a blue blazer and glasses speaks in a formal indoor setting, \
  framed by wooden furniture and a filled bookshelf. \
  Quiet room acoustics underscore his measured tone as he delivers his remarks. \
  At one point, he says, \“I would also believe that this advance in AI recently wasn’t unexpected.\“” \
  --image-path “https://github.com/OpenMOSS/MOVA/raw/main/assets/single_person.jpg” \
  --adjust-frames false \
  --num-gpus 4 \
  --ring-degree 2 \
  --ulysses-degree 2 \
  --num-frames 193 \
  --fps 24 \
  --seed 67 \
  --num-inference-steps 25 \
  --save-output
```

I got error:

```shell
[02-01 08:32:55] [MOVADenoisingStage] Error during execution after 27802.2017 ms: 'NoneType' object has no attribute 'dtype'
Traceback (most recent call last):
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 203, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/model_stages/mova.py", line 478, in forward
    pos = self._predict(
          ^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/model_stages/mova.py", line 183, in _predict
    return self.inference_single_step(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/model_stages/mova.py", line 736, in inference_single_step
    visual_x, audio_x = self.forward_dual_tower_dit(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/model_stages/mova.py", line 831, in forward_dual_tower_dit
    visual_x, audio_x = self.dual_tower_bridge(
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/bridges/mova_dual_tower.py", line 638, in forward
    visual_conditioned = self.apply_conditional_control(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/bridges/mova_dual_tower.py", line 602, in apply_conditional_control
    conditioned_features = conditioner(
                           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/bridges/mova_dual_tower.py", line 394, in forward
    return self.inner(x=x, y=y, x_freqs=x_freqs, y_freqs=y_freqs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/models/bridges/mova_dual_tower.py", line 293, in forward
    x = self.attn(q, k, v)
        ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/layers/attention/layer.py", line 376, in forward
    out = ring_attn(
          ^^^^^^^^^^
  File "/home/lmsys/bbuf/sglang/python/sglang/multimodal_gen/runtime/layers/usp.py", line 244, in ring_attn
    out, *_ = _templated_ring_attention(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/experimental/_attention.py", line 473, in _templated_ring_attention
    sdpa_merger.step(out, logsumexp, partial)
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/experimental/_attention.py", line 209, in step
    self._lse_dtype = lse.dtype
                      ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'dtype'
[02-01 08:32:55] Error executing request 1682b242-c4cf-44f9-8dc9-6257559b6624: 'NoneType' object has no attribute 'dtype'
```

With pr:

<img width="1638" height="380" alt="图片" src="https://github.com/user-attachments/assets/5f1ffc23-2577-4326-bfad-a138bca4d736" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
