### PR TITLE
[ModelOpt] Fix broken Qwen3-235B-A22B-Instruct-2507-NVFP4 launch

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -890,6 +890,14 @@ class Qwen3MoeModel(Qwen2MoeModel):
 class Qwen3MoeForCausalLM(nn.Module):
     fall_back_to_pt_during_load = False
 
+    # Mapping from fused module names to their component weight names.
+    # Required for quantization configs (e.g., ModelOpt FP4) to correctly identify
+    # which layers should be skipped based on the exclude_modules/ignore list.
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
     def __init__(
         self,
         config: Qwen3MoeConfig,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Support https://huggingface.co/nvidia/Qwen3-235B-A22B-Instruct-2507-NVFP4

Previously it failed to launch on SGLang.
However, the 30B NVFP4 always worked.
https://huggingface.co/nvidia/Qwen3-30B-A3B-NVFP4/blob/main/hf_quant_config.json

## Root cause

 ### Qwen3-235B-A22B-Instruct-2507-NVFP4 (Broken)                                                    
  
MoE Expert MLPs (gate_proj, up_proj, down_proj) NVFP4

Attention Projections (q_proj, k_proj, v_proj, o_proj) BF16

Router Gates (mlp.gate)  BF16

Lm_head BF16
The config.json quantization_config.ignore list contains all 94 layers × 3 projections = 282    
  entries for q/k/v:                                                                              
  "ignore": [                                                                                     
      "model.layers.0.self_attn.k_proj",                                                          
      "model.layers.0.self_attn.q_proj",                                                          
      "model.layers.0.self_attn.v_proj",                                                          
      "model.layers.0.mlp.gate",                                                                  
      // ... repeated for all 94 layers                                                           
      "lm_head"                                                                                   
  ] 

### Qwen3-30B-A3B-NVFP4 (Works)           
MoE Expert MLPs (gate_proj, up_proj, down_proj) NVFP4

Attention Projections (q_proj, k_proj, v_proj, o_proj) NVFP4

Router Gates (mlp.gate)  BF16

Lm_head BF16

The config.json quantization_config.ignore list contains only router gates:                     
  "ignore": [                                                                                     
      "model.layers.0.mlp.gate",                                                                  
      // ... repeated for all 48 layers                                                           
      "lm_head"                                                                                   
  ]   


                                    
Qwen3MoeForCausalLM has no packed_modules_mapping

Buggy behaviour: 


Layer: model.layers.0.self_attn.qkv_proj                                                        
  ├── packed_modules_mapping = {}                                                                 
  ├── is_layer_skipped("...qkv_proj", ignore_list, {})                                            
  │   ├── proj_name = "qkv_proj"                                                                  
  │   ├── "qkv_proj" in {} → False                                                                
  │   └── Fallback: is "qkv_proj" in ignore_list? → NO (only q_proj, k_proj, v_proj are)          
  ├── Returns: False (NOT skipped)                                                                
  ├── Quant method: ModelOptFp4LinearMethod                                                       
  └── Creates param shape: [128, 2048] (FP4 packed, input_size/2 for k_proj shard) 


30B
Layer: model.layers.0.self_attn.qkv_proj                                                        
  ├── packed_modules_mapping = {}                                                                 
  ├── is_layer_skipped("...qkv_proj", ignore_list, {})                                            
  │   ├── proj_name = "qkv_proj"                                                                  
  │   ├── "qkv_proj" in {} → False                                                                
  │   └── Fallback: is "qkv_proj" in ignore_list? → NO                                            
  ├── Returns: False (NOT skipped)                                                                
  ├── Quant method: ModelOptFp4LinearMethod                                                       
  └── Creates param shape: [64, 1024] (FP4 packed) 

(Really, it oly worked by coincidence)

So we add packed_modules_mapping for Qwen3MoE

Which produces:
Layer: model.layers.0.self_attn.qkv_proj                                                        
  ├── packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"], ...}                  
  ├── is_layer_skipped("...qkv_proj", ignore_list, mapping)                                       
  │   ├── proj_name = "qkv_proj"                                                                  
  │   ├── "qkv_proj" in mapping → True                                                            
  │   ├── Expand to: [...q_proj, ...k_proj, ...v_proj]                                            
  │   └── All three in ignore_list? → YES                                                         
  ├── Returns: True (SKIPPED)                                                                     
  ├── Quant method: UnquantizedLinearMethod                                                       
  └── Creates param shape: [128, 4096] (BF16, full size)


30B behavoiur is unchange                      





- Bug:
```
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3022, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 350, in __init__
    self.init_model_worker()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 539, in init_model_worker
    self.init_tp_model_worker()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 501, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 242, in __init__
    self._init_model_runner()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 325, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 391, in __init__
    self.initialize(min_per_gpu_memory)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 471, in initialize
    self.load_model()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 909, in load_model
    self.model = self.loader.load_model(
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 2618, in load_model
    return super().load_model(
           ^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 671, in load_model
    self.load_weights_and_postprocess(
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 684, in load_weights_and_postprocess
    model.load_weights(weights)
  File "/sgl-workspace/sglang/python/sglang/srt/models/qwen3_moe.py", line 1074, in load_weights
    weight_loader(param, loaded_weight, shard_id)
  File "/sgl-workspace/sglang/python/sglang/srt/layers/linear.py", line 1004, in weight_loader_v2
    param.load_qkv_weight(
  File "/sgl-workspace/sglang/python/sglang/srt/layers/parameter.py", line 266, in load_qkv_weight
    param_data.shape == loaded_weight.shape
AssertionError: param_data.shape=torch.Size([128, 2048]), loaded_weight.shape=torch.Size([128, 4096])

```



<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Add packed modules mapping

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 2500 --parallel 2500 --platinum
Loading GSM8K Platinum dataset from HuggingFace...
100%|█████████████████████████████████████████████████████████| 1209/1209 [00:16<00:00, 74.04it/s]
Accuracy: 0.980
Invalid: 0.000
Latency: 16.442 s
Output throughput: 9916.770 token/s
```

```
❯ python3 -m sglang.launch_server --model-path nvidia/Qwen3-30B-A3B-NVFP4 --quantization modelopt_fp4
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
