### PR TITLE
feat(docs): add markdown/notebook export targets for downstream integration

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -89,4 +89,3 @@ clean:
 	find . -name "*.ipynb" -exec nbstripout {} \;
 	rm -rf $(BUILDDIR)
 	rm -rf logs
-

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,6 +11,9 @@ help:
 	@echo ""
 	@echo "Additional targets:"
 	@echo "  serve       to build and serve documentation with auto-build and live reload"
+	@echo "  markdown    to build Markdown documentation for downstream consumption"
+	@echo "  export      to export source documentation files (md/rst/ipynb)"
+	@echo "  export-all  to run compile, export, and markdown in sequence"
 
 # Compile Notebook files and record execution time
 compile:
@@ -47,7 +50,37 @@ serve:
 		--watch $(SOURCEDIR) \
 		--re-ignore ".*\.(ipynb_checkpoints|pyc|pyo|pyd|git)"
 
-.PHONY: help Makefile compile clean serve
+# Build Markdown documentation for downstream consumption (RAG, LLM, etc.)
+markdown:
+	@echo "Building Markdown documentation..."
+	@$(SPHINXBUILD) -M markdown "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo "Markdown documentation built in $(BUILDDIR)/markdown/"
+
+# Export source documentation files to a structured directory
+export:
+	@echo "Exporting documentation source files..."
+	@mkdir -p $(BUILDDIR)/export
+	@find $(SOURCEDIR) -path "$(BUILDDIR)" -prune -o \( -name "*.md" -o -name "*.rst" -o -name "*.ipynb" \) -type f -print | \
+		while read f; do \
+			rel=$${f#./}; \
+			mkdir -p "$(BUILDDIR)/export/$$(dirname $$rel)"; \
+			cp "$$f" "$(BUILDDIR)/export/$$rel"; \
+		done
+	@echo "Documentation exported to $(BUILDDIR)/export/"
+	@echo "Files exported: $$(find $(BUILDDIR)/export -type f | wc -l | tr -d ' ')"
+
+# Full export pipeline: compile notebooks, export sources, build markdown
+export-all: compile export markdown
+	@echo ""
+	@echo "==============================================="
+	@echo "Full documentation export complete!"
+	@echo "==============================================="
+	@echo "  - Executed notebooks: source files (in-place)"
+	@echo "  - Source export:      $(BUILDDIR)/export/"
+	@echo "  - Markdown output:    $(BUILDDIR)/markdown/"
+	@echo ""
+
+.PHONY: help Makefile compile clean serve markdown export export-all
 
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -56,3 +89,4 @@ clean:
 	find . -name "*.ipynb" -exec nbstripout {} \;
 	rm -rf $(BUILDDIR)
 	rm -rf logs
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -60,10 +60,10 @@ markdown:
 export:
 	@echo "Exporting documentation source files..."
 	@mkdir -p $(BUILDDIR)/export
-	@find $(SOURCEDIR) -path "$(BUILDDIR)" -prune -o \( -name "*.md" -o -name "*.rst" -o -name "*.ipynb" \) -type f -print | \
-		while read f; do \
+	@find $(SOURCEDIR) -path "$(BUILDDIR)" -prune -o \( -name "*.md" -o -name "*.rst" -o -name "*.ipynb" \) -type f -print0 | \
+		while IFS= read -r -d '' f; do \
 			rel=$${f#./}; \
-			mkdir -p "$(BUILDDIR)/export/$$(dirname $$rel)"; \
+			mkdir -p "$(BUILDDIR)/export/$$(dirname "$$rel")"; \
 			cp "$$f" "$(BUILDDIR)/export/$$rel"; \
 		done
 	@echo "Documentation exported to $(BUILDDIR)/export/"

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,4 +75,3 @@ make export-all
   - Reuse the launched server as much as possible to reduce server launch time.
 - Do not use absolute links (e.g., `https://docs.sglang.io/get_started/install.html`). Always prefer relative links (e.g., `../get_started/install.md`).
 - Follow the existing examples to learn how to launch a server, send a query and other common styles.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,26 @@ find . -name '*.ipynb' -exec nbstripout {} \;
 # After these checks pass, push your changes and open a PR on your branch
 pre-commit run --all-files
 ```
+
+### Export for Downstream Integration
+
+For downstream systems like RAG pipelines, LLM-based tools, or internal documentation platforms, use the export targets:
+
+```bash
+# Export source files (md/rst/ipynb) to _build/export/
+make export
+
+# Build Markdown output from Sphinx to _build/markdown/
+make markdown
+
+# Full pipeline: compile notebooks, export sources, build markdown
+make export-all
+```
+
+**Output directories:**
+- `_build/export/` - Original source files (Markdown, RST, Jupyter Notebooks)
+- `_build/markdown/` - Rendered Markdown output from Sphinx (all formats converted to MD)
+
 ---
 
 ## Documentation Style Guidelines
@@ -55,3 +75,4 @@ pre-commit run --all-files
   - Reuse the launched server as much as possible to reduce server launch time.
 - Do not use absolute links (e.g., `https://docs.sglang.io/get_started/install.html`). Always prefer relative links (e.g., `../get_started/install.md`).
 - Follow the existing examples to learn how to launch a server, send a query and other common styles.
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinxcontrib.mermaid",
     "nbsphinx",
     "sphinx.ext.mathjax",
+    "sphinx_markdown_builder",
 ]
 
 nbsphinx_allow_errors = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,4 +18,4 @@ sphinxcontrib-mermaid
 urllib3<2.0.0
 gguf>=0.17.1
 sphinx-autobuild
-sphinx-markdown-builder
+sphinx-markdown-builder==0.6.7

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,3 +18,4 @@ sphinxcontrib-mermaid
 urllib3<2.0.0
 gguf>=0.17.1
 sphinx-autobuild
+sphinx-markdown-builder


### PR DESCRIPTION
Closes #18081

## Motivation

Currently, SGLang's documentation system targets HTML for web display. This creates a bottleneck for downstream systems (like internal documentation platforms or LLM-based RAG pipelines) that require structured Markdown or Jupyter Notebook files.

This PR adds new make targets to export documentation in formats suitable for downstream consumption while preserving the existing HTML build workflow.

## Changes

### New Make Targets

| Target | Description | Output Directory |
|--------|-------------|------------------|
| `make export` | Copies source files (md/rst/ipynb) | `_build/export/` |
| `make markdown` | Builds rendered Markdown via Sphinx | `_build/markdown/` |
| `make export-all` | Full pipeline: compile → export → markdown | Both directories |

### Files Modified

- **[docs/requirements.txt](cci:7://file:///Users/yifanchen/Workspace/sglang/docs/requirements.txt:0:0-0:0)** - Added `sphinx-markdown-builder`
- **[docs/conf.py](cci:7://file:///Users/yifanchen/Workspace/sglang/docs/conf.py:0:0-0:0)** - Added extension to Sphinx config
- **[docs/Makefile](cci:7://file:///Users/yifanchen/Workspace/sglang/docs/Makefile:0:0-0:0)** - Added 3 new targets + help text
- **[docs/README.md](cci:7://file:///Users/yifanchen/Workspace/sglang/docs/README.md:0:0-0:0)** - Added export workflow documentation

## Testing

Tested on Ubuntu (Google Cloud Shell):
```
emecii23@cloudshell:~/sglang/docs$ echo "## Test Evidence" && echo "" && echo "- Files exported: $(find _build/export -type f | wc -l)" && echo "- Markdown files: $(find _build/markdown -name '*.md' | wc -l)" && echo "" && echo "Sample structure:" && ls _build/markdown/ | head -5
## Test Evidence

- Files exported: 103
- Markdown files: 103

Sample structure:
advanced_features
basic_usage
developer_guide
get_started
index.md
```