### PR TITLE
fix: bumping nightly whl version

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -63,8 +63,17 @@ jobs:
           if [ "$DIST" = "0" ]; then
             TAG=$(echo "$DESC" | cut -d- -f1)
             HASH="g$(git rev-parse --short HEAD)"
-            FORCE_VERSION="${TAG#v}.dev0+${HASH}"
-            echo "Building at exact tag, forcing version to: $FORCE_VERSION"
+
+            # Increment patch version for nightlies (e.g., v0.5.8 -> 0.5.9.dev0)
+            VERSION=${TAG#v}  # Remove 'v' prefix
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+            NEXT_PATCH=$((PATCH + 1))
+            NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+            FORCE_VERSION="${NEXT_VERSION}.dev0+${HASH}"
+            echo "Building at exact tag $TAG, forcing nightly version to: $FORCE_VERSION"
             export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"
           fi
 


### PR DESCRIPTION
## Motivation

To ensure nightly builds take precedent over stable builds when an index-url is specified, we bump nightly versions to +1 over the current version. ie. nightly builds between v0.5.8 and v0.5.9 will be labeled as 0.5.9.dev0+<hash> to indicate they're development versions leading to the next release.

Currently we have to manually specify the version when installing the pypi and that is unsustainble as the webpage would need to be updated daily with the new nightly version.

## Modifications

Increment the patch version by 1 in the nightly pypi workflow.

## Accuracy Tests

https://github.com/sgl-project/whl/releases/tag/nightly-2026-02-04-d44d19744

<img width="767" height="267" alt="Screenshot 2026-02-03 at 6 47 34 PM" src="https://github.com/user-attachments/assets/c509b18e-28b9-4c7d-b961-329f8356875e" />


## Benchmarking and Profiling

None.

## Checklist

- [ Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
