### PR TITLE
fix streaming parallel tool calls with tool_choice=auto for qwen25

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -173,12 +173,15 @@ class BaseFormatDetector(ABC):
                 # mistakenly identify that as the start of a new tool.
                 # We also skip the separator match when it is actually the start of
                 # an eot_token (e.g. separator="\n" and eot_token="\n</tool_call>").
-                eot_suffix = self.eot_token[len(self.tool_call_separator) :]
                 is_separator = (
                     self.current_tool_id > 0
                     and current_text.startswith(self.tool_call_separator)
-                    and not current_text[len(self.tool_call_separator) :].startswith(
-                        eot_suffix
+                    and not (
+                        self.eot_token
+                        and self.eot_token.startswith(self.tool_call_separator)
+                        and current_text[len(self.tool_call_separator) :].startswith(
+                            self.eot_token[len(self.tool_call_separator) :]
+                        )
                     )
                 )
                 if is_separator:

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -166,13 +166,9 @@ class BaseFormatDetector(ABC):
 
         try:
             try:
-                # Priority check: if we're processing a subsequent tool (current_tool_id > 0),
-                # first check if text starts with the tool separator. This is critical for
-                # parallel tool calls because the bot_token (e.g., '[') can also
-                # appear inside array parameters of the current tool, and we must not
-                # mistakenly identify that as the start of a new tool.
-                # We also skip the separator match when it is actually the start of
-                # an eot_token (e.g. separator="\n" and eot_token="\n</tool_call>").
+                # Check if text starts with tool_call_separator for subsequent tools.
+                # Skip separator match when it's actually the start of eot_token
+                # (e.g. separator="\n" and eot_token="\n</tool_call>").
                 is_separator = (
                     self.current_tool_id > 0
                     and current_text.startswith(self.tool_call_separator)

--- a/test/registered/function_call/test_parallel_tool_calls.py
+++ b/test/registered/function_call/test_parallel_tool_calls.py
@@ -21,6 +21,7 @@ import unittest
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(1.0, "default")
@@ -157,6 +158,72 @@ class TestParallelToolCalls(unittest.TestCase):
         self.assertEqual(len(tool_calls), 2, "Should parse 2 tool calls")
         self.assertEqual(tool_calls[0]["name"], "search_docs")
         self.assertEqual(tool_calls[1]["name"], "search_docs")
+
+
+class TestQwen25ParallelToolCalls(unittest.TestCase):
+    """Test Qwen25Detector streaming with multiple tool calls."""
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Qwen25Detector()
+
+    def _accumulate_tool_calls(self, tool_calls, result):
+        if not result.calls:
+            return
+        for call in result.calls:
+            if call.tool_index is None:
+                continue
+            while len(tool_calls) <= call.tool_index:
+                tool_calls.append({"name": "", "parameters": ""})
+            if call.name:
+                tool_calls[call.tool_index]["name"] = call.name
+            if call.parameters:
+                tool_calls[call.tool_index]["parameters"] += call.parameters
+
+    def test_two_tool_calls(self):
+        """Two <tool_call> blocks streamed incrementally.
+
+        The separator "\\n" is a prefix of eot_token "\\n</tool_call>",
+        which caused the second tool call to be dropped before the fix.
+        """
+        chunks = [
+            "<tool_call>\n",
+            '{"name": "get_weather", ',
+            '"arguments": {"city": "New York"}}',
+            "\n</tool_call>",
+            "\n<tool_call>\n",
+            '{"name": "get_weather", ',
+            '"arguments": {"city": "London"}}',
+            "\n</tool_call>",
+        ]
+
+        tool_calls = []
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            self._accumulate_tool_calls(tool_calls, result)
+
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+        self.assertEqual(tool_calls[1]["name"], "get_weather")
+        params0 = json.loads(tool_calls[0]["parameters"])
+        params1 = json.loads(tool_calls[1]["parameters"])
+        self.assertEqual(params0["city"], "New York")
+        self.assertEqual(params1["city"], "London")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #18001: 

when streaming multiple tool calls with tool_choice="auto", only the first tool call was emitted because parse_streaming_increment mistakenly treated the start of the eot token as a separator, for example separator \n matching the leading \n</tool_call>, which broke parsing of the second tool call. This patch skips separator matching when the candidate match is actually the prefix of an eot token. Impacts the Qwen25 and Trinity detectors.