### PR TITLE
[NPU]MindSpore backend support profile

### DIFF
--- a/python/sglang/srt/managers/scheduler_profiler_mixin.py
+++ b/python/sglang/srt/managers/scheduler_profiler_mixin.py
@@ -14,7 +14,11 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_npu
 from sglang.srt.utils.profile_merger import ProfileMerger
-from sglang.srt.utils.profile_utils import ProfileManager
+from sglang.srt.utils.profile_utils import (
+    ProfileManager,
+    get_npu_trace_handler,
+    init_npu_profiler,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import ScheduleBatch
@@ -22,14 +26,7 @@ if TYPE_CHECKING:
 
 _is_npu = is_npu()
 if _is_npu:
-    import torch_npu
-
-    patches = [
-        ["profiler.profile", torch_npu.profiler.profile],
-        ["profiler.ProfilerActivity.CUDA", torch_npu.profiler.ProfilerActivity.NPU],
-        ["profiler.ProfilerActivity.CPU", torch_npu.profiler.ProfilerActivity.CPU],
-    ]
-    torch_npu._apply_patches(patches)
+    init_npu_profiler()
 
 logger = logging.getLogger(__name__)
 
@@ -195,9 +192,7 @@ class SchedulerProfilerMixin:
                 on_trace_ready=(
                     None
                     if not _is_npu
-                    else torch_npu.profiler.tensorboard_trace_handler(
-                        str(self.torch_profiler_output_dir)
-                    )
+                    else get_npu_trace_handler(str(self.torch_profiler_output_dir))
                 ),
             )
             self.torch_profiler.start()

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -57,6 +57,7 @@ from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_cuda,
     is_npu,
+    is_mindspore,
     next_power_of_2,
 )
 from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
@@ -242,6 +243,10 @@ class EagleDraftWorker(BaseDraftWorker):
         self.cuda_graph_runner_for_draft_extend = None
 
         if self.server_args.disable_cuda_graph:
+            return
+
+        if is_mindspore():
+            logger.info("Skip CUDA graph capture for MindSpore backend.")
             return
 
         Device2DraftCudaGraphRunner = {

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -162,6 +162,22 @@ def is_npu() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_mindspore() -> bool:
+    if not is_npu():
+        return False
+
+    from sglang.srt.server_args import get_global_server_args
+
+    try:
+        args = get_global_server_args()
+        model_impl = args.model_impl
+    except ValueError:
+        model_impl = None
+
+    return model_impl == "mindspore"
+
+
+@lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()
     return (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Currently, the NPU profiling logic is tightly coupled with torch_npu . To support profiling on the MindSpore backend, we need to decouple the profiler initialization and trace handler retrieval, allowing the system to switch between torch_npu and mindspore profilers dynamically based on the active backend.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. python/sglang/srt/utils/common.py :

- Added is_mindspore() utility function to detect the MindSpore backend.

2. python/sglang/srt/utils/profile_utils.py :

- Enhanced init_npu_profiler to apply patches for mindspore.profiler when running on MindSpore.
- Implemented get_npu_trace_handler to return the correct tensorboard trace handler for either mindspore or torch_npu .

3. python/sglang/srt/managers/scheduler_profiler_mixin.py :

- Updated start_profile to utilize get_npu_trace_handler , enabling unified profiling support for NPU devices across different backends.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
- Verified that is_mindspore() correctly returns True when the MindSpore backend is active.
- Confirmed that the existing torch_npu profiling workflow remains unaffected and functions correctly on Ascend NPUs using PyTorch.
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
