### PR TITLE
[Diffusion] fix serving image_edit get input image bug

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -332,6 +332,9 @@ class DiffusersExecutionStage(PipelineStage):
         if not batch.image_path:
             return None
 
+        if isinstance(batch.image_path, list):
+            batch.image_path = batch.image_path[0]
+
         try:
             if batch.image_path.startswith(("http://", "https://")):
                 response = requests.get(batch.image_path, timeout=30)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Server:

```shell
#!/bin/bash
# export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so.1:$LD_PRELOAD
# export FLASHINFER_DISABLE_VERSION_CHECK=1

# Set default values
MODEL_PATH="/nas/shared/models/FLUX.1-Kontext-dev"

PORT=30000
HOST="0.0.0.0"
NUM_GPUS=1
TP_SIZE=1
USP_SIZE=1
RING_SIZE=1

# Launch the multimodal_gen server with optimizations enabled
python3 -m sglang.multimodal_gen.runtime.launch_server \
  --model-path "$MODEL_PATH" \
  --port "$PORT" \
  --host "$HOST" \
  --num-gpus "$NUM_GPUS" \
  --tp-size "$TP_SIZE" \
  --ulysses-degree "$USP_SIZE" \
  --ring-degree "$RING_SIZE" \
  --attention-backend fa3 \
  --pin-cpu-memory \
  --warmup \
  --enable-torch-compile

```

Client:

```python
#!/usr/bin/env python3
"""Test script for FLUX.1-Kontext-dev (image-to-image editing)"""

import argparse
import base64
import requests
import os
import time


def main():
    parser = argparse.ArgumentParser(description="Test SGLang FLUX.1-Kontext-dev image editing")
    parser.add_argument("--host", type=str, default="127.0.0.1", help="Server host")
    parser.add_argument("--port", type=int, default=30000, help="Server port")
    parser.add_argument("--input-image", type=str, default="/nas/bbuf/cat.png", help="Input image path")
    parser.add_argument("--prompt", type=str, default="Add a hat to the cat", help="Edit instruction prompt")
    parser.add_argument("--guidance", type=float, default=2.5, help="Guidance scale (Kontext uses 2.5)")
    parser.add_argument("--steps", type=int, default=28, help="Number of inference steps")
    parser.add_argument("--seed", type=int, default=42, help="Random seed")
    parser.add_argument("--output", type=str, default="kontext-output.png", help="Output filename")
    args = parser.parse_args()

    # Check if input image exists
    if not os.path.exists(args.input_image):
        print(f"❌ Error: Input image not found: {args.input_image}")
        return 1

    # Prepare multipart form data
    url = f"http://{args.host}:{args.port}/v1/images/edits"
    
    # Read input image
    with open(args.input_image, "rb") as f:
        image_bytes = f.read()
    
    # Prepare files - use simple 'image' field (single file, not list)
    files = {
        "image": (os.path.basename(args.input_image), image_bytes, "image/png")
    }
    
    data = {
        "prompt": args.prompt,
        "guidance_scale": args.guidance,
        "num_inference_steps": args.steps,
        "seed": args.seed,
        "response_format": "b64_json",
        "n": 1
    }

    # Generate edited image
    print(f"🎨 FLUX.1-Kontext-dev: Editing image with {args.steps} steps (guidance={args.guidance})...")
    print(f"🖼️  Input image: {args.input_image}")
    print(f"📝 Prompt: {args.prompt}")
    print(f"🔢 Seed: {args.seed}")
    
    start_time = time.time()
    try:
        response = requests.post(url, files=files, data=data, timeout=600)
        response.raise_for_status()
        elapsed = time.time() - start_time
        
        # Save output image
        result = response.json()
        image_data = base64.b64decode(result["data"][0]["b64_json"])
        with open(args.output, "wb") as f:
            f.write(image_data)
        
        print(f"✅ Success! Edited image saved to: {args.output}")
        print(f"⏱️  Time: {elapsed:.2f}s")
        return 0
        
    except requests.exceptions.HTTPError as e:
        print(f"❌ HTTP Error: {e}")
        print(f"Response: {e.response.text if e.response else 'No response'}")
        return 1
    except Exception as e:
        print(f"❌ Error: {e}")
        return 1


if __name__ == "__main__":
    import sys
    sys.exit(main())
```

The input image is:

<img width="1310" height="766" alt="图片" src="https://github.com/user-attachments/assets/624163ec-9cc3-40fb-b225-79200ab929a6" />

After send requests, I got this error :

<img width="1758" height="1012" alt="20260202-170023" src="https://github.com/user-attachments/assets/10f5f67f-1a70-42d3-aa8e-9f94c78d806d" />

And the result is bad:

<img width="894" height="794" alt="图片" src="https://github.com/user-attachments/assets/b9cf9146-cdd0-4c5b-baac-111df68e0650" />

After pr fix, I can got the correct result:

<img width="840" height="808" alt="图片" src="https://github.com/user-attachments/assets/139cf333-eadb-4c37-b52f-d8ef31222291" />



## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
