### PR TITLE
[Fix] fix `_is_cpu` to `is_cpu()`

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -331,7 +331,7 @@ class BaseMultimodalProcessor(ABC):
             and isinstance(processor.image_processor, BaseImageProcessorFast)
             and not self.server_args.disable_fast_image_processor
         ):
-            if _is_cpu or get_global_server_args().rl_on_policy_target is not None:
+            if is_cpu() or get_global_server_args().rl_on_policy_target is not None:
                 kwargs["device"] = "cpu"
             elif _is_xpu:
                 kwargs["device"] = "xpu"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When running Qwen3VL-8B on H20 with sglang main branch @ 3167bc, we met a error as below:

> [2026-02-10 18:36:40] ERROR:    Exception in ASGI application
>   + Exception Group Traceback (most recent call last):
>   |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_utils.py", line 81, in collapse_excgroups
>   |     yield
>   |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 270, in __call__
>   |     async with anyio.create_task_group() as task_group:
>   |   File "/home/wili/.local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
>   |     raise BaseExceptionGroup(
>   | exceptiongroup.ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
>   +-+---------------- 1 ----------------
>     | Traceback (most recent call last):
>     |   File "/home/wili/.local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 410, in run_asgi
>     |     result = await app(  # type: ignore[func-returns-value]
>     |   File "/home/wili/.local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
>     |     return await self.app(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/applications.py", line 1138, in __call__
>     |     await super().__call__(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/applications.py", line 107, in __call__
>     |     await self.middleware_stack(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 186, in __call__
>     |     raise exc
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 164, in __call__
>     |     await self.app(scope, receive, _send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 87, in __call__
>     |     await self.app(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
>     |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
>     |     raise exc
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
>     |     await app(scope, receive, sender)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
>     |     await self.app(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/routing.py", line 716, in __call__
>     |     await self.middleware_stack(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/routing.py", line 736, in app
>     |     await route.handle(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/routing.py", line 290, in handle
>     |     await self.app(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/routing.py", line 121, in app
>     |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
>     |     raise exc
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
>     |     await app(scope, receive, sender)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/routing.py", line 108, in app
>     |     await response(scope, receive, send)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 269, in __call__
>     |     with collapse_excgroups():
>     |   File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
>     |     self.gen.throw(typ, value, traceback)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
>     |     raise exc
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 273, in wrap
>     |     await func()
>     |   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 253, in stream_response
>     |     async for chunk in self.body_iterator:
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/entrypoints/openai/serving_chat.py", line 619, in _generate_chat_stream
>     |     async for content in self.tokenizer_manager.generate_request(
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/tokenizer_manager.py", line 519, in generate_request
>     |     tokenized_obj = await self._tokenize_one_request(obj)
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/tokenizer_manager.py", line 725, in _tokenize_one_request
>     |     mm_inputs: Dict = await self.mm_data_processor.process(
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/async_mm_data_processor.py", line 99, in process
>     |     return await asyncio.wait_for(_invoke(), timeout=self.timeout_s)
>     |   File "/usr/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
>     |     return fut.result()
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/async_mm_data_processor.py", line 70, in _invoke
>     |     return await self._proc_async(
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/qwen_vl.py", line 345, in process_mm_data_async
>     |     mm_items, input_ids, ret = self.process_and_combine_mm_data(
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/base_processor.py", line 1022, in process_and_combine_mm_data
>     |     collected_items, input_ids, ret = self._process_and_collect_mm_items(
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/base_processor.py", line 970, in _process_and_collect_mm_items
>     |     ret = self.process_mm_data(
>     |   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/base_processor.py", line 335, in process_mm_data
>     |     if _is_cpu or get_global_server_args().rl_on_policy_target is not None:
>     | NameError: name '_is_cpu' is not defined. Did you mean: 'is_cpu'?
>     +------------------------------------
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/home/wili/.local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 410, in run_asgi
>     result = await app(  # type: ignore[func-returns-value]
>   File "/home/wili/.local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
>     return await self.app(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/applications.py", line 1138, in __call__
>     await super().__call__(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/applications.py", line 107, in __call__
>     await self.middleware_stack(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 186, in __call__
>     raise exc
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 164, in __call__
>     await self.app(scope, receive, _send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 87, in __call__
>     await self.app(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
>     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
>     raise exc
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
>     await app(scope, receive, sender)
>   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
>     await self.app(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/routing.py", line 716, in __call__
>     await self.middleware_stack(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/routing.py", line 736, in app
>     await route.handle(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/routing.py", line 290, in handle
>     await self.app(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/routing.py", line 121, in app
>     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
>     raise exc
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
>     await app(scope, receive, sender)
>   File "/home/wili/.local/lib/python3.10/site-packages/fastapi/routing.py", line 108, in app
>     await response(scope, receive, send)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 269, in __call__
>     with collapse_excgroups():
>   File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
>     self.gen.throw(typ, value, traceback)
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
>     raise exc
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 273, in wrap
>     await func()
>   File "/home/wili/.local/lib/python3.10/site-packages/starlette/responses.py", line 253, in stream_response
>     async for chunk in self.body_iterator:
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/entrypoints/openai/serving_chat.py", line 619, in _generate_chat_stream
>     async for content in self.tokenizer_manager.generate_request(
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/tokenizer_manager.py", line 519, in generate_request
>     tokenized_obj = await self._tokenize_one_request(obj)
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/tokenizer_manager.py", line 725, in _tokenize_one_request
>     mm_inputs: Dict = await self.mm_data_processor.process(
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/async_mm_data_processor.py", line 99, in process
>     return await asyncio.wait_for(_invoke(), timeout=self.timeout_s)
>   File "/usr/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
>     return fut.result()
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/managers/async_mm_data_processor.py", line 70, in _invoke
>     return await self._proc_async(
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/qwen_vl.py", line 345, in process_mm_data_async
>     mm_items, input_ids, ret = self.process_and_combine_mm_data(
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/base_processor.py", line 1022, in process_and_combine_mm_data
>     collected_items, input_ids, ret = self._process_and_collect_mm_items(
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/base_processor.py", line 970, in _process_and_collect_mm_items
>     ret = self.process_mm_data(
>   File "/home/wili/.local/lib/python3.10/site-packages/sglang/srt/multimodal/processors/base_processor.py", line 335, in process_mm_data
>     if _is_cpu or get_global_server_args().rl_on_policy_target is not None:
> NameError: name '_is_cpu' is not defined. Did you mean: 'is_cpu'?


## Modifications

<!-- Detail the changes made in this pull request. -->

+ `_is_cpu` is surely not defined in this file, and the error disappears after adding the fix below.

+ Change `_is_cpu` in `python/sglang/srt/multimodal/processors/base_processor.py` Line334 into `is_cpu()`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

No.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

No.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
