### PR TITLE
Automatically resolve NVFP4 MoE backend to `flashinfer_trtllm` instead of `flashinfer_cutlass`

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1788,7 +1788,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             ("w2", layer.w2_weight_scale),
         ]:
             # For NVFP4 TRTLLM we require one scale per 16 inputs (last dim == expected_blocks[name]).
-            if get_moe_runner_backend().is_flashinfer_trtllm():
+            if self.enable_flashinfer_trtllm_moe:
                 expected_blocks = {
                     "w13": layer.w13_weight.shape[2] * 2 // block_size,
                     "w2": layer.w2_weight.shape[2] * 2 // block_size,
@@ -1900,7 +1900,13 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        if get_moe_runner_backend().is_flashinfer_trtllm():
+        moe_runner_backend = get_moe_runner_backend()
+
+        if moe_runner_backend.is_auto():
+            moe_runner_backend = MoeRunnerBackend.FLASHINFER_TRTLLM
+
+        if moe_runner_backend.is_flashinfer_trtllm():
+            self.enable_flashinfer_trtllm_moe = True
             self.runner = MoeRunner(
                 MoeRunnerBackend.FLASHINFER_TRTLLM, moe_runner_config
             )

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1532,22 +1532,21 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 " quantization. Please use Blackwell and"
                 " above."
             )
-        self.enable_flashinfer_trtllm_moe = (
-            get_moe_runner_backend().is_flashinfer_trtllm()
-        )
         self._cache_permute_indices = {}
 
     @property
-    def enable_flashinfer_cutlass_moe(self) -> bool:
-        from sglang.srt.layers.moe import get_moe_runner_backend
+    def enable_flashinfer_trtllm_moe(self) -> bool:
+        """For FP4, auto resolves to flashinfer_trtllm."""
+        backend = get_moe_runner_backend()
+        return backend.is_flashinfer_trtllm() or backend.is_auto()
 
+    @property
+    def enable_flashinfer_cutlass_moe(self) -> bool:
         """Access the global enable_flashinfer_cutlass_moe setting."""
         return get_moe_runner_backend().is_flashinfer_cutlass()
 
     @property
     def enable_flashinfer_cutedsl_moe(self) -> bool:
-        from sglang.srt.layers.moe import get_moe_runner_backend
-
         """Access the global enable_flashinfer_cutedsl_moe setting."""
         return get_moe_runner_backend().is_flashinfer_cutedsl()
 
@@ -1906,7 +1905,6 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             moe_runner_backend = MoeRunnerBackend.FLASHINFER_TRTLLM
 
         if moe_runner_backend.is_flashinfer_trtllm():
-            self.enable_flashinfer_trtllm_moe = True
             self.runner = MoeRunner(
                 MoeRunnerBackend.FLASHINFER_TRTLLM, moe_runner_config
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Generally the performance of `trtllm-gen` in most workloads is better, and there is a lot of hardcoding in server args for every architecture (Qwen/Q3N/Deepseek/GLM+), thus I think it'd just be best to change it for new architectures. And now, it also supports a variety of routing types and dtypes, so it seems safe to change from a compatibility perspective. If a model doesn't explicitly support the routing type detection and needs it in the modelling file, we can also change that when needed.

## Modifications

Change the default