### PR TITLE
Tiny fix wrong metric collect key name `forward_prefill` -> `forward_extend`

### DIFF
--- a/test/registered/metrics/test_metrics.py
+++ b/test/registered/metrics/test_metrics.py
@@ -46,10 +46,13 @@ class TestEnableMetrics(CustomTestCase):
                     "sglang:dp_cooperation_realtime_tokens_total",
                     {"mode": "prefill_compute"},
                 ),
-                ("sglang:dp_cooperation_realtime_tokens_total", {"mode": "decode"}),
+                (
+                    "sglang:dp_cooperation_realtime_tokens_total",
+                    {"mode": "decode"},
+                ),
                 (
                     "sglang:dp_cooperation_gpu_execution_seconds_total",
-                    {"category": "forward_prefill"},
+                    {"category": "forward_extend"},
                 ),
                 (
                     "sglang:dp_cooperation_gpu_execution_seconds_total",

--- a/test/registered/metrics/test_metrics.py
+++ b/test/registered/metrics/test_metrics.py
@@ -203,6 +203,7 @@ def _get_sample_value_by_labels(samples: List[Sample], labels: Dict[str, str]) -
 
 def _check_metrics_positive(test_case, metrics, metrics_to_check):
     for metric_name, labels in metrics_to_check:
+        print(f"[DEBUG] Checking metric: {metric_name=} {labels=}")
         value = _get_sample_value_by_labels(metrics[metric_name], labels)
         test_case.assertGreater(value, 0, f"{metric_name} {labels}")
 

--- a/test/registered/metrics/test_metrics.py
+++ b/test/registered/metrics/test_metrics.py
@@ -20,7 +20,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=32, suite="stage-a-test-1")
+register_cuda_ci(est_time=32, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=32, suite="stage-b-test-small-1-gpu-amd")
 
 _MODEL_NAME = "Qwen/Qwen3-0.6B"
@@ -206,7 +206,6 @@ def _get_sample_value_by_labels(samples: List[Sample], labels: Dict[str, str]) -
 
 def _check_metrics_positive(test_case, metrics, metrics_to_check):
     for metric_name, labels in metrics_to_check:
-        print(f"[DEBUG] Checking metric: {metric_name=} {labels=}")
         value = _get_sample_value_by_labels(metrics[metric_name], labels)
         test_case.assertGreater(value, 0, f"{metric_name} {labels}")
 

--- a/test/registered/metrics/test_metrics.py
+++ b/test/registered/metrics/test_metrics.py
@@ -20,7 +20,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=32, suite="stage-b-test-small-1-gpu")
+register_cuda_ci(est_time=32, suite="stage-a-test-1")
 register_amd_ci(est_time=32, suite="stage-b-test-small-1-gpu-amd")
 
 _MODEL_NAME = "Qwen/Qwen3-0.6B"


### PR DESCRIPTION
All modifications are dead code. This test has actually failed. linked a [**Good First Issue**](https://github.com/sgl-project/sglang/issues/18509)