### PR TITLE
[PD] improve kv offset calculation for MHA model with different tp size

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -464,142 +464,44 @@ class MooncakeKVManager(CommonKVManager):
             )
             return -1
 
-        use_numpy_opt = envs.SGLANG_DISAGGREGATION_OPT_DIFF_TP_NUMPY.get()
-        # Whether to use numpy optimization for different TP size on prefill node
+        # The original for loop is replaced by numpy optimization for different TP size on prefill node
+        prefill_kv_indices_reshaped = prefill_kv_indices.astype(np.int64).reshape(-1, 1)
+        dst_kv_indices_reshaped = dst_kv_indices.astype(np.int64).reshape(-1, 1)
+        token_offsets = np.arange(page_size, dtype=np.int64).reshape(1, -1)
+        bytes_per_token_on_prefill = src_kv_item_len // page_size
+        bytes_per_token_on_decode = dst_kv_item_len // page_size
+        src_token_offsets_base = (
+            token_offsets * bytes_per_token_on_prefill + src_head_slice_offset
+        )
+        dst_token_offsets_base = (
+            token_offsets * bytes_per_token_on_decode + dst_head_slice_offset
+        )
 
-        if use_numpy_opt:
-            # Compute indices and offsets
-            prefill_kv_indices_reshaped = prefill_kv_indices.astype(np.int64).reshape(
-                -1, 1
+        def process_layer_tp_aware(ptrs):
+            src_ptr, dst_ptr = ptrs
+            src_page_starts = src_ptr + prefill_kv_indices_reshaped * src_kv_item_len
+            dst_page_starts = dst_ptr + dst_kv_indices_reshaped * dst_kv_item_len
+            src_addrs = src_page_starts + src_token_offsets_base
+            dst_addrs = dst_page_starts + dst_token_offsets_base
+            src_addr_list = src_addrs.reshape(-1).tolist()
+            if not src_addr_list:
+                return 0
+            dst_addr_list = dst_addrs.reshape(-1).tolist()
+            total_chunks = len(src_addr_list)
+            length_list = [heads_bytes_per_token_to_send] * total_chunks
+            return self.engine.batch_transfer_sync(
+                mooncake_session_id, src_addr_list, dst_addr_list, length_list
             )
-            dst_kv_indices_reshaped = dst_kv_indices.astype(np.int64).reshape(-1, 1)
-            token_offsets = np.arange(page_size, dtype=np.int64).reshape(1, -1)
-            bytes_per_token_on_prefill = src_kv_item_len // page_size
-            bytes_per_token_on_decode = dst_kv_item_len // page_size
-            src_token_offsets_base = (
-                token_offsets * bytes_per_token_on_prefill + src_head_slice_offset
+
+        futures = []
+        for i in range(layers_current_pp_stage):
+            futures.append(
+                executor.submit(process_layer_tp_aware, (src_k_ptrs[i], dst_k_ptrs[i]))
             )
-            dst_token_offsets_base = (
-                token_offsets * bytes_per_token_on_decode + dst_head_slice_offset
+        for i in range(layers_current_pp_stage):
+            futures.append(
+                executor.submit(process_layer_tp_aware, (src_v_ptrs[i], dst_v_ptrs[i]))
             )
-
-            def process_layer_tp_aware(ptrs):
-                src_ptr, dst_ptr = ptrs
-                src_page_starts = (
-                    src_ptr + prefill_kv_indices_reshaped * src_kv_item_len
-                )
-                dst_page_starts = dst_ptr + dst_kv_indices_reshaped * dst_kv_item_len
-                src_addrs = src_page_starts + src_token_offsets_base
-                dst_addrs = dst_page_starts + dst_token_offsets_base
-                src_addr_list = src_addrs.reshape(-1).tolist()
-                if not src_addr_list:
-                    return 0
-                dst_addr_list = dst_addrs.reshape(-1).tolist()
-                total_chunks = len(src_addr_list)
-                length_list = [heads_bytes_per_token_to_send] * total_chunks
-                return self.engine.batch_transfer_sync(
-                    mooncake_session_id, src_addr_list, dst_addr_list, length_list
-                )
-
-            futures = []
-            for i in range(layers_current_pp_stage):
-                futures.append(
-                    executor.submit(
-                        process_layer_tp_aware, (src_k_ptrs[i], dst_k_ptrs[i])
-                    )
-                )
-            for i in range(layers_current_pp_stage):
-                futures.append(
-                    executor.submit(
-                        process_layer_tp_aware, (src_v_ptrs[i], dst_v_ptrs[i])
-                    )
-                )
-        else:
-            layers_params = [
-                (
-                    src_k_ptrs[layer_id],
-                    dst_k_ptrs[layer_id],
-                    src_kv_item_len,
-                    dst_kv_item_len,
-                    src_head_slice_offset,
-                    dst_head_slice_offset,
-                    heads_bytes_per_token_to_send,
-                )
-                for layer_id in range(layers_current_pp_stage)
-            ] + [
-                (
-                    src_v_ptrs[layer_id],
-                    dst_v_ptrs[layer_id],
-                    src_kv_item_len,
-                    dst_kv_item_len,
-                    src_head_slice_offset,
-                    dst_head_slice_offset,
-                    heads_bytes_per_token_to_send,
-                )
-                for layer_id in range(layers_current_pp_stage)
-            ]
-
-            def process_layer_tp_aware(layer_params):
-                (
-                    src_ptr,
-                    dst_ptr,
-                    src_item_len,
-                    dst_item_len,
-                    src_head_slice_offset,
-                    dst_head_slice_offset,
-                    heads_bytes_per_token_to_send,
-                ) = layer_params
-                src_addr_list = []
-                dst_addr_list = []
-                length_list = []
-
-                # Calculate strides for a single token slot
-                bytes_per_token_on_prefill = src_item_len // page_size
-                bytes_per_token_on_decode = dst_item_len // page_size
-
-                for i in range(len(prefill_kv_indices)):
-                    prefill_page_idx = int(prefill_kv_indices[i])
-                    decode_page_idx = int(dst_kv_indices[i])
-
-                    # Get the starting addresses for the current src and dst pages
-                    src_page_start_addr = src_ptr + prefill_page_idx * src_item_len
-                    dst_page_start_addr = dst_ptr + decode_page_idx * dst_item_len
-
-                    # Iterate through each valid token slot within the current page
-                    for token_slot_in_page in range(page_size):
-                        # Calculate the start address of the current token slot
-                        src_token_slot_start_addr = (
-                            src_page_start_addr
-                            + token_slot_in_page * bytes_per_token_on_prefill
-                        )
-                        dst_token_slot_start_addr = (
-                            dst_page_start_addr
-                            + token_slot_in_page * bytes_per_token_on_decode
-                        )
-
-                        # Calculate final src and dst addresses by applying head-slice offsets
-                        src_slice_addr = (
-                            src_token_slot_start_addr + src_head_slice_offset
-                        )
-                        dst_slice_addr = (
-                            dst_token_slot_start_addr + dst_head_slice_offset
-                        )
-
-                        src_addr_list.append(src_slice_addr)
-                        dst_addr_list.append(dst_slice_addr)
-                        length_list.append(heads_bytes_per_token_to_send)
-
-                return self.engine.batch_transfer_sync(
-                    mooncake_session_id, src_addr_list, dst_addr_list, length_list
-                )
-
-            futures = [
-                executor.submit(
-                    process_layer_tp_aware,
-                    layer_params,
-                )
-                for layer_params in layers_params
-            ]
 
         for future in concurrent.futures.as_completed(futures):
             status = future.result()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -464,87 +464,142 @@ class MooncakeKVManager(CommonKVManager):
             )
             return -1
 
-        layers_params = [
-            (
-                src_k_ptrs[layer_id],
-                dst_k_ptrs[layer_id],
-                src_kv_item_len,
-                dst_kv_item_len,
-                src_head_slice_offset,
-                dst_head_slice_offset,
-                heads_bytes_per_token_to_send,
+        use_numpy_opt = envs.SGLANG_DISAGGREGATION_OPT_DIFF_TP_NUMPY.get()
+        # Whether to use numpy optimization for different TP size on prefill node
+
+        if use_numpy_opt:
+            # Compute indices and offsets
+            prefill_kv_indices_reshaped = prefill_kv_indices.astype(np.int64).reshape(
+                -1, 1
             )
-            for layer_id in range(layers_current_pp_stage)
-        ] + [
-            (
-                src_v_ptrs[layer_id],
-                dst_v_ptrs[layer_id],
-                src_kv_item_len,
-                dst_kv_item_len,
-                src_head_slice_offset,
-                dst_head_slice_offset,
-                heads_bytes_per_token_to_send,
+            dst_kv_indices_reshaped = dst_kv_indices.astype(np.int64).reshape(-1, 1)
+            token_offsets = np.arange(page_size, dtype=np.int64).reshape(1, -1)
+            bytes_per_token_on_prefill = src_kv_item_len // page_size
+            bytes_per_token_on_decode = dst_kv_item_len // page_size
+            src_token_offsets_base = (
+                token_offsets * bytes_per_token_on_prefill + src_head_slice_offset
             )
-            for layer_id in range(layers_current_pp_stage)
-        ]
+            dst_token_offsets_base = (
+                token_offsets * bytes_per_token_on_decode + dst_head_slice_offset
+            )
 
-        def process_layer_tp_aware(layer_params):
-            (
-                src_ptr,
-                dst_ptr,
-                src_item_len,
-                dst_item_len,
-                src_head_slice_offset,
-                dst_head_slice_offset,
-                heads_bytes_per_token_to_send,
-            ) = layer_params
-            src_addr_list = []
-            dst_addr_list = []
-            length_list = []
+            def process_layer_tp_aware(ptrs):
+                src_ptr, dst_ptr = ptrs
+                src_page_starts = (
+                    src_ptr + prefill_kv_indices_reshaped * src_kv_item_len
+                )
+                dst_page_starts = dst_ptr + dst_kv_indices_reshaped * dst_kv_item_len
+                src_addrs = src_page_starts + src_token_offsets_base
+                dst_addrs = dst_page_starts + dst_token_offsets_base
+                src_addr_list = src_addrs.reshape(-1).tolist()
+                if not src_addr_list:
+                    return 0
+                dst_addr_list = dst_addrs.reshape(-1).tolist()
+                total_chunks = len(src_addr_list)
+                length_list = [heads_bytes_per_token_to_send] * total_chunks
+                return self.engine.batch_transfer_sync(
+                    mooncake_session_id, src_addr_list, dst_addr_list, length_list
+                )
 
-            # Calculate strides for a single token slot
-            bytes_per_token_on_prefill = src_item_len // page_size
-            bytes_per_token_on_decode = dst_item_len // page_size
-
-            for i in range(len(prefill_kv_indices)):
-                prefill_page_idx = int(prefill_kv_indices[i])
-                decode_page_idx = int(dst_kv_indices[i])
-
-                # Get the starting addresses for the current src and dst pages
-                src_page_start_addr = src_ptr + prefill_page_idx * src_item_len
-                dst_page_start_addr = dst_ptr + decode_page_idx * dst_item_len
-
-                # Iterate through each valid token slot within the current page
-                for token_slot_in_page in range(page_size):
-                    # Calculate the start address of the current token slot
-                    src_token_slot_start_addr = (
-                        src_page_start_addr
-                        + token_slot_in_page * bytes_per_token_on_prefill
+            futures = []
+            for i in range(layers_current_pp_stage):
+                futures.append(
+                    executor.submit(
+                        process_layer_tp_aware, (src_k_ptrs[i], dst_k_ptrs[i])
                     )
-                    dst_token_slot_start_addr = (
-                        dst_page_start_addr
-                        + token_slot_in_page * bytes_per_token_on_decode
+                )
+            for i in range(layers_current_pp_stage):
+                futures.append(
+                    executor.submit(
+                        process_layer_tp_aware, (src_v_ptrs[i], dst_v_ptrs[i])
                     )
+                )
+        else:
+            layers_params = [
+                (
+                    src_k_ptrs[layer_id],
+                    dst_k_ptrs[layer_id],
+                    src_kv_item_len,
+                    dst_kv_item_len,
+                    src_head_slice_offset,
+                    dst_head_slice_offset,
+                    heads_bytes_per_token_to_send,
+                )
+                for layer_id in range(layers_current_pp_stage)
+            ] + [
+                (
+                    src_v_ptrs[layer_id],
+                    dst_v_ptrs[layer_id],
+                    src_kv_item_len,
+                    dst_kv_item_len,
+                    src_head_slice_offset,
+                    dst_head_slice_offset,
+                    heads_bytes_per_token_to_send,
+                )
+                for layer_id in range(layers_current_pp_stage)
+            ]
 
-                    # Calculate final src and dst addresses by applying head-slice offsets
-                    src_slice_addr = src_token_slot_start_addr + src_head_slice_offset
-                    dst_slice_addr = dst_token_slot_start_addr + dst_head_slice_offset
+            def process_layer_tp_aware(layer_params):
+                (
+                    src_ptr,
+                    dst_ptr,
+                    src_item_len,
+                    dst_item_len,
+                    src_head_slice_offset,
+                    dst_head_slice_offset,
+                    heads_bytes_per_token_to_send,
+                ) = layer_params
+                src_addr_list = []
+                dst_addr_list = []
+                length_list = []
 
-                    src_addr_list.append(src_slice_addr)
-                    dst_addr_list.append(dst_slice_addr)
-                    length_list.append(heads_bytes_per_token_to_send)
+                # Calculate strides for a single token slot
+                bytes_per_token_on_prefill = src_item_len // page_size
+                bytes_per_token_on_decode = dst_item_len // page_size
 
-            return self.engine.batch_transfer_sync(
-                mooncake_session_id, src_addr_list, dst_addr_list, length_list
-            )
+                for i in range(len(prefill_kv_indices)):
+                    prefill_page_idx = int(prefill_kv_indices[i])
+                    decode_page_idx = int(dst_kv_indices[i])
 
-        futures = [
-            executor.submit(
-                process_layer_tp_aware,
-                layer_params,
-            )
-            for layer_params in layers_params
-        ]
+                    # Get the starting addresses for the current src and dst pages
+                    src_page_start_addr = src_ptr + prefill_page_idx * src_item_len
+                    dst_page_start_addr = dst_ptr + decode_page_idx * dst_item_len
+
+                    # Iterate through each valid token slot within the current page
+                    for token_slot_in_page in range(page_size):
+                        # Calculate the start address of the current token slot
+                        src_token_slot_start_addr = (
+                            src_page_start_addr
+                            + token_slot_in_page * bytes_per_token_on_prefill
+                        )
+                        dst_token_slot_start_addr = (
+                            dst_page_start_addr
+                            + token_slot_in_page * bytes_per_token_on_decode
+                        )
+
+                        # Calculate final src and dst addresses by applying head-slice offsets
+                        src_slice_addr = (
+                            src_token_slot_start_addr + src_head_slice_offset
+                        )
+                        dst_slice_addr = (
+                            dst_token_slot_start_addr + dst_head_slice_offset
+                        )
+
+                        src_addr_list.append(src_slice_addr)
+                        dst_addr_list.append(dst_slice_addr)
+                        length_list.append(heads_bytes_per_token_to_send)
+
+                return self.engine.batch_transfer_sync(
+                    mooncake_session_id, src_addr_list, dst_addr_list, length_list
+                )
+
+            futures = [
+                executor.submit(
+                    process_layer_tp_aware,
+                    layer_params,
+                )
+                for layer_params in layers_params
+            ]
 
         for future in concurrent.futures.as_completed(futures):
             status = future.result()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -464,7 +464,6 @@ class MooncakeKVManager(CommonKVManager):
             )
             return -1
 
-        # The original for loop is replaced by numpy optimization for different TP size on prefill node
         prefill_kv_indices_reshaped = prefill_kv_indices.astype(np.int64).reshape(-1, 1)
         dst_kv_indices_reshaped = dst_kv_indices.astype(np.int64).reshape(-1, 1)
         token_offsets = np.arange(page_size, dtype=np.int64).reshape(1, -1)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -236,6 +236,7 @@ class Envs:
     SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE = EnvInt(2)
     SGLANG_DISAGGREGATION_WAITING_TIMEOUT = EnvInt(300)
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
+    SGLANG_DISAGGREGATION_OPT_DIFF_TP_NUMPY = EnvBool(False)
 
     # Scheduler: others:
     SGLANG_EMPTY_CACHE_INTERVAL = EnvFloat(-1)  # in seconds. Set if you observe high memory accumulation over a long serving period.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -236,7 +236,6 @@ class Envs:
     SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE = EnvInt(2)
     SGLANG_DISAGGREGATION_WAITING_TIMEOUT = EnvInt(300)
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
-    SGLANG_DISAGGREGATION_OPT_DIFF_TP_NUMPY = EnvBool(False)
 
     # Scheduler: others:
     SGLANG_EMPTY_CACHE_INTERVAL = EnvFloat(-1)  # in seconds. Set if you observe high memory accumulation over a long serving period.


### PR DESCRIPTION
…efore KV transfer

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When deploying an **MHA** model with PD disaggregation, if the TP sizes of the prefill and decode nodes are different, KV transfer is performed by token, which leads to high TTFT. 

SGLANG_DISAGGREGATION_DIFF_TP_NUMPY: use NumPy vectorization to accelerate the computation of destination pointers on the prefill side.


## Modifications

<!-- Detail the changes made in this pull request. -->

Use Numpy vectorization to accelerate dst ptr computation in send_kvcache_slice


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

|  deploy |  Acc |  Latency | 
|---|---|---|
|  baseline |  0.844 |  71.910 | 
|  w/ this PR |  0.849 |  68.468 | 

w/o this PR:
```
root@dsw-292900-7db9ddf7db-2tll9:/sgl-workspace/sglang# bash tmp/eval.sh 
Loading GSM8K Platinum dataset from HuggingFace...
100%|██████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [01:11<00:00, 16.86it/s]
Accuracy: 0.844
Invalid: 0.001
Latency: 71.910 s
Output throughput: 2805.579 token/s
```

w/ this PR, enable SGLANG_DISAGGREGATION_DIFF_TP_NUMPY
```
root@dsw-292900-7db9ddf7db-2tll9:/sgl-workspace/sglang# bash tmp/eval.sh 
Loading GSM8K Platinum dataset from HuggingFace...
100%|██████████████████████████████████████████████████████████████████████████████████████| 1209/1209 [01:08<00:00, 17.70it/s]
Accuracy: 0.849
Invalid: 0.000
Latency: 68.468 s
Output throughput: 2800.606 token/s
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->


The results by benching 4K:1K, max-concurrency=64

|  deploy |  TTFT |  TPOT | 
|---|---|---|
|  baseline |  899.37 |  30.74 | 
|  +numpy |  719.44 |  30.89 | 


w/o this PR:
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 64        
Successful requests:                     1000      
Benchmark duration (s):                  264.08    
Total input tokens:                      1995681   
Total generated tokens:                  500246    
Total generated tokens (retokenized):    499851    
Request throughput (req/s):              3.79      
Input token throughput (tok/s):          7557.10   
Output token throughput (tok/s):         1894.30   
Total token throughput (tok/s):          9451.39   
Concurrency:                             61.54     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16252.07  
Median E2E Latency (ms):                 15713.56  
---------------Time to First Token----------------
Mean TTFT (ms):                          899.37    
Median TTFT (ms):                        436.68    
P99 TTFT (ms):                           9384.51   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           30.91     
Median ITL (ms):                         30.90     
P95 ITL (ms):                            33.34     
P99 ITL (ms):                            36.31     
Max ITL (ms):                            290.79    
Mean TPOT (ms):                          30.74     
Median TPOT (ms):                        30.96     
P95 TPOT (ms):                           32.12     
P99 TPOT (ms):                           32.50     
Max TPOT (ms):                           35.81     
==================================================
```

w/ this PR, enable SGLANG_DISAGGREGATION_DIFF_TP_NUMPY
```
============ Serving Benchmark Result ============
Backend:                                 vllm      
Traffic request rate:                    inf       
Max request concurrency:                 64        
Successful requests:                     1000      
Benchmark duration (s):                  260.38    
Total input tokens:                      1995681   
Total generated tokens:                  500246    
Total generated tokens (retokenized):    499864    
Request throughput (req/s):              3.84      
Input token throughput (tok/s):          7664.46   
Output token throughput (tok/s):         1921.21   
Total token throughput (tok/s):          9585.67   
Concurrency:                             61.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16141.67  
Median E2E Latency (ms):                 15858.06  
---------------Time to First Token----------------
Mean TTFT (ms):                          719.44    
Median TTFT (ms):                        395.77    
P99 TTFT (ms):                           6386.17   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           31.03     
Median ITL (ms):                         31.03     
P95 ITL (ms):                            33.90     
P99 ITL (ms):                            36.21     
Max ITL (ms):                            236.73    
Mean TPOT (ms):                          30.89     
Median TPOT (ms):                        31.06     
P95 TPOT (ms):                           32.85     
P99 TPOT (ms):                           33.57     
Max TPOT (ms):                           34.59     
==================================================
```

## Scripts

Prefill (TP4)
```
# ====== start of numpy opt ======
export SGLANG_DISAGGREGATION_DIFF_TP_NUMPY=1
# ====== end of numpy opt ======

python3 -m sglang.launch_server \
    --model-path /dev/shm/GLM-4.5-Air-FP8 \
    --served-model-name=GLM-4.5-Air-FP8 \
    --disaggregation-mode prefill \
    --tp-size 4 \
    --mem-fraction-static 0.8 \
    --disable-cuda-graph \
    --max-running-requests 320 \
    --kv-cache-dtype fp8_e4m3 \
    --disable-radix-cache \
    --host 0.0.0.0 \
    --enable-metrics \
    --attention-backend fa3 \
    --port 30001 \
    --page-size 64 \
    --chunked-prefill-size $((16384 * 4)) \
    --max-prefill-tokens $((16384 * 4))
```

Decode (2xTP2)
```
python3 -m sglang.launch_server \
    --model-path /dev/shm/GLM-4.5-Air-FP8 \
    --served-model-name=GLM-4.5-Air-FP8 \
    --disaggregation-mode decode \
    --tp-size 2 \
    --mem-fraction-static 0.8 \
    --max-running-requests 128 \
    --kv-cache-dtype fp8_e4m3 \
    --host 0.0.0.0 \
    --enable-metrics \
    --attention-backend fa3 \
    --port 30011 \
    --page-size 64 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 1 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 2 \
    --disable-shared-experts-fusion
```

sglang-router
```
python3 -m sglang_router.launch_router \
  --pd-disaggregation \
  --prefill http://localhost:30001 \
  --decode http://localhost:30011 \
  --decode http://localhost:30021 --mini-lb
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
