### PR TITLE
[MXFP8] Speedup MXFP8 gemm via cuBLAS

### DIFF
--- a/benchmark/kernels/quantization/bench_mxfp8_gemm.py
+++ b/benchmark/kernels/quantization/bench_mxfp8_gemm.py
@@ -1,0 +1,265 @@
+# Copyright 2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+Benchmark for MXFP8 block-scaled matrix multiplication.
+
+This benchmarks the triton MXFP8 kernels used for Blackwell GPUs (SM100+).
+Tests both the optimized TensorDescriptor kernel (N >= 128) and the simple
+tl.load kernel (N < 128).
+
+Usage:
+    python bench_mxfp8_gemm.py
+"""
+
+import numpy as np
+import torch
+from flashinfer.testing import bench_gpu_time
+
+from sglang.srt.utils import is_sm100_supported
+
+
+def check_sm100():
+    if not is_sm100_supported():
+        print("MXFP8 requires Blackwell GPUs (SM100+). Skipping benchmark.")
+        return False
+    return True
+
+
+def get_mxfp8_functions():
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        mxfp8_block_scaled_matmul_triton,
+        mxfp8_block_scaled_matmul_triton_simple,
+    )
+    from sglang.srt.layers.quantization.fp8_utils import (
+        _pack_mxfp8_scales,
+        mxfp8_group_quantize,
+    )
+
+    return (
+        mxfp8_block_scaled_matmul_triton,
+        mxfp8_block_scaled_matmul_triton_simple,
+        _pack_mxfp8_scales,
+        mxfp8_group_quantize,
+    )
+
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def bench_mxfp8_optimized(M, N, K):
+    """Benchmark optimized MXFP8 GEMM using TensorDescriptor (requires N >= 128)."""
+    (
+        mxfp8_block_scaled_matmul_triton,
+        _,
+        _pack_mxfp8_scales,
+        mxfp8_group_quantize,
+    ) = get_mxfp8_functions()
+
+    x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+    x_fp8, x_scale = mxfp8_group_quantize(x)
+    w_fp8, w_scale = mxfp8_group_quantize(w)
+
+    # Pad M if needed
+    block_m = 128
+    if M % block_m != 0:
+        pad_rows = ceil_div(M, block_m) * block_m - M
+        x_fp8 = torch.cat(
+            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)],
+            dim=0,
+        )
+        x_scale = torch.cat(
+            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)],
+            dim=0,
+        )
+
+    a_scale_packed = _pack_mxfp8_scales(x_scale)
+    b_scale_packed = _pack_mxfp8_scales(w_scale)
+    w_fp8_c = w_fp8.contiguous()
+    block_n = 256 if N % 256 == 0 else 128
+
+    def run(x_fp8, a_scale_packed, w_fp8, b_scale_packed):
+        return mxfp8_block_scaled_matmul_triton(
+            x_fp8, a_scale_packed, w_fp8, b_scale_packed,
+            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
+        )
+
+    measurements = bench_gpu_time(
+        run,
+        input_args=(x_fp8, a_scale_packed, w_fp8_c, b_scale_packed),
+        use_cuda_graph=True,
+    )
+    ms = np.median(measurements)
+    tflops = 2 * M * N * K * 1e-9 / ms
+    return ms, tflops
+
+
+def bench_mxfp8_simple(M, N, K):
+    """Benchmark simple MXFP8 GEMM using tl.load (works with any N)."""
+    (
+        _,
+        mxfp8_block_scaled_matmul_triton_simple,
+        _,
+        mxfp8_group_quantize,
+    ) = get_mxfp8_functions()
+
+    x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+    x_fp8, x_scale = mxfp8_group_quantize(x)
+    w_fp8, w_scale = mxfp8_group_quantize(w)
+
+    # Pad M if needed
+    block_m = 128
+    if M % block_m != 0:
+        pad_rows = ceil_div(M, block_m) * block_m - M
+        x_fp8 = torch.cat(
+            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)],
+            dim=0,
+        )
+        x_scale = torch.cat(
+            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)],
+            dim=0,
+        )
+
+    if N <= 64:
+        block_n = N if N in [16, 32, 64] else 64
+    else:
+        block_n = 64
+
+    w_fp8_c = w_fp8.contiguous()
+    w_scale_c = w_scale.contiguous()
+
+    def run(x_fp8, x_scale, w_fp8, w_scale):
+        return mxfp8_block_scaled_matmul_triton_simple(
+            x_fp8, x_scale, w_fp8, w_scale,
+            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
+        )
+
+    measurements = bench_gpu_time(
+        run,
+        input_args=(x_fp8, x_scale, w_fp8_c, w_scale_c),
+        use_cuda_graph=True,
+    )
+    ms = np.median(measurements)
+    tflops = 2 * M * N * K * 1e-9 / ms
+    return ms, tflops
+
+
+def bench_bf16(M, N, K):
+    """Benchmark BF16 matmul reference."""
+    x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+    w_t = w.T.contiguous()
+
+    def run(x, w_t):
+        return torch.matmul(x, w_t)
+
+    measurements = bench_gpu_time(
+        run,
+        input_args=(x, w_t),
+        use_cuda_graph=True,
+    )
+    ms = np.median(measurements)
+    tflops = 2 * M * N * K * 1e-9 / ms
+    return ms, tflops
+
+
+def test_accuracy():
+    """Test accuracy of MXFP8 kernels."""
+    (
+        mxfp8_block_scaled_matmul_triton,
+        mxfp8_block_scaled_matmul_triton_simple,
+        _pack_mxfp8_scales,
+        mxfp8_group_quantize,
+    ) = get_mxfp8_functions()
+
+    shapes = [(1, 128, 4096), (128, 128, 4096), (128, 4096, 4096), (256, 4096, 14336)]
+
+    print("Running accuracy tests...")
+    for M, N, K in shapes:
+        x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+        w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+        x_fp8, x_scale = mxfp8_group_quantize(x)
+        w_fp8, w_scale = mxfp8_group_quantize(w)
+
+        # Pad M
+        block_m = 128
+        if M % block_m != 0:
+            pad_rows = ceil_div(M, block_m) * block_m - M
+            x_fp8_pad = torch.cat([x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)], dim=0)
+            x_scale_pad = torch.cat([x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)], dim=0)
+        else:
+            x_fp8_pad, x_scale_pad = x_fp8, x_scale
+
+        # Simple kernel
+        block_n = 64
+        out_simple = mxfp8_block_scaled_matmul_triton_simple(
+            x_fp8_pad, x_scale_pad, w_fp8.contiguous(), w_scale.contiguous(),
+            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
+        )[:M, :]
+
+        # Optimized kernel
+        a_scale_packed = _pack_mxfp8_scales(x_scale_pad)
+        b_scale_packed = _pack_mxfp8_scales(w_scale)
+        block_n_opt = 256 if N % 256 == 0 else 128
+        out_opt = mxfp8_block_scaled_matmul_triton(
+            x_fp8_pad, a_scale_packed, w_fp8.contiguous(), b_scale_packed,
+            output_dtype=torch.bfloat16, block_m=128, block_n=block_n_opt, block_k=128,
+        )[:M, :]
+
+        # They should be identical
+        torch.testing.assert_close(out_opt, out_simple, atol=0, rtol=0)
+        print(f"  M={M}, N={N}, K={K}: OK")
+
+    print("All accuracy tests passed!\n")
+
+
+# Benchmark shapes: (M, N, K, description)
+SHAPES = [
+    # Small N (simple kernel only)
+    (1, 64, 4096, "decode bs=1, small N"),
+    (128, 64, 4096, "decode bs=128, small N"),
+    # Large N (both kernels)
+    (1, 4096, 4096, "decode bs=1"),
+    (32, 4096, 4096, "decode bs=32"),
+    (128, 4096, 4096, "decode bs=128"),
+    (512, 4096, 4096, "prefill"),
+    (1, 14336, 4096, "MLP up proj bs=1"),
+    (128, 14336, 4096, "MLP up proj bs=128"),
+]
+
+
+if __name__ == "__main__":
+    if not check_sm100():
+        exit(0)
+
+    test_accuracy()
+
+    print(f"{'Shape':<35} {'Kernel':<12} {'Time (us)':<12} {'TFLOPS':<10}")
+    print("=" * 75)
+
+    for M, N, K, desc in SHAPES:
+        shape_str = f"M={M}, N={N}, K={K}"
+
+        if N >= 128:
+            ms_opt, tflops_opt = bench_mxfp8_optimized(M, N, K)
+            print(f"{shape_str:<35} {'optimized':<12} {ms_opt*1000:<12.2f} {tflops_opt:<10.2f}")
+
+        ms_simple, tflops_simple = bench_mxfp8_simple(M, N, K)
+        print(f"{shape_str:<35} {'simple':<12} {ms_simple*1000:<12.2f} {tflops_simple:<10.2f}")
+
+        ms_bf16, tflops_bf16 = bench_bf16(M, N, K)
+        print(f"{shape_str:<35} {'bf16':<12} {ms_bf16*1000:<12.2f} {tflops_bf16:<10.2f}")
+        print()

--- a/benchmark/kernels/quantization/bench_mxfp8_gemm.py
+++ b/benchmark/kernels/quantization/bench_mxfp8_gemm.py
@@ -14,8 +14,9 @@
 """
 Benchmark for MXFP8 block-scaled matrix multiplication.
 
-Compares baseline tutorial kernel vs improved kernel with GROUP_SIZE_M
-swizzling and tuned num_warps/num_stages.
+Strategies tested:
+  - Baseline: Tutorial kernel from sglang (simple linear pid mapping)
+  - Split-K: Split K dimension across blocks for increased SM occupancy
 
 Usage:
     python bench_mxfp8_gemm.py
@@ -40,7 +41,7 @@ from sglang.srt.utils import is_sm100_supported
 
 def check_sm100():
     if not is_sm100_supported():
-        print("MXFP8 requires Blackwell GPUs (SM100+). Skipping benchmark.", file=sys.stderr)
+        print("MXFP8 requires Blackwell GPUs (SM100+).", file=sys.stderr)
         return False
     return True
 
@@ -53,7 +54,6 @@ def get_mxfp8_functions():
         _pack_mxfp8_scales,
         mxfp8_group_quantize,
     )
-
     return (
         mxfp8_block_scaled_matmul_triton,
         _pack_mxfp8_scales,
@@ -66,47 +66,34 @@ def ceil_div(a, b):
 
 
 # ---------------------------------------------------------------------------
-# Improved MXFP8 kernel with GROUP_SIZE_M swizzling
+# Split-K MXFP8 kernel
 # ---------------------------------------------------------------------------
 
 @triton.jit
-def _mxfp8_matmul_kernel_v2(
+def _mxfp8_matmul_splitk_kernel(
     a_desc,
     a_scale_desc,
     b_desc,
     b_scale_desc,
-    c_desc,
-    M: tl.constexpr,
-    N: tl.constexpr,
-    K: tl.constexpr,
-    output_type: tl.constexpr,
+    partial_ptr,
+    stride_partial_sk,
+    stride_partial_m,
+    num_pid_m,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     rep_m: tl.constexpr,
     rep_n: tl.constexpr,
     rep_k: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
+    K_ITERS_PER_SPLIT: tl.constexpr,
     NUM_STAGES: tl.constexpr,
+    SWAP_AB: tl.constexpr,
 ):
-    if output_type == 0:
-        output_dtype = tl.float32
-    elif output_type == 1:
-        output_dtype = tl.float16
-    elif output_type == 2:
-        output_dtype = tl.bfloat16
-
     pid = tl.program_id(axis=0)
-    num_pid_m = tl.cdiv(M, BLOCK_M)
-    num_pid_n = tl.cdiv(N, BLOCK_N)
+    split_k_id = tl.program_id(axis=1)
 
-    # GROUP_SIZE_M swizzling for L2 cache locality
-    num_pid_in_group = GROUP_SIZE_M * num_pid_n
-    group_id = pid // num_pid_in_group
-    first_pid_m = group_id * GROUP_SIZE_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-    pid_m = first_pid_m + (pid % group_size_m)
-    pid_n = (pid % num_pid_in_group) // group_size_m
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
 
     offs_am = pid_m * BLOCK_M
     offs_bn = pid_n * BLOCK_N
@@ -114,9 +101,15 @@ def _mxfp8_matmul_kernel_v2(
     offs_scale_n = pid_n * rep_n
 
     VEC_SIZE: tl.constexpr = 32
+    k_start = split_k_id * K_ITERS_PER_SPLIT
 
-    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES):
+    if SWAP_AB:
+        accumulator = tl.zeros((BLOCK_N, BLOCK_M), dtype=tl.float32)
+    else:
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_offset in tl.range(0, K_ITERS_PER_SPLIT, num_stages=NUM_STAGES):
+        k = k_start + k_offset
         a = a_desc.load([offs_am, k * BLOCK_K])
         b = b_desc.load([offs_bn, k * BLOCK_K])
         scale_a = a_scale_desc.load([0, offs_scale_m, k * rep_k, 0, 0])
@@ -133,30 +126,58 @@ def _mxfp8_matmul_kernel_v2(
             .reshape(BLOCK_N, BLOCK_K // VEC_SIZE)
         )
 
-        accumulator = tl.dot_scaled(
-            a, scale_a, "e4m3", b.T, scale_b, "e4m3", accumulator
-        )
+        if SWAP_AB:
+            # b (BLOCK_N, BLOCK_K) as LHS, a.T (BLOCK_K, BLOCK_M) as RHS
+            accumulator = tl.dot_scaled(
+                b, scale_b, "e4m3", a.T, scale_a, "e4m3", accumulator
+            )
+        else:
+            accumulator = tl.dot_scaled(
+                a, scale_a, "e4m3", b.T, scale_b, "e4m3", accumulator
+            )
 
-    c_desc.store([offs_am, offs_bn], accumulator.to(output_dtype))
+    if SWAP_AB:
+        accumulator = tl.trans(accumulator, (1, 0))
+
+    # Pointer-based store to fp32 partial buffer
+    offs_m = offs_am + tl.arange(0, BLOCK_M)
+    offs_n = offs_bn + tl.arange(0, BLOCK_N)
+    partial_ptrs = (
+        partial_ptr
+        + split_k_id * stride_partial_sk
+        + offs_m[:, None] * stride_partial_m
+        + offs_n[None, :]
+    )
+    tl.store(partial_ptrs, accumulator)
 
 
-def mxfp8_matmul_v2(
+def should_swap_ab_mxfp8(M, N, K, block_m=128, block_n=256, block_k=128,
+                          target_sms=192):
+    """Swap A/B when BLOCK_N > BLOCK_M and there are few tiles (small M, large K).
+
+    Only beneficial when split-K is also used, on shapes with low SM occupancy.
+    """
+    if block_n <= block_m:
+        return False
+    tiles = ceil_div(M, block_m) * ceil_div(N, block_n)
+    k_iters = K // block_k
+    # Only swap when: few tiles (need split-K) and enough K to split
+    return tiles < target_sms and k_iters >= 16
+
+
+def mxfp8_matmul_splitk(
     a, a_scale, b, b_scale, output_dtype,
     *, block_m=128, block_n=256, block_k=128,
-    num_stages=4, group_size_m=8, num_warps=4,
+    num_stages=4, num_warps=4, split_k=2, swap_ab=False,
 ):
     M, K = a.shape
     N, K_b = b.shape
     assert K == K_b
 
-    if output_dtype == torch.float32:
-        output_type = 0
-    elif output_dtype == torch.float16:
-        output_type = 1
-    elif output_dtype == torch.bfloat16:
-        output_type = 2
-    else:
-        raise ValueError(f"Unsupported output dtype: {output_dtype}")
+    k_iters = K // block_k
+    assert k_iters % split_k == 0, \
+        f"K iters ({k_iters}) not divisible by split_k ({split_k})"
+    k_iters_per_split = k_iters // split_k
 
     rep_m = block_m // 128
     rep_n = block_n // 128
@@ -164,19 +185,29 @@ def mxfp8_matmul_v2(
 
     a_desc = TensorDescriptor.from_tensor(a, [block_m, block_k])
     b_desc = TensorDescriptor.from_tensor(b, [block_n, block_k])
-    a_scale_desc = TensorDescriptor.from_tensor(a_scale, block_shape=[1, rep_m, rep_k, 2, 256])
-    b_scale_desc = TensorDescriptor.from_tensor(b_scale, block_shape=[1, rep_n, rep_k, 2, 256])
-
-    output = torch.empty((M, N), dtype=output_dtype, device=a.device)
-    c_desc = TensorDescriptor.from_tensor(output, [block_m, block_n])
-
-    grid = (triton.cdiv(M, block_m) * triton.cdiv(N, block_n), 1)
-    _mxfp8_matmul_kernel_v2[grid](
-        a_desc, a_scale_desc, b_desc, b_scale_desc, c_desc,
-        M, N, K, output_type,
-        block_m, block_n, block_k, rep_m, rep_n, rep_k,
-        group_size_m, num_stages, num_warps=num_warps,
+    a_scale_desc = TensorDescriptor.from_tensor(
+        a_scale, block_shape=[1, rep_m, rep_k, 2, 256]
     )
+    b_scale_desc = TensorDescriptor.from_tensor(
+        b_scale, block_shape=[1, rep_n, rep_k, 2, 256]
+    )
+
+    num_pid_m = triton.cdiv(M, block_m)
+    num_pid_n = triton.cdiv(N, block_n)
+
+    partial = torch.empty((split_k, M, N), dtype=torch.float32, device=a.device)
+
+    grid = (num_pid_m * num_pid_n, split_k)
+    _mxfp8_matmul_splitk_kernel[grid](
+        a_desc, a_scale_desc, b_desc, b_scale_desc,
+        partial, partial.stride(0), partial.stride(1),
+        num_pid_m,
+        block_m, block_n, block_k, rep_m, rep_n, rep_k,
+        k_iters_per_split, num_stages, swap_ab,
+        num_warps=num_warps,
+    )
+
+    output = partial.sum(dim=0).to(output_dtype)
     return output
 
 
@@ -186,7 +217,6 @@ def mxfp8_matmul_v2(
 
 def prepare_mxfp8_inputs(M, N, K):
     (_, _pack_mxfp8_scales, mxfp8_group_quantize) = get_mxfp8_functions()
-
     x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
     w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
     x_fp8, x_scale = mxfp8_group_quantize(x)
@@ -196,10 +226,12 @@ def prepare_mxfp8_inputs(M, N, K):
     if M % block_m != 0:
         pad_rows = ceil_div(M, block_m) * block_m - M
         x_fp8 = torch.cat(
-            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)], dim=0,
+            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)],
+            dim=0,
         )
         x_scale = torch.cat(
-            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)], dim=0,
+            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)],
+            dim=0,
         )
 
     a_scale_packed = _pack_mxfp8_scales(x_scale)
@@ -239,11 +271,71 @@ def bench_bf16(M, N, K):
     return ms, tflops
 
 
-def test_accuracy_v2():
-    (mxfp8_block_scaled_matmul_triton, _pack_mxfp8_scales, mxfp8_group_quantize) = get_mxfp8_functions()
+def bench_torch_scaled_mm(M, N, K):
+    """Benchmark torch._scaled_mm with MXFP8 (cuBLAS path)."""
+    (_, _pack_mxfp8_scales, mxfp8_group_quantize) = get_mxfp8_functions()
+    x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
+    x_fp8, x_scale = mxfp8_group_quantize(x)
+    w_fp8, w_scale = mxfp8_group_quantize(w)
 
-    shapes = [(128, 128, 4096), (128, 4096, 4096), (256, 4096, 14336), (512, 8192, 8192)]
-    print("Running v2 accuracy tests...", file=sys.stderr)
+    # Pack scales into cuBLAS interleaved layout (same as tl.dot_scaled layout)
+    sa = _pack_mxfp8_scales(x_scale).reshape(M, K // 32).view(torch.float8_e8m0fnu)
+    sb = _pack_mxfp8_scales(w_scale).reshape(N, K // 32).view(torch.float8_e8m0fnu)
+    w_fp8_t = w_fp8.t()  # column-major for cuBLAS
+
+    def run(x_fp8, w_fp8_t, sa, sb):
+        return torch._scaled_mm(
+            x_fp8, w_fp8_t, scale_a=sa, scale_b=sb, out_dtype=torch.bfloat16,
+        )
+
+    measurements = bench_gpu_time(
+        run, input_args=(x_fp8, w_fp8_t, sa, sb), use_cuda_graph=True,
+    )
+    ms = np.median(measurements)
+    tflops = 2 * M * N * K * 1e-9 / ms
+    return ms, tflops
+
+
+def valid_split_k_values(K, block_k=128, max_split_k=16):
+    k_iters = K // block_k
+    return [sk for sk in [1, 2, 3, 4, 6, 8, 16] if sk <= max_split_k and k_iters % sk == 0]
+
+
+def pick_split_k(M, N, K, block_m=128, block_n=256, block_k=128,
+                  target_sms=192, min_k_iters_per_split=8):
+    """Heuristic: pick smallest split_k so tiles * split_k >= target_sms.
+
+    Only splits when each partition has enough K iterations (≥min_k_iters_per_split)
+    to amortize the reduction overhead.
+    """
+    tiles = ceil_div(M, block_m) * ceil_div(N, block_n)
+    k_iters = K // block_k
+    if tiles >= target_sms or k_iters < min_k_iters_per_split * 2:
+        return 1
+    for sk in [1, 2, 3, 4, 6, 8, 16]:
+        if k_iters % sk != 0:
+            continue
+        if k_iters // sk < min_k_iters_per_split:
+            continue
+        if tiles * sk >= target_sms:
+            return sk
+    # Return max valid split_k that respects min_k_iters
+    valid = [sk for sk in [1, 2, 3, 4, 6, 8, 16]
+             if k_iters % sk == 0 and k_iters // sk >= min_k_iters_per_split]
+    return valid[-1] if valid else 1
+
+
+def test_accuracy_splitk():
+    (mxfp8_block_scaled_matmul_triton, _pack_mxfp8_scales, mxfp8_group_quantize) = (
+        get_mxfp8_functions()
+    )
+
+    shapes = [
+        (128, 128, 4096), (128, 4096, 4096),
+        (256, 4096, 8192), (512, 8192, 8192),
+    ]
+    print("Running split-K + swap_ab accuracy tests...", file=sys.stderr)
     for M, N, K in shapes:
         x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
         w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
@@ -258,29 +350,30 @@ def test_accuracy_v2():
             x_fp8, a_scale_packed, w_fp8_c, b_scale_packed,
             output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
         )
-        for gsm in [4, 8]:
-            for nw in [4, 8]:
-                out_v2 = mxfp8_matmul_v2(
+        for sab in [False, True]:
+            for sk in valid_split_k_values(K):
+                if sk == 1 and not sab:
+                    continue
+                out_sk = mxfp8_matmul_splitk(
                     x_fp8, a_scale_packed, w_fp8_c, b_scale_packed,
                     output_dtype=torch.bfloat16,
                     block_m=128, block_n=block_n, block_k=128,
-                    group_size_m=gsm, num_warps=nw,
+                    split_k=sk, swap_ab=sab,
                 )
-                assert torch.isfinite(out_v2).all(), f"NaN/Inf at M={M},N={N},K={K},gsm={gsm},nw={nw}"
-                assert torch.equal(out_baseline, out_v2), \
-                    f"Mismatch at M={M},N={N},K={K},gsm={gsm},nw={nw}: max_diff={(out_baseline-out_v2).abs().max().item()}"
+                assert torch.isfinite(out_sk).all(), \
+                    f"NaN/Inf at M={M},N={N},K={K},sk={sk},sab={sab}"
+                abs_diff = (out_baseline.float() - out_sk.float()).abs()
+                max_val = out_baseline.float().abs().max().item()
+                rel_diff = abs_diff.max().item() / max(max_val, 1e-6)
+                assert rel_diff < 0.02, \
+                    f"Mismatch M={M},N={N},K={K},sk={sk},sab={sab}: rel={rel_diff:.4f}"
         print(f"  M={M},N={N},K={K}: OK", file=sys.stderr)
-    print("All v2 accuracy tests passed!\n", file=sys.stderr)
+    print("All accuracy tests passed!\n", file=sys.stderr)
 
 
-# Configs to sweep
-V2_CONFIGS = [
-    (gsm, ns, nw)
-    for gsm in [4, 8, 16]
-    for ns in [2, 3, 4]
-    for nw in [4, 8]
-]
-
+# ---------------------------------------------------------------------------
+# Shapes
+# ---------------------------------------------------------------------------
 Ms = [128, 256, 512, 1024, 2048, 4096]
 Ns = [128, 256, 512, 1024, 1536, 2048, 4096, 8192]
 Ks = [768, 2048, 4096, 8192]
@@ -290,70 +383,131 @@ if __name__ == "__main__":
     if not check_sm100():
         exit(0)
 
-    test_accuracy_v2()
+    torch_only = "--torch-only" in sys.argv
+
+    if torch_only:
+        # Only benchmark torch._scaled_mm (cuBLAS MXFP8 path)
+        print("# torch._scaled_mm MXFP8 benchmark (cuBLAS)", file=sys.stderr)
+        print(
+            "M,N,K,torch_us,torch_tflops,bf16_us,bf16_tflops,"
+            "torch_vs_bf16"
+        )
+        for K in Ks:
+            for N in Ns:
+                for M in Ms:
+                    ms_torch, tflops_torch = bench_torch_scaled_mm(M, N, K)
+                    ms_bf16, tflops_bf16 = bench_bf16(M, N, K)
+                    torch_vs_bf16 = ms_bf16 / ms_torch
+                    print(
+                        f"{M},{N},{K},"
+                        f"{ms_torch*1000:.2f},{tflops_torch:.2f},"
+                        f"{ms_bf16*1000:.2f},{tflops_bf16:.2f},"
+                        f"{torch_vs_bf16:.3f}"
+                    )
+                print(f"  K={K},N={N} done", file=sys.stderr)
+        exit(0)
+
+    test_accuracy_splitk()
 
     (mxfp8_block_scaled_matmul_triton, _, _) = get_mxfp8_functions()
 
-    # Phase 1: Config sweep
-    print("# Phase 1: Config sweep", file=sys.stderr)
-    print("M,N,K,baseline_us,best_v2_us,v2_vs_base,best_gsm,best_stages,best_warps")
+    # Phase 1: Split-K + swap_ab sweep on representative shapes
+    print("# Phase 1: Split-K + swap_ab sweep", file=sys.stderr)
+    print("M,N,K,baseline_us,best_us,speedup,best_sk,best_sab,tiles_base,tiles_best")
 
     sweep_shapes = [
-        (128, 4096, 8192), (256, 4096, 8192), (512, 4096, 4096),
-        (512, 8192, 8192), (1024, 2048, 4096), (1024, 4096, 4096),
-        (2048, 4096, 4096), (2048, 8192, 8192), (4096, 4096, 4096),
-        (4096, 8192, 8192),
+        (128, 4096, 8192), (128, 8192, 8192),
+        (256, 4096, 8192), (256, 8192, 8192),
+        (512, 4096, 4096), (512, 8192, 8192),
+        (1024, 4096, 4096), (1024, 8192, 8192),
+        (2048, 4096, 4096), (2048, 8192, 8192),
+        (4096, 4096, 4096), (4096, 8192, 8192),
     ]
 
+    # (split_k, swap_ab) -> best config per shape
     best_configs = {}
     for M, N, K in sweep_shapes:
         block_n = 256 if N % 256 == 0 else 128
-        ms_base, _ = bench_kernel(M, N, K, mxfp8_block_scaled_matmul_triton,
-                                   block_m=128, block_n=block_n, block_k=128)
+        tiles_base = ceil_div(M, 128) * ceil_div(N, block_n)
+        ms_base, _ = bench_kernel(
+            M, N, K, mxfp8_block_scaled_matmul_triton,
+            block_m=128, block_n=block_n, block_k=128,
+        )
 
-        best_ms = float('inf')
-        best_cfg = None
-        for gsm, ns, nw in V2_CONFIGS:
-            ms_v2, _ = bench_kernel(M, N, K, mxfp8_matmul_v2,
-                                     block_m=128, block_n=block_n, block_k=128,
-                                     num_stages=ns, group_size_m=gsm, num_warps=nw)
-            if ms_v2 < best_ms:
-                best_ms = ms_v2
-                best_cfg = (gsm, ns, nw)
+        best_ms = ms_base
+        best_sk = 1
+        best_sab = False
+        for sab in [False, True]:
+            for sk in valid_split_k_values(K):
+                if sk == 1 and not sab:
+                    continue
+                ms_sk, _ = bench_kernel(
+                    M, N, K, mxfp8_matmul_splitk,
+                    block_m=128, block_n=block_n, block_k=128,
+                    split_k=sk, swap_ab=sab,
+                )
+                if ms_sk < best_ms:
+                    best_ms = ms_sk
+                    best_sk = sk
+                    best_sab = sab
 
-        ratio = best_ms / ms_base
-        print(f"{M},{N},{K},{ms_base*1000:.2f},{best_ms*1000:.2f},{ratio:.3f},{best_cfg[0]},{best_cfg[1]},{best_cfg[2]}")
-        best_configs[(M, N, K)] = best_cfg
-        print(f"  {M}x{N}x{K} done", file=sys.stderr)
+        tiles_best = tiles_base * best_sk
+        speedup = ms_base / best_ms
+        sab_str = "T" if best_sab else "F"
+        print(
+            f"{M},{N},{K},{ms_base*1000:.2f},{best_ms*1000:.2f},"
+            f"{speedup:.3f},{best_sk},{sab_str},{tiles_base},{tiles_best}"
+        )
+        best_configs[(M, N, K)] = (best_sk, best_sab)
+        print(
+            f"  {M}x{N}x{K} done (sk={best_sk},sab={best_sab})",
+            file=sys.stderr,
+        )
 
-    # Phase 2: Full comparison
+    # Phase 2: Full comparison using heuristic split-K + swap_ab
     print(file=sys.stderr)
     print("# Phase 2: Full comparison", file=sys.stderr)
     print()
-    print("M,N,K,baseline_us,v2_us,bf16_us,baseline_tflops,v2_tflops,bf16_tflops,v2_vs_base,v2_speedup_vs_bf16")
-
-    default_cfg = (8, 3, 4)
+    print(
+        "M,N,K,baseline_us,best_us,bf16_us,"
+        "baseline_tflops,best_tflops,bf16_tflops,"
+        "best_vs_base,best_vs_bf16,split_k,swap_ab"
+    )
 
     for K in Ks:
         for N in Ns:
             for M in Ms:
                 block_n = 256 if N % 256 == 0 else 128
+
                 ms_base, tflops_base = bench_kernel(
                     M, N, K, mxfp8_block_scaled_matmul_triton,
-                    block_m=128, block_n=block_n, block_k=128)
+                    block_m=128, block_n=block_n, block_k=128,
+                )
                 ms_bf16, tflops_bf16 = bench_bf16(M, N, K)
 
-                cfg = best_configs.get((M, N, K), default_cfg)
-                gsm, ns, nw = cfg
-                ms_v2, tflops_v2 = bench_kernel(
-                    M, N, K, mxfp8_matmul_v2,
-                    block_m=128, block_n=block_n, block_k=128,
-                    num_stages=ns, group_size_m=gsm, num_warps=nw)
+                # Use Phase 1 result if available, else heuristic
+                if (M, N, K) in best_configs:
+                    sk, sab = best_configs[(M, N, K)]
+                else:
+                    sk = pick_split_k(M, N, K, block_n=block_n)
+                    sab = should_swap_ab_mxfp8(M, N, K, block_n=block_n)
 
-                v2_vs_base = ms_v2 / ms_base
-                v2_vs_bf16 = ms_bf16 / ms_v2
+                if sk <= 1 and not sab:
+                    ms_best, tflops_best = ms_base, tflops_base
+                else:
+                    ms_best, tflops_best = bench_kernel(
+                        M, N, K, mxfp8_matmul_splitk,
+                        block_m=128, block_n=block_n, block_k=128,
+                        split_k=max(sk, 1), swap_ab=sab,
+                    )
 
-                print(f"{M},{N},{K},{ms_base*1000:.2f},{ms_v2*1000:.2f},{ms_bf16*1000:.2f},"
-                      f"{tflops_base:.2f},{tflops_v2:.2f},{tflops_bf16:.2f},"
-                      f"{v2_vs_base:.3f},{v2_vs_bf16:.2f}")
+                best_vs_base = ms_base / ms_best
+                best_vs_bf16 = ms_bf16 / ms_best
+                sab_str = "T" if sab else "F"
+
+                print(
+                    f"{M},{N},{K},{ms_base*1000:.2f},{ms_best*1000:.2f},{ms_bf16*1000:.2f},"
+                    f"{tflops_base:.2f},{tflops_best:.2f},{tflops_bf16:.2f},"
+                    f"{best_vs_base:.3f},{best_vs_bf16:.2f},{sk},{sab_str}"
+                )
             print(f"  K={K},N={N} done", file=sys.stderr)

--- a/benchmark/kernels/quantization/bench_mxfp8_gemm.py
+++ b/benchmark/kernels/quantization/bench_mxfp8_gemm.py
@@ -14,16 +14,25 @@
 """
 Benchmark for MXFP8 block-scaled matrix multiplication.
 
-This benchmarks the triton MXFP8 kernels used for Blackwell GPUs (SM100+).
-Tests both the optimized TensorDescriptor kernel (N >= 128) and the simple
-tl.load kernel (N < 128).
+Compares baseline tutorial kernel vs improved kernel with GROUP_SIZE_M
+swizzling and tuned num_warps/num_stages.
 
 Usage:
     python bench_mxfp8_gemm.py
 """
 
+import sys
+
 import numpy as np
 import torch
+import triton
+import triton.language as tl
+
+try:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+except Exception:
+    pass
+
 from flashinfer.testing import bench_gpu_time
 
 from sglang.srt.utils import is_sm100_supported
@@ -31,7 +40,7 @@ from sglang.srt.utils import is_sm100_supported
 
 def check_sm100():
     if not is_sm100_supported():
-        print("MXFP8 requires Blackwell GPUs (SM100+). Skipping benchmark.")
+        print("MXFP8 requires Blackwell GPUs (SM100+). Skipping benchmark.", file=sys.stderr)
         return False
     return True
 
@@ -39,7 +48,6 @@ def check_sm100():
 def get_mxfp8_functions():
     from sglang.srt.layers.quantization.fp8_kernel import (
         mxfp8_block_scaled_matmul_triton,
-        mxfp8_block_scaled_matmul_triton_simple,
     )
     from sglang.srt.layers.quantization.fp8_utils import (
         _pack_mxfp8_scales,
@@ -48,7 +56,6 @@ def get_mxfp8_functions():
 
     return (
         mxfp8_block_scaled_matmul_triton,
-        mxfp8_block_scaled_matmul_triton_simple,
         _pack_mxfp8_scales,
         mxfp8_group_quantize,
     )
@@ -58,98 +65,159 @@ def ceil_div(a, b):
     return (a + b - 1) // b
 
 
-def bench_mxfp8_optimized(M, N, K):
-    """Benchmark optimized MXFP8 GEMM using TensorDescriptor (requires N >= 128)."""
-    (
-        mxfp8_block_scaled_matmul_triton,
-        _,
-        _pack_mxfp8_scales,
-        mxfp8_group_quantize,
-    ) = get_mxfp8_functions()
+# ---------------------------------------------------------------------------
+# Improved MXFP8 kernel with GROUP_SIZE_M swizzling
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def _mxfp8_matmul_kernel_v2(
+    a_desc,
+    a_scale_desc,
+    b_desc,
+    b_scale_desc,
+    c_desc,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    output_type: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    rep_m: tl.constexpr,
+    rep_n: tl.constexpr,
+    rep_k: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    if output_type == 0:
+        output_dtype = tl.float32
+    elif output_type == 1:
+        output_dtype = tl.float16
+    elif output_type == 2:
+        output_dtype = tl.bfloat16
+
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+
+    # GROUP_SIZE_M swizzling for L2 cache locality
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_am = pid_m * BLOCK_M
+    offs_bn = pid_n * BLOCK_N
+    offs_scale_m = pid_m * rep_m
+    offs_scale_n = pid_n * rep_n
+
+    VEC_SIZE: tl.constexpr = 32
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES):
+        a = a_desc.load([offs_am, k * BLOCK_K])
+        b = b_desc.load([offs_bn, k * BLOCK_K])
+        scale_a = a_scale_desc.load([0, offs_scale_m, k * rep_k, 0, 0])
+        scale_b = b_scale_desc.load([0, offs_scale_n, k * rep_k, 0, 0])
+
+        scale_a = (
+            scale_a.reshape(rep_m, rep_k, 32, 4, 4)
+            .trans(0, 3, 2, 1, 4)
+            .reshape(BLOCK_M, BLOCK_K // VEC_SIZE)
+        )
+        scale_b = (
+            scale_b.reshape(rep_n, rep_k, 32, 4, 4)
+            .trans(0, 3, 2, 1, 4)
+            .reshape(BLOCK_N, BLOCK_K // VEC_SIZE)
+        )
+
+        accumulator = tl.dot_scaled(
+            a, scale_a, "e4m3", b.T, scale_b, "e4m3", accumulator
+        )
+
+    c_desc.store([offs_am, offs_bn], accumulator.to(output_dtype))
+
+
+def mxfp8_matmul_v2(
+    a, a_scale, b, b_scale, output_dtype,
+    *, block_m=128, block_n=256, block_k=128,
+    num_stages=4, group_size_m=8, num_warps=4,
+):
+    M, K = a.shape
+    N, K_b = b.shape
+    assert K == K_b
+
+    if output_dtype == torch.float32:
+        output_type = 0
+    elif output_dtype == torch.float16:
+        output_type = 1
+    elif output_dtype == torch.bfloat16:
+        output_type = 2
+    else:
+        raise ValueError(f"Unsupported output dtype: {output_dtype}")
+
+    rep_m = block_m // 128
+    rep_n = block_n // 128
+    rep_k = block_k // 32 // 4
+
+    a_desc = TensorDescriptor.from_tensor(a, [block_m, block_k])
+    b_desc = TensorDescriptor.from_tensor(b, [block_n, block_k])
+    a_scale_desc = TensorDescriptor.from_tensor(a_scale, block_shape=[1, rep_m, rep_k, 2, 256])
+    b_scale_desc = TensorDescriptor.from_tensor(b_scale, block_shape=[1, rep_n, rep_k, 2, 256])
+
+    output = torch.empty((M, N), dtype=output_dtype, device=a.device)
+    c_desc = TensorDescriptor.from_tensor(output, [block_m, block_n])
+
+    grid = (triton.cdiv(M, block_m) * triton.cdiv(N, block_n), 1)
+    _mxfp8_matmul_kernel_v2[grid](
+        a_desc, a_scale_desc, b_desc, b_scale_desc, c_desc,
+        M, N, K, output_type,
+        block_m, block_n, block_k, rep_m, rep_n, rep_k,
+        group_size_m, num_stages, num_warps=num_warps,
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Benchmark helpers
+# ---------------------------------------------------------------------------
+
+def prepare_mxfp8_inputs(M, N, K):
+    (_, _pack_mxfp8_scales, mxfp8_group_quantize) = get_mxfp8_functions()
 
     x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
     w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
     x_fp8, x_scale = mxfp8_group_quantize(x)
     w_fp8, w_scale = mxfp8_group_quantize(w)
 
-    # Pad M if needed
     block_m = 128
     if M % block_m != 0:
         pad_rows = ceil_div(M, block_m) * block_m - M
         x_fp8 = torch.cat(
-            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)],
-            dim=0,
+            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)], dim=0,
         )
         x_scale = torch.cat(
-            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)],
-            dim=0,
+            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)], dim=0,
         )
 
     a_scale_packed = _pack_mxfp8_scales(x_scale)
     b_scale_packed = _pack_mxfp8_scales(w_scale)
-    w_fp8_c = w_fp8.contiguous()
-    block_n = 256 if N % 256 == 0 else 128
+    return x_fp8, a_scale_packed, w_fp8.contiguous(), b_scale_packed
+
+
+def bench_kernel(M, N, K, kernel_fn, **kernel_kwargs):
+    x_fp8, a_scale_packed, w_fp8_c, b_scale_packed = prepare_mxfp8_inputs(M, N, K)
 
     def run(x_fp8, a_scale_packed, w_fp8, b_scale_packed):
-        return mxfp8_block_scaled_matmul_triton(
+        return kernel_fn(
             x_fp8, a_scale_packed, w_fp8, b_scale_packed,
-            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
+            output_dtype=torch.bfloat16, **kernel_kwargs,
         )
 
     measurements = bench_gpu_time(
-        run,
-        input_args=(x_fp8, a_scale_packed, w_fp8_c, b_scale_packed),
-        use_cuda_graph=True,
-    )
-    ms = np.median(measurements)
-    tflops = 2 * M * N * K * 1e-9 / ms
-    return ms, tflops
-
-
-def bench_mxfp8_simple(M, N, K):
-    """Benchmark simple MXFP8 GEMM using tl.load (works with any N)."""
-    (
-        _,
-        mxfp8_block_scaled_matmul_triton_simple,
-        _,
-        mxfp8_group_quantize,
-    ) = get_mxfp8_functions()
-
-    x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
-    w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
-    x_fp8, x_scale = mxfp8_group_quantize(x)
-    w_fp8, w_scale = mxfp8_group_quantize(w)
-
-    # Pad M if needed
-    block_m = 128
-    if M % block_m != 0:
-        pad_rows = ceil_div(M, block_m) * block_m - M
-        x_fp8 = torch.cat(
-            [x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)],
-            dim=0,
-        )
-        x_scale = torch.cat(
-            [x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)],
-            dim=0,
-        )
-
-    if N <= 64:
-        block_n = N if N in [16, 32, 64] else 64
-    else:
-        block_n = 64
-
-    w_fp8_c = w_fp8.contiguous()
-    w_scale_c = w_scale.contiguous()
-
-    def run(x_fp8, x_scale, w_fp8, w_scale):
-        return mxfp8_block_scaled_matmul_triton_simple(
-            x_fp8, x_scale, w_fp8, w_scale,
-            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
-        )
-
-    measurements = bench_gpu_time(
-        run,
-        input_args=(x_fp8, x_scale, w_fp8_c, w_scale_c),
+        run, input_args=(x_fp8, a_scale_packed, w_fp8_c, b_scale_packed),
         use_cuda_graph=True,
     )
     ms = np.median(measurements)
@@ -158,7 +226,6 @@ def bench_mxfp8_simple(M, N, K):
 
 
 def bench_bf16(M, N, K):
-    """Benchmark BF16 matmul reference."""
     x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
     w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
     w_t = w.T.contiguous()
@@ -166,100 +233,127 @@ def bench_bf16(M, N, K):
     def run(x, w_t):
         return torch.matmul(x, w_t)
 
-    measurements = bench_gpu_time(
-        run,
-        input_args=(x, w_t),
-        use_cuda_graph=True,
-    )
+    measurements = bench_gpu_time(run, input_args=(x, w_t), use_cuda_graph=True)
     ms = np.median(measurements)
     tflops = 2 * M * N * K * 1e-9 / ms
     return ms, tflops
 
 
-def test_accuracy():
-    """Test accuracy of MXFP8 kernels."""
-    (
-        mxfp8_block_scaled_matmul_triton,
-        mxfp8_block_scaled_matmul_triton_simple,
-        _pack_mxfp8_scales,
-        mxfp8_group_quantize,
-    ) = get_mxfp8_functions()
+def test_accuracy_v2():
+    (mxfp8_block_scaled_matmul_triton, _pack_mxfp8_scales, mxfp8_group_quantize) = get_mxfp8_functions()
 
-    shapes = [(1, 128, 4096), (128, 128, 4096), (128, 4096, 4096), (256, 4096, 14336)]
-
-    print("Running accuracy tests...")
+    shapes = [(128, 128, 4096), (128, 4096, 4096), (256, 4096, 14336), (512, 8192, 8192)]
+    print("Running v2 accuracy tests...", file=sys.stderr)
     for M, N, K in shapes:
         x = torch.randn((M, K), device="cuda", dtype=torch.bfloat16)
         w = torch.randn((N, K), device="cuda", dtype=torch.bfloat16)
         x_fp8, x_scale = mxfp8_group_quantize(x)
         w_fp8, w_scale = mxfp8_group_quantize(w)
-
-        # Pad M
-        block_m = 128
-        if M % block_m != 0:
-            pad_rows = ceil_div(M, block_m) * block_m - M
-            x_fp8_pad = torch.cat([x_fp8, torch.zeros((pad_rows, K), device="cuda", dtype=x_fp8.dtype)], dim=0)
-            x_scale_pad = torch.cat([x_scale, torch.full((pad_rows, K // 32), 127, device="cuda", dtype=x_scale.dtype)], dim=0)
-        else:
-            x_fp8_pad, x_scale_pad = x_fp8, x_scale
-
-        # Simple kernel
-        block_n = 64
-        out_simple = mxfp8_block_scaled_matmul_triton_simple(
-            x_fp8_pad, x_scale_pad, w_fp8.contiguous(), w_scale.contiguous(),
-            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
-        )[:M, :]
-
-        # Optimized kernel
-        a_scale_packed = _pack_mxfp8_scales(x_scale_pad)
+        a_scale_packed = _pack_mxfp8_scales(x_scale)
         b_scale_packed = _pack_mxfp8_scales(w_scale)
-        block_n_opt = 256 if N % 256 == 0 else 128
-        out_opt = mxfp8_block_scaled_matmul_triton(
-            x_fp8_pad, a_scale_packed, w_fp8.contiguous(), b_scale_packed,
-            output_dtype=torch.bfloat16, block_m=128, block_n=block_n_opt, block_k=128,
-        )[:M, :]
+        w_fp8_c = w_fp8.contiguous()
+        block_n = 256 if N % 256 == 0 else 128
 
-        # They should be identical
-        torch.testing.assert_close(out_opt, out_simple, atol=0, rtol=0)
-        print(f"  M={M}, N={N}, K={K}: OK")
+        out_baseline = mxfp8_block_scaled_matmul_triton(
+            x_fp8, a_scale_packed, w_fp8_c, b_scale_packed,
+            output_dtype=torch.bfloat16, block_m=128, block_n=block_n, block_k=128,
+        )
+        for gsm in [4, 8]:
+            for nw in [4, 8]:
+                out_v2 = mxfp8_matmul_v2(
+                    x_fp8, a_scale_packed, w_fp8_c, b_scale_packed,
+                    output_dtype=torch.bfloat16,
+                    block_m=128, block_n=block_n, block_k=128,
+                    group_size_m=gsm, num_warps=nw,
+                )
+                assert torch.isfinite(out_v2).all(), f"NaN/Inf at M={M},N={N},K={K},gsm={gsm},nw={nw}"
+                assert torch.equal(out_baseline, out_v2), \
+                    f"Mismatch at M={M},N={N},K={K},gsm={gsm},nw={nw}: max_diff={(out_baseline-out_v2).abs().max().item()}"
+        print(f"  M={M},N={N},K={K}: OK", file=sys.stderr)
+    print("All v2 accuracy tests passed!\n", file=sys.stderr)
 
-    print("All accuracy tests passed!\n")
 
-
-# Benchmark shapes: (M, N, K, description)
-SHAPES = [
-    # Small N (simple kernel only)
-    (1, 64, 4096, "decode bs=1, small N"),
-    (128, 64, 4096, "decode bs=128, small N"),
-    # Large N (both kernels)
-    (1, 4096, 4096, "decode bs=1"),
-    (32, 4096, 4096, "decode bs=32"),
-    (128, 4096, 4096, "decode bs=128"),
-    (512, 4096, 4096, "prefill"),
-    (1, 14336, 4096, "MLP up proj bs=1"),
-    (128, 14336, 4096, "MLP up proj bs=128"),
+# Configs to sweep
+V2_CONFIGS = [
+    (gsm, ns, nw)
+    for gsm in [4, 8, 16]
+    for ns in [2, 3, 4]
+    for nw in [4, 8]
 ]
+
+Ms = [128, 256, 512, 1024, 2048, 4096]
+Ns = [128, 256, 512, 1024, 1536, 2048, 4096, 8192]
+Ks = [768, 2048, 4096, 8192]
 
 
 if __name__ == "__main__":
     if not check_sm100():
         exit(0)
 
-    test_accuracy()
+    test_accuracy_v2()
 
-    print(f"{'Shape':<35} {'Kernel':<12} {'Time (us)':<12} {'TFLOPS':<10}")
-    print("=" * 75)
+    (mxfp8_block_scaled_matmul_triton, _, _) = get_mxfp8_functions()
 
-    for M, N, K, desc in SHAPES:
-        shape_str = f"M={M}, N={N}, K={K}"
+    # Phase 1: Config sweep
+    print("# Phase 1: Config sweep", file=sys.stderr)
+    print("M,N,K,baseline_us,best_v2_us,v2_vs_base,best_gsm,best_stages,best_warps")
 
-        if N >= 128:
-            ms_opt, tflops_opt = bench_mxfp8_optimized(M, N, K)
-            print(f"{shape_str:<35} {'optimized':<12} {ms_opt*1000:<12.2f} {tflops_opt:<10.2f}")
+    sweep_shapes = [
+        (128, 4096, 8192), (256, 4096, 8192), (512, 4096, 4096),
+        (512, 8192, 8192), (1024, 2048, 4096), (1024, 4096, 4096),
+        (2048, 4096, 4096), (2048, 8192, 8192), (4096, 4096, 4096),
+        (4096, 8192, 8192),
+    ]
 
-        ms_simple, tflops_simple = bench_mxfp8_simple(M, N, K)
-        print(f"{shape_str:<35} {'simple':<12} {ms_simple*1000:<12.2f} {tflops_simple:<10.2f}")
+    best_configs = {}
+    for M, N, K in sweep_shapes:
+        block_n = 256 if N % 256 == 0 else 128
+        ms_base, _ = bench_kernel(M, N, K, mxfp8_block_scaled_matmul_triton,
+                                   block_m=128, block_n=block_n, block_k=128)
 
-        ms_bf16, tflops_bf16 = bench_bf16(M, N, K)
-        print(f"{shape_str:<35} {'bf16':<12} {ms_bf16*1000:<12.2f} {tflops_bf16:<10.2f}")
-        print()
+        best_ms = float('inf')
+        best_cfg = None
+        for gsm, ns, nw in V2_CONFIGS:
+            ms_v2, _ = bench_kernel(M, N, K, mxfp8_matmul_v2,
+                                     block_m=128, block_n=block_n, block_k=128,
+                                     num_stages=ns, group_size_m=gsm, num_warps=nw)
+            if ms_v2 < best_ms:
+                best_ms = ms_v2
+                best_cfg = (gsm, ns, nw)
+
+        ratio = best_ms / ms_base
+        print(f"{M},{N},{K},{ms_base*1000:.2f},{best_ms*1000:.2f},{ratio:.3f},{best_cfg[0]},{best_cfg[1]},{best_cfg[2]}")
+        best_configs[(M, N, K)] = best_cfg
+        print(f"  {M}x{N}x{K} done", file=sys.stderr)
+
+    # Phase 2: Full comparison
+    print(file=sys.stderr)
+    print("# Phase 2: Full comparison", file=sys.stderr)
+    print()
+    print("M,N,K,baseline_us,v2_us,bf16_us,baseline_tflops,v2_tflops,bf16_tflops,v2_vs_base,v2_speedup_vs_bf16")
+
+    default_cfg = (8, 3, 4)
+
+    for K in Ks:
+        for N in Ns:
+            for M in Ms:
+                block_n = 256 if N % 256 == 0 else 128
+                ms_base, tflops_base = bench_kernel(
+                    M, N, K, mxfp8_block_scaled_matmul_triton,
+                    block_m=128, block_n=block_n, block_k=128)
+                ms_bf16, tflops_bf16 = bench_bf16(M, N, K)
+
+                cfg = best_configs.get((M, N, K), default_cfg)
+                gsm, ns, nw = cfg
+                ms_v2, tflops_v2 = bench_kernel(
+                    M, N, K, mxfp8_matmul_v2,
+                    block_m=128, block_n=block_n, block_k=128,
+                    num_stages=ns, group_size_m=gsm, num_warps=nw)
+
+                v2_vs_base = ms_v2 / ms_base
+                v2_vs_bf16 = ms_bf16 / ms_v2
+
+                print(f"{M},{N},{K},{ms_base*1000:.2f},{ms_v2*1000:.2f},{ms_bf16*1000:.2f},"
+                      f"{tflops_base:.2f},{tflops_v2:.2f},{tflops_bf16:.2f},"
+                      f"{v2_vs_base:.3f},{v2_vs_bf16:.2f}")
+            print(f"  K={K},N={N} done", file=sys.stderr)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

How can we avoid write custom MXFP8 gemm kernel? In fact, `torch.scaled_mm` can be an easy way to improve naive gemms, like the current triton ones used for MXFP8 gemm. Later, there is an opportunity to write custom MXFP8 gemm in the following priority

- Flashinfer (tested)


Untested
- CuteDSL
- Triton (improve existing)
- Pure CUTLASS

Easy way: copy existing impl from various cuteDSL lib.

Problem (why not)?
- libs like Quack doesn't have MXFP8 gemm
- And ideally, CUTLASS cpp should be replace with CuteDSL
- Also, this should work on SM90F as well. 

PR contents-- we include:
- Some iterated gemms, that can be on avg 1.4x faster than the existing triton ones
- The code changes to enable cuBLAS for MXFP8 via torch scaled MM, which can produce the following speedup:

We make the following observations to use cuBLAS:

# Fusion
- Scales are stored as e8m0 block scale

<img width="596" height="106" alt="CleanShot 2026-02-05 at 18 53 42@2x" src="https://github.com/user-attachments/assets/b493e942-251d-4819-9a6e-22dd27176f24" />


- `torch._scaled_mm` requires swizzling.
- We also add Preprocessing Fusion where weights and scales are transformed before gemm, the old approach
- cuBLAS needs B to be Column-Major. Observe: layer.weight -> layer.weight_t.

- `prepare_mxfp8_weight_for_cublas` will convert to swizzling: in `float8_e8m0fnu`

# Scale Layout
- Before, the triton kernels has packing format:
- `(1, scale_m, scale_k, 2, 256)`
- Now, we do the following procedure:
1. reshape input scale to `(m // 128, 4, 32, k // 128, 4)`
2. permute to `(0, 3, 2, 1, 4)` 
3. So the indexing is fused into memory layout itself.

## Ablation

We found that the speedup of pure GEMM benchmark is about 2x on average with cuBLAS. All other gains can be attribute to the fusion step. And it helps most at large bs (~500 -> 25% speedup in mxfp8, which can be similar to BF16 model).

```
_Speed up MXFP8 Gemm by cuBlas_
# cublas
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    4.462    |  512   |   1.000    |     114.74      |
+-------------+--------+------------+-----------------+
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:20<00:00, 64.23it/s]
Accuracy: 0.583
Invalid: 0.004
Latency: 20.610 s
Output throughput: 11711.634 token/s

# Cutlass
Build flashinfer from src

+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    4.338    |  512   |   1.000    |     118.02      |
+-------------+--------+------------+-----------------+
and use 

# triton

+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    4.896    |  512   |   1.000    |     104.57      |
+-------------+--------+------------+-----------------+


❯ python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:25<00:00, 52.48it/s]
Accuracy: 0.583
Invalid: 0.004
Latency: 25.428 s
Output throughput: 9492.356 token/s
```

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
