### PR TITLE
[JIT-Kernel] Enable CTA path for QKNorm to support head_dim 512/1024

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/qknorm.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/qknorm.cuh
@@ -41,26 +41,47 @@ __global__ void fused_qknorm(const QKNormParams __grid_constant__ params) {
   static_assert(sizeof(Float) == 2, "Only support FP16/BF16");
   const auto& [q, k, q_stride, k_stride, num_qo_heads, num_kv_heads, eps, q_weight, k_weight, num_tokens] = params;
 
-  const auto num_blks = gridDim.x;
-  const auto num_workers = num_blks * kWarpsPerBlock;
-  const auto num_q_and_k_heads = num_qo_heads + num_kv_heads;
-  const auto num_works = num_q_and_k_heads * num_tokens;
-  const auto start_worker_id = blockIdx.x * kWarpsPerBlock + threadIdx.x / kWarpThreads;
-  const auto gmem = tile::Memory<Storage>::warp();
-
   PDLWaitPrimary<kUsePDL>();  // wait for primary kernel
 
-  for (auto idx = start_worker_id; idx < num_works; idx += num_workers) {
-    const int64_t token_id = idx / num_q_and_k_heads;
-    const int64_t head_id = idx % num_q_and_k_heads;
-    const auto load_q = head_id < num_qo_heads;
-    const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * kHeadDim))
-                              : pointer::offset(k, 2 * (token_id * k_stride + head_id * kHeadDim));
-    const auto weight = load_q ? q_weight : k_weight;
-    const auto input_vec = gmem.load(input);
-    const auto weight_vec = gmem.load(weight);
-    const auto output_vec = norm::apply_norm_warp<kHeadDim>(input_vec, weight_vec, eps);
-    gmem.store(input, output_vec);
+  const auto num_q_and_k_heads = num_qo_heads + num_kv_heads;
+  const auto num_works = num_q_and_k_heads * num_tokens;
+
+  if constexpr (host::norm::should_use_cta<Float, kHeadDim>()) {
+    constexpr auto kNumThreads = host::norm::get_cta_threads<Float, kHeadDim>();
+    constexpr auto kNumWarps = kNumThreads / kWarpThreads;
+    const auto gmem = tile::Memory<Storage>::cta(kNumThreads);
+    __shared__ float smem[norm::kSmemBufferSize];
+
+    for (auto idx = static_cast<uint32_t>(blockIdx.x); idx < num_works; idx += gridDim.x) {
+      const int64_t token_id = idx / num_q_and_k_heads;
+      const int64_t head_id = idx % num_q_and_k_heads;
+      const auto load_q = head_id < num_qo_heads;
+      const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * kHeadDim))
+                                : pointer::offset(k, 2 * (token_id * k_stride + head_id * kHeadDim));
+      const auto weight = load_q ? q_weight : k_weight;
+      const auto input_vec = gmem.load(input);
+      const auto weight_vec = gmem.load(weight);
+      const auto output_vec = norm::apply_norm_cta<kHeadDim>(input_vec, weight_vec, eps, smem, kNumWarps);
+      gmem.store(input, output_vec);
+    }
+  } else {
+    const auto num_blks = gridDim.x;
+    const auto num_workers = num_blks * kWarpsPerBlock;
+    const auto start_worker_id = blockIdx.x * kWarpsPerBlock + threadIdx.x / kWarpThreads;
+    const auto gmem = tile::Memory<Storage>::warp();
+
+    for (auto idx = start_worker_id; idx < num_works; idx += num_workers) {
+      const int64_t token_id = idx / num_q_and_k_heads;
+      const int64_t head_id = idx % num_q_and_k_heads;
+      const auto load_q = head_id < num_qo_heads;
+      const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * kHeadDim))
+                                : pointer::offset(k, 2 * (token_id * k_stride + head_id * kHeadDim));
+      const auto weight = load_q ? q_weight : k_weight;
+      const auto input_vec = gmem.load(input);
+      const auto weight_vec = gmem.load(weight);
+      const auto output_vec = norm::apply_norm_warp<kHeadDim>(input_vec, weight_vec, eps);
+      gmem.store(input, output_vec);
+    }
   }
 
   PDLTriggerSecondary<kUsePDL>();  // launch secondary kernel
@@ -69,7 +90,7 @@ __global__ void fused_qknorm(const QKNormParams __grid_constant__ params) {
 template <int64_t kHeadDim, bool kUsePDL, typename DType>
 struct QKNormKernel {
   static_assert(std::is_same_v<DType, fp16_t> || std::is_same_v<DType, bf16_t>);
-  static_assert(!host::norm::should_use_cta<DType, kHeadDim>(), "Head dim too large for QKNorm");
+  static_assert(host::norm::is_config_supported<DType, kHeadDim>(), "Head dim invalid for QKNorm");
   static constexpr auto kernel = fused_qknorm<kHeadDim, kUsePDL, DType>;
 
   static void
@@ -124,16 +145,27 @@ struct QKNormKernel {
         .num_tokens = num_tokens,
     };
 
-    static const uint32_t max_occupancy = runtime::get_blocks_per_sm(kernel, kThreadsPerBlock);
+    static constexpr bool kUseCTA = host::norm::should_use_cta<DType, kHeadDim>();
+    static constexpr uint32_t kNumThreads = []() constexpr {
+      if constexpr (kUseCTA) {
+        return norm::get_cta_threads<DType, kHeadDim>();
+      }
+      return kThreadsPerBlock;
+    }();
+    static const uint32_t max_occupancy = runtime::get_blocks_per_sm(kernel, kNumThreads);
     static const uint32_t kNumSM = runtime::get_sm_count(device.unwrap().device_id);
 
-    // choose kernel based on dtype
     const auto num_works = (num_qo_heads + num_kv_heads) * num_tokens;
-    const auto needed_blocks = div_ceil(num_works, kWarpsPerBlock);
+    uint32_t num_blocks = 0;
+    if constexpr (kUseCTA) {
+      num_blocks = std::min<uint32_t>(num_works, max_occupancy * kNumSM);
+    } else {
+      const auto needed_blocks = div_ceil(num_works, kWarpsPerBlock);
+      // we use persistent kernel, which limit the number of blocks to reduce overhead
+      num_blocks = std::min(kNumSM * max_occupancy, needed_blocks);
+    }
 
-    // we use persistent kernel, which limit the number of blocks to reduce overhead
-    const auto num_blocks = std::min(kNumSM * max_occupancy, needed_blocks);
-    LaunchKernel(num_blocks, kThreadsPerBlock, device.unwrap())  //
+    LaunchKernel(num_blocks, kNumThreads, device.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);
   }
 };

--- a/python/sglang/jit_kernel/tests/test_qknorm.py
+++ b/python/sglang/jit_kernel/tests/test_qknorm.py
@@ -63,7 +63,7 @@ BS_LIST = [2**n for n in range(0, 14)]
 BS_LIST += [x + 1 + i for i, x in enumerate(BS_LIST)]
 N_K_LIST = [2, 4]
 N_Q_LIST = [8, 16]
-HEAD_DIM_LIST = [64, 128, 256]
+HEAD_DIM_LIST = [64, 128, 256, 512, 1024]
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
 


### PR DESCRIPTION
## Motivation
Based on https://github.com/sgl-project/sglang/issues/17035 Known Limitations

QK norm was previously incompatible with `head_dim` 512 and 1024. The existing implementation only supported a **warp-level** RMS norm path, where each warp (32 threads) processes one head with up to `32 × 8 = 256` elements (for fp16/bf16). A `static_assert` explicitly blocked any `head_dim > 256` from compiling. This PR adds support for larger head dimensions by introducing a CTA-level (block-level cooperative) norm path.

## Modifications

### JIT CUDA Kernel (`qknorm.cuh`)
- Added an `if constexpr` branch to select between **CTA path** (head_dim > 256) and **warp path** (head_dim ≤ 256) at compile time
- **CTA path**: multiple warps collaborate on a single head using shared memory for cross-warp reduction of sum-of-squares, then broadcast the RMS factor to all threads
  - `head_dim=512` → 2 warps (64 threads per block)
  - `head_dim=1024` → 4 warps (128 threads per block)
- Updated `static_assert` from `!should_use_cta` (which blocked large head dims) to `is_config_supported` (which allows head dims up to 1024)
- Adapted launch configuration: thread count and block count are now determined based on the selected path

### Tests (`test_qknorm.py`)
- Extended `HEAD_DIM_LIST` from `[64, 128, 256]` to `[64, 128, 256, 512, 1024]`
- All combinations with batch sizes (1 to ~16K), num_q_heads (8, 16), and num_k_heads (2, 4) are tested

### Backward Compatibility
- `head_dim ≤ 256` still uses the original warp-level path with no behavior change
- Python dispatch layer (`can_use_fused_inplace_qknorm`) already supports `[64, 128, 256, 512, 1024]`


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).