### PR TITLE
[CI] Install python3-dev for Triton JIT compilation on fresh runners

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -26,10 +26,10 @@ echo "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-}"
 # Install apt packages (including python3/pip which may be missing on some runners)
 # Use --no-install-recommends and ignore errors from unrelated broken packages on the runner
 # The NVIDIA driver packages may have broken dependencies that are unrelated to these packages
-apt-get install -y --no-install-recommends python3 python3-pip python3-venv git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils || {
+apt-get install -y --no-install-recommends python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils || {
     echo "Warning: apt-get install failed, checking if required packages are available..."
     # Verify the packages we need are actually installed
-    for pkg in python3 python3-pip python3-venv git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
+    for pkg in python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
         if ! dpkg -l "$pkg" 2>/dev/null | grep -q "^ii"; then
             echo "ERROR: Required package $pkg is not installed and apt-get failed"
             exit 1


### PR DESCRIPTION
## Summary
- Add `python3-dev` to apt-get install in CI dependency script
- Provides `Python.h` headers needed by Triton to JIT-compile its CUDA driver utilities

## Root Cause
Some CI runners (e.g. `runner-l2-kqb9p-gpu-45`) are missing the Python development headers. When Triton tries to JIT-compile `cuda_utils.c`, it fails with:
```
fatal error: Python.h: No such file or directory
```
This breaks any test that uses Triton kernels (MoE models, piecewise CUDA graph tests, etc.).

## Example Failure
https://github.com/sgl-project/sglang/actions/runs/21916574771/job/63288147727#step:5:1940

Followup to #18609 which added `python3`/`python3-pip`/`python3-venv` but missed the dev headers.

## Test plan
- [ ] CI passes on runners that were previously missing `Python.h`
- [ ] Triton MoE kernels compile successfully during CUDA graph capture