### PR TITLE
[BugFix] Normalize Qwen3.5 RoPE config by mapping rope_parameters to rope_scaling

### DIFF
--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -15,13 +15,10 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
 
     def __init__(
         self,
+        rope_parameters=None,
         **kwargs,
     ):
-        rope_scaling = kwargs.get("rope_scaling") or {}
-        if "rope_type" not in rope_scaling and "type" not in rope_scaling:
-            rope_scaling = dict(rope_scaling)
-            rope_scaling["rope_type"] = "default"
-        kwargs["rope_scaling"] = rope_scaling
+        kwargs["rope_scaling"] = rope_parameters
         super().__init__(**kwargs)
 
 

--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -17,9 +17,12 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
         self,
         **kwargs,
     ):
+        rope_scaling = kwargs.get("rope_scaling") or {}
+        if "rope_type" not in rope_scaling and "type" not in rope_scaling:
+            rope_scaling = dict(rope_scaling)
+            rope_scaling["rope_type"] = "default"
+        kwargs["rope_scaling"] = rope_scaling
         super().__init__(**kwargs)
-        if self.rope_scaling is None:
-            self.rope_scaling = {}
 
 
 class Qwen3_5Config(PretrainedConfig):

--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -20,6 +20,8 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
     ):
         kwargs["rope_scaling"] = rope_parameters
         super().__init__(**kwargs)
+        if self.rope_scaling is None:
+            self.rope_scaling = {}
 
 
 class Qwen3_5Config(PretrainedConfig):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Qwen3.5 checkpoints provide RoPE settings in `rope_parameters` instead of rope_scaling.
The runtime RoPE path expects rope_scaling, so this mismatch can lead to missing RoPE scaling config and trigger initialization errors (e.g. unknown RoPE scaling type) during model loading.

`get_rope()` expects a scaling type and may raise:
`ValueError: Unknown RoPE scaling type`.

cmd:
```
python -m sglang.launch_server \
    --model /root/Qwen3.5-35B-A3B-Base \
    --tp-size 8 \
    --enable-multimodal \
    --max-mamba-cache-size 128 \
    --max-running-requests 128 \
    --chunked-prefill-size 2048 \
    --mamba-ssm-dtype bfloat16 \
    --speculative-algo NEXTN    \
    --speculative-num-steps 3     \
    --speculative-eagle-topk 1     \
    --speculative-num-draft-tokens 4
```

Before this PR
<img width="2236" height="1322" alt="image" src="https://github.com/user-attachments/assets/c5411387-d7d6-4271-9e98-4b010e505c27" />

After this PR
<img width="2194" height="764" alt="image" src="https://github.com/user-attachments/assets/c4ba5244-9c7a-4d83-b79a-95a9c6867897" />

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Updated Qwen3_5TextConfig.__init__ to accept rope_parameters
Directly map rope_parameters to kwargs["rope_scaling"] before calling super().__init__(**kwargs) 
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
