### PR TITLE
Use environment variables for input in kernel bump workflow to prevent shell injection

### DIFF
--- a/.github/workflows/bot-bump-kernel-version.yml
+++ b/.github/workflows/bot-bump-kernel-version.yml
@@ -31,17 +31,21 @@ jobs:
           pip install tomli
 
       - name: Configure Git and branch
+        env:
+          NEW_VERSION: ${{ github.event.inputs.new_version }}
         run: |
           git config user.name "sglang-bot"
           git config user.email "sglang-bot@users.noreply.github.com"
           RANDOM_SUFFIX=$(echo $RANDOM | md5sum | head -c 4)
-          BRANCH_NAME="bot/bump-kernel-version-${{ github.event.inputs.new_version }}-${RANDOM_SUFFIX}"
+          BRANCH_NAME="bot/bump-kernel-version-${NEW_VERSION}-${RANDOM_SUFFIX}"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Run kernel version bump script
+        env:
+          NEW_VERSION: ${{ github.event.inputs.new_version }}
         run: |
-          python scripts/release/bump_kernel_version.py "${{ github.event.inputs.new_version }}"
+          python scripts/release/bump_kernel_version.py "$NEW_VERSION"
 
       - name: Commit and create PR
         env:


### PR DESCRIPTION
## Motivation

Current workflow `bot-bump-kernel-version.yml` interpolates `github.event.inputs.new_version` directly into shell commands. This pattern creates a potential shell injection vector if malicious input is provided to the workflow.

## Modifications

- Moved `github.event.inputs.new_version` to a dedicated environment variable `NEW_VERSION` in the `Configure Git and branch` and `Run kernel version bump script` steps.
- Referenced the environment variable in the shell commands instead of direct interpolation.

## Accuracy Tests

N/A (CI/CD workflow change only)

## Benchmarking and Profiling

N/A

## Checklist

- [x] Follow the SGLang code style guidance.
- [x] Verified workflow syntax locally.