### PR TITLE
[Z-Image] Replace TextEncoderConfig with Qwen3TextConfig

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -8,12 +8,12 @@ import torch
 from sglang.multimodal_gen.configs.models import DiTConfig, EncoderConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.zimage import ZImageDitConfig
 from sglang.multimodal_gen.configs.models.encoders import BaseEncoderOutput
+from sglang.multimodal_gen.configs.models.encoders.qwen3 import Qwen3TextConfig
 from sglang.multimodal_gen.configs.models.vaes.flux import FluxVAEConfig
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ImagePipelineConfig,
     ModelTaskType,
 )
-from sglang.multimodal_gen.configs.models.encoders.qwen3 import Qwen3TextConfig
 from sglang.multimodal_gen.runtime.distributed.communication_op import (
     sequence_model_parallel_all_gather,
 )

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -7,10 +7,7 @@ import torch
 
 from sglang.multimodal_gen.configs.models import DiTConfig, EncoderConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.zimage import ZImageDitConfig
-from sglang.multimodal_gen.configs.models.encoders import (
-    BaseEncoderOutput,
-    TextEncoderConfig,
-)
+from sglang.multimodal_gen.configs.models.encoders import BaseEncoderOutput
 from sglang.multimodal_gen.configs.models.vaes.flux import FluxVAEConfig
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ImagePipelineConfig,

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -16,6 +16,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ImagePipelineConfig,
     ModelTaskType,
 )
+from sglang.multimodal_gen.configs.models.encoders.qwen3 import Qwen3TextConfig
 from sglang.multimodal_gen.runtime.distributed.communication_op import (
     sequence_model_parallel_all_gather,
 )
@@ -49,7 +50,7 @@ class ZImagePipelineConfig(ImagePipelineConfig):
     dit_config: DiTConfig = field(default_factory=ZImageDitConfig)
     vae_config: VAEConfig = field(default_factory=FluxVAEConfig)
     text_encoder_configs: tuple[EncoderConfig, ...] = field(
-        default_factory=lambda: (TextEncoderConfig(),)
+        default_factory=lambda: (Qwen3TextConfig(),)
     )
 
     preprocess_text_funcs: tuple[Callable, ...] = field(

--- a/python/sglang/multimodal_gen/test/server/perf_baselines.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines.json
@@ -525,7 +525,7 @@
             "stages_ms": {
                 "ConditioningStage": 0.01,
                 "DecodingStage": 33.93,
-                "TextEncodingStage": 104.21,
+                "TextEncodingStage": 409.74,
                 "InputValidationStage": 0.03,
                 "DenoisingStage": 808.69,
                 "LatentPreparationStage": 0.14,
@@ -2001,7 +2001,7 @@
         "fsdp-inference": {
             "stages_ms": {
                 "InputValidationStage": 0.04,
-                "TextEncodingStage": 128.3,
+                "TextEncodingStage": 411.12,
                 "ConditioningStage": 0.01,
                 "TimestepPreparationStage": 1.44,
                 "LatentPreparationStage": 0.1,
@@ -2019,7 +2019,7 @@
                 "7": 178.53,
                 "8": 178.08
             },
-            "expected_e2e_ms": 1742.7,
+            "expected_e2e_ms": 2103.05,
             "expected_avg_denoise_ms": 173.83,
             "expected_median_denoise_ms": 178.08
         }

--- a/python/sglang/multimodal_gen/test/server/perf_baselines.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines.json
@@ -549,7 +549,7 @@
         "zimage_image_t2i_multi_lora": {
             "stages_ms": {
                 "InputValidationStage": 0.04,
-                "TextEncodingStage": 103.81,
+                "TextEncodingStage": 413.69,
                 "ConditioningStage": 0.01,
                 "TimestepPreparationStage": 1.3,
                 "LatentPreparationStage": 0.11,
@@ -599,7 +599,7 @@
         "zimage_image_t2i_warmup": {
             "stages_ms": {
                 "InputValidationStage": 0.02,
-                "TextEncodingStage": 100.65,
+                "TextEncodingStage": 456.16,
                 "ConditioningStage": 0.01,
                 "TimestepPreparationStage": 0.98,
                 "LatentPreparationStage": 0.06,

--- a/python/sglang/multimodal_gen/test/server/perf_baselines.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines.json
@@ -542,7 +542,7 @@
                 "7": 99.3,
                 "8": 100.83
             },
-            "expected_e2e_ms": 952.09,
+            "expected_e2e_ms": 1461.08,
             "expected_avg_denoise_ms": 89.36,
             "expected_median_denoise_ms": 99.67
         },
@@ -567,14 +567,14 @@
                 "7": 100.86,
                 "8": 103.87
             },
-            "expected_e2e_ms": 955.14,
+            "expected_e2e_ms": 1464.31,
             "expected_avg_denoise_ms": 89.96,
             "expected_median_denoise_ms": 99.72
         },
         "zimage_image_t2i_2_gpus": {
             "stages_ms": {
                 "InputValidationStage": 0.08,
-                "TextEncodingStage": 118.66,
+                "TextEncodingStage": 420.74,
                 "ConditioningStage": 0.01,
                 "TimestepPreparationStage": 1.5,
                 "LatentPreparationStage": 0.12,
@@ -617,7 +617,7 @@
                 "7": 110.54,
                 "8": 115.24
             },
-            "expected_e2e_ms": 1029.96,
+            "expected_e2e_ms": 1184.45,
             "expected_avg_denoise_ms": 98.46,
             "expected_median_denoise_ms": 109.65
         },


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

I found that deploying Z-Image with sglang requires 33GB VRAM comparing to diffusers which only need 25GB maximum (include inferencing). The reason might coming from the text encoder is being loaded in native mode.

After the change, now we only need about 18GB for loading the model, 23GB when inferencing
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Add supported Qwen3 config for text encoder config in z-image

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
