### PR TITLE
[AMD] Raise nofile ulimit for ROCm CI container

### DIFF
--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -154,8 +154,12 @@ else
     CACHE_VOLUME=""
 fi
 
+NOFILE_LIMIT="${SGLANG_NOFILE_LIMIT:-1048576}"
+ULIMIT_ARGS=(--ulimit "nofile=${NOFILE_LIMIT}:${NOFILE_LIMIT}")
+
 echo "Launching container: ci_sglang"
 docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
+  "${ULIMIT_ARGS[@]}" \
   -v "${GITHUB_WORKSPACE:-$PWD}:/sglang-checkout" \
   $CACHE_VOLUME \
   --group-add video \


### PR DESCRIPTION
CI can fail with connection setup errors when the container exhausts file descriptors.

Increase the container nofile limit via docker --ulimit at startup to reduce flakiness. 

## Motivation

To eliminate flakiness like [this](https://github.com/sgl-project/sglang/actions/runs/21656869879/job/62433366507#step:5:3022).

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests 

## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
