### PR TITLE
Docs: allow context override for speculative notebooks

### DIFF
--- a/python/sglang/test/doc_patch.py
+++ b/python/sglang/test/doc_patch.py
@@ -5,6 +5,7 @@ Do some monkey patch to make the documentation compilation faster and more relia
 - Reduce the server launch time
 """
 
+import os
 import weakref
 
 import nest_asyncio
@@ -16,6 +17,9 @@ from sglang.utils import execute_shell_command, reserve_port
 
 DEFAULT_MAX_RUNNING_REQUESTS = 128
 DEFAULT_MAX_TOTAL_TOKENS = 20480  # To allow multiple servers on the same machine
+
+# Allow draft models to override derived context length during docs builds.
+os.environ.setdefault("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", "1")
 
 _original_post_init = server_args_mod.ServerArgs.__post_init__
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Quick fix for #18220. I saw PR #18225, but it sets `SGLANG_IS_IN_CI` in workflows (broad flag with other side effects). This change instead opts into the context‑length override only for docs runs, which matches the intent of #9388 while keeping the global guard, and relies on the safe draft override behavior added in #10787.

## Modifications

Set `SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1` for docs notebook execution so speculative notebooks can run; keep the safety check intact elsewhere.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
