### PR TITLE
MoE Refactor: Refactor `modelopt_quant.py` -> `flashinfer_cutedsl.py`

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -138,6 +138,7 @@ class DeepEPMoE(FusedMoE):
             and not _is_hip
             and not (
                 get_moe_runner_backend().is_flashinfer_cutedsl()
+                and self.quant_config is not None
                 and self.quant_config.get_name() == "modelopt_fp4"
             )
         ):
@@ -224,6 +225,16 @@ class DeepEPMoE(FusedMoE):
 
         from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
 
+        if DispatchOutputChecker.format_is_deepep_ll(dispatch_output) and (
+            get_moe_runner_backend().is_flashinfer_cutedsl()
+            and self.quant_config is not None
+            and self.quant_config.get_name() == "modelopt_fp4"
+        ):
+            # Route through the unified MoeRunner framework (Stage 3 adoption):
+            # ModelOpt NVFP4 + FlashInfer CuteDSL owns its forward implementation
+            # in `moe_runner/flashinfer_cutedsl.py`.
+            return super().run_moe_core(dispatch_output)
+
         if _use_aiter:
             assert DispatchOutputChecker.format_is_deepep(dispatch_output)
             # in forward_aiter, we skip token permutation and unpermutation, which have been fused inside aiter kernel
@@ -237,12 +248,7 @@ class DeepEPMoE(FusedMoE):
             else:
                 assert False, "forward_deepgemm_contiguous is deprecated"
         elif DispatchOutputChecker.format_is_deepep_ll(dispatch_output):
-            if (
-                get_moe_runner_backend().is_flashinfer_cutedsl()
-                and self.quant_config.get_name() == "modelopt_fp4"
-            ):
-                output = self.forward_flashinfer_cutedsl(dispatch_output)
-            elif self.use_w4afp8:
+            if self.use_w4afp8:
                 output = self.forward_cutlass_w4afp8_masked(dispatch_output)
             else:
                 assert False, "forward_deepgemm_masked is deprecated"
@@ -308,22 +314,6 @@ class DeepEPMoE(FusedMoE):
             ),
             expert_mask=self.expert_mask,
         )
-
-    def forward_flashinfer_cutedsl(
-        self,
-        dispatch_output: DeepEPLLDispatchOutput,
-    ):
-        hidden_states, hidden_states_scale, _, _, masked_m, _ = dispatch_output
-        assert self.quant_method is not None
-        assert self.moe_runner_config.activation == "silu"
-
-        output = self.quant_method.apply_without_routing_weights(
-            layer=self,
-            x=(hidden_states, hidden_states_scale),
-            masked_m=masked_m,
-            moe_runner_config=self.moe_runner_config,
-        )
-        return output
 
     def forward_cutlass_w4afp8(
         self,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class FlashInferCuteDslNvFp4MoeQuantInfo(MoeQuantInfo):
     """Quantization payload consumed by FlashInfer CuteDSL NVFP4 MoE kernels."""
 
-    input_global_scale: Optional[torch.Tensor]
+    input_global_scale: torch.Tensor | None
     w13_weight: torch.Tensor
     w13_blockscale_swizzled: torch.Tensor
     g1_alphas: torch.Tensor
@@ -38,7 +38,7 @@ class FlashInferCuteDslNvFp4MoeQuantInfo(MoeQuantInfo):
 
 @dataclass
 class FlashInferCuteDslRunnerInput(RunnerInput):
-    hidden_states: Tuple[torch.Tensor, Optional[torch.Tensor]]
+    hidden_states: tuple[torch.Tensor, torch.Tensor | None]
     masked_m: torch.Tensor
 
     @property
@@ -86,7 +86,7 @@ class FlashInferCuteDslRunnerCore(MoeRunnerCore):
             flashinfer_cutedsl_moe_masked,
         )
 
-        down_gemm_overlap_args: Optional[DownGemmOverlapArgs] = running_state.get(
+        down_gemm_overlap_args: DownGemmOverlapArgs | None = running_state.get(
             "down_gemm_overlap_args"
         )
 
@@ -116,7 +116,7 @@ class FlashInferCuteDslRunnerCore(MoeRunnerCore):
 
 @register_pre_permute("deepep_ll", "flashinfer_cutedsl")
 def pre_permute_deepep_ll_to_flashinfer_cutedsl(
-    dispatch_output: "DeepEPLLDispatchOutput",
+    dispatch_output: DeepEPLLDispatchOutput,
     quant_info: FlashInferCuteDslNvFp4MoeQuantInfo,
     runner_config: MoeRunnerConfig,
     running_state: dict,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -20,6 +20,7 @@ from sglang.srt.utils.common import is_flashinfer_available, is_sm100_supported
 if TYPE_CHECKING:
     from sglang.srt.batch_overlap.single_batch_overlap import DownGemmOverlapArgs
     from sglang.srt.layers.moe.token_dispatcher import DeepEPLLDispatchOutput
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
 
 
 @dataclass
@@ -140,7 +141,7 @@ def post_permute_flashinfer_cutedsl_to_deepep_ll(
     quant_info: FlashInferCuteDslNvFp4MoeQuantInfo,
     runner_config: MoeRunnerConfig,
     running_state: dict,
-):
+) -> "DeepEPLLCombineInput":
     from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
 
     return DeepEPLLCombineInput(

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    MoeRunnerCore,
+    RunnerInput,
+    RunnerOutput,
+    register_post_permute,
+    register_pre_permute,
+)
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+from sglang.srt.utils.common import is_flashinfer_available, is_sm100_supported
+
+if TYPE_CHECKING:
+    from sglang.srt.batch_overlap.single_batch_overlap import DownGemmOverlapArgs
+    from sglang.srt.layers.moe.token_dispatcher import DeepEPLLDispatchOutput
+
+
+@dataclass
+class FlashInferCuteDslNvFp4MoeQuantInfo(MoeQuantInfo):
+    """Quantization payload consumed by FlashInfer CuteDSL NVFP4 MoE kernels."""
+
+    input_global_scale: Optional[torch.Tensor]
+    w13_weight: torch.Tensor
+    w13_blockscale_swizzled: torch.Tensor
+    g1_alphas: torch.Tensor
+    w2_weight: torch.Tensor
+    w2_input_scale_quant: torch.Tensor
+    w2_blockscale_swizzled: torch.Tensor
+    g2_alphas: torch.Tensor
+
+
+@dataclass
+class FlashInferCuteDslRunnerInput(RunnerInput):
+    hidden_states: Tuple[torch.Tensor, Optional[torch.Tensor]]
+    masked_m: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.FLASHINFER_CUTEDSL
+
+
+@dataclass
+class FlashInferCuteDslRunnerOutput(RunnerOutput):
+    hidden_states: torch.Tensor
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.FLASHINFER_CUTEDSL
+
+
+class FlashInferCuteDslRunnerCore(MoeRunnerCore):
+    """Runner core for FlashInfer CuteDSL masked MoE kernels (NVFP4 path)."""
+
+    @property
+    def runner_backend(self) -> MoeRunnerBackend:
+        return MoeRunnerBackend.FLASHINFER_CUTEDSL
+
+    def run(
+        self,
+        runner_input: RunnerInput,
+        quant_info: MoeQuantInfo,
+        running_state: dict,
+    ) -> RunnerOutput:
+        if not is_flashinfer_available() or not is_sm100_supported():
+            raise RuntimeError(
+                "flashinfer_cutedsl MoE requires FlashInfer and SM100 support."
+            )
+
+        if not isinstance(runner_input, FlashInferCuteDslRunnerInput):
+            raise TypeError(
+                f"Unexpected runner_input type for flashinfer_cutedsl: {type(runner_input)}"
+            )
+        if not isinstance(quant_info, FlashInferCuteDslNvFp4MoeQuantInfo):
+            raise TypeError(
+                f"Unexpected quant_info type for flashinfer_cutedsl: {type(quant_info)}"
+            )
+
+        from sglang.srt.layers.moe.flashinfer_cutedsl_moe import (
+            flashinfer_cutedsl_moe_masked,
+        )
+
+        down_gemm_overlap_args: Optional[DownGemmOverlapArgs] = running_state.get(
+            "down_gemm_overlap_args"
+        )
+
+        out = flashinfer_cutedsl_moe_masked(
+            hidden_states=runner_input.hidden_states,
+            input_global_scale=quant_info.input_global_scale,
+            w1=quant_info.w13_weight,
+            w1_blockscale=quant_info.w13_blockscale_swizzled,
+            w1_alpha=quant_info.g1_alphas,
+            w2=quant_info.w2_weight,
+            a2_global_scale=quant_info.w2_input_scale_quant,
+            w2_blockscale=quant_info.w2_blockscale_swizzled,
+            w2_alpha=quant_info.g2_alphas,
+            masked_m=runner_input.masked_m,
+            **(
+                dict(
+                    down_sm_count=down_gemm_overlap_args.num_sms,
+                    down_signals=down_gemm_overlap_args.signal,
+                    down_start_event=down_gemm_overlap_args.start_event,
+                )
+                if down_gemm_overlap_args is not None
+                else {}
+            ),
+        )
+        return FlashInferCuteDslRunnerOutput(hidden_states=out)
+
+
+@register_pre_permute("deepep_ll", "flashinfer_cutedsl")
+def pre_permute_deepep_ll_to_flashinfer_cutedsl(
+    dispatch_output: "DeepEPLLDispatchOutput",
+    quant_info: FlashInferCuteDslNvFp4MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> FlashInferCuteDslRunnerInput:
+    hidden_states, hidden_states_scale, topk_ids, topk_weights, masked_m, _ = (
+        dispatch_output
+    )
+
+    running_state["topk_ids"] = topk_ids
+    running_state["topk_weights"] = topk_weights
+
+    return FlashInferCuteDslRunnerInput(
+        hidden_states=(hidden_states, hidden_states_scale),
+        masked_m=masked_m,
+    )
+
+
+@register_post_permute("flashinfer_cutedsl", "deepep_ll")
+def post_permute_flashinfer_cutedsl_to_deepep_ll(
+    runner_output: FlashInferCuteDslRunnerOutput,
+    quant_info: FlashInferCuteDslNvFp4MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+):
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
+
+    return DeepEPLLCombineInput(
+        hidden_states=runner_output.hidden_states,
+        topk_ids=running_state["topk_ids"],
+        topk_weights=running_state["topk_weights"],
+    )

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -47,6 +47,12 @@ class MoeRunner:
             self.runner_core = TritonKernelsRunnerCore(config)
         elif runner_backend.is_deep_gemm():
             self.runner_core = DeepGemmRunnerCore(config)
+        elif runner_backend.is_flashinfer_cutedsl():
+            from sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl import (
+                FlashInferCuteDslRunnerCore,
+            )
+
+            self.runner_core = FlashInferCuteDslRunnerCore(config)
         elif runner_backend.is_marlin():
             self.runner_core = None  # Marlin only supports fused path
         elif (

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -60,10 +60,10 @@ from sglang.srt.utils.custom_op import register_custom_op
 from sglang.srt.utils.patch_torch import register_fake_if_exists
 
 if TYPE_CHECKING:
-    from sglang.srt.batch_overlap.single_batch_overlap import DownGemmOverlapArgs
     from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
     from sglang.srt.layers.moe.token_dispatcher import (
         CombineInput,
+        DispatchOutput,
         StandardDispatchOutput,
     )
     from sglang.srt.models.utils import WeightsMapper
@@ -1887,12 +1887,62 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             self.runner = MoeRunner(
                 MoeRunnerBackend.FLASHINFER_TRTLLM, moe_runner_config
             )
+        elif get_moe_runner_backend().is_flashinfer_cutedsl():
+            self.runner = MoeRunner(
+                MoeRunnerBackend.FLASHINFER_CUTEDSL, moe_runner_config
+            )
 
     def apply(
         self,
         layer: FusedMoE,
-        dispatch_output: StandardDispatchOutput,
+        dispatch_output: DispatchOutput,
     ) -> CombineInput:
+        from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
+
+        if DispatchOutputChecker.format_is_deepep_ll(dispatch_output):
+            assert (
+                self.enable_flashinfer_cutedsl_moe
+            ), "deepep_ll dispatch is only supported for flashinfer_cutedsl"
+            assert (
+                self.runner is not None
+            ), "flashinfer_cutedsl requires MoeRunner to be created"
+            assert (
+                self.moe_runner_config.activation == "silu"
+            ), "Only SiLU activation is supported."
+            assert (
+                not self.moe_runner_config.apply_router_weight_on_input
+            ), "apply_router_weight_on_input is not supported for Flashinfer"
+
+            from sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl import (
+                FlashInferCuteDslNvFp4MoeQuantInfo,
+            )
+
+            quant_info = FlashInferCuteDslNvFp4MoeQuantInfo(
+                input_global_scale=(
+                    None if MOE_NVFP4_DISPATCH else layer.w13_input_scale_quant
+                ),
+                w13_weight=layer.w13_weight,
+                w13_blockscale_swizzled=layer.w13_blockscale_swizzled,
+                g1_alphas=layer.g1_alphas,
+                w2_weight=layer.w2_weight,
+                w2_input_scale_quant=layer.w2_input_scale_quant,
+                w2_blockscale_swizzled=layer.w2_blockscale_swizzled,
+                g2_alphas=layer.g2_alphas,
+            )
+            return self.runner.run(dispatch_output, quant_info)
+
+        if self.enable_flashinfer_cutedsl_moe:
+            raise NotImplementedError(
+                "flashinfer_cutedsl ModelOpt NVFP4 MoE currently only supports deepep_ll dispatch output."
+            )
+
+        if not DispatchOutputChecker.format_is_standard(dispatch_output):
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports standard/deepep_ll dispatch outputs, "
+                f"got {dispatch_output.format=}."
+            )
+        if TYPE_CHECKING:
+            assert isinstance(dispatch_output, StandardDispatchOutput)
 
         x = dispatch_output.hidden_states
         x_sf = dispatch_output.hidden_states_scale
@@ -2019,52 +2069,3 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
         return StandardCombineInput(hidden_states=output)
-
-    def apply_without_routing_weights(
-        self,
-        layer: FusedMoE,
-        x: tuple[torch.Tensor, Optional[torch.Tensor]],
-        masked_m: torch.Tensor,
-        moe_runner_config: MoeRunnerConfig,
-    ) -> torch.Tensor:
-        assert (
-            moe_runner_config.activation == "silu"
-        ), "Only SiLU activation is supported."
-
-        assert self.enable_flashinfer_cutedsl_moe, "only support flashinfer cutedsl moe"
-        assert (
-            not moe_runner_config.apply_router_weight_on_input
-        ), "apply_router_weight_on_input is not supported for Flashinfer"
-
-        from sglang.srt.layers.moe.flashinfer_cutedsl_moe import (
-            flashinfer_cutedsl_moe_masked,
-        )
-
-        down_gemm_overlap_args: Optional[DownGemmOverlapArgs] = getattr(
-            layer, "down_gemm_overlap_args", None
-        )
-
-        out = flashinfer_cutedsl_moe_masked(
-            hidden_states=x,
-            input_global_scale=(
-                None if MOE_NVFP4_DISPATCH else layer.w13_input_scale_quant
-            ),
-            w1=layer.w13_weight,
-            w1_blockscale=layer.w13_blockscale_swizzled,
-            w1_alpha=layer.g1_alphas,
-            w2=layer.w2_weight,
-            a2_global_scale=layer.w2_input_scale_quant,
-            w2_blockscale=layer.w2_blockscale_swizzled,
-            w2_alpha=layer.g2_alphas,
-            masked_m=masked_m,
-            **(
-                dict(
-                    down_sm_count=down_gemm_overlap_args.num_sms,
-                    down_signals=down_gemm_overlap_args.signal,
-                    down_start_event=down_gemm_overlap_args.start_event,
-                )
-                if down_gemm_overlap_args is not None
-                else {}
-            ),
-        )
-        return out


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Part of https://github.com/sgl-project/sglang/issues/8715

## Testing commands:
```
SGLANG_DEEPEP_BF16_DISPATCH=1 \
SGLANG_NVFP4_CKPT_FP8_GEMM_IN_ATTN=1 \
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=512 \
python3 -m sglang.launch_server \
    --model-path nvidia/DeepSeek-R1-0528-NVFP4-v2 \
    --max-running-requests 256 \
    --chunked-prefill-size 1024 \
    --max-prefill-tokens 16384 \
    --cuda-graph-bs 128 \
    --tp 4 \
    --enable-dp-attention \
    --dp 4 \
    --ep 4 \
    --attention-backend trtllm_mla \
    --moe-runner-backend flashinfer_cutedsl \
    --moe-dense-tp-size 1 \
    --moe-a2a-backend deepep \
    --deepep-mode low_latency \
    --quantization modelopt_fp4 \
    --kv-cache-dtype fp8_e4m3 \
    --speculative-moe-runner-backend deep_gemm \
    --speculative-moe-a2a-backend deepep
```

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 200
```