### PR TITLE
fix: /metrics endpoint always reports engine_type="unified" in PD disaggregation mode

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -325,7 +325,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 token_ids_logprob=None,
             )
             # Set disaggregation params if needed
-            if self.server_args.disaggregation_mode != DisaggregationMode.NULL:
+            if self.server_args.disaggregation_mode != DisaggregationMode.NULL.value:
                 health_req.bootstrap_host = FAKE_BOOTSTRAP_HOST
                 health_req.bootstrap_room = 0
         else:
@@ -1087,7 +1087,7 @@ def _execute_grpc_server_warmup(server_args: ServerArgs):
             }
 
             # Set disaggregation params if needed
-            if server_args.disaggregation_mode != DisaggregationMode.NULL:
+            if server_args.disaggregation_mode != DisaggregationMode.NULL.value:
                 warmup_request_kwargs["disaggregated_params"] = (
                     sglang_scheduler_pb2.DisaggregatedParams(
                         bootstrap_host=FAKE_BOOTSTRAP_HOST,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -489,7 +489,7 @@ async def health_generate(request: Request) -> Response:
         )
         if (
             _global_state.tokenizer_manager.server_args.disaggregation_mode
-            != DisaggregationMode.NULL
+            != DisaggregationMode.NULL.value
         ):
             gri.bootstrap_host = FAKE_BOOTSTRAP_HOST
             gri.bootstrap_room = 0

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -93,9 +93,11 @@ class SchedulerMetricsMixin:
         )
 
         if self.enable_metrics:
-            if self.server_args.disaggregation_mode == DisaggregationMode.PREFILL:
+            if self.server_args.disaggregation_mode == DisaggregationMode.PREFILL.value:
                 engine_type = "prefill"
-            elif self.server_args.disaggregation_mode == DisaggregationMode.DECODE:
+            elif (
+                self.server_args.disaggregation_mode == DisaggregationMode.DECODE.value
+            ):
                 engine_type = "decode"
             else:
                 engine_type = "unified"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
<!-- Describe the purpose and goals of this pull request. -->
### 1) Issue
When deploying in PD disaggregation mode, the **/metrics** endpoint incorrectly labels the `engine_type` as "unified" always.
### 2) Expected Behavior
- **Prefill** node should report `engine_type="prefill"`
- **Decode** node should report `engine_type="decode"`
### 3) Cause
- Type mismatch in comparison: String vs Enum object
- `self.server_args.disaggregation_mode == DisaggregationMode.PREFILL` always evaluates to **False**

https://github.com/sgl-project/sglang/blob/99101ce30b2de4ca25366d91f3dee8457f954670/python/sglang/srt/managers/scheduler_metrics_mixin.py#L96


## Modifications
<!-- Detail the changes made in this pull request. -->
This PR resolves the issue by accessing the `.value` attribute of the Enum for correct comparison.
``` python
if self.server_args.disaggregation_mode == DisaggregationMode.PREFILL.value:
```
Fixed all invalid enum-to-string comparisons by accessing the `.value` attribute of the enum:

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.