### PR TITLE
[Bug]Fix PP-safe v_head_dim usage in Triton backend

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -99,9 +99,9 @@ class TritonAttnBackend(AttentionBackend):
             # For hybrid linear models, layer_id = 0 may not be full attention
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
         else:
-            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[
-                -1
-            ]
+            # PP-safe: v_head_dim is a global metadata, do not rely on layer 0 buffer which might be non-existent or have different shape due to PP partition. 
+            # Instead, get it from model config which is consistent across layers.
+            self.v_head_dim = model_runner.token_to_kv_pool.v_head_dim
         self.max_context_len = model_runner.model_config.context_len
         self.device = model_runner.device
         self.device_core_count = get_device_core_count(model_runner.gpu_id)


### PR DESCRIPTION
## Accuracy Tests

Tested inference correctness with Qwen3-32B model under pipeline parallel (PP) and tensor parallel (TP) settings on H2O cluster.  
All outputs matched expected results when using the Triton attention backend.
![20260206-171951](https://github.com/user-attachments/assets/75af1661-1b18-41d2-91eb-122f64c55b2a)
![20260206-172239](https://github.com/user-attachments/assets/42b4b184-d62f-45eb-9980-0dbb55d1967e)
![20260206-172311](https://github.com/user-attachments/assets/743de819-a9a9-4d27-b4e3-bf2ca5959662)

## Benchmarking and Profiling

Tested with the following multi-GPU configuration on H2O nodes:

```bash
# Prefill server (H2O node 0)
HIP_VISIBLE_DEVICES=0,1,2,3 python3 -m sglang.launch_server \
  --model-path /models/qwen3/Qwen3-32B \
  --disaggregation-mode prefill \
  --port 30003 \
  --tp-size 1 \
  --pp-size 4 \
  --context-len 4096 \
  --attention-backend triton

# Decode server (H2O node 1)
HIP_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server \
  --model-path /models/qwen3/Qwen3-32B \
  --disaggregation-mode decode \
  --port 30001 \
  --tp-size 4 \
  --context-len 4096 \
  --attention-backend triton \
  --cuda-graph-max-bs 32

# Router
python -m sglang_router.launch_router \
  --pd-disaggregation \
  --prefill http://127.0.0.1:30003 \
  --decode http://127.0.0.1:30001 \
  --host 0.0.0.0 \
  --port 8000
