### PR TITLE
[AMD] Fix Multimodal Test 1 GPU

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -272,7 +272,16 @@ def load_model_from_full_model_state_dict(
             else:
                 sharded_tensor = full_tensor
 
-            if cpu_offload:
+            # Important: `cpu_offload` is intended for FSDP-managed parameter movement.
+            # If a parameter is not sharded into a DTensor (i.e., no `device_mesh`), FSDP
+            # will NOT manage it. Offloading it here would leave CPU parameters that
+            # later participate in GPU kernels (e.g., conv/embedding), causing device/dtype
+            # mismatches like "Input type (CUDABFloat16Type) and weight type (CPUBFloat16Type)".
+            #
+            # Therefore:
+            # - For non-FSDP models, keep the historical behavior (allow CPU offload).
+            # - For FSDP models, do NOT offload non-sharded parameters here.
+            if cpu_offload and not is_fsdp_model:
                 sharded_tensor = sharded_tensor.cpu()
         else:
             full_tensor = full_tensor.to(device=device, dtype=param_dtype)
@@ -309,7 +318,7 @@ def load_model_from_full_model_state_dict(
             sharded_tensor = torch.zeros_like(
                 meta_sharded_param, device=device, dtype=param_dtype
             )
-            if cpu_offload:
+            if cpu_offload and not is_fsdp_model:
                 sharded_tensor = sharded_tensor.cpu()
         else:
             # Initialize with zeros and distribute

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
@@ -119,6 +119,7 @@ class DmdDenoisingStage(DenoisingStage):
                         )
                     else:
                         current_model = self.transformer
+                        self._manage_device_placement(current_model, None, server_args)
                     # Expand latents for I2V
                     noise_latents = latents.clone()
                     latent_model_input = latents.to(target_dtype)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fix multimodal tests errors in AMD CI 
1. `sglang/multimodal_gen/test/server/test_server_b.py::TestDiffusionServerOneGpu::test_diffusion_perf[fastwan2_2_ti2v_5b]`
https://github.com/sgl-project/sglang/actions/runs/21918151590/job/63328247649#step:9:2294 
<img width="3008" height="1107" alt="image" src="https://github.com/user-attachments/assets/afdf50aa-6f94-4353-8814-d792b03905b7" />

2. `sglang/multimodal_gen/test/server/test_server_a.py::TestDiffusionServerOneGpu::test_diffusion_perf[zimage_image_t2i_warmup]`
https://github.com/sgl-project/sglang/actions/runs/21918151590/job/63328247657#step:9:377
<img width="2351" height="1265" alt="image" src="https://github.com/user-attachments/assets/72d77b9d-c360-4547-86bb-557ca31e124d" />


<!-- Describe the purpose and goals of this pull request. -->

## Modifications
This PR fixes three issues causing the multimodal generation 1-GPU test to fail on AMD:
1. **Strict missing-weights check in text encoder loader** -- Previously, unloaded text encoder weights were silently warned about. Now, unexpected missing weights raise a `ValueError` to catch checkpoint/model-arch mismatches early, preventing hard-to-debug NaN errors downstream. Known-optional patterns can be whitelisted via `_allowed_missing_weights_patterns`.
2. **CPU offload fix for FSDP models** -- Non-sharded parameters in FSDP models were being offloaded to CPU, causing device mismatches (e.g., `CUDABFloat16Typ`e vs `CPUBFloat16Type`) when those params later hit GPU kernels. The fix skips CPU offload for non-sharded parameters when `is_fsdp_model` is true.
4. **Missing device placement call in DMD denoising** -- Added a `_manage_device_placement` call for the transformer model in a code path that was missing it, ensuring the model is on the correct device before inference.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
