### PR TITLE
fix: ensuring nightly whls are tagged with latest commit

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -62,7 +62,7 @@ jobs:
           # If building at exact tag (distance=0), force dev0 version for unique wheel names
           if [ "$DIST" = "0" ]; then
             TAG=$(echo "$DESC" | cut -d- -f1)
-            HASH=$(echo "$DESC" | cut -d- -f3-)
+            HASH="g$(git rev-parse --short HEAD)"
             FORCE_VERSION="${TAG#v}.dev0+${HASH}"
             echo "Building at exact tag, forcing version to: $FORCE_VERSION"
             export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"


### PR DESCRIPTION
## Motivation

There was a bug where current nightly whls were all tagged with the 0.5.8 tag's hash instead of the latest commit hash at the whl build time. This caused the nightly whls from the past week to overwrite each other, resulting in the siutation below:

```
# latest whl was from a test run of this pr
<!DOCTYPE html>
<h1>SGLang Nightly Wheels (cu129)</h1>
<a href="https://github.com/sgl-project/whl/releases/download/nightly-2026-02-03-8873d972e/sglang-0.5.8.dev0+g8873d972e-py3-none-any.whl#sha256=82721dfe735f7cdf420a110849b4cf495d2d25d48c8623aff42a734fd70d0ef7">sglang-0.5.8.dev0+g8873d972e-py3-none-any.whl</a><br>
<a href="https://github.com/sgl-project/whl/releases/download/nightly-2026-02-03-9b1619c14/sglang-0.5.8.dev0+g0189f41c3-py3-none-any.whl#sha256=4eb6864aed78ecba8eaa2ca6d5d86aaee7f2dbfb9f22756b3829f82ce7814b74">sglang-0.5.8.dev0+g0189f41c3-py3-none-any.whl</a><br>
```

## Modifications

In the nightly workflow, ensured that each whl was built with the latest commit hash with:

`HASH="g$(git rev-parse --short HEAD)" `

## Accuracy Tests

https://github.com/sgl-project/whl/releases/tag/nightly-2026-02-03-8873d972e

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
