### PR TITLE
refactor FAKE transfer backend and remove --disaggregation-decode-enable-fake-auto parameter

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -492,7 +492,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--disaggregation-prefill-pp` | Prefill pp size. If not set, it is default to 1. This is only set on the decode server. | `1` | Type: int |
 | `--disaggregation-ib-device` | The InfiniBand devices for disaggregation transfer, accepts single device (e.g., --disaggregation-ib-device mlx5_0) or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). Default is None, which triggers automatic device detection when mooncake backend is enabled. | `None` | Type: str |
 | `--disaggregation-decode-enable-offload-kvcache` | Enable async KV cache offloading on decode server (PD mode). | `False` | bool flag (set to enable) |
-| `--disaggregation-decode-enable-fake-auto` | Auto enable FAKE mode for decode node testing, no need to pass bootstrap_host and bootstrap_room in request. | `False` | bool flag (set to enable) |
 | `--num-reserved-decode-tokens` | Number of decode tokens that will have memory reserved when adding new request to the running batch. | `512` | Type: int |
 | `--disaggregation-decode-polling-interval` | The interval to poll requests in decode server. Can be set to >1 to reduce the overhead of this. | `1` | Type: int |
 

--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -26,7 +26,6 @@ class AscendKVManager(MooncakeKVManager):
             hostname=local_ip,
             npu_id=self.kv_args.gpu_id,
             disaggregation_mode=self.disaggregation_mode,
-            disaggregation_decode_enable_fake_auto=self.disaggregation_decode_enable_fake_auto,
         )
 
     def register_buffer_to_engine(self):

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -25,7 +25,6 @@ class AscendTransferEngine(MooncakeTransferEngine):
         hostname: str,
         npu_id: int,
         disaggregation_mode: DisaggregationMode,
-        disaggregation_decode_enable_fake_auto: bool,
     ):
         if import_error is not None:
             logger.warning(
@@ -36,9 +35,6 @@ class AscendTransferEngine(MooncakeTransferEngine):
         self.engine = TransferEngine()
         self.hostname = hostname
         self.npu_id = npu_id
-        self.disaggregation_decode_enable_fake_auto = (
-            disaggregation_decode_enable_fake_auto
-        )
 
         # Centralized storage address of the AscendTransferEngine
         self.store_url = os.getenv("ASCEND_MF_STORE_URL")
@@ -74,12 +70,6 @@ class AscendTransferEngine(MooncakeTransferEngine):
                 output_tensor_list, tmp_tensor, group=get_tp_group().device_group
             )
         """Initialize the ascend transfer instance."""
-        if self.disaggregation_decode_enable_fake_auto:
-            logger.info(
-                "Ascend Transfer Engine is not initialized in decode fake transfer mode."
-            )
-            return
-
         ret_value = self.engine.initialize(
             self.store_url, self.session_id, self.role, self.npu_id, trans_op_type
         )

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -52,9 +52,6 @@ class CommonKVManager(BaseKVManager):
         self.kv_args = args
         self.is_mla_backend = is_mla_backend
         self.disaggregation_mode = disaggregation_mode
-        self.disaggregation_decode_enable_fake_auto = (
-            server_args.disaggregation_decode_enable_fake_auto
-        )
         # for p/d multi node infer
         self.bootstrap_host = server_args.host
         self.bootstrap_port = server_args.disaggregation_bootstrap_port

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -344,7 +344,7 @@ class DecodePreallocQueue:
             # Auto enable FAKE mode if configured
             if req.bootstrap_host == FAKE_BOOTSTRAP_HOST or (
                 req.bootstrap_host is None
-                and self.scheduler.server_args.disaggregation_decode_enable_fake_auto
+                and self.scheduler.server_args.disaggregation_transfer_backend == "fake"
             ):
                 kv_receiver_class = get_kv_class(
                     TransferBackend.FAKE, KVClassType.RECEIVER
@@ -759,7 +759,7 @@ class DecodeTransferQueue:
 
         if decode_req.req.bootstrap_host == FAKE_BOOTSTRAP_HOST or (
             decode_req.req.bootstrap_host is None
-            and self.scheduler.server_args.disaggregation_decode_enable_fake_auto
+            and self.scheduler.server_args.disaggregation_transfer_backend == "fake"
         ):
             # Warm up or fake transfer mode
             pass

--- a/python/sglang/srt/disaggregation/fake/__init__.py
+++ b/python/sglang/srt/disaggregation/fake/__init__.py
@@ -1,1 +1,5 @@
-from sglang.srt.disaggregation.fake.conn import FakeKVReceiver, FakeKVSender
+from sglang.srt.disaggregation.fake.conn import (
+    FakeKVManager,
+    FakeKVReceiver,
+    FakeKVSender,
+)

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -8,13 +8,27 @@ from sglang.srt.disaggregation.base.conn import (
     BaseKVManager,
     BaseKVReceiver,
     BaseKVSender,
+    KVArgs,
     KVPoll,
 )
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
 
 
-# For warmup reqs, we don't kv transfer, we use the fake sender and receiver
+# For warmup reqs, we don't kv transfer, we use the fake manager, sender and receiver
+class FakeKVManager(BaseKVManager):
+    def __init__(
+        self,
+        args: KVArgs,
+        disaggregation_mode: DisaggregationMode,
+        server_args: ServerArgs,
+        is_mla_backend: Optional[bool] = False,
+    ):
+        super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+
+
 class FakeKVSender(BaseKVSender):
     def __init__(
         self,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -335,10 +335,15 @@ def get_kv_class(
         return class_mapping.get(class_type)
     elif transfer_backend == TransferBackend.FAKE:
         from sglang.srt.disaggregation.base import KVArgs
-        from sglang.srt.disaggregation.fake import FakeKVReceiver, FakeKVSender
+        from sglang.srt.disaggregation.fake import (
+            FakeKVManager,
+            FakeKVReceiver,
+            FakeKVSender,
+        )
 
         class_mapping = {
             KVClassType.KVARGS: KVArgs,
+            KVClassType.MANAGER: FakeKVManager,
             KVClassType.SENDER: FakeKVSender,
             KVClassType.RECEIVER: (FakeKVReceiver),
         }

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -505,7 +505,7 @@ class DataParallelController:
         # Set default bootstrap_room if in FAKE auto mode and room is None
         if (
             req.bootstrap_room is None
-            and self.server_args.disaggregation_decode_enable_fake_auto
+            and self.server_args.disaggregation_transfer_backend == "fake"
         ):
             req.bootstrap_room = self.round_robin_counter
             self.round_robin_counter = (self.round_robin_counter + 1) % len(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -654,8 +654,6 @@ class ServerArgs:
     disaggregation_prefill_pp: Optional[int] = 1
     disaggregation_ib_device: Optional[str] = None
     disaggregation_decode_enable_offload_kvcache: bool = False
-    # Enable auto FAKE mode for decode node testing, no need to pass bootstrap_host in request
-    disaggregation_decode_enable_fake_auto: bool = False
     num_reserved_decode_tokens: int = 512  # used for decode kv cache offload in PD
     # FIXME: hack to reduce ITL when decode bs is small
     disaggregation_decode_polling_interval: int = 1
@@ -4762,12 +4760,6 @@ class ServerArgs:
             "--disaggregation-decode-enable-offload-kvcache",
             action="store_true",
             help="Enable async KV cache offloading on decode server (PD mode).",
-        )
-        parser.add_argument(
-            "--disaggregation-decode-enable-fake-auto",
-            action="store_true",
-            help="Auto enable FAKE mode for decode node testing, "
-            "no need to pass bootstrap_host and bootstrap_room in request.",
         )
         parser.add_argument(
             "--num-reserved-decode-tokens",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When the --disaggregation-decode-enable-fake-auto parameter is enabled, the fake transfer backend is used. Therefore, the fake transfer backend is refactored so that a specific fake transfer backend can be explicitly specified, enabling requests to be sent directly to the decode stage.

previous discussion #17811

## Modifications

1.Add the FakeKVManager class.
2.Remove the --disaggregation-decode-enable-fake-auto parameter and replace it with the --disaggregation-transfer-backend parameter to enable this functionality. When the value of --disaggregation-transfer-backend is set to fake, requests can be sent directly to the decode stage.

## Accuracy Tests
1.NPU
```
MODEL_PATH=/home/weights/Qwen3-32B/
python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
--tp 2 \
--dp-size 2 \
--trust-remote-code \
--device npu \
--disaggregation-mode decode \
--attention-backend ascend \
--disaggregation-transfer-backend fake \
--load-balance-method follow_bootstrap_room \
--mem-fraction-static 0.8 \
--base-gpu-id 12 \
--host 127.0.0.1 \
--port 8008 \
```
```
curl http://localhost:8008/generate \
  -H "Content-Type: application/json" \
  -d '{
    "text": "The capital of France is",
    "sampling_params": {
      "temperature": 0,
      "max_new_tokens": 128
    }
  }' 
```
<img width="1958" height="73" alt="image" src="https://github.com/user-attachments/assets/7edeb3c2-94b0-4912-ab5e-c2818f320266" />

2.GPU
```
MODEL_PATH=/home/weight/Qwen3-32B/
python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
--tp 2 \
--dp-size 2 \
--trust-remote-code \
--disaggregation-mode decode \
--attention-backend fa3 \
--piecewise-cuda-graph-max-tokens 4096 \
--chunked-prefill-size 8192 \
--disaggregation-transfer-backend fake \
--load-balance-method follow_bootstrap_room \
--mem-fraction-static 0.8 \
--base-gpu-id 4 \
--host 127.0.0.1 \
--port 8001 \
```
```
curl http://localhost:8001/generate \
  -H "Content-Type: application/json" \
  -d '{
    "text": "The capital of France is",
    "sampling_params": {
      "temperature": 0,
      "max_new_tokens": 128
    }
  }' 
```
<img width="1952" height="75" alt="image" src="https://github.com/user-attachments/assets/d4718dde-5f15-4706-ba48-4cd6e3fc9297" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
