### PR TITLE
feat: add SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE env var

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -259,6 +259,9 @@ class Envs:
     # Model Parallel
     SGLANG_USE_MESSAGE_QUEUE_BROADCASTER = EnvBool(True)
     SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS = EnvBool(False)
+    # Override the distributed init method used by torch.distributed.init_process_group.
+    # Set to "env://" to use an externally-created TCPStore via MASTER_ADDR/MASTER_PORT.
+    SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE = EnvStr(None)
 
     # Tool Calling
     SGLANG_FORWARD_UNKNOWN_TOOLS = EnvBool(False)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -758,7 +758,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if not self.server_args.enable_p2p_check:
             monkey_patch_p2p_access_check()
 
-        if self.server_args.dist_init_addr:
+        # Allow external orchestrators (e.g. trainpi) to override the distributed
+        # init method.  When set to "env://", torch uses MASTER_ADDR/MASTER_PORT
+        # env-vars and an externally-created TCPStore, completely avoiding port
+        # conflicts with intra-host collocation.
+        dist_init_method_override = envs.SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE.get()
+        if dist_init_method_override:
+            dist_init_method = dist_init_method_override
+        elif self.server_args.dist_init_addr:
             dist_init_method = f"tcp://{self.server_args.dist_init_addr}"
         else:
             dist_init_method = f"tcp://127.0.0.1:{self.dist_port}"


### PR DESCRIPTION
## Summary
- Add `SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE` environment variable to allow external orchestrators to override the distributed init method used by `torch.distributed.init_process_group`.
- When set to `"env://"`, torch uses `MASTER_ADDR`/`MASTER_PORT` env-vars and an externally-created `TCPStore`, completely avoiding port conflicts with intra-host collocation.

## Test plan
- External Bootstrapping.

Made with [Cursor](https://cursor.com)