### PR TITLE
Fix test_return_routed_experts to use response-level sglext

### DIFF
--- a/test/registered/rl/test_return_routed_experts.py
+++ b/test/registered/rl/test_return_routed_experts.py
@@ -215,15 +215,13 @@ async def make_request(session, url, payload):
 def extract_routed_experts_from_openai_response(response):
     if "error" in response:
         raise ValueError(f"OpenAI response error: {response['error']}")
-    choices = response.get("choices", [])
-    if not choices:
-        raise ValueError("OpenAI response has no choices.")
-    sgl_ext = choices[0].get("sgl_ext", None)
-    if sgl_ext is None:
-        raise ValueError("OpenAI response missing sgl_ext.")
-    routed_experts = sgl_ext.get("routed_experts", None)
+    # sglext is at response level (not in choices) as of PR #17648
+    sglext = response.get("sglext", None)
+    if sglext is None:
+        raise ValueError("OpenAI response missing sglext.")
+    routed_experts = sglext.get("routed_experts", None)
     if routed_experts is None:
-        raise ValueError("OpenAI response sgl_ext missing routed_experts.")
+        raise ValueError("OpenAI response sglext missing routed_experts.")
     return extract_routed_experts_from_meta_info(
         {"meta_info": {"routed_experts": routed_experts}}
     )


### PR DESCRIPTION
## Summary
- Fix `test_return_routed_experts.py` to access `sglext` at response level instead of `sgl_ext` in choices

PR #17648 moved the `sgl_ext` field from `choices[0]` to the response level and renamed it to `sglext` (no underscore). The test was not updated accordingly, causing CI failures.

## Test plan
- [ ] CI passes for `stage-c-test-large-4-gpu` suite

🔗 [Failure example](https://github.com/sgl-project/sglang/actions/runs/21653054987/job/62421861711)