### PR TITLE
fix(model-config): guard rope scaling factor access

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -450,7 +450,7 @@ class ModelConfig:
                     or rope_scaling.get("type")
                     or "default"
                 )
-                if rope_type != "default":
+                if rope_type != "default" and "factor" in rope_scaling:
                     mscale_all_dim = rope_scaling.get("mscale_all_dim", False)
                     scaling_factor = rope_scaling["factor"]
                     mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))


### PR DESCRIPTION
# Motivation
Some MLA model configs provide `rope_scaling` with a non-default rope type but without `factor`.

Current code directly reads `rope_scaling["factor"]` once rope type is non-default, which can raise a runtime `KeyError` during model config initialization.

This PR adds a guard so scaling adjustment is only applied when `factor` exists.

# Modifications
- `python/sglang/srt/configs/model_config.py`
  - Change condition from `if rope_type != "default":` to `if rope_type != "default" and "factor" in rope_scaling:`.
  - Behavior is unchanged when `factor` exists; it safely skips scaling adjustment otherwise.

# Testing
- Verified diff and logic locally.

# Checklist
- [ ] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [ ] Follow the SGLang code style guidance.
