### PR TITLE
add streaming parallel tool call test case

### DIFF
--- a/python/sglang/test/tool_call_test_runner.py
+++ b/python/sglang/test/tool_call_test_runner.py
@@ -24,6 +24,7 @@ class ToolCallTestParams:
     test_multiturn: bool = True
     test_thinking: bool = False  # model-specific, e.g. DeepSeek
     test_parallel: bool = True
+    test_streaming_parallel: bool = True
 
 
 @dataclass
@@ -237,6 +238,36 @@ def _test_parallel(client, model):
     assert tc and len(tc) >= 2, f"expected >= 2 tool calls, got {len(tc) if tc else 0}"
 
 
+def _test_streaming_parallel(client, model):
+    """Streaming with tool_choice=auto should return multiple tool calls."""
+    response = _call(
+        client,
+        model,
+        "What is 3+5 and what is the weather in Tokyo?",
+        tools=[ADD_TOOL, WEATHER_TOOL],
+        tool_choice="auto",
+        stream=True,
+    )
+    # collect tool calls from streaming chunks
+    tool_calls = {}
+    for chunk in response:
+        if not chunk.choices[0].delta.tool_calls:
+            continue
+        for tc in chunk.choices[0].delta.tool_calls:
+            idx = tc.index
+            if idx not in tool_calls:
+                tool_calls[idx] = {"name": "", "arguments": ""}
+            if tc.function.name:
+                tool_calls[idx]["name"] = tc.function.name
+            if tc.function.arguments:
+                tool_calls[idx]["arguments"] += tc.function.arguments
+    assert len(tool_calls) >= 2, f"expected >= 2 tool calls, got {len(tool_calls)}"
+    for idx, tc in tool_calls.items():
+        assert tc["name"], f"tool call {idx} missing function name"
+        args = json.loads(tc["arguments"])
+        assert isinstance(args, dict), f"tool call {idx} arguments not a dict"
+
+
 _TESTS = [
     ("basic_format", _test_basic_format, "test_basic"),
     ("streaming", _test_streaming, "test_streaming"),
@@ -247,6 +278,7 @@ _TESTS = [
     ("multiturn", _test_multiturn, "test_multiturn"),
     ("thinking", _test_thinking, "test_thinking"),
     ("parallel", _test_parallel, "test_parallel"),
+    ("streaming_parallel", _test_streaming_parallel, "test_streaming_parallel"),
 ]
 
 


### PR DESCRIPTION
Add streaming_parallel test case to verify multiple tool calls work correctly with stream=True and tool_choice=auto.