### PR TITLE
[CI] Fix human-eval install failure from setuptools 80.x

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -937,7 +937,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install -e .
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30
@@ -1041,7 +1041,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
           git clone https://github.com/merrymercy/human-eval.git
           cd human-eval
-          pip install -e .
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -121,7 +121,7 @@ esac
 #docker exec -w / ci_sglang git clone https://github.com/merrymercy/human-eval.git
 git_clone_with_retry https://github.com/merrymercy/human-eval.git human-eval
 docker cp human-eval ci_sglang:/
-install_with_retry docker exec -w /human-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
+install_with_retry docker exec -w /human-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e . --no-build-isolation
 
 docker exec -w / ci_sglang mkdir -p /dummy-grok
 # Create dummy grok config inline (bypasses Azure blob storage which may have auth issues)


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError: No module named 'pkg_resources'` when installing `human-eval` in CI
- The CI runners now have setuptools 80.9.0, which no longer bundles `pkg_resources` in pip's build isolation environment. Adding `--no-build-isolation` uses the system's setuptools where `pkg_resources` is still available.
- Applied fix to all 3 locations: `stage-b-test-small-1-gpu`, `stage-b-test-large-2-gpu` (pr-test.yml), and AMD CI (amd_ci_install_dependency.sh)

Failure example: https://github.com/sgl-project/sglang/actions/runs/21832535494/job/62994687488

## Test plan
- [ ] Verify `stage-b-test-small-1-gpu` passes the install step
- [ ] Verify `stage-b-test-large-2-gpu` passes the install step