### PR TITLE
[ModelOpt MXFP8] 

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -837,6 +837,7 @@ class ModelConfig:
         compatible_quantization_methods = {
             "modelopt_fp8": ["modelopt"],
             "modelopt_fp4": ["modelopt"],
+            "modelopt_mxfp8": ["modelopt"],
             "petit_nvfp4": ["modelopt"],
             "w8a8_int8": ["compressed-tensors", "compressed_tensors"],
             "w8a8_fp8": ["compressed-tensors", "compressed_tensors"],

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -7,6 +7,10 @@ import torch
 from sglang.srt.layers.moe.cutlass_moe_params import CutlassMoEParams
 from sglang.srt.utils import is_cuda, is_sm90_supported, is_sm100_supported
 
+# Workspace size required by CUTLASS grouped GEMM kernels (bytes).
+# Used by both FP8 and MXFP8 MoE paths.
+CUTLASS_MOE_WORKSPACE_BYTES = 90000
+
 _is_cuda = is_cuda()
 if _is_cuda:
     from sgl_kernel import (

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -58,7 +58,10 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors_moe im
     CompressedTensorsMxInt4MoEMethod,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
-from sglang.srt.layers.quantization.modelopt_quant import ModelOptNvFp4FusedMoEMethod
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptMxfp8MoEMethod,
+    ModelOptNvFp4FusedMoEMethod,
+)
 from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
 from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
 from sglang.srt.server_args import get_global_server_args

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -784,6 +784,11 @@ class FusedMoE(torch.nn.Module):
                         expert_data=expert_data,
                         tp_rank=tp_rank,
                     )
+                else:
+                    logger.warning(
+                        "MXFP8 MoE: ignoring unrecognized weight %s",
+                        weight_name,
+                    )
                 return
 
             # FP4 uses "weight_scale_2" for per-tensor, FP8 uses "weight_scale" for per-tensor

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -58,7 +58,10 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors_moe im
     CompressedTensorsMxInt4MoEMethod,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
-from sglang.srt.layers.quantization.modelopt_quant import ModelOptNvFp4FusedMoEMethod
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptMxfp8MoEMethod,
+    ModelOptNvFp4FusedMoEMethod,
+)
 from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
 from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
 from sglang.srt.server_args import get_global_server_args
@@ -769,6 +772,19 @@ class FusedMoE(torch.nn.Module):
 
         if "ModelOpt" in self.quant_method.__class__.__name__:
             is_fp4_variant = isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
+            is_mxfp8_variant = isinstance(self.quant_method, ModelOptMxfp8MoEMethod)
+
+            if is_mxfp8_variant:
+                # MXFP8: weight_scale is block scale (uint8 UE8M0), not per-tensor
+                if "weight_scale" in weight_name or "weight" in weight_name:
+                    self._load_model_weight_or_group_weight_scale(
+                        shard_id=shard_id,
+                        shard_dim=shard_dim,
+                        loaded_weight=loaded_weight,
+                        expert_data=expert_data,
+                        tp_rank=tp_rank,
+                    )
+                return
 
             # FP4 uses "weight_scale_2" for per-tensor, FP8 uses "weight_scale" for per-tensor
             per_tensor_conditions = (

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -58,10 +58,7 @@ from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors_moe im
     CompressedTensorsMxInt4MoEMethod,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
-from sglang.srt.layers.quantization.modelopt_quant import (
-    ModelOptMxfp8MoEMethod,
-    ModelOptNvFp4FusedMoEMethod,
-)
+from sglang.srt.layers.quantization.modelopt_quant import ModelOptNvFp4FusedMoEMethod
 from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
 from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
 from sglang.srt.server_args import get_global_server_args
@@ -707,7 +704,6 @@ class FusedMoE(torch.nn.Module):
         # Flashinfer assumes w31 format for w13_weight. Same for the scales.
         if self.use_flashinfer_trtllm_moe and (
             isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
-            or isinstance(self.quant_method, ModelOptMxfp8MoEMethod)
             or isinstance(self.quant_method, Fp8MoEMethod)
             or isinstance(self.quant_method, UnquantizedFusedMoEMethod)
             or isinstance(self.quant_method, CompressedTensorsMxInt4MoEMethod)
@@ -773,19 +769,6 @@ class FusedMoE(torch.nn.Module):
 
         if "ModelOpt" in self.quant_method.__class__.__name__:
             is_fp4_variant = isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
-            is_mxfp8_variant = isinstance(self.quant_method, ModelOptMxfp8MoEMethod)
-
-            if is_mxfp8_variant:
-                # MXFP8: weight_scale is block scale (uint8 UE8M0), not per-tensor
-                if "weight_scale" in weight_name or "weight" in weight_name:
-                    self._load_model_weight_or_group_weight_scale(
-                        shard_id=shard_id,
-                        shard_dim=shard_dim,
-                        loaded_weight=loaded_weight,
-                        expert_data=expert_data,
-                        tp_rank=tp_rank,
-                    )
-                return
 
             # FP4 uses "weight_scale_2" for per-tensor, FP8 uses "weight_scale" for per-tensor
             per_tensor_conditions = (

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -181,104 +181,6 @@ def align_fp4_moe_weights_for_flashinfer_trtllm(layer: Module) -> None:
     )
 
 
-def align_mxfp8_moe_weights_for_flashinfer_trtllm(
-    layer: Module, quantize: bool = True
-) -> None:
-    """Prepare MXFP8 MoE weights/scales for FlashInfer TRT-LLM kernels.
-
-    For the trtllm MXFP8 path, weights must be:
-    1. Quantized to MXFP8 using flashinfer's mxfp8_quantize (swizzled scales)
-    2. Rows reordered for gated activation (w13 only)
-    3. Shuffled for transposed MMA output
-
-    Args:
-        layer: The MoE layer to process.
-        quantize: If True, quantize BF16 weights to MXFP8.
-            If False, assume weights are already MXFP8 quantized.
-    """
-    from flashinfer import reorder_rows_for_gated_act_gemm, shuffle_matrix_a
-    from flashinfer.fp8_quantization import mxfp8_quantize
-
-    w13_weight = cast(torch.Tensor, layer.w13_weight)
-    w2_weight = cast(torch.Tensor, layer.w2_weight)
-    num_experts = w13_weight.shape[0]
-
-    def _dequantize_mxfp8_2d(fp8_weight: torch.Tensor, scale_u8: torch.Tensor):
-        group_size = 32
-        n, k = fp8_weight.shape
-        n_groups = k // group_size
-        scales_f32 = torch.pow(
-            2.0, scale_u8.to(dtype=torch.float32, device=fp8_weight.device) - 127.0
-        )
-        weight_f32 = fp8_weight.to(torch.float32).view(n, n_groups, group_size)
-        return (weight_f32 * scales_f32.unsqueeze(-1)).view(n, k).to(torch.bfloat16)
-
-    if not quantize:
-        # Pre-quantized FP8 checkpoint stores raw FP8 mantissas plus 2D UE8M0
-        # block scales. Reconstruct bf16 first, then requantize to flashinfer's
-        # swizzled scale layout expected by the TRT-LLM kernel.
-        w13_scale = cast(torch.Tensor, layer.w13_weight_scale_inv)
-        w2_scale = cast(torch.Tensor, layer.w2_weight_scale_inv)
-        w13_weight = torch.stack(
-            [
-                _dequantize_mxfp8_2d(w13_weight[i], w13_scale[i])
-                for i in range(num_experts)
-            ]
-        )
-        w2_weight = torch.stack(
-            [
-                _dequantize_mxfp8_2d(w2_weight[i], w2_scale[i])
-                for i in range(num_experts)
-            ]
-        )
-
-    # Quantize (or re-quantize) to MXFP8 with swizzled scales for weights
-    w13_q_list, w13_s_list = [], []
-    w2_q_list, w2_s_list = [], []
-    for i in range(num_experts):
-        w13_q, w13_s = mxfp8_quantize(
-            w13_weight[i], is_sf_swizzled_layout=True, backend="cuda"
-        )
-        w13_q_list.append(w13_q)
-        w13_s_list.append(w13_s.view(torch.uint8))
-
-        w2_q, w2_s = mxfp8_quantize(
-            w2_weight[i], is_sf_swizzled_layout=True, backend="cuda"
-        )
-        w2_q_list.append(w2_q)
-        w2_s_list.append(w2_s.view(torch.uint8))
-
-    w13_weight = torch.stack(w13_q_list)
-    w13_scales = torch.stack(w13_s_list)
-    w2_weight = torch.stack(w2_q_list)
-    w2_scales = torch.stack(w2_s_list)
-
-    # Reorder rows for gated activation (w13 only — interleaves gate/up halves)
-    w13_interleaved = torch.stack(
-        [reorder_rows_for_gated_act_gemm(w13_weight[i]) for i in range(num_experts)]
-    ).reshape_as(w13_weight)
-
-    # Shuffle weights for transposed MMA output (both w13 and w2)
-    epilogue_tile_m = 128
-    w13_shuffled = torch.stack(
-        [
-            shuffle_matrix_a(w13_interleaved[i].view(torch.uint8), epilogue_tile_m)
-            for i in range(num_experts)
-        ]
-    ).view(torch.float8_e4m3fn)
-    w2_shuffled = torch.stack(
-        [
-            shuffle_matrix_a(w2_weight[i].view(torch.uint8), epilogue_tile_m)
-            for i in range(num_experts)
-        ]
-    ).view(torch.float8_e4m3fn)
-
-    layer.w13_weight = Parameter(w13_shuffled, requires_grad=False)
-    layer.w2_weight = Parameter(w2_shuffled, requires_grad=False)
-    layer.w13_weight_scale_inv = Parameter(w13_scales, requires_grad=False)
-    layer.w2_weight_scale_inv = Parameter(w2_scales, requires_grad=False)
-
-
 @dataclass
 class FlashInferTrtllmFp8MoeQuantInfo(MoeQuantInfo):
     """Quantization payload consumed by FlashInfer TRT-LLM FP8 MoE kernels."""
@@ -308,9 +210,6 @@ class FlashInferTrtllmFp8MoeQuantInfo(MoeQuantInfo):
     output2_scales_scalar: torch.Tensor | None = None
     use_routing_scales_on_input: bool = False
 
-    # MXFP8 path
-    use_mxfp8: bool = False
-
 
 def fused_experts_none_to_flashinfer_trtllm_fp8(
     dispatch_output: StandardDispatchOutput,
@@ -318,7 +217,6 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
     from flashinfer.fused_moe import (
-        Fp8QuantizationType,
         trtllm_fp8_block_scale_moe,
         trtllm_fp8_per_tensor_scale_moe,
     )
@@ -345,28 +243,12 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
     routing_method_type = quant_info.routing_method_type
 
     if quant_info.block_quant:
+        assert quant_info.weight_block_k is not None
         assert quant_info.w13_weight_scale_inv is not None
         assert quant_info.w2_weight_scale_inv is not None
 
-        if quant_info.use_mxfp8:
-            # MXFP8 path: quantize activations with flashinfer's mxfp8_quantize
-            from flashinfer.fp8_quantization import mxfp8_quantize
-
-            a_q, a_sf = mxfp8_quantize(
-                hidden_states, is_sf_swizzled_layout=False, backend="cuda"
-            )
-            a_sf = a_sf.view(torch.uint8).reshape(hidden_states.shape[0], -1)
-            fp8_quant_type = Fp8QuantizationType.MxFp8
-            use_shuffled_weight = True
-        else:
-            # DeepSeek FP8 block scale path
-            assert quant_info.weight_block_k is not None
-            a_q, a_sf = per_token_group_quant_fp8(
-                hidden_states, quant_info.weight_block_k
-            )
-            a_sf = a_sf.t().contiguous()
-            fp8_quant_type = Fp8QuantizationType.DeepSeekFp8
-            use_shuffled_weight = False
+        a_q, a_sf = per_token_group_quant_fp8(hidden_states, quant_info.weight_block_k)
+        a_sf_t = a_sf.t().contiguous()
 
         with use_symmetric_memory(
             get_tp_group(), disabled=not is_allocation_symmetric()
@@ -375,16 +257,15 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
             # It ignored the `output` argument. https://github.com/flashinfer-ai/flashinfer/blob/da01b1bd8f9f22aec8c0eea189ad54860b034947/flashinfer/fused_moe/core.py#L1323-L1325
             # so we put the whole function under the ``use_symmetric_memory`` context manager.
             # If the bug is fixed, we can only put the output tensor allocation under the context manager.
-            _rl = (
-                router_logits.to(torch.float32)
-                if routing_method_type == RoutingMethodType.DeepSeekV3
-                else router_logits
-            )
             output = trtllm_fp8_block_scale_moe(
-                routing_logits=_rl,
+                routing_logits=(
+                    router_logits.to(torch.float32)
+                    if routing_method_type == RoutingMethodType.DeepSeekV3
+                    else router_logits
+                ),
                 routing_bias=correction_bias,
                 hidden_states=a_q,
-                hidden_states_scale=a_sf,
+                hidden_states_scale=a_sf_t,
                 gemm1_weights=quant_info.w13_weight,
                 gemm1_weights_scale=quant_info.w13_weight_scale_inv,
                 gemm2_weights=quant_info.w2_weight,
@@ -404,9 +285,8 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                     else 1.0
                 ),
                 routing_method_type=routing_method_type,
-                use_shuffled_weight=use_shuffled_weight,
+                use_shuffled_weight=False,
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
-                fp8_quantization_type=fp8_quant_type,
             )
     else:
         assert quant_info.w13_input_scale is not None

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -31,6 +31,7 @@ from sglang.srt.layers.quantization.gptq import GPTQConfig, GPTQMarlinConfig
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp8Config,
+    ModelOptMxfp8Config,
 )
 from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
 from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
@@ -57,6 +58,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "modelopt": ModelOptFp8Config,  # Auto-detect, defaults to FP8
     "modelopt_fp8": ModelOptFp8Config,
     "modelopt_fp4": ModelOptFp4Config,
+    "modelopt_mxfp8": ModelOptMxfp8Config,
     "w8a8_int8": W8A8Int8Config,
     "w8a8_fp8": W8A8Fp8Config,
     "awq": AWQConfig,

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -171,16 +171,22 @@ class QuantizationConfig(ABC):
 
         # If user specified generic "modelopt", auto-detect the specific method
         if user_quant == "modelopt":
-            if "FP8" in quant_algo:
+            # Check MXFP8 before FP8 since "MXFP8" contains "FP8"
+            if "MXFP8" in quant_algo:
+                return "modelopt_mxfp8"
+            elif "FP8" in quant_algo:
                 return "modelopt_fp8"
             elif "NVFP4" in quant_algo or "FP4" in quant_algo:
                 return "modelopt_fp4"
 
         # The hf_quant_config may be a parsed quant config, so we need to check the
         # quant_method.
-        if hf_quant_config.get("quant_method", "") == "modelopt_fp8":
+        quant_method = hf_quant_config.get("quant_method", "")
+        if quant_method == "modelopt_mxfp8":
+            return "modelopt_mxfp8"
+        elif quant_method == "modelopt_fp8":
             return "modelopt_fp8"
-        elif hf_quant_config.get("quant_method", "") == "modelopt_fp4":
+        elif quant_method == "modelopt_fp4":
             return "modelopt_fp4"
 
         return None

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.amx_utils import (
 )
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.cutlass_moe import CUTLASS_MOE_WORKSPACE_BYTES
 from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
 from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
     FlashInferTrtllmFp8MoeQuantInfo,
@@ -1553,7 +1554,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.c_strides2 = torch.full(
             (num_experts,), hidden_size, device=device, dtype=torch.int64
         )
-        self.workspace = torch.empty(90000, device=device, dtype=torch.uint8)
+        self.workspace = torch.empty(
+            CUTLASS_MOE_WORKSPACE_BYTES, device=device, dtype=torch.uint8
+        )
         self.a_ptr = torch.empty(num_experts, device=device, dtype=torch.int64)
         self.b_ptr = torch.empty(num_experts, device=device, dtype=torch.int64)
         self.out_ptr = torch.empty(num_experts, device=device, dtype=torch.int64)

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -972,15 +972,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if not (_is_cuda and is_sm100_supported()):
             raise RuntimeError("MXFP8 MoE quantization requires SM100.")
 
-        # For trtllm backend, use flashinfer-native MXFP8 weight preparation
-        if get_moe_runner_backend().is_flashinfer_trtllm():
-            from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
-                align_mxfp8_moe_weights_for_flashinfer_trtllm,
-            )
-
-            align_mxfp8_moe_weights_for_flashinfer_trtllm(layer, quantize=quantize)
-            return
-
         def _quantize_and_swizzle_with_cutlass_es_kernel(weight: torch.Tensor):
             from sgl_kernel import es_sm100_mxfp8_blockscaled_grouped_quant
 
@@ -1508,7 +1499,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     if not self.block_quant
                     else None
                 ),
-                use_mxfp8=self.use_mxfp8,
             )
         elif self.runner.runner_backend.is_triton():
             quant_info = TritonMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -972,6 +972,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if not (_is_cuda and is_sm100_supported()):
             raise RuntimeError("MXFP8 MoE quantization requires SM100.")
 
+        # For trtllm backend, use flashinfer-native MXFP8 weight preparation
+        if get_moe_runner_backend().is_flashinfer_trtllm():
+            from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+                align_mxfp8_moe_weights_for_flashinfer_trtllm,
+            )
+
+            align_mxfp8_moe_weights_for_flashinfer_trtllm(layer, quantize=quantize)
+            return
+
         def _quantize_and_swizzle_with_cutlass_es_kernel(weight: torch.Tensor):
             from sgl_kernel import es_sm100_mxfp8_blockscaled_grouped_quant
 
@@ -1499,6 +1508,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     if not self.block_quant
                     else None
                 ),
+                use_mxfp8=self.use_mxfp8,
             )
         elif self.runner.runner_backend.is_triton():
             quant_info = TritonMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -654,6 +654,111 @@ def _pack_mxfp8_scales(scale_u8: torch.Tensor) -> torch.Tensor:
     return packed.view(1, scale_m, scale_k, 2, 256)
 
 
+def _interleave_mxfp8_scales_for_cublas(
+    scale_u8: torch.Tensor, m_padded: int, k: int
+) -> torch.Tensor:
+    """Convert natural MXFP8 scales (M, K//32) to cuBLAS interleaved layout."""
+    k_groups = k // 32
+    return (
+        scale_u8.view(m_padded // 128, 4, 32, k // 128, 4)
+        .permute(0, 3, 2, 1, 4)
+        .contiguous()
+        .view(m_padded, k_groups)
+        .view(torch.float8_e8m0fnu)
+    )
+
+
+def prepare_mxfp8_weight_for_cublas(
+    weight: torch.Tensor, weight_scale: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pre-compute (K, N) weight view and interleaved scales for torch._scaled_mm."""
+    n, k = weight.shape
+    assert n % 128 == 0, f"N={n} must be divisible by 128 for MXFP8"
+    assert k % 128 == 0, f"K={k} must be divisible by 128 for MXFP8"
+    # Keep non-contiguous transpose view for column-major B expected by cuBLAS.
+    weight_t = weight.t()
+    weight_scale_cublas = _interleave_mxfp8_scales_for_cublas(weight_scale, n, k)
+    return weight_t, weight_scale_cublas
+
+
+def cublas_mxfp8_blockscaled_linear(
+    input: torch.Tensor,
+    weight_t: torch.Tensor,
+    weight_scale_cublas: torch.Tensor,
+    input_scale: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """MXFP8 dense linear via cuBLAS torch._scaled_mm."""
+    if not (_is_cuda and is_sm100_supported()):
+        raise RuntimeError("MXFP8 cuBLAS linear requires Blackwell GPUs (SM100+).")
+
+    if not hasattr(cublas_mxfp8_blockscaled_linear, "_logged"):
+        logger.info("Using cuBLAS MXFP8 dense linear (torch._scaled_mm)")
+        cublas_mxfp8_blockscaled_linear._logged = True
+
+    input_2d = input.view(-1, input.shape[-1]).contiguous()
+    k, n = weight_t.shape
+    output_shape = [*input.shape[:-1], n]
+    m = input_2d.shape[0]
+    assert (
+        input_2d.shape[1] == k
+    ), f"K mismatch: input {input_2d.shape[1]} vs weight {k}"
+
+    if input_scale is None:
+        q_input, x_scale_u8 = mxfp8_group_quantize(input_2d)
+    else:
+        q_input = input_2d
+        x_scale_u8 = input_scale
+        assert x_scale_u8.dtype == torch.uint8, "MXFP8 input_scale must be UE8M0 uint8."
+        assert x_scale_u8.shape == (m, k // 32)
+
+    if output_dtype is None:
+        if input_2d.dtype in (torch.float16, torch.bfloat16, torch.float32):
+            output_dtype = input_2d.dtype
+        else:
+            output_dtype = torch.bfloat16
+
+    if m % 128 != 0:
+        m_padded = ceil_div(m, 128) * 128
+        pad_rows = m_padded - m
+        q_input = torch.cat(
+            [
+                q_input,
+                torch.zeros((pad_rows, k), device=q_input.device, dtype=q_input.dtype),
+            ],
+            dim=0,
+        )
+        x_scale_u8 = torch.cat(
+            [
+                x_scale_u8,
+                torch.full(
+                    (pad_rows, k // 32),
+                    127,
+                    device=x_scale_u8.device,
+                    dtype=x_scale_u8.dtype,
+                ),
+            ],
+            dim=0,
+        )
+    else:
+        m_padded = m
+
+    sa = _interleave_mxfp8_scales_for_cublas(x_scale_u8, m_padded, k)
+    output = torch._scaled_mm(
+        q_input,
+        weight_t,
+        scale_a=sa,
+        scale_b=weight_scale_cublas,
+        out_dtype=output_dtype,
+    )
+
+    output = output[:m, :]
+    if bias is not None:
+        output += bias
+    return output.view(*output_shape)
+
+
 def triton_mxfp8_blockscaled_linear(
     input: torch.Tensor,
     weight: torch.Tensor,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -654,109 +654,29 @@ def _pack_mxfp8_scales(scale_u8: torch.Tensor) -> torch.Tensor:
     return packed.view(1, scale_m, scale_k, 2, 256)
 
 
-def _interleave_mxfp8_scales_for_cublas(
-    scale_u8: torch.Tensor, m_padded: int, k: int
+def dequantize_mxfp8(
+    data: torch.Tensor, scale_u8: torch.Tensor, group_size: int = 32
 ) -> torch.Tensor:
-    """Convert natural MXFP8 scales (M, K//32) to cuBLAS interleaved layout."""
-    k_groups = k // 32
-    return (
-        scale_u8.view(m_padded // 128, 4, 32, k // 128, 4)
-        .permute(0, 3, 2, 1, 4)
-        .contiguous()
-        .view(m_padded, k_groups)
-        .view(torch.float8_e8m0fnu)
+    """Dequantize MXFP8 tensor with UE8M0 scales back to bf16.
+
+    Applies per-group scaling: fp8_val * 2^(scale - 127).
+
+    Args:
+        data: FP8 tensor of shape (M, K).
+        scale_u8: uint8 UE8M0 scales of shape (M, K // group_size).
+        group_size: Number of elements per scale group (default 32).
+
+    Returns:
+        bf16 tensor of shape (M, K).
+    """
+    m, k = data.shape
+    n_groups = k // group_size
+    scales_f32 = torch.pow(
+        2.0, scale_u8.to(dtype=torch.float32, device=data.device) - 127.0
     )
-
-
-def prepare_mxfp8_weight_for_cublas(
-    weight: torch.Tensor, weight_scale: torch.Tensor
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Pre-compute (K, N) weight view and interleaved scales for torch._scaled_mm."""
-    n, k = weight.shape
-    assert n % 128 == 0, f"N={n} must be divisible by 128 for MXFP8"
-    assert k % 128 == 0, f"K={k} must be divisible by 128 for MXFP8"
-    # Keep non-contiguous transpose view for column-major B expected by cuBLAS.
-    weight_t = weight.t()
-    weight_scale_cublas = _interleave_mxfp8_scales_for_cublas(weight_scale, n, k)
-    return weight_t, weight_scale_cublas
-
-
-def cublas_mxfp8_blockscaled_linear(
-    input: torch.Tensor,
-    weight_t: torch.Tensor,
-    weight_scale_cublas: torch.Tensor,
-    input_scale: Optional[torch.Tensor] = None,
-    bias: Optional[torch.Tensor] = None,
-    output_dtype: Optional[torch.dtype] = None,
-) -> torch.Tensor:
-    """MXFP8 dense linear via cuBLAS torch._scaled_mm."""
-    if not (_is_cuda and is_sm100_supported()):
-        raise RuntimeError("MXFP8 cuBLAS linear requires Blackwell GPUs (SM100+).")
-
-    if not hasattr(cublas_mxfp8_blockscaled_linear, "_logged"):
-        logger.info("Using cuBLAS MXFP8 dense linear (torch._scaled_mm)")
-        cublas_mxfp8_blockscaled_linear._logged = True
-
-    input_2d = input.view(-1, input.shape[-1]).contiguous()
-    k, n = weight_t.shape
-    output_shape = [*input.shape[:-1], n]
-    m = input_2d.shape[0]
-    assert (
-        input_2d.shape[1] == k
-    ), f"K mismatch: input {input_2d.shape[1]} vs weight {k}"
-
-    if input_scale is None:
-        q_input, x_scale_u8 = mxfp8_group_quantize(input_2d)
-    else:
-        q_input = input_2d
-        x_scale_u8 = input_scale
-        assert x_scale_u8.dtype == torch.uint8, "MXFP8 input_scale must be UE8M0 uint8."
-        assert x_scale_u8.shape == (m, k // 32)
-
-    if output_dtype is None:
-        if input_2d.dtype in (torch.float16, torch.bfloat16, torch.float32):
-            output_dtype = input_2d.dtype
-        else:
-            output_dtype = torch.bfloat16
-
-    if m % 128 != 0:
-        m_padded = ceil_div(m, 128) * 128
-        pad_rows = m_padded - m
-        q_input = torch.cat(
-            [
-                q_input,
-                torch.zeros((pad_rows, k), device=q_input.device, dtype=q_input.dtype),
-            ],
-            dim=0,
-        )
-        x_scale_u8 = torch.cat(
-            [
-                x_scale_u8,
-                torch.full(
-                    (pad_rows, k // 32),
-                    127,
-                    device=x_scale_u8.device,
-                    dtype=x_scale_u8.dtype,
-                ),
-            ],
-            dim=0,
-        )
-    else:
-        m_padded = m
-
-    sa = _interleave_mxfp8_scales_for_cublas(x_scale_u8, m_padded, k)
-    output = torch._scaled_mm(
-        q_input,
-        weight_t,
-        scale_a=sa,
-        scale_b=weight_scale_cublas,
-        out_dtype=output_dtype,
-    )
-
-    output = output[:m, :]
-    if bias is not None:
-        output += bias
-    return output.view(*output_shape)
+    data_f32 = data.to(torch.float32).view(m, n_groups, group_size)
+    scales_f32 = scales_f32.view(m, n_groups, 1)
+    return (data_f32 * scales_f32).view(m, k).to(torch.bfloat16)
 
 
 def triton_mxfp8_blockscaled_linear(

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2208,7 +2208,13 @@ class ModelOptMxfp8MoEMethod(FusedMoEMethodBase):
                 local_expert_offset=layer.moe_ep_rank * layer.num_local_experts,
                 local_num_experts=layer.num_local_experts,
                 intermediate_size=layer.w2_weight.shape[2],
-                routing_method_type=RoutingMethodType.Default,
+                routing_method_type=int(
+                    getattr(
+                        layer,
+                        "routing_method_type",
+                        RoutingMethodType.Renormalize,
+                    )
+                ),
                 block_quant=True,
                 w13_weight_scale_inv=layer.w13_weight_scale_inv,
                 w2_weight_scale_inv=layer.w2_weight_scale_inv,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1951,7 +1951,11 @@ class ModelOptMxfp8LinearMethod(LinearMethodBase):
     """Linear method for ModelOpt MXFP8 quantization.
 
     Loads FP8 weights with uint8 UE8M0 block scales (group_size=32).
-    Uses the existing MXFP8 blockscaled linear infrastructure.
+    Uses flashinfer's bmm_mxfp8 (cuDNN) for inference.
+
+    During process_weights_after_loading, the weight [N, K] is transposed to
+    [K, N] and re-quantized with mxfp8_quantize so that the MXFP8 block scales
+    align with the K-contiguous layout expected by bmm_mxfp8.
     """
 
     BLOCK_K = 32  # MXFP8 group size
@@ -2007,9 +2011,19 @@ class ModelOptMxfp8LinearMethod(LinearMethodBase):
         layer.register_parameter("weight_scale", scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # Rename weight_scale → weight_scale_inv for downstream MXFP8 code
+        from flashinfer.fp8_quantization import mxfp8_quantize
+
+        # Checkpoint weight is [N, K] fp8 with scales for [N, K] layout.
+        # bmm_mxfp8 needs B as [K, N] (column-major) with scales for that layout.
+        # Re-quantize the transposed weight to get correct MXFP8 block scales.
+        weight_bf16 = layer.weight.data.to(torch.bfloat16)  # [N, K]
+        weight_t = weight_bf16.T.contiguous()  # [K, N] row-major
+        weight_t_q, weight_t_scale = mxfp8_quantize(
+            weight_t, is_sf_swizzled_layout=False
+        )
+        layer.weight = Parameter(weight_t_q, requires_grad=False)  # [K, N] fp8
         layer.weight_scale_inv = Parameter(
-            layer.weight_scale.data, requires_grad=False
+            weight_t_scale.view(torch.uint8), requires_grad=False
         )
 
     def apply(
@@ -2018,24 +2032,34 @@ class ModelOptMxfp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        from sglang.srt.layers.quantization.fp8_utils import (
-            triton_mxfp8_blockscaled_linear,
-        )
+        from flashinfer import bmm_mxfp8
+        from flashinfer.fp8_quantization import mxfp8_quantize
 
+        input_2d = x.view(-1, x.shape[-1])  # [M, K]
+        output_shape = [*x.shape[:-1], layer.weight.shape[1]]  # [..., N]
+
+        # Quantize activations to MXFP8
         if isinstance(x, tuple):
-            return triton_mxfp8_blockscaled_linear(
-                input=x[0],
-                weight=layer.weight,
-                weight_scale=layer.weight_scale_inv,
-                input_scale=x[1],
-                bias=bias,
+            input_q = input_2d
+            input_scale = x[1]
+        else:
+            input_q, input_scale = mxfp8_quantize(
+                input_2d, is_sf_swizzled_layout=False
             )
-        return triton_mxfp8_blockscaled_linear(
-            input=x,
-            weight=layer.weight,
-            weight_scale=layer.weight_scale_inv,
-            bias=bias,
+
+        # bmm_mxfp8: A [1, M, K] @ B [1, K, N] → [1, M, N]
+        out = bmm_mxfp8(
+            input_q.unsqueeze(0),
+            layer.weight.unsqueeze(0),
+            input_scale,
+            layer.weight_scale_inv,
+            dtype=torch.bfloat16,
         )
+        out = out.squeeze(0)  # [M, N]
+
+        if bias is not None:
+            out = out + bias
+        return out.view(*output_shape)
 
 
 class ModelOptMxfp8MoEMethod(FusedMoEMethodBase):
@@ -2089,9 +2113,7 @@ class ModelOptMxfp8MoEMethod(FusedMoEMethodBase):
             weight_loader=weight_loader,
         )
         layer.register_parameter("w13_weight", w13_weight)
-        set_weight_attrs(w13_weight, extra_weight_attrs)
         layer.register_parameter("w2_weight", w2_weight)
-        set_weight_attrs(w2_weight, extra_weight_attrs)
 
         # Block scales: uint8 UE8M0, named "weight_scale" to match ModelOpt checkpoint
         # Shape: [num_experts, N, K // 32]

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2030,7 +2030,9 @@ class ModelOptMxfp8LinearMethod(LinearMethodBase):
         # Reconstruct bf16 values first, then requantize to flashinfer swizzled
         # scales so mm_mxfp8 can consume them directly.
         weight_bf16 = self._dequantize_mxfp8(layer.weight.data, layer.weight_scale.data)
-        weight_q, weight_scale = mxfp8_quantize(weight_bf16, is_sf_swizzled_layout=True)
+        weight_q, weight_scale = mxfp8_quantize(
+            weight_bf16, is_sf_swizzled_layout=True, backend="cuda"
+        )
 
         # mm_mxfp8 expects B as [K, N] column-major.
         layer.weight = Parameter(weight_q.t(), requires_grad=False)
@@ -2075,7 +2077,9 @@ class ModelOptMxfp8LinearMethod(LinearMethodBase):
             input_padded[:m_actual, :] = input_2d
             input_2d = input_padded
 
-        input_q, input_scale = mxfp8_quantize(input_2d, is_sf_swizzled_layout=True)
+        input_q, input_scale = mxfp8_quantize(
+            input_2d, is_sf_swizzled_layout=True, backend="cuda"
+        )
 
         out = mm_mxfp8(
             input_q,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1298,8 +1298,7 @@ class ServerArgs:
                 if (
                     self.moe_a2a_backend == "none"
                     and self.moe_runner_backend == "auto"
-                    and self.quantization
-                    in ["fp8", "modelopt_fp8", "modelopt_mxfp8", "modelopt_fp4"]
+                    and self.quantization in ["fp8", "modelopt_fp8", "modelopt_fp4"]
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
@@ -1458,7 +1457,7 @@ class ServerArgs:
                 "intel_xpu",
             }, f"fa3, aiter, triton, trtllm_mha or intel_xpu is required for Llama4 model but got {self.attention_backend}"
             if is_sm100_supported() and self.moe_runner_backend == "auto":
-                if self.quantization in {"fp8", "modelopt_fp8", "modelopt_mxfp8"}:
+                if self.quantization in {"fp8", "modelopt_fp8"}:
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
@@ -2080,7 +2079,6 @@ class ServerArgs:
                 "modelopt_fp4",
                 "fp8",
                 "modelopt_fp8",
-                "modelopt_mxfp8",
                 "compressed-tensors",
                 None,
             ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'fp8', 'modelopt_fp8', 'compressed-tensors', or bfloat16 (None)."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2055,6 +2055,13 @@ class ServerArgs:
             ), "Please enable dp attention when setting enable_dp_lm_head. "
 
     def _handle_moe_kernel_config(self):
+        if self.quantization == "modelopt_mxfp8" and not self.disable_cuda_graph:
+            logger.warning(
+                "Cuda graph is disabled for modelopt_mxfp8 because bmm_mxfp8 currently uses "
+                "a cuDNN path that is not graph-capture safe."
+            )
+            self.disable_cuda_graph = True
+
         if self.quantization == "mxfp8":
             if self.moe_runner_backend not in ["auto", "cutlass"]:
                 logger.warning(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1298,7 +1298,8 @@ class ServerArgs:
                 if (
                     self.moe_a2a_backend == "none"
                     and self.moe_runner_backend == "auto"
-                    and self.quantization in ["fp8", "modelopt_fp8", "modelopt_mxfp8", "modelopt_fp4"]
+                    and self.quantization
+                    in ["fp8", "modelopt_fp8", "modelopt_mxfp8", "modelopt_fp4"]
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
@@ -2055,13 +2056,6 @@ class ServerArgs:
             ), "Please enable dp attention when setting enable_dp_lm_head. "
 
     def _handle_moe_kernel_config(self):
-        if self.quantization == "modelopt_mxfp8" and not self.disable_cuda_graph:
-            logger.warning(
-                "Cuda graph is disabled for modelopt_mxfp8 because bmm_mxfp8 currently uses "
-                "a cuDNN path that is not graph-capture safe."
-            )
-            self.disable_cuda_graph = True
-
         if self.quantization == "mxfp8":
             if self.moe_runner_backend not in ["auto", "cutlass"]:
                 logger.warning(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -102,6 +102,7 @@ QUANTIZATION_CHOICES = [
     "bitsandbytes",
     "gguf",
     "modelopt",
+    "modelopt_mxfp8",
     "modelopt_fp8",
     "modelopt_fp4",
     "petit_nvfp4",
@@ -1297,7 +1298,7 @@ class ServerArgs:
                 if (
                     self.moe_a2a_backend == "none"
                     and self.moe_runner_backend == "auto"
-                    and self.quantization in ["fp8", "modelopt_fp8", "modelopt_fp4"]
+                    and self.quantization in ["fp8", "modelopt_fp8", "modelopt_mxfp8", "modelopt_fp4"]
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
@@ -1456,7 +1457,7 @@ class ServerArgs:
                 "intel_xpu",
             }, f"fa3, aiter, triton, trtllm_mha or intel_xpu is required for Llama4 model but got {self.attention_backend}"
             if is_sm100_supported() and self.moe_runner_backend == "auto":
-                if self.quantization in {"fp8", "modelopt_fp8"}:
+                if self.quantization in {"fp8", "modelopt_fp8", "modelopt_mxfp8"}:
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
@@ -2078,6 +2079,7 @@ class ServerArgs:
                 "modelopt_fp4",
                 "fp8",
                 "modelopt_fp8",
+                "modelopt_mxfp8",
                 "compressed-tensors",
                 None,
             ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'fp8', 'modelopt_fp8', 'compressed-tensors', or bfloat16 (None)."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

**Support both MOE and Dense for Modelopt MXFP8**

https://github.com/NVIDIA/Model-Optimizer/pull/736 adds MXFP8 PTQ.

```bash
python3 examples/llm_ptq/hf_ptq.py --pyt_ckpt_path /root/.cache/huggingface/hub/models--Qwen--Qwen3-30B-A3B-Instruct-2507/snapshots/0d7cf23991f47feeb3a57ecb4c9cee8ea4a17bfe --qformat mxfp8 --export_path ./Qwen3-30B-A3B-Instruct-2507-MXFP8
```

After the checkpoint is exported, users should be able to use `--quantization modelopt_mxfp8`.

https://github.com/sgl-project/sglang/issues/18258

We use GEMM here: https://github.com/flashinfer-ai/flashinfer/pull/2464  
**bmm_mxfp8 seems buggy and is incompatible with CUDA Graph.** Follow-up needed.

We tried using https://github.com/flashinfer-ai/flashinfer/pull/2505, but the results seem incorrect, and its tests are not passing locally. Future: add a `trtllm_moe` runner for MXFP8.

This PR depends on https://github.com/flashinfer-ai/flashinfer/pull/2464 being merged.

TRTLLM MXFP8 flashinfer: https://github.com/flashinfer-ai/flashinfer/pull/2505

We support `moe-runner-backend` with Cutlass and Triton.

Triton is very slow at the moment. Both are correct.

Future:

In order of difficulty:

**Minor**
- Use the cuteDSL quantization backend introduced in the flashinfer PR https://github.com/flashinfer-ai/flashinfer/pull/2443 (cutedsl). It should be more performant. Right now we use `cuda` (default).
- Refactor Triton code, keep as an option, and tune fused MoE. And investigate the extremely low performance.
- Remove cublas as an option (torch scaled MM), since `mm_mxfp8` should always be better (but it is slower for small sizes).

**Medium**
- Further optimize our usage of the Cutlass MoE runner `cutlass_fused_experts_fp8`, until the TRTLLM MoE runner is unblocked.
- Further optimize `_swizzle_mxfp8_scales`, and figure out why non-swizzled produces wrong outputs.
- Avoid upcast to BF16 then downcast + swizzle, to reduce peak memory on startup; `process_weights_after_loading` for MXFP8 ModelOpt.

**High**
- `CUTLASS MXFP8` requires `m >= 32`, which fails on models like Qwen-3-next coder / Qwen 3 next 80b. Fix the kernel
- Need to determine flashinfer cutlass mxfp8 support. Whether `flashinfer::cutlass_fused_moe` supports mxfp8. And add it if necessary, so flashinfer_cutlass is valid. It may not be more performant than trtllm_moe, and it is similar to regular cutlass.
- Make this PR work on SM90, since even though Blackwell has MXFP8 quantize HW, SM90 supports it too.
- Support deepgemm with `ue8m0` scale, it supports MXFP8.
- use TRTLLM MoE runner default with MXFP8. It requires it to be correct.
- Refactor `ModelOptQuantConfig`, which has grown extremely large and hard to reason about across configs, and has many brittle/duplicated code paths for special cases that cause severe bugs.


## Benchmark

**Expected performance** (MXFP8 should be similar to Block FP8):

| Runner backend | MXFP8 expected (tok/s) | Reference (Block FP8 / BF16) | Notes |
|---|---:|---:|---|
| Cutlass MoE | ~130–135 | Block FP8 Cutlass: 135 | Current MXFP8 is ~115; target is to close the ~15–20 tok/s gap. |
| TRTLLM MoE | ~200 | Block FP8 TRTLLM MoE: 202 | MXFP8 TRTLLM path is currently blocked/unverified; once correct it should match Block FP8. |
| Triton MoE | N/A (not a perf target) | — | Currently very slow; kept mainly for correctness/debug. |

MXFP8 (ModelOpt), using FlashInfer MXFP8 GEMM:

`--moe-runner-backend cutlass` (SGL Cutlass MoE runner, not `flashinfer_cutlass`). `flashinfer_cutlass` MXFP8 support needs to be verified; if/when it supports `MxE4m3`, it may be a better option.
```md
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    4.419    |  512   |   1.000    |     115.87      |
+-------------+--------+------------+-----------------+
```

Expected >130 tok/s; current gap should be addressable with further Cutlass MoE integration/kernel optimizations.

Triton MoE runner:

```md
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   12.077    |  512   |   1.000    |      42.39      |
+-------------+--------+------------+-----------------+
```

BF16 (FlashInfer `trtllm_moe`):
```md
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    2.344    |  512   |   1.000    |     218.40      |
+-------------+--------+------------+-----------------+
```

Block FP8 (FlashInfer `trtllm_moe`):
```md
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    2.527    |  512   |   1.000    |     202.59      |
+-------------+--------+------------+-----------------+
```

Block FP8 (Cutlass MoE runner):
```md
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    3.789    |  512   |   1.000    |     135.14      |
+-------------+--------+------------+-----------------+
```


<!-- Describe the purpose and goals of this pull request. -->


<!-- Detail the changes made in this pull request. -->


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
