### PR TITLE
fix(ci): use --no-deps for Blackwell editable install to prevent pip race

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -115,8 +115,16 @@ else
 fi
 
 # Clean up existing installations
-$PIP_UNINSTALL_CMD sgl-kernel sglang $PIP_UNINSTALL_SUFFIX || true
-$PIP_UNINSTALL_CMD flashinfer-python flashinfer-cubin flashinfer-jit-cache $PIP_UNINSTALL_SUFFIX || true
+if [ "$IS_BLACKWELL" = "1" ]; then
+    # On Blackwell, only uninstall sglang (keep pre-installed sgl-kernel to avoid race conditions)
+    $PIP_UNINSTALL_CMD sglang $PIP_UNINSTALL_SUFFIX || true
+else
+    $PIP_UNINSTALL_CMD sgl-kernel sglang $PIP_UNINSTALL_SUFFIX || true
+fi
+if [ "$IS_BLACKWELL" != "1" ]; then
+    # On Blackwell, flashinfer is pre-installed and shared across runners; skip uninstall to avoid race conditions
+    $PIP_UNINSTALL_CMD flashinfer-python flashinfer-cubin flashinfer-jit-cache $PIP_UNINSTALL_SUFFIX || true
+fi
 $PIP_UNINSTALL_CMD opencv-python opencv-python-headless $PIP_UNINSTALL_SUFFIX || true
 
 # Install the main package
@@ -126,7 +134,14 @@ if [ -n "$OPTIONAL_DEPS" ]; then
 fi
 echo "Installing python extras: [${EXTRAS}]"
 
-$PIP_CMD install -e "python[${EXTRAS}]" --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX
+if [ "$IS_BLACKWELL" = "1" ]; then
+    # On Blackwell, use --no-deps to avoid pip race conditions with nvidia packages.
+    # Dependencies are pre-installed on the machine. The CI script manages sgl-kernel,
+    # nvidia-nvshmem, nvidia-cudnn, flashinfer, etc. separately below.
+    $PIP_CMD install -e "python[${EXTRAS}]" --no-deps --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX
+else
+    $PIP_CMD install -e "python[${EXTRAS}]" --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX
+fi
 
 # Install router for pd-disagg test
 $PIP_CMD install sglang-router $PIP_INSTALL_SUFFIX
@@ -218,57 +233,63 @@ fi
 $PIP_CMD uninstall xformers || true
 
 # Install flashinfer-jit-cache with caching and retry logic (flashinfer.ai can have transient DNS issues)
-# Cache directory for flashinfer wheels (persists across CI runs on self-hosted runners)
-FLASHINFER_CACHE_DIR="${HOME}/.cache/flashinfer-wheels"
-mkdir -p "${FLASHINFER_CACHE_DIR}"
+if [ "$IS_BLACKWELL" = "1" ]; then
+    # On Blackwell, flashinfer is pre-installed and shared across runners; skip to avoid race conditions
+    echo "Blackwell: skipping flashinfer install (pre-installed)"
+    FLASHINFER_INSTALLED=true
+else
+    # Cache directory for flashinfer wheels (persists across CI runs on self-hosted runners)
+    FLASHINFER_CACHE_DIR="${HOME}/.cache/flashinfer-wheels"
+    mkdir -p "${FLASHINFER_CACHE_DIR}"
 
-# Clean up old versions to avoid cache bloat
-find "${FLASHINFER_CACHE_DIR}" -name "flashinfer_jit_cache-*.whl" ! -name "flashinfer_jit_cache-${FLASHINFER_VERSION}*" -type f -delete 2>/dev/null || true
+    # Clean up old versions to avoid cache bloat
+    find "${FLASHINFER_CACHE_DIR}" -name "flashinfer_jit_cache-*.whl" ! -name "flashinfer_jit_cache-${FLASHINFER_VERSION}*" -type f -delete 2>/dev/null || true
 
-FLASHINFER_WHEEL_PATTERN="flashinfer_jit_cache-${FLASHINFER_VERSION}*.whl"
-CACHED_WHEEL=$(find "${FLASHINFER_CACHE_DIR}" -name "${FLASHINFER_WHEEL_PATTERN}" -type f 2>/dev/null | head -n 1)
+    FLASHINFER_WHEEL_PATTERN="flashinfer_jit_cache-${FLASHINFER_VERSION}*.whl"
+    CACHED_WHEEL=$(find "${FLASHINFER_CACHE_DIR}" -name "${FLASHINFER_WHEEL_PATTERN}" -type f 2>/dev/null | head -n 1)
 
-FLASHINFER_INSTALLED=false
+    FLASHINFER_INSTALLED=false
 
-# Try to install from cache first
-if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then
-    echo "Found cached flashinfer wheel: $CACHED_WHEEL"
-    if $PIP_CMD install "$CACHED_WHEEL" $PIP_INSTALL_SUFFIX; then
-        FLASHINFER_INSTALLED=true
-        echo "Successfully installed flashinfer-jit-cache from cache"
-    else
-        echo "Failed to install from cache, will try downloading..."
-        rm -f "$CACHED_WHEEL"
-    fi
-fi
-
-# If not installed from cache, download with retry logic
-if [ "$FLASHINFER_INSTALLED" = false ]; then
-    for i in {1..5}; do
-        # Download wheel to cache directory (use pip directly as uv pip doesn't support download)
-        if pip download flashinfer-jit-cache==${FLASHINFER_VERSION} \
-            --index-url https://flashinfer.ai/whl/${CU_VERSION} \
-            -d "${FLASHINFER_CACHE_DIR}"; then
-
-            CACHED_WHEEL=$(find "${FLASHINFER_CACHE_DIR}" -name "${FLASHINFER_WHEEL_PATTERN}" -type f 2>/dev/null | head -n 1)
-            if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then
-                if $PIP_CMD install "$CACHED_WHEEL" $PIP_INSTALL_SUFFIX; then
-                    FLASHINFER_INSTALLED=true
-                    echo "Successfully downloaded and installed flashinfer-jit-cache"
-                    break
-                fi
-            else
-                echo "Warning: Download succeeded but wheel file not found"
-            fi
+    # Try to install from cache first
+    if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then
+        echo "Found cached flashinfer wheel: $CACHED_WHEEL"
+        if $PIP_CMD install "$CACHED_WHEEL" $PIP_INSTALL_SUFFIX; then
+            FLASHINFER_INSTALLED=true
+            echo "Successfully installed flashinfer-jit-cache from cache"
+        else
+            echo "Failed to install from cache, will try downloading..."
+            rm -f "$CACHED_WHEEL"
         fi
-        echo "Attempt $i to download flashinfer-jit-cache failed, retrying in 10 seconds..."
-        sleep 10
-    done
-fi
+    fi
 
-if [ "$FLASHINFER_INSTALLED" = false ]; then
-    echo "ERROR: Failed to install flashinfer-jit-cache after 5 attempts"
-    exit 1
+    # If not installed from cache, download with retry logic
+    if [ "$FLASHINFER_INSTALLED" = false ]; then
+        for i in {1..5}; do
+            # Download wheel to cache directory (use pip directly as uv pip doesn't support download)
+            if pip download flashinfer-jit-cache==${FLASHINFER_VERSION} \
+                --index-url https://flashinfer.ai/whl/${CU_VERSION} \
+                -d "${FLASHINFER_CACHE_DIR}"; then
+
+                CACHED_WHEEL=$(find "${FLASHINFER_CACHE_DIR}" -name "${FLASHINFER_WHEEL_PATTERN}" -type f 2>/dev/null | head -n 1)
+                if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then
+                    if $PIP_CMD install "$CACHED_WHEEL" $PIP_INSTALL_SUFFIX; then
+                        FLASHINFER_INSTALLED=true
+                        echo "Successfully downloaded and installed flashinfer-jit-cache"
+                        break
+                    fi
+                else
+                    echo "Warning: Download succeeded but wheel file not found"
+                fi
+            fi
+            echo "Attempt $i to download flashinfer-jit-cache failed, retrying in 10 seconds..."
+            sleep 10
+        done
+    fi
+
+    if [ "$FLASHINFER_INSTALLED" = false ]; then
+        echo "ERROR: Failed to install flashinfer-jit-cache after 5 attempts"
+        exit 1
+    fi
 fi
 
 # Show current packages


### PR DESCRIPTION
## Summary
- Use `--no-deps` for `pip install -e` on Blackwell (5090) runners to prevent pip race conditions
- Skip uninstalling pre-installed `sgl-kernel` on Blackwell machines
- Dependencies are pre-installed on the machine; the CI script already manages sgl-kernel, nvidia-nvshmem, nvidia-cudnn, flashinfer separately below

## Problem
On Blackwell (5090) machines, 8 CI runners share a single system Python. When `pip install -e "python[dev]"` resolves dependencies, torch 2.9.1's pinned nvidia package versions (e.g. `nvidia-cudnn-cu12==9.10.2.21`) conflict with the CI-required versions (`nvidia-cudnn-cu12==9.16.0.29`). Concurrent pip operations from 8 runners racing to downgrade/upgrade these packages corrupt `dist-info` directories, causing errors like:
```
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory:
'/usr/local/lib/python3.10/dist-packages/nvidia_cudnn_cu12-9.10.2.21.dist-info/METADATA'
```

Example failure: https://github.com/sgl-project/sglang/actions/runs/21892238662/job/63200667604

## Also fixed on-machine
- Upgraded CUDA toolkit from 12.4 to 12.8 on both 5090 machines (required for SM120 `compute_120` JIT compilation)
- Updated `/usr/local/bin/nvcc` wrapper, symlinks, systemd service PATH, and `sglang-ci.sh` LD_LIBRARY_PATH

## Test plan
- [x] Verified `nvcc --version` shows 12.8 on both machines
- [x] Verified `compute_120` JIT compilation works on both machines
- [x] Verified torch, sgl_kernel, cudnn imports work on both machines
- [x] All 16 runners online in GitHub
- [ ] Monitor next CI run on 5090 runners