### PR TITLE
fix(rocm): add parentheses to chained boolean in Triton kernel for ROCm compatibility

### DIFF
--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -178,7 +178,7 @@ def assign_draft_cache_locs(
         mask = copy_offset < copy_len
         data = tl.load(out_cache_ptr + copy_offset, mask=mask)
         tl.store(token_pool + kv_start + copy_offset, data, mask=mask)
-    if page_size != 1 and topk != 1 and duplicate_cache_len > 0:
+    if (page_size != 1 and topk != 1) and duplicate_cache_len > 0:
         # Part 2: Copy indices into source_cache_loc and target_cache_loc
         # Expected output: src:[8,9,10,8,9,10...] tgt:[16,17,18,24,25,26...]
         prefix_len = tl.load(seq_lens + pid)


### PR DESCRIPTION
## Motivation

The `assign_draft_cache_locs` Triton kernel in `spec_utils.py` uses a chained boolean expression:

```python
if page_size != 1 and topk != 1 and duplicate_cache_len > 0:
```

The ROCm Triton compiler does not support chained boolean operators (`A and B and C`) and requires parentheses to split the chain into binary expressions. This causes a runtime crash on AMD GPUs when speculative decoding (MTP/EAGLE) processes its first decode request:

```
triton.compiler.errors.UnsupportedLanguageConstruct:
    if page_size != 1 and topk != 1 and duplicate_cache_len > 0:
       ^
chained boolean operators (A or B or C) are not supported;
use parentheses to split the chain.
```

## Modifications

- `python/sglang/srt/speculative/spec_utils.py`: Change `if A and B and C:` to `if (A and B) and C:` — semantically identical, ROCm Triton compatible.

## Testing

Tested on RunPod MI300X (single GPU, 192GB HBM3) with:
- Model: `Qwen/Qwen3-Next-80B-A3B-Instruct-FP8`
- Image: `lmsysorg/sglang:v0.5.8.post1-rocm630-mi30x`
- Speculative decoding: `--speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1`
- Result: 30 concurrent requests all returned HTTP 200 successfully

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Related

- PR #18571 fixes other ROCm issues (AITER v_head_dim, CuTe-DSL import guard) but does not address this Triton kernel compatibility issue.
