### PR TITLE
[CI] Guard python3 call in install script for fresh runners

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -23,20 +23,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 bash "${SCRIPT_DIR}/../../killall_sglang.sh"
 echo "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-}"
 
-# Clear torch compilation cache (python3 may not be in PATH yet on fresh runners)
-if command -v python3 &>/dev/null; then
-    python3 -c 'import os, shutil, tempfile, getpass; cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR") or os.path.join(tempfile.gettempdir(), "torchinductor_" + getpass.getuser()); shutil.rmtree(cache_dir, ignore_errors=True)'
-else
-    echo "python3 not found, skipping torchinductor cache cleanup"
-fi
-
-# Install apt packages
+# Install apt packages (including python3/pip which may be missing on some runners)
 # Use --no-install-recommends and ignore errors from unrelated broken packages on the runner
 # The NVIDIA driver packages may have broken dependencies that are unrelated to these packages
-apt-get install -y --no-install-recommends git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils || {
+apt-get install -y --no-install-recommends python3 python3-pip python3-venv git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils || {
     echo "Warning: apt-get install failed, checking if required packages are available..."
     # Verify the packages we need are actually installed
-    for pkg in git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
+    for pkg in python3 python3-pip git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
         if ! dpkg -l "$pkg" 2>/dev/null | grep -q "^ii"; then
             echo "ERROR: Required package $pkg is not installed and apt-get failed"
             exit 1
@@ -44,6 +37,9 @@ apt-get install -y --no-install-recommends git libnuma-dev libssl-dev pkg-config
     done
     echo "All required packages are already installed, continuing..."
 }
+
+# Clear torch compilation cache
+python3 -c 'import os, shutil, tempfile, getpass; cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR") or os.path.join(tempfile.gettempdir(), "torchinductor_" + getpass.getuser()); shutil.rmtree(cache_dir, ignore_errors=True)'
 
 # Check if protoc of correct architecture is already installed
 if command -v protoc >/dev/null 2>&1; then
@@ -97,8 +93,8 @@ else
     echo "protoc already installed: $(protoc --version)"
 fi
 
-# Install uv
-pip install --upgrade pip
+# Install uv (use python3 -m pip for robustness since some runners only have pip3)
+python3 -m pip install --upgrade pip
 
 if [ "$IS_BLACKWELL" = "1" ]; then
     # The blackwell CI runner has some issues with pip and uv,

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -29,7 +29,7 @@ echo "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-}"
 apt-get install -y --no-install-recommends python3 python3-pip python3-venv git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils || {
     echo "Warning: apt-get install failed, checking if required packages are available..."
     # Verify the packages we need are actually installed
-    for pkg in python3 python3-pip git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
+    for pkg in python3 python3-pip python3-venv git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
         if ! dpkg -l "$pkg" 2>/dev/null | grep -q "^ii"; then
             echo "ERROR: Required package $pkg is not installed and apt-get failed"
             exit 1

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -23,8 +23,12 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 bash "${SCRIPT_DIR}/../../killall_sglang.sh"
 echo "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-}"
 
-# Clear torch compilation cache
-python3 -c 'import os, shutil, tempfile, getpass; cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR") or os.path.join(tempfile.gettempdir(), "torchinductor_" + getpass.getuser()); shutil.rmtree(cache_dir, ignore_errors=True)'
+# Clear torch compilation cache (python3 may not be in PATH yet on fresh runners)
+if command -v python3 &>/dev/null; then
+    python3 -c 'import os, shutil, tempfile, getpass; cache_dir = os.environ.get("TORCHINDUCTOR_CACHE_DIR") or os.path.join(tempfile.gettempdir(), "torchinductor_" + getpass.getuser()); shutil.rmtree(cache_dir, ignore_errors=True)'
+else
+    echo "python3 not found, skipping torchinductor cache cleanup"
+fi
 
 # Install apt packages
 # Use --no-install-recommends and ignore errors from unrelated broken packages on the runner


### PR DESCRIPTION
## Summary
- Guard the `python3` call on line 27 of `ci_install_dependency.sh` with `command -v python3` check
- On some self-hosted runners (e.g. `runner-l2-kqb9p-gpu-45`), `python3` is not in PATH before `pip install` runs
- The unconditional `python3` call causes the entire install script to fail with exit code 127 (due to `set -euxo pipefail`), blocking all CI jobs on affected runners
- The torchinductor cache cleanup is non-critical and can safely be skipped when python3 is unavailable

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/21902112120/job/63233644886?pr=18211 (`stage-b-test-large-2-gpu`)

```
scripts/ci/cuda/ci_install_dependency.sh: line 27: python3: command not found
Error: Process completed with exit code 127.
```

## Test plan
- [ ] CI passes on runners where python3 is available (no behavior change)
- [ ] CI passes on fresh runners where python3 is not in PATH before pip install