### PR TITLE
[CI] Test new DO-ATL MI35x runner labels (shadow mode)

### DIFF
--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -528,7 +528,7 @@ jobs:
   # MI35x 1-GPU tests - platform-agnostic tests that may work on CDNA4 (gfx950)
   nightly-test-1-gpu-mi35x:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-1-gpu-mi35x')
-    runs-on: linux-mi35x-gpu-1
+    runs-on: linux-mi35x-gpu-1.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -560,7 +560,7 @@ jobs:
   # MI35x 8-GPU Accuracy Tests - GPT-OSS (accuracy only)
   nightly-accuracy-8-gpu-mi35x:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-accuracy-8-gpu-mi35x')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -592,7 +592,7 @@ jobs:
   # MI35x 8-GPU Grok1-INT4 (Accuracy + Performance combined)
   nightly-8-gpu-mi35x-grok1-int4:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-mi35x-grok1-int4')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -638,7 +638,7 @@ jobs:
   # MI35x 8-GPU Grok2 (Accuracy + Performance combined)
   nightly-8-gpu-mi35x-grok2:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-mi35x-grok2')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -684,7 +684,7 @@ jobs:
   # MI35x 8-GPU DeepSeek-R1-MXFP4 (Accuracy + Performance combined)
   nightly-8-gpu-mi35x-deepseek-r1-mxfp4:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-mi35x-deepseek-r1-mxfp4')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -728,7 +728,7 @@ jobs:
   # MI35x 8-GPU DeepSeek-V3.2 Accuracy Test
   nightly-accuracy-8-gpu-mi35x-deepseek-v32:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-accuracy-8-gpu-mi35x-deepseek-v32')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -761,7 +761,7 @@ jobs:
   # MI35x 8-GPU DeepSeek-V3.2 TP+MTP Accuracy Test
   nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -794,7 +794,7 @@ jobs:
   # MI35x 8-GPU DeepSeek-V3.2 Performance Test (Basic)
   nightly-perf-8-gpu-mi35x-deepseek-v32-basic:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-perf-8-gpu-mi35x-deepseek-v32-basic')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -827,7 +827,7 @@ jobs:
   # MI35x 8-GPU Kimi-K2.5 (Accuracy)
   nightly-8-gpu-mi35x-kimi-k25:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-mi35x-kimi-k25')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -860,7 +860,7 @@ jobs:
   # MI35x 8-GPU DeepSeek-V3.2 Performance Test (MTP)
   nightly-perf-8-gpu-mi35x-deepseek-v32-mtp:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-perf-8-gpu-mi35x-deepseek-v32-mtp')
-    runs-on: linux-mi35x-gpu-8
+    runs-on: linux-mi35x-gpu-8.test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -290,7 +290,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi35x-gpu-1]
+        runner: [linux-mi35x-gpu-1.test]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -696,7 +696,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi35x-gpu-8]
+        runner: [linux-mi35x-gpu-8.test]
         part: [0]
     runs-on: ${{matrix.runner}}
     steps:


### PR DESCRIPTION
## Summary

As part of the **TW-mi355 → DO-ATL migration**, new CI runners have been brought up in shadow mode:
- `linux-mi35x-gpu-1.test`
- `linux-mi35x-gpu-2.test`
- `linux-mi35x-gpu-8.test`

This PR updates the MI35x runner labels in `pr-test-amd.yml` and `nightly-test-amd.yml` to point to the `.test` variants so we can validate the new DigitalOcean Atlanta runners.

### Changes
- **`pr-test-amd.yml`**: Updated `linux-mi35x-gpu-1` → `linux-mi35x-gpu-1.test` and `linux-mi35x-gpu-8` → `linux-mi35x-gpu-8.test`
- **`nightly-test-amd.yml`**: Updated all MI35x runner labels (`gpu-1` and `gpu-8`) to their `.test` variants
- The `linux-mi35x-gpu-8.fabric` label is **intentionally unchanged** (no `.test` variant provisioned)

### What this tests
- Validates that the new DO-ATL runners can pick up and execute the existing MI35x CI jobs
- Shadow mode means these runners coexist with the existing TW-mi355 runners

## Test plan
- [ ] PR CI jobs targeting `linux-mi35x-gpu-1.test` pick up on the new runner
- [ ] PR CI jobs targeting `linux-mi35x-gpu-8.test` pick up on the new runner
- [ ] All MI35x test suites pass on the new hardware
- [ ] Revert labels back to non-.test once validated

cc: @sunxxuns @XiaoSun-AMD

Made with [Cursor](https://cursor.com)