### PR TITLE
Make per‑token expert‑distribution recorder use asynchronous data syncing

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -52,6 +52,147 @@ class ExpertDistributionMetrics:
         self.eplb_balancedness = self.eplb_balancedness.to("cpu", non_blocking=True)
 
 
+@dataclass
+class GathererTensorAddress:
+    offset: int
+    length: int
+    shape: tuple
+    dtype: torch.dtype
+
+
+@torch.jit.script
+def cast_tensor_to_int32(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype == torch.int64:
+        x = tensor.to(torch.int64)
+        low = (x & 0xFFFFFFFF).to(torch.int32)
+        high = ((x >> 32) & 0xFFFFFFFF).to(torch.int32)
+        packed = torch.stack((low, high), dim=-1)
+        return packed.reshape(-1)
+    else:
+        return tensor.to(torch.int32, non_blocking=True)
+
+
+@torch.jit.script
+def cast_tensor_from_int32(
+    tensor: torch.Tensor, original_dtype: torch.dtype
+) -> torch.Tensor:
+    if original_dtype == torch.int64:
+        low = tensor[0::2].to(torch.int64) & 0xFFFFFFFF
+        high = tensor[1::2].to(torch.int64) & 0xFFFFFFFF
+        return low | (high << 32)
+    else:
+        return tensor.to(original_dtype, non_blocking=True)
+
+
+class ExpertRecorderBuffer:
+    def __init__(
+        self,
+        buffer_size_mb: int,
+        device: torch.device = torch.device("cpu"),
+    ):
+        # buffer copy stream
+        self._log_stream = torch.cuda.Stream()
+        # clone done event to synchronize with the copy stream
+        self._log_ready = torch.cuda.Event()
+        # buffer to store the recorded tensors, using int32 as the universal
+        self._buffer = torch.zeros(
+            buffer_size_mb * 1024 * 1024 // torch.int32.itemsize,
+            dtype=torch.int32,
+            device=device,
+            pin_memory=True,
+        )
+        # pointer to the current write position in the buffer
+        self._write_ptr = 0
+        # flag to indicate if the buffer is full
+        # (i.e. no more records can be stored until reset)
+        self._is_full = False
+
+    def store(self, tensor: torch.Tensor) -> GathererTensorAddress:
+        assert tensor.is_cuda, "Input tensor must be on CUDA device"
+
+        if self._is_full:
+            return None
+
+        # protective contiguous clone
+        t = tensor.clone(memory_format=torch.contiguous_format).view(-1)
+        t.record_stream(self._log_stream)  # keep tensor alive
+
+        # make sure previous copy is done
+        self._log_ready.record(torch.cuda.current_stream())
+
+        # backup tensor to buffer asynchronously
+        with torch.cuda.stream(self._log_stream):
+            # report event
+            self._log_ready.wait(self._log_stream)
+
+            # cast tensor if needed
+            if t.dtype != self._buffer.dtype:
+                t = cast_tensor_to_int32(t)
+
+            # compute dimensions
+            length = t.numel()
+
+            # compute buffer slice
+            start = self._write_ptr
+            end = start + length
+
+            # buffer size check
+            if end <= self._buffer.numel():
+                self._buffer[start:end].copy_(t, non_blocking=True)
+                self._write_ptr = end
+            else:
+                # notice the user
+                logger.info(
+                    "ExpertRecorder's buffer is full. Further records will be dropped until reset."
+                )
+                self._is_full = True
+
+        if self._is_full:
+            return None
+
+        # return address and metadata needed for reconstruction
+        return GathererTensorAddress(
+            offset=start,
+            length=length,
+            shape=tuple(tensor.shape),
+            dtype=tensor.dtype,
+        )
+
+    def get(self, address: GathererTensorAddress):
+        t = self._buffer[address.offset : address.offset + address.length]
+
+        # cast tensor if needed
+        if address.dtype != self._buffer.dtype:
+            t = cast_tensor_from_int32(t, address.dtype)
+
+        # Reshape to original dimensions
+        return t.reshape(address.shape).clone()
+
+    def synchronize(self):
+        self._log_stream.synchronize()
+
+    def is_full(self):
+        return self._is_full
+
+    def reset(self):
+        self._write_ptr = 0
+        self._is_full = False
+
+
+def init_recorder_buffer(
+    server_args: ServerArgs,
+) -> Optional[ExpertRecorderBuffer]:
+    if server_args.expert_distribution_recorder_mode == "per_token_buffered":
+        # preallocate a large pinned CPU buffer
+        buffer_size_mb = server_args.expert_distribution_recorder_buffer_size
+        # adjust buffer size
+        if buffer_size_mb is None or buffer_size_mb <= 0:
+            buffer_size_mb = 1024  # default to 1GB
+        return ExpertRecorderBuffer(buffer_size_mb)
+    else:
+        return None
+
+
 class ExpertDistributionRecorder(ABC):
     """Global expert distribution recording"""
 
@@ -144,11 +285,14 @@ class _ExpertDistributionRecorderReal(ExpertDistributionRecorder):
         self._current_forward_pass_id = Withable()
         self._current_layer_idx = Withable()
         self._current_debug_name = Withable()
+        self._buffer = init_recorder_buffer(server_args)
         self._accumulator = _Accumulator.init_new(
-            server_args, expert_location_metadata, rank
+            server_args, expert_location_metadata, rank, self._buffer
         )
         self._single_pass_gatherers = {
-            k: _SinglePassGatherer.init_new(server_args, expert_location_metadata, rank)
+            k: _SinglePassGatherer.init_new(
+                server_args, expert_location_metadata, rank, self._buffer
+            )
             for k in self._accumulator.get_single_pass_gatherer_keys()
         }
 
@@ -301,11 +445,19 @@ class _SinglePassGatherer(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
+        buffer: Optional[ExpertRecorderBuffer] = None,
     ) -> "_SinglePassGatherer":
         if server_args.expert_distribution_recorder_mode == "per_token":
             return _DetailSinglePassGatherer(
                 server_args, expert_location_metadata, rank
             )
+
+        if server_args.expert_distribution_recorder_mode == "per_token_buffered":
+            gatherer = _BufferedDetailSinglePassGatherer(
+                server_args, expert_location_metadata, rank
+            )
+            gatherer.set_buffer(buffer)
+            return gatherer
 
         if server_args.expert_distribution_recorder_mode == "stat_approx":
             if server_args.moe_a2a_backend != "none" and (
@@ -357,6 +509,98 @@ class _SinglePassGatherer(ABC):
 
     def collect(self) -> Dict:
         raise NotImplementedError
+
+
+class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
+    # DeepSeek V3 has this value; should generalize later
+    _TOP_K_NUM = 8
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        expert_location_metadata: ExpertLocationMetadata,
+        rank: int,
+    ):
+        super().__init__(expert_location_metadata, rank)
+        self._metadata: Optional[Dict[str, Any]] = None
+        self._num_tokens = 0
+        self._topk_ids_of_layer = torch.zeros(
+            (
+                expert_location_metadata.num_layers,
+                # TODO determine the max number
+                server_args.chunked_prefill_size * 8,
+                self._TOP_K_NUM,
+            ),
+            dtype=torch.int32,
+            device=server_args.device,
+        )
+        self._misc_objects: List[Dict[str, Any]] = []
+        self._data = None
+        assert (
+            not server_args.enable_two_batch_overlap
+        ), "DetailSinglePassGatherer does not support TBO yet"
+        # TODO assert shared experts fusion is disabled, o/w data is wrong
+
+    def on_forward_pass_start(self, forward_batch: ForwardBatch):
+        assert self._metadata is None
+        self._num_tokens = forward_batch.input_ids.shape[0]
+        self._metadata = dict(
+            # TODO pr-chain
+            # rids=forward_batch.rids,
+            input_ids=self._data.store(forward_batch.input_ids),
+            positions=self._data.store(forward_batch.positions),
+            extend_seq_lens=forward_batch.extend_seq_lens_cpu,
+            forward_mode=forward_batch.forward_mode.value,
+        )
+
+    def on_select_experts(self, layer_idx: int, topk_ids: torch.Tensor):
+        self._topk_ids_of_layer[layer_idx, : topk_ids.shape[0], : topk_ids.shape[1]] = (
+            topk_ids
+        )
+
+    def on_deepep_dispatch_normal(
+        self,
+        layer_idx: int,
+        local_physical_count_of_layer: List[int],
+        num_tokens_per_rank,
+        num_tokens_per_rdma_rank,
+        num_tokens_per_expert,
+    ):
+        self._misc_objects.append(
+            dict(
+                layer_id=layer_idx,
+                num_tokens_per_rank=self._data.store(num_tokens_per_rank),
+                num_tokens_per_rdma_rank=self._data.store(num_tokens_per_rdma_rank),
+                num_tokens_per_expert=self._data.store(num_tokens_per_expert),
+            )
+        )
+
+    def set_buffer(self, buffer: ExpertRecorderBuffer):
+        self._data = buffer
+
+    def reset(self):
+        self._topk_ids_of_layer[...] = -1
+        self._misc_objects.clear()
+        self._metadata = None
+
+    def collect(self) -> Dict:
+        num_tokens = self._num_tokens
+
+        global_physical_count = _convert_per_token_to_global_physical_count(
+            num_tokens,
+            num_layers=self._expert_location_metadata.num_layers,
+            num_physical_experts=self._expert_location_metadata.num_physical_experts,
+            _topk_ids_of_layer=self._topk_ids_of_layer,
+        )
+
+        return dict(
+            **self._metadata,
+            topk_ids_of_layer=self._data.store(
+                self._topk_ids_of_layer[:, :num_tokens, :]
+            ),
+            misc_objects=self._misc_objects,
+            global_physical_count=self._data.store(global_physical_count),
+        )
 
 
 class _DetailSinglePassGatherer(_SinglePassGatherer):
@@ -616,9 +860,10 @@ class _Accumulator(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
+        buffer: Optional[ExpertRecorderBuffer] = None,
     ) -> "_Accumulator":
         return _Accumulator.get_class(server_args)(
-            server_args, expert_location_metadata, rank
+            server_args, expert_location_metadata, rank, buffer
         )
 
     @staticmethod
@@ -628,6 +873,7 @@ class _Accumulator(ABC):
             "stat_approx": _StatAccumulator,
             "per_pass": _DetailAccumulator,
             "per_token": _DetailAccumulator,
+            "per_token_buffered": _BufferedDetailAccumulator,
         }[server_args.expert_distribution_recorder_mode]
 
     def __init__(
@@ -635,10 +881,12 @@ class _Accumulator(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
+        buffer: Optional[ExpertRecorderBuffer] = None,
     ):
         self._server_args = server_args
         self._expert_location_metadata = expert_location_metadata
         self._rank = rank
+        self._data = buffer
 
     def get_single_pass_gatherer_keys(self):
         return [_SINGLE_PASS_GATHERER_KEY_PRIMARY]
@@ -775,6 +1023,72 @@ class _DequeCollection:
 
     def mean(self) -> Dict[int, float]:
         return {d.maxlen: sum(d) / len(d) for d in self._dequeues}
+
+
+class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._records = []
+
+        # ensure buffer is set correctly
+        assert self._data is not None
+
+    def get_single_pass_gatherer_keys(self):
+        if False:  # TODO `server_args.enable_two_batch_overlap`
+            return [_SINGLE_PASS_GATHERER_KEY_PRIMARY, "child_a", "child_b"]
+        return super().get_single_pass_gatherer_keys()
+
+    def get_single_pass_gatherer_key(self, debug_name: Optional[str]):
+        if False:  # TODO `server_args.enable_two_batch_overlap`
+            return debug_name or _SINGLE_PASS_GATHERER_KEY_PRIMARY
+        return super().get_single_pass_gatherer_key(debug_name)
+
+    def append(
+        self,
+        forward_pass_id: int,
+        gatherer_key: str,
+        single_pass_data: Dict,
+        outputs: Dict[str, Any],
+    ):
+        if self._data.is_full():
+            return  # drop potential broken records
+
+        super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
+
+        self._records.append(
+            dict(
+                forward_pass_id=forward_pass_id,
+                rank=self._rank,
+                gatherer_key=gatherer_key,
+                **single_pass_data,
+            )
+        )
+
+    def reset(self):
+        super().reset()
+        self._records.clear()
+        self._data.reset()
+
+    def dump(self, output_mode: _OutputMode):
+        assert output_mode == "file"
+
+        # ensure all data is written to the buffer
+        self._data.synchronize()
+
+        for record in self._records:
+            # convert all GathererTensorAddress in record to actual tensors
+            for k, v in record.items():
+                if isinstance(v, GathererTensorAddress):
+                    record[k] = self._data.get(v)
+
+        output = dict(
+            records=self._records,
+            # NOTE: This may change during recording, so here we say it is the "last" one
+            last_physical_to_logical_map=self._expert_location_metadata.physical_to_logical_map,
+        )
+        _dump_to_file(
+            f"expert_distribution_recorder_{time.time()}_{self._rank}.pt", output
+        )
 
 
 class _DetailAccumulator(_UtilizationRateAccumulatorMixin):

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -53,32 +53,38 @@ class ExpertDistributionMetrics:
 
 
 @dataclass
-class RecordMetadata:
+class _Record:
+    buffer: "RecordBuffer"
     offset: int
     length: int
     shape: tuple
     dtype: torch.dtype
 
+    def __reduce_ex__(self, protocol: int):
+        tensor = self.buffer.get(self).clone()
+        return tensor.__reduce_ex__(protocol)
+
 
 class RecordBuffer:
     def __init__(self, buffer_size_mb: int):
         self._buffer_stream = torch.cuda.Stream()
+        self._buffer_ready = torch.cuda.Event()
         self._buffer_size = buffer_size_mb * 1024 * 1024
         self._buffer = torch.as_tensor(
             torch.UntypedStorage(self._buffer_size, device=torch.device("cpu")),
             dtype=torch.uint8,
-            pin_memory=True,
-        )
+        ).pin_memory()
         self._head = 0
         self._is_full = False
 
-    def store(self, tensor: torch.Tensor) -> Optional[RecordMetadata]:
+    def store(self, tensor: torch.Tensor) -> Optional[_Record]:
         assert tensor.is_cuda, "Input tensor must be on CUDA device"
 
         if self._is_full:
             return None
         if tensor.numel() == 0:
-            return RecordMetadata(
+            return _Record(
+                self,
                 offset=self._head,
                 length=0,
                 shape=tuple(tensor.shape),
@@ -94,6 +100,9 @@ class RecordBuffer:
         # Keep tensor alive until buffer stream finishes
         t.record_stream(self._buffer_stream)
 
+        # Ensure the tensor is ready before copying to the pinned buffer
+        self._buffer_ready.record()
+
         nbytes = t.numel()
         start = self._head
         end = start + nbytes
@@ -106,19 +115,23 @@ class RecordBuffer:
 
         # Asynchronously copy tensor data to the pinned buffer
         with torch.cuda.stream(self._buffer_stream):
+            self._buffer_ready.wait(self._buffer_stream)
             self._buffer[start:end].copy_(t, non_blocking=True)
+
+        # Advance head pointer
         self._head = end
 
-        return RecordMetadata(
+        return _Record(
+            self,
             offset=start,
             length=nbytes,
             shape=tuple(tensor.shape),
             dtype=tensor.dtype,
         )
 
-    def get(self, address: RecordMetadata) -> torch.Tensor:
-        raw_bytes = self._buffer[address.offset : address.offset + address.length]
-        return raw_bytes.view(address.dtype).reshape(address.shape).clone()
+    def get(self, record: _Record) -> torch.Tensor:
+        raw = self._buffer[record.offset : record.offset + record.length]
+        return raw.view(record.dtype).reshape(record.shape)
 
     def synchronize(self):
         self._buffer_stream.synchronize()
@@ -130,20 +143,6 @@ class RecordBuffer:
     @property
     def is_full(self) -> bool:
         return self._is_full
-
-
-def init_recorder_buffer(
-    server_args: ServerArgs,
-) -> Optional[RecordBuffer]:
-    if server_args.expert_distribution_recorder_mode == "per_token_buffered":
-        # preallocate a large pinned CPU buffer
-        buffer_size_mb = server_args.expert_distribution_recorder_buffer_size
-        # adjust buffer size
-        if buffer_size_mb is None or buffer_size_mb <= 0:
-            buffer_size_mb = 1024  # default to 1GB
-        return RecordBuffer(buffer_size_mb)
-    else:
-        return None
 
 
 class ExpertDistributionRecorder(ABC):
@@ -238,14 +237,11 @@ class _ExpertDistributionRecorderReal(ExpertDistributionRecorder):
         self._current_forward_pass_id = Withable()
         self._current_layer_idx = Withable()
         self._current_debug_name = Withable()
-        self._buffer = init_recorder_buffer(server_args)
         self._accumulator = _Accumulator.init_new(
-            server_args, expert_location_metadata, rank, self._buffer
+            server_args, expert_location_metadata, rank
         )
         self._single_pass_gatherers = {
-            k: _SinglePassGatherer.init_new(
-                server_args, expert_location_metadata, rank, self._buffer
-            )
+            k: _SinglePassGatherer.init_new(server_args, expert_location_metadata, rank)
             for k in self._accumulator.get_single_pass_gatherer_keys()
         }
 
@@ -398,7 +394,6 @@ class _SinglePassGatherer(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
-        buffer: Optional[RecordBuffer] = None,
     ) -> "_SinglePassGatherer":
         if server_args.expert_distribution_recorder_mode == "per_token":
             return _DetailSinglePassGatherer(
@@ -406,11 +401,9 @@ class _SinglePassGatherer(ABC):
             )
 
         if server_args.expert_distribution_recorder_mode == "per_token_buffered":
-            gatherer = _BufferedDetailSinglePassGatherer(
+            return _BufferedDetailSinglePassGatherer(
                 server_args, expert_location_metadata, rank
             )
-            gatherer.set_buffer(buffer)
-            return gatherer
 
         if server_args.expert_distribution_recorder_mode == "stat_approx":
             if server_args.moe_a2a_backend != "none" and (
@@ -476,7 +469,6 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
     ):
         super().__init__(expert_location_metadata, rank)
         self._metadata: Optional[Dict[str, Any]] = None
-        self._num_tokens = 0
         self._topk_ids_of_layer = torch.zeros(
             (
                 expert_location_metadata.num_layers,
@@ -488,7 +480,6 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
             device=server_args.device,
         )
         self._misc_objects: List[Dict[str, Any]] = []
-        self._data = None
         assert (
             not server_args.enable_two_batch_overlap
         ), "DetailSinglePassGatherer does not support TBO yet"
@@ -500,8 +491,8 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
         self._metadata = dict(
             # TODO pr-chain
             # rids=forward_batch.rids,
-            input_ids=self._data.store(forward_batch.input_ids),
-            positions=self._data.store(forward_batch.positions),
+            input_ids=forward_batch.input_ids,
+            positions=forward_batch.positions,
             extend_seq_lens=forward_batch.extend_seq_lens_cpu,
             forward_mode=forward_batch.forward_mode.value,
         )
@@ -522,14 +513,11 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
         self._misc_objects.append(
             dict(
                 layer_id=layer_idx,
-                num_tokens_per_rank=self._data.store(num_tokens_per_rank),
-                num_tokens_per_rdma_rank=self._data.store(num_tokens_per_rdma_rank),
-                num_tokens_per_expert=self._data.store(num_tokens_per_expert),
+                num_tokens_per_rank=num_tokens_per_rank,
+                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+                num_tokens_per_expert=num_tokens_per_expert,
             )
         )
-
-    def set_buffer(self, buffer: RecordBuffer):
-        self._data = buffer
 
     def reset(self):
         self._topk_ids_of_layer[...] = -1
@@ -537,7 +525,7 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
         self._metadata = None
 
     def collect(self) -> Dict:
-        num_tokens = self._num_tokens
+        num_tokens = len(self._metadata["input_ids"])
 
         global_physical_count = _convert_per_token_to_global_physical_count(
             num_tokens,
@@ -548,11 +536,9 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
 
         return dict(
             **self._metadata,
-            topk_ids_of_layer=self._data.store(
-                self._topk_ids_of_layer[:, :num_tokens, :]
-            ),
+            topk_ids_of_layer=self._topk_ids_of_layer[:, :num_tokens, :],
             misc_objects=self._misc_objects,
-            global_physical_count=self._data.store(global_physical_count),
+            global_physical_count=global_physical_count,
         )
 
 
@@ -813,10 +799,9 @@ class _Accumulator(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
-        buffer: Optional[RecordBuffer] = None,
     ) -> "_Accumulator":
         return _Accumulator.get_class(server_args)(
-            server_args, expert_location_metadata, rank, buffer
+            server_args, expert_location_metadata, rank
         )
 
     @staticmethod
@@ -834,12 +819,10 @@ class _Accumulator(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
-        buffer: Optional[RecordBuffer] = None,
     ):
         self._server_args = server_args
         self._expert_location_metadata = expert_location_metadata
         self._rank = rank
-        self._data = buffer
 
     def get_single_pass_gatherer_keys(self):
         return [_SINGLE_PASS_GATHERER_KEY_PRIMARY]
@@ -982,9 +965,10 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._records = []
-
-        # ensure buffer is set correctly
-        assert self._data is not None
+        buffer_size_mb = self._server_args.expert_distribution_recorder_buffer_size
+        if buffer_size_mb is None or buffer_size_mb <= 0:
+            buffer_size_mb = 1024  # default to 1GB
+        self._buffer = RecordBuffer(buffer_size_mb)
 
     def get_single_pass_gatherer_keys(self):
         if False:  # TODO `server_args.enable_two_batch_overlap`
@@ -1003,37 +987,40 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         single_pass_data: Dict,
         outputs: Dict[str, Any],
     ):
-        if self._data.is_full:
-            return  # drop potential broken records
+        # Buffer is full, skip recording to avoid OOM.
+        if self._buffer.is_full:
+            return
 
         super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
+
+        def _process_object(obj):
+            if isinstance(obj, torch.Tensor):
+                return self._buffer.store(obj)
+            return obj
+
+        single_pass_data_processed = {
+            k: _process_object(v) for k, v in single_pass_data.items()
+        }
 
         self._records.append(
             dict(
                 forward_pass_id=forward_pass_id,
                 rank=self._rank,
                 gatherer_key=gatherer_key,
-                **single_pass_data,
+                **single_pass_data_processed,
             )
         )
 
     def reset(self):
         super().reset()
         self._records.clear()
-        self._data.reset()
+        self._buffer.reset()
 
     def dump(self, output_mode: _OutputMode):
         assert output_mode == "file"
 
-        # Ensure all data is written to the buffer
-        self._data.synchronize()
-
-        for record in self._records:
-            # De-reference RecordMetadata to actual tensor data
-            for k, v in record.items():
-                if isinstance(v, RecordMetadata):
-                    record[k] = self._data.get(v, sync=False)
-
+        # ensure D2H copies are completed
+        self._buffer.synchronize()
         output = dict(
             records=self._records,
             # NOTE: This may change during recording, so here we say it is the "last" one

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -53,35 +53,11 @@ class ExpertDistributionMetrics:
 
 
 @dataclass
-class GathererTensorAddress:
+class TensorAddress:
     offset: int
     length: int
     shape: tuple
     dtype: torch.dtype
-
-
-@torch.jit.script
-def cast_tensor_to_int32(tensor: torch.Tensor) -> torch.Tensor:
-    if tensor.dtype == torch.int64:
-        x = tensor.to(torch.int64)
-        low = (x & 0xFFFFFFFF).to(torch.int32)
-        high = ((x >> 32) & 0xFFFFFFFF).to(torch.int32)
-        packed = torch.stack((low, high), dim=-1)
-        return packed.reshape(-1)
-    else:
-        return tensor.to(torch.int32, non_blocking=True)
-
-
-@torch.jit.script
-def cast_tensor_from_int32(
-    tensor: torch.Tensor, original_dtype: torch.dtype
-) -> torch.Tensor:
-    if original_dtype == torch.int64:
-        low = tensor[0::2].to(torch.int64) & 0xFFFFFFFF
-        high = tensor[1::2].to(torch.int64) & 0xFFFFFFFF
-        return low | (high << 32)
-    else:
-        return tensor.to(original_dtype, non_blocking=True)
 
 
 class ExpertRecorderBuffer:
@@ -90,51 +66,54 @@ class ExpertRecorderBuffer:
         buffer_size_mb: int,
         device: torch.device = torch.device("cpu"),
     ):
-        # buffer copy stream
-        self._log_stream = torch.cuda.Stream()
-        # clone done event to synchronize with the copy stream
-        self._log_ready = torch.cuda.Event()
-        # buffer to store the recorded tensors, using int32 as the universal
-        self._buffer = torch.zeros(
-            buffer_size_mb * 1024 * 1024 // torch.int32.itemsize,
-            dtype=torch.int32,
-            device=device,
-            pin_memory=True,
+        self._buffer_stream = torch.cuda.Stream()
+        self._buffer = torch.as_tensor(
+            torch.UntypedStorage(buffer_size_mb * 1024 * 1024, device=device),
+            dtype=torch.uint8,
         )
-        # pointer to the current write position in the buffer
+        if self._buffer.device.type == "cpu":
+            self._buffer = self._buffer.pin_memory()
+        # pointer to the current write position in the buffer (in bytes)
         self._write_ptr = 0
         # flag to indicate if the buffer is full
         # (i.e. no more records can be stored until reset)
         self._is_full = False
 
-    def store(self, tensor: torch.Tensor) -> GathererTensorAddress:
+    def store(self, tensor: torch.Tensor) -> Optional[TensorAddress]:
         assert tensor.is_cuda, "Input tensor must be on CUDA device"
 
         if self._is_full:
             return None
+        if tensor.numel() == 0:
+            return TensorAddress(
+                offset=self._write_ptr,
+                length=0,
+                shape=tuple(tensor.shape),
+                dtype=tensor.dtype,
+            )
 
-        # protective contiguous clone
-        t = tensor.clone(memory_format=torch.contiguous_format).view(-1)
-        t.record_stream(self._log_stream)  # keep tensor alive
+        # Ensure tensor is contiguous and in uint8 format for storage
+        t = (
+            tensor.clone(memory_format=torch.contiguous_format)
+            .view(-1)
+            .view(torch.uint8)
+        )
 
-        # make sure previous copy is done
-        self._log_ready.record(torch.cuda.current_stream())
+        # Keep tensor alive until buffer stream finishes
+        t.record_stream(self._buffer_stream)
+
+        # Ensure that the current stream waits for the buffer stream to finish
+        ready = torch.cuda.Event()
+        ready.record(torch.cuda.current_stream())
 
         # backup tensor to buffer asynchronously
-        with torch.cuda.stream(self._log_stream):
-            # report event
-            self._log_ready.wait(self._log_stream)
+        with torch.cuda.stream(self._buffer_stream):
+            ready.wait(self._buffer_stream)
 
-            # cast tensor if needed
-            if t.dtype != self._buffer.dtype:
-                t = cast_tensor_to_int32(t)
-
-            # compute dimensions
-            length = t.numel()
-
-            # compute buffer slice
+            # compute byte length and buffer slice
+            nbytes = t.numel()
             start = self._write_ptr
-            end = start + length
+            end = start + nbytes
 
             # buffer size check
             if end <= self._buffer.numel():
@@ -151,32 +130,44 @@ class ExpertRecorderBuffer:
             return None
 
         # return address and metadata needed for reconstruction
-        return GathererTensorAddress(
+        return TensorAddress(
             offset=start,
-            length=length,
+            length=nbytes,
             shape=tuple(tensor.shape),
             dtype=tensor.dtype,
         )
 
-    def get(self, address: GathererTensorAddress):
-        t = self._buffer[address.offset : address.offset + address.length]
-
-        # cast tensor if needed
-        if address.dtype != self._buffer.dtype:
-            t = cast_tensor_from_int32(t, address.dtype)
-
-        # Reshape to original dimensions
-        return t.reshape(address.shape).clone()
+    def get(self, address: TensorAddress, sync: bool = True) -> torch.Tensor:
+        if sync:
+            self.synchronize()
+        raw_bytes = self._buffer[address.offset : address.offset + address.length]
+        return raw_bytes.view(address.dtype).reshape(address.shape).clone()
 
     def synchronize(self):
-        self._log_stream.synchronize()
-
-    def is_full(self):
-        return self._is_full
+        self._buffer_stream.synchronize()
 
     def reset(self):
         self._write_ptr = 0
         self._is_full = False
+
+    @property
+    def is_full(self) -> bool:
+        return self._is_full
+
+    @property
+    def bytes_total(self) -> int:
+        """Total buffer capacity in bytes."""
+        return self._buffer.numel()
+
+    @property
+    def bytes_used(self) -> int:
+        """Bytes written since last reset."""
+        return self._write_ptr
+
+    @property
+    def usage_ratio(self) -> float:
+        """Fraction of buffer used (0.0 ~ 1.0)."""
+        return self._write_ptr / self._buffer.numel()
 
 
 def init_recorder_buffer(
@@ -1050,7 +1041,7 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         single_pass_data: Dict,
         outputs: Dict[str, Any],
     ):
-        if self._data.is_full():
+        if self._data.is_full:
             return  # drop potential broken records
 
         super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
@@ -1072,14 +1063,14 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
     def dump(self, output_mode: _OutputMode):
         assert output_mode == "file"
 
-        # ensure all data is written to the buffer
+        # Ensure all data is written to the buffer
         self._data.synchronize()
 
         for record in self._records:
-            # convert all GathererTensorAddress in record to actual tensors
+            # De-reference TensorAddress to actual tensor data
             for k, v in record.items():
-                if isinstance(v, GathererTensorAddress):
-                    record[k] = self._data.get(v)
+                if isinstance(v, TensorAddress):
+                    record[k] = self._data.get(v, sync=False)
 
         output = dict(
             records=self._records,

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -53,40 +53,33 @@ class ExpertDistributionMetrics:
 
 
 @dataclass
-class TensorAddress:
+class RecordMetadata:
     offset: int
     length: int
     shape: tuple
     dtype: torch.dtype
 
 
-class ExpertRecorderBuffer:
-    def __init__(
-        self,
-        buffer_size_mb: int,
-        device: torch.device = torch.device("cpu"),
-    ):
+class RecordBuffer:
+    def __init__(self, buffer_size_mb: int):
         self._buffer_stream = torch.cuda.Stream()
+        self._buffer_size = buffer_size_mb * 1024 * 1024
         self._buffer = torch.as_tensor(
-            torch.UntypedStorage(buffer_size_mb * 1024 * 1024, device=device),
+            torch.UntypedStorage(self._buffer_size, device=torch.device("cpu")),
             dtype=torch.uint8,
+            pin_memory=True,
         )
-        if self._buffer.device.type == "cpu":
-            self._buffer = self._buffer.pin_memory()
-        # pointer to the current write position in the buffer (in bytes)
-        self._write_ptr = 0
-        # flag to indicate if the buffer is full
-        # (i.e. no more records can be stored until reset)
+        self._head = 0
         self._is_full = False
 
-    def store(self, tensor: torch.Tensor) -> Optional[TensorAddress]:
+    def store(self, tensor: torch.Tensor) -> Optional[RecordMetadata]:
         assert tensor.is_cuda, "Input tensor must be on CUDA device"
 
         if self._is_full:
             return None
         if tensor.numel() == 0:
-            return TensorAddress(
-                offset=self._write_ptr,
+            return RecordMetadata(
+                offset=self._head,
                 length=0,
                 shape=tuple(tensor.shape),
                 dtype=tensor.dtype,
@@ -98,48 +91,32 @@ class ExpertRecorderBuffer:
             .view(-1)
             .view(torch.uint8)
         )
-
         # Keep tensor alive until buffer stream finishes
         t.record_stream(self._buffer_stream)
 
-        # Ensure that the current stream waits for the buffer stream to finish
-        ready = torch.cuda.Event()
-        ready.record(torch.cuda.current_stream())
-
-        # backup tensor to buffer asynchronously
-        with torch.cuda.stream(self._buffer_stream):
-            ready.wait(self._buffer_stream)
-
-            # compute byte length and buffer slice
-            nbytes = t.numel()
-            start = self._write_ptr
-            end = start + nbytes
-
-            # buffer size check
-            if end <= self._buffer.numel():
-                self._buffer[start:end].copy_(t, non_blocking=True)
-                self._write_ptr = end
-            else:
-                # notice the user
-                logger.info(
-                    "ExpertRecorder's buffer is full. Further records will be dropped until reset."
-                )
-                self._is_full = True
-
-        if self._is_full:
+        nbytes = t.numel()
+        start = self._head
+        end = start + nbytes
+        if end >= self._buffer_size:
+            self._is_full = True
+            logger.info(
+                "ExpertRecorder's buffer is full. Further records will be dropped."
+            )
             return None
 
-        # return address and metadata needed for reconstruction
-        return TensorAddress(
+        # Asynchronously copy tensor data to the pinned buffer
+        with torch.cuda.stream(self._buffer_stream):
+            self._buffer[start:end].copy_(t, non_blocking=True)
+        self._head = end
+
+        return RecordMetadata(
             offset=start,
             length=nbytes,
             shape=tuple(tensor.shape),
             dtype=tensor.dtype,
         )
 
-    def get(self, address: TensorAddress, sync: bool = True) -> torch.Tensor:
-        if sync:
-            self.synchronize()
+    def get(self, address: RecordMetadata) -> torch.Tensor:
         raw_bytes = self._buffer[address.offset : address.offset + address.length]
         return raw_bytes.view(address.dtype).reshape(address.shape).clone()
 
@@ -147,39 +124,24 @@ class ExpertRecorderBuffer:
         self._buffer_stream.synchronize()
 
     def reset(self):
-        self._write_ptr = 0
+        self._head = 0
         self._is_full = False
 
     @property
     def is_full(self) -> bool:
         return self._is_full
 
-    @property
-    def bytes_total(self) -> int:
-        """Total buffer capacity in bytes."""
-        return self._buffer.numel()
-
-    @property
-    def bytes_used(self) -> int:
-        """Bytes written since last reset."""
-        return self._write_ptr
-
-    @property
-    def usage_ratio(self) -> float:
-        """Fraction of buffer used (0.0 ~ 1.0)."""
-        return self._write_ptr / self._buffer.numel()
-
 
 def init_recorder_buffer(
     server_args: ServerArgs,
-) -> Optional[ExpertRecorderBuffer]:
+) -> Optional[RecordBuffer]:
     if server_args.expert_distribution_recorder_mode == "per_token_buffered":
         # preallocate a large pinned CPU buffer
         buffer_size_mb = server_args.expert_distribution_recorder_buffer_size
         # adjust buffer size
         if buffer_size_mb is None or buffer_size_mb <= 0:
             buffer_size_mb = 1024  # default to 1GB
-        return ExpertRecorderBuffer(buffer_size_mb)
+        return RecordBuffer(buffer_size_mb)
     else:
         return None
 
@@ -436,7 +398,7 @@ class _SinglePassGatherer(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
-        buffer: Optional[ExpertRecorderBuffer] = None,
+        buffer: Optional[RecordBuffer] = None,
     ) -> "_SinglePassGatherer":
         if server_args.expert_distribution_recorder_mode == "per_token":
             return _DetailSinglePassGatherer(
@@ -566,7 +528,7 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
             )
         )
 
-    def set_buffer(self, buffer: ExpertRecorderBuffer):
+    def set_buffer(self, buffer: RecordBuffer):
         self._data = buffer
 
     def reset(self):
@@ -851,7 +813,7 @@ class _Accumulator(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
-        buffer: Optional[ExpertRecorderBuffer] = None,
+        buffer: Optional[RecordBuffer] = None,
     ) -> "_Accumulator":
         return _Accumulator.get_class(server_args)(
             server_args, expert_location_metadata, rank, buffer
@@ -872,7 +834,7 @@ class _Accumulator(ABC):
         server_args: ServerArgs,
         expert_location_metadata: ExpertLocationMetadata,
         rank: int,
-        buffer: Optional[ExpertRecorderBuffer] = None,
+        buffer: Optional[RecordBuffer] = None,
     ):
         self._server_args = server_args
         self._expert_location_metadata = expert_location_metadata
@@ -1067,9 +1029,9 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         self._data.synchronize()
 
         for record in self._records:
-            # De-reference TensorAddress to actual tensor data
+            # De-reference RecordMetadata to actual tensor data
             for k, v in record.items():
-                if isinstance(v, TensorAddress):
+                if isinstance(v, RecordMetadata):
                     record[k] = self._data.get(v, sync=False)
 
         output = dict(

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -1170,6 +1170,9 @@ class _RecordBatch:
     def fits(self, size_bytes: int):
         return self._buffer.available() >= size_bytes
 
+    def is_empty(self):
+        return len(self._records) == 0
+
     def append(
         self, record: Dict[str, Any], staged_tensors: List[_StagedTensor]
     ):
@@ -1195,29 +1198,58 @@ class _RecordBatch:
 class _StagingRecordCollection(_RecordCollection):
     def __init__(self, num_batches: int, batch_size: int):
         self._ring = [_RecordBatch(batch_size) for _ in range(num_batches)]
-        self._current_batch = self._ring[0]
+        self._num_batches = num_batches
+        self._batch_size = batch_size
+        self._current_idx = 0
+        # Serializes append (forward pass) and get_records/reset (dump).
+        self._lock = threading.Lock()
+
+    @property
+    def _current_batch(self) -> _RecordBatch:
+        return self._ring[self._current_idx]
 
     def append(self, record: Dict[str, Any]) -> bool:
-        # TODO: check ring buffer status
-        processed, record_staged_tensors, record_tensor_size = (
-            self._prepare_record(record)
-        )
-
-        if not self._current_batch.fits(record_tensor_size):
-            return False    # TODO: find next empty batch
-
-        self._current_batch.append(processed, record_staged_tensors)
-        return True
+        # A dump is in progress: drop this record instead of blocking the forward pass.
+        if not self._lock.acquire(blocking=False):
+            return False
+        try:
+            processed, record_staged_tensors, record_tensor_size = (
+                self._prepare_record(record)
+            )
+            if record_tensor_size > self._batch_size:
+                return False  # Record cannot fit in any batch.
+            if not self._current_batch.fits(record_tensor_size):
+                if not self._rotate_to_next_empty_batch():
+                    return False  # Ring is full of not-yet-dumped records.
+            self._current_batch.append(processed, record_staged_tensors)
+            return True
+        finally:
+            self._lock.release()
 
     def get_records(self):
-        # TODO: collect from all batches, start from current batch
-        # TODO: block new records
-        return self._current_batch.get()
+        # Collect records from every batch in chronological order (oldest first),
+        # starting the traversal at the current append position. Holding the lock
+        # for the whole collection blocks new records during the dump.
+        with self._lock:
+            records = []
+            for offset in range(self._num_batches):
+                batch = self._ring[(self._current_idx + 1 + offset) % self._num_batches]
+                records.extend(batch.get())
+            return records
 
     def reset(self):
-        # TODO: unblock new records
-        for batch in self._ring:
-            batch.reset()
+        with self._lock:
+            self._current_idx = 0
+            for batch in self._ring:
+                batch.reset()
+
+    def _rotate_to_next_empty_batch(self) -> bool:
+        for offset in range(1, self._num_batches):
+            candidate_idx = (self._current_idx + offset) % self._num_batches
+            if self._ring[candidate_idx].is_empty():
+                self._current_idx = candidate_idx
+                return True
+        return False
 
     def _prepare_record(self, record: Dict[str, Any]):
         processed: Dict[str, Any] = {}

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -872,9 +872,10 @@ class _DequeCollection:
 class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._lock = threading.Lock()
-        self._record_batches = self._init_record_batches()
-        self._current_idx = 0
+        num_batches, batch_size = self._get_collection_layout(
+            self._server_args.expert_distribution_recorder_buffer_size
+        )
+        self._record_collection = _RecordCollection.init_new(num_batches, batch_size)
 
     # ------------------------------------------------------------------
     # Accumulator API
@@ -898,40 +899,24 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         outputs: Dict[str, Any],
     ):
         super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
-
-        record = dict(
-            forward_pass_id=forward_pass_id,
-            rank=self._rank,
-            gatherer_key=gatherer_key,
-            **single_pass_data,
+        self._record_collection.append(
+            dict(
+                forward_pass_id=forward_pass_id,
+                rank=self._rank,
+                gatherer_key=gatherer_key,
+                **single_pass_data,
+            )
         )
-
-        with self._lock:
-            num = len(self._record_batches)
-            # Advance past full batches and evict as we go
-            while not self._record_batches[self._current_idx].append(record):
-                self._current_idx = (self._current_idx + 1) % num
-                self._record_batches[self._current_idx].reset()
 
     def reset(self):
         super().reset()
-        with self._lock:
-            for batch in self._record_batches:
-                batch.reset()
+        self._record_collection.reset()
 
     def dump(self, output_mode: _OutputMode):
         assert output_mode == "file"
 
-        with self._lock:
-            num = len(self._record_batches)
-            records = []
-            # Walk ring from oldest (idx+1) to newest (idx)
-            for offset in range(1, num + 1):
-                batch = self._record_batches[(self._current_idx + offset) % num]
-                records.extend(batch.get_records())
-
         output = dict(
-            records=records,
+            records=self._record_collection.get_records(),
             # NOTE: This may change during recording, so here we say it is the "last" one
             last_physical_to_logical_map=self._expert_location_metadata.physical_to_logical_map,
         )
@@ -939,39 +924,31 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
             f"expert_distribution_recorder_{time.time()}_{self._rank}.pt", output
         )
 
-    def _get_batch_layout(self, num_records):
-        MAX_RECORDS_PER_BATCH = 16  # cap for bounded async-D2H batch latency
-        MIN_BATCHES = 4             # ring buffer needs ≥4 for meaningful rotation
-        MIN_RECORDS_PER_BATCH = 2   # each batch must hold ≥2 for progress
-
-        # Primary constraint: records per batch; then derive batch count
-        records_per_batch = max(
-            MIN_RECORDS_PER_BATCH,
-            min(MAX_RECORDS_PER_BATCH, math.ceil(num_records / MIN_BATCHES)),
-        )
-        num_batches = max(MIN_BATCHES, math.ceil(num_records / records_per_batch))
-
-        # Per-record byte estimate (matches _BufferedDetailSinglePassGatherer tensors):
-        L = self._expert_location_metadata.num_layers
-        E = self._expert_location_metadata.num_physical_experts
-        N = self._server_args.chunked_prefill_size * 8  # max tokens per forward pass
-        topk_bytes = L * N * 8 * 4          # topk_ids_of_layer (int32)
-        meta_bytes = N * (4 + 8)            # input_ids (int32) + positions (int64)
-        gpc_bytes = L * E * 4               # global_physical_count (int32)
-        bytes_per_record = topk_bytes + meta_bytes + gpc_bytes
-
-        return num_batches, (records_per_batch * bytes_per_record)
-
-    def _init_record_batches(self) -> List[_RecordBatch]:
-        num_records = self._server_args.expert_distribution_recorder_buffer_size
-        num_batches, batch_size = self._get_batch_layout(
-            self._server_args.expert_distribution_recorder_buffer_size
-        )
-
+    def _get_collection_layout(self, num_records):
         if num_records >= 0:
-            return [_RecordBatch(batch_size) for _ in range(num_batches)]
+            MAX_RECORDS_PER_BATCH = 16  # cap for bounded async-D2H batch latency
+            MIN_BATCHES = 4  # ring buffer needs ≥4 for meaningful rotation
+            MIN_RECORDS_PER_BATCH = 2  # each batch must hold ≥2 for progress
+
+            # Primary constraint: records per batch; then derive batch count
+            records_per_batch = max(
+                MIN_RECORDS_PER_BATCH,
+                min(MAX_RECORDS_PER_BATCH, math.ceil(num_records / MIN_BATCHES)),
+            )
+            num_batches = max(MIN_BATCHES, math.ceil(num_records / records_per_batch))
+
+            # Per-record byte estimate (matches _BufferedDetailSinglePassGatherer tensors):
+            L = self._expert_location_metadata.num_layers
+            E = self._expert_location_metadata.num_physical_experts
+            N = self._server_args.chunked_prefill_size * 8  # max tokens per forward pass
+            topk_bytes = L * N * 8 * 4  # topk_ids_of_layer (int32)
+            meta_bytes = N * (4 + 8)  # input_ids (int32) + positions (int64)
+            gpc_bytes = L * E * 4  # global_physical_count (int32)
+            bytes_per_record = topk_bytes + meta_bytes + gpc_bytes
+
+            return num_batches, (records_per_batch * bytes_per_record)
         else:
-            return [_RecordBatch(batch_size)]   # infinite batch
+            return 1, -1 # infinite batch
 
 
 class _DetailAccumulator(_UtilizationRateAccumulatorMixin):
@@ -1129,91 +1106,173 @@ def _dump_to_file(name, data):
     torch.save(data, str(path_output))
 
 
-@dataclass
-class _RecordLoc:
-    segment: torch.Tensor
-    offset: int
-    length: int
+class _RecordCollection:
+    @staticmethod
+    def init_new(num_batches: int, batch_size: int):
+        if batch_size > 0:
+            return _StagingRecordCollection(num_batches, batch_size)
+        else:
+            return _InfiniteRecordCollection()
 
-    def get(self) -> torch.Tensor:
-        return self.segment[self.offset : self.offset + self.length]
+    def append(self, record: Dict[str, Any]):
+        raise NotImplementedError
 
+    def get_records(self):
+        raise NotImplementedError
 
-@dataclass
-class _Record:
-    loc: _RecordLoc
-    shape: tuple
-    dtype: torch.dtype
-
-    def __reduce_ex__(self, protocol: int):
-        t = self.loc.get().view(self.dtype).reshape(self.shape).clone()
-        return t.__reduce_ex__(protocol)
+    def reset(self):
+        raise NotImplementedError
 
 
-class _RecordBatch:
-    def __init__(self, size_bytes: int):
-        self._segment_size = size_bytes
-        self._segment_head = 0
-        self._segment = torch.as_tensor(
-            torch.UntypedStorage(size_bytes, device=torch.device("cpu")),
-            dtype=torch.uint8,
-        ).pin_memory()
-
-        self._stream = torch.cuda.Stream()
-        self._event = torch.cuda.Event()
+class _InfiniteRecordCollection(_RecordCollection):
+    def __init__(self):
         self._records: List[Dict[str, Any]] = []
 
     def append(self, record: Dict[str, Any]) -> bool:
-        record_size = self._get_record_size(record)
-        if self._segment_head + record_size >= self._segment_size:
-            return False
+        def _process_object(obj):
+            if isinstance(obj, torch.Tensor):
+                return obj.cpu().clone()
+            return obj
 
-        processed: Dict[str, Any] = {}
-        for k, v in record.items():
-            if not isinstance(v, torch.Tensor):
-                processed[k] = v
-            else:
-                t = (
-                    v.clone(memory_format=torch.contiguous_format)
-                    .view(-1)
-                    .view(torch.uint8)
-                )
-
-                loc = _RecordLoc(
-                    segment=self._segment,
-                    offset=self._segment_head,
-                    length=t.numel()
-                )
-
-                t.record_stream(self._stream)
-                self._event.record()
-                with torch.cuda.stream(self._stream):
-                    self._event.wait(self._stream)
-                    self._segment[loc.offset : loc.offset + loc.length].copy_(
-                        t, non_blocking=True
-                    )
-
-                self._segment_head += loc.length
-                processed[k] = _Record(loc, tuple(v.shape), v.dtype)
-
-        self._records.append(processed)
+        self._records.append({k: _process_object(v) for k, v in record.items()})
         return True
 
     def get_records(self):
+        return self._records
+
+    def reset(self):
+        self._records.clear()
+
+
+@dataclass
+class _StagedTensor:
+    tensor: torch.Tensor
+    offset: int
+    length: int
+    shape: tuple
+    dtype: torch.dtype
+
+    def get_tensor(self) -> torch.Tensor:
+        t = self.tensor[self.offset : self.offset + self.length]
+        return t.view(self.dtype).reshape(self.shape).clone()
+
+    def __reduce_ex__(self, protocol: int):
+        return self.get_tensor().__reduce_ex__(protocol)
+
+
+class _RecordBatch:
+    def __init__(self, batch_size: int):
+        self._buffer = _StagingBuffer(batch_size, torch.device("cpu"))
+        self._records: List[Dict[str, Any]] = []
+        self._stream = torch.cuda.Stream()
+        self._event = torch.cuda.Event()
+
+    def fits(self, size_bytes: int):
+        return self._buffer.available() >= size_bytes
+
+    def append(
+        self, record: Dict[str, Any], staged_tensors: List[_StagedTensor]
+    ):
+        for t in staged_tensors:
+            t.tensor.record_stream(self._stream)
+            self._event.record()
+            with torch.cuda.stream(self._stream):
+                self._event.wait(self._stream)
+                t.tensor = self._buffer.get_all()
+                t.offset, t.length = self._buffer.append(t)
+        self._records.append(record)
+
+    def get(self) -> List[Dict[str, Any]]:
         if len(self._records) > 0:
             self._stream.synchronize()
         return self._records
 
     def reset(self):
         self._records.clear()
-        self._segment_head = 0
+        self._buffer.reset()
 
-    def _get_record_size(self, record: Dict[str, Any]):
-        total_bytes = 0
-        for v in record.values():
-            if isinstance(v, torch.Tensor) and v.numel() > 0:
-                total_bytes += v.numel() * v.element_size()
-        return total_bytes
+
+class _StagingRecordCollection(_RecordCollection):
+    def __init__(self, num_batches: int, batch_size: int):
+        self._ring = [_RecordBatch(batch_size) for _ in range(num_batches)]
+        self._current_batch = self._ring[0]
+
+    def append(self, record: Dict[str, Any]) -> bool:
+        # TODO: check ring buffer status
+        processed, record_staged_tensors, record_tensor_size = (
+            self._prepare_record(record)
+        )
+
+        if not self._current_batch.fits(record_tensor_size):
+            return False    # TODO: find next empty batch
+
+        self._current_batch.append(processed, record_staged_tensors)
+        return True
+
+    def get_records(self):
+        # TODO: collect from all batches, start from current batch
+        # TODO: block new records
+        return self._current_batch.get()
+
+    def reset(self):
+        # TODO: unblock new records
+        for batch in self._ring:
+            batch.reset()
+
+    def _prepare_record(self, record: Dict[str, Any]):
+        processed: Dict[str, Any] = {}
+        staged_tensors: List[_StagedTensor] = []
+        tensor_size: int = 0
+        for k, v in record.items():
+            if isinstance(v, torch.Tensor) and v.device != torch.device("cpu"):
+                if v.numel() > 0:
+                    t = (
+                        v.clone(memory_format=torch.contiguous_format)
+                        .view(-1)
+                        .view(torch.uint8)
+                    )
+                    # dummy staged tensor
+                    s = _StagedTensor(
+                        tensor=t,
+                        offset=0,
+                        length=t.numel(),
+                        shape=tuple(v.shape),
+                        dtype=v.dtype,
+                    )
+                    processed[k] = s
+                    staged_tensors.append(s)
+                    tensor_size += s.length
+                else:
+                    processed[k] = torch.empty(0, device=torch.device("cpu"))
+            else:
+                processed[k] = v
+        return processed, staged_tensors, tensor_size
+
+
+class _StagingBuffer:
+    def __init__(self, buffer_size, device):
+        self._buffer = torch.empty(
+            buffer_size, dtype=torch.uint8, device=device, pin_memory=True
+        )
+        self._capacity = buffer_size
+        self._offset = 0
+
+    def append(self, value: torch.Tensor) -> int:
+        assert value.dim() == 1, "Only 1D tensors are supported for staging buffer"
+        offset = self._offset
+        length = min(value.numel(), self._capacity - self._offset)
+        self._buffer[offset : offset + length].copy_(value[:length], non_blocking=True)
+        self._offset += length
+        return offset, length
+
+    def get_all(self) -> torch.Tensor:
+        return self._buffer
+
+    def available(self):
+        return self._capacity - self._offset
+
+    def reset(self):
+        self._offset = 0
 
 
 class _Buffer:

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 import time
 from abc import ABC
 from collections import deque
@@ -50,99 +51,6 @@ class ExpertDistributionMetrics:
 
     def copy_to_cpu(self):
         self.eplb_balancedness = self.eplb_balancedness.to("cpu", non_blocking=True)
-
-
-@dataclass
-class _Record:
-    buffer: "RecordBuffer"
-    offset: int
-    length: int
-    shape: tuple
-    dtype: torch.dtype
-
-    def __reduce_ex__(self, protocol: int):
-        tensor = self.buffer.get(self).clone()
-        return tensor.__reduce_ex__(protocol)
-
-
-class RecordBuffer:
-    def __init__(self, buffer_size_mb: int):
-        self._buffer_stream = torch.cuda.Stream()
-        self._buffer_ready = torch.cuda.Event()
-        self._buffer_size = buffer_size_mb * 1024 * 1024
-        self._buffer = torch.as_tensor(
-            torch.UntypedStorage(self._buffer_size, device=torch.device("cpu")),
-            dtype=torch.uint8,
-        ).pin_memory()
-        self._head = 0
-        self._is_full = False
-
-    def store(self, tensor: torch.Tensor) -> Optional[_Record]:
-        assert tensor.is_cuda, "Input tensor must be on CUDA device"
-
-        if self._is_full:
-            return None
-        if tensor.numel() == 0:
-            return _Record(
-                self,
-                offset=self._head,
-                length=0,
-                shape=tuple(tensor.shape),
-                dtype=tensor.dtype,
-            )
-
-        # Ensure tensor is contiguous and in uint8 format for storage
-        t = (
-            tensor.clone(memory_format=torch.contiguous_format)
-            .view(-1)
-            .view(torch.uint8)
-        )
-        # Keep tensor alive until buffer stream finishes
-        t.record_stream(self._buffer_stream)
-
-        # Ensure the tensor is ready before copying to the pinned buffer
-        self._buffer_ready.record()
-
-        nbytes = t.numel()
-        start = self._head
-        end = start + nbytes
-        if end >= self._buffer_size:
-            self._is_full = True
-            logger.info(
-                "ExpertRecorder's buffer is full. Further records will be dropped."
-            )
-            return None
-
-        # Asynchronously copy tensor data to the pinned buffer
-        with torch.cuda.stream(self._buffer_stream):
-            self._buffer_ready.wait(self._buffer_stream)
-            self._buffer[start:end].copy_(t, non_blocking=True)
-
-        # Advance head pointer
-        self._head = end
-
-        return _Record(
-            self,
-            offset=start,
-            length=nbytes,
-            shape=tuple(tensor.shape),
-            dtype=tensor.dtype,
-        )
-
-    def get(self, record: _Record) -> torch.Tensor:
-        raw = self._buffer[record.offset : record.offset + record.length]
-        return raw.view(record.dtype).reshape(record.shape)
-
-    def synchronize(self):
-        self._buffer_stream.synchronize()
-
-    def reset(self):
-        self._head = 0
-        self._is_full = False
-
-    @property
-    def is_full(self) -> bool:
-        return self._is_full
 
 
 class ExpertDistributionRecorder(ABC):
@@ -513,9 +421,9 @@ class _BufferedDetailSinglePassGatherer(_SinglePassGatherer):
         self._misc_objects.append(
             dict(
                 layer_id=layer_idx,
-                num_tokens_per_rank=num_tokens_per_rank,
-                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
-                num_tokens_per_expert=num_tokens_per_expert,
+                num_tokens_per_rank=num_tokens_per_rank.cpu().tolist(),
+                num_tokens_per_rdma_rank=num_tokens_per_rdma_rank.cpu().tolist(),
+                num_tokens_per_expert=num_tokens_per_expert.cpu().tolist(),
             )
         )
 
@@ -964,11 +872,13 @@ class _DequeCollection:
 class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._records = []
-        buffer_size_mb = self._server_args.expert_distribution_recorder_buffer_size
-        if buffer_size_mb is None or buffer_size_mb <= 0:
-            buffer_size_mb = 1024  # default to 1GB
-        self._buffer = RecordBuffer(buffer_size_mb)
+        self._lock = threading.Lock()
+        self._record_batches = self._init_record_batches()
+        self._current_batch = self._record_batches[0]
+
+    # ------------------------------------------------------------------
+    # Accumulator API
+    # ------------------------------------------------------------------
 
     def get_single_pass_gatherer_keys(self):
         if False:  # TODO `server_args.enable_two_batch_overlap`
@@ -987,48 +897,61 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         single_pass_data: Dict,
         outputs: Dict[str, Any],
     ):
-        # Buffer is full, skip recording to avoid OOM.
-        if self._buffer.is_full:
-            return
-
         super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
 
-        def _process_object(obj):
-            if isinstance(obj, torch.Tensor):
-                return self._buffer.store(obj)
-            return obj
-
-        single_pass_data_processed = {
-            k: _process_object(v) for k, v in single_pass_data.items()
-        }
-
-        self._records.append(
-            dict(
-                forward_pass_id=forward_pass_id,
-                rank=self._rank,
-                gatherer_key=gatherer_key,
-                **single_pass_data_processed,
+        with self._lock:
+            self._current_batch = self._current_batch.append(
+                dict(
+                    forward_pass_id=forward_pass_id,
+                    rank=self._rank,
+                    gatherer_key=gatherer_key,
+                    **single_pass_data,
+                )
             )
-        )
 
     def reset(self):
         super().reset()
-        self._records.clear()
-        self._buffer.reset()
+        with self._lock:
+            for batch in self._record_batches:
+                batch.reset()
 
     def dump(self, output_mode: _OutputMode):
         assert output_mode == "file"
 
-        # ensure D2H copies are completed
-        self._buffer.synchronize()
+        with self._lock:
+            records = []
+            batch = self._current_batch.get_next()
+            for _ in range(len(self._record_batches)):
+                records.extend(batch.get_records())
+                batch = batch.get_next()
+
         output = dict(
-            records=self._records,
+            records=records,
             # NOTE: This may change during recording, so here we say it is the "last" one
             last_physical_to_logical_map=self._expert_location_metadata.physical_to_logical_map,
         )
         _dump_to_file(
             f"expert_distribution_recorder_{time.time()}_{self._rank}.pt", output
         )
+
+    def _init_record_batches(self) -> List[_RecordBatch]:
+        max_records = self._server_args.expert_distribution_recorder_buffer_size
+
+        # Split capacity into batches: ≤16 records/batch, ≥4 batches, ≥2 records/batch
+        num_batches = max(4, math.ceil(max_records / 16))
+        records_per_batch = max(2, math.ceil(max_records / num_batches))
+
+        # Per-record byte estimate mirrors _BufferedDetailSinglePassGatherer tensor shapes:
+        #   topk_ids:   layers × (P*8) × 8 × 4
+        #   metadata:   (P*8) × 2 × 4
+        P8 = self._server_args.chunked_prefill_size * 8
+        bytes_per_record = 4 * P8 * (self._expert_location_metadata.num_layers * 8 + 2)
+
+        buffer_size = records_per_batch * bytes_per_record
+        batches = [_RecordBatch(buffer_size) for _ in range(num_batches)]
+        for i in range(num_batches):
+            batches[i].set_next(batches[(i + 1) % num_batches])
+        return batches
 
 
 class _DetailAccumulator(_UtilizationRateAccumulatorMixin):
@@ -1184,6 +1107,110 @@ def _dump_to_file(name, data):
     if not save_dir.exists():
         save_dir.mkdir(parents=True, exist_ok=True)
     torch.save(data, str(path_output))
+
+
+@dataclass
+class _RecordLoc:
+    segment: torch.Tensor
+    offset: int
+    length: int
+
+    def get(self) -> torch.Tensor:
+        return self.segment[self.offset : self.offset + self.length]
+
+
+@dataclass
+class _Record:
+    loc: _RecordLoc
+    shape: tuple
+    dtype: torch.dtype
+
+    def __reduce_ex__(self, protocol: int):
+        t = self.loc.get().view(self.dtype).reshape(self.shape).clone()
+        return t.__reduce_ex__(protocol)
+
+
+class _RecordBatch:
+    def __init__(self, size_bytes: int):
+        self._segment_size = size_bytes
+        self._segment_head = 0
+        self._segment = torch.as_tensor(
+            torch.UntypedStorage(size_bytes, device=torch.device("cpu")),
+            dtype=torch.uint8,
+        ).pin_memory()
+
+        self._stream = torch.cuda.Stream()
+        self._event = torch.cuda.Event()
+
+        self._records: List[Dict[str, Any]] = []
+        self._next: Optional["_RecordBatch"] = None
+
+    def append(self, record: Dict[str, Any], evict: bool = False) -> _RecordBatch:
+        if not evict and not self._segment_fits(record):
+            return self._next.append(record, True)
+
+        # Eviction (TODO: lock check here)
+        if evict and len(self._records) > 0:
+            self._evict_all()
+
+        # Store each tensor sequentially into the underlying segment
+        processed: Dict[str, Any] = {}
+        for k, v in record.items():
+            if not isinstance(v, torch.Tensor):
+                processed[k] = v
+            else:
+                t = (
+                    v.clone(memory_format=torch.contiguous_format)
+                    .view(-1)
+                    .view(torch.uint8)
+                )
+                processed[k] = _Record(
+                    loc=self._segment_append(t),
+                    shape=tuple(v.shape),
+                    dtype=v.dtype,
+                )
+
+        self._records.append(processed)
+        return self
+
+    def get_records(self):
+        # TODO: invoked by dump, need to lock check
+        if len(self._records) > 0:
+            self._stream.synchronize()
+        return self._records
+
+    def reset(self):
+        self._evict_all()
+
+    def set_next(self, next_batch: _RecordBatch):
+        self._next = next_batch
+
+    def get_next(self) -> _RecordBatch:
+        return self._next
+
+    def _evict_all(self):
+        self._records.clear()
+        self._segment_head = 0
+
+    def _segment_fits(self, record: Dict[str, Any]):
+        total_bytes = 0
+        for v in record.values():
+            if isinstance(v, torch.Tensor) and v.numel() > 0:
+                total_bytes += v.numel() * v.element_size()
+        return self._segment_head + total_bytes < self._segment_size
+
+    def _segment_append(self, t: torch.Tensor) -> _RecordLoc:
+        start = self._segment_head
+        nbytes = t.numel()
+        end = start + nbytes
+
+        t.record_stream(self._stream)
+        self._event.record()
+        with torch.cuda.stream(self._stream):
+            self._event.wait(self._stream)
+            self._segment[start:end].copy_(t, non_blocking=True)
+        self._segment_head = end
+        return _RecordLoc(self._segment, start, nbytes)
 
 
 class _Buffer:

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -874,7 +874,7 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         super().__init__(*args, **kwargs)
         self._lock = threading.Lock()
         self._record_batches = self._init_record_batches()
-        self._current_batch = self._record_batches[0]
+        self._current_idx = 0
 
     # ------------------------------------------------------------------
     # Accumulator API
@@ -899,15 +899,19 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
     ):
         super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
 
+        record = dict(
+            forward_pass_id=forward_pass_id,
+            rank=self._rank,
+            gatherer_key=gatherer_key,
+            **single_pass_data,
+        )
+
         with self._lock:
-            self._current_batch = self._current_batch.append(
-                dict(
-                    forward_pass_id=forward_pass_id,
-                    rank=self._rank,
-                    gatherer_key=gatherer_key,
-                    **single_pass_data,
-                )
-            )
+            num = len(self._record_batches)
+            # Advance past full batches and evict as we go
+            while not self._record_batches[self._current_idx].append(record):
+                self._current_idx = (self._current_idx + 1) % num
+                self._record_batches[self._current_idx].reset()
 
     def reset(self):
         super().reset()
@@ -919,11 +923,12 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
         assert output_mode == "file"
 
         with self._lock:
+            num = len(self._record_batches)
             records = []
-            batch = self._current_batch.get_next()
-            for _ in range(len(self._record_batches)):
+            # Walk ring from oldest (idx+1) to newest (idx)
+            for offset in range(1, num + 1):
+                batch = self._record_batches[(self._current_idx + offset) % num]
                 records.extend(batch.get_records())
-                batch = batch.get_next()
 
         output = dict(
             records=records,
@@ -934,24 +939,39 @@ class _BufferedDetailAccumulator(_UtilizationRateAccumulatorMixin):
             f"expert_distribution_recorder_{time.time()}_{self._rank}.pt", output
         )
 
+    def _get_batch_layout(self, num_records):
+        MAX_RECORDS_PER_BATCH = 16  # cap for bounded async-D2H batch latency
+        MIN_BATCHES = 4             # ring buffer needs ≥4 for meaningful rotation
+        MIN_RECORDS_PER_BATCH = 2   # each batch must hold ≥2 for progress
+
+        # Primary constraint: records per batch; then derive batch count
+        records_per_batch = max(
+            MIN_RECORDS_PER_BATCH,
+            min(MAX_RECORDS_PER_BATCH, math.ceil(num_records / MIN_BATCHES)),
+        )
+        num_batches = max(MIN_BATCHES, math.ceil(num_records / records_per_batch))
+
+        # Per-record byte estimate (matches _BufferedDetailSinglePassGatherer tensors):
+        L = self._expert_location_metadata.num_layers
+        E = self._expert_location_metadata.num_physical_experts
+        N = self._server_args.chunked_prefill_size * 8  # max tokens per forward pass
+        topk_bytes = L * N * 8 * 4          # topk_ids_of_layer (int32)
+        meta_bytes = N * (4 + 8)            # input_ids (int32) + positions (int64)
+        gpc_bytes = L * E * 4               # global_physical_count (int32)
+        bytes_per_record = topk_bytes + meta_bytes + gpc_bytes
+
+        return num_batches, (records_per_batch * bytes_per_record)
+
     def _init_record_batches(self) -> List[_RecordBatch]:
-        max_records = self._server_args.expert_distribution_recorder_buffer_size
+        num_records = self._server_args.expert_distribution_recorder_buffer_size
+        num_batches, batch_size = self._get_batch_layout(
+            self._server_args.expert_distribution_recorder_buffer_size
+        )
 
-        # Split capacity into batches: ≤16 records/batch, ≥4 batches, ≥2 records/batch
-        num_batches = max(4, math.ceil(max_records / 16))
-        records_per_batch = max(2, math.ceil(max_records / num_batches))
-
-        # Per-record byte estimate mirrors _BufferedDetailSinglePassGatherer tensor shapes:
-        #   topk_ids:   layers × (P*8) × 8 × 4
-        #   metadata:   (P*8) × 2 × 4
-        P8 = self._server_args.chunked_prefill_size * 8
-        bytes_per_record = 4 * P8 * (self._expert_location_metadata.num_layers * 8 + 2)
-
-        buffer_size = records_per_batch * bytes_per_record
-        batches = [_RecordBatch(buffer_size) for _ in range(num_batches)]
-        for i in range(num_batches):
-            batches[i].set_next(batches[(i + 1) % num_batches])
-        return batches
+        if num_records >= 0:
+            return [_RecordBatch(batch_size) for _ in range(num_batches)]
+        else:
+            return [_RecordBatch(batch_size)]   # infinite batch
 
 
 class _DetailAccumulator(_UtilizationRateAccumulatorMixin):
@@ -1141,19 +1161,13 @@ class _RecordBatch:
 
         self._stream = torch.cuda.Stream()
         self._event = torch.cuda.Event()
-
         self._records: List[Dict[str, Any]] = []
-        self._next: Optional["_RecordBatch"] = None
 
-    def append(self, record: Dict[str, Any], evict: bool = False) -> _RecordBatch:
-        if not evict and not self._segment_fits(record):
-            return self._next.append(record, True)
+    def append(self, record: Dict[str, Any]) -> bool:
+        record_size = self._get_record_size(record)
+        if self._segment_head + record_size >= self._segment_size:
+            return False
 
-        # Eviction (TODO: lock check here)
-        if evict and len(self._records) > 0:
-            self._evict_all()
-
-        # Store each tensor sequentially into the underlying segment
         processed: Dict[str, Any] = {}
         for k, v in record.items():
             if not isinstance(v, torch.Tensor):
@@ -1164,53 +1178,42 @@ class _RecordBatch:
                     .view(-1)
                     .view(torch.uint8)
                 )
-                processed[k] = _Record(
-                    loc=self._segment_append(t),
-                    shape=tuple(v.shape),
-                    dtype=v.dtype,
+
+                loc = _RecordLoc(
+                    segment=self._segment,
+                    offset=self._segment_head,
+                    length=t.numel()
                 )
 
+                t.record_stream(self._stream)
+                self._event.record()
+                with torch.cuda.stream(self._stream):
+                    self._event.wait(self._stream)
+                    self._segment[loc.offset : loc.offset + loc.length].copy_(
+                        t, non_blocking=True
+                    )
+
+                self._segment_head += loc.length
+                processed[k] = _Record(loc, tuple(v.shape), v.dtype)
+
         self._records.append(processed)
-        return self
+        return True
 
     def get_records(self):
-        # TODO: invoked by dump, need to lock check
         if len(self._records) > 0:
             self._stream.synchronize()
         return self._records
 
     def reset(self):
-        self._evict_all()
-
-    def set_next(self, next_batch: _RecordBatch):
-        self._next = next_batch
-
-    def get_next(self) -> _RecordBatch:
-        return self._next
-
-    def _evict_all(self):
         self._records.clear()
         self._segment_head = 0
 
-    def _segment_fits(self, record: Dict[str, Any]):
+    def _get_record_size(self, record: Dict[str, Any]):
         total_bytes = 0
         for v in record.values():
             if isinstance(v, torch.Tensor) and v.numel() > 0:
                 total_bytes += v.numel() * v.element_size()
-        return self._segment_head + total_bytes < self._segment_size
-
-    def _segment_append(self, t: torch.Tensor) -> _RecordLoc:
-        start = self._segment_head
-        nbytes = t.numel()
-        end = start + nbytes
-
-        t.record_stream(self._stream)
-        self._event.record()
-        with torch.cuda.stream(self._stream):
-            self._event.wait(self._stream)
-            self._segment[start:end].copy_(t, non_blocking=True)
-        self._segment_head = end
-        return _RecordLoc(self._segment, start, nbytes)
+        return total_bytes
 
 
 class _Buffer:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -565,7 +565,7 @@ class ServerArgs:
     eplb_rebalance_layers_per_chunk: Optional[int] = None
     eplb_min_rebalancing_utilization_threshold: float = 1.0
     expert_distribution_recorder_mode: Optional[
-        Literal["stat", "stat_approx", "per_pass", "per_token"]
+        Literal["stat", "stat_approx", "per_pass", "per_token", "per_token_buffered"]
     ] = None
     expert_distribution_recorder_buffer_size: Optional[int] = None
     enable_expert_distribution_metrics: bool = False


### PR DESCRIPTION
## Motivation

Detailed expert-distribution recording (`--expert-distribution-recorder-mode per_token` / `per_pass`) converts device tensors to host inside every forward pass and keeps every record in host memory without a bound, which makes it unusable for long recordings or production traffic (background: #18587).

This PR makes the detailed modes stage records asynchronously:

- the batch loop no longer blocks on a device-to-host copy: a snapshot is cloned on the producing stream and copied non-blocking into pinned host memory on a dedicated side stream, and only `dump` synchronizes;
- staged host memory is bounded by `SGLANG_EXPERT_DISTRIBUTION_RECORDER_MAX_BYTES` (default 2 GiB), with records beyond the budget dropped and counted;
- the gatherer no longer converts tensors on the host per pass.

Related to #18587.

## Modifications

- `python/sglang/srt/eplb/expert_distribution.py`
  - `_DetailSinglePassGatherer` keeps device tensors in the pass metadata (`rids`, `input_ids`, `positions`) and no longer does per-pass `.cpu().tolist()` / `.clone().cpu()`; conversion happens once, at staging time.
  - New `_StagingRecordCollection`: snapshots each tensor with a stream-ordered `clone` (kept alive via `record_stream`), then copies non-blocking into pinned host memory on a side stream; `get_records()` synchronizes that stream before the dump and logs the staged bytes and the drop count. Async staging is used on CUDA; other devices fall back to the blocking `v.cpu().clone()` path.
  - `_DetailAccumulator` (the accumulator behind `per_pass` / `per_token`) stages through the collection.
- `python/sglang/srt/environ.py`
  - New `SGLANG_EXPERT_DISTRIBUTION_RECORDER_MAX_BYTES` (default 2 GiB) bounding the staged host bytes. A non-negative budget enables async staging and drops records beyond the budget (counted); a negative value disables async staging and keeps the previous unlimited behavior (pinned host memory is not swappable).
- Behavior change for dump consumers: `input_ids` / `positions` in the dumped records are host tensors now (they were Python lists).

## Verification

- Manually exercised `per_pass` and `per_token` on a local MoE server run (TP=2): start -> generate -> stop -> dump all succeed; the staging log reports `async (device=cuda)`.
- Dumps load with `torch.load()`; `global_physical_count` has shape `(num_layers, num_physical_experts)` with each layer's count equal to `num_tokens * top_k`, consistent across records.
- A `per_token` prefill record carries `topk_ids_of_layer` of shape `(num_layers, num_tokens, top_k)` matching the prefill token count.