### PR TITLE
[Scheduler] Add early finish check for overlap mode to prevent redundant decode

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -33,6 +33,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD` | Sets the threshold for enabling chunked prefix caching | `8192` |
 | `SGLANG_FUSED_MLA_ENABLE_ROPE_FUSION` | Enable RoPE fusion in Fused Multi-Layer Attention | `1` |
 | `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP` | Disable overlap schedule for consecutive prefill batches | `false` |
+| `SGLANG_ENABLE_OVERLAP_EARLY_FINISH_CHECK` | Enable early termination check in overlap mode to prevent redundant decodes for requests that have reached their `max_new_tokens` limit. | `false` |
 | `SGLANG_SCHEDULER_MAX_RECV_PER_POLL` | Set the maximum number of requests per poll, with a negative value indicating no limit | `-1` |
 | `SGLANG_DISABLE_FA4_WARMUP` | Disable Flash Attention 4 warmup passes (set to `1`, `true`, `yes`, or `on` to disable) | `false` |
 | `SGLANG_DATA_PARALLEL_BUDGET_INTERVAL` | Interval for DPBudget updates | `1` |

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -246,6 +246,7 @@ class Envs:
     # Scheduler: others:
     SGLANG_EMPTY_CACHE_INTERVAL = EnvFloat(-1)  # in seconds. Set if you observe high memory accumulation over a long serving period.
     SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(False)
+    SGLANG_ENABLE_OVERLAP_EARLY_FINISH_CHECK = EnvBool(False)
     SGLANG_SCHEDULER_MAX_RECV_PER_POLL = EnvInt(-1)
     SGLANG_EXPERIMENTAL_CPP_RADIX_TREE = EnvBool(False)
     SGLANG_DYNAMIC_CHUNKING_SMOOTH_FACTOR = EnvFloat(0.75)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -142,6 +142,7 @@ from sglang.srt.managers.prefill_delayer import (
 )
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
+    FINISH_LENGTH,
     ModelWorkerBatch,
     MultimodalInputs,
     Req,
@@ -306,6 +307,9 @@ class Scheduler(
         self.enable_lora_overlap_loading = server_args.enable_lora_overlap_loading
         self.max_loras_per_batch = server_args.max_loras_per_batch
         self.enable_overlap = not server_args.disable_overlap_schedule
+        self.enable_overlap_early_finish_check = (
+            envs.SGLANG_ENABLE_OVERLAP_EARLY_FINISH_CHECK.get()
+        )
         self.enable_pdmux = server_args.enable_pdmux
         self.skip_tokenizer_init = server_args.skip_tokenizer_init
         self.enable_metrics = server_args.enable_metrics
@@ -1895,6 +1899,34 @@ class Scheduler(
             chunked_req_to_exclude.add(self.chunked_req)
             self.stash_chunked_request(self.chunked_req)
 
+        # Filter requests in last_batch that have reached or will reach max_new_tokens
+        # In overlap mode, process_batch_result hasn't been called yet, so output_ids hasn't been updated
+        # We check if current output length + 1 (the token to be generated) will reach the limit
+        # Mark them with to_finish and filter them out to prevent redundant decode iterations
+        # This optimization is controlled by SGLANG_ENABLE_OVERLAP_EARLY_FINISH_CHECK (default: False)
+        if (
+            self.last_batch
+            and self.enable_overlap
+            and self.enable_overlap_early_finish_check
+        ):
+            finishing_req_indices = []
+            for i, req in enumerate(self.last_batch.reqs):
+                max_new_tokens = req.sampling_params.max_new_tokens
+                if max_new_tokens is not None and max_new_tokens > 0:
+                    current_output_len = len(req.output_ids)
+                    if current_output_len + 1 >= max_new_tokens:
+                        req.to_finish = FINISH_LENGTH(length=max_new_tokens)
+                        finishing_req_indices.append(i)
+
+            if finishing_req_indices:
+                finishing_req_indices_set = set(finishing_req_indices)
+                keep_indices = [
+                    i
+                    for i in range(len(self.last_batch.reqs))
+                    if i not in finishing_req_indices_set
+                ]
+                self.last_batch.filter_batch(keep_indices=keep_indices)
+
         if self.last_batch and self.last_batch.forward_mode.is_extend():
             if self.last_batch.chunked_req is not None:
                 # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked_req.
@@ -1956,7 +1988,7 @@ class Scheduler(
 
     def get_num_allocatable_reqs(self, running_bs):
         res = get_global_server_args().pp_max_micro_batch_size - running_bs
-        if self.pp_size > 1:
+        if self.pp_size > 1 or self.enable_overlap_early_finish_check:
             res = min(res, self.req_to_token_pool.available_size())
         return res
 


### PR DESCRIPTION
## Motivation

Based on [#18165](https://github.com/sgl-project/sglang/pull/18165), we find redundant decode in overlap mode, not only for requests with attribute max_tokens=1, but all requests due to overlap mechanism, which would not check results after forward immediately.

Problem:
In event_loop_overlap scheduling mode, when a request reaches its max_tokens limit, it cannot terminate early before the next batch starts. This causes redundant decode iterations because:
1. Batch N completes forward pass
2. Batch N+1 is prepared and started before batch N's results are processed
3. Requests that reached max_tokens in batch N are incorrectly included in batch N+1, wasting GPU compute

## Modifications

Add environment variable SGLANG_ENABLE_OVERLAP_EARLY_FINISH_CHECK (default: false) to enable early termination check in get_next_batch_to_run(). When enabled:
- Checks current output_ids length against max_new_tokens before batch preparation
- Marks requests with to_finish flag if they've reached the limit
- Filters them out to prevent inclusion in the next batch

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
