### PR TITLE
[Diffusion] [BUG] Fix missing initialization of GLM-Image text encoder config

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, field
 import torch
 from diffusers.image_processor import VaeImageProcessor
 
+from python.sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
+from python.sglang.multimodal_gen.configs.models.encoders.t5 import T5Config
 from sglang.multimodal_gen.configs.models import DiTConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.glmimage import GlmImageDitConfig
 from sglang.multimodal_gen.configs.models.vaes.glmimage import GlmImageVAEConfig
@@ -24,6 +26,10 @@ class GlmImagePipelineConfig(ImagePipelineConfig):
     vae_tiling: bool = False
 
     vae_sp: bool = False
+
+    text_encoder_configs: tuple[EncoderConfig, ...] = field(
+        default_factory=lambda: (T5Config(),)
+    )
 
     dit_config: DiTConfig = field(default_factory=GlmImageDitConfig)
     # VAE


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

cc @zhaochenyang20 

Error in GLM-Image initialization
cmd: `sglang serve --model-path zai-org/GLM-Image --backend sglang --num-gpus 1`

```
[02-12 07:44:04] Loading pipeline modules from config: {'_class_name': 'GlmImagePipeline', '_diffusers_version': '0.37.0.dev0', '_name_or_path': 'zai-org/GLM-Image-Decoder', 'text_encoder': ['transformers', 'T5EncoderModel'], 'vision_language_encoder': ['transformers', 'GlmImageForConditionalGeneration'], 'scheduler': ['diffusers', 'FlowMatchEulerDiscreteScheduler'], 'tokenizer': ['transformers', 'ByT5Tokenizer'], 'processor': ['transformers', 'GlmImageProcessor'], 'transformer': ['diffusers', 'GlmImageTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderKL']}
[02-12 07:44:04] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'vision_language_encoder', 'processor', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0/7 [00:00<?, ?it/s][02-12 07:44:04] Loading text_encoder from /workspace/.hf_home/hub/models--zai-org--GLM-Image/snapshots/2c433cc0cbc293bde2ac8ca9624f279b5d23fcf4/text_encoder. avail mem: 87.75 GB
Traceback (most recent call last):
  File "/workspace/sglang/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py", line 93, in load
    component = self.load_customized(
                ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sglang/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py", line 205, in load_customized
    return self.load_model(
           ^^^^^^^^^^^^^^^^
  File "/workspace/sglang/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py", line 242, in load_model
    model = model_cls(model_config)
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sglang/python/sglang/multimodal_gen/runtime/models/encoders/t5.py", line 574, in __init__
    tp_group = _get_folding_tp_group(config)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sglang/python/sglang/multimodal_gen/runtime/distributed/__init__.py", line 64, in _get_folding_tp_group
    if config.parallel_folding:
       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/sglang/python/sglang/multimodal_gen/configs/models/base.py", line 56, in __getattr__
    raise AttributeError(
AttributeError: 'EncoderConfig' object has no attribute 'parallel_folding'
```

## Modifications

Initialize text_encoder_config to T5Config instead of base Encoder config

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
