### PR TITLE
fix(sgl-kernel): use >= 120 for SM12x CUDA kernel dispatch

### DIFF
--- a/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
+++ b/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
@@ -448,7 +448,7 @@ torch::Tensor fp8_blockwise_scaled_mm(
 
 #if defined(CUTLASS_ARCH_MMA_SM120A_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
-  if (sm_version == 120) {
+  if (sm_version >= 120) {
     if (out_dtype == torch::kBFloat16) {
       sm120_fp8_blockwise_dispatch_shape<cutlass::bfloat16_t>(
           out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b);

--- a/sgl-kernel/csrc/gemm/nvfp4_scaled_mm_kernels.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_scaled_mm_kernels.cu
@@ -663,7 +663,7 @@ void cutlass_scaled_fp4_mm_sm100a_sm120a(
   // Check SM version and dispatch accordingly
   auto sm_version = getSMVersion();
 
-  if (sm_version == 120) {
+  if (sm_version >= 120) {
     // Use SM120 specific dispatch
     if (out_dtype == at::ScalarType::Half) {
       cutlass_fp4_f16_gemm_dispatch_sm120(D, A, B, A_sf, B_sf, alpha, m, n, k, stream);

--- a/sgl-kernel/csrc/moe/nvfp4_blockwise_moe.cu
+++ b/sgl-kernel/csrc/moe/nvfp4_blockwise_moe.cu
@@ -665,7 +665,7 @@ void cutlass_fp4_group_mm(
           N,
           K);
     }
-  } else if (sm_version == 120) {
+  } else if (sm_version >= 120) {
     if (output.scalar_type() == torch::kBFloat16) {
       run_fp4_blockwise_scaled_group_mm_sm120(
           output,


### PR DESCRIPTION
## Summary
- Fix SM12x variant dispatch in three CUDA kernel files where `getSMVersion() == 120` exact match misses SM121a (DGX Spark, which returns 121)
- Changed `== 120` to `>= 120` to cover SM120, SM120a, SM121a, and future SM12x variants
- Consistent with `fp8_gemm_kernel.cu` which already correctly uses `>= 120`

## Files Changed
| File | Line | Change |
|------|------|--------|
| `sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu` | 451 | `== 120` → `>= 120` |
| `sgl-kernel/csrc/gemm/nvfp4_scaled_mm_kernels.cu` | 666 | `== 120` → `>= 120` |
| `sgl-kernel/csrc/moe/nvfp4_blockwise_moe.cu` | 668 | `== 120` → `>= 120` |

## Context
`getSMVersion()` in `utils.h` returns `major * 10 + minor`. SM121a (DGX Spark GB10) returns 121, not 120. The exact match caused these kernels to fall through to `TORCH_CHECK_NOT_IMPLEMENTED` or take the wrong SM100 code path instead of the SM12x path.

Reference: `fp8_gemm_kernel.cu:1492` already uses the correct `>= 120` pattern.

## Test plan
- [ ] Verify `getSMVersion()` returns 121 on SM121a hardware
- [ ] Confirm FP8 blockwise GEMM dispatches to SM12x path on DGX Spark
- [ ] Confirm NVFP4 scaled MM dispatches to SM12x path on DGX Spark
- [ ] Confirm NVFP4 blockwise MOE dispatches to SM12x path on DGX Spark
- [ ] Existing CI tests pass (SM90/SM100 dispatch unaffected)

*Tested on DGX Spark (GB10, SM121a, CUDA 13.0, aarch64) provided by [Second Nature Computing](https://joinsecondnature.com), an applied AI lab.*

Related: #18203, #15342

🤖 Generated with [Claude Code](https://claude.com/claude-code)