### PR TITLE
Fix KV cache scale loading from quantization_param_path

### DIFF
--- a/docs/advanced_features/quantized_kv_cache.md
+++ b/docs/advanced_features/quantized_kv_cache.md
@@ -59,7 +59,7 @@ python3 -m sglang.launch_server \
 FP8 quantization requires scaling factors to properly quantize and dequantize the KV cache.
 
 ```{note}
-Currently, only per-tensor (scalar) scaling factors are supported.
+Currently, only per-tensor (scalar) scaling factors are supported, and each layer must provide two scalars: `k_scale` and `v_scale`. If they are the same, you still need to provide both values (e.g., `[x, x]`).
 ```
 
 Scaling factors can be:
@@ -75,8 +75,8 @@ The JSON file should follow this format:
     "dtype": "float8_e4m3fn",
     "scaling_factor": {
       "0": {
-        "0": 1.0,
-        "1": 1.0
+        "0": [1.0, 1.0],
+        "1": [1.0, 1.0]
       }
     }
   }

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -923,7 +923,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.pyt_hooks = PytHooks()
             self.pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        if self.server_args.kv_cache_dtype == "fp8_e4m3":
+        if self.server_args.kv_cache_dtype in ("fp8_e4m3", "fp8_e5m2"):
             if self.server_args.quantization_param_path is not None:
                 if callable(getattr(self.model, "load_kv_cache_scales", None)):
                     self.model.load_kv_cache_scales(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -1237,13 +1237,13 @@ class KVCacheQuantSchema(BaseModel):
     # layer indices to their per-tensor KV cache scaling factor.
     # TODO: Consider pulling this and its validation methods out into its
     # own schema class (tricky as its members are variable)
-    scaling_factor: Dict[int, Dict[int, float]]
+    scaling_factor: Dict[int, Dict[int, List[float]]]
 
     @model_validator(mode="after")
     def check_is_fp8(self) -> "KVCacheQuantSchema":
-        assert self.dtype == "float8_e4m3fn", (
+        assert self.dtype in {"float8_e4m3fn", "float8_e5m2"}, (
             "Loaded scaling factors intended for KV cache dtype = "
-            f"{self.dtype} rather than float8_e4m3fn!"
+            f"{self.dtype} rather than {sorted(supported_dtypes)}!"
         )
         return self
 
@@ -1311,7 +1311,7 @@ def kv_cache_scales_loader(
     tp_size: int,
     num_hidden_layers: int,
     model_type: Optional[str],
-) -> Iterable[Tuple[int, float]]:
+) -> Iterable[Tuple[int, float, float]]:
     """
     A simple utility to read in KV cache scaling factors that have been
     previously serialized to disk. Used by the model to populate the appropriate
@@ -1330,7 +1330,17 @@ def kv_cache_scales_loader(
             schema_dct = json.load(f)
             schema = QuantParamSchema.model_validate(schema_dct, context=context)
             layer_scales_map = schema.kv_cache.scaling_factor[tp_rank]
-            return layer_scales_map.items()
+            scales = []
+            for layer_idx, scale in layer_scales_map.items():
+                if not isinstance(scale, list) or len(scale) != 2:
+                    raise ValueError(
+                        f"Layer {layer_idx} scale must be a list [k_scale, v_scale]. "
+                        "Use [x, x] to represent shared k/v scales."
+                    )
+                k_scale = float(scale[0])
+                v_scale = float(scale[1])
+                scales.append((layer_idx, k_scale, v_scale))
+            return scales
     except FileNotFoundError:
         logger.error("File or directory '%s' not found.", filename)
     except json.JSONDecodeError:
@@ -1346,6 +1356,31 @@ def kv_cache_scales_loader(
         tp_rank,
     )
     return []
+
+
+def apply_kv_cache_scales(
+    layer_self_attn: torch.nn.Module, k_scale: float, v_scale: float
+) -> None:
+    attn = layer_self_attn.attn
+    device = next(layer_self_attn.parameters()).device
+
+    if isinstance(attn.k_scale, torch.nn.Parameter):
+        attn.k_scale.fill_(k_scale)
+    else:
+        attn.k_scale = torch.nn.Parameter(
+            torch.tensor(k_scale, dtype=torch.float32, device=device),
+            requires_grad=False,
+        )
+
+    if isinstance(attn.v_scale, torch.nn.Parameter):
+        attn.v_scale.fill_(v_scale)
+    else:
+        attn.v_scale = torch.nn.Parameter(
+            torch.tensor(v_scale, dtype=torch.float32, device=device),
+            requires_grad=False,
+        )
+    attn.k_scale_float = k_scale
+    attn.v_scale_float = v_scale
 
 
 def get_actual_shard_size(shard_size, weight_start, weight_end):


### PR DESCRIPTION
  ## Motivation

  Current quantization_param_path handling has several issues:

  - Only a single scale per layer is supported, forcing k_scale == v_scale and preventing per‑layer k/v distinction.
  - k_scale_float / v_scale_float are not updated, so some backends(flashinfer) fall back to default 1.0.
  - Parameters can be overwritten with plain floats, which breaks compatibility and can trigger FlashAttention errors
<img width="1712" height="892" alt="image" src="https://github.com/user-attachments/assets/1763244b-1de5-49e4-a411-f78c7e5d780d" />

  ## Modifications

  - Require per‑layer scale entries to be [k_scale, v_scale] (list only).
  - Apply KV cache scales via apply_kv_cache_scales, updating both Parameter and *_float values consistently.
  - Prevent accidental overwrite of Parameter with a float.
  - Update KV cache JSON format in docs.
  - Qwen2 path only.