### PR TITLE
[Multimodal] Initial batching support

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -113,7 +113,7 @@ class SamplingParams:
     # NOTE: this is temporary, we need a way to know if width or height is not provided, or do the image resize earlier
     height_not_provided: bool = False
     width_not_provided: bool = False
-    fps: int = 24
+    fps: list[int] | int | None = 24
 
     # Resolution validation
     supported_resolutions: list[tuple[int, int]] | None = (
@@ -321,8 +321,10 @@ class SamplingParams:
         """
         # TODO: SamplingParams should not rely on ServerArgs
         pipeline_config = server_args.pipeline_config
-        if not isinstance(self.prompt, str):
-            raise TypeError(f"`prompt` must be a string, but got {type(self.prompt)}")
+        if not (isinstance(self.prompt, str) or isinstance(self.prompt, list)):
+            raise TypeError(
+                f"`prompt` must be a string or a list, but got {type(self.prompt)}"
+            )
 
         self.data_type = server_args.pipeline_config.task_type.data_type()
 

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -100,6 +100,7 @@ class SamplingParams:
 
     # Batch info
     num_outputs_per_prompt: int = 1
+    per_prompt_num_outputs: list[int] | None = None
     seed: int = 42
     generator_device: str = "cuda"  # Device for random generator: "cuda" or "cpu"
 

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -91,7 +91,7 @@ class SamplingParams:
 
     # Text inputs
     prompt: str | list[str] | None = None
-    negative_prompt: str = (
+    negative_prompt: str | list[str] | None = (
         "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
     )
     prompt_path: str | None = None

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -283,7 +283,7 @@ class DiffGenerator:
                             "size": (
                                 batch_req.sampling_params.height,
                                 batch_req.sampling_params.width,
-                                batch_req.sampling_params.num_frames
+                                batch_req.sampling_params.num_frames,
                             ),
                             "generation_time": timer.duration / num_outputs,
                             "peak_memory_mb": output_batch.peak_memory_mb,
@@ -301,9 +301,6 @@ class DiffGenerator:
 
         except Exception as e:
             logger.error(f"Error processing batch: {e}")
-            import traceback
-
-            traceback.print_exc()
 
         total_gen_time = time.perf_counter() - total_start_time
         log_batch_completion(logger, len(results), total_gen_time)

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -219,10 +219,8 @@ async def process_generation_batch(
         save_file_path_list = []
         audio_sample_rate = result.audio_sample_rate
         if batch.data_type == DataType.VIDEO:
+            num_outputs = len(result.output)
             for idx, output in enumerate(result.output):
-                save_file_path = str(
-                    os.path.join(batch.output_path, batch.output_file_name)
-                )
                 sample = result.output[idx]
                 audio = result.audio
                 if isinstance(audio, torch.Tensor) and audio.ndim >= 2:
@@ -231,6 +229,7 @@ async def process_generation_batch(
                     isinstance(sample, (tuple, list)) and len(sample) == 2
                 ):
                     sample = (sample, audio)
+                save_file_path = batch.output_file_path(num_outputs, idx)
                 post_process_sample(
                     sample,
                     batch.data_type,

--- a/python/sglang/multimodal_gen/runtime/managers/batch_scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/batch_scheduler.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Memory-aware batch scheduler for diffusion model serving.
+
+This module provides batching functionality that:
+- Groups requests by compatible configurations (resolution, frames, steps)
+- Estimates memory requirements to determine safe batch sizes
+- Prevents starvation with configurable max wait time
+- Adapts to actual memory usage over time
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+
+logger = init_logger(__name__)
+
+
+class RequestConfig(NamedTuple):
+    """
+    Hashable key for grouping compatible requests.
+
+    Requests can only be batched together if they have identical RequestConfig.
+    This ensures tensor shapes are compatible for batched execution.
+    """
+
+    height: int
+    width: int
+    num_frames: int
+    num_inference_steps: int
+    has_cfg: bool  # guidance_scale > 1.0 and negative_prompt exists
+    effective_batch_size: int  # num_prompts × num_outputs_per_prompt
+
+    @classmethod
+    def from_req(cls, req: "Req") -> "RequestConfig":
+        """Create RequestConfig from a Req object."""
+        # Calculate effective batch size
+        if isinstance(req.prompt, list):
+            num_prompts = len(req.prompt)
+        elif req.prompt is not None:
+            num_prompts = 1
+        else:
+            num_prompts = 1
+
+        effective_batch = num_prompts * req.num_outputs_per_prompt
+
+        # Handle potential list types for dimensions
+        height = req.height[0] if isinstance(req.height, list) else (req.height or 480)
+        width = req.width[0] if isinstance(req.width, list) else (req.width or 848)
+        num_frames = (
+            req.num_frames[0] if isinstance(req.num_frames, list) else req.num_frames
+        )
+
+        return cls(
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=req.num_inference_steps,
+            has_cfg=req.do_classifier_free_guidance,
+            effective_batch_size=effective_batch,
+        )
+
+    def __str__(self) -> str:
+        return f"({self.height}×{self.width}×{self.num_frames}f, {self.num_inference_steps}steps, cfg={self.has_cfg}, batch={self.effective_batch_size})"
+
+
+@dataclass
+class QueuedRequest:
+    """Wrapper for queued requests with metadata."""
+
+    identity: bytes
+    req: "Req"
+    config: RequestConfig
+    arrival_time: float = field(default_factory=time.monotonic)
+
+    @property
+    def wait_time(self) -> float:
+        """Time in seconds since request arrived."""
+        return time.monotonic() - self.arrival_time
+
+
+class BatchScheduler:
+    """
+    Memory-aware batch scheduler that groups compatible requests.
+
+    Features:
+    - Groups requests by compatible configurations (same resolution, frames, steps)
+    - Estimates memory to determine safe batch sizes
+    - Prevents starvation with max wait time
+    - Adapts to actual memory usage over time
+
+    Requests with different `effective_batch_size` (num_outputs_per_prompt) are
+    bucketed separately to simplify output distribution. This trades some batching
+    efficiency for implementation simplicity.
+    """
+
+    def __init__(
+        self,
+        max_batch_size: int = 8,
+        max_wait_time_s: float = 30.0,
+    ):
+        """
+        Args:
+            max_batch_size: Hard cap on number of requests per batch
+            max_wait_time_s: Force dispatch after this wait time (starvation prevention)
+        """
+        self.max_batch_size = max_batch_size
+        self.max_wait_time_s = max_wait_time_s
+
+        # Buckets: config -> deque of QueuedRequest
+        self._buckets: Dict[RequestConfig, deque] = defaultdict(deque)
+
+        # Track total queue size for monitoring
+        self._total_queued = 0
+
+        # Track current batch for result distribution
+        self._current_batch_identities: List[bytes] = []
+        self._current_batch_config: Optional[RequestConfig] = None
+        self._current_batch_size: int = 0
+        self._current_batch_per_request_counts: list[int] = []
+
+    def add_request(self, identity: bytes, req: "Req") -> None:
+        """Add a new request to the appropriate bucket."""
+        config = RequestConfig.from_req(req)
+        queued = QueuedRequest(identity=identity, req=req, config=config)
+        self._buckets[config].append(queued)
+        self._total_queued += 1
+
+        logger.debug(f"Queued request {req.request_id} into bucket {config}")
+
+    def add_requests(self, requests: List[Tuple[bytes, "Req"]]) -> None:
+        """Add multiple requests."""
+        for identity, req in requests:
+            self.add_request(identity, req)
+
+    @property
+    def queue_size(self) -> int:
+        """Total number of queued requests."""
+        return self._total_queued
+
+    def is_empty(self) -> bool:
+        """Check if queue is empty."""
+        return self._total_queued == 0
+
+    def get_queue_stats(self) -> Dict[str, Any]:
+        """Get queue statistics for monitoring."""
+        stats = {
+            "total_queued": self._total_queued,
+            "num_buckets": len([b for b in self._buckets.values() if b]),
+            "buckets": {},
+        }
+        for config, queue in self._buckets.items():
+            if queue:
+                stats["buckets"][str(config)] = {
+                    "count": len(queue),
+                    "oldest_wait_s": queue[0].wait_time if queue else 0,
+                }
+        return stats
+
+    def _get_oldest_bucket(self) -> Optional[RequestConfig]:
+        """Find bucket with the oldest waiting request."""
+        oldest_config = None
+        oldest_time = float("inf")
+
+        for config, queue in self._buckets.items():
+            if queue and queue[0].arrival_time < oldest_time:
+                oldest_time = queue[0].arrival_time
+                oldest_config = config
+
+        return oldest_config
+
+    def _select_best_bucket(self) -> Optional[RequestConfig]:
+        """
+        Select the best bucket to process next.
+
+        Strategy:
+        1. If any request has waited > max_wait_time_s, prioritize that bucket (starvation prevention)
+        2. Otherwise, prefer buckets with larger potential batch sizes
+        3. Tie-break by oldest request
+        """
+        best_config = None
+        best_score = -1
+
+        for config, queue in self._buckets.items():
+            if not queue:
+                continue
+
+            oldest_wait = queue[0].wait_time
+
+            # Starvation check - force this bucket if waited too long
+            if oldest_wait > self.max_wait_time_s:
+                logger.info(
+                    f"Starvation prevention: forcing bucket {config} after {oldest_wait:.1f}s wait"
+                )
+                return config
+
+            # Score = potential batch size with bonus for older requests
+            score = min(oldest_wait / self.max_wait_time_s, 1.0)
+            if score > best_score:
+                best_score = score
+                best_config = config
+
+        return best_config
+
+    def _select_batch_from_bucket(self, config: RequestConfig) -> List[QueuedRequest]:
+        """Select requests from a bucket up to max batch size."""
+        queue = self._buckets[config]
+        if not queue:
+            return []
+
+        # Collect batch
+        batch = []
+
+        while queue and len(batch) + queue[0].req.batch_size <= self.max_batch_size:
+            batch.append(queue.popleft())
+            self._total_queued -= 1
+
+        return batch
+
+    def _merge_requests(
+        self, queued_items: List[QueuedRequest]
+    ) -> Tuple["Req", List[int]]:
+        """
+        Merge multiple Req objects into a single batched Req.
+        All requests must have compatible configurations.
+
+        For atomic batching (same effective_batch_size), we concatenate prompts
+        but keep num_outputs_per_prompt the same.
+        """
+        if len(queued_items) == 1:
+            return queued_items[0].req, [queued_items[0].req.batch_size]
+
+        from copy import deepcopy
+
+        base_req = queued_items[0].req
+
+        # Collect all prompts
+        all_prompts = []
+        all_negative_prompts = []
+        all_seeds = []
+        per_prompt_num_outputs = []
+        per_req_num_outputs = []
+
+        for item in queued_items:
+            req = item.req
+
+            all_prompts.extend(req.prompts_as_list)
+
+            # Handle negative prompt
+            if req.sampling_params.negative_prompt:
+                all_negative_prompts.extend(req.negative_prompts_as_list)
+
+            if req.seeds:
+                all_seeds.extend(req.seeds)
+            elif req.sampling_params.seed is not None:
+                for i in range(req.batch_size):
+                    all_seeds.append(req.sampling_params.seed + i)
+
+            num_prompts = len(req.prompts_as_list)
+            if req.sampling_params.per_prompt_num_outputs:
+                per_prompt_num_outputs.extend(
+                    req.sampling_params.per_prompt_num_outputs
+                )
+                per_req_num_outputs.append(
+                    sum(req.sampling_params.per_prompt_num_outputs)
+                )
+            else:
+                per_prompt_num_outputs.extend(
+                    [req.sampling_params.num_outputs_per_prompt] * num_prompts
+                )
+                per_req_num_outputs.append(
+                    req.sampling_params.num_outputs_per_prompt * num_prompts
+                )
+
+        self._current_batch_per_request_counts = per_prompt_num_outputs
+
+        # Create merged request
+        merged = deepcopy(base_req)
+        merged.sampling_params.prompt = all_prompts
+        merged.sampling_params.negative_prompt = (
+            all_negative_prompts if all_negative_prompts else None
+        )
+        merged.seeds = all_seeds if all_seeds else None
+        # merged.seed = None  # Use seeds list instead
+        merged.sampling_params.seed = queued_items[0].req.sampling_params.seed
+        merged.sampling_params.request_id = (
+            f"batch_{len(queued_items)}_{base_req.sampling_params.request_id}"
+        )
+        merged.sampling_params.per_prompt_num_outputs = per_prompt_num_outputs
+
+        logger.info(f"Merged {len(queued_items)} requests into batch")
+
+        return merged, per_req_num_outputs
+
+    def get_next_batch(self) -> Optional[Tuple[List[bytes], "Req", RequestConfig]]:
+        """
+        Get the next batch to process.
+
+        Returns:
+            Tuple of (identities, merged_req, config) or None if queue is empty
+        """
+        if self.is_empty():
+            return None
+
+        # Select best bucket
+        best_config = self._select_best_bucket()
+        if best_config is None:
+            return None
+
+        # Form batch from selected bucket
+        batch = self._select_batch_from_bucket(best_config)
+        if not batch:
+            return None
+
+        # Extract identities and merge requests
+        identities = [item.identity for item in batch]
+        merged_req, per_req_num_outputs = self._merge_requests(batch)
+
+        # Store for result distribution
+        self._current_batch_identities = identities
+        self._current_batch_config = best_config
+        self._current_batch_size = len(batch)
+
+        logger.info(
+            f"Formed batch of {len(batch)} requests from bucket {best_config}, "
+            f"queue remaining: {self._total_queued}"
+            f"buckets: {[(b,len(v)) for b, v in self._buckets.items()]}"
+        )
+
+        return identities, per_req_num_outputs, merged_req, best_config

--- a/python/sglang/multimodal_gen/runtime/managers/batch_scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/batch_scheduler.py
@@ -129,6 +129,11 @@ class BatchScheduler:
 
     def add_request(self, identity: bytes, req: "Req") -> None:
         """Add a new request to the appropriate bucket."""
+        if req.batch_size > self.max_batch_size:
+            raise ValueError(
+                f"Request batch size ({req.batch_size}) exceeds max_batch_size ({self.max_batch_size})"
+            )
+
         config = RequestConfig.from_req(req)
         queued = QueuedRequest(identity=identity, req=req, config=config)
         self._buckets[config].append(queued)

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -197,7 +197,6 @@ class Scheduler:
         if self.enable_batching and self.batch_scheduler is not None:
             result = self.batch_scheduler.get_next_batch()
             if result is None:
-
                 return None
 
             identities, per_req_num_outputs, merged_req, config = result
@@ -439,7 +438,6 @@ class Scheduler:
                         else:
                             logger.info(f"Warmup req processing failed")
 
-                # TODO: Support sending back to multiple identities if batched
                 self.return_result(
                     output_batch, identities, per_req_num_outputs, is_warmup=is_warmup
                 )

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -224,7 +224,7 @@ class Scheduler:
                                 [identity, b"", pickle.dumps(OutputBatch(error=str(e)))]
                             )
                 else:
-                    self.waiting_queue.append((identity, req.batch_size, req))
+                    self.waiting_queue.append(([identity], [req.batch_size], req))
 
     def prepare_server_warmup_reqs(self):
         if (

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -19,6 +19,7 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
     _parse_size,
     save_image_to_path,
 )
+from sglang.multimodal_gen.runtime.managers.batch_scheduler import BatchScheduler
 from sglang.multimodal_gen.runtime.managers.gpu_worker import GPUWorker
 from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
@@ -89,8 +90,22 @@ class Scheduler:
             ListLorasReq: self._handle_list_loras,
         }
 
+        self.enable_batching = server_args.enable_batching
+        if self.enable_batching:
+            self.batch_scheduler = BatchScheduler(
+                max_batch_size=server_args.max_batch_size,
+                max_wait_time_s=server_args.batch_max_wait_time_s,
+            )
+            logger.info(
+                f"Batching enabled: max_batch_size={server_args.max_batch_size}, "
+                f"max_wait_time={server_args.batch_max_wait_time_s}s, "
+            )
+        else:
+            self.batch_scheduler = None
+            logger.info("Batching disabled, processing requests sequentially")
+
         # FIFO, new reqs are appended
-        self.waiting_queue: deque[tuple[bytes, Req]] = deque()
+        self.waiting_queue: deque[tuple[list[bytes], list[int], Req]] = deque()
 
         # whether we've send the necessary warmup reqs
         self.warmed_up = False
@@ -138,24 +153,71 @@ class Scheduler:
     def return_result(
         self,
         output_batch: OutputBatch,
-        identity: bytes | None = None,
+        identities: list[bytes] | None = None,
+        per_req_num_outputs: list[int] | None = None,
         is_warmup: bool = False,
     ):
         """
-        replies to client, only on rank 0
+        replies to all clients, only on rank 0
         """
-        if not is_warmup and self.receiver is not None and identity is not None:
-            self.receiver.send_multipart([identity, b"", pickle.dumps(output_batch)])
 
-    def get_next_batch_to_run(self) -> list[tuple[bytes, Req]] | None:
-        """pull a req from waiting_queue"""
-        if not self.waiting_queue:
-            return None
+        if self.enable_batching and self.batch_scheduler:
+            # TODO record memory usage
+            batch_size = len(output_batch.output)
 
-        # pop the first (earliest)
-        item = self.waiting_queue.popleft()
+            assert len(identities) == len(per_req_num_outputs)
+            assert batch_size == sum(per_req_num_outputs)
 
-        return [item]
+            idx = 0
+            for ident, per_req_count in zip(identities, per_req_num_outputs):
+                single = OutputBatch(
+                    output=output_batch.output[idx : idx + per_req_count],
+                    timings=output_batch.timings,  # Shared timing info
+                    peak_memory_mb=output_batch.peak_memory_mb / batch_size,
+                    error=output_batch.error,
+                )
+                self.receiver.send_multipart([ident, b"", pickle.dumps(single)])
+                idx += per_req_count
+
+        elif not is_warmup and self.receiver and identities and identities[0]:
+            self.receiver.send_multipart(
+                [identities[0], b"", pickle.dumps(output_batch)]
+            )
+
+    def get_next_batch_to_run(self) -> tuple[list[bytes], list[int], Req] | None:
+        """
+        Get the next batch of requests to run.
+
+        When batching is enabled, uses BatchScheduler to form optimal batches.
+        Otherwise, returns single requests from the waiting queue.
+        """
+        if self.enable_batching and self.batch_scheduler is not None:
+            result = self.batch_scheduler.get_next_batch()
+            if result is None:
+
+                return None
+
+            identities, per_req_num_outputs, merged_req, config = result
+            # Return in expected format - the merged req with first identity
+            # return [(identities[0], merged_req)]
+            return identities, per_req_num_outputs, merged_req
+        else:
+            if not self.waiting_queue:
+                return None
+            item = self.waiting_queue.popleft()
+            return item
+
+    def _add_requests_to_queue(self, requests: List[tuple[bytes, Any]]) -> None:
+        """
+        Add received requests to the appropriate queue.
+        Separates generation requests from control requests.
+        """
+        for identity, req in requests:
+            if isinstance(req, Req):
+                if self.enable_batching and self.batch_scheduler is not None:
+                    self.batch_scheduler.add_request(identity, req)
+                else:
+                    self.waiting_queue.append((identity, req.batch_size, req))
 
     def prepare_server_warmup_reqs(self):
         if (
@@ -202,7 +264,7 @@ class Scheduler:
                         prompt="",
                         is_warmup=True,
                     )
-                self.waiting_queue.append((None, req))
+                self.waiting_queue.append((None, req.batch_size, req))
             # if server is warmed-up, set this flag to avoid req-based warmup
             self.warmed_up = True
 
@@ -234,23 +296,22 @@ class Scheduler:
         For non-main schedulers, reqs are broadcasted from main using broadcast_pyobj
         """
         if self.receiver is not None:
-            try:
+            recv_reqs = []
+            # Drain all requests
+            while True:
                 try:
-                    identity, _, payload = self.receiver.recv_multipart(zmq.NOBLOCK)
-                    recv_reqs = pickle.loads(payload)
-                except zmq.Again:
-                    recv_reqs = []
-            except zmq.ZMQError:
-                # re-raise or handle appropriately to let the outer loop continue
-                raise
+                    try:
+                        identity, _, payload = self.receiver.recv_multipart(zmq.NOBLOCK)
+                        req = pickle.loads(payload)
 
-            if recv_reqs:
-                # Ensure recv_reqs is a list
-                if not isinstance(recv_reqs, list):
-                    recv_reqs = [recv_reqs]
-
-                # Pack with identity for rank 0
-                recv_reqs = [(identity, req) for req in recv_reqs]
+                        if not isinstance(req, list):
+                            req = [req]
+                        recv_reqs.extend([(identity, r) for r in req])
+                    except zmq.Again:
+                        break
+                except zmq.ZMQError:
+                    # re-raise or handle appropriately to let the outer loop continue
+                    raise
         else:
             recv_reqs = None
 
@@ -298,7 +359,7 @@ class Scheduler:
             try:
                 new_reqs = self.recv_reqs()
                 new_reqs = self.process_received_reqs_with_req_based_warmup(new_reqs)
-                self.waiting_queue.extend(new_reqs)
+                self._add_requests_to_queue(new_reqs)
                 # Reset error count on success
                 self._consecutive_error_count = 0
             except Exception as e:
@@ -320,21 +381,19 @@ class Scheduler:
                 continue
 
             # 2: execute, make sure a reply is always sent
-            items = self.get_next_batch_to_run()
-            if not items:
+            next_batch = self.get_next_batch_to_run()
+            if not next_batch:
                 continue
 
-            identities = [item[0] for item in items]
-            reqs = [item[1] for item in items]
+            identities, per_req_num_outputs, req = next_batch
 
             try:
-                processed_req = reqs[0]
-                handler = self.request_handlers.get(type(processed_req))
+                handler = self.request_handlers.get(type(req))
                 if handler:
-                    output_batch = handler(reqs)
+                    output_batch = handler([req])
                 else:
                     output_batch = OutputBatch(
-                        error=f"Unknown request type: {type(processed_req)}"
+                        error=f"Unknown request type: {type(req)}"
                     )
             except Exception as e:
                 logger.error(
@@ -344,16 +403,14 @@ class Scheduler:
                 # Determine appropriate error response format
                 output_batch = (
                     OutputBatch(error=str(e))
-                    if reqs and isinstance(reqs[0], Req)
+                    if req and isinstance(req, Req)
                     else OutputBatch(error=str(e))
                 )
 
             # 3. return results
             try:
                 # log warmup info
-                is_warmup = (
-                    processed_req.is_warmup if isinstance(processed_req, Req) else False
-                )
+                is_warmup = req.is_warmup if isinstance(req, Req) else False
                 if is_warmup:
                     if output_batch.error is None:
                         if self._warmup_total > 0:
@@ -375,7 +432,9 @@ class Scheduler:
                             logger.info(f"Warmup req processing failed")
 
                 # TODO: Support sending back to multiple identities if batched
-                self.return_result(output_batch, identities[0], is_warmup=is_warmup)
+                self.return_result(
+                    output_batch, identities, per_req_num_outputs, is_warmup=is_warmup
+                )
             except zmq.ZMQError as e:
                 # Reply failed; log and keep loop alive to accept future requests
                 logger.error(f"ZMQ error sending reply: {e}")

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -228,16 +228,34 @@ class Req:
     @property
     def batch_size(self):
         # Determine batch size
-        if isinstance(self.prompt, list):
-            batch_size = len(self.prompt)
-        elif self.prompt is not None:
+        if isinstance(self.sampling_params.prompt, list):
+            batch_size = len(self.sampling_params.prompt)
+        elif self.sampling_params.prompt is not None:
             batch_size = 1
         else:
             batch_size = self.prompt_embeds[0].shape[0]
 
         # Adjust batch size for number of videos per prompt
-        batch_size *= self.num_outputs_per_prompt
+        batch_size *= self.sampling_params.num_outputs_per_prompt
         return batch_size
+
+    @property
+    def prompts_as_list(self) -> list[str]:
+        """Always return prompts as a list."""
+        if self.sampling_params.prompt is None:
+            return []
+        if isinstance(self.sampling_params.prompt, str):
+            return [self.sampling_params.prompt]
+        return self.sampling_params.prompt
+
+    @property
+    def negative_prompts_as_list(self) -> list[str]:
+        """Always return negative prompts as a list matching batch size."""
+        if self.sampling_params.negative_prompt is None:
+            return [""] * self.batch_size
+        if isinstance(self.sampling_params.negative_prompt, str):
+            return [self.sampling_params.negative_prompt] * self.batch_size
+        return self.sampling_params.negative_prompt
 
     def output_file_path(self, num_outputs=1, output_idx=None):
         output_file_name = self.output_file_name

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -229,6 +229,8 @@ class Req:
     def batch_size(self):
         # Determine batch size
         if isinstance(self.sampling_params.prompt, list):
+            if self.sampling_params.per_prompt_num_outputs:
+                return sum(self.sampling_params.per_prompt_num_outputs)
             batch_size = len(self.sampling_params.prompt)
         elif self.sampling_params.prompt is not None:
             batch_size = 1
@@ -251,10 +253,15 @@ class Req:
     @property
     def negative_prompts_as_list(self) -> list[str]:
         """Always return negative prompts as a list matching batch size."""
+        prompts_count = (
+            len(self.sampling_params.prompt)
+            if isinstance(self.sampling_params.prompt, list)
+            else 1
+        )
         if self.sampling_params.negative_prompt is None:
-            return [""] * self.batch_size
+            return [""] * prompts_count
         if isinstance(self.sampling_params.negative_prompt, str):
-            return [self.sampling_params.negative_prompt] * self.batch_size
+            return [self.sampling_params.negative_prompt] * prompts_count
         return self.sampling_params.negative_prompt
 
     def get_fps_for_index(self, idx: int) -> int:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -335,6 +335,7 @@ class Req:
                         seed: {self.seed}
                  infer_steps: {self.num_inference_steps}
       num_outputs_per_prompt: {self.num_outputs_per_prompt}
+      per_prompt_num_outputs: {self.sampling_params.per_prompt_num_outputs}
               guidance_scale: {self.guidance_scale}
      embedded_guidance_scale: {server_args.pipeline_config.embedded_cfg_scale}
                     n_tokens: {self.n_tokens}

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -257,8 +257,18 @@ class Req:
             return [self.sampling_params.negative_prompt] * self.batch_size
         return self.sampling_params.negative_prompt
 
+    def get_fps_for_index(self, idx: int) -> int:
+        """Get fps for a specific batch index."""
+        if isinstance(self.sampling_params.fps, list):
+            return (
+                self.sampling_params.fps[idx]
+                if idx < len(self.sampling_params.fps)
+                else self.sampling_params.fps[0]
+            )
+        return self.sampling_params.fps
+
     def output_file_path(self, num_outputs=1, output_idx=None):
-        output_file_name = self.output_file_name
+        output_file_name = self.sampling_params.output_file_name
         if num_outputs > 1 and output_file_name:
             base, ext = os.path.splitext(output_file_name)
             output_file_name = f"{base}_{output_idx}{ext}"

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/input_validation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/input_validation.py
@@ -68,12 +68,13 @@ class InputValidationStage(PipelineStage):
 
     def _generate_seeds(self, batch: Req, server_args: ServerArgs):
         """Generate seeds for the inference"""
-        seed = batch.seed
-        num_videos_per_prompt = batch.num_outputs_per_prompt
-
-        assert seed is not None
-        seeds = [seed + i for i in range(num_videos_per_prompt)]
-        batch.seeds = seeds
+        if batch.seeds is not None and len(batch.seeds) > 0:
+            seeds = batch.seeds
+        else:
+            seed = batch.sampling_params.seed
+            assert seed is not None, "Either seed or seeds must be provided"
+            seeds = [seed + i for i in range(batch.batch_size)]
+            batch.seeds = seeds
 
         # Create generators based on generator_device parameter
         # Note: This will overwrite any existing batch.generator

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -87,6 +87,13 @@ class TextEncodingStage(PipelineStage):
 
         # Encode negative prompt if CFG is enabled
         if batch.do_classifier_free_guidance:
+            assert (
+                negative_prompts is not None
+            ), "Negative prompts cannot be None for CFG "
+            assert len(prompts) == len(
+                negative_prompts
+            ), "Negative prompts number must match number of prompts"
+
             neg_embeds_list, neg_masks_list, neg_pooler_list = self.encode_text(
                 negative_prompts,
                 server_args,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -150,7 +150,8 @@ class TextEncodingStage(PipelineStage):
         result.add_check(
             "negative_prompt",
             batch.negative_prompt,
-            lambda x: not batch.do_classifier_free_guidance or V.string_not_none(x),
+            lambda x: not batch.do_classifier_free_guidance
+            or V.string_or_list_strings(x),
         )
         result.add_check(
             "do_classifier_free_guidance",

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -59,51 +59,80 @@ class TextEncodingStage(PipelineStage):
             server_args.pipeline_config.text_encoder_configs
         )
 
-        # Encode positive prompt with all available encoders
-        assert batch.prompt is not None
-        prompt_text: str | list[str] = batch.prompt
+        if batch.is_prompt_processed:
+            return batch
 
+        # Normalize prompts to list for batch processing
+        prompts: list[str] = batch.prompts_as_list
+        negative_prompts: list[str] = batch.negative_prompts_as_list
+
+        batch_size = len(prompts)
+        logger.info(f"Encoding {batch_size} prompts in batch")
         all_indices: list[int] = list(range(len(self.text_encoders)))
 
+        # Encode all positive prompts together
         prompt_embeds_list, prompt_masks_list, pooler_embeds_list = self.encode_text(
-            prompt_text,
+            prompts,  # Pass full list for batched encoding
             server_args,
             encoder_index=all_indices,
             return_attention_mask=True,
         )
 
-        for pe in prompt_embeds_list:
-            batch.prompt_embeds.append(pe)
-
-        for pe in pooler_embeds_list:
-            batch.pooled_embeds.append(pe)
-
-        if batch.prompt_attention_mask is None:
-            batch.prompt_attention_mask = []
-            for am in prompt_masks_list:
-                batch.prompt_attention_mask.append(am)
+        # Store batched embeddings - shape: [batch_size, seq_len, hidden_dim]
+        batch.prompt_embeds = prompt_embeds_list
+        if prompt_masks_list:
+            batch.prompt_attention_mask = prompt_masks_list
+        if pooler_embeds_list:
+            batch.pooled_embeds = pooler_embeds_list
 
         # Encode negative prompt if CFG is enabled
         if batch.do_classifier_free_guidance:
-            assert isinstance(batch.negative_prompt, str)
-            neg_embeds_list, neg_masks_list, neg_pooler_embeds_list = self.encode_text(
-                batch.negative_prompt,
+            neg_embeds_list, neg_masks_list, neg_pooler_list = self.encode_text(
+                negative_prompts,
                 server_args,
                 encoder_index=all_indices,
                 return_attention_mask=True,
             )
+            batch.negative_prompt_embeds = neg_embeds_list
+            if neg_masks_list:
+                batch.negative_attention_mask = neg_masks_list
+            if neg_pooler_list:
+                batch.neg_pooled_embeds = neg_pooler_list
 
-            assert batch.negative_prompt_embeds is not None
+        expansion_factors = batch.sampling_params.num_outputs_per_prompt
+        logger.info(f"Expansion factos: {expansion_factors}")
 
-            for ne in neg_embeds_list:
-                batch.negative_prompt_embeds.append(ne)
+        if expansion_factors > 1:
+            batch.prompt_embeds = [
+                pe.repeat_interleave(expansion_factors, dim=0)
+                for pe in prompt_embeds_list
+            ]
+            batch.pooled_embeds = [
+                pe.repeat_interleave(expansion_factors, dim=0)
+                for pe in pooler_embeds_list
+            ]
 
-            for pe in neg_pooler_embeds_list:
-                batch.neg_pooled_embeds.append(pe)
-            if batch.negative_attention_mask is None:
-                batch.negative_attention_mask = []
-                for nm in neg_masks_list:
-                    batch.negative_attention_mask.append(nm)
+            if batch.do_classifier_free_guidance:
+                batch.negative_prompt_embeds = [
+                    pe.repeat_interleave(expansion_factors, dim=0)
+                    for pe in neg_embeds_list
+                ]
+                batch.negative_prompt_embeds = [
+                    pe.repeat_interleave(expansion_factors, dim=0)
+                    for pe in neg_embeds_list
+                ]
+                if neg_masks_list:
+                    batch.negative_attention_mask = [
+                        pe.repeat_interleave(expansion_factors, dim=0)
+                        for pe in neg_masks_list
+                    ]
+                if neg_pooler_list:
+                    batch.neg_pooled_embeds = [
+                        pe.repeat_interleave(expansion_factors, dim=0)
+                        for pe in neg_pooler_list
+                    ]
+
+        batch.is_prompt_processed = True
 
         return batch
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -124,10 +124,6 @@ class TextEncodingStage(PipelineStage):
                     pe.repeat_interleave(expansion_factors, dim=0)
                     for pe in neg_embeds_list
                 ]
-                batch.negative_prompt_embeds = [
-                    pe.repeat_interleave(expansion_factors, dim=0)
-                    for pe in neg_embeds_list
-                ]
                 if neg_masks_list:
                     batch.negative_attention_mask = [
                         pe.repeat_interleave(expansion_factors, dim=0)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -100,9 +100,16 @@ class TextEncodingStage(PipelineStage):
                 batch.neg_pooled_embeds = neg_pooler_list
 
         expansion_factors = batch.sampling_params.num_outputs_per_prompt
-        logger.info(f"Expansion factos: {expansion_factors}")
+        factor = expansion_factors
+        if batch.sampling_params.per_prompt_num_outputs:
+            expansion_factors = torch.tensor(
+                batch.sampling_params.per_prompt_num_outputs,
+                dtype=torch.long,
+                device=prompt_embeds_list[0].device,
+            )
+            factor = len(expansion_factors)
 
-        if expansion_factors > 1:
+        if factor > 1:
             batch.prompt_embeds = [
                 pe.repeat_interleave(expansion_factors, dim=0)
                 for pe in prompt_embeds_list

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -303,6 +303,11 @@ class ServerArgs:
     # Compilation
     enable_torch_compile: bool = False
 
+    # Batching configuration
+    enable_batching: bool = True
+    max_batch_size: int = 4
+    batch_max_wait_time_s: float = 30.0
+
     # warmup
     warmup: bool = False
     warmup_resolutions: list[str] = None
@@ -614,6 +619,30 @@ class ServerArgs:
             default=ServerArgs.enable_torch_compile,
             help="Use torch.compile to speed up DiT inference."
             + "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
+        )
+
+        # Batching configuration
+        parser.add_argument(
+            "--enable-batching",
+            action=StoreBoolean,
+            default=ServerArgs.enable_batching,
+            help="Enable request batching to improve throughput. When enabled, "
+            "requests with compatible configurations are batched together.",
+        )
+        parser.add_argument(
+            "--max-batch-size",
+            type=int,
+            default=ServerArgs.max_batch_size,
+            help="Maximum number of requests to batch together. Higher values "
+            "increase throughput but also memory usage.",
+        )
+        parser.add_argument(
+            "--batch-max-wait-time",
+            type=float,
+            default=ServerArgs.batch_max_wait_time_s,
+            dest="batch_max_wait_time_s",
+            help="Maximum time (seconds) a request can wait before being dispatched, "
+            "even if batch is not full. Prevents starvation.",
         )
 
         # warmup


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Currently, the (multimodal) framework supports generating multiple outputs for a single prompt, which is not working correctly. Additionally, there is no concept of request batching - requests are processed sequentially.

The goal of this pull request is to:

* fix the generation of multiple outputs per prompt
* add basic support for request batching (with the logic to be further improved in future PRs)

## Modifications

* fix the generation of multiple outputs per prompt (extend prompt embeddings to match the number of outputs per prompt)
* add an option to specify the number of outputs per prompt (e.g. [1, 2])
* introduce a batch scheduler:
    * requests are bucketed based on (height, width, number of frames, number of inference steps, CFG)
    * selects the largest possible batch, or a batch that has exceeded a timeout (to prevent starvation)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

