### PR TITLE
[Bug] Fix GLM4-MoE TopK output format mismatch for unquantized models

### DIFF
--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -62,7 +62,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.moe.topk import TopK, TopKOutputFormat
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
@@ -397,6 +397,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
                 self.experts, "should_fuse_routed_scaling_factor_in_topk", False
             ),
             fused_shared_experts_scaling_factor=1,
+            output_format=TopKOutputFormat.STANDARD if quant_config is None else None,
         )
 
         # shared expert


### PR DESCRIPTION
- Set explicit output_format=TopKOutputFormat.STANDARD for unquantized GLM4-MoE models
- Add validation check in triton MoE runner to catch format mismatches early
- Fixes ValueError when using EAGLE speculative decoding with unquantized GLM4-MoE

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes ValueError: too many values to unpack (expected 3) when using EAGLE speculative decoding with unquantized GLM4-MoE models. The server crashes immediately after warmup during the first generation request.

```
File "sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 206, in fused_experts
    topk_weights, topk_ids, _ = topk_output
ValueError: too many values to unpack (expected 3)
```

Launch command to reproduce:
```
python3 -m sglang.launch_server \
  --model-path baseten-admin/glm-4.7-fp4 \
  --port 12345 \
  --enable-metrics \
  --tp-size 4 \
  --moe-runner-backend flashinfer_trtllm \
  --attention-backend flashinfer \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --mem-fraction-static 0.8 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --served-model-name baseten-admin/glm-4.7-fp4 \
  --host 0.0.0.0 \
  --context-length 202752 \
  --crash-dump-folder /var/log/sglang/
```

Hardware: B200
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Root Cause: GLM4-MoE's TopK layer doesn't explicitly set `output_format`, causing auto-detection to incorrectly produce `BypassedTopKOutput` (5 fields) instead of `StandardTopKOutput` (3 fields) when using EAGLE with unquantized models.

Fix: Set explicit `output_format=TopKOutputFormat.STANDARD` for unquantized GLM4-MoE models in `glm4_moe.py`:

```
output_format=TopKOutputFormat.STANDARD if quant_config is None else None,
```


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

✅ Tested unquantized GLM4-MoE with EAGLE speculative decoding (no longer crashes)
✅ Verified FP4 quantized models still work correctly with flashinfer_trtllm backend

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
