### PR TITLE
Fix dllm scheduler crash: missing prefill_stats on batch

### DIFF
--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -8,7 +8,6 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase
 from sglang.srt.managers.schedule_batch import Req, RequestStage, ScheduleBatch
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
-from sglang.srt.managers.scheduler_metrics_mixin import PrefillStats
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 logger = logging.getLogger(__name__)
@@ -195,6 +194,9 @@ class SchedulerDllmMixin:
         new_batch.decoding_reqs = None
 
         # Record prefill stats for logging after forward (matches scheduler.py normal path)
+        # Import here to avoid circular import: scheduler -> dllm/scheduler -> scheduler_metrics_mixin -> scheduler
+        from sglang.srt.managers.scheduler_metrics_mixin import PrefillStats
+
         new_batch.prefill_stats = PrefillStats(
             log_input_tokens=self.adder.log_input_tokens,
             log_hit_tokens=self.adder.log_hit_tokens,

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -8,6 +8,7 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase
 from sglang.srt.managers.schedule_batch import Req, RequestStage, ScheduleBatch
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sglang.srt.managers.scheduler_metrics_mixin import PrefillStats
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 logger = logging.getLogger(__name__)
@@ -192,6 +193,16 @@ class SchedulerDllmMixin:
         new_batch.prepare_for_extend()
         new_batch.forward_mode = forward_mode
         new_batch.decoding_reqs = None
+
+        # Record prefill stats for logging after forward (matches scheduler.py normal path)
+        new_batch.prefill_stats = PrefillStats(
+            log_input_tokens=self.adder.log_input_tokens,
+            log_hit_tokens=self.adder.log_hit_tokens,
+            new_token_ratio=self.adder.new_token_ratio,
+            running_bs=self.running_bs,
+            num_new_seqs=len(can_run_list),
+        )
+
         return new_batch
 
     def process_dllm_incoming_reqs(


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'NoneType' object has no attribute 'log_input_tokens'` crash in dllm code path
- `_create_dllm_batch()` never set `prefill_stats` on the batch, so when metrics are enabled, `process_batch_result_dllm` passes `None` to `log_prefill_stats`, crashing the scheduler
- Set `prefill_stats` in `_create_dllm_batch()` to match the normal prefill path in `scheduler.py`

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/21907111579/job/63260720970?pr=18609

```
Scheduler hit an exception:
  File "scheduler_output_processor_mixin.py", line 421, in process_batch_result_dllm
    self.log_prefill_stats(
  File "scheduler_metrics_mixin.py", line 168, in log_prefill_stats
    self.last_prefill_tokens = prefill_stats.log_input_tokens
AttributeError: 'NoneType' object has no attribute 'log_input_tokens'
```

may be related: https://github.com/sgl-project/sglang/pull/18570

## Test plan
- [ ] `test_llada2_mini.py` passes (currently consistently failing on CI)