### PR TITLE
[diffusion] feat: support saving videos directly on the server to avoid the overhead of tensor transfer

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -153,7 +153,7 @@ class SamplingParams:
     # if True, suppress verbose logging for this request
     suppress_logs: bool = False
 
-    return_file_paths_only: bool = False
+    return_file_paths_only: bool = True
 
     def _set_output_file_ext(self):
         # add extension if needed
@@ -742,9 +742,9 @@ class SamplingParams:
         )
         parser.add_argument(
             "--return-file-paths-only",
-            action="store_true",
+            action=StoreBoolean,
             default=SamplingParams.return_file_paths_only,
-            help="If set, only return the file paths instead of the tensors.",
+            help="If set, output file will be saved early to get a performance boost, while output tensors will not be returned.",
         )
         return parser
 
@@ -814,9 +814,6 @@ class SamplingParams:
         else:
             n_tokens = -1
         return n_tokens
-
-    def output_file_path(self):
-        return os.path.join(self.output_path, self.output_file_name)
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -153,6 +153,8 @@ class SamplingParams:
     # if True, suppress verbose logging for this request
     suppress_logs: bool = False
 
+    return_file_paths_only: bool = False
+
     def _set_output_file_ext(self):
         # add extension if needed
         if not any(
@@ -737,6 +739,12 @@ class SamplingParams:
                 "and satisfy model temporal constraints. If disabled, tokens might be padded for SP."
                 "Default: true. Examples: --adjust-frames, --adjust-frames true, --adjust-frames false."
             ),
+        )
+        parser.add_argument(
+            "--return-file-paths-only",
+            action="store_true",
+            default=SamplingParams.return_file_paths_only,
+            help="If set, only return the file paths instead of the tensors.",
         )
         return parser
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -229,7 +229,10 @@ class DiffGenerator:
                     if output_batch.error:
                         raise Exception(f"{output_batch.error}")
 
-                    if output_batch.output is None:
+                    if (
+                        output_batch.output is None
+                        and output_batch.output_file_paths is None
+                    ):
                         logger.error(
                             "Received empty output from scheduler for prompt %d",
                             request_idx + 1,

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -236,6 +236,33 @@ class DiffGenerator:
                         )
                         continue
                     audio_sample_rate = output_batch.audio_sample_rate
+
+                    if req.save_output and req.return_file_paths_only:
+                        for output_idx, output_path in enumerate(
+                            output_batch.output_file_paths
+                        ):
+                            result_item: dict[str, Any] = {
+                                "samples": None,
+                                "frames": None,
+                                "audio": None,
+                                "prompts": req.prompt,
+                                "size": (req.height, req.width, req.num_frames),
+                                "generation_time": timer.duration,
+                                "peak_memory_mb": output_batch.peak_memory_mb,
+                                "timings": (
+                                    output_batch.timings.to_dict()
+                                    if output_batch.timings
+                                    else {}
+                                ),
+                                "trajectory": output_batch.trajectory_latents,
+                                "trajectory_timesteps": output_batch.trajectory_timesteps,
+                                "trajectory_decoded": output_batch.trajectory_decoded,
+                                "prompt_index": output_idx,
+                                "output_file_path": output_path,
+                            }
+                            results.append(result_item)
+                        continue
+
                     for output_idx, sample in enumerate(output_batch.output):
                         num_outputs = len(output_batch.output)
                         audio = output_batch.audio

--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -16,8 +16,8 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
     VertexGenerateReqInput,
 )
 from sglang.multimodal_gen.runtime.entrypoints.utils import (
-    post_process_sample,
     prepare_request,
+    save_outputs,
 )
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
@@ -117,32 +117,18 @@ async def forward_to_scheduler(req_obj, sp):
         if response.output is None and response.output_file_paths is None:
             raise RuntimeError("Model generation returned no output.")
 
-        output_file_path = sp.output_file_path()
         if response.output_file_paths:
             output_file_path = response.output_file_paths[0]
         else:
-            sample = response.output[0]
-            try:
-                audio = response.audio
-            except AttributeError:
-                audio = None
-            if isinstance(audio, torch.Tensor) and audio.ndim >= 2:
-                audio = audio[0]
-            if audio is not None and not (
-                isinstance(sample, (tuple, list)) and len(sample) == 2
-            ):
-                sample = (sample, audio)
-            post_process_sample(
-                sample=sample,
-                data_type=sp.data_type,
-                fps=sp.fps or 24,
-                save_output=True,
-                save_file_path=output_file_path,
-                audio_sample_rate=(
-                    response.audio_sample_rate
-                    if hasattr(response, "audio_sample_rate")
-                    else None
-                ),
+            output_file_path = sp.output_file_path()
+            save_outputs(
+                [response.output[0]],
+                sp.data_type,
+                sp.fps,
+                True,
+                lambda _idx: output_file_path,
+                audio=response.audio,
+                audio_sample_rate=response.audio_sample_rate,
             )
 
         if hasattr(response, "model_dump"):

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -7,11 +7,10 @@ import time
 from typing import Any, List, Optional, Union
 
 import httpx
-import torch
 from fastapi import UploadFile
 
 from sglang.multimodal_gen.configs.sample.sampling_params import DataType
-from sglang.multimodal_gen.runtime.entrypoints.utils import post_process_sample
+from sglang.multimodal_gen.runtime.entrypoints.utils import save_outputs
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
@@ -219,48 +218,35 @@ async def process_generation_batch(
         save_file_path_list = []
         # If output_file_paths is provided, use it instead of output.
         if result.output_file_paths:
-            for output_path in result.output_file_paths:
-                save_file_path_list.append(output_path)
+            save_file_path_list = result.output_file_paths
         else:
             audio_sample_rate = result.audio_sample_rate
             if batch.data_type == DataType.VIDEO:
-                for idx, output in enumerate(result.output):
-                    save_file_path = str(
+                save_file_path_list = save_outputs(
+                    result.output,
+                    batch.data_type,
+                    batch.fps,
+                    batch.save_output,
+                    lambda _idx: str(
                         os.path.join(batch.output_path, batch.output_file_name)
-                    )
-                    sample = result.output[idx]
-                    audio = result.audio
-                    if isinstance(audio, torch.Tensor) and audio.ndim >= 2:
-                        audio = audio[idx] if audio.shape[0] > idx else None
-                    if audio is not None and not (
-                        isinstance(sample, (tuple, list)) and len(sample) == 2
-                    ):
-                        sample = (sample, audio)
-                    post_process_sample(
-                        sample,
-                        batch.data_type,
-                        batch.fps,
-                        batch.save_output,
-                        save_file_path,
-                        audio_sample_rate=audio_sample_rate,
-                    )
-                    save_file_path_list.append(save_file_path)
+                    ),
+                    audio=result.audio,
+                    audio_sample_rate=audio_sample_rate,
+                )
             else:
-                for idx, output in enumerate(result.output):
-                    save_file_path = str(
+                save_file_path_list = save_outputs(
+                    result.output,
+                    batch.data_type,
+                    batch.fps,
+                    batch.save_output,
+                    lambda idx: str(
                         os.path.join(
-                            batch.output_path, f"sample_{idx}_" + batch.output_file_name
+                            batch.output_path,
+                            f"sample_{idx}_" + batch.output_file_name,
                         )
-                    )
-                    post_process_sample(
-                        output,
-                        batch.data_type,
-                        batch.fps,
-                        batch.save_output,
-                        save_file_path,
-                        audio_sample_rate=audio_sample_rate,
-                    )
-                    save_file_path_list.append(save_file_path)
+                    ),
+                    audio_sample_rate=audio_sample_rate,
+                )
 
     total_time = time.perf_counter() - total_start_time
     log_batch_completion(logger, 1, total_time)

--- a/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import Any, Optional
+from typing import Any, Callable, Optional, Sequence
 
 import imageio
 import numpy as np
@@ -232,6 +232,72 @@ def prepare_request(
         )
 
     return req
+
+
+def attach_audio_to_video_sample(
+    sample: Any,
+    audio: Any,
+    output_idx: int,
+) -> Any:
+    """Attach per-sample audio for video outputs when available."""
+    if audio is None:
+        return sample
+    if isinstance(audio, torch.Tensor) and audio.ndim >= 2:
+        audio = audio[output_idx] if audio.shape[0] > output_idx else None
+    elif isinstance(audio, np.ndarray) and audio.ndim >= 2:
+        audio = audio[output_idx] if audio.shape[0] > output_idx else None
+
+    if audio is not None and not (
+        isinstance(sample, (tuple, list)) and len(sample) == 2
+    ):
+        return (sample, audio)
+    return sample
+
+
+def save_outputs(
+    outputs: Sequence[Any],
+    data_type: DataType,
+    fps: int,
+    save_output: bool,
+    build_output_path: Callable[[int], str],
+    *,
+    audio: Any = None,
+    audio_sample_rate: Optional[int] = None,
+    samples_out: Optional[list[Any]] = None,
+    audios_out: Optional[list[Any]] = None,
+    frames_out: Optional[list[Any]] = None,
+) -> list[str]:
+    """Save outputs to files and return the list of file paths."""
+    output_paths: list[str] = []
+    for idx, output in enumerate(outputs):
+        save_file_path = build_output_path(idx)
+        sample = output
+        if data_type == DataType.VIDEO:
+            sample = attach_audio_to_video_sample(sample, audio, idx)
+        frames = post_process_sample(
+            sample,
+            data_type,
+            fps,
+            save_output,
+            save_file_path,
+            audio_sample_rate=audio_sample_rate,
+        )
+        if samples_out is not None:
+            samples_out.append(sample)
+        if audios_out is not None:
+            if data_type == DataType.VIDEO:
+                audio_item = audio
+                if isinstance(audio, torch.Tensor) and audio.ndim >= 2:
+                    audio_item = audio[idx] if audio.shape[0] > idx else None
+                elif isinstance(audio, np.ndarray) and audio.ndim >= 2:
+                    audio_item = audio[idx] if audio.shape[0] > idx else None
+                audios_out.append(audio_item)
+            else:
+                audios_out.append(audio)
+        if frames_out is not None:
+            frames_out.append(frames)
+        output_paths.append(save_file_path)
+    return output_paths
 
 
 def post_process_sample(

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -6,12 +6,10 @@ import os
 import time
 from typing import List, Union
 
-import numpy as np
 import torch
 from setproctitle import setproctitle
 
 from sglang.multimodal_gen import envs
-from sglang.multimodal_gen.configs.sample.sampling_params import DataType
 from sglang.multimodal_gen.runtime.distributed import (
     get_sp_group,
     maybe_init_distributed_environment_and_model_parallel,
@@ -20,7 +18,7 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_cfg_group,
     get_tp_group,
 )
-from sglang.multimodal_gen.runtime.entrypoints.utils import post_process_sample
+from sglang.multimodal_gen.runtime.entrypoints.utils import save_outputs
 from sglang.multimodal_gen.runtime.pipelines_core import (
     ComposedPipelineBase,
     LoRAPipeline,
@@ -189,41 +187,17 @@ class GPUWorker:
             output_batch.timings.total_duration_ms = duration_ms
 
             # Save output to file and return file path only if requested. Avoid the serialization
-            # and deserialization overhead between scheduler_client and GPU worker.
+            # and deserialization overhead between scheduler_client and gpu_worker.
             if req.save_output and req.return_file_paths_only:
-                output_paths: list[str] = []
-                # Copied from DiffGenerator.generate()
-                audio_sample_rate = output_batch.audio_sample_rate
-                for output_idx, sample in enumerate(output_batch.output):
-                    num_outputs = len(output_batch.output)
-                    audio = output_batch.audio
-                    if req.data_type == DataType.VIDEO:
-                        if isinstance(audio, torch.Tensor) and audio.ndim >= 2:
-                            audio = (
-                                audio[output_idx]
-                                if audio.shape[0] > output_idx
-                                else None
-                            )
-                        elif isinstance(audio, np.ndarray) and audio.ndim >= 2:
-                            audio = (
-                                audio[output_idx]
-                                if audio.shape[0] > output_idx
-                                else None
-                            )
-                        if audio is not None and not (
-                            isinstance(sample, (tuple, list)) and len(sample) == 2
-                        ):
-                            sample = (sample, audio)
-                    save_file_path = req.output_file_path(num_outputs, output_idx)
-                    post_process_sample(
-                        sample,
-                        fps=req.fps,
-                        save_output=True,
-                        save_file_path=save_file_path,
-                        data_type=req.data_type,
-                        audio_sample_rate=audio_sample_rate,
-                    )
-                    output_paths.append(save_file_path)
+                output_paths = save_outputs(
+                    output_batch.output,
+                    req.data_type,
+                    req.fps,
+                    True,
+                    lambda idx: req.output_file_path(len(output_batch.output), idx),
+                    audio=output_batch.audio,
+                    audio_sample_rate=output_batch.audio_sample_rate,
+                )
                 output_batch.output_file_paths = output_paths
                 output_batch.output = None
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -100,7 +100,6 @@ class Req:
     raw_audio_latent_shape: tuple[int, ...] | None = None
 
     # Audio Parameters
-    fps: float = 24.0
     generate_audio: bool = True
 
     raw_latent_shape: torch.Tensor | None = None
@@ -295,6 +294,7 @@ class Req:
                        width: {target_width}
                       height: {target_height}
                   num_frames: {self.num_frames}
+                         fps: {self.fps}
                       prompt: {self.prompt}
                   neg_prompt: {self.negative_prompt}
                         seed: {self.seed}

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -325,6 +325,7 @@ class OutputBatch:
     trajectory_latents: torch.Tensor | None = None
     trajectory_decoded: list[torch.Tensor] | None = None
     error: str | None = None
+    output_file_paths: list[str] | None = None
 
     # logged timings info, directly from Req.timings
     timings: Optional["RequestTimings"] = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The `scheduler_client` connects with the `gpu_worker` via ZMQ. The workflow is as follows:

* `sglang generate`: diffusion_generate --(sync_scheduler_client.forward)--> gpu_worker

* `sglang serve`: http_server --(async_scheduler_client.forward)--> gpu_worker

Old method: The `scheduler_client` and `gpu_worker` exchanged output tensors, which introduced serialization and deserialization overhead.

New method: The `gpu_worker` directly processes and saves the output tensor as video, then returns the file path to the `scheduler_client`.

## Modifications

<!-- Detail the changes made in this pull request. -->

Main code changes:

1. A common save function is implemented in `multimodal_gen/runtime/entrypoints/utils.py`. The saving logic in the following sections now uses this common function:

* `multimodal_gen/runtime/entrypoints/openai/utils.py`

* `multimodal_gen/runtime/managers/gpu_worker.py`

* `multimodal_gen/runtime/entrypoints/http_server.py`

* `multimodal_gen/runtime/entrypoints/diffusion_generator.py`

2. The default value of `return_file_paths_only` is set to `True`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
