### PR TITLE
Fix wrong prefill log.

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict
 
     from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.managers.scheduler_metrics_mixin import PrefillStats
     from sglang.srt.speculative.eagle_info import EagleDraftInput
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 
@@ -1304,6 +1305,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # Metrics
     dp_cooperation_info: Optional[DPCooperationInfo] = None
+    prefill_stats: Optional[PrefillStats] = None
 
     @classmethod
     def init_new(
@@ -2243,6 +2245,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_mask=self.mamba_track_mask,
             mamba_track_seqlens=self.mamba_track_seqlens,
             dp_cooperation_info=self.dp_cooperation_info,
+            prefill_stats=self.prefill_stats,
         )
 
     def maybe_evict_swa(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -151,6 +151,7 @@ from sglang.srt.managers.scheduler_dp_attn_mixin import SchedulerDPAttnMixin
 from sglang.srt.managers.scheduler_input_blocker import SchedulerInputBlocker
 from sglang.srt.managers.scheduler_metrics_mixin import (
     RECORD_STEP_TIME,
+    PrefillStats,
     SchedulerMetricsMixin,
 )
 from sglang.srt.managers.scheduler_output_processor_mixin import (
@@ -2120,6 +2121,15 @@ class Scheduler(
             )
 
         new_batch.prepare_for_extend()
+
+        # Record prefill stats for logging after forward
+        new_batch.prefill_stats = PrefillStats(
+            log_input_tokens=adder.log_input_tokens,
+            log_hit_tokens=adder.log_hit_tokens,
+            new_token_ratio=adder.new_token_ratio,
+            running_bs=len(self.running_batch.reqs),
+            num_new_seqs=len(can_run_list),
+        )
 
         # Mixed-style chunked prefill
         if (

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from sglang.srt.disaggregation.kv_events import EventPublisherFactory, KVEventBatch
 from sglang.srt.disaggregation.utils import DisaggregationMode
@@ -20,8 +21,7 @@ from sglang.srt.managers.io_struct import (
     QueueMetrics,
     SpeculativeMetrics,
 )
-from sglang.srt.managers.schedule_policy import PrefillAdder
-from sglang.srt.managers.scheduler import Req, ScheduleBatch
+from sglang.srt.managers.scheduler import ScheduleBatch
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.metrics.collector import (
     SchedulerMetricsCollector,
@@ -40,6 +40,17 @@ logger = logging.getLogger(__name__)
 RECORD_STEP_TIME = get_bool_env_var("SGLANG_RECORD_STEP_TIME")
 LOG_FORWARD_ITERS = envs.SGLANG_LOG_FORWARD_ITERS.get()
 ENABLE_METRICS_DEVICE_TIMER = envs.SGLANG_ENABLE_METRICS_DEVICE_TIMER.get()
+
+
+@dataclasses.dataclass
+class PrefillStats:
+    """Stats for logging prefill batch metrics."""
+
+    log_input_tokens: int
+    log_hit_tokens: int
+    new_token_ratio: float
+    running_bs: int
+    num_new_seqs: int  # len(can_run_list)
 
 
 class KvMetrics:
@@ -148,21 +159,18 @@ class SchedulerMetricsMixin:
 
     def log_prefill_stats(
         self: Scheduler,
-        adder: PrefillAdder,
-        can_run_list: List[Req],
-        running_bs: int,
-        running_bs_offline_batch: int,
+        prefill_stats: PrefillStats,
         can_run_cuda_graph: bool,
     ):
         gap_latency = time.perf_counter() - self.last_prefill_stats_tic
         self.last_prefill_stats_tic = time.perf_counter()
         self.last_input_throughput = self.last_prefill_tokens / gap_latency
-        self.last_prefill_tokens = adder.log_input_tokens
+        self.last_prefill_tokens = prefill_stats.log_input_tokens
 
         assert self.temp_prefill_info is None
         self.temp_prefill_info = dict(
-            adder_log_input_tokens=adder.log_input_tokens,
-            adder_log_hit_tokens=adder.log_hit_tokens,
+            adder_log_input_tokens=prefill_stats.log_input_tokens,
+            adder_log_hit_tokens=prefill_stats.log_hit_tokens,
         )
 
         # TODO: generalize this for various memory pools
@@ -204,16 +212,16 @@ class SchedulerMetricsMixin:
             num_used, token_usage, _, _ = self._get_token_info()
             token_usage_msg = f"token usage: {token_usage:.2f}, "
 
-        self.stats.new_token_ratio = adder.new_token_ratio
+        self.stats.new_token_ratio = prefill_stats.new_token_ratio
         iter_msg = f" [{self.forward_ct + 1}]" if LOG_FORWARD_ITERS else ""
 
         msg = (
             f"Prefill batch{iter_msg}, "
-            f"#new-seq: {len(can_run_list)}, "
-            f"#new-token: {adder.log_input_tokens}, "
-            f"#cached-token: {adder.log_hit_tokens}, "
+            f"#new-seq: {prefill_stats.num_new_seqs}, "
+            f"#new-token: {prefill_stats.log_input_tokens}, "
+            f"#cached-token: {prefill_stats.log_hit_tokens}, "
             f"{token_usage_msg}"
-            f"#running-req: {running_bs}, "
+            f"#running-req: {prefill_stats.running_bs}, "
             f"#queue-req: {len(self.waiting_queue)}, "
         )
 
@@ -240,13 +248,13 @@ class SchedulerMetricsMixin:
 
         if self.enable_metrics:
             # Basics
-            total_tokens = adder.log_input_tokens + adder.log_hit_tokens
+            total_tokens = prefill_stats.log_input_tokens + prefill_stats.log_hit_tokens
             cache_hit_rate = (
-                adder.log_hit_tokens / total_tokens if total_tokens > 0 else 0.0
+                prefill_stats.log_hit_tokens / total_tokens if total_tokens > 0 else 0.0
             )
 
-            self.stats.num_running_reqs = running_bs
-            self.stats.num_running_reqs_offline_batch = running_bs_offline_batch
+            self.stats.num_running_reqs = prefill_stats.running_bs
+            self.stats.num_running_reqs_offline_batch = 0
             self.stats.num_used_tokens = num_used
             self.stats.token_usage = token_usage
             if self.is_hybrid_swa:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -343,10 +343,7 @@ class SchedulerOutputProcessorMixin:
         if self.current_scheduler_metrics_enabled:
             can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
             self.log_prefill_stats(
-                adder=self.adder,
-                can_run_list=self.can_run_list,
-                running_bs=self.running_bs,
-                running_bs_offline_batch=0,
+                prefill_stats=batch.prefill_stats,
                 can_run_cuda_graph=can_run_cuda_graph,
             )
 
@@ -422,10 +419,7 @@ class SchedulerOutputProcessorMixin:
         if self.current_scheduler_metrics_enabled:
             can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
             self.log_prefill_stats(
-                adder=self.adder,
-                can_run_list=self.can_run_list,
-                running_bs=self.running_bs,
-                running_bs_offline_batch=0,
+                prefill_stats=batch.prefill_stats,
                 can_run_cuda_graph=can_run_cuda_graph,
             )
 


### PR DESCRIPTION
This PR fixes a bug in overlap mode where prefill stats were stored on the scheduler and could be overwritten by subsequent batches before being logged. When two consecutive prefill batches occurred, the first batch's stats would be lost, and the second batch's stats would be logged twice.

The fix introduces a `PrefillStats` dataclass that binds the logging information directly to each `ScheduleBatch`, ensuring each batch's stats are preserved correctly through the overlap pipeline.

wrong log before this PR:

```log
[DEBUG] get new batch prefill: id(adder)=137914754617600
[DEBUG] get new batch prefill: len(can_run_list)=1
[DEBUG] get new batch prefill: id(adder)=137916237338032
[DEBUG] get new batch prefill: len(can_run_list)=2
[DEBUG] id(batch)=137914906515776
[DEBUG] prefill batch: ['5501e53c58974e86bc717219b0a6315c']
[2026-02-10 23:32:05] Prefill batch, #new-seq: 2, #new-token: 578, #cached-token: 0, token usage: 0.00, #running-req: 1, #queue-req: 0, input throughput (token/s): 0.14, cuda graph: False
[DEBUG] id(batch)=137914893085360
[DEBUG] prefill batch: ['b71ccc545c5845c8b594435cd0d943ed', '87e713a14333495787b82dd55d2bc712']
[2026-02-10 23:32:05] Prefill batch, #new-seq: 2, #new-token: 578, #cached-token: 0, token usage: 0.00, #running-req: 1, #queue-req: 0, input throughput (token/s): 9610.84, cuda graph: False
[2026-02-10 23:32:05] Decode batch, #running-req: 3, #token: 986, token usage: 0.00, cuda graph: True, gen throughput (token/s): 7.49, #queue-req: 0
[2026-02-10 23:32:05] Decode batch, #running-req: 3, #token: 1106, token usage: 0.00, cuda graph: True, gen throughput (token/s): 2178.13, #queue-req: 0
```

log after this PR

```log
[DEBUG] get new batch prefill: id(adder)=126975144495728
[DEBUG] get new batch prefill: len(can_run_list)=1
[2026-02-10 23:26:25] INFO:     127.0.0.1:49692 - "POST /generate HTTP/1.1" 200 OK
[DEBUG] get new batch prefill: id(adder)=126975003123568
[DEBUG] get new batch prefill: len(can_run_list)=2
[DEBUG] id(batch)=126975142210512
[DEBUG] prefill batch: ['e00867833e23416da3f8be479d0f95f0']
[2026-02-10 23:26:25] Prefill batch, #new-seq: 1, #new-token: 289, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.14, cuda graph: False
[DEBUG] id(batch)=126974998773936
[DEBUG] prefill batch: ['6bcf30a6427a49269a8ded22eb73435e', 'a2fd1bf5be3c4e43ad661a42c8e1de4f']
[2026-02-10 23:26:25] Prefill batch, #new-seq: 2, #new-token: 578, #cached-token: 0, token usage: 0.00, #running-req: 1, #queue-req: 0, input throughput (token/s): 5272.16, cuda graph: False
[2026-02-10 23:26:25] Decode batch, #running-req: 3, #token: 986, token usage: 0.00, cuda graph: True, gen throughput (token/s): 7.21, #queue-req: 0
[2026-02-10 23:26:25] Decode batch, #running-req: 3, #token: 1106, token usage: 0.00, cuda graph: True, gen throughput (token/s): 2097.15, #queue-req: 0
```