### PR TITLE
[Diffusion] Fix Ulysses SP for QwenImageEdit: shard text/cond/noisy tokens correctly

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -184,7 +184,14 @@ class QwenImagePipelineConfig(ImagePipelineConfig):
                 )
             ]
         ] * batch_size
-        txt_seq_lens = [prompt_embeds[0].shape[1]]
+
+        # Use original txt seq len (before SP sharding) for RoPE generation
+        # so each rank gets the correct global position embeddings
+        original_txt_seq_len = getattr(batch, "original_txt_seq_len", None)
+        if original_txt_seq_len is not None:
+            txt_seq_lens = [original_txt_seq_len]
+        else:
+            txt_seq_lens = [prompt_embeds[0].shape[1]]
 
         freqs_cis = self.get_freqs_cis(
             img_shapes, txt_seq_lens, rotary_emb, device, dtype
@@ -192,6 +199,7 @@ class QwenImagePipelineConfig(ImagePipelineConfig):
 
         img_cache, txt_cache = freqs_cis
         img_cache = shard_rotary_emb_for_sp(img_cache)
+        txt_cache = shard_rotary_emb_for_sp(txt_cache)
         return {
             "txt_seq_lens": txt_seq_lens,
             "freqs_cis": (img_cache, txt_cache),
@@ -253,21 +261,29 @@ class QwenImageEditPipelineConfig(QwenImagePipelineConfig):
                 ),
             ],
         ] * batch_size
-        txt_seq_lens = [prompt_embeds[0].shape[1]]
+
+        # Use original txt seq len (before SP sharding) for RoPE generation
+        original_txt_seq_len = getattr(batch, "original_txt_seq_len", None)
+        if original_txt_seq_len is not None:
+            txt_seq_lens = [original_txt_seq_len]
+        else:
+            txt_seq_lens = [prompt_embeds[0].shape[1]]
+
         freqs_cis = QwenImagePipelineConfig.get_freqs_cis(
             img_shapes, txt_seq_lens, rotary_emb, device, dtype
         )
 
-        # perform sp shard on noisy image tokens
         noisy_img_seq_len = (
             1 * (height // vae_scale_factor // 2) * (width // vae_scale_factor // 2)
         )
 
         img_cache, txt_cache = freqs_cis
         noisy_img_cache = shard_rotary_emb_for_sp(img_cache[:noisy_img_seq_len, :])
-        img_cache = torch.cat(
-            [noisy_img_cache, img_cache[noisy_img_seq_len:, :]], dim=0
-        ).to(device=device)
+        cond_img_cache = shard_rotary_emb_for_sp(img_cache[noisy_img_seq_len:, :])
+        img_cache = torch.cat([noisy_img_cache, cond_img_cache], dim=0).to(
+            device=device
+        )
+        txt_cache = shard_rotary_emb_for_sp(txt_cache)
         return {
             "txt_seq_lens": txt_seq_lens,
             "freqs_cis": (img_cache, txt_cache),
@@ -434,13 +450,18 @@ class QwenImageEditPlusPipelineConfig(QwenImageEditPipelineConfig):
                 ],
             ],
         ] * batch_size
-        txt_seq_lens = [prompt_embeds[0].shape[1]]
+
+        # Use original txt seq len (before SP sharding) for RoPE generation
+        original_txt_seq_len = getattr(batch, "original_txt_seq_len", None)
+        if original_txt_seq_len is not None:
+            txt_seq_lens = [original_txt_seq_len]
+        else:
+            txt_seq_lens = [prompt_embeds[0].shape[1]]
 
         freqs_cis = QwenImageEditPlusPipelineConfig.get_freqs_cis(
             img_shapes, txt_seq_lens, rotary_emb, device, dtype
         )
 
-        # perform sp shard on noisy image tokens
         noisy_img_seq_len = (
             1 * (height // vae_scale_factor // 2) * (width // vae_scale_factor // 2)
         )
@@ -448,9 +469,11 @@ class QwenImageEditPlusPipelineConfig(QwenImageEditPipelineConfig):
         if isinstance(freqs_cis[0], torch.Tensor) and freqs_cis[0].dim() == 2:
             img_cache, txt_cache = freqs_cis
             noisy_img_cache = shard_rotary_emb_for_sp(img_cache[:noisy_img_seq_len, :])
-            img_cache = torch.cat(
-                [noisy_img_cache, img_cache[noisy_img_seq_len:, :]], dim=0
-            ).to(device=device)
+            cond_img_cache = shard_rotary_emb_for_sp(img_cache[noisy_img_seq_len:, :])
+            img_cache = torch.cat([noisy_img_cache, cond_img_cache], dim=0).to(
+                device=device
+            )
+            txt_cache = shard_rotary_emb_for_sp(txt_cache)
             return {
                 "txt_seq_lens": txt_seq_lens,
                 "freqs_cis": (img_cache, txt_cache),
@@ -461,13 +484,14 @@ class QwenImageEditPlusPipelineConfig(QwenImageEditPipelineConfig):
         noisy_img_cos = shard_rotary_emb_for_sp(img_cos[:noisy_img_seq_len, :])
         noisy_img_sin = shard_rotary_emb_for_sp(img_sin[:noisy_img_seq_len, :])
 
-        # concat back the img_cos for input image (since it is not sp-shared later)
-        img_cos = torch.cat([noisy_img_cos, img_cos[noisy_img_seq_len:, :]], dim=0).to(
-            device=device
-        )
-        img_sin = torch.cat([noisy_img_sin, img_sin[noisy_img_seq_len:, :]], dim=0).to(
-            device=device
-        )
+        cond_img_cos = shard_rotary_emb_for_sp(img_cos[noisy_img_seq_len:, :])
+        cond_img_sin = shard_rotary_emb_for_sp(img_sin[noisy_img_seq_len:, :])
+
+        img_cos = torch.cat([noisy_img_cos, cond_img_cos], dim=0).to(device=device)
+        img_sin = torch.cat([noisy_img_sin, cond_img_sin], dim=0).to(device=device)
+
+        txt_cos = shard_rotary_emb_for_sp(txt_cos)
+        txt_sin = shard_rotary_emb_for_sp(txt_sin)
 
         return {
             "txt_seq_lens": txt_seq_lens,
@@ -504,16 +528,17 @@ class QwenImageLayeredPipelineConfig(QwenImageEditPipelineConfig):
             img_shapes, txt_seq_lens, rotary_emb, device, dtype
         )
 
-        # perform sp shard on noisy image tokens
         noisy_img_seq_len = (
             1 * (height // vae_scale_factor // 2) * (width // vae_scale_factor // 2)
         )
 
         img_cache, txt_cache = freqs_cis
         noisy_img_cache = shard_rotary_emb_for_sp(img_cache[:noisy_img_seq_len, :])
-        img_cache = torch.cat(
-            [noisy_img_cache, img_cache[noisy_img_seq_len:, :]], dim=0
-        ).to(device=device)
+        cond_img_cache = shard_rotary_emb_for_sp(img_cache[noisy_img_seq_len:, :])
+        img_cache = torch.cat([noisy_img_cache, cond_img_cache], dim=0).to(
+            device=device
+        )
+        txt_cache = shard_rotary_emb_for_sp(txt_cache)
 
         return {
             "txt_seq_lens": txt_seq_lens,


### PR DESCRIPTION
### Motivation

Running `QwenImageEdit` (or `QwenImageEditPlus`) with `ulysses_degree >= 2` crashes or produces corrupted output. The root cause is that only the noisy latent tokens are sharded across SP ranks, while **condition image tokens**, **text embeddings**, and their corresponding **RoPE** and **modulate_index** remain un-sharded. This creates shape mismatches in attention and modulation, leading to either a runtime crash or visually broken outputs (mosaic artifacts in the lower half of the generated image).

### Problem Analysis

In the Ulysses SP paradigm, an all-to-all exchange maps `[B, S_local, H, D] → [B, S_global, H_local, D]`. This assumes **all** sequence tokens entering the DiT are already partitioned across SP ranks. For `QwenImageEdit` I2I tasks, the DiT input is `torch.cat([noisy_local, cond_image_local], dim=1)`, plus text tokens fed separately.

**Shape flow comparison (per-rank, 768x1024, ulysses=2):**

<img width="1104" height="1253" alt="image" src="https://github.com/user-attachments/assets/15610a4b-7fc8-4ad6-bcb8-b30cb3bf1ba5" />


### Test

**Model:** `Qwen-Image-Edit-2511` (QwenImageEditPlus)  
**Resolution:** 768 x 1024  
**Config:** `ulysses_degree=2`, `num_gpus=2`, `guidance_scale=1`, `seed=42`  

**Test script:**

```python
from sglang.multimodal_gen import DiffGenerator

def main():
    generator = DiffGenerator.from_pretrained(
        model_path="<path-to>/Qwen-Image-Edit-2511",
        num_gpus=2,
        ulysses_degree=2,
        tp_size=1,
        enable_torch_compile=False,
        dit_cpu_offload=False,
        text_encoder_cpu_offload=False,
        vae_cpu_offload=False,
        image_encoder_cpu_offload=False,
        image_encoder_precision="bf16",
        vae_precision="bf16",
        use_fsdp_inference=False,
    )

    image = generator.generate(
        sampling_params_kwargs=dict(
            prompt="make the clothes to red",
            image_path="<path-to>/768x1024.png",
            output_path="output/",
            save_output=True,
            height=1024,
            width=768,
            num_inference_steps=40,
            guidance_scale=1,
            seed=42,
        )
    )
    generator.shutdown()

if __name__ == "__main__":
    main()
```

**Input image** :
<img width="768" height="1024" alt="768x1024" src="https://github.com/user-attachments/assets/91ab7106-58de-4636-aa4f-c2688f6acd0e" />


**Results image** (prompt: "make the clothes to red"):
<img width="768" height="1024" alt="make_the_clothes_to_red_20260210-024537_10fd71fb" src="https://github.com/user-attachments/assets/7a95152d-afc9-4c92-a1d2-34c33cc9a7dc" />
