### PR TITLE
fix: update Blackwell log/error messages to include SM12x

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1207,7 +1207,7 @@ class ServerArgs:
                 if model_arch == "GlmMoeDsaForCausalLM" and is_blackwell_supported():
                     envs.SGLANG_NSA_FORCE_MLA.set(True)
                     logger.warning(
-                        "Force NSA prefill to use MLA (i.e. disable MHA_ONE_SHOT) for GlmMoeDsaForCausalLM on SM100."
+                        "Force NSA prefill to use MLA (i.e. disable MHA_ONE_SHOT) for GlmMoeDsaForCausalLM on Blackwell."
                     )
                 if self.is_attention_backend_not_set():
                     self.attention_backend = "nsa"
@@ -1372,7 +1372,7 @@ class ServerArgs:
                 if is_blackwell_supported() and is_mxfp4_quant_format:
                     self.moe_runner_backend = "flashinfer_mxfp4"
                     logger.warning(
-                        "Detected SM100 and MXFP4 quantization format for GPT-OSS model, enabling FlashInfer MXFP4 MOE kernel."
+                        "Detected Blackwell and MXFP4 quantization format for GPT-OSS model, enabling FlashInfer MXFP4 MOE kernel."
                     )
                 elif (
                     is_hip() and get_bool_env_var("SGLANG_USE_AITER")
@@ -1861,7 +1861,7 @@ class ServerArgs:
         ):
             if not is_blackwell_supported():
                 raise ValueError(
-                    "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100). Please use a different backend."
+                    "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend."
                 )
 
             if self.page_size not in [32, 64]:


### PR DESCRIPTION
## Summary
- Three warning/error messages in `server_args.py` reference only "SM100" but the code uses `is_blackwell_supported()` which covers both SM100 and SM12x (consumer Blackwell, DGX Spark)
- Updated messages to say "Blackwell" or "SM100/SM12x" to avoid confusing users on SM12x devices

## Changes
| Line | Before | After |
|------|--------|-------|
| 1204 | `...on SM100.` | `...on Blackwell.` |
| 1369 | `Detected SM100 and MXFP4...` | `Detected Blackwell and MXFP4...` |
| 1858 | `...Blackwell GPUs (SM100)...` | `...Blackwell GPUs (SM100/SM12x)...` |

## Context
`is_blackwell_supported()` in `common.py` checks `device_capability_majors=[10, 12]`, so it returns `True` for both SM100 (datacenter Blackwell) and SM12x (consumer Blackwell / DGX Spark). The log and error messages should reflect this.

No behavior changes — only string literals updated.

## Test plan
- [ ] Grep for remaining "SM100" references that should say "Blackwell"
- [ ] Existing CI tests pass (no behavior change)

*Identified on DGX Spark (SM121a) hardware provided by [Second Nature Computing](https://joinsecondnature.com), an applied AI lab.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)