### PR TITLE
[Perf] Use safetensors `load_file` in multithread loader

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -840,12 +840,8 @@ def multi_thread_safetensors_weights_iterator(
     def _load_file(st_file: str):
         if disable_mmap:
             with open(st_file, "rb") as f:
-                result = safetensors.torch.load(f.read())
-        else:
-            with safetensors.safe_open(st_file, framework="pt", device="cpu") as f:
-                result = {k: f.get_tensor(k) for k in f.keys()}
-
-        return result
+                return safetensors.torch.load(f.read())
+        return safetensors.torch.load_file(st_file, device="cpu")
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(_load_file, st_file) for st_file in hf_weights_files]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Switch shard loading to `safetensors.torch.load_file(..., device="cpu")` to route the eager “load all tensors” path through the Rust-backed safetensors loader and avoid Python-level per-key iteration overhead.

This should mainly cut Python/metadata overhead; once that’s reduced, model loading is often ultimately limited by storage/I/O (and mmap-style access can be particularly slow on network mounts due to many small/random reads).

## Modifications

Replaced the manual tensor extraction loop using `safetensors.safe_open` with `safetensors.torch.load_file` in `multi_thread_safetensors_weights_iterator` to leverage the efficient Rust-based loader.

## Tests

On my test using `--model-loader-extra-config '{"enable_multithread_load": true,"num_threads": 64}'` with Kimi-K2.5 (64 shards, ~10 GB each), performed on the exact same machine and storage with no caches, the results were significant. The shard-loading phase accelerated from 18:24 to just 02:33 (7.2x faster). Consequently, the total end-to-end weight loading time dropped from ~24 minutes 46 seconds to ~6 minutes 11 seconds, a 4x speedup that reduced the overall wait time by 75%.

Before:
```
Multi-thread loading shards:   0% Completed | 0/64 [00:00<?, ?it/s]
Multi-thread loading shards:   5% Completed | 3/64 [00:01<00:31,  1.92it/s]
Multi-thread loading shards:   6% Completed | 4/64 [01:17<24:49, 24.82s/it]
Multi-thread loading shards:   8% Completed | 5/64 [17:41<5:21:55, 327.38s/it]
Multi-thread loading shards:   9% Completed | 6/64 [17:51<3:41:04, 228.70s/it]
Multi-thread loading shards:  11% Completed | 7/64 [17:53<2:31:04, 159.03s/it]
Multi-thread loading shards:  14% Completed | 9/64 [17:54<1:17:56, 85.03s/it]
Multi-thread loading shards:  20% Completed | 13/64 [18:01<25:04, 29.51s/it]
Multi-thread loading shards:  25% Completed | 16/64 [18:01<11:55, 14.90s/it]
Multi-thread loading shards:  28% Completed | 18/64 [18:02<07:52, 10.27s/it]
Multi-thread loading shards:  30% Completed | 19/64 [18:05<06:39,  8.88s/it]
Multi-thread loading shards:  33% Completed | 21/64 [18:05<04:12,  5.88s/it]
Multi-thread loading shards:  36% Completed | 23/64 [18:05<02:43,  3.99s/it]
Multi-thread loading shards:  38% Completed | 24/64 [18:07<02:19,  3.49s/it]
Multi-thread loading shards:  39% Completed | 25/64 [18:08<01:59,  3.07s/it]
Multi-thread loading shards:  41% Completed | 26/64 [18:09<01:31,  2.40s/it]
Multi-thread loading shards:  48% Completed | 31/64 [18:10<00:35,  1.08s/it]
Multi-thread loading shards:  50% Completed | 32/64 [18:11<00:32,  1.01s/it]
Multi-thread loading shards:  52% Completed | 33/64 [18:13<00:36,  1.19s/it]
Multi-thread loading shards:  55% Completed | 35/64 [18:15<00:35,  1.24s/it]
Multi-thread loading shards:  59% Completed | 38/64 [18:16<00:20,  1.25it/s]
Multi-thread loading shards:  64% Completed | 41/64 [18:17<00:14,  1.56it/s]
Multi-thread loading shards:  67% Completed | 43/64 [18:18<00:12,  1.63it/s]
Multi-thread loading shards:  73% Completed | 47/64 [18:18<00:06,  2.75it/s]
Multi-thread loading shards:  78% Completed | 50/64 [18:19<00:04,  3.22it/s]
Multi-thread loading shards:  80% Completed | 51/64 [18:20<00:04,  2.62it/s]
Multi-thread loading shards:  81% Completed | 52/64 [18:20<00:04,  2.70it/s]
Multi-thread loading shards:  84% Completed | 54/64 [18:20<00:02,  3.67it/s]
Multi-thread loading shards:  86% Completed | 55/64 [18:21<00:03,  2.64it/s]
Multi-thread loading shards:  88% Completed | 56/64 [18:22<00:03,  2.21it/s]
Multi-thread loading shards:  92% Completed | 59/64 [18:23<00:02,  2.07it/s]
Multi-thread loading shards:  94% Completed | 60/64 [18:24<00:02,  1.80it/s]
Multi-thread loading shards: 100% Completed | 64/64 [18:24<00:00, 17.26s/it]
[2026-01-30 16:14:41 TP0] Loading weights took 1456.72 seconds
[2026-01-30 16:14:41 TP0] Load weight end. elapsed=1471.93 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.73 GB, mem usage=72.30 GB.
[2026-01-30 16:14:54 TP3] Loading weights took 1471.83 seconds
[2026-01-30 16:14:54 TP7] Loading weights took 1470.35 seconds
[2026-01-30 16:14:54 TP3] Load weight end. elapsed=1485.36 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 16:14:54 TP7] Load weight end. elapsed=1485.38 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.92 GB, mem usage=72.30 GB.
[2026-01-30 16:14:55 TP4] Loading weights took 1470.69 seconds
[2026-01-30 16:14:55 TP4] Load weight end. elapsed=1485.81 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 16:14:55 TP6] Loading weights took 1472.64 seconds
[2026-01-30 16:14:55 TP1] Loading weights took 1472.09 seconds
[2026-01-30 16:14:55 TP6] Load weight end. elapsed=1485.91 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 16:14:55 TP1] Load weight end. elapsed=1485.96 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 16:14:55 TP2] Loading weights took 1471.82 seconds
[2026-01-30 16:14:55 TP5] Loading weights took 1471.21 seconds
[2026-01-30 16:14:55 TP2] Load weight end. elapsed=1486.05 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 16:14:55 TP5] Load weight end. elapsed=1486.07 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 16:14:55 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-30 16:14:55 TP7] KV Cache is allocated. #tokens: 615760, KV size: 40.30 GB
```

After:
```
Multi-thread loading shards:   0% Completed | 0/64 [00:00<?, ?it/s]
Multi-thread loading shards:   6% Completed | 4/64 [00:23<05:46,  5.77s/it]
Multi-thread loading shards:   8% Completed | 5/64 [02:29<36:52, 37.50s/it]
Multi-thread loading shards:   9% Completed | 6/64 [02:29<26:23, 27.31s/it]
Multi-thread loading shards:  14% Completed | 9/64 [02:29<11:33, 12.60s/it]
Multi-thread loading shards:  17% Completed | 11/64 [02:30<07:26,  8.42s/it]
Multi-thread loading shards:  19% Completed | 12/64 [02:30<05:54,  6.81s/it]
Multi-thread loading shards:  20% Completed | 13/64 [02:30<04:33,  5.35s/it]
Multi-thread loading shards:  30% Completed | 19/64 [02:30<01:24,  1.88s/it]
Multi-thread loading shards:  34% Completed | 22/64 [02:31<00:55,  1.31s/it]
Multi-thread loading shards:  39% Completed | 25/64 [02:31<00:35,  1.09it/s]
Multi-thread loading shards:  42% Completed | 27/64 [02:31<00:27,  1.35it/s]
Multi-thread loading shards:  45% Completed | 29/64 [02:31<00:20,  1.71it/s]
Multi-thread loading shards:  50% Completed | 32/64 [02:31<00:12,  2.53it/s]
Multi-thread loading shards:  59% Completed | 38/64 [02:31<00:05,  4.79it/s]
Multi-thread loading shards:  66% Completed | 42/64 [02:32<00:03,  6.61it/s]
Multi-thread loading shards:  80% Completed | 51/64 [02:32<00:01, 12.47it/s]
Multi-thread loading shards:  94% Completed | 60/64 [02:33<00:00, 11.30it/s]
Multi-thread loading shards: 100% Completed | 64/64 [02:33<00:00,  2.39s/it]
[2026-01-30 18:49:42 TP5] Loading weights took 365.50 seconds
[2026-01-30 18:49:43 TP5] Load weight end. elapsed=369.28 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 18:49:43 TP3] Loading weights took 366.40 seconds
[2026-01-30 18:49:43 TP3] Load weight end. elapsed=369.65 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 18:49:43 TP7] Load weight end. elapsed=369.71 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.92 GB, mem usage=72.30 GB.
[2026-01-30 18:49:43 TP2] Loading weights took 365.20 seconds
[2026-01-30 18:49:43 TP2] Load weight end. elapsed=369.89 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 18:49:43 TP0] Loading weights took 364.16 seconds
[2026-01-30 18:49:43 TP4] Loading weights took 367.56 seconds
[2026-01-30 18:49:43 TP0] Load weight end. elapsed=370.00 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.73 GB, mem usage=72.30 GB.
[2026-01-30 18:49:43 TP4] Load weight end. elapsed=370.01 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 18:49:43 TP6] Loading weights took 365.13 seconds
[2026-01-30 18:49:43 TP6] Load weight end. elapsed=370.26 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 18:49:44 TP1] Loading weights took 366.71 seconds
[2026-01-30 18:49:44 TP1] Load weight end. elapsed=370.91 s, type=KimiK25ForConditionalGeneration, dtype=torch.bfloat16, avail mem=65.69 GB, mem usage=72.30 GB.
[2026-01-30 18:49:44 TP0] Using KV cache dtype: torch.bfloat16
[2026-01-30 18:49:44 TP2] KV Cache is allocated. #tokens: 615760, KV size: 40.30 GB
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
