### PR TITLE
Re-enable test_mla_int8_deepseek_v3.py after HF token fix

### DIFF
--- a/test/registered/mla/test_mla_int8_deepseek_v3.py
+++ b/test/registered/mla/test_mla_int8_deepseek_v3.py
@@ -16,11 +16,7 @@ from sglang.test.test_utils import (
 )
 
 # DeepSeek-V3 INT8 quantization tests (channel and block INT8)
-register_cuda_ci(
-    est_time=341,
-    suite="stage-b-test-large-1-gpu",
-    disabled="HF token doesn't have private repository access",
-)
+register_cuda_ci(est_time=341, suite="stage-b-test-large-1-gpu")
 
 
 class TestMLADeepseekV3ChannelInt8(CustomTestCase):


### PR DESCRIPTION
## Summary

- Re-enable `test_mla_int8_deepseek_v3.py` which was disabled due to HF token not having private repository access
- The machine token is now fixed and has access to `sgl-project/sglang-ci-dsv3-channel-int8-test` and related models

## Test plan

- [ ] CI passes on `stage-b-test-large-1-gpu` suite with the re-enabled test