### PR TITLE
[Doc] Update CUDA 13 install guide to install torch first

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -37,7 +37,7 @@ uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgl_
 uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgl_kernel-X.Y.Z+cu130-cp310-abi3-manylinux2014_aarch64.whl"
 ```
 
-**Quick fixes to common problems**
+### **Quick fixes to common problems**
 - If you encounter `OSError: CUDA_HOME environment variable is not set`. Please set it to your CUDA install root with either of the following solutions:
   1. Use `export CUDA_HOME=/usr/local/cuda-<your-cuda-version>` to set the `CUDA_HOME` environment variable.
   2. Install FlashInfer first following [FlashInfer installation doc](https://docs.flashinfer.ai/installation.html), then install SGLang as described above.

--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -20,7 +20,8 @@ Docker is recommended (see Method 3 note on B300/GB300/CUDA 13). If you do not h
 
 1. Install PyTorch with CUDA 13 support first:
 ```bash
-uv pip install torch==2.9.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
+# Replace X.Y.Z with the version by your SGLang install
+uv pip install torch==X.Y.Z torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
 ```
 
 2. Install sglang:

--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -11,22 +11,33 @@ It is recommended to use uv for faster installation:
 ```bash
 pip install --upgrade pip
 pip install uv
-uv pip install "sglang"
+uv pip install sglang
+```
+
+### For CUDA 13
+
+Docker is recommended (see Method 3 note on B300/GB300/CUDA 13). If you do not have Docker access, follow these steps:
+
+1. Install PyTorch with CUDA 13 support first:
+```bash
+uv pip install torch==2.9.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
+```
+
+2. Install sglang:
+```bash
+uv pip install sglang
+```
+
+3. Install the `sgl_kernel` wheel for CUDA 13 from [the sgl-project whl releases](https://github.com/sgl-project/whl/blob/gh-pages/cu130/sgl-kernel/index.html). Replace `X.Y.Z` with the `sgl_kernel` version required by your SGLang install (you can find this by running `uv pip show sgl_kernel`). Examples:
+```bash
+# x86_64
+uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgl_kernel-X.Y.Z+cu130-cp310-abi3-manylinux2014_x86_64.whl"
+
+# aarch64
+uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgl_kernel-X.Y.Z+cu130-cp310-abi3-manylinux2014_aarch64.whl"
 ```
 
 **Quick fixes to common problems**
-- For CUDA 13, Docker is recommended (see Method 3 note on B300/GB300/CUDA 13). If you do not have Docker access, an extra index url needs to be provided when installing wheels:
-```
-uv pip install "sglang" --extra-index-url https://download.pytorch.org/whl/cu130
-```
-- The `sgl_kernel` wheel for CUDA 13 can be downloaded from [the sgl-project whl releases](https://github.com/sgl-project/whl/blob/gh-pages/cu130/sgl-kernel/index.html). Replace `X.Y.Z` with the `sgl_kernel` version required by your SGLang install (you can find this by running `uv pip show sgl_kernel`). Examples:
-  ```bash
-  # x86_64
-  uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgl_kernel-X.Y.Z+cu130-cp310-abi3-manylinux2014_x86_64.whl"
-
-  # aarch64
-  uv pip install "https://github.com/sgl-project/whl/releases/download/vX.Y.Z/sgl_kernel-X.Y.Z+cu130-cp310-abi3-manylinux2014_aarch64.whl"
-  ```
 - If you encounter `OSError: CUDA_HOME environment variable is not set`. Please set it to your CUDA install root with either of the following solutions:
   1. Use `export CUDA_HOME=/usr/local/cuda-<your-cuda-version>` to set the `CUDA_HOME` environment variable.
   2. Install FlashInfer first following [FlashInfer installation doc](https://docs.flashinfer.ai/installation.html), then install SGLang as described above.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Resolve #18392

The current CUDA 13 installation instructions in the documentation lead to dependency resolution issues when using `uv pip`:

1. Using `--extra-index-url https://download.pytorch.org/whl/cu130` results in installing an incomplete and outdated sglang version (0.5.2) instead of the latest:
    ```
    uv pip install "sglang" --extra-index-url https://download.pytorch.org/whl/cu130

    Using Python 3.12.12 environment at: test
    Resolved 34 packages in 5.26s
    Prepared 34 packages in 1.14s
    Installed 34 packages in 43ms
     + aiohappyeyeballs==2.6.1
     + aiohttp==3.13.3
     + aiosignal==1.4.0
     + asttokens==3.0.1
     + attrs==25.4.0
     + certifi==2022.12.7
     + charset-normalizer==2.1.1
     + decorator==5.2.1
     + executing==2.2.1
     + frozenlist==1.8.0
     + idna==3.4
     + ipython==9.10.0
     + ipython-pygments-lexers==1.1.1
     + jedi==0.19.2
     + matplotlib-inline==0.2.1
     + multidict==6.7.1
     + numpy==2.3.5
     + parso==0.8.5
     + pexpect==4.9.0
     + prompt-toolkit==3.0.52
     + propcache==0.4.1
     + ptyprocess==0.7.0
     + pure-eval==0.2.3
     + pygments==2.19.2
     + requests==2.28.1
     + setproctitle==1.3.7
     + sglang==0.5.2
     + stack-data==0.6.3
     + tqdm==4.66.5
     + traitlets==5.14.3
     + typing-extensions==4.15.0
     + urllib3==1.26.13
     + wcwidth==0.6.0
     + yarl==1.22.0
    ```

2. Specifying the latest version (`sglang==0.5.8post1`) fails with a torchao dependency error due to uv's index strategy - it only considers versions from the first index that contains a package to avoid dependency confusion attacks:
    ```
    uv pip install "sglang==0.5.8post1" --extra-index-url https://download.pytorch.org/whl/cu130
    
    Using Python 3.12.12 environment at: test
      × No solution found when resolving dependencies:
      ╰─▶ Because there is no version of torchao==0.9.0 and sglang==0.5.8.post1 depends on torchao==0.9.0, we can conclude that sglang==0.5.8.post1 cannot be used.
          And because you require sglang==0.5.8.post1, we can conclude that your requirements are unsatisfiable.
    
          hint: `torchao` was found on https://download.pytorch.org/whl/cu130, but not at the requested version (torchao==0.9.0). A compatible version may be available on a
          subsequent index (e.g., https://pypi.org/simple). By default, uv will only consider versions that are published on the first index that contains a given package,
          to avoid dependency confusion attacks. If all indexes are equally trusted, use `--index-strategy unsafe-best-match` to consider all versions from all indexes,
          regardless of the order in which they were defined.
    ```

The proposed 3-step approach resolves these issues by:
- Installing PyTorch with CUDA 13 support first using `--index-url`
- Then installing sglang normally
- Finally installing the CUDA 13 specific sgl_kernel wheel

This is the method I have personally been using for CUDA 13 installations and it has always worked best.

cc @Fridge003 

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
