### PR TITLE
[Mlperf] [Modelopt] Fix model launch task for NVFP4 Qwen 3 VL MoE

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -312,21 +312,30 @@ class ModelOptQuantConfig(QuantizationConfig):
     def get_scaled_act_names(self) -> List[str]:
         return []
 
-    def apply_weight_name_mapper(
-        self, hf_to_sglang_mapper: "WeightsMapper"
-    ):  # noqa: B027
-        # Map excluded module patterns from HF layout to sglang layout.
-        # Ref: HF hf_quant_config.json for nvidia/Kimi-K2.5-NVFP4
-        # https://huggingface.co/nvidia/Kimi-K2.5-NVFP4/blob/main/hf_quant_config.json
+    def apply_weight_name_mapper(self, hf_to_sglang_mapper: "WeightsMapper"):
         if self.exclude_modules:
-            mapped = hf_to_sglang_mapper.apply_list(self.exclude_modules)
-            expanded: List[str] = []
-            for name in mapped:
-                expanded.append(name)
-                if name.startswith("language_model."):
-                    expanded.append(name.removeprefix("language_model."))
-            # Preserve order, drop duplicates.
-            self.exclude_modules = list(dict.fromkeys(expanded))
+            self.exclude_modules = [
+                self._remap_wildcard_name(m, hf_to_sglang_mapper)
+                for m in self.exclude_modules
+            ]
+        if self.packed_modules_mapping:
+            self.packed_modules_mapping = hf_to_sglang_mapper.apply_dict(
+                self.packed_modules_mapping
+            )
+
+    @staticmethod
+    def _remap_wildcard_name(name: str, mapper: "WeightsMapper") -> str:
+        """Remap a module name through a WeightsMapper, preserving wildcards.
+
+        Temporarily replaces ``*`` with a dotted sentinel so _map_name's
+        longest-prefix matching isn't short-circuited (e.g. "model.visual*"
+        won't fall through to the shorter "model." prefix).
+        """
+        _SENTINEL = ".__wildcard__"
+        mapped = mapper._map_name(name.replace("*", _SENTINEL))
+        if mapped is not None:
+            return mapped.replace(_SENTINEL, "*")
+        return name
 
     def is_layer_excluded(self, prefix: str) -> bool:
         """Check if a layer should be excluded from quantization.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Bug: https://github.com/sgl-project/sglang/issues/18137



We aim to reproduce:
https://mlcommons.org/2026/02/vlm-inference-shopify/
https://github.com/mlcommons/inference/tree/master/multimodal/qwen3-vl

Where the model is:
https://huggingface.co/nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0
NVFP4 modelopt
The exclude in quant config was not working.

Exclude has `            "model.visual*"` but the current sgl code would not exclude it properly
Now it does.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
sglang ❯ OPENAI_API_KEY=sk-123456 OPENAI_API_BASE=http://localhost:30000/v1 \
  python3 -m lmms_eval \
    --model openai_compatible \
    --model_args 'model_version=nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0,tp=4' \
    --tasks gsm8k \
    --batch_size 1024 \
    --num_fewshot 0 \
    --log_samples \
    --output_path ./logs/gsm8k

2026-02-03 03:21:06 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2026-02-03 03:21:07 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'output_path': './logs/gsm8k'}
2026-02-03 03:21:07 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['gsm8k']
2026-02-03 03:21:07 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-03 03:21:10 | WARNING  | lmms_eval.evaluator:_adjust_config:235 - Overwriting default num_fewshot of gsm8k from 5 to 0
2026-02-03 03:21:10 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2026-02-03 03:21:10 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for gsm8k on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:00<00:00, 6104.43it/s]
2026-02-03 03:21:10 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████| 2/2 [02:42<00:00, 73.42s/it]2026-02-03 03:23:53 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 4973.799s, Total tokens: 275444, Avg speed: 55.4 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████| 2/2 [02:42<00:00, 81.34s/it]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:00<00:00, 3011.46it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:00<00:00, 3058.24it/s]
2026-02-03 03:23:54 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:188 - Saving results aggregated
2026-02-03 03:23:54 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_samples:287 - Saving samples to logs/gsm8k/nvidia__Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0/20260203_112107_samples_gsm8k.jsonl
openai_compatible (model_version=nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0,tp=4), gen_kwargs: (), limit: None, num_fewshot: 0, batch_size: 1024
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     0|exact_match|↑  |0.8954|±  |0.0084|
|gsm8k|      3|strict-match    |     0|exact_match|↑  |0.0000|±  |0.0000|
```

**LMMS eval in different venv**
```
OPENAI_API_KEY=sk-123456 OPENAI_API_BASE=http://localhost:30000/v1 python3 -m lmms_eval --model openai_compatible --model_args 'model_version="nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",tp=4' --tasks mmmu_val --batch_size 512 --log_samples --output_path ./logs
2026-02-03 02:43:00 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2026-02-03 02:43:01 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'output_path': './logs'}
2026-02-03 02:43:01 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2026-02-03 02:43:01 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-03 02:43:03 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2026-02-03 02:43:03 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 30984.76it/s]
2026-02-03 02:43:03 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [02:07<00:00, 59.07s/it]2026-02-03 02:45:11 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 2369.355s, Total tokens: 2993, Avg speed: 1.3 tokens/s
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [02:07<00:00, 63.97s/it]
Postprocessing: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13740.05it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.75}, 'Art': {'num': 30, 'acc': 0.76667}, 'Art_Theory': {'num': 30, 'acc': 0.93333}, 'Design': {'num': 30, 'acc': 0.86667}, 'Music': {'num': 30, 'acc': 0.43333}, 'Overall-Business': {'num': 150, 'acc': 0.58667}, 'Accounting': {'num': 30, 'acc': 0.56667}, 'Economics': {'num': 30, 'acc': 0.8}, 'Finance': {'num': 30, 'acc': 0.33333}, 'Manage': {'num': 30, 'acc': 0.46667}, 'Marketing': {'num': 30, 'acc': 0.76667}, 'Overall-Science': {'num': 150, 'acc': 0.55333}, 'Biology': {'num': 30, 'acc': 0.63333}, 'Chemistry': {'num': 30, 'acc': 0.46667}, 'Geography': {'num': 30, 'acc': 0.56667}, 'Math': {'num': 30, 'acc': 0.4}, 'Physics': {'num': 30, 'acc': 0.7}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.67333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.73333}, 'Clinical_Medicine': {'num': 30, 'acc': 0.76667}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.43333}, 'Pharmacy': {'num': 30, 'acc': 0.7}, 'Public_Health': {'num': 30, 'acc': 0.73333}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.80833}, 'History': {'num': 30, 'acc': 0.83333}, 'Literature': {'num': 30, 'acc': 0.93333}, 'Sociology': {'num': 30, 'acc': 0.73333}, 'Psychology': {'num': 30, 'acc': 0.73333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.47143}, 'Agriculture': {'num': 30, 'acc': 0.56667}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.36667}, 'Computer_Science': {'num': 30, 'acc': 0.63333}, 'Electronics': {'num': 30, 'acc': 0.4}, 'Energy_and_Power': {'num': 30, 'acc': 0.6}, 'Materials': {'num': 30, 'acc': 0.43333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.3}, 'Overall': {'num': 900, 'acc': 0.62}}
2026-02-03 02:45:12 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:188 - Saving results aggregated
2026-02-03 02:45:12 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_samples:287 - Saving samples to logs/__nvidia__Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0__/20260203_104301_samples_mmmu_val.jsonl
openai_compatible (model_version="nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",tp=4), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 512
| Tasks  |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|--------|------:|------|-----:|--------|---|----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  | 0.62|±  |   N/A|

```
_Official score: 0.69_


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

B300 TP4

```Input lens: [8192]. Output lens: [1024].
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) | acc length   |   ITL (ms) |   input cost ($/1M) |   output cost ($/1M) | cache hit rate   |
|--------------|-------------|---------------|----------------------------|-----------------------------|--------------|------------|---------------------|----------------------|------------------|
|            1 |        8192 |          7.99 |                    60252.6 |                      130.38 | n/a          |       7.67 |                0.03 |                 8.52 | n/a              |
|            4 |        8192 |          9.63 |                    63423.5 |                      449.48 | n/a          |       8.9  |                0.03 |                 2.47 | n/a              |
|            8 |        8192 |         11.11 |                    63974.2 |                      812.51 | n/a          |       9.85 |                0.02 |                 1.37 | n/a              |
|           16 |        8192 |         14.06 |                    66665.1 |                     1354.42 | n/a          |      11.81 |                0.02 |                 0.82 | n/a              |
|           32 |        8192 |         17.98 |                    67565.7 |                     2323.93 | n/a          |      13.77 |                0.02 |                 0.48 | n/a              |
|           64 |        8192 |         26.62 |                    67672.6 |                     3472.37 | n/a          |      18.43 |                0.02 |                 0.32 | n/a              |
|          128 |        8192 |         39.53 |                    67604.3 |                     5457.37 | n/a          |      23.45 |                0.02 |                 0.2  | n/a              |
|          256 |        8192 |         67.41 |                    67595.5 |                     7204.71 | n/a          |      35.53 |                0.02 |                 0.15 | n/a              |
```

```
sglang ❯ OPENAI_API_KEY=sk-123456 OPENAI_API_BASE=http://localhost:30000/v1 \
python3 -m lmms_eval \
  --model openai_compatible \
  --model_args 'model_version="nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",tp=4' \
  --tasks mmmu_pro \
  --batch_size 1024 \
  --log_samples \
  --output_path ./logs/mmmu_pro
2026-02-03 02:48:19 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2026-02-03 02:48:20 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'output_path': './logs/mmmu_pro'}
2026-02-03 02:48:20 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_pro']
2026-02-03 02:48:20 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
README.md: 9.20kB [00:00, 40.4MB/s]
standard (10 options)/test-00000-of-0000(…): 100%|████████████████████████████████████████████████████████| 346M/346M [00:03<00:00, 92.4MB/s]
standard (10 options)/test-00001-of-0000(…): 100%|████████████████████████████████████████████████████████| 332M/332M [00:04<00:00, 80.6MB/s]
Generating test split: 100%|████████████████████████████████████████████████████████████████████| 1730/1730 [00:01<00:00, 1447.91 examples/s]
vision/test-00003-of-00004.parquet: 100%|██████████████████████████████████████████████████████████████████| 437M/437M [00:04<00:00, 102MB/s]
vision/test-00002-of-00004.parquet: 100%|█████████████████████████████████████████████████████████████████| 309M/309M [00:04<00:00, 69.0MB/s]
vision/test-00000-of-00004.parquet: 100%|█████████████████████████████████████████████████████████████████| 423M/423M [00:04<00:00, 89.9MB/s]
vision/test-00001-of-00004.parquet: 100%|█████████████████████████████████████████████████████████████████| 462M/462M [00:05<00:00, 90.7MB/s]
Generating test split: 100%|█████████████████████████████████████████████████████████████████████| 1730/1730 [00:03<00:00, 536.55 examples/s]
2026-02-03 02:48:39 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2026-02-03 02:48:39 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_pro_vision on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1730/1730 [00:00<00:00, 9125.71it/s]
2026-02-03 02:48:39 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_pro_standard on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 1730/1730 [00:00<00:00, 28299.99it/s]
2026-02-03 02:48:39 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|███████████████████████████████████████████████████████████████████████████████████████| 4/4 [22:49<00:00, 249.03s/it]2026-02-03 03:11:28 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 31339.523s, Total tokens: 27398, Avg speed: 0.9 tokens/s
Model Responding: 100%|███████████████████████████████████████████████████████████████████████████████████████| 4/4 [22:49<00:00, 342.25s/it]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████| 1730/1730 [00:00<00:00, 5814.44it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████| 1730/1730 [00:00<00:00, 4817.50it/s]
{'Overall-Art and Design': {'num': 228, 'acc': 0.3114}, 'Art': {'num': 53, 'acc': 0.28302}, 'Art_Theory': {'num': 55, 'acc': 0.43636}, 'Design': {'num': 60, 'acc': 0.28333}, 'Music': {'num': 60, 'acc': 0.25}, 'Overall-Business': {'num': 286, 'acc': 0.15035}, 'Accounting': {'num': 58, 'acc': 0.12069}, 'Economics': {'num': 59, 'acc': 0.13559}, 'Finance': {'num': 60, 'acc': 0.11667}, 'Manage': {'num': 50, 'acc': 0.2}, 'Marketing': {'num': 59, 'acc': 0.18644}, 'Overall-Science': {'num': 291, 'acc': 0.2268}, 'Biology': {'num': 59, 'acc': 0.32203}, 'Chemistry': {'num': 60, 'acc': 0.18333}, 'Geography': {'num': 52, 'acc': 0.34615}, 'Math': {'num': 60, 'acc': 0.13333}, 'Physics': {'num': 60, 'acc': 0.16667}, 'Overall-Health and Medicine': {'num': 286, 'acc': 0.24825}, 'Basic_Medical_Science': {'num': 52, 'acc': 0.32692}, 'Clinical_Medicine': {'num': 59, 'acc': 0.16949}, 'Diagnostics_and_Laboratory_Medicine': {'num': 60, 'acc': 0.2}, 'Pharmacy': {'num': 57, 'acc': 0.40351}, 'Public_Health': {'num': 58, 'acc': 0.15517}, 'Overall-Humanities and Social Science': {'num': 222, 'acc': 0.35586}, 'History': {'num': 56, 'acc': 0.375}, 'Literature': {'num': 52, 'acc': 0.40385}, 'Sociology': {'num': 54, 'acc': 0.44444}, 'Psychology': {'num': 60, 'acc': 0.21667}, 'Overall-Tech and Engineering': {'num': 417, 'acc': 0.13909}, 'Agriculture': {'num': 60, 'acc': 0.16667}, 'Architecture_and_Engineering': {'num': 60, 'acc': 0.06667}, 'Computer_Science': {'num': 60, 'acc': 0.35}, 'Electronics': {'num': 60, 'acc': 0.2}, 'Energy_and_Power': {'num': 58, 'acc': 0.01724}, 'Materials': {'num': 60, 'acc': 0.01667}, 'Mechanical_Engineering': {'num': 59, 'acc': 0.15254}, 'Overall': {'num': 1730, 'acc': 0.22428}}
{'Overall-Art and Design': {'num': 228, 'acc': 0.61842}, 'Art': {'num': 53, 'acc': 0.71698}, 'Art_Theory': {'num': 55, 'acc': 0.76364}, 'Design': {'num': 60, 'acc': 0.7}, 'Music': {'num': 60, 'acc': 0.31667}, 'Overall-Business': {'num': 286, 'acc': 0.47203}, 'Accounting': {'num': 58, 'acc': 0.37931}, 'Economics': {'num': 59, 'acc': 0.62712}, 'Finance': {'num': 60, 'acc': 0.4}, 'Manage': {'num': 50, 'acc': 0.48}, 'Marketing': {'num': 59, 'acc': 0.47458}, 'Overall-Science': {'num': 291, 'acc': 0.44674}, 'Biology': {'num': 59, 'acc': 0.55932}, 'Chemistry': {'num': 60, 'acc': 0.51667}, 'Geography': {'num': 52, 'acc': 0.46154}, 'Math': {'num': 60, 'acc': 0.25}, 'Physics': {'num': 60, 'acc': 0.45}, 'Overall-Health and Medicine': {'num': 286, 'acc': 0.44406}, 'Basic_Medical_Science': {'num': 52, 'acc': 0.53846}, 'Clinical_Medicine': {'num': 59, 'acc': 0.50847}, 'Diagnostics_and_Laboratory_Medicine': {'num': 60, 'acc': 0.28333}, 'Pharmacy': {'num': 57, 'acc': 0.54386}, 'Public_Health': {'num': 58, 'acc': 0.36207}, 'Overall-Humanities and Social Science': {'num': 222, 'acc': 0.62162}, 'History': {'num': 56, 'acc': 0.64286}, 'Literature': {'num': 52, 'acc': 0.71154}, 'Sociology': {'num': 54, 'acc': 0.55556}, 'Psychology': {'num': 60, 'acc': 0.58333}, 'Overall-Tech and Engineering': {'num': 417, 'acc': 0.41727}, 'Agriculture': {'num': 60, 'acc': 0.43333}, 'Architecture_and_Engineering': {'num': 60, 'acc': 0.35}, 'Computer_Science': {'num': 60, 'acc': 0.53333}, 'Electronics': {'num': 60, 'acc': 0.61667}, 'Energy_and_Power': {'num': 58, 'acc': 0.24138}, 'Materials': {'num': 60, 'acc': 0.28333}, 'Mechanical_Engineering': {'num': 59, 'acc': 0.45763}, 'Overall': {'num': 1730, 'acc': 0.48844}}
2026-02-03 03:11:29 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:188 - Saving results aggregated
2026-02-03 03:11:29 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_samples:287 - Saving samples to logs/mmmu_pro/__nvidia__Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0__/20260203_104820_samples_mmmu_pro_standard.jsonl
2026-02-03 03:11:29 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_samples:287 - Saving samples to logs/mmmu_pro/__nvidia__Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0__/20260203_104820_samples_mmmu_pro_vision.jsonl
openai_compatible (model_version="nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4-MLPerf-Inference-Closed-V6.0",tp=4), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 1024
|       Tasks        |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------------------|-------|------|-----:|--------|---|-----:|---|------|
|mmmu_pro            |    N/A|      |      |        |   |      |   |      |
| - mmmu_pro_standard|      0|none  |     0|mmmu_acc|↑  |0.4884|±  |   N/A|
| - mmmu_pro_vision  |      0|none  |     0|mmmu_acc|↑  |0.2243|±  |   N/A|
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
