### PR TITLE
Merge stage-c-test-large-4-gpu suites into partitioned suites

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1106,92 +1106,6 @@ jobs:
         run: |
           IS_BLACKWELL=1 python3 -m pytest -q python/sglang/jit_kernel/tests/test_flash_attention_4.py
 
-  stage-c-test-large-4-gpu:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
-    if: |
-      always() &&
-      (
-        (inputs.target_stage == 'stage-c-test-large-4-gpu') ||
-        (
-          !inputs.target_stage &&
-          ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
-          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
-        )
-      )
-    runs-on: 4-gpu-h100
-    timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 4-gpu-h100
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          path: sgl-kernel/dist/
-          merge-multiple: true
-          pattern: wheel-python3.10-cuda12.9
-
-      - name: Install dependencies
-        timeout-minutes: 20
-        run: |
-          CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
-          python3 run_suite.py --hw cuda --suite stage-c-test-large-4-gpu $CONTINUE_ON_ERROR_FLAG
-
-  stage-c-test-large-4-gpu-b200:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
-    if: |
-      always() &&
-      (
-        (inputs.target_stage == 'stage-c-test-large-4-gpu-b200') ||
-        (
-          !inputs.target_stage &&
-          ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
-          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
-        )
-      )
-    runs-on: ${{ needs.check-changes.outputs.b200_runner }}
-    timeout-minutes: 240
-    env:
-      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
-        uses: actions/download-artifact@v6
-        with:
-          path: sgl-kernel/dist/
-          merge-multiple: true
-          pattern: wheel-python3.10-cuda12.9
-
-      - name: Install dependencies
-        timeout-minutes: 20
-        run: |
-          CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} IS_BLACKWELL=1 bash scripts/ci/cuda/ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          cd test/
-          IS_BLACKWELL=1 python3 run_suite.py --hw cuda --suite stage-c-test-large-4-gpu-b200
-
   multimodal-gen-test-1-gpu:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: |
@@ -1664,7 +1578,6 @@ jobs:
         stage-b-test-small-1-gpu,
         stage-b-test-large-1-gpu,
         stage-b-test-large-2-gpu,
-        stage-c-test-large-4-gpu,
         stage-b-test-4-gpu-b200,
         stage-c-test-4-gpu-h100,
         stage-c-test-8-gpu-h20,

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -256,8 +256,6 @@ def handle_rerun_stage(
         "stage-b-test-small-1-gpu",
         "stage-b-test-large-1-gpu",
         "stage-b-test-large-2-gpu",
-        "stage-c-test-large-4-gpu",
-        "stage-c-test-large-4-gpu-b200",
         "stage-c-test-4-gpu-h100",
         "stage-c-test-8-gpu-h200",
         "stage-c-test-8-gpu-h20",

--- a/test/README.md
+++ b/test/README.md
@@ -100,7 +100,8 @@ If a test cannot run on 5090 due to any of the above, use `stage-b-test-large-1-
 **Per-Commit (CUDA)**:
 - Stage A: `stage-a-test-1` (locked), `stage-a-test-2`, `stage-a-test-cpu`
 - Stage B: `stage-b-test-small-1-gpu` (5090), `stage-b-test-large-1-gpu` (H100), `stage-b-test-large-2-gpu`
-- Stage C: `stage-c-test-4-gpu-h100`, `stage-c-test-4-gpu-b200`, `stage-c-test-8-gpu-b200`
+- Stage C (4-GPU): `stage-c-test-4-gpu-h100`, `stage-c-test-4-gpu-b200`, `stage-c-test-4-gpu-gb200`, `stage-c-test-deepep-4-gpu`
+- Stage C (8-GPU): `stage-c-test-8-gpu-h20`, `stage-c-test-8-gpu-h200`, `stage-c-test-8-gpu-b200`, `stage-c-test-deepep-8-gpu-h200`
 
 **Per-Commit (AMD)**:
 - `stage-a-test-1`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`

--- a/test/README.md
+++ b/test/README.md
@@ -100,7 +100,7 @@ If a test cannot run on 5090 due to any of the above, use `stage-b-test-large-1-
 **Per-Commit (CUDA)**:
 - Stage A: `stage-a-test-1` (locked), `stage-a-test-2`, `stage-a-test-cpu`
 - Stage B: `stage-b-test-small-1-gpu` (5090), `stage-b-test-large-1-gpu` (H100), `stage-b-test-large-2-gpu`
-- Stage C: `stage-c-test-large-4-gpu`, `stage-c-test-large-4-gpu-b200`, `stage-c-test-large-8-gpu-b200`
+- Stage C: `stage-c-test-4-gpu-h100`, `stage-c-test-4-gpu-b200`, `stage-c-test-8-gpu-b200`
 
 **Per-Commit (AMD)**:
 - `stage-a-test-1`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`

--- a/test/registered/attention/test_local_attn.py
+++ b/test/registered/attention/test_local_attn.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
 )
 
 # Local attention with FA3 (requires SM 90+ / H100, tp=4)
-register_cuda_ci(est_time=200, suite="stage-c-test-large-4-gpu")
+register_cuda_ci(est_time=200, suite="stage-c-test-4-gpu-h100")
 
 
 @unittest.skipIf(get_device_sm() < 90, "Test requires CUDA SM 90 or higher")

--- a/test/registered/distributed/test_dp_attention_large.py
+++ b/test/registered/distributed/test_dp_attention_large.py
@@ -23,7 +23,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=350, suite="stage-c-test-large-4-gpu")
+register_cuda_ci(est_time=350, suite="stage-c-test-4-gpu-h100")
 
 
 class TestDPAttentionDP2TP4(

--- a/test/registered/moe/test_cutedsl_moe.py
+++ b/test/registered/moe/test_cutedsl_moe.py
@@ -12,7 +12,7 @@ from sglang.srt.layers.moe.flashinfer_cutedsl_moe import flashinfer_cutedsl_moe_
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=300, suite="stage-c-test-large-4-gpu-b200")
+register_cuda_ci(est_time=300, suite="stage-c-test-4-gpu-b200")
 
 SKIP_TEST = torch.cuda.get_device_capability() < (10, 0)
 SKIP_REASON = "Nvfp4 Requires compute capability of 10 or above."

--- a/test/registered/rl/test_return_routed_experts.py
+++ b/test/registered/rl/test_return_routed_experts.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=360, suite="stage-c-test-large-4-gpu")
+register_cuda_ci(est_time=360, suite="stage-c-test-4-gpu-h100")
 
 SHAREGPT_URL = (
     "https://huggingface.co/datasets/anon8231489123/"

--- a/test/registered/spec/eagle/test_eagle_dp_attention.py
+++ b/test/registered/spec/eagle/test_eagle_dp_attention.py
@@ -20,7 +20,7 @@ from sglang.test.test_utils import (
 )
 
 # EAGLE3 with DP attention (tp=2, dp=2, requires 4 GPUs)
-register_cuda_ci(est_time=200, suite="stage-c-test-large-4-gpu")
+register_cuda_ci(est_time=200, suite="stage-c-test-4-gpu-h100")
 
 
 class TestEAGLE3EngineDPAttention(CustomTestCase):

--- a/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 )
 
 # EAGLE with DP attention on B200 (tp=2, dp=2, requires 4 B200 GPUs)
-register_cuda_ci(est_time=300, suite="stage-c-test-large-4-gpu-b200")
+register_cuda_ci(est_time=300, suite="stage-c-test-4-gpu-b200")
 
 
 def test_gsm8k(base_url: str):

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -32,7 +32,6 @@ PER_COMMIT_SUITES = {
         "stage-b-test-small-1-gpu",
         "stage-b-test-large-1-gpu",
         "stage-b-test-large-2-gpu",
-        "stage-c-test-large-4-gpu",
         "stage-c-test-4-gpu-h100",
         "stage-c-test-4-gpu-b200",
         "stage-c-test-4-gpu-gb200",


### PR DESCRIPTION
## Summary
- Consolidate non-partitioned 4-GPU test suites into their partitioned counterparts
- `stage-c-test-large-4-gpu` → `stage-c-test-4-gpu-h100`
- `stage-c-test-large-4-gpu-b200` → `stage-c-test-4-gpu-b200`

**Tests migrated to stage-c-test-4-gpu-h100:**
| Test | Est. Time |
|------|-----------|
| test_return_routed_experts.py | 360s |
| test_eagle_dp_attention.py | 200s |
| test_dp_attention_large.py | 350s |
| test_local_attn.py | 200s |
| **Total** | **1110s** |

**Tests migrated to stage-c-test-4-gpu-b200:**
| Test | Est. Time |
|------|-----------|
| test_cutedsl_moe.py | 300s |
| test_eagle_infer_beta_dp_attention.py | 300s |
| **Total** | **600s** |

Both target suites already use 3-way auto-partitioning, so tests will be distributed automatically.

## Test plan
- [ ] CI passes for `stage-c-test-4-gpu-h100` 
- [ ] CI passes for `stage-c-test-4-gpu-b200`