### PR TITLE
[NPU] allgather after qlora for dsv3.2

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -292,6 +292,10 @@ class AscendAttnBackend(AttentionBackend):
         ):
             seq_lens_list_cumsum = np.cumsum(forward_batch.extend_seq_lens_cpu)
             self.forward_metadata.seq_lens_list_cumsum = seq_lens_list_cumsum
+            self.forward_metadata.seq_lens = forward_batch.seq_lens
+            self.forward_metadata.seq_lens_cum_sum = torch.cumsum(
+                forward_batch.seq_lens, dim=0
+            )
 
         if forward_batch.forward_mode.is_target_verify():
             self.forward_metadata.seq_lens_cpu_int += self.speculative_num_draft_tokens
@@ -628,7 +632,7 @@ class AscendAttnBackend(AttentionBackend):
             if self.forward_metadata.actual_seq_lengths_q is not None:
                 actual_seq_qlen = self.forward_metadata.actual_seq_lengths_q
             else:
-                actual_seq_qlen = torch.cumsum(forward_batch.extend_seq_lens, dim=0)
+                actual_seq_qlen = self.forward_metadata.seq_lens_cum_sum
         else:
             if self.forward_metadata.actual_seq_lengths_q is None:
                 if (

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -371,13 +371,13 @@ def forward_dsa_prepare_npu(
             )
 
     topk_indices = m.indexer(
-        hidden_states,
-        q_lora,
-        positions,
-        forward_batch,
-        m.layer_id,
-        dynamic_scale,
-        layer_scatter_modes,
+        x=hidden_states,
+        q_lora=q_lora,
+        positions=positions,
+        forward_batch=forward_batch,
+        layer_id=m.layer_id,
+        layer_scatter_modes=layer_scatter_modes,
+        dynamic_scale=dynamic_scale,
     )
 
     return (

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -177,7 +177,6 @@ class AttnTpContext:
             get_global_server_args().enable_attn_tp_input_scattered
             and (_is_cuda or _is_npu)
             and q_lora_rank is not None
-            and not is_nsa
             and get_tensor_model_parallel_world_size() > 1
             and not is_dp_attention_enabled()
             and get_moe_a2a_backend().is_none()

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -168,12 +168,14 @@ class AttnTpContext:
     def __init__(self):
         self.allow_input_scattered = False
         self.input_scattered_ = False
+        self.is_nsa = False
         self.attn_inputs_: Optional[AttentionInputs] = None
 
     def init_context(self, q_lora_rank, is_nsa):
+        self.is_nsa = is_nsa
         self.allow_input_scattered = (
             get_global_server_args().enable_attn_tp_input_scattered
-            and _is_cuda
+            and (_is_cuda or _is_npu)
             and q_lora_rank is not None
             and not is_nsa
             and get_tensor_model_parallel_world_size() > 1
@@ -231,6 +233,29 @@ ATTN_TP_CONTEXT = AttnTpContext()
 
 def get_attn_tp_context():
     return ATTN_TP_CONTEXT
+
+
+def delay_gather_for_dsa():
+    return (
+        get_global_server_args().enable_attn_tp_input_scattered
+        and get_attn_tp_context().is_nsa
+    )
+
+
+def scattered_to_tp_attn_full(
+    hidden_states: torch.Tensor,
+    forward_batch,
+) -> torch.Tensor:
+    hidden_states, local_hidden_states = (
+        torch.empty(
+            (forward_batch.input_ids.shape[0], hidden_states.shape[1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        ),
+        hidden_states,
+    )
+    attn_tp_all_gather_into_tensor(hidden_states, local_hidden_states.contiguous())
+    return hidden_states
 
 
 @dataclass
@@ -654,6 +679,8 @@ class CommunicateSimpleFn:
         if (input_mode == ScatterMode.SCATTERED) and (
             output_mode == ScatterMode.TP_ATTN_FULL
         ):
+            if delay_gather_for_dsa():
+                return CommunicateSimpleFn._trivial
             return CommunicateSimpleFn._scattered_to_tp_attn_full
 
         raise NotImplementedError(f"{input_mode=} {output_mode=}")

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1353,6 +1353,7 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        layer_scatter_modes: LayerScatterModes,
         llama_4_scaling: Optional[torch.Tensor] = None,
     ):
         s = self.forward_prepare(
@@ -1360,6 +1361,7 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
             hidden_states=hidden_states,
             forward_batch=forward_batch,
             zero_allocator=zero_allocator,
+            layer_scatter_modes=layer_scatter_modes,
             llama_4_scaling=llama_4_scaling,
         )
         return self.forward_core(s)
@@ -1370,6 +1372,7 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        layer_scatter_modes: LayerScatterModes,
         llama_4_scaling: Optional[torch.Tensor] = None,
     ):
         if self.attn_mha.kv_b_proj is None:
@@ -1430,7 +1433,12 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
             )
         elif attn_forward_method == AttnForwardMethod.DSA_NPU:
             inner_state = forward_dsa_prepare_npu(
-                self, positions, hidden_states, forward_batch, zero_allocator
+                self,
+                positions,
+                hidden_states,
+                forward_batch,
+                zero_allocator,
+                layer_scatter_modes,
             )
         else:
             raise NotImplementedError
@@ -2377,6 +2385,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states=hidden_states,
             forward_batch=forward_batch,
             zero_allocator=zero_allocator,
+            layer_scatter_modes=self.layer_scatter_modes,
             llama_4_scaling=llama_4_scaling,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In DeepSeek-V3.2, due to the large hidden dimension of the model, performing all-gather on hidden_states before attention  introduces a high-dimensional communication operation. The scale of this communication is proportional to hidden_dim × token_num, which can quickly amplify in multi-card TP scenarios, making communication rather than computation the primary performance bottleneck in the attention stage.

## Modifications

allgather_after_q_lora addresses this by removing the pre-attention all-gather of hidden_states and moving the communication before the indexer. It performs all-gather only on low-dimensional tensors such as q_lora, k, and weights just before indexer execution. This reduces high-dimensional communication overhead while maintaining equivalence. Since the all-gather communication occurs after layernorm, it effectively reduces the computational overhead of related operators.

## Accuracy Tests

100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [15:25<00:00,  1.43it/s]
Accuracy: 0.959
Invalid: 0.000
Latency: 927.711 s
Output throughput: 154.077 token/s


## Benchmarking and Profiling

Serving Benchmark Result

Backend: sglang
Traffic request rate: 7.0
Max request concurrency: 416
Successful requests: 1664
Benchmark duration (s): 276.95
Total input tokens: 3494400
Total input text tokens: 3494400
Total input vision tokens: 0
Total generated tokens: 1497600
Total generated tokens (retokenized): 1497276
Request throughput (req/s): 6.01
Input token throughput (tok/s): 12617.32
Output token throughput (tok/s): 5407.42
Peak output token throughput (tok/s): 6835.00
Peak concurrent requests: 265
Total token throughput (tok/s): 18024.74
Concurrency: 196.95
Accept length: 3.23
-----------------End-to-End Latency-----------------
Mean E2E Latency (ms): 32779.85
Median E2E Latency (ms): 32644.49
-----------------Time to First Token-----------------
Mean TTFT (ms): 5600.41
Median TTFT (ms): 4935.13
P99 TTFT (ms): 12345.78
-----------------Time per Output Token (excl. 1st token)-----------------
Mean TPOT (ms): 30.23
Median TPOT (ms): 30.64
P99 TPOT (ms): 38.63
-----------------Inter-Token Latency-----------------
Mean ITL (ms): 30.23
Median ITL (ms): 25.18
P95 ITL (ms): 49.39
P99 ITL (ms): 66.04
Max ITL (ms): 521.57

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
