### PR TITLE
fix: use --no-build-isolation for human-eval install

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -937,7 +937,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install -e .
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30
@@ -1041,7 +1041,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install -e .
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30


### PR DESCRIPTION
## Summary
- `setuptools>=81` removed `pkg_resources`, causing `pip install -e .` to fail for human-eval in isolated build env
- Add `--no-build-isolation` to skip isolated build env and use system setuptools

Fixes https://github.com/sgl-project/sglang/actions/runs/21799185200/job/62898578639?pr=18273