### PR TITLE
perf: reduce JIT overhead by using fixed step size in Triton kernels

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1463,11 +1463,17 @@ class FlashInferMultiStepDraftBackend:
         topk: int,
         speculative_num_steps: int,
     ):
-        from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+        from sglang.srt.speculative.spec_utils import (
+            _SPEC_MAX_NUM_LOOPS,
+            _SPEC_STEP_SIZE,
+            generate_draft_decode_kv_indices,
+        )
 
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.generate_draft_decode_kv_indices = generate_draft_decode_kv_indices
+        self._spec_step_size = _SPEC_STEP_SIZE
+        self._spec_max_num_loops = _SPEC_MAX_NUM_LOOPS
         self.page_size = model_runner.page_size
 
         max_bs = model_runner.req_to_token_pool.size * self.topk
@@ -1520,9 +1526,11 @@ class FlashInferMultiStepDraftBackend:
             self.pool_len,
             kv_indices_buffer.shape[1],
             self.kv_indptr.shape[1],
-            next_power_of_2(num_seqs),
+            self._spec_step_size,
+            self._spec_max_num_loops,
             next_power_of_2(self.speculative_num_steps),
-            next_power_of_2(bs),
+            self._spec_step_size,
+            self._spec_max_num_loops,
             self.page_size,
         )
 

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -907,7 +907,11 @@ class FlashInferMLAMultiStepDraftBackend:
         topk: int,
         speculative_num_steps: int,
     ):
-        from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+        from sglang.srt.speculative.spec_utils import (
+            _SPEC_MAX_NUM_LOOPS,
+            _SPEC_STEP_SIZE,
+            generate_draft_decode_kv_indices,
+        )
 
         if topk > 1:
             raise ValueError(
@@ -916,6 +920,8 @@ class FlashInferMLAMultiStepDraftBackend:
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.generate_draft_decode_kv_indices = generate_draft_decode_kv_indices
+        self._spec_step_size = _SPEC_STEP_SIZE
+        self._spec_max_num_loops = _SPEC_MAX_NUM_LOOPS
 
         max_bs = model_runner.req_to_token_pool.size * self.topk
         self.kv_indptr = torch.zeros(
@@ -969,9 +975,11 @@ class FlashInferMLAMultiStepDraftBackend:
             self.pool_len,
             kv_indices_buffer.shape[1],
             self.kv_indptr.shape[1],
-            next_power_of_2(num_seqs),
+            self._spec_step_size,
+            self._spec_max_num_loops,
             next_power_of_2(self.speculative_num_steps),
-            next_power_of_2(bs),
+            self._spec_step_size,
+            self._spec_max_num_loops,
             self.page_size,
         )
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -12,7 +12,11 @@ from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_trito
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
+from sglang.srt.speculative.spec_utils import (
+    _SPEC_MAX_NUM_LOOPS,
+    _SPEC_STEP_SIZE,
+    generate_draft_decode_kv_indices,
+)
 from sglang.srt.utils import (
     get_bool_env_var,
     get_device_core_count,
@@ -1098,9 +1102,11 @@ class TritonMultiStepDraftBackend:
             self.pool_len,
             kv_indices_buffer.shape[1],
             self.kv_indptr.shape[1],
-            next_power_of_2(num_seqs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             next_power_of_2(self.speculative_num_steps),
-            next_power_of_2(bs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             self.page_size,
         )
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -28,6 +28,8 @@ from sglang.srt.speculative.eagle_info_v2 import (
 from sglang.srt.speculative.eagle_utils import verify_tree_greedy_func
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.speculative.spec_utils import (
+    _SPEC_MAX_NUM_LOOPS,
+    _SPEC_STEP_SIZE,
     SIMULATE_ACC_LEN,
     TREE_SPEC_KERNEL_AVAILABLE,
     align_evict_mask_to_page_size,
@@ -492,7 +494,8 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     batch.out_cache_loc,
                     self.draft_token_num,
                     next_power_of_2(self.draft_token_num),
-                    next_power_of_2(bs),
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
                 )
 
                 # Free the kv cache
@@ -577,7 +580,8 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                         tgt_cache_loc,
                         accept_length,
                         accept_length_filter,
-                        next_power_of_2(bs),
+                        _SPEC_STEP_SIZE,
+                        _SPEC_MAX_NUM_LOOPS,
                         next_power_of_2(self.draft_token_num),
                     )
 
@@ -719,7 +723,9 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             self.accept_length,
             self.positions,
             self.verified_id,
-            next_power_of_2(max(speculative_num_steps + 1, len(batch.seq_lens))),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+            next_power_of_2(speculative_num_steps + 1),
         )
 
     def generate_attn_arg_prefill(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -48,6 +48,8 @@ from sglang.srt.speculative.eagle_utils import (
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
+    _SPEC_MAX_NUM_LOOPS,
+    _SPEC_STEP_SIZE,
     assign_draft_cache_locs,
     detect_nan,
     draft_tp_context,
@@ -491,7 +493,8 @@ class EAGLEWorker(TpModelWorker):
             self.topk,
             self.speculative_num_steps,
             self.page_size,
-            next_power_of_2(num_seqs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             next_power_of_2(self.speculative_num_steps + self.page_size),
         )
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -37,6 +37,8 @@ from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
 )
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_info_v2 import (
+    _FILL_ACCEPTED_CACHE_LOC_MAX_NUM_LOOPS,
+    _FILL_ACCEPTED_CACHE_LOC_STEP_SIZE,
     assign_extend_cache_locs,
     fill_accepted_out_cache_loc,
     fill_new_verified_id,
@@ -837,7 +839,8 @@ class EAGLEWorkerV2(BaseSpecWorker):
             accept_index,
             batch.out_cache_loc,
             accepted_out_cache_loc,
-            next_power_of_2(size),
+            _FILL_ACCEPTED_CACHE_LOC_STEP_SIZE,
+            _FILL_ACCEPTED_CACHE_LOC_MAX_NUM_LOOPS,
         )
         self.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
             tgt_cache_loc, accepted_out_cache_loc

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -29,6 +29,8 @@ from sglang.srt.mem_cache.common import (
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.speculative.spec_utils import (
+    _SPEC_MAX_NUM_LOOPS,
+    _SPEC_STEP_SIZE,
     TREE_SPEC_KERNEL_AVAILABLE,
     assign_req_to_token_pool,
     get_src_tgt_cache_loc,
@@ -250,7 +252,8 @@ class NgramVerifyInput(SpecInput):
                 batch.out_cache_loc,
                 self.draft_token_num,
                 next_power_of_2(self.draft_token_num),
-                next_power_of_2(bs),
+                _SPEC_STEP_SIZE,
+                _SPEC_MAX_NUM_LOOPS,
             )
 
             # Free the kv cache

--- a/python/sglang/test/speculative/test_spec_utils.py
+++ b/python/sglang/test/speculative/test_spec_utils.py
@@ -4,7 +4,11 @@ import numpy as np
 import torch
 
 from sglang.srt.mem_cache.memory_pool import copy_all_layer_kv_cache_tiled
-from sglang.srt.speculative.spec_utils import assign_draft_cache_locs
+from sglang.srt.speculative.spec_utils import (
+    _SPEC_MAX_NUM_LOOPS,
+    _SPEC_STEP_SIZE,
+    assign_draft_cache_locs,
+)
 from sglang.srt.utils import next_power_of_2
 
 BYTES_PER_TILE = 128
@@ -87,7 +91,8 @@ class TestSpecUtils(unittest.TestCase):
             topk,
             speculative_num_steps,
             page_size,
-            next_power_of_2(num_seqs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             next_power_of_2(speculative_num_steps + page_size),
         )
 
@@ -167,7 +172,8 @@ class TestSpecUtils(unittest.TestCase):
             topk,
             speculative_num_steps,
             page_size,
-            next_power_of_2(num_seqs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             next_power_of_2(speculative_num_steps + page_size),
         )
         out_cache_loc = out_cache_loc[: num_seqs * topk * speculative_num_steps]
@@ -271,7 +277,8 @@ class TestSpecUtils(unittest.TestCase):
             topk,
             speculative_num_steps,
             page_size,
-            next_power_of_2(num_seqs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             next_power_of_2(speculative_num_steps + page_size),
         )
         out_cache_loc = out_cache_loc[: num_seqs * topk * speculative_num_steps]
@@ -330,7 +337,8 @@ class TestSpecUtils(unittest.TestCase):
             topk,
             speculative_num_steps,
             page_size,
-            next_power_of_2(num_seqs),
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
             next_power_of_2(speculative_num_steps + page_size),
         )
         trimmed = out_cache_loc[: num_seqs * topk * speculative_num_steps]

--- a/test/srt/test_triton_assign_extend_cache_locs.py
+++ b/test/srt/test_triton_assign_extend_cache_locs.py
@@ -1,0 +1,448 @@
+import time
+import unittest
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.speculative.eagle_info_v2 import assign_extend_cache_locs
+from sglang.srt.utils.common import next_power_of_2
+
+# Test configurations
+BATCH_SIZES = [1, 32, 64]
+DRAFT_TOKEN_NUMS = [5, 10, 20]
+POOL_LEN = 8192
+
+
+@triton.jit
+def assign_extend_cache_locs_v1(
+    req_pool_indices,
+    req_to_token,
+    start_offset,
+    end_offset,
+    out_cache_loc,
+    pool_len: tl.constexpr,
+    bs_upper: tl.constexpr,
+):
+    """Old version of assign_extend_cache_locs that depends on bs_upper as constexpr."""
+    BLOCK_SIZE: tl.constexpr = 32
+    pid = tl.program_id(axis=0)
+    kv_start = tl.load(start_offset + pid)
+    kv_end = tl.load(end_offset + pid)
+    token_pool = req_to_token + tl.load(req_pool_indices + pid) * pool_len
+
+    length_offset = tl.arange(0, bs_upper)
+    start = tl.load(start_offset + length_offset, mask=length_offset < pid, other=0)
+    end = tl.load(end_offset + length_offset, mask=length_offset < pid, other=0)
+    out_offset = tl.sum(end - start, axis=0)
+
+    out_cache_ptr = out_cache_loc + out_offset
+
+    load_offset = tl.arange(0, BLOCK_SIZE) + kv_start
+    save_offset = tl.arange(0, BLOCK_SIZE)
+
+    num_loop = tl.cdiv(kv_end - kv_start, BLOCK_SIZE)
+    for _ in range(num_loop):
+        mask = load_offset < kv_end
+        data = tl.load(token_pool + load_offset, mask=mask)
+        tl.store(out_cache_ptr + save_offset, data, mask=mask)
+        load_offset += BLOCK_SIZE
+        save_offset += BLOCK_SIZE
+
+
+def setup_assign_extend_test(bs, draft_token_num, seq_len_base=100, device="cuda"):
+    """Setup test tensors for assign_extend_cache_locs test.
+
+    Simulates the extend phase where each request extends by draft_token_num tokens.
+    - req_pool_indices: indices into req_to_token pool
+    - req_to_token: 2D tensor mapping (req_idx, token_idx) -> cache_loc
+    - start_offset: starting kv length for each request
+    - end_offset: ending kv length for each request (start + draft_token_num)
+    """
+    req_pool_indices = torch.arange(bs, dtype=torch.int64, device=device)
+
+    # Create req_to_token with unique cache locations
+    # Each request has POOL_LEN slots, filled with sequential values
+    req_to_token = torch.zeros((bs, POOL_LEN), dtype=torch.int64, device=device)
+    for i in range(bs):
+        # Fill with unique values: req_i gets values [i*POOL_LEN, (i+1)*POOL_LEN)
+        req_to_token[i] = torch.arange(
+            i * POOL_LEN, (i + 1) * POOL_LEN, dtype=torch.int64, device=device
+        )
+
+    # start_offset and end_offset define the range to copy
+    start_offset = torch.full((bs,), seq_len_base, dtype=torch.int64, device=device)
+    end_offset = start_offset + draft_token_num
+
+    total_tokens = bs * draft_token_num
+    out_cache_loc = torch.empty((total_tokens,), dtype=torch.int64, device=device)
+
+    return req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc
+
+
+class TestAssignExtendCacheLocs(unittest.TestCase):
+    """Test assign_extend_cache_locs kernel functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Skip tests if CUDA is not available."""
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    # ==================== Compilation Time Tests ====================
+
+    def _test_compile_time_v1(self, bs, draft_token_num):
+        """Test compilation time for assign_extend_cache_locs_v1."""
+        req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+            setup_assign_extend_test(bs, draft_token_num, device="cuda")
+        )
+        bs_pow2 = next_power_of_2(bs)
+
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            assign_extend_cache_locs_v1[(bs,)](
+                req_pool_indices,
+                req_to_token,
+                start_offset,
+                end_offset,
+                out_cache_loc,
+                POOL_LEN,
+                bs_pow2,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(
+            f"Old - bs={bs}, draft_token_num={draft_token_num}: "
+            f"max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
+    def _test_compile_time_v2(self, bs, draft_token_num):
+        """Test compilation time for assign_extend_cache_locs (new version)."""
+        step_size_bs = 512
+        max_num_loops_bs = 8  # Support up to 4096 batch size
+        req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+            setup_assign_extend_test(bs, draft_token_num, device="cuda")
+        )
+
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            assign_extend_cache_locs[(bs,)](
+                req_pool_indices,
+                req_to_token,
+                start_offset,
+                end_offset,
+                out_cache_loc,
+                POOL_LEN,
+                next_power_of_2(step_size_bs),
+                max_num_loops_bs,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(
+            f"New - bs={bs}, draft_token_num={draft_token_num}: "
+            f"max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
+    def test_assign_extend_all_compile_v1(self):
+        """Test compilation time for old kernel with various batch sizes."""
+        print()
+        for bs in BATCH_SIZES:
+            for draft_token_num in DRAFT_TOKEN_NUMS:
+                with self.subTest(bs=bs, draft_token_num=draft_token_num):
+                    self._test_compile_time_v1(bs, draft_token_num)
+                    torch.cuda.empty_cache()
+
+    def test_assign_extend_all_compile_v2(self):
+        """Test compilation time for new kernel with various batch sizes."""
+        print()
+        for bs in BATCH_SIZES:
+            for draft_token_num in DRAFT_TOKEN_NUMS:
+                with self.subTest(bs=bs, draft_token_num=draft_token_num):
+                    self._test_compile_time_v2(bs, draft_token_num)
+                    torch.cuda.empty_cache()
+
+    # ==================== Runtime Performance Tests ====================
+
+    def _test_performance_v1(self, bs, draft_token_num):
+        """Test runtime performance for assign_extend_cache_locs_v1."""
+        # Warmup
+        for _ in range(10):
+            req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+                setup_assign_extend_test(bs, draft_token_num, device="cuda")
+            )
+            bs_pow2 = next_power_of_2(bs)
+            assign_extend_cache_locs_v1[(bs,)](
+                req_pool_indices,
+                req_to_token,
+                start_offset,
+                end_offset,
+                out_cache_loc,
+                POOL_LEN,
+                bs_pow2,
+            )
+            torch.cuda.synchronize()
+
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        torch.cuda.synchronize()
+        start_event.record()
+
+        for _ in range(100):
+            req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+                setup_assign_extend_test(bs, draft_token_num, device="cuda")
+            )
+            bs_pow2 = next_power_of_2(bs)
+            assign_extend_cache_locs_v1[(bs,)](
+                req_pool_indices,
+                req_to_token,
+                start_offset,
+                end_offset,
+                out_cache_loc,
+                POOL_LEN,
+                bs_pow2,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        print(
+            f"Old - bs={bs}, draft_token_num={draft_token_num}: avg={avg_runtime:.3f}ms"
+        )
+        return avg_runtime
+
+    def _test_performance_v2(self, bs, draft_token_num):
+        """Test runtime performance for assign_extend_cache_locs (new version)."""
+        step_size_bs = 512
+        max_num_loops_bs = 8
+
+        # Warmup
+        for _ in range(10):
+            req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+                setup_assign_extend_test(bs, draft_token_num, device="cuda")
+            )
+            assign_extend_cache_locs[(bs,)](
+                req_pool_indices,
+                req_to_token,
+                start_offset,
+                end_offset,
+                out_cache_loc,
+                POOL_LEN,
+                next_power_of_2(step_size_bs),
+                max_num_loops_bs,
+            )
+            torch.cuda.synchronize()
+
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        torch.cuda.synchronize()
+        start_event.record()
+
+        for _ in range(100):
+            req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+                setup_assign_extend_test(bs, draft_token_num, device="cuda")
+            )
+            assign_extend_cache_locs[(bs,)](
+                req_pool_indices,
+                req_to_token,
+                start_offset,
+                end_offset,
+                out_cache_loc,
+                POOL_LEN,
+                next_power_of_2(step_size_bs),
+                max_num_loops_bs,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        print(
+            f"New - bs={bs}, draft_token_num={draft_token_num}: avg={avg_runtime:.3f}ms"
+        )
+        return avg_runtime
+
+    def test_assign_extend_all_performance_v1(self):
+        """Test runtime performance for old kernel with various configurations."""
+        print()
+        for bs in BATCH_SIZES:
+            for draft_token_num in DRAFT_TOKEN_NUMS:
+                with self.subTest(bs=bs, draft_token_num=draft_token_num):
+                    self._test_performance_v1(bs, draft_token_num)
+                    torch.cuda.empty_cache()
+
+    def test_assign_extend_all_performance_v2(self):
+        """Test runtime performance for new kernel with various configurations."""
+        print()
+        for bs in BATCH_SIZES:
+            for draft_token_num in DRAFT_TOKEN_NUMS:
+                with self.subTest(bs=bs, draft_token_num=draft_token_num):
+                    self._test_performance_v2(bs, draft_token_num)
+                    torch.cuda.empty_cache()
+
+    # ==================== Correctness Tests ====================
+
+    def _test_correctness(self, bs, draft_token_num, seq_len_base):
+        """Test consistency between old and new versions of assign_extend_cache_locs."""
+        step_size_bs = 512
+
+        # Setup for old version
+        req_pool_indices, req_to_token, start_offset, end_offset, out_v1 = (
+            setup_assign_extend_test(bs, draft_token_num, seq_len_base, device="cuda")
+        )
+
+        # Setup for new version (need separate output)
+        out_v2 = torch.empty((bs * draft_token_num,), dtype=torch.int64, device="cuda")
+
+        # Run old version
+        bs_pow2 = next_power_of_2(bs)
+        assign_extend_cache_locs_v1[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_v1,
+            POOL_LEN,
+            bs_pow2,
+        )
+        torch.cuda.synchronize()
+
+        # Run new version
+        max_num_loops_bs = 8
+        assign_extend_cache_locs[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_v2,
+            POOL_LEN,
+            next_power_of_2(step_size_bs),
+            max_num_loops_bs,
+        )
+        torch.cuda.synchronize()
+
+        # Check bounds
+        max_valid_index = bs * POOL_LEN
+        self.assertTrue(
+            torch.all(out_v1 >= 0) and torch.all(out_v1 < max_valid_index),
+            "Old version output out of bounds",
+        )
+        self.assertTrue(
+            torch.all(out_v2 >= 0) and torch.all(out_v2 < max_valid_index),
+            "New version output out of bounds",
+        )
+
+        # Check consistency
+        if not torch.equal(out_v1, out_v2):
+            diff_mask = out_v1 != out_v2
+            diff_indices = torch.where(diff_mask)[0]
+            first_diff_idx = diff_indices[0].item()
+            # Find which request this belongs to
+            req_idx = first_diff_idx // draft_token_num
+            self.fail(
+                f"Output mismatch for bs={bs}, draft_token_num={draft_token_num}, "
+                f"seq_len_base={seq_len_base}\n"
+                f"First diff at index {first_diff_idx} (request {req_idx})\n"
+                f"Old[{first_diff_idx}]={out_v1[first_diff_idx].item()}, "
+                f"New[{first_diff_idx}]={out_v2[first_diff_idx].item()}\n"
+                f"Total diffs: {diff_mask.sum().item()}"
+            )
+
+    def _test_correctness_values(self, bs, draft_token_num, seq_len_base):
+        """Test that output values are correct (not just consistent between versions)."""
+        step_size_bs = 512
+        max_num_loops_bs = 8
+
+        req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc = (
+            setup_assign_extend_test(bs, draft_token_num, seq_len_base, device="cuda")
+        )
+
+        assign_extend_cache_locs[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_cache_loc,
+            POOL_LEN,
+            next_power_of_2(step_size_bs),
+            max_num_loops_bs,
+        )
+        torch.cuda.synchronize()
+
+        # Verify output values
+        # For each request i, the output should contain:
+        # req_to_token[i, start_offset[i]:end_offset[i]]
+        # which equals [i*POOL_LEN + seq_len_base, i*POOL_LEN + seq_len_base + draft_token_num)
+        expected = []
+        for i in range(bs):
+            for j in range(draft_token_num):
+                expected.append(i * POOL_LEN + seq_len_base + j)
+        expected = torch.tensor(expected, dtype=torch.int64, device="cuda")
+
+        if not torch.equal(out_cache_loc, expected):
+            diff_mask = out_cache_loc != expected
+            diff_indices = torch.where(diff_mask)[0]
+            first_diff_idx = diff_indices[0].item()
+            req_idx = first_diff_idx // draft_token_num
+            token_idx = first_diff_idx % draft_token_num
+            self.fail(
+                f"Output values mismatch for bs={bs}, draft_token_num={draft_token_num}\n"
+                f"First diff at index {first_diff_idx} (request {req_idx}, token {token_idx})\n"
+                f"Expected: {expected[first_diff_idx].item()}, Got: {out_cache_loc[first_diff_idx].item()}\n"
+                f"Total diffs: {diff_mask.sum().item()}"
+            )
+
+    def test_assign_extend_correctness(self):
+        """Test correctness by comparing old and new kernel outputs.
+
+        Note: Old kernel uses bs_upper as constexpr which may have issues
+        with very large batch sizes. For bs > 512, use test_assign_extend_correctness_values
+        to verify new kernel correctness independently.
+        """
+        print()
+        for bs in BATCH_SIZES:
+            for draft_token_num in DRAFT_TOKEN_NUMS:
+                for seq_len_base in [100, 200, 300, 400, 500]:
+                    with self.subTest(
+                        bs=bs,
+                        draft_token_num=draft_token_num,
+                        seq_len_base=seq_len_base,
+                    ):
+                        self._test_correctness(bs, draft_token_num, seq_len_base)
+                        torch.cuda.empty_cache()
+
+    def test_assign_extend_correctness_values(self):
+        """Test that output values are correct (independent of old kernel)."""
+        print()
+        for bs in BATCH_SIZES:
+            for draft_token_num in DRAFT_TOKEN_NUMS:
+                for seq_len_base in [100, 200, 300, 400, 500]:
+                    with self.subTest(
+                        bs=bs,
+                        draft_token_num=draft_token_num,
+                        seq_len_base=seq_len_base,
+                    ):
+                        self._test_correctness_values(bs, draft_token_num, seq_len_base)
+                        torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_triton_fill_accepted_out_cache_loc.py
+++ b/test/srt/test_triton_fill_accepted_out_cache_loc.py
@@ -1,0 +1,333 @@
+import time
+import unittest
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.speculative.eagle_info_v2 import fill_accepted_out_cache_loc
+from sglang.srt.utils.common import next_power_of_2
+
+# Test configurations
+BATCH_SIZES = [1, 32, 64, 128, 256, 512]
+ACCEPT_RATES = [0.3, 0.5, 0.8, 1.0]  # Fraction of valid entries
+STEP_SIZE = 512
+MAX_NUM_LOOPS = 8
+
+
+@triton.jit
+def fill_accepted_out_cache_loc_v1(
+    accept_index,
+    out_cache_loc,
+    accepted_out_cache_loc,
+    size_upper: tl.constexpr,
+):
+    """V1 version of fill_accepted_out_cache_loc that depends on size_upper as constexpr."""
+    pid = tl.program_id(axis=0)
+    offset = tl.arange(0, size_upper)
+
+    masks = (tl.load(accept_index + offset, offset < pid, other=-1) != -1).to(tl.int64)
+    dst = tl.sum(masks)
+    src = tl.load(accept_index + pid)
+    if src > -1:
+        value = tl.load(out_cache_loc + src)
+        tl.store(accepted_out_cache_loc + dst, value)
+
+
+def setup_fill_accepted_test(size, accept_rate=0.5, device="cuda"):
+    """Setup test tensors for fill_accepted_out_cache_loc test.
+
+    Args:
+        size: Total number of entries in accept_index
+        accept_rate: Fraction of entries that are valid (not -1)
+        device: Device to create tensors on
+
+    Returns:
+        accept_index: Tensor with some valid indices (>=0) and some invalid (-1)
+        out_cache_loc: Source cache locations
+        accepted_out_cache_loc: Output tensor for accepted locations
+        num_valid: Number of valid entries
+    """
+    # Create accept_index with some valid and some invalid entries
+    accept_index = torch.full((size,), -1, dtype=torch.int32, device=device)
+    num_valid = int(size * accept_rate)
+
+    # Set first num_valid entries to valid indices
+    if num_valid > 0:
+        valid_indices = torch.arange(num_valid, dtype=torch.int32, device=device)
+        accept_index[:num_valid] = valid_indices
+
+    # Shuffle to distribute valid entries randomly
+    perm = torch.randperm(size, device=device)
+    accept_index = accept_index[perm]
+
+    # Create out_cache_loc with unique values
+    out_cache_loc = torch.arange(size * 2, dtype=torch.int64, device=device)
+
+    # Output tensor
+    accepted_out_cache_loc = torch.empty((num_valid,), dtype=torch.int64, device=device)
+
+    return accept_index, out_cache_loc, accepted_out_cache_loc, num_valid
+
+
+class TestFillAcceptedOutCacheLoc(unittest.TestCase):
+    """Test fill_accepted_out_cache_loc kernel functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Skip tests if CUDA is not available."""
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    # ==================== Compilation Time Tests ====================
+
+    def _test_compile_time_v1(self, size):
+        """Test compilation time for fill_accepted_out_cache_loc_v1."""
+        accept_index, out_cache_loc, accepted_out_cache_loc, _ = (
+            setup_fill_accepted_test(size, accept_rate=0.5, device="cuda")
+        )
+        size_pow2 = next_power_of_2(size)
+
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            fill_accepted_out_cache_loc_v1[(size,)](
+                accept_index,
+                out_cache_loc,
+                accepted_out_cache_loc,
+                size_pow2,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(
+            f"V1 - size={size}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
+    def _test_compile_time_v2(self, size):
+        """Test compilation time for fill_accepted_out_cache_loc (v2 version)."""
+        accept_index, out_cache_loc, accepted_out_cache_loc, _ = (
+            setup_fill_accepted_test(size, accept_rate=0.5, device="cuda")
+        )
+
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            fill_accepted_out_cache_loc[(size,)](
+                accept_index,
+                out_cache_loc,
+                accepted_out_cache_loc,
+                STEP_SIZE,
+                MAX_NUM_LOOPS,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(
+            f"V2 - size={size}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
+    def test_fill_accepted_all_compile_v1(self):
+        """Test compilation time for v1 kernel with various sizes."""
+        print()
+        for size in BATCH_SIZES:
+            with self.subTest(size=size):
+                self._test_compile_time_v1(size)
+                torch.cuda.empty_cache()
+
+    def test_fill_accepted_all_compile_v2(self):
+        """Test compilation time for v2 kernel with various sizes."""
+        print()
+        for size in BATCH_SIZES:
+            with self.subTest(size=size):
+                self._test_compile_time_v2(size)
+
+    # ==================== Runtime Performance Tests ====================
+
+    def _test_performance_v1(self, size):
+        """Test runtime performance for fill_accepted_out_cache_loc_v1."""
+        # Warmup
+        for _ in range(10):
+            accept_index, out_cache_loc, accepted_out_cache_loc, _ = (
+                setup_fill_accepted_test(size, accept_rate=0.5, device="cuda")
+            )
+            size_pow2 = next_power_of_2(size)
+            fill_accepted_out_cache_loc_v1[(size,)](
+                accept_index,
+                out_cache_loc,
+                accepted_out_cache_loc,
+                size_pow2,
+            )
+            torch.cuda.synchronize()
+
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        torch.cuda.synchronize()
+        start_event.record()
+
+        for _ in range(100):
+            accept_index, out_cache_loc, accepted_out_cache_loc, _ = (
+                setup_fill_accepted_test(size, accept_rate=0.5, device="cuda")
+            )
+            size_pow2 = next_power_of_2(size)
+            fill_accepted_out_cache_loc_v1[(size,)](
+                accept_index,
+                out_cache_loc,
+                accepted_out_cache_loc,
+                size_pow2,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        print(f"V1 - size={size}: avg={avg_runtime:.3f}ms")
+        return avg_runtime
+
+    def _test_performance_v2(self, size):
+        """Test runtime performance for fill_accepted_out_cache_loc (v2 version)."""
+        # Warmup
+        for _ in range(10):
+            accept_index, out_cache_loc, accepted_out_cache_loc, _ = (
+                setup_fill_accepted_test(size, accept_rate=0.5, device="cuda")
+            )
+            fill_accepted_out_cache_loc[(size,)](
+                accept_index,
+                out_cache_loc,
+                accepted_out_cache_loc,
+                STEP_SIZE,
+                MAX_NUM_LOOPS,
+            )
+            torch.cuda.synchronize()
+
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        torch.cuda.synchronize()
+        start_event.record()
+
+        for _ in range(100):
+            accept_index, out_cache_loc, accepted_out_cache_loc, _ = (
+                setup_fill_accepted_test(size, accept_rate=0.5, device="cuda")
+            )
+            fill_accepted_out_cache_loc[(size,)](
+                accept_index,
+                out_cache_loc,
+                accepted_out_cache_loc,
+                STEP_SIZE,
+                MAX_NUM_LOOPS,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        print(f"V2 - size={size}: avg={avg_runtime:.3f}ms")
+        return avg_runtime
+
+    def test_fill_accepted_all_performance_v1(self):
+        """Test runtime performance for v1 kernel with various sizes."""
+        print()
+        for size in [64, 128, 256]:
+            with self.subTest(size=size):
+                self._test_performance_v1(size)
+
+    def test_fill_accepted_all_performance_v2(self):
+        """Test runtime performance for v2 kernel with various sizes."""
+        print()
+        for size in [64, 128, 256, 512]:
+            with self.subTest(size=size):
+                self._test_performance_v2(size)
+
+    # ==================== Correctness Tests ====================
+
+    def _test_correctness(self, size, accept_rate):
+        """Test consistency between v1 and v2 versions of fill_accepted_out_cache_loc."""
+        # Use fixed seed for reproducibility
+        torch.manual_seed(42)
+
+        # Setup for v1
+        accept_index, out_cache_loc, out_v1, num_valid = setup_fill_accepted_test(
+            size, accept_rate, device="cuda"
+        )
+
+        # Setup for v2 (need separate output)
+        out_v2 = torch.empty((num_valid,), dtype=torch.int64, device="cuda")
+
+        if num_valid == 0:
+            # Skip if no valid entries
+            return
+
+        # Run v1 version
+        size_pow2 = next_power_of_2(size)
+        fill_accepted_out_cache_loc_v1[(size,)](
+            accept_index,
+            out_cache_loc,
+            out_v1,
+            size_pow2,
+        )
+        torch.cuda.synchronize()
+
+        # Run v2 version
+        fill_accepted_out_cache_loc[(size,)](
+            accept_index,
+            out_cache_loc,
+            out_v2,
+            STEP_SIZE,
+            MAX_NUM_LOOPS,
+        )
+        torch.cuda.synchronize()
+
+        # Check consistency
+        if not torch.equal(out_v1, out_v2):
+            diff_mask = out_v1 != out_v2
+            diff_indices = torch.where(diff_mask)[0]
+            first_diff_idx = diff_indices[0].item()
+            self.fail(
+                f"Output mismatch for size={size}, accept_rate={accept_rate}\n"
+                f"First diff at index {first_diff_idx}\n"
+                f"V1[{first_diff_idx}]={out_v1[first_diff_idx].item()}, "
+                f"V2[{first_diff_idx}]={out_v2[first_diff_idx].item()}\n"
+                f"Total diffs: {diff_mask.sum().item()}"
+            )
+
+    def test_fill_accepted_correctness(self):
+        """Test correctness by comparing v1 and v2 kernel outputs."""
+        print()
+        for size in BATCH_SIZES:
+            for accept_rate in ACCEPT_RATES:
+                with self.subTest(size=size, accept_rate=accept_rate):
+                    self._test_correctness(size, accept_rate)
+                    torch.cuda.empty_cache()
+
+    def test_fill_accepted_large_batch_v2(self):
+        """Test correctness with large sizes (> step_size)."""
+        print()
+        test_cases = [
+            # (size, accept_rate) - sizes > STEP_SIZE to test loop
+            (513, 0.5),
+            (768, 0.5),
+            (1024, 0.5),
+        ]
+
+        for size, accept_rate in test_cases:
+            with self.subTest(size=size, accept_rate=accept_rate):
+                self._test_correctness(size, accept_rate)
+                torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_triton_page_alloc_decode.py
+++ b/test/srt/test_triton_page_alloc_decode.py
@@ -1,0 +1,351 @@
+import time
+import unittest
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.mem_cache.allocator import alloc_decode_kernel
+from sglang.srt.utils.common import next_power_of_2
+
+# Test configurations
+BATCH_SIZES = [1, 32, 64]
+SEQ_LENS = [666]
+PAGE_SIZE = 64
+NUM_PAGES = 100000
+
+
+@triton.jit
+def alloc_decode_kernel_v1(
+    seq_lens_ptr,
+    last_loc_ptr,
+    free_page_ptr,
+    out_indices,
+    bs_upper: tl.constexpr,
+    page_size: tl.constexpr,
+):
+    """Old version of alloc_decode_kernel that depends on bs_upper as constexpr."""
+    pid = tl.program_id(0)
+
+    load_offset = tl.arange(0, bs_upper)
+    seq_lens = tl.load(seq_lens_ptr + load_offset, mask=load_offset <= pid)
+    pre_lens = tl.where(load_offset <= pid, seq_lens - 1, seq_lens)
+
+    seq_len = tl.load(seq_lens_ptr + pid)
+    pre_len = seq_len - 1
+
+    num_pages_after = (seq_lens + page_size - 1) // page_size
+    num_pages_before = (pre_lens + page_size - 1) // page_size
+    num_v2_pages = num_pages_after - num_pages_before
+
+    num_page_start_loc_self = (seq_len + page_size - 1) // page_size - (
+        pre_len + page_size - 1
+    ) // page_size
+    sum_num_v2_pages = tl.sum(num_v2_pages)
+    new_page_start_loc = sum_num_v2_pages - num_page_start_loc_self
+
+    if num_page_start_loc_self == 0:
+        last_loc = tl.load(last_loc_ptr + pid)
+        tl.store(out_indices + pid, last_loc + 1)
+    else:
+        page = tl.load(free_page_ptr + new_page_start_loc)
+        tl.store(out_indices + pid, page * page_size)
+
+
+def setup_decode_test(bs, seq_len, device="cuda"):
+    """Setup test tensors for decode allocation test.
+
+    In decode phase, each request extends by exactly 1 token.
+    seq_len is the length AFTER adding the new token (i.e., after decode).
+
+    The constraint from allocator.py:
+        (last_loc + 2) % page_size == seq_len % page_size
+
+    This means: last_loc % page_size == (seq_len - 2) % page_size
+    We place last_loc in page 1 (offset PAGE_SIZE) for simplicity.
+    """
+    seq_lens = torch.full((bs,), seq_len, dtype=torch.int64, device=device)
+
+    # last_loc should satisfy: (last_loc + 2) % page_size == seq_len % page_size
+    # => last_loc % page_size == (seq_len - 2) % page_size
+    # We place last_loc in page 1 for simplicity
+    last_loc_offset = (seq_len - 2) % PAGE_SIZE
+    last_loc = torch.full(
+        (bs,), PAGE_SIZE + last_loc_offset, dtype=torch.int64, device=device
+    )
+
+    free_pages = torch.arange(1, NUM_PAGES + 1, dtype=torch.int64, device=device)
+    out_indices = torch.empty((bs,), dtype=torch.int64, device=device)
+
+    return seq_lens, last_loc, free_pages, out_indices
+
+
+class TestAllocDecode(unittest.TestCase):
+    """Test alloc_decode_kernel functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Skip tests if CUDA is not available."""
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    # ==================== Compilation Time Tests ====================
+
+    def _test_alloc_decode_compile_time_v1(self, bs, seq_len):
+        """Test compilation time for alloc_decode_kernel_v1."""
+        seq_lens, last_loc, free_pages, out_indices = setup_decode_test(
+            bs, seq_len, "cuda"
+        )
+        bs_pow2 = next_power_of_2(bs)
+
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            alloc_decode_kernel_v1[(bs,)](
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_pow2,
+                PAGE_SIZE,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(
+            f"Old - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
+    def _test_alloc_decode_compile_time_v2(self, bs, seq_len):
+        """Test compilation time for alloc_decode_kernel (new version)."""
+        step_size_bs = 512
+        seq_lens, last_loc, free_pages, out_indices = setup_decode_test(
+            bs, seq_len, "cuda"
+        )
+
+        # Measure compilation time
+        torch.cuda.synchronize()
+        compile_times = []
+        for _ in range(3):
+            start = time.perf_counter()
+            alloc_decode_kernel[(bs,)](
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                next_power_of_2(step_size_bs),
+                PAGE_SIZE,
+            )
+            torch.cuda.synchronize()
+            compile_times.append(time.perf_counter() - start)
+
+        max_compile_time = max(compile_times) * 1000
+        avg_compile_time = sum(compile_times) / len(compile_times) * 1000
+        print(
+            f"New - bs={bs}, seq_len={seq_len}: max={max_compile_time:.2f}ms, avg={avg_compile_time:.2f}ms"
+        )
+
+    def test_alloc_decode_all_compile_v1(self):
+        """Test compilation time for old kernel with various batch sizes."""
+        print()
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_decode_compile_time_v1(bs, seq_len)
+                    torch.cuda.empty_cache()
+
+    def test_alloc_decode_all_compile_v2(self):
+        """Test compilation time for new kernel with various batch sizes."""
+        print()
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_decode_compile_time_v2(bs, seq_len)
+                    torch.cuda.empty_cache()
+
+    # ==================== Runtime Performance Tests ====================
+
+    def _test_alloc_decode_performance_v1(self, bs, seq_len):
+        """Test runtime performance for alloc_decode_kernel_v1."""
+        # Warmup
+        for _ in range(10):
+            seq_lens, last_loc, free_pages, out_indices = setup_decode_test(
+                bs, seq_len, "cuda"
+            )
+            bs_pow2 = next_power_of_2(bs)
+            alloc_decode_kernel_v1[(bs,)](
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_pow2,
+                PAGE_SIZE,
+            )
+            torch.cuda.synchronize()
+
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        torch.cuda.synchronize()
+        start_event.record()
+
+        for _ in range(100):
+            seq_lens, last_loc, free_pages, out_indices = setup_decode_test(
+                bs, seq_len, "cuda"
+            )
+            bs_pow2 = next_power_of_2(bs)
+            alloc_decode_kernel_v1[(bs,)](
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_pow2,
+                PAGE_SIZE,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        print(f"Old - bs={bs}, seq_len={seq_len}: avg={avg_runtime:.3f}ms")
+        return avg_runtime
+
+    def _test_alloc_decode_performance_v2(self, bs, seq_len):
+        """Test runtime performance for alloc_decode_kernel (new version)."""
+        step_size_bs = 512
+
+        # Warmup
+        for _ in range(10):
+            seq_lens, last_loc, free_pages, out_indices = setup_decode_test(
+                bs, seq_len, "cuda"
+            )
+            alloc_decode_kernel[(bs,)](
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                next_power_of_2(step_size_bs),
+                PAGE_SIZE,
+            )
+            torch.cuda.synchronize()
+
+        # Performance measurement
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        torch.cuda.synchronize()
+        start_event.record()
+
+        for _ in range(100):
+            seq_lens, last_loc, free_pages, out_indices = setup_decode_test(
+                bs, seq_len, "cuda"
+            )
+            alloc_decode_kernel[(bs,)](
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                next_power_of_2(step_size_bs),
+                PAGE_SIZE,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        total_runtime = start_event.elapsed_time(end_event)
+        avg_runtime = total_runtime / 100
+        print(f"New - bs={bs}, seq_len={seq_len}: avg={avg_runtime:.3f}ms")
+        return avg_runtime
+
+    def test_alloc_decode_all_performance_v1(self):
+        """Test runtime performance for old kernel with various configurations."""
+        print()
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_decode_performance_v1(bs, seq_len)
+                    torch.cuda.empty_cache()
+
+    def test_alloc_decode_all_performance_v2(self):
+        """Test runtime performance for new kernel with various configurations."""
+        print()
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_decode_performance_v2(bs, seq_len)
+                    torch.cuda.empty_cache()
+
+    # ==================== Correctness Tests ====================
+
+    def _test_alloc_decode_correctness(self, bs, seq_len):
+        """Test consistency between alloc_decode_kernel_v1 and alloc_decode_kernel (new)."""
+        step_size_bs = 512
+
+        # Setup for old version
+        seq_lens, last_loc, free_pages_v1, out_v1 = setup_decode_test(
+            bs, seq_len, "cuda"
+        )
+
+        # Setup for new version (need separate free_pages and output)
+        free_pages_v2 = torch.arange(1, NUM_PAGES + 1, dtype=torch.int64, device="cuda")
+        out_v2 = torch.empty((bs,), dtype=torch.int64, device="cuda")
+
+        # Run old version
+        bs_pow2 = next_power_of_2(bs)
+        alloc_decode_kernel_v1[(bs,)](
+            seq_lens,
+            last_loc,
+            free_pages_v1,
+            out_v1,
+            bs_pow2,
+            PAGE_SIZE,
+        )
+        torch.cuda.synchronize()
+
+        # Run new version
+        alloc_decode_kernel[(bs,)](
+            seq_lens,
+            last_loc,
+            free_pages_v2,
+            out_v2,
+            next_power_of_2(step_size_bs),
+            PAGE_SIZE,
+        )
+        torch.cuda.synchronize()
+
+        # Check bounds
+        max_valid_index = NUM_PAGES * PAGE_SIZE
+        self.assertTrue(
+            torch.all(out_v1 >= 0) and torch.all(out_v1 < max_valid_index),
+            "Old version output out of bounds",
+        )
+        self.assertTrue(
+            torch.all(out_v2 >= 0) and torch.all(out_v2 < max_valid_index),
+            "New version output out of bounds",
+        )
+
+        # Check consistency
+        self.assertTrue(
+            torch.equal(out_v1, out_v2),
+            f"Output mismatch for bs={bs}, seq_len={seq_len}\n"
+            f"Old: {out_v1[:10]}...\nNew: {out_v2[:10]}...",
+        )
+
+    def test_alloc_decode_correctness(self):
+        """Test correctness with various test cases."""
+        print()
+        for bs in BATCH_SIZES:
+            for seq_len in SEQ_LENS:
+                with self.subTest(bs=bs, seq_len=seq_len):
+                    self._test_alloc_decode_correctness(bs, seq_len)
+                    torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_triton_spec_utils.py
+++ b/test/srt/test_triton_spec_utils.py
@@ -1,0 +1,1711 @@
+"""
+Test Triton kernels in spec_utils.py with JIT optimization.
+
+Tests compile time, runtime performance, and correctness for:
+1. create_extend_after_decode_spec_info
+2. assign_req_to_token_pool
+3. assign_draft_cache_locs
+4. generate_draft_decode_kv_indices
+5. get_target_cache_loc
+6. filter_finished_cache_loc_kernel
+"""
+
+import time
+import unittest
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.speculative.spec_utils import (
+    _SPEC_MAX_NUM_LOOPS,
+    _SPEC_STEP_SIZE,
+    assign_draft_cache_locs,
+    assign_req_to_token_pool,
+    create_extend_after_decode_spec_info,
+    filter_finished_cache_loc_kernel,
+    generate_draft_decode_kv_indices,
+    get_target_cache_loc,
+)
+from sglang.srt.utils.common import next_power_of_2
+
+# Additional constants for generate_draft_decode_kv_indices
+_NUM_TOKENS_STEP_SIZE = next_power_of_2(512)
+_NUM_TOKENS_MAX_LOOPS = 8
+
+# Test configurations
+BATCH_SIZES = [1, 8, 32, 64, 128, 256, 512]
+LARGE_BATCH_SIZES = [513, 768, 1024]  # For v2 kernel independent tests
+
+
+# ==================== V1 Kernels (Original, for comparison) ====================
+
+
+@triton.jit
+def create_extend_after_decode_spec_info_v1(
+    verified_id,
+    seq_lens,
+    accept_lens,
+    positions,
+    new_verified_id,
+    bs_upper: tl.constexpr,
+):
+    """V1: Original kernel with bs_upper constexpr."""
+    pid = tl.program_id(axis=0)
+    offsets = tl.arange(0, bs_upper)
+    seq_length = tl.load(seq_lens + pid)
+    accept_length = tl.load(accept_lens + pid)
+
+    accept_len_cumsum = tl.sum(
+        tl.load(accept_lens + offsets, mask=offsets < pid, other=0)
+    )
+    positions_ptr = positions + accept_len_cumsum
+    mask = offsets < accept_length
+    tl.store(positions_ptr + offsets, seq_length - accept_length + offsets, mask)
+
+    accept_len_cumsum += accept_length - 1
+    verified_id_data = tl.load(verified_id + accept_len_cumsum)
+    tl.store(new_verified_id + pid, verified_id_data)
+
+
+@triton.jit
+def assign_req_to_token_pool_v1(
+    req_pool_indices,
+    req_to_token,
+    start_offset,
+    end_offset,
+    out_cache_loc,
+    pool_len: tl.constexpr,
+    bs_upper: tl.constexpr,
+):
+    """V1: Original kernel with bs_upper constexpr."""
+    BLOCK_SIZE: tl.constexpr = 32
+    pid = tl.program_id(axis=0)
+    kv_start = tl.load(start_offset + pid)
+    kv_end = tl.load(end_offset + pid)
+    token_pool = req_to_token + tl.load(req_pool_indices + pid) * pool_len
+
+    length_offset = tl.arange(0, bs_upper)
+    start = tl.load(start_offset + length_offset, mask=length_offset < pid, other=0)
+    end = tl.load(end_offset + length_offset, mask=length_offset < pid, other=0)
+    out_offset = tl.sum(end - start, axis=0)
+
+    out_cache_ptr = out_cache_loc + out_offset
+
+    save_offset = tl.arange(0, BLOCK_SIZE) + kv_start
+    load_offset = tl.arange(0, BLOCK_SIZE)
+
+    num_loop = tl.cdiv(kv_end - kv_start, BLOCK_SIZE)
+    for _ in range(num_loop):
+        mask = save_offset < kv_end
+        data = tl.load(out_cache_ptr + load_offset, mask=mask)
+        tl.store(token_pool + save_offset, data, mask=mask)
+        save_offset += BLOCK_SIZE
+        load_offset += BLOCK_SIZE
+
+
+@triton.jit
+def get_target_cache_loc_v1(
+    tgt_cache_loc,
+    to_free_slots,
+    accept_length,
+    to_free_num_slots,
+    out_cache_loc,
+    num_verify_tokens: tl.constexpr,
+    num_verify_tokens_upper: tl.constexpr,
+    bs_upper: tl.constexpr,
+):
+    """V1: Original kernel with bs_upper constexpr."""
+    bid = tl.program_id(axis=0)
+    offset = tl.arange(0, num_verify_tokens_upper)
+    bs_offset = tl.arange(0, bs_upper)
+
+    accept_len_all = tl.load(accept_length + bs_offset, mask=bs_offset < bid)
+    tgt_cache_loc_start = tl.sum(accept_len_all) + bid
+    copy_len = tl.load(accept_length + bid) + 1
+    out_cache_loc_row = tl.load(
+        out_cache_loc + bid * num_verify_tokens + offset, mask=offset < copy_len
+    )
+    tl.store(
+        tgt_cache_loc + tgt_cache_loc_start + offset,
+        out_cache_loc_row,
+        mask=offset < copy_len,
+    )
+
+    to_free_num_slots_all = tl.load(to_free_num_slots + bs_offset, mask=bs_offset < bid)
+    to_free_num_slots_cur = tl.load(to_free_num_slots + bid)
+    out_cache_loc_start = num_verify_tokens - to_free_num_slots_cur
+    to_free_slots_start = tl.sum(to_free_num_slots_all)
+
+    copy_len = to_free_num_slots_cur
+    out_cache_loc_row = tl.load(
+        out_cache_loc + bid * num_verify_tokens + out_cache_loc_start + offset,
+        mask=offset < copy_len,
+    )
+    tl.store(
+        to_free_slots + to_free_slots_start + offset,
+        out_cache_loc_row,
+        mask=offset < copy_len,
+    )
+
+
+@triton.jit
+def filter_finished_cache_loc_kernel_v1(
+    out_cache_loc,
+    tgt_cache_loc,
+    accept_length,
+    accept_length_filter,
+    bs_upper: tl.constexpr,
+    num_verify_tokens_upper: tl.constexpr,
+):
+    """V1: Original kernel with bs_upper constexpr."""
+    bid = tl.program_id(0)
+    bs_offset = tl.arange(0, bs_upper)
+
+    accept_length_all = tl.load(accept_length + bs_offset, mask=bs_offset < bid)
+    old_start = tl.sum(accept_length_all) + bid
+
+    accept_length_filter_all = tl.load(
+        accept_length_filter + bs_offset, mask=bs_offset < bid
+    )
+    new_start = tl.sum(accept_length_filter_all)
+
+    copy_len = tl.load(accept_length_filter + bid)
+    copy_offset = tl.arange(0, num_verify_tokens_upper)
+    value = tl.load(
+        tgt_cache_loc + old_start + copy_offset, mask=copy_offset < copy_len
+    )
+    tl.store(
+        out_cache_loc + new_start + copy_offset, value, mask=copy_offset < copy_len
+    )
+
+
+@triton.jit
+def assign_draft_cache_locs_v1(
+    req_pool_indices,
+    req_to_token,
+    seq_lens,
+    extend_lens,
+    num_new_pages_per_topk,
+    out_cache_loc,
+    source_cache_loc,
+    target_cache_loc,
+    last_page_lens_cumsum,
+    duplicate_cache_len: tl.constexpr,
+    pool_len: tl.constexpr,
+    topk: tl.constexpr,
+    speculative_num_steps: tl.constexpr,
+    page_size: tl.constexpr,
+    bs_upper: tl.constexpr,
+    iter_upper: tl.constexpr,
+):
+    """V1: Original kernel with bs_upper constexpr."""
+    BLOCK_SIZE: tl.constexpr = 128
+    pid = tl.program_id(axis=0)
+
+    if page_size == 1 or topk == 1:
+        copy_len = topk * speculative_num_steps
+        out_cache_ptr = out_cache_loc + pid * topk * speculative_num_steps
+    else:
+        # Use bs_upper for cumsum
+        length_offset = tl.arange(0, bs_upper)
+        cum_copy_len = tl.sum(
+            tl.load(extend_lens + length_offset, mask=length_offset < pid, other=0)
+        )
+        copy_len = tl.load(extend_lens + pid)
+        out_cache_ptr = out_cache_loc + cum_copy_len
+
+    # Part 1: Copy from out_cache_loc to req_to_token
+    kv_start = tl.load(seq_lens + pid)
+    token_pool = req_to_token + tl.load(req_pool_indices + pid) * pool_len
+    num_loop = tl.cdiv(copy_len, BLOCK_SIZE)
+    for i in range(num_loop):
+        copy_offset = tl.arange(0, BLOCK_SIZE) + i * BLOCK_SIZE
+        mask = copy_offset < copy_len
+        data = tl.load(out_cache_ptr + copy_offset, mask=mask)
+        tl.store(token_pool + kv_start + copy_offset, data, mask=mask)
+    if page_size != 1 and topk != 1 and duplicate_cache_len > 0:
+        # Part 2: Copy indices into source_cache_loc and target_cache_loc
+        prefix_len = tl.load(seq_lens + pid)
+        last_page_len = prefix_len % page_size
+        offsets = tl.arange(0, page_size)
+        mask = offsets < last_page_len
+        num_new_pages_per_topk_ = tl.load(num_new_pages_per_topk + pid)
+        prefix_base = token_pool + prefix_len - last_page_len
+        src_indices = tl.load(prefix_base + offsets, mask=mask)
+        last_page_lens_cumsum_ = tl.load(last_page_lens_cumsum + pid)
+        # Skip the first one since no copy is needed
+        for topk_id in range(1, topk):
+            tl.store(
+                source_cache_loc
+                + (topk - 1) * (last_page_lens_cumsum_ - last_page_len)
+                + (topk_id - 1) * last_page_len
+                + offsets,
+                src_indices,
+                mask=mask,
+            )
+            tgt_indices = tl.load(
+                prefix_base + topk_id * num_new_pages_per_topk_ * page_size + offsets,
+                mask=mask,
+            )
+            tl.store(
+                target_cache_loc
+                + (topk - 1) * (last_page_lens_cumsum_ - last_page_len)
+                + (topk_id - 1) * last_page_len
+                + offsets,
+                tgt_indices,
+                mask=mask,
+            )
+        # Part 3: Copy and remove the used indices for duplication
+        iter_offset = tl.arange(0, iter_upper)
+        for topk_id in range(topk):
+            mask_upper = iter_offset < (speculative_num_steps + last_page_len)
+            mask_lower = iter_offset >= last_page_len
+            combined_mask = mask_upper & mask_lower
+            indices = tl.load(
+                prefix_base
+                + topk_id * num_new_pages_per_topk_ * page_size
+                + iter_offset,
+                mask=combined_mask,
+                other=0,
+            )
+            ptr_offset = pid * speculative_num_steps * topk
+            tl.store(
+                out_cache_loc
+                + ptr_offset
+                + topk_id * speculative_num_steps
+                - last_page_len
+                + iter_offset,
+                indices,
+                mask=combined_mask,
+            )
+
+
+@triton.jit
+def generate_draft_decode_kv_indices_v1(
+    req_pool_indices,
+    req_to_token,
+    paged_kernel_lens,
+    kv_indices,
+    kv_indptr,
+    positions,
+    pool_len: tl.constexpr,
+    kv_indices_stride: tl.constexpr,
+    kv_indptr_stride: tl.constexpr,
+    bs_upper: tl.constexpr,
+    num_tokens_upper: tl.constexpr,
+    iter_upper: tl.constexpr,
+    page_size: tl.constexpr,
+):
+    """V1: Original kernel with bs_upper constexpr."""
+    BLOCK_SIZE: tl.constexpr = 128
+    iters = tl.program_id(axis=0)
+    bid = tl.program_id(axis=1)
+    topk_id = tl.program_id(axis=2)
+
+    num_steps = tl.num_programs(axis=0)
+    num_seqs = tl.num_programs(axis=1)
+    topk = tl.num_programs(axis=2)
+
+    kv_indices += kv_indices_stride * iters
+    kv_indptr += kv_indptr_stride * iters
+    iters += 1
+
+    # Use bs_upper for cumsum
+    bs_offset = tl.arange(0, bs_upper)
+    cum_seq_len = tl.sum(
+        tl.load(paged_kernel_lens + bs_offset, mask=bs_offset < bid, other=0)
+    )
+    seq_len = tl.load(paged_kernel_lens + bid)
+
+    # Update kv_indices
+    kv_offset = cum_seq_len * topk + bid * iters * topk + topk_id * (seq_len + iters)
+    kv_ptr = kv_indices + kv_offset
+    token_pool_ptr = req_to_token + tl.load(req_pool_indices + bid) * pool_len
+
+    kv_offset = tl.arange(0, BLOCK_SIZE)
+    num_loop = tl.cdiv(seq_len, BLOCK_SIZE)
+    for _ in range(num_loop):
+        mask = kv_offset < seq_len
+        data = tl.load(token_pool_ptr + kv_offset, mask=mask)
+        tl.store(kv_ptr + kv_offset, data, mask=mask)
+        kv_offset += BLOCK_SIZE
+
+    extend_offset = tl.arange(0, iter_upper)
+    if page_size == 1 or topk == 1:
+        extend_data = tl.load(
+            token_pool_ptr + seq_len + topk_id * num_steps + tl.arange(0, iter_upper),
+            mask=extend_offset < iters,
+        )
+    else:
+        prefix_len = seq_len
+        last_page_len = prefix_len % page_size
+        num_new_pages_per_topk = (
+            last_page_len + num_steps + page_size - 1
+        ) // page_size
+        prefix_base = seq_len // page_size * page_size
+        start = (
+            prefix_base + topk_id * num_new_pages_per_topk * page_size + last_page_len
+        )
+        extend_data = tl.load(
+            token_pool_ptr + start + extend_offset,
+            mask=extend_offset < iters,
+        )
+
+    tl.store(kv_ptr + seq_len + extend_offset, extend_data, mask=extend_offset < iters)
+
+    # Update kv_indptr - use num_tokens_upper for positions accumulation
+    zid = bid * topk + topk_id
+    if zid == 0:
+        zid = num_seqs * topk
+
+    tokens_offset = tl.arange(0, num_tokens_upper)
+    base = tl.sum(tl.load(positions + tokens_offset, mask=tokens_offset < zid, other=0))
+
+    tl.store(kv_indptr + zid, base + zid * iters)
+
+
+# ==================== Setup Functions ====================
+
+
+def setup_assign_draft_cache_locs_test(
+    bs, pool_len=1024, topk=4, speculative_num_steps=5, page_size=16, device="cuda"
+):
+    """Setup test tensors for assign_draft_cache_locs.
+
+    This tests the simple case where page_size == 1 or topk == 1.
+    """
+    req_pool_indices = torch.arange(bs, dtype=torch.int32, device=device)
+    req_to_token = torch.full((bs, pool_len), -1, dtype=torch.int32, device=device)
+
+    # Random seq_lens (prefix lengths)
+    seq_lens = torch.randint(50, 200, (bs,), dtype=torch.int32, device=device)
+
+    # extend_lens: how many tokens to copy for each request
+    extend_lens = torch.full(
+        (bs,), topk * speculative_num_steps, dtype=torch.int32, device=device
+    )
+
+    # For simple case (page_size=1 or topk=1), these are not used much
+    num_new_pages_per_topk = torch.ones((bs,), dtype=torch.int32, device=device)
+
+    # Total out_cache_loc size
+    total_extend = (extend_lens.sum()).item()
+    out_cache_loc = torch.arange(total_extend, dtype=torch.int32, device=device)
+
+    # source/target cache loc (for complex case)
+    source_cache_loc = torch.zeros(
+        (bs * topk * page_size,), dtype=torch.int32, device=device
+    )
+    target_cache_loc = torch.zeros(
+        (bs * topk * page_size,), dtype=torch.int32, device=device
+    )
+
+    # last_page_lens_cumsum
+    last_page_lens = seq_lens % page_size
+    last_page_lens_cumsum = torch.cumsum(last_page_lens, dim=0).to(torch.int32)
+
+    duplicate_cache_len = 0  # Simple case
+
+    return (
+        req_pool_indices,
+        req_to_token,
+        seq_lens,
+        extend_lens,
+        num_new_pages_per_topk,
+        out_cache_loc,
+        source_cache_loc,
+        target_cache_loc,
+        last_page_lens_cumsum,
+        duplicate_cache_len,
+        pool_len,
+        topk,
+        speculative_num_steps,
+        page_size,
+    )
+
+
+def setup_generate_draft_decode_kv_indices_test(
+    bs,
+    num_steps=5,
+    topk=4,
+    pool_len=1024,
+    page_size=1,
+    device="cuda",
+    fixed_stride=True,
+):
+    """Setup test tensors for generate_draft_decode_kv_indices.
+
+    Args:
+        fixed_stride: If True, use fixed stride values to avoid kernel recompilation.
+                     This is useful for compile time testing.
+    """
+    req_pool_indices = torch.arange(bs, dtype=torch.int32, device=device)
+
+    # Initialize req_to_token with valid indices
+    req_to_token = torch.zeros((bs, pool_len), dtype=torch.int32, device=device)
+    for i in range(bs):
+        req_to_token[i, :] = (
+            torch.arange(pool_len, dtype=torch.int32, device=device) + i * 1000
+        )
+
+    # Use fixed seq_len for consistent stride values
+    fixed_seq_len = 64
+    paged_kernel_lens = torch.full(
+        (bs,), fixed_seq_len, dtype=torch.int32, device=device
+    )
+
+    # positions for kv_indptr calculation (seq_len + iters for each (bid, topk_id))
+    # Use fixed max_bs for consistent stride
+    max_bs = 512 if fixed_stride else bs
+    num_tokens = max_bs * topk
+    positions = torch.zeros((num_tokens,), dtype=torch.int32, device=device)
+    for bid in range(bs):
+        seq_len = paged_kernel_lens[bid].item()
+        for topk_id in range(topk):
+            positions[bid * topk + topk_id] = seq_len + num_steps
+
+    # Use fixed sizes for consistent constexpr values
+    if fixed_stride:
+        # Fixed sizes to avoid recompilation
+        kv_indices_size = (
+            max_bs * fixed_seq_len + max_bs * num_steps
+        ) * topk + max_bs * num_steps * topk
+        kv_indptr_stride = max_bs * topk + 1
+    else:
+        total_seq_len = paged_kernel_lens.sum().item()
+        kv_indices_size = (
+            total_seq_len + bs * num_steps
+        ) * topk + bs * num_steps * topk
+        kv_indptr_stride = bs * topk + 1
+
+    kv_indices = torch.zeros(
+        (num_steps, kv_indices_size), dtype=torch.int32, device=device
+    )
+    kv_indptr = torch.zeros(
+        (num_steps, kv_indptr_stride), dtype=torch.int64, device=device
+    )
+
+    kv_indices_stride = kv_indices_size
+
+    return (
+        req_pool_indices,
+        req_to_token,
+        paged_kernel_lens,
+        kv_indices,
+        kv_indptr,
+        positions,
+        pool_len,
+        kv_indices_stride,
+        kv_indptr_stride,
+        num_steps,
+        topk,
+        page_size,
+    )
+
+
+def setup_create_extend_test(bs, max_accept_len=6, device="cuda"):
+    """Setup test tensors for create_extend_after_decode_spec_info."""
+    # Random accept lengths between 1 and max_accept_len
+    accept_lens = torch.randint(
+        1, max_accept_len + 1, (bs,), dtype=torch.int32, device=device
+    )
+    total_accept = accept_lens.sum().item()
+
+    # Random verified_id with enough elements
+    verified_id = torch.randint(
+        0, 1000, (total_accept,), dtype=torch.int32, device=device
+    )
+
+    # Random seq_lens (should be >= accept_lens)
+    seq_lens = accept_lens + torch.randint(
+        10, 100, (bs,), dtype=torch.int32, device=device
+    )
+
+    # Output tensors
+    positions = torch.empty((total_accept,), dtype=torch.int64, device=device)
+    new_verified_id = torch.empty((bs,), dtype=torch.int32, device=device)
+
+    return verified_id, seq_lens, accept_lens, positions, new_verified_id
+
+
+def setup_assign_req_to_token_pool_test(bs, pool_len=1024, device="cuda"):
+    """Setup test tensors for assign_req_to_token_pool."""
+    req_pool_indices = torch.arange(bs, dtype=torch.int32, device=device)
+    req_to_token = torch.full((bs, pool_len), -1, dtype=torch.int32, device=device)
+
+    # Random start/end offsets
+    start_offset = torch.randint(0, 10, (bs,), dtype=torch.int32, device=device)
+    end_offset = start_offset + torch.randint(
+        1, 20, (bs,), dtype=torch.int32, device=device
+    )
+
+    total_len = (end_offset - start_offset).sum().item()
+    out_cache_loc = torch.arange(total_len, dtype=torch.int32, device=device)
+
+    return (
+        req_pool_indices,
+        req_to_token,
+        start_offset,
+        end_offset,
+        out_cache_loc,
+        pool_len,
+    )
+
+
+def setup_get_target_cache_loc_test(bs, num_verify_tokens=16, device="cuda"):
+    """Setup test tensors for get_target_cache_loc."""
+    # Random accept lengths
+    accept_length = torch.randint(
+        0, num_verify_tokens - 1, (bs,), dtype=torch.int32, device=device
+    )
+    total_accept = (accept_length + 1).sum().item()
+
+    # Random to_free_num_slots
+    to_free_num_slots = torch.randint(0, 5, (bs,), dtype=torch.int32, device=device)
+    total_free = to_free_num_slots.sum().item()
+
+    # Random out_cache_loc
+    out_cache_loc = torch.randint(
+        0, 10000, (bs, num_verify_tokens), dtype=torch.int64, device=device
+    )
+
+    # Output tensors
+    tgt_cache_loc = torch.empty((total_accept,), dtype=torch.int64, device=device)
+    to_free_slots = torch.empty((max(1, total_free),), dtype=torch.int64, device=device)
+
+    return (
+        tgt_cache_loc,
+        to_free_slots,
+        accept_length,
+        to_free_num_slots,
+        out_cache_loc,
+        num_verify_tokens,
+    )
+
+
+def setup_filter_finished_test(bs, num_verify_tokens=16, device="cuda"):
+    """Setup test tensors for filter_finished_cache_loc_kernel."""
+    # Random accept lengths
+    accept_length = torch.randint(
+        0, num_verify_tokens - 1, (bs,), dtype=torch.int32, device=device
+    )
+
+    # Filter (subset of accept_length)
+    accept_length_filter = accept_length.clone()
+    # Mark some as finished (0)
+    if bs > 1:
+        accept_length_filter[::2] = 0
+
+    total_accept = (accept_length + 1).sum().item()
+    total_filter = accept_length_filter.sum().item()
+
+    # Random tgt_cache_loc
+    tgt_cache_loc = torch.randint(
+        0, 10000, (total_accept,), dtype=torch.int64, device=device
+    )
+
+    # Output tensor
+    out_cache_loc = torch.empty(
+        (max(1, total_filter),), dtype=torch.int64, device=device
+    )
+
+    return (
+        out_cache_loc,
+        tgt_cache_loc,
+        accept_length,
+        accept_length_filter,
+        num_verify_tokens,
+    )
+
+
+# ==================== Test Class ====================
+
+
+class TestSpecUtilsKernels(unittest.TestCase):
+    """Test spec_utils Triton kernels."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Skip tests if CUDA is not available."""
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    # ==================== create_extend_after_decode_spec_info Tests ====================
+
+    def _test_create_extend_compile_v1(self, bs):
+        """Test compilation time for v1 kernel."""
+        verified_id, seq_lens, accept_lens, positions, new_verified_id = (
+            setup_create_extend_test(bs)
+        )
+        bs_upper = next_power_of_2(max(6, bs))
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        create_extend_after_decode_spec_info_v1[(bs,)](
+            verified_id, seq_lens, accept_lens, positions, new_verified_id, bs_upper
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def _test_create_extend_compile_v2(self, bs):
+        """Test compilation time for v2 kernel."""
+        verified_id, seq_lens, accept_lens, positions, new_verified_id = (
+            setup_create_extend_test(bs)
+        )
+        max_accept_len = next_power_of_2(6)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        create_extend_after_decode_spec_info[(bs,)](
+            verified_id,
+            seq_lens,
+            accept_lens,
+            positions,
+            new_verified_id,
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+            max_accept_len,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def test_create_extend_all_compile_v1(self):
+        """Test v1 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_create_extend_compile_v1(bs)
+                print(f"create_extend v1 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_create_extend_all_compile_v2(self):
+        """Test v2 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_create_extend_compile_v2(bs)
+                print(f"create_extend v2 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_create_extend_correctness(self):
+        """Test correctness by comparing v1 and v2 outputs."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                verified_id, seq_lens, accept_lens, positions_v1, new_verified_id_v1 = (
+                    setup_create_extend_test(bs)
+                )
+                positions_v2 = torch.empty_like(positions_v1)
+                new_verified_id_v2 = torch.empty_like(new_verified_id_v1)
+
+                bs_upper = next_power_of_2(max(6, bs))
+                max_accept_len = next_power_of_2(6)
+
+                # Run v1
+                create_extend_after_decode_spec_info_v1[(bs,)](
+                    verified_id,
+                    seq_lens,
+                    accept_lens,
+                    positions_v1,
+                    new_verified_id_v1,
+                    bs_upper,
+                )
+
+                # Run v2
+                create_extend_after_decode_spec_info[(bs,)](
+                    verified_id,
+                    seq_lens,
+                    accept_lens,
+                    positions_v2,
+                    new_verified_id_v2,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    max_accept_len,
+                )
+
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(positions_v1, positions_v2),
+                    f"Positions mismatch at bs={bs}",
+                )
+                self.assertTrue(
+                    torch.equal(new_verified_id_v1, new_verified_id_v2),
+                    f"new_verified_id mismatch at bs={bs}",
+                )
+                print(f"create_extend correctness bs={bs}: PASSED")
+
+    # ==================== assign_req_to_token_pool Tests ====================
+
+    def _test_assign_req_compile_v1(self, bs):
+        """Test compilation time for v1 kernel."""
+        (
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_cache_loc,
+            pool_len,
+        ) = setup_assign_req_to_token_pool_test(bs)
+        bs_upper = next_power_of_2(bs)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        assign_req_to_token_pool_v1[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_cache_loc,
+            pool_len,
+            bs_upper,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def _test_assign_req_compile_v2(self, bs):
+        """Test compilation time for v2 kernel."""
+        (
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_cache_loc,
+            pool_len,
+        ) = setup_assign_req_to_token_pool_test(bs)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        assign_req_to_token_pool[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            start_offset,
+            end_offset,
+            out_cache_loc,
+            pool_len,
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def test_assign_req_all_compile_v1(self):
+        """Test v1 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_assign_req_compile_v1(bs)
+                print(f"assign_req v1 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_assign_req_all_compile_v2(self):
+        """Test v2 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_assign_req_compile_v2(bs)
+                print(f"assign_req v2 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_assign_req_correctness(self):
+        """Test correctness by comparing v1 and v2 outputs."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    req_pool_indices,
+                    req_to_token_v1,
+                    start_offset,
+                    end_offset,
+                    out_cache_loc,
+                    pool_len,
+                ) = setup_assign_req_to_token_pool_test(bs)
+                req_to_token_v2 = req_to_token_v1.clone()
+
+                bs_upper = next_power_of_2(bs)
+
+                # Run v1
+                assign_req_to_token_pool_v1[(bs,)](
+                    req_pool_indices,
+                    req_to_token_v1,
+                    start_offset,
+                    end_offset,
+                    out_cache_loc,
+                    pool_len,
+                    bs_upper,
+                )
+
+                # Run v2
+                assign_req_to_token_pool[(bs,)](
+                    req_pool_indices,
+                    req_to_token_v2,
+                    start_offset,
+                    end_offset,
+                    out_cache_loc,
+                    pool_len,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                )
+
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(req_to_token_v1, req_to_token_v2),
+                    f"req_to_token mismatch at bs={bs}",
+                )
+                print(f"assign_req correctness bs={bs}: PASSED")
+
+    # ==================== get_target_cache_loc Tests ====================
+
+    def _test_get_target_compile_v1(self, bs):
+        """Test compilation time for v1 kernel."""
+        (
+            tgt_cache_loc,
+            to_free_slots,
+            accept_length,
+            to_free_num_slots,
+            out_cache_loc,
+            num_verify_tokens,
+        ) = setup_get_target_cache_loc_test(bs)
+        num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+        bs_upper = next_power_of_2(bs)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        get_target_cache_loc_v1[(bs,)](
+            tgt_cache_loc,
+            to_free_slots,
+            accept_length,
+            to_free_num_slots,
+            out_cache_loc,
+            num_verify_tokens,
+            num_verify_tokens_upper,
+            bs_upper,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def _test_get_target_compile_v2(self, bs):
+        """Test compilation time for v2 kernel."""
+        (
+            tgt_cache_loc,
+            to_free_slots,
+            accept_length,
+            to_free_num_slots,
+            out_cache_loc,
+            num_verify_tokens,
+        ) = setup_get_target_cache_loc_test(bs)
+        num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        get_target_cache_loc[(bs,)](
+            tgt_cache_loc,
+            to_free_slots,
+            accept_length,
+            to_free_num_slots,
+            out_cache_loc,
+            num_verify_tokens,
+            num_verify_tokens_upper,
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def test_get_target_all_compile_v1(self):
+        """Test v1 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_get_target_compile_v1(bs)
+                print(f"get_target v1 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_get_target_all_compile_v2(self):
+        """Test v2 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_get_target_compile_v2(bs)
+                print(f"get_target v2 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_get_target_correctness(self):
+        """Test correctness by comparing v1 and v2 outputs."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    tgt_cache_loc_v1,
+                    to_free_slots_v1,
+                    accept_length,
+                    to_free_num_slots,
+                    out_cache_loc,
+                    num_verify_tokens,
+                ) = setup_get_target_cache_loc_test(bs)
+                tgt_cache_loc_v2 = torch.empty_like(tgt_cache_loc_v1)
+                to_free_slots_v2 = torch.empty_like(to_free_slots_v1)
+
+                num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+                bs_upper = next_power_of_2(bs)
+
+                # Run v1
+                get_target_cache_loc_v1[(bs,)](
+                    tgt_cache_loc_v1,
+                    to_free_slots_v1,
+                    accept_length,
+                    to_free_num_slots,
+                    out_cache_loc,
+                    num_verify_tokens,
+                    num_verify_tokens_upper,
+                    bs_upper,
+                )
+
+                # Run v2
+                get_target_cache_loc[(bs,)](
+                    tgt_cache_loc_v2,
+                    to_free_slots_v2,
+                    accept_length,
+                    to_free_num_slots,
+                    out_cache_loc,
+                    num_verify_tokens,
+                    num_verify_tokens_upper,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                )
+
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(tgt_cache_loc_v1, tgt_cache_loc_v2),
+                    f"tgt_cache_loc mismatch at bs={bs}",
+                )
+                self.assertTrue(
+                    torch.equal(to_free_slots_v1, to_free_slots_v2),
+                    f"to_free_slots mismatch at bs={bs}",
+                )
+                print(f"get_target correctness bs={bs}: PASSED")
+
+    # ==================== filter_finished_cache_loc_kernel Tests ====================
+
+    def _test_filter_finished_compile_v1(self, bs):
+        """Test compilation time for v1 kernel."""
+        (
+            out_cache_loc,
+            tgt_cache_loc,
+            accept_length,
+            accept_length_filter,
+            num_verify_tokens,
+        ) = setup_filter_finished_test(bs)
+        num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+        bs_upper = next_power_of_2(bs)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        filter_finished_cache_loc_kernel_v1[(bs,)](
+            out_cache_loc,
+            tgt_cache_loc,
+            accept_length,
+            accept_length_filter,
+            bs_upper,
+            num_verify_tokens_upper,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def _test_filter_finished_compile_v2(self, bs):
+        """Test compilation time for v2 kernel."""
+        (
+            out_cache_loc,
+            tgt_cache_loc,
+            accept_length,
+            accept_length_filter,
+            num_verify_tokens,
+        ) = setup_filter_finished_test(bs)
+        num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        filter_finished_cache_loc_kernel[(bs,)](
+            out_cache_loc,
+            tgt_cache_loc,
+            accept_length,
+            accept_length_filter,
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+            num_verify_tokens_upper,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def test_filter_finished_all_compile_v1(self):
+        """Test v1 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_filter_finished_compile_v1(bs)
+                print(f"filter_finished v1 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_filter_finished_all_compile_v2(self):
+        """Test v2 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_filter_finished_compile_v2(bs)
+                print(f"filter_finished v2 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_filter_finished_correctness(self):
+        """Test correctness by comparing v1 and v2 outputs."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    out_cache_loc_v1,
+                    tgt_cache_loc,
+                    accept_length,
+                    accept_length_filter,
+                    num_verify_tokens,
+                ) = setup_filter_finished_test(bs)
+                out_cache_loc_v2 = torch.empty_like(out_cache_loc_v1)
+
+                num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+                bs_upper = next_power_of_2(bs)
+
+                # Run v1
+                filter_finished_cache_loc_kernel_v1[(bs,)](
+                    out_cache_loc_v1,
+                    tgt_cache_loc,
+                    accept_length,
+                    accept_length_filter,
+                    bs_upper,
+                    num_verify_tokens_upper,
+                )
+
+                # Run v2
+                filter_finished_cache_loc_kernel[(bs,)](
+                    out_cache_loc_v2,
+                    tgt_cache_loc,
+                    accept_length,
+                    accept_length_filter,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    num_verify_tokens_upper,
+                )
+
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(out_cache_loc_v1, out_cache_loc_v2),
+                    f"out_cache_loc mismatch at bs={bs}",
+                )
+                print(f"filter_finished correctness bs={bs}: PASSED")
+
+    # ==================== Large Batch Size Tests for v2 ====================
+
+    def test_create_extend_large_batch_v2(self):
+        """Test v2 kernel correctness with large batch sizes."""
+        print("\n")
+        for bs in LARGE_BATCH_SIZES:
+            with self.subTest(bs=bs):
+                verified_id, seq_lens, accept_lens, positions, new_verified_id = (
+                    setup_create_extend_test(bs)
+                )
+                max_accept_len = next_power_of_2(6)
+
+                create_extend_after_decode_spec_info[(bs,)](
+                    verified_id,
+                    seq_lens,
+                    accept_lens,
+                    positions,
+                    new_verified_id,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    max_accept_len,
+                )
+                torch.cuda.synchronize()
+
+                # Verify basic properties
+                self.assertEqual(positions.shape[0], accept_lens.sum().item())
+                self.assertEqual(new_verified_id.shape[0], bs)
+                print(f"create_extend large batch bs={bs}: PASSED")
+
+    def test_assign_req_large_batch_v2(self):
+        """Test v2 kernel correctness with large batch sizes."""
+        print("\n")
+        for bs in LARGE_BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    req_pool_indices,
+                    req_to_token,
+                    start_offset,
+                    end_offset,
+                    out_cache_loc,
+                    pool_len,
+                ) = setup_assign_req_to_token_pool_test(bs)
+
+                assign_req_to_token_pool[(bs,)](
+                    req_pool_indices,
+                    req_to_token,
+                    start_offset,
+                    end_offset,
+                    out_cache_loc,
+                    pool_len,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                )
+                torch.cuda.synchronize()
+
+                # Verify basic properties
+                self.assertEqual(req_to_token.shape[0], bs)
+                print(f"assign_req large batch bs={bs}: PASSED")
+
+    def test_get_target_large_batch_v2(self):
+        """Test v2 kernel correctness with large batch sizes."""
+        print("\n")
+        for bs in LARGE_BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    tgt_cache_loc,
+                    to_free_slots,
+                    accept_length,
+                    to_free_num_slots,
+                    out_cache_loc,
+                    num_verify_tokens,
+                ) = setup_get_target_cache_loc_test(bs)
+                num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+
+                get_target_cache_loc[(bs,)](
+                    tgt_cache_loc,
+                    to_free_slots,
+                    accept_length,
+                    to_free_num_slots,
+                    out_cache_loc,
+                    num_verify_tokens,
+                    num_verify_tokens_upper,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                )
+                torch.cuda.synchronize()
+
+                # Verify basic properties
+                total_accept = (accept_length + 1).sum().item()
+                self.assertEqual(tgt_cache_loc.shape[0], total_accept)
+                print(f"get_target large batch bs={bs}: PASSED")
+
+    def test_filter_finished_large_batch_v2(self):
+        """Test v2 kernel correctness with large batch sizes."""
+        print("\n")
+        for bs in LARGE_BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    out_cache_loc,
+                    tgt_cache_loc,
+                    accept_length,
+                    accept_length_filter,
+                    num_verify_tokens,
+                ) = setup_filter_finished_test(bs)
+                num_verify_tokens_upper = next_power_of_2(num_verify_tokens)
+
+                filter_finished_cache_loc_kernel[(bs,)](
+                    out_cache_loc,
+                    tgt_cache_loc,
+                    accept_length,
+                    accept_length_filter,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    num_verify_tokens_upper,
+                )
+                torch.cuda.synchronize()
+
+                # Verify basic properties
+                total_filter = accept_length_filter.sum().item()
+                self.assertGreaterEqual(out_cache_loc.shape[0], total_filter)
+                print(f"filter_finished large batch bs={bs}: PASSED")
+
+    # ==================== assign_draft_cache_locs Tests ====================
+
+    def _test_assign_draft_compile_v1(self, bs):
+        """Test compilation time for v1 kernel."""
+        (
+            req_pool_indices,
+            req_to_token,
+            seq_lens,
+            extend_lens,
+            num_new_pages_per_topk,
+            out_cache_loc,
+            source_cache_loc,
+            target_cache_loc,
+            last_page_lens_cumsum,
+            duplicate_cache_len,
+            pool_len,
+            topk,
+            speculative_num_steps,
+            page_size,
+        ) = setup_assign_draft_cache_locs_test(bs, topk=1, page_size=1)
+
+        bs_upper = next_power_of_2(bs)
+        iter_upper = next_power_of_2(speculative_num_steps + page_size)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        assign_draft_cache_locs_v1[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            seq_lens,
+            extend_lens,
+            num_new_pages_per_topk,
+            out_cache_loc,
+            source_cache_loc,
+            target_cache_loc,
+            last_page_lens_cumsum,
+            duplicate_cache_len,
+            pool_len,
+            topk,
+            speculative_num_steps,
+            page_size,
+            bs_upper,
+            iter_upper,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def _test_assign_draft_compile_v2(self, bs):
+        """Test compilation time for v2 kernel."""
+        (
+            req_pool_indices,
+            req_to_token,
+            seq_lens,
+            extend_lens,
+            num_new_pages_per_topk,
+            out_cache_loc,
+            source_cache_loc,
+            target_cache_loc,
+            last_page_lens_cumsum,
+            duplicate_cache_len,
+            pool_len,
+            topk,
+            speculative_num_steps,
+            page_size,
+        ) = setup_assign_draft_cache_locs_test(bs, topk=1, page_size=1)
+
+        iter_upper = next_power_of_2(speculative_num_steps + page_size)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        assign_draft_cache_locs[(bs,)](
+            req_pool_indices,
+            req_to_token,
+            seq_lens,
+            extend_lens,
+            num_new_pages_per_topk,
+            out_cache_loc,
+            source_cache_loc,
+            target_cache_loc,
+            last_page_lens_cumsum,
+            duplicate_cache_len,
+            pool_len,
+            topk,
+            speculative_num_steps,
+            page_size,
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+            iter_upper,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def test_assign_draft_all_compile_v1(self):
+        """Test v1 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_assign_draft_compile_v1(bs)
+                print(f"assign_draft v1 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_assign_draft_all_compile_v2(self):
+        """Test v2 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_assign_draft_compile_v2(bs)
+                print(f"assign_draft v2 bs={bs}: compile_time={compile_time:.2f}ms")
+                self.assertGreater(compile_time, 0)
+
+    def test_assign_draft_correctness(self):
+        """Test correctness by comparing v1 and v2 outputs (simple case: topk=1, page_size=1)."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    req_pool_indices,
+                    req_to_token_v1,
+                    seq_lens,
+                    extend_lens,
+                    num_new_pages_per_topk,
+                    out_cache_loc,
+                    source_cache_loc_v1,
+                    target_cache_loc_v1,
+                    last_page_lens_cumsum,
+                    duplicate_cache_len,
+                    pool_len,
+                    topk,
+                    speculative_num_steps,
+                    page_size,
+                ) = setup_assign_draft_cache_locs_test(bs, topk=1, page_size=1)
+
+                req_to_token_v2 = req_to_token_v1.clone()
+                source_cache_loc_v2 = source_cache_loc_v1.clone()
+                target_cache_loc_v2 = target_cache_loc_v1.clone()
+
+                bs_upper = next_power_of_2(bs)
+                iter_upper = next_power_of_2(speculative_num_steps + page_size)
+
+                # Run v1
+                assign_draft_cache_locs_v1[(bs,)](
+                    req_pool_indices,
+                    req_to_token_v1,
+                    seq_lens,
+                    extend_lens,
+                    num_new_pages_per_topk,
+                    out_cache_loc,
+                    source_cache_loc_v1,
+                    target_cache_loc_v1,
+                    last_page_lens_cumsum,
+                    duplicate_cache_len,
+                    pool_len,
+                    topk,
+                    speculative_num_steps,
+                    page_size,
+                    bs_upper,
+                    iter_upper,
+                )
+
+                # Run v2
+                assign_draft_cache_locs[(bs,)](
+                    req_pool_indices,
+                    req_to_token_v2,
+                    seq_lens,
+                    extend_lens,
+                    num_new_pages_per_topk,
+                    out_cache_loc,
+                    source_cache_loc_v2,
+                    target_cache_loc_v2,
+                    last_page_lens_cumsum,
+                    duplicate_cache_len,
+                    pool_len,
+                    topk,
+                    speculative_num_steps,
+                    page_size,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    iter_upper,
+                )
+
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(req_to_token_v1, req_to_token_v2),
+                    f"req_to_token mismatch at bs={bs}",
+                )
+                print(f"assign_draft correctness bs={bs}: PASSED")
+
+    def test_assign_draft_large_batch_v2(self):
+        """Test v2 kernel correctness with large batch sizes."""
+        print("\n")
+        for bs in LARGE_BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    req_pool_indices,
+                    req_to_token,
+                    seq_lens,
+                    extend_lens,
+                    num_new_pages_per_topk,
+                    out_cache_loc,
+                    source_cache_loc,
+                    target_cache_loc,
+                    last_page_lens_cumsum,
+                    duplicate_cache_len,
+                    pool_len,
+                    topk,
+                    speculative_num_steps,
+                    page_size,
+                ) = setup_assign_draft_cache_locs_test(bs, topk=1, page_size=1)
+
+                iter_upper = next_power_of_2(speculative_num_steps + page_size)
+
+                assign_draft_cache_locs[(bs,)](
+                    req_pool_indices,
+                    req_to_token,
+                    seq_lens,
+                    extend_lens,
+                    num_new_pages_per_topk,
+                    out_cache_loc,
+                    source_cache_loc,
+                    target_cache_loc,
+                    last_page_lens_cumsum,
+                    duplicate_cache_len,
+                    pool_len,
+                    topk,
+                    speculative_num_steps,
+                    page_size,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    iter_upper,
+                )
+                torch.cuda.synchronize()
+
+                # Verify basic properties
+                self.assertEqual(req_to_token.shape[0], bs)
+                print(f"assign_draft large batch bs={bs}: PASSED")
+
+    # ==================== generate_draft_decode_kv_indices Tests ====================
+
+    def _test_generate_kv_indices_compile_v1(self, bs):
+        """Test compilation time for v1 kernel."""
+        (
+            req_pool_indices,
+            req_to_token,
+            paged_kernel_lens,
+            kv_indices,
+            kv_indptr,
+            positions,
+            pool_len,
+            kv_indices_stride,
+            kv_indptr_stride,
+            num_steps,
+            topk,
+            page_size,
+        ) = setup_generate_draft_decode_kv_indices_test(bs, page_size=1)
+
+        bs_upper = next_power_of_2(bs)
+        num_tokens_upper = next_power_of_2(bs * topk)
+        iter_upper = next_power_of_2(num_steps)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        generate_draft_decode_kv_indices_v1[(num_steps, bs, topk)](
+            req_pool_indices,
+            req_to_token,
+            paged_kernel_lens,
+            kv_indices,
+            kv_indptr,
+            positions,
+            pool_len,
+            kv_indices_stride,
+            kv_indptr_stride,
+            bs_upper,
+            num_tokens_upper,
+            iter_upper,
+            page_size,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def _test_generate_kv_indices_compile_v2(self, bs):
+        """Test compilation time for v2 kernel."""
+        (
+            req_pool_indices,
+            req_to_token,
+            paged_kernel_lens,
+            kv_indices,
+            kv_indptr,
+            positions,
+            pool_len,
+            kv_indices_stride,
+            kv_indptr_stride,
+            num_steps,
+            topk,
+            page_size,
+        ) = setup_generate_draft_decode_kv_indices_test(bs, page_size=1)
+
+        iter_upper = next_power_of_2(num_steps)
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        generate_draft_decode_kv_indices[(num_steps, bs, topk)](
+            req_pool_indices,
+            req_to_token,
+            paged_kernel_lens,
+            kv_indices,
+            kv_indptr,
+            positions,
+            pool_len,
+            kv_indices_stride,
+            kv_indptr_stride,
+            _SPEC_STEP_SIZE,
+            _SPEC_MAX_NUM_LOOPS,
+            iter_upper,
+            _NUM_TOKENS_STEP_SIZE,
+            _NUM_TOKENS_MAX_LOOPS,
+            page_size,
+        )
+        torch.cuda.synchronize()
+        compile_time = (time.perf_counter() - start) * 1000
+        return compile_time
+
+    def test_generate_kv_indices_all_compile_v1(self):
+        """Test v1 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_generate_kv_indices_compile_v1(bs)
+                print(
+                    f"generate_kv_indices v1 bs={bs}: compile_time={compile_time:.2f}ms"
+                )
+                self.assertGreater(compile_time, 0)
+
+    def test_generate_kv_indices_all_compile_v2(self):
+        """Test v2 compile times across batch sizes."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                compile_time = self._test_generate_kv_indices_compile_v2(bs)
+                print(
+                    f"generate_kv_indices v2 bs={bs}: compile_time={compile_time:.2f}ms"
+                )
+                self.assertGreater(compile_time, 0)
+
+    def test_generate_kv_indices_correctness(self):
+        """Test correctness by comparing v1 and v2 outputs."""
+        print("\n")
+        for bs in BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    req_pool_indices,
+                    req_to_token,
+                    paged_kernel_lens,
+                    kv_indices_v1,
+                    kv_indptr_v1,
+                    positions,
+                    pool_len,
+                    kv_indices_stride,
+                    kv_indptr_stride,
+                    num_steps,
+                    topk,
+                    page_size,
+                ) = setup_generate_draft_decode_kv_indices_test(
+                    bs, page_size=1, fixed_stride=False
+                )
+
+                kv_indices_v2 = kv_indices_v1.clone()
+                kv_indptr_v2 = kv_indptr_v1.clone()
+
+                bs_upper = next_power_of_2(bs)
+                num_tokens_upper = next_power_of_2(bs * topk)
+                iter_upper = next_power_of_2(num_steps)
+
+                # Run v1
+                generate_draft_decode_kv_indices_v1[(num_steps, bs, topk)](
+                    req_pool_indices,
+                    req_to_token,
+                    paged_kernel_lens,
+                    kv_indices_v1,
+                    kv_indptr_v1,
+                    positions,
+                    pool_len,
+                    kv_indices_stride,
+                    kv_indptr_stride,
+                    bs_upper,
+                    num_tokens_upper,
+                    iter_upper,
+                    page_size,
+                )
+
+                # Run v2
+                generate_draft_decode_kv_indices[(num_steps, bs, topk)](
+                    req_pool_indices,
+                    req_to_token,
+                    paged_kernel_lens,
+                    kv_indices_v2,
+                    kv_indptr_v2,
+                    positions,
+                    pool_len,
+                    kv_indices_stride,
+                    kv_indptr_stride,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    iter_upper,
+                    _NUM_TOKENS_STEP_SIZE,
+                    _NUM_TOKENS_MAX_LOOPS,
+                    page_size,
+                )
+
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(kv_indices_v1, kv_indices_v2),
+                    f"kv_indices mismatch at bs={bs}",
+                )
+                self.assertTrue(
+                    torch.equal(kv_indptr_v1, kv_indptr_v2),
+                    f"kv_indptr mismatch at bs={bs}",
+                )
+                print(f"generate_kv_indices correctness bs={bs}: PASSED")
+
+    def test_generate_kv_indices_large_batch_v2(self):
+        """Test v2 kernel correctness with large batch sizes."""
+        print("\n")
+        for bs in LARGE_BATCH_SIZES:
+            with self.subTest(bs=bs):
+                (
+                    req_pool_indices,
+                    req_to_token,
+                    paged_kernel_lens,
+                    kv_indices,
+                    kv_indptr,
+                    positions,
+                    pool_len,
+                    kv_indices_stride,
+                    kv_indptr_stride,
+                    num_steps,
+                    topk,
+                    page_size,
+                ) = setup_generate_draft_decode_kv_indices_test(
+                    bs, page_size=1, fixed_stride=False
+                )
+
+                iter_upper = next_power_of_2(num_steps)
+
+                generate_draft_decode_kv_indices[(num_steps, bs, topk)](
+                    req_pool_indices,
+                    req_to_token,
+                    paged_kernel_lens,
+                    kv_indices,
+                    kv_indptr,
+                    positions,
+                    pool_len,
+                    kv_indices_stride,
+                    kv_indptr_stride,
+                    _SPEC_STEP_SIZE,
+                    _SPEC_MAX_NUM_LOOPS,
+                    iter_upper,
+                    _NUM_TOKENS_STEP_SIZE,
+                    _NUM_TOKENS_MAX_LOOPS,
+                    page_size,
+                )
+                torch.cuda.synchronize()
+
+                # Verify basic properties
+                self.assertEqual(kv_indices.shape[0], num_steps)
+                self.assertEqual(kv_indptr.shape[0], num_steps)
+                print(f"generate_kv_indices large batch bs={bs}: PASSED")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Hi from [novita.ai](https://novita.ai/)!

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Speculative decoding Triton kernels define `constexpr` parameters based on runtime batch size / seq_len. This causes **JIT recompilation overhead** each time these dimensions change — a frequent occurrence in online inference.
This PR switches to fixed step sizes, allowing kernel reuse and eliminating redundant compilations.

## Modifications

Refactor speculative decoding Triton kernels to use fixed step sizes instead of dynamic batch-size-dependent constexpr parameters.

Key changes:
- Add _SPEC_STEP_SIZE and _SPEC_MAX_NUM_LOOPS constants
- Refactor kernels to use loop-based accumulation
- Keep v1 (original) kernels for AMD backend compatibility
- Add v2 suffix for optimized kernels
- Add comprehensive unit tests

Based on community PR [#17485](https://github.com/sgl-project/sglang/pull/17485) implementation pattern.

### This PR

| Kernel | File |
|--------|------|
| `alloc_decode_kernel` | `allocator.py` |
| `create_extend_after_decode_spec_info` | `spec_utils.py` |
| `assign_req_to_token_pool` | `spec_utils.py` |
| `assign_draft_cache_locs` | `spec_utils.py` |
| `generate_draft_decode_kv_indices` | `spec_utils.py` |
| `get_target_cache_loc` | `spec_utils.py` |
| `filter_finished_cache_loc_kernel` | `spec_utils.py` |
| `fill_accepted_out_cache_loc` | `eagle_info_v2.py` |
| `assign_extend_cache_locs` | `eagle_info_v2.py` |

### Community PR #17485

| Kernel | File |
|--------|------|
| `alloc_extend_kernel` | `allocator.py` |

### Compatibility

- **Maximum batch size**: 4096 (`_SPEC_STEP_SIZE=512` × `_SPEC_MAX_NUM_LOOPS=8`)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

```
cd test/srt
python3 -m unittest test_triton_assign_extend_cache_locs -k "*_correctness"
python3 -m unittest test_triton_fill_accepted_out_cache_loc -k "*_correctness"
python3 -m unittest test_triton_page_alloc_decode -k "*_correctness"
python3 -m unittest test_triton_spec_utils -k "*_correctness"

.
----------------------------------------------------------------------
Ran 1 test in 0.485s

OK

.
----------------------------------------------------------------------
Ran 1 test in 0.478s

OK

.
----------------------------------------------------------------------
Ran 1 test in 0.443s

OK


assign_draft correctness bs=1: PASSED
assign_draft correctness bs=8: PASSED
assign_draft correctness bs=32: PASSED
assign_draft correctness bs=64: PASSED
assign_draft correctness bs=128: PASSED
assign_draft correctness bs=256: PASSED
assign_draft correctness bs=512: PASSED
.

assign_req correctness bs=1: PASSED
assign_req correctness bs=8: PASSED
assign_req correctness bs=32: PASSED
assign_req correctness bs=64: PASSED
assign_req correctness bs=128: PASSED
assign_req correctness bs=256: PASSED
assign_req correctness bs=512: PASSED
.

create_extend correctness bs=1: PASSED
create_extend correctness bs=8: PASSED
create_extend correctness bs=32: PASSED
create_extend correctness bs=64: PASSED
create_extend correctness bs=128: PASSED
create_extend correctness bs=256: PASSED
create_extend correctness bs=512: PASSED
.

filter_finished correctness bs=1: PASSED
filter_finished correctness bs=8: PASSED
filter_finished correctness bs=32: PASSED
filter_finished correctness bs=64: PASSED
filter_finished correctness bs=128: PASSED
filter_finished correctness bs=256: PASSED
filter_finished correctness bs=512: PASSED
.

generate_kv_indices correctness bs=1: PASSED
generate_kv_indices correctness bs=8: PASSED
generate_kv_indices correctness bs=32: PASSED
generate_kv_indices correctness bs=64: PASSED
generate_kv_indices correctness bs=128: PASSED
generate_kv_indices correctness bs=256: PASSED
generate_kv_indices correctness bs=512: PASSED
.

get_target correctness bs=1: PASSED
get_target correctness bs=8: PASSED
get_target correctness bs=32: PASSED
get_target correctness bs=64: PASSED
get_target correctness bs=128: PASSED
get_target correctness bs=256: PASSED
get_target correctness bs=512: PASSED
.
----------------------------------------------------------------------
Ran 6 tests in 0.609s

OK
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

```
rm -r ~/.triton
                              
python3 -m unittest test_triton_assign_extend_cache_locs -k "*_compile_v1"
python3 -m unittest test_triton_fill_accepted_out_cache_loc -k "*_compile_v1"
python3 -m unittest test_triton_page_alloc_decode -k "*_compile_v1"
python3 -m unittest test_triton_spec_utils -k "*_compile_v1"

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN


assign_draft v1 bs=1: compile_time=472.39ms
assign_draft v1 bs=8: compile_time=30.45ms
assign_draft v1 bs=32: compile_time=28.47ms
assign_draft v1 bs=64: compile_time=27.93ms
assign_draft v1 bs=128: compile_time=28.23ms
assign_draft v1 bs=256: compile_time=27.70ms
assign_draft v1 bs=512: compile_time=27.47ms
.

assign_req v1 bs=1: compile_time=175.15ms
assign_req v1 bs=8: compile_time=43.88ms
assign_req v1 bs=32: compile_time=41.25ms
assign_req v1 bs=64: compile_time=43.44ms
assign_req v1 bs=128: compile_time=43.16ms
assign_req v1 bs=256: compile_time=44.68ms
assign_req v1 bs=512: compile_time=48.55ms
.

create_extend v1 bs=1: compile_time=159.98ms
create_extend v1 bs=8: compile_time=0.04ms
create_extend v1 bs=32: compile_time=29.83ms
create_extend v1 bs=64: compile_time=29.27ms
create_extend v1 bs=128: compile_time=31.49ms
create_extend v1 bs=256: compile_time=34.02ms
create_extend v1 bs=512: compile_time=33.84ms
.

filter_finished v1 bs=1: compile_time=155.71ms
filter_finished v1 bs=8: compile_time=32.51ms
filter_finished v1 bs=32: compile_time=29.72ms
filter_finished v1 bs=64: compile_time=32.56ms
filter_finished v1 bs=128: compile_time=36.22ms
filter_finished v1 bs=256: compile_time=34.63ms
filter_finished v1 bs=512: compile_time=33.66ms
.

generate_kv_indices v1 bs=1: compile_time=198.31ms
generate_kv_indices v1 bs=8: compile_time=56.37ms
generate_kv_indices v1 bs=32: compile_time=59.60ms
generate_kv_indices v1 bs=64: compile_time=60.29ms
generate_kv_indices v1 bs=128: compile_time=62.39ms
generate_kv_indices v1 bs=256: compile_time=63.89ms
generate_kv_indices v1 bs=512: compile_time=70.38ms
.

get_target v1 bs=1: compile_time=164.87ms
get_target v1 bs=8: compile_time=35.70ms
get_target v1 bs=32: compile_time=32.89ms
get_target v1 bs=64: compile_time=35.36ms
get_target v1 bs=128: compile_time=38.58ms
get_target v1 bs=256: compile_time=38.99ms
get_target v1 bs=512: compile_time=39.02ms
.
----------------------------------------------------------------------
Ran 6 tests in 3.183s

OK
```

```
rm -r ~/.triton
python3 -m unittest test_triton_assign_extend_cache_locs -k "*_compile_v2"
python3 -m unittest test_triton_fill_accepted_out_cache_loc -k "*_compile_v2"
python3 -m unittest test_triton_page_alloc_decode -k "*_compile_v2"
python3 -m unittest test_triton_spec_utils -k "*_compile_v2"

New - bs=1, draft_token_num=5: max=480.48ms, avg=160.19ms
New - bs=1, draft_token_num=10: max=0.04ms, avg=0.03ms
New - bs=1, draft_token_num=20: max=0.03ms, avg=0.02ms
New - bs=32, draft_token_num=5: max=0.03ms, avg=0.02ms
New - bs=32, draft_token_num=10: max=0.03ms, avg=0.02ms
New - bs=32, draft_token_num=20: max=0.03ms, avg=0.02ms
New - bs=64, draft_token_num=5: max=0.03ms, avg=0.02ms
New - bs=64, draft_token_num=10: max=0.03ms, avg=0.02ms
New - bs=64, draft_token_num=20: max=0.03ms, avg=0.02ms
.
----------------------------------------------------------------------
Ran 1 test in 0.643s

OK

V2 - size=1: max=448.08ms, avg=149.38ms
V2 - size=32: max=0.03ms, avg=0.02ms
V2 - size=64: max=0.02ms, avg=0.02ms
V2 - size=128: max=0.02ms, avg=0.02ms
V2 - size=256: max=0.02ms, avg=0.02ms
V2 - size=512: max=0.02ms, avg=0.02ms
.
----------------------------------------------------------------------
Ran 1 test in 0.626s

OK

New - bs=1, seq_len=666: max=482.72ms, avg=160.93ms
New - bs=32, seq_len=666: max=0.05ms, avg=0.03ms
New - bs=64, seq_len=666: max=0.03ms, avg=0.02ms
.
----------------------------------------------------------------------
Ran 1 test in 0.643s

OK


assign_draft v2 bs=1: compile_time=472.08ms
assign_draft v2 bs=8: compile_time=0.06ms
assign_draft v2 bs=32: compile_time=0.03ms
assign_draft v2 bs=64: compile_time=0.03ms
assign_draft v2 bs=128: compile_time=0.03ms
assign_draft v2 bs=256: compile_time=0.03ms
assign_draft v2 bs=512: compile_time=0.05ms
.

assign_req v2 bs=1: compile_time=62.47ms
assign_req v2 bs=8: compile_time=0.04ms
assign_req v2 bs=32: compile_time=0.03ms
assign_req v2 bs=64: compile_time=0.02ms
assign_req v2 bs=128: compile_time=0.02ms
assign_req v2 bs=256: compile_time=0.02ms
assign_req v2 bs=512: compile_time=0.02ms
.

create_extend v2 bs=1: compile_time=45.41ms
create_extend v2 bs=8: compile_time=0.04ms
create_extend v2 bs=32: compile_time=0.03ms
create_extend v2 bs=64: compile_time=0.02ms
create_extend v2 bs=128: compile_time=0.02ms
create_extend v2 bs=256: compile_time=0.02ms
create_extend v2 bs=512: compile_time=0.02ms
.

filter_finished v2 bs=1: compile_time=183.20ms
filter_finished v2 bs=8: compile_time=0.04ms
filter_finished v2 bs=32: compile_time=0.03ms
filter_finished v2 bs=64: compile_time=0.02ms
filter_finished v2 bs=128: compile_time=0.02ms
filter_finished v2 bs=256: compile_time=0.02ms
filter_finished v2 bs=512: compile_time=0.02ms
.

generate_kv_indices v2 bs=1: compile_time=221.65ms
generate_kv_indices v2 bs=8: compile_time=0.04ms
generate_kv_indices v2 bs=32: compile_time=0.03ms
generate_kv_indices v2 bs=64: compile_time=0.03ms
generate_kv_indices v2 bs=128: compile_time=0.03ms
generate_kv_indices v2 bs=256: compile_time=0.04ms
generate_kv_indices v2 bs=512: compile_time=0.05ms
.

get_target v2 bs=1: compile_time=193.34ms
get_target v2 bs=8: compile_time=0.04ms
get_target v2 bs=32: compile_time=0.03ms
get_target v2 bs=64: compile_time=0.02ms
get_target v2 bs=128: compile_time=0.02ms
get_target v2 bs=256: compile_time=0.02ms
get_target v2 bs=512: compile_time=0.02ms
.
----------------------------------------------------------------------
Ran 6 tests in 1.539s

OK
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
