### PR TITLE
[Diffusion] Reduce the CPU memory peak by offloading lora weight to disk

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -286,6 +286,8 @@ class ServerArgs:
     # can restrict layers to adapt, e.g. ["q_proj"]
     # Will adapt only q, k, v, o by default.
     lora_target_modules: list[str] | None = None
+    # Weight backup mode for LoRA: "cpu" (keep in CPU RAM), "disk" (offload to disk), "none" (no backup, disable hot-swapping)
+    lora_weight_backup_mode: str = "cpu"
 
     # CPU offload parameters
     dit_cpu_offload: bool | None = None
@@ -747,6 +749,15 @@ class ServerArgs:
             type=float,
             default=ServerArgs.lora_scale,
             help="LoRA scale for merging (e.g., 0.125 for Hyper-SD). Same as lora_scale in Diffusers",
+        )
+        parser.add_argument(
+            "--lora-weight-backup-mode",
+            type=str,
+            choices=["cpu", "disk", "none"],
+            default=ServerArgs.lora_weight_backup_mode,
+            help='Weight backup mode for LoRA: "cpu" (keep in CPU RAM, fastest hot-swap), '
+            '"disk" (offload to disk, slower hot-swap but saves CPU RAM), '
+            '"none" (no backup, disable hot-swapping, minimal memory usage).',
         )
         # Add pipeline configuration arguments
         PipelineConfig.add_cli_args(parser)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Using LoRA adapters causes unused weights to remain in memory, potentially causing OOM errors when memory is limited. This change offloads idle LoRA weights to disk or discards them to reduce memory usage.

before:

```
sglang serve \
--model-path Qwen-Image-Edit-2511 \
--lora-path Qwen-Image-Edit-2511-Lightning/Qwen-Image-Edit-2511-Lightning-8steps-V1.0-fp32.safetensors \
--dit-layerwise-offload \
--host 0.0.0.0 \
--port 8000
```

![img_v3_02up_ae5e52b0-05f5-4462-bfd3-62c2e3b09cfg](https://github.com/user-attachments/assets/0b9731d4-0262-455e-a67e-25656ca1b52d)

In this case, we need 141G.

With PR:

```
sglang serve \
--model-path Qwen-Image-Edit-2511 \
--lora-path Qwen-Image-Edit-2511-Lightning/Qwen-Image-Edit-2511-Lightning-8steps-V1.0-fp32.safetensors \
--dit-layerwise-offload \
--lora-weight-backup-mode disk \
--host 0.0.0.0 \
--port 8000
```

![img_v3_02up_423b671f-1e7a-428d-8602-61389840b84g](https://github.com/user-attachments/assets/e7a3a1f4-e4a6-4bae-bfd0-0e34f613feb3)

The required CPU memory has been reduced to 111G. (Make this model available on a machine with 128G)

## Modifications

The weight of LoRA can backup to disk or just discard by set **--lora-weight-backup-mode** to **disk** or **none**.

## Accuracy Tests

Test request:

```
curl -sS -X POST "http://localhost:8000/v1/images/edits" \
  -H "Authorization: Bearer sk-proj-1234567890" \
  -F "url=https://github.com/lm-sys/lm-sys.github.io/releases/download/test/TI2I_Qwen_Image_Edit_Input.jpg" \
  -F "prompt=Convert 2D style to 3D style" \
  -F "size=1536x1024" \
  -F "num_inference_steps=16" \
  -F "response_format=b64_json"
```

before:
![img_v3_02up_b4f3e968-e67f-47fc-9755-d724863ecb3g](https://github.com/user-attachments/assets/bbb6152a-6e37-468e-97ab-7704c57ea5b2)

after:
![img_v3_02up_eee9e5be-ac70-4e1c-a87c-703509bc16dg](https://github.com/user-attachments/assets/495534c4-78c3-457e-ba30-4337d109ab4f)


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
