### PR TITLE
Tiny fix regex warning

### DIFF
--- a/test/registered/distributed/test_pp_single_node.py
+++ b/test/registered/distributed/test_pp_single_node.py
@@ -415,7 +415,7 @@ class TestGLM41VPPAccuracy(unittest.TestCase):
             eval_name="mmmu",
             num_examples=None,
             num_threads=32,
-            response_answer_regex="<\|begin_of_box\|>(.*)<\|end_of_box\|>",
+            response_answer_regex=r"<\|begin_of_box\|>(.*)<\|end_of_box\|>",
         )
 
         metrics = run_eval(args)


### PR DESCRIPTION
https://github.com/sgl-project/sglang/actions/runs/21888874794/job/63202148074?pr=18566#step:5:16

The regex should be included in `r"<regex>"`