### PR TITLE
Fix PP‑safe v_head_dim usage in triton_backend

### DIFF
--- a/.github/workflows/release-docker-cu13.yml
+++ b/.github/workflows/release-docker-cu13.yml
@@ -63,6 +63,7 @@ jobs:
                     --build-arg CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) \
                     --build-arg GRACE_BLACKWELL=${{ matrix.grace_blackwell }} \
                     --build-arg USE_LATEST_SGLANG=1 \
+                    --build-arg INSTALL_FLASHINFER_JIT_CACHE=1 \
                     -t lmsysorg/sglang:${{ matrix.tag }} \
                     --no-cache \
                     .

--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -6,6 +6,8 @@ ARG VER_SGLANG=main
 
 ARG VER_TORCH=2.9.0
 ARG VER_TORCHVISION=0.24.0
+ARG VER_TORCHAUDIO=2.9.0
+ARG VER_TORCHAO=0.14.1
 ARG VER_TRITON=3.5.0
 
 RUN apt-get update && \
@@ -31,7 +33,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     source $HOME/.local/bin/env && \
     uv venv --python 3.12
 
-RUN echo -e '[[index]]\nname = "torch"\nurl = "https://download.pytorch.org/whl/cpu"\n\n[[index]]\nname = "torchvision"\nurl = "https://download.pytorch.org/whl/cpu"\n\n[[index]]\nname = "triton"\nurl = "https://download.pytorch.org/whl/cpu"' > .venv/uv.toml
+RUN echo -e '[[index]]\nname = "torch"\nurl = "https://download.pytorch.org/whl/cpu"\n\n[[index]]\nname = "torchvision"\nurl = "https://download.pytorch.org/whl/cpu"\n\n[[index]]\nname = "torchaudio"\nurl = "https://download.pytorch.org/whl/cpu"\n\n[[index]]\nname = "triton"\nurl = "https://download.pytorch.org/whl/cpu"' > .venv/uv.toml
 
 ENV UV_CONFIG_FILE=/opt/.venv/uv.toml
 
@@ -44,7 +46,7 @@ RUN source $HOME/.local/bin/env && \
     cd python && \
     cp pyproject_cpu.toml pyproject.toml && \
     uv pip install . && \
-    uv pip install torch==${VER_TORCH} torchvision==${VER_TORCHVISION} triton==${VER_TRITON} --force-reinstall && \
+    uv pip install torch==${VER_TORCH} torchvision==${VER_TORCHVISION} torchaudio==${VER_TORCHAUDIO} torchao==${VER_TORCHAO} triton==${VER_TRITON} --force-reinstall && \
     uv pip install tabulate && \
     cd ../sgl-kernel && \
     cp pyproject_cpu.toml pyproject.toml && \

--- a/docs/platforms/cpu_server.md
+++ b/docs/platforms/cpu_server.md
@@ -93,6 +93,10 @@ name = "torchvision"
 url = "https://download.pytorch.org/whl/cpu"
 
 [[index]]
+name = "torchaudio"
+url = "https://download.pytorch.org/whl/cpu"
+
+[[index]]
 name = "triton"
 url = "https://download.pytorch.org/whl/cpu"
 
@@ -119,7 +123,7 @@ cp pyproject_cpu.toml pyproject.toml
 # Install SGLang dependent libs, and build SGLang main package
 uv pip install --upgrade pip setuptools
 uv pip install .
-uv pip install torch==2.9.0 torchvision==0.24.0 triton==3.5.0 --force-reinstall
+uv pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 torchao==0.14.1 triton==3.5.0 --force-reinstall
 
 # Build the CPU backend kernels
 cd ../sgl-kernel

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
   "timm==1.0.16",
   "torch_memory_saver==0.0.9",
   "torch==2.9.1",
+  "torchao==0.9.0",
   "torchaudio==2.9.1",
   "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
   "torchvision",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "wheel", "grpcio-tools==1
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "sglang"
+name = "sglang-cpu"
 dynamic = ["version"]
 description = "SGLang is a fast serving framework for large language models and vision language models."
 readme = "README.md"

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -57,6 +57,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",
+  "torchao==0.9.0",
   "tqdm",
   "transformers==4.57.1",
   "uvicorn",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -57,6 +57,7 @@ runtime_common = [
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",
+  "torchao==0.9.0",
   "tqdm",
   "transformers==4.57.1",
   "uvicorn",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -61,6 +61,7 @@ dependencies = [
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",
+  "torchao==0.9.0",
   "tqdm",
   "transformers==4.57.1",
   "uvicorn",

--- a/python/sglang/multimodal_gen/runtime/platforms/interface.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/interface.py
@@ -343,6 +343,11 @@ class Platform:
         """Get the CPU architecture of the current platform."""
         return CpuArchEnum.UNSPECIFIED
 
+    @classmethod
+    def enable_dit_layerwise_offload_for_wan_by_default(cls) -> bool:
+        """Whether to enable DIT layerwise offload by default on the current platform."""
+        return True
+
     def get_attn_backend(self, *args, **kwargs) -> AttentionImpl:
         attention_cls_str = self.get_attn_backend_cls_str(*args, **kwargs)
         return resolve_obj_by_qualname(attention_cls_str)

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -165,3 +165,8 @@ class RocmPlatform(Platform):
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         return "sglang.multimodal_gen.runtime.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # works for ROCm too
+
+    @classmethod
+    def enable_dit_layerwise_offload_for_wan_by_default(cls) -> bool:
+        """ROCm performs better without DIT layerwise offload on Wan."""
+        return False

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -943,6 +943,7 @@ class ServerArgs:
             if (
                 "wan" in self.pipeline_config.__class__.__name__.lower()
                 and self.dit_layerwise_offload is None
+                and current_platform.enable_dit_layerwise_offload_for_wan_by_default()
             ):
                 logger.info(
                     "Automatically enable dit_layerwise_offload for Wan for best performance"

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -238,8 +238,21 @@ class GroupCoordinator:
         self.cpu_group = None
         self.local_size = get_int_env_var("LOCAL_SIZE", 0)
 
+        if is_cuda_alike():
+            device_id = (
+                0 if envs.SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS.get() else local_rank
+            )
+            self.device = torch.device(f"cuda:{device_id}")
+        elif _is_npu:
+            self.device = torch.device(f"npu:{local_rank}")
+        elif _is_xpu:
+            self.device = torch.device(f"xpu:{local_rank}")
+        else:
+            self.device = torch.device("cpu")
+        self.device_module = torch.get_device_module(self.device)
+
         for ranks in group_ranks:
-            active_ranks = torch.ones(len(ranks), dtype=torch.int32, device="cuda")
+            active_ranks = torch.ones(len(ranks), dtype=torch.int32, device=self.device)
             active_ranks_cpu = torch.ones(len(ranks), dtype=torch.int32)
             if "mooncake" in torch_distributed_backend:
                 from mooncake.ep import MooncakeBackendOptions
@@ -274,17 +287,6 @@ class GroupCoordinator:
 
         assert self.cpu_group is not None
         assert self.device_group is not None
-
-        if is_cuda_alike():
-            device_id = (
-                0 if envs.SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS.get() else local_rank
-            )
-            self.device = torch.device(f"cuda:{device_id}")
-        elif _is_npu:
-            self.device = torch.device(f"npu:{local_rank}")
-        else:
-            self.device = torch.device("cpu")
-        self.device_module = torch.get_device_module(self.device)
 
         # Import communicators
         self.use_pynccl = use_pynccl

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -186,7 +186,7 @@ class Indexer(MultiPlatformOp):
             self.hidden_size,
             self.n_heads,
             bias=False,
-            params_dtype=torch.bfloat16,
+            params_dtype=torch.bfloat16 if _is_cuda else torch.float32,
             prefix=add_prefix("weights_proj", prefix),
         )
         self.k_norm = LayerNorm(self.head_dim, dtype=torch.float32)

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -99,9 +99,8 @@ class TritonAttnBackend(AttentionBackend):
             # For hybrid linear models, layer_id = 0 may not be full attention
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
         else:
-            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[
-                -1
-            ]
+            # PP-safe: v_head_dim is a global metadata, do not rely on layer 0 buffer which might be non-existent or have different shape due to PP partition. Instead, get it from model config which is consistent across layers.
+            self.v_head_dim = model_runner.token_to_kv_pool.v_head_dim
         self.max_context_len = model_runner.model_config.context_len
         self.device = model_runner.device
         self.device_core_count = get_device_core_count(model_runner.gpu_id)

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -80,7 +80,24 @@ if _use_aiter and _is_gfx95_supported:
 elif _is_npu:
     from sglang.srt.hardware_backend.npu.cmo import prepare_weight_cache
 
+
+# TODO: According to the discussion in https://github.com/flashinfer-ai/flashinfer/issues/1223#issuecomment-3047256465
+# We set the max token num to 128 for allreduce fusion with min-latency case(use_oneshot=True).
 FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
+
+
+def apply_flashinfer_allreduce_fusion(batch_size: int):
+    return (
+        # TODO: flashinfer 0.6.1 caused performance regression on sm100 for allreduce fusion
+        # Temporarily disable it on sm100. Add it back after its performance is restored.
+        # Ref: https://github.com/sgl-project/sglang/issues/17237
+        _is_sm90_supported
+        and _is_flashinfer_available
+        and batch_size > 0
+        and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
+        and not is_dp_attention_enabled()
+        and get_global_server_args().enable_flashinfer_allreduce_fusion
+    )
 
 
 class ScatterMode(Enum):
@@ -581,24 +598,11 @@ class LayerCommunicator:
             if hasattr(forward_batch, "input_ids")
             else 0
         )
-        if batch_size > FUSE_ALLREDUCE_MAX_BATCH_SIZE:
-            return False
-
-        static_conditions_met = (
-            (not self.is_last_layer)
-            and (self._context.tp_size > 1)
-            and not is_dp_attention_enabled()
-            and get_global_server_args().enable_flashinfer_allreduce_fusion
-            and _is_flashinfer_available
-        )
-
-        if not static_conditions_met:
-            return False
 
         return (
-            batch_size > 0
-            and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
+            apply_flashinfer_allreduce_fusion(batch_size)
             and (not self.is_last_layer)
+            and (self._context.tp_size > 1)
         )
 
 
@@ -796,14 +800,8 @@ class CommunicateWithAllReduceAndLayerNormFn:
                 if hidden_states.shape[0] != 0:
                     hidden_states = layernorm(hidden_states)
         else:
-            # According to the discussion in https://github.com/flashinfer-ai/flashinfer/issues/1223#issuecomment-3047256465
-            # We set the max token num to 128 for allreduce fusion with min-latency case(use_oneshot=True).
-            if (
-                (_is_sm100_supported or _is_sm90_supported)
-                and _is_flashinfer_available
-                and hasattr(layernorm, "forward_with_allreduce_fusion")
-                and get_global_server_args().enable_flashinfer_allreduce_fusion
-                and hidden_states.shape[0] <= 2048
+            if apply_flashinfer_allreduce_fusion(hidden_states.shape[0]) and hasattr(
+                layernorm, "forward_with_allreduce_fusion"
             ):
                 hidden_states, residual = layernorm.forward_with_allreduce_fusion(
                     hidden_states, residual

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -88,10 +88,9 @@ FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
 
 def apply_flashinfer_allreduce_fusion(batch_size: int):
     return (
-        # TODO: flashinfer 0.6.1 caused performance regression on sm100 for allreduce fusion
-        # Temporarily disable it on sm100. Add it back after its performance is restored.
+        # NOTE: flashinfer 0.6.1 caused performance regression on sm100 for allreduce fusion
         # Ref: https://github.com/sgl-project/sglang/issues/17237
-        _is_sm90_supported
+        (_is_sm90_supported or _is_sm100_supported)
         and _is_flashinfer_available
         and batch_size > 0
         and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -492,7 +492,7 @@ class GptOssModel(nn.Module):
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
 
-        if is_npu:
+        if _is_npu:
             config.hidden_act = "npu_swiglu_oai"
 
         if self.pp_group.is_first_rank:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2530,11 +2530,6 @@ class ServerArgs:
                 )
                 self.attention_backend = "triton"
         elif not self.disable_cuda_graph:
-            if self.cuda_graph_bs != [1]:
-                logger.warning(
-                    "Cuda graph bs is set to [1] because of using diffusion LLM inference"
-                )
-                self.cuda_graph_bs = [1]
             if self.attention_backend != "flashinfer":
                 logger.warning(
                     "Attention backend is set to flashinfer because of enabling cuda graph in diffusion LLM inference"

--- a/sgl-kernel/pyproject_cpu.toml
+++ b/sgl-kernel/pyproject_cpu.toml
@@ -1,13 +1,13 @@
 [build-system]
 requires = [
   "scikit-build-core>=0.10",
-  "torch>=2.7.1",
+  "torch==2.9.0",
   "wheel",
 ]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "sgl-kernel"
+name = "sgl-kernel-cpu"
 version = "0.3.21"
 description = "Kernel Library for SGLang"
 readme = "README.md"
@@ -33,3 +33,4 @@ exclude = [
 cmake.source-dir = "csrc/cpu"
 cmake.build-type = "Release"
 minimum-version = "build-system.requires"
+wheel.packages = ["python/sgl_kernel"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In the Triton attention backend, `v_head_dim` was previously read from layer 0 buffer. Under pipeline parallel (PP) partitioning, layer 0 buffer may not exist or may have a different shape, leading to potential incorrect behavior during inference.  
This PR fixes this issue by using the global metadata from the model config, ensuring consistent behavior across all layers.
![20260206-171951](https://github.com/user-attachments/assets/0523a815-e3ce-4972-8164-5238ffe078b3)
Fix bug:
![20260206-172239](https://github.com/user-attachments/assets/ff7a33cf-f4da-4f28-adc3-84fb9b20f79a)
![20260206-172311](https://github.com/user-attachments/assets/8797da42-33d3-4075-a75a-9d4c9831946f)

## Modifications

- Replaced layer 0 buffer read with `model_runner.token_to_kv_pool.v_head_dim` in `python/sglang/srt/layers/attention/triton_backend.py`.
- Ensures PP-safe usage of `v_head_dim` for multi-GPU pipeline parallel inference.
- No other changes to model logic or outputs.

## Accuracy Tests

Tested inference correctness with Qwen3-32B model under pipeline parallel (PP) and tensor parallel (TP) settings.  
All outputs matched expected results when using the Triton attention backend.

## Benchmarking and Profiling

Tested with the following multi-GPU configuration on H2O nodes:

```bash
# Prefill server
HIP_VISIBLE_DEVICES=0,1,2,3 python3 -m sglang.launch_server \
  --model-path /models/qwen3/Qwen3-32B \
  --disaggregation-mode prefill \
  --port 30003 \
  --tp-size 1 \
  --pp-size 4 \
  --context-len 4096 \
  --attention-backend triton

# Decode server
HIP_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server \
  --model-path /models/qwen3/Qwen3-32B \
  --disaggregation-mode decode \
  --port 30001 \
  --tp-size 4 \
  --context-len 4096 \
  --attention-backend triton \
  --cuda-graph-max-bs 32

# Router
python -m sglang_router.launch_router \
  --pd-disaggregation \
  --prefill http://127.0.0.1:30003 \
  --decode http:/


