### PR TITLE
Fix long prompt KV allocation by falling back to torch native APIs when exceeding Triton tensor limit

### DIFF
--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -423,16 +423,28 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
-        alloc_extend_kernel[(bs,)](
-            prefix_lens,
-            seq_lens,
-            last_loc,
-            self.free_pages,
-            out_indices,
-            next_power_of_2(bs),
-            self.page_size,
-            self.seen_max_num_extend_tokens_next_power_of_2,
-        )
+
+        if extend_num_tokens < tl.core.TRITON_MAX_TENSOR_NUMEL:
+            alloc_extend_kernel[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                self.free_pages,
+                out_indices,
+                next_power_of_2(bs),
+                self.page_size,
+                next_power_of_2(extend_num_tokens),
+            )
+        else:
+            alloc_extend_naive(
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                self.free_pages,
+                out_indices,
+                self.page_size,
+                self.device,
+            )
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -411,7 +411,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         self.seen_max_num_extend_tokens_next_power_of_2 = max(
             self.seen_max_num_extend_tokens_next_power_of_2,
-            next_power_of_2(extend_num_tokens),
+            min(tl.core.TRITON_MAX_TENSOR_NUMEL, next_power_of_2(extend_num_tokens)),
         )
 
         bs = len(prefix_lens)
@@ -433,7 +433,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 out_indices,
                 next_power_of_2(bs),
                 self.page_size,
-                next_power_of_2(extend_num_tokens),
+                self.seen_max_num_extend_tokens_next_power_of_2,
             )
         else:
             alloc_extend_naive(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When processing very long prompts, the number of extend tokens can exceed `TRITON_MAX_TENSOR_NUMEL`, causing the Triton-based `alloc_extend_kernel` to fail. This limits the maximum prompt length that SGLang can handle with paged KV cache allocation.

## Modifications

- **Added `alloc_extend_naive` function** (`python/sglang/srt/mem_cache/allocator.py`): A pure PyTorch fallback implementation for KV cache allocation that handles the same logic as `alloc_extend_kernel` but without Triton tensor size constraints.
- **Added conditional dispatch in `alloc_extend`**: When `extend_num_tokens < tl.core.TRITON_MAX_TENSOR_NUMEL`, the existing Triton kernel is used. Otherwise, the new `alloc_extend_naive` fallback is invoked.
- **Clamped `seen_max_num_extend_tokens_next_power_of_2`**: The tracked maximum is now capped at `TRITON_MAX_TENSOR_NUMEL` to avoid allocating oversized Triton buffers.

## Accuracy Tests

N/A — This change does not modify model forward logic or kernel computation. The fallback produces the same KV index mappings as the Triton kernel.

## Benchmarking and Profiling

N/A — The fallback path is only triggered for very long prompts that exceed Triton limits. For normal-length prompts, the existing Triton kernel continues to be used with no performance impact.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.