### PR TITLE
fix: normalize module_name in get_hidden_dim fallback

### DIFF
--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -60,6 +60,13 @@ def get_hidden_dim(
     if hasattr(base_model, "get_hidden_dim"):
         return base_model.get_hidden_dim(module_name, layer_idx)
     else:
+        orig_module_name = module_name
+        normalized_modules = get_normalized_target_modules([module_name])
+        assert (
+            len(normalized_modules) == 1
+        ), f"Expected 1 normalized module for '{orig_module_name}', got {len(normalized_modules)}"
+        module_name = normalized_modules.pop()
+
         """
         WARNING: get_hidden_dim() is not defined,
         which is used to get the hidden dim for different lora modules
@@ -93,7 +100,7 @@ def get_hidden_dim(
             return config.hidden_size, config.vocab_size + lora_added_vocab_size
         else:
             raise NotImplementedError(
-                "get_hidden_dim not implemented for " + module_name
+                "get_hidden_dim not implemented for " + orig_module_name
             )
 
 


### PR DESCRIPTION
## Motivation

This PR makes **LoRA initialization work for Qwen models** (e.g. Qwen2.5 / Qwen3) in the fallback path of `sglang.srt.lora.utils.get_hidden_dim()` when the HF model does **not** implement `base_model.get_hidden_dim()`.

Before this change, the fallback only accepted SGLang internal stacked module names (e.g. `qkv_proj`, `gate_up_proj`) and raised `NotImplementedError` for common HF-style module names like `q_proj/k_proj/v_proj` (including dotted names such as `layers.0.self_attn.q_proj`). This prevented LoRA init for Qwen when `lora_target_modules` used HF-style names.

## Modifications

- In `python/sglang/srt/lora/utils.py:get_hidden_dim()` (fallback branch only), normalize `module_name` via the existing `get_normalized_target_modules()` mapping before applying the default dimension logic.
- Preserve the original user-provided name (`orig_module_name`) only for the error message, so `NotImplementedError` still reports the pre-normalization module name (useful for dotted module names).
- No behavior change for models that already implement `base_model.get_hidden_dim()` (fast-path).

## Benchmarking and Profiling

N/A (this change affects LoRA init fallback logic, not inference hotpath).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
