### PR TITLE
[CI] fix: notebook ci may not working

### DIFF
--- a/.github/workflows/execute-notebook.yml
+++ b/.github/workflows/execute-notebook.yml
@@ -3,10 +3,13 @@ name: Execute Notebooks
 on:
   pull_request:
     branches: [ main ]
-    types: [synchronize, labeled]
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "python/sglang/**"
       - "docs/**"
+    paths-ignore:
+      - "python/sglang/**/*.md"
+      - "docs/**/*.md"
   workflow_dispatch:
 
 
@@ -18,9 +21,16 @@ env:
   SGLANG_IS_IN_CI: true
 
 jobs:
+  call-gate:
+    # Align with PR Test: fail fast if PR doesn't have run-ci label.
+    # This makes /tag-and-rerun-ci work by rerunning this failed workflow.
+    uses: ./.github/workflows/pr-gate.yml
+    secrets: inherit
+
   run-all-notebooks:
+    needs: [call-gate]
     runs-on: 1-gpu-runner
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
+    if: github.event_name != 'pull_request' || needs.call-gate.result == 'success'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,9 +56,11 @@ jobs:
 
   notebook-finish:
     needs: [
+      call-gate,
       run-all-notebooks
     ]
     runs-on: ubuntu-latest
+    if: always() && needs.run-all-notebooks.result != 'skipped'
     steps:
       - name: Check all dependent job statuses
         run: |

--- a/.github/workflows/execute-notebook.yml
+++ b/.github/workflows/execute-notebook.yml
@@ -7,9 +7,8 @@ on:
     paths:
       - "python/sglang/**"
       - "docs/**"
-    paths-ignore:
-      - "python/sglang/**/*.md"
-      - "docs/**/*.md"
+      - "!python/sglang/**/*.md"
+      - "!docs/**/*.md"
   workflow_dispatch:
 
 


### PR DESCRIPTION
## Motivation
trying to fix https://github.com/sgl-project/sglang/issues/18430

In the previous code, the `Execute Notebooks` workflow could be effectively skipped due to a combination of factors:

- When a PR is created (`opened`), the notebook workflow is **not** triggered because `pull_request.types` did not include `opened`.
- If the PR does not receive any further pushes (`synchronize`) and no other triggering events occur (such as adding a label),
- Then **no notebook workflow run is ever created for that head SHA**.
- However, `/tag-and-rerun-ci` can only rerun jobs if there is already a workflow run record (either `skipped` or `failure`) for that head SHA.
- As a result, the entire notebook CI effectively gets skipped.

Adding `opened` alone only solves part of the problem: the workflow run will at least **exist**. But even if `run-all-notebooks` is skipped, the overall workflow often still ends in `success` instead of `skipped`. In that case, `handle_rerun_failed_ci` will not pick it up as a failed/skipped target to rerun. To fully address this, we also need to adjust both `call-gate` and the finish job (following the pattern used in the `PR Test `workflow).

### how to reproduce
1. Modify files under docs/** and submit a PR.
2. Tag the PR with /tag-and-rerun-ci.
3. After the run-ci label is added, the notebook CI is still not triggered and does not even appear in the Checks list.
For example: 
https://github.com/sgl-project/sglang/pull/18418

## Benchmarking and Profiling
See https://github.com/sgl-project/sglang/pull/18416.
After this fix, any non-markdown changes will correctly trigger the notebook CI once it is tagged with `/tag-and-rerun-ci`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
