### PR TITLE
Fix/flashinfer prefix lens cpu sum

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1241,8 +1241,6 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
     ):
         if use_ragged:
-            # TODO: remove this device sync, we can use forward_batch.extend_prefix_lens_cpu
-            # and forward_batch.extend_seq_lens_cpu
             paged_kernel_lens = prefix_lens
             if prefix_lens_cpu is not None:
                 # Avoid CUDA sync from .item() by using CPU lengths when available.


### PR DESCRIPTION
## Motivation                                                                 
                 
  Addresses the existing TODO in                                                
  `FlashInferIndicesUpdaterPrefill.update_single_wrapper`: avoid a CUDA device
  sync caused by `prefix_lens.sum().item()` on the ragged prefill path. Calling 
  `.item()` on a CUDA tensor forces synchronization and can reduce CPU–GPU async
   overlap.

  ## Modifications

  - Thread `forward_batch.extend_prefix_lens_cpu` through the prefill updater
  call chain as `prefix_lens_cpu`.
  - When available, compute `paged_kernel_lens_sum = int(prefix_lens_cpu.sum())`
   on CPU, avoiding the CUDA sync.
  - Retain the original `.sum().item()` fallback when no CPU tensor is provided.
  - Remove resolved TODO comment.

  ## Accuracy Tests

  No change to model outputs. Same value computed, only on CPU instead of GPU.

  ## Benchmarking and Profiling

  **Profiling:** In a PyTorch profiler trace, cumulative `Tensor.item()` time on
   this path dropped from ~1.6s to ~0.32s.

  **Benchmark (no regression):** Qwen2.5-7B-Instruct on RTX 3090, `bench_serving
   --num-prompts 50`, 5 runs per branch:

  | Branch | Output tok/s | Mean TTFT (ms) | Mean ITL (ms) |
  |--------|-------------|----------------|---------------|
  | fix | 366.98 ± 0.78 | 156.20 ± 7.48 | 20.11 ± 0.03 |
  | main | 365.34 ± 0.29 | 162.03 ± 6.92 | 20.20 ± 0.04 |

  Differences within noise at this scale; primary goal is removing the avoidable
   sync.
