### PR TITLE
[diffusion][hot fix] fix torch.compile graph break caused by torch._dynamo.disable

### DIFF
--- a/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
@@ -201,8 +201,6 @@ class ScaleResidualNormScaleShift:
         value = tXrX.load()
         if cutlass.const_expr(isinstance(tGrG, cute.Tensor)):
             value = tGrG.load() * value
-        elif cutlass.const_expr(isinstance(tGrG, cutlass.Int32)):
-            value = tGrG * value
         # Compute: value = value + <residual>
         if cutlass.const_expr(isinstance(tRrR, cute.Tensor)):
             value = value + tRrR.load()
@@ -319,9 +317,8 @@ def fused_norm_scale_shift(
         scale = broadcast_tensor_for_bsfd(scale, *x.shape)  # handle various shapes
         shift = broadcast_tensor_for_bsfd(shift, *x.shape)  # handle various shapes
         # Use scalar placeholders for None tensors as a workaround, since the CuTe DSL
-        # TVM-FFI backend does not support None parameters. Unless explicitly handled
-        # (e.g., for gate), scalar values do not result in code generation and have no
-        # impact on runtime performance.
+        # TVM-FFI backend does not support None parameters. scalar values do not result
+        # in code generation and have no impact on runtime performance.
         weight = 1 if weight is None else weight
         bias = 0 if bias is None else bias
         ResOut, Residual, Gate = 0, 0, 1
@@ -369,7 +366,7 @@ def fused_scale_residual_norm_scale_shift(
 
     Expects:
       - residual, x: [B, S, D]
-      - gate: None, 1, [1], [D], [1/B, D], [1/B, 1/S, D] or [B, F, 1, D]
+      - gate: None, [1], [D], [1/B, D], [1/B, 1/S, D] or [B, F, 1, D]
       - weight/bias: None, [D]
       - scale/shift: [1], [D], [1/B, D], [1/B, 1/S, D] or [B, F, 1, D]
       - norm_type: str, "layer" or "rms"
@@ -402,9 +399,8 @@ def fused_scale_residual_norm_scale_shift(
         scale = broadcast_tensor_for_bsfd(scale, *x.shape)  # handle various shapes
         shift = broadcast_tensor_for_bsfd(shift, *x.shape)  # handle various shapes
         # Use scalar placeholders for None tensors as a workaround, since the CuTe DSL
-        # TVM-FFI backend does not support None parameters. Unless explicitly handled
-        # (e.g., for gate), scalar values do not result in code generation and have no
-        # impact on runtime performance.
+        # TVM-FFI backend does not support None parameters. scalar values do not result
+        # in code generation and have no impact on runtime performance.
         gate = 1 if gate is None else gate
         weight = 1 if weight is None else weight
         bias = 0 if bias is None else bias

--- a/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/cutedsl/scale_residual_norm_scale_shift.py
@@ -344,14 +344,14 @@ def fused_norm_scale_shift(
 
 
 @fused_norm_scale_shift.register_fake
-def _fused_norm_scale_shift_fake(
-    x, weight, bias, scale, shift, norm_type, eps
-):
+def _fused_norm_scale_shift_fake(x, weight, bias, scale, shift, norm_type, eps):
     y = x.new_empty(x.shape)
     return y
 
 
-@torch.library.custom_op("sglang::fused_scale_residual_norm_scale_shift", mutates_args=())
+@torch.library.custom_op(
+    "sglang::fused_scale_residual_norm_scale_shift", mutates_args=()
+)
 def fused_scale_residual_norm_scale_shift(
     residual: torch.Tensor,
     x: torch.Tensor,

--- a/python/sglang/jit_kernel/tests/test_fused_norm_scale_shift.py
+++ b/python/sglang/jit_kernel/tests/test_fused_norm_scale_shift.py
@@ -115,8 +115,6 @@ def fused_scale_residual_norm_scale_shift_ref(
 
 
 def _make_tensor(index_mode: str, shape: Tuple, dtype: torch.dtype):
-    if index_mode == "int1":
-        return 1
     if index_mode == "NAT":
         return None
     return torch.randn(*SHAPE_MAP[index_mode](*shape), device=DEVICE, dtype=dtype)
@@ -229,7 +227,7 @@ class TestFusedScaleResidualNormScaleShift:
             scale_mode=index_mode, shift_mode=index_mode, norm_type=norm_type
         )
 
-    @pytest.mark.parametrize("index_mode", INDEX_MODES + ["int1"])
+    @pytest.mark.parametrize("index_mode", INDEX_MODES)
     def test_gate_index_mode(self, index_mode, norm_type):
         run_scale_resi_norm_scale_shift(gate_mode=index_mode, norm_type=norm_type)
 

--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -319,6 +319,11 @@ class _ScaleResidualNormScaleShift(CustomOp):
             fused_scale_residual_norm_scale_shift,
         )
 
+        if isinstance(gate, int) and gate != 1:
+            raise ValueError(
+                f"Only gate value of 1 is supported for int type, but got {gate}"
+            )
+
         return fused_scale_residual_norm_scale_shift(
             residual.contiguous(),
             x.contiguous(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
[PR14717](https://github.com/sgl-project/sglang/pull/14717) decorated the jit kernel with `@torch._dynamo.disable`, introducing a torch.compile graph break. This increases cpu overhead and, in certain models (e.g. QwenImage 263ms -> 287ms per step), leads to some gpu bubbles, as shown below.

This PR fixes the issue by decorate the kernel with a `torch.library.custom_op`, following the approach described in the [pytorch documentation](https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/compile/programming_model.fullgraph_true.html#strategy-1-rewrite-the-unsupported-code-to-use-features-supported-by-dynamo:~:text=Use%20torch.library.custom_op%20to%20define%20a%20new%20custom%20operator.).

<img width="1788" height="254" alt="image" src="https://github.com/user-attachments/assets/95c9ee8f-aaad-4764-8498-1a9a82180fd9" /> 

after fix (this pr):
<img width="1844" height="276" alt="image" src="https://github.com/user-attachments/assets/fd609f52-26f4-4550-a3ce-ea05447ba484" />

* PR14717 did not rerun e2e benchmarks after the latest commits, so the regression was not caught in time. After fix, this pr reran e2e benchmarks: QwenImage showed a ~9% slowdown (fixed in this PR), while no regressions were observed in other models (wan, hunyuan). 
  * QwenImage denoise stage: ~1.9% speedup;
  * Wan2.2-T2V denoise stage: ~2.0% speedup;
  * Wan2.1-T2V denoise stage: ~2.8% speedup;
  * hunyuan denoise stage: <1% speedup;
  * (detailed in `Benchmarking and Profiling`)
* The ~2% speedup is expected, as the time reduced by the fusion kernel accounts for roughly the same proportion of a single layer’s execution time.
  * taking QwenImage as an example, a single layer takes approximately 2200 µs, while kernel fusion reduces about 50–60 µs, which corresponds to roughly ~2% of the layer execution time.
  * the previously observed ~10% speedup came from two factors: faster gpu kernels and the elimination of gpu bubbles. The bubbles now appear to have been removed by other mechanisms as well (e.g., torch.compile or other cpu-side optimizations), leaving only the kernel-level speedup.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Compare image between this pr and 669a9bd (before 14717).

#### Qwen

669a9bd:

<img width="956" height="926" alt="image" src="https://github.com/user-attachments/assets/2d1b7646-38d0-409a-844f-d91fc0bcd6dc" />

this pr:

<img width="946" height="928" alt="image" src="https://github.com/user-attachments/assets/d4872459-bf4e-4541-903f-00ee71009713" />

#### hunyuan video

669a9bd:

<img width="1736" height="916" alt="image" src="https://github.com/user-attachments/assets/5a845925-9f6c-411c-bc1e-8a6102fe4017" />

this pr:

<img width="1666" height="924" alt="image" src="https://github.com/user-attachments/assets/81398a11-d119-4d90-86bc-49a3bf8b5535" />

#### Wan-AI/Wan2.2-T2V-A14B-Diffusers

669a9bd:

<img width="1688" height="948" alt="image" src="https://github.com/user-attachments/assets/1286064e-6257-4a80-b65d-794349cbfe2b" />

this pr:

<img width="1722" height="904" alt="image" src="https://github.com/user-attachments/assets/4f822670-27d2-425f-a63f-849798a78aa5" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Benchmark on H200

#### QwenImage

Command

```
sglang generate --model-path=Qwen/Qwen-Image-2512 --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k" '--negative-prompt= ' --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.0 --seed=42 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false
```

before regression (669a9bd):

```
[02-06 02:04:27] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 50/50 [00:13<00:00,  3.79it/s]
[02-06 02:04:40] [DenoisingStage] average time per step: 0.2637 seconds
[02-06 02:04:40] [DenoisingStage] finished in 13.1895 seconds
```

after regression (4739f2e):

```
[02-06 02:02:08] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 50/50 [00:14<00:00,  3.48it/s]
[02-06 02:02:23] [DenoisingStage] average time per step: 0.2876 seconds
[02-06 02:02:23] [DenoisingStage] finished in 14.3843 seconds
```

after fix (this pr):
```
[02-06 01:20:15] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 50/50 [00:12<00:00,  3.87it/s]
[02-06 01:20:27] [DenoisingStage] average time per step: 0.2582 seconds
[02-06 01:20:27] [DenoisingStage] finished in 12.9134 seconds
```

#### Wan2.2

Command

```
sglang generate --model-path=Wan-AI/Wan2.2-T2V-A14B-Diffusers --log-level=info --prompt="A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window." --negative-prompt=" " --720p --num-inference-steps=40 --num-frames=81 --guidance-scale=5.0 --seed=42 --save-output  --num-gpus=8 --enable-cfg-parallel --ulysses-degree=4 --dit-layerwise-offload true --dit-cpu-offload false --vae-cpu-offload false --text-encoder-cpu-offload true --warmup --enable-torch-compile true
```

before regression (669a9bd):
```
[02-06 01:44:49] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 40/40 [03:19<00:00,  4.98s/it]
[02-06 01:48:09] [DenoisingStage] average time per step: 4.9828 seconds
[02-06 01:48:09] [DenoisingStage] finished in 199.3217 seconds
```

after regression (4739f2e, no regression)
```
[02-06 01:56:30] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 40/40 [03:15<00:00,  4.89s/it]
[02-06 01:59:45] [DenoisingStage] average time per step: 4.8867 seconds
[02-06 01:59:45] [DenoisingStage] finished in 195.4734 seconds
```

after fix (this pr):
```
[02-06 02:45:31] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████████████████████| 40/40 [03:15<00:00,  4.89s/it]
[02-06 02:48:47] [DenoisingStage] average time per step: 4.8879 seconds
[02-06 02:48:47] [DenoisingStage] finished in 195.5214 seconds
```

#### Wan-AI/Wan2.1-T2V-1.3B-Diffusers

Command

```
sglang generate --model-path=Wan-AI/Wan2.1-T2V-1.3B-Diffusers --log-level=info --prompt="A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window." --negative-prompt=" " --720p --num-inference-steps=40 --num-frames=81 --guidance-scale=5.0 --seed=42 --save-output  --num-gpus=8 --enable-cfg-parallel --ulysses-degree=4 --dit-layerwise-offload true --dit-cpu-offload false --vae-cpu-offload false --text-encoder-cpu-offload true --warmup --enable-torch-compile true
```

before regression (669a9bd):
```
[02-06 02:25:02] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 40/40 [00:43<00:00,  1.08s/it]
[02-06 02:25:45] [DenoisingStage] average time per step: 1.0801 seconds
[02-06 02:25:45] [DenoisingStage] finished in 43.2059 seconds
```

after regression (4739f2e, no regression)
```
[02-06 02:29:26] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 40/40 [00:42<00:00,  1.05s/it]
[02-06 02:30:08] [DenoisingStage] average time per step: 1.0508 seconds
[02-06 02:30:08] [DenoisingStage] finished in 42.0333 seconds
```

after fix (this pr):
```
[02-06 02:33:34] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████| 40/40 [00:42<00:00,  1.05s/it]
[02-06 02:34:16] [DenoisingStage] average time per step: 1.0533 seconds
[02-06 02:34:16] [DenoisingStage] finished in 42.1340 seconds
```

#### hunyuan

Command

```
sglang generate --model-path hunyuanvideo-community/HunyuanVideo --text-encoder-cpu-offload --pin-cpu-memory --prompt "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window." --save-output --num-frames 65 --width 848 --height 480 --num-inference-steps 30 --seed=42 --save-output --warmup --enable-torch-compile true --dit-layerwise-offload true --dit-cpu-offload false --vae-cpu-offload false --text-encoder-cpu-offload true --warmup --enable-torch-compile true
```

before regression (669a9bd):
```
[02-06 03:33:08] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████████████████████| 30/30 [00:52<00:00,  1.76s/it]
[02-06 03:34:01] [DenoisingStage] average time per step: 1.7645 seconds
[02-06 03:34:01] [DenoisingStage] finished in 52.9382 seconds
```

after regression (4739f2e, no regression)
```
[02-06 03:36:20] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████████████████████| 30/30 [00:52<00:00,  1.76s/it]
[02-06 03:37:13] [DenoisingStage] average time per step: 1.7637 seconds
[02-06 03:37:13] [DenoisingStage] finished in 52.9137 seconds
```

after fix (this pr):
```
[02-06 03:30:12] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████████████████████| 30/30 [00:52<00:00,  1.76s/it]
[02-06 03:31:05] [DenoisingStage] average time per step: 1.7611 seconds
[02-06 03:31:05] [DenoisingStage] finished in 52.8349 seconds
```



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
