### PR TITLE
[Diffusion] [AMD] fuse norm & rope for qwen-image

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -289,6 +289,7 @@ class Envs:
     SGLANG_USE_AITER = EnvBool(False)
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
+    SGLANG_ENABLE_FUSED_ROPE_RMS_2WAY = EnvBool(False)
 
     # NPU
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)


### PR DESCRIPTION
## Motivation

Optimize Qwen-Image cross-attention on AMD ROCm by fusing RMSNorm (Q/K normalization) and RoPE into a single fast path (via AITER), while keeping a safe fallback for other platforms/configs.

## Modifications

**qwen_image.py:** Add an AITER-based fused RoPE + RMSNorm 2-way execution path for joint text+image attention
**environ.py:** Add SGLANG_ENABLE_FUSED_ROPE_RMS_2WAY environment flag(default off)

## Accuracy Tests

Here is my script:
```
export SGLANG_DIFFUSION_ATTENTION_BACKEND=AITER
export SGLANG_ENABLE_FUSED_ROPE_RMS_2WAY=true
python3 run_qwen_image_edit.py 
```

the  run_qwen_image_edit.py is:
```
from sglang.multimodal_gen import DiffGenerator

def main():
    # Create a diff generator from a pre-trained model
    generator = DiffGenerator.from_pretrained(
        model_path="/mnt/raid0/models/Qwen-Image-Edit-2511",
        # lora_path="/data/models/lightx2v/Qwen-Image-Edit-2511-Lightning/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
        num_gpus=1,
        ulysses_degree=1,
        enable_torch_compile=True,
        dit_cpu_offload=False,
        text_encoder_cpu_offload=False,
        vae_cpu_offload=False,
        image_encoder_cpu_offload=False,
        image_encoder_precision="bf16",
        vae_precision="bf16",
    )

    # Generate the image
    for i in range(1):
        image = generator.generate(
            sampling_params_kwargs=dict(
                prompt="make the clothes to red",
                image_path="/root/sglang/evaluation/768x1024.png",
                output_path="qwen_image_edit/",
                save_output=False,
                height=1024,
                width=768,
                num_inference_steps=8,
                seed=42,
                guidance_scale=1,
            )
        )

        image = generator.generate(
            sampling_params_kwargs=dict(
                prompt="make the clothes to red",
                image_path="/root/sglang/evaluation/768x1024.png",
                output_path="qwen_image_edit/",
                save_output=True,
                height=1024,
                width=768,
                num_inference_steps=40,
                seed=42,
                guidance_scale=1,
                # profile=True,
                # profile_all_stages=True,
            )
        )

if __name__ == "__main__":
    main()
```
The input image is:
<img width="768" height="1024" alt="768x1024" src="https://github.com/user-attachments/assets/d6ead1f7-380a-44b3-8702-f462d9b33007" />

The result is:

<img width="768" height="1024" alt="make_the_clothes_to_red_20260214-074538_bc451cc9" src="https://github.com/user-attachments/assets/4b0879ed-91cb-4ba0-a513-a35d1ec50197" />

## Benchmarking and Profiling
The uplift is 5.6% (84.48s->79.72s) like the screenshot shows:

before PR:
<img width="918" height="68" alt="image" src="https://github.com/user-attachments/assets/2a94e3ec-2b44-44ad-abc7-26636e38c068" />


after PR:
<img width="923" height="66" alt="image" src="https://github.com/user-attachments/assets/450a1146-8540-4ba0-b3db-c2ae8c1e254e" />

