### PR TITLE
fix: add SGLANG_IS_IN_CI env var to release-docs workflow

### DIFF
--- a/.github/workflows/execute-notebook.yml
+++ b/.github/workflows/execute-notebook.yml
@@ -13,6 +13,8 @@ concurrency:
   group: execute-notebook-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SGLANG_IS_IN_CI: true
 
 jobs:
   run-all-notebooks:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -14,6 +14,9 @@ concurrency:
   group: release-docs-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SGLANG_IS_IN_CI: true
+
 jobs:
   execute-and-deploy:
     runs-on: 1-gpu-runner


### PR DESCRIPTION
## Summary
- Add `SGLANG_IS_IN_CI: true` environment variable to `release-docs.yml` workflow
- This fixes the speculative decoding notebook CI failure where `_derive_context_length()` raised a ValueError

## Root Cause
The documentation CI was failing because `is_in_ci()` returned `False` (since `SGLANG_IS_IN_CI` was not set), causing the context length validation to fail when the draft model's context_length (2048) was less than the target model's context_length (8192).

Other CI workflows (`pr-test.yml`, `nightly-test-nvidia.yml`, etc.) already set this environment variable. This fix aligns `release-docs.yml` with them.

Using git blame on [python/sglang/srt/configs/model_config.py](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/configs/model_config.py) (lines 361-363):
```
eb19ccadae (Liangsheng Yin 2025-08-21) or is_in_ci()  # FIXME: fix this special case
```
The is_in_ci() check was introduced in PR #9388 (eb19ccadae) on 2025-08-21, titled [bug] fix errors related to context length in SD. This PR added the special case handling for CI environments, but the release-docs.yml workflow was not updated to set the required environment variable.

## Test Plan
- [ ] Documentation CI should pass after this change

Fixes #18220