### PR TITLE
Fix KV cache scale loading from quantization_param_path

### DIFF
--- a/docs/advanced_features/quantized_kv_cache.md
+++ b/docs/advanced_features/quantized_kv_cache.md
@@ -59,7 +59,7 @@ python3 -m sglang.launch_server \
 FP8 quantization requires scaling factors to properly quantize and dequantize the KV cache.
 
 ```{note}
-Currently, only per-tensor (scalar) scaling factors are supported.
+Currently, only per-tensor (scalar) scaling factors are supported, and each layer must provide two scalars: `k_scale` and `v_scale`. If they are the same, you still need to provide both values (e.g., `[x, x]`).
 ```
 
 Scaling factors can be:
@@ -75,8 +75,8 @@ The JSON file should follow this format:
     "dtype": "float8_e4m3fn",
     "scaling_factor": {
       "0": {
-        "0": 1.0,
-        "1": 1.0
+        "0": [1.0, 1.0],
+        "1": [1.0, 1.0]
       }
     }
   }

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -967,6 +967,10 @@ class MHATokenToKVPool(KVCache):
                 cache_k.div_(k_scale)
             if v_scale is not None:
                 cache_v.div_(v_scale)
+            if self.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+                max_val = torch.finfo(self.dtype).max
+                cache_k.clamp_(-max_val, max_val)
+                cache_v.clamp_(-max_val, max_val)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -923,7 +923,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.pyt_hooks = PytHooks()
             self.pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        if self.server_args.kv_cache_dtype == "fp8_e4m3":
+        if self.server_args.kv_cache_dtype in ("fp8_e4m3", "fp8_e5m2"):
             if self.server_args.quantization_param_path is not None:
                 if callable(getattr(self.model, "load_kv_cache_scales", None)):
                     self.model.load_kv_cache_scales(


### PR DESCRIPTION
  ## Motivation

  Current quantization_param_path handling has several issues:

  - Only a single scale per layer is supported, forcing k_scale == v_scale and preventing per‑layer k/v distinction.
  - k_scale_float / v_scale_float are not updated, so some backends(flashinfer) fall back to default 1.0.
  - Parameters can be overwritten with plain floats, which breaks compatibility and can trigger FlashAttention errors.
<img width="1712" height="892" alt="image" src="https://github.com/user-attachments/assets/9823198f-d521-447b-b04b-7a18c260be9d" />
  - When casting KV buffers to FP8 (e4m3/e5m2), values can overflow during scaling/cast, producing inf/NaN.


  ## Modifications

  - Require per‑layer scale entries to be [k_scale, v_scale] (list only).
  - Apply KV cache scales via apply_kv_cache_scales, updating both Parameter and *_float values consistently.
  - Prevent accidental overwrite of Parameter with a float.
  - For FP8 KV cache dtypes (float8_e4m3fn/float8_e5m2), clamp scaled KV values to torch.finfo(fp8).max before casting to prevent NaN.
  - Update KV cache JSON format in docs.
  - Qwen2 path and MHATokenToKVPool only.