### PR TITLE
fix: image version in pypi pr workflow

### DIFF
--- a/.github/workflows/release-pypi-pr.yml
+++ b/.github/workflows/release-pypi-pr.yml
@@ -34,13 +34,14 @@ jobs:
       - name: Generate PR wheel version
         id: gen_version
         run: |
-          # Get base version from setuptools_scm
-          cd python
-          pip install setuptools-scm
-          FULL_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version(root='..'))")
-          # Strip any existing .dev or + suffix to get clean base version
-          BASE_VERSION=$(echo "$FULL_VERSION" | sed 's/\.dev.*//;s/+.*//')
-          cd ..
+          # Get base version from the latest v*.*.* git tag directly
+          # Note: We cannot use setuptools_scm here because the [tool.setuptools_scm]
+          # config (with custom git_describe_command) lives in python/pyproject.toml,
+          # not at the repo root. Without that config, setuptools_scm falls back to
+          # default git describe which finds gateway-* tags instead of v*.*.* release tags.
+          LATEST_TAG=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1)
+          BASE_VERSION=${LATEST_TAG#v}
+          echo "Latest release tag: ${LATEST_TAG}"
 
           # Get commit info
           COMMIT_HASH=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Motivation

Replacing setuptools_scm with git describe to get accurate image version for pypi pr workflow.

## Modifications

See above.

## Accuracy Tests

`<a href="https://github.com/sgl-project/whl/releases/download/pr-18598-2026-02-12-fec757fd3/sglang-0.5.8.post1.dev9646+pr.18598.gfec757fd3-py3-none-any.whl#sha256=cb3de666ba77589afe54d05dc2eeefa7b032c3d5cdc870e7b35dd6716c3ddfa2">sglang-0.5.8.post1.dev9646+pr.18598.gfec757fd3-py3-none-any.whl</a><br>`

from run: https://github.com/sgl-project/sglang/actions/runs/21954091508

## Benchmarking and Profiling

n/a

## Checklist

- [ Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
