### PR TITLE
[AMD] Fix/qwen3 5 amd rope cutedsl fallback

### DIFF
--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -17,9 +17,18 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
         self,
         **kwargs,
     ):
+        # HF Qwen3.5 checkpoints may provide RoPE settings under rope_parameters.
+        # Normalize it before parent init so downstream code sees the expected values.
+        rope_parameters = kwargs.pop("rope_parameters", None)
+        if kwargs.get("rope_scaling") is None and rope_parameters is not None:
+            kwargs["rope_scaling"] = rope_parameters
+
         super().__init__(**kwargs)
         if self.rope_scaling is None:
-            self.rope_scaling = {}
+            self.rope_scaling = rope_parameters or {}
+
+        # Keep both names for compatibility with model code paths that read either.
+        self.rope_parameters = rope_parameters or self.rope_scaling
 
 
 class Qwen3_5Config(PretrainedConfig):

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -37,9 +37,14 @@ from sglang.srt.utils.common import rank0_log
 
 if not is_cpu() and not is_npu():
     # fix import error on CPU device, no impacts when non-CPU path
-    from sglang.jit_kernel.cutedsl_gdn import (
-        cutedsl_fused_sigmoid_gating_delta_rule_update,
-    )
+    try:
+        from sglang.jit_kernel.cutedsl_gdn import (
+            cutedsl_fused_sigmoid_gating_delta_rule_update,
+        )
+    except ModuleNotFoundError:
+        # CuTe DSL path requires cuda-python (cuda.bindings.*). Keep runtime usable
+        # by falling back to non-CuTe kernels when it's unavailable.
+        cutedsl_fused_sigmoid_gating_delta_rule_update = None
     from sglang.srt.layers.attention.fla.chunk import chunk_gated_delta_rule
     from sglang.srt.layers.attention.fla.chunk_delta_h import (
         CHUNK_SIZE as FLA_CHUNK_SIZE,
@@ -820,6 +825,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
             ), f"{self.conv_states_shape[-1]=} should be less than {FLA_CHUNK_SIZE}"
 
         use_cutedsl = Envs.SGLANG_USE_CUTEDSL_GDN_DECODE.get()
+        if use_cutedsl and cutedsl_fused_sigmoid_gating_delta_rule_update is None:
+            rank0_log(
+                "CuTe DSL GDN decode requested but unavailable "
+                "(missing cuda.bindings). Falling back to FLA decode kernel."
+            )
+            use_cutedsl = False
         rank0_log(f"CuTe DSL GDN decode enabled: {use_cutedsl}")
         self._kernel_func = (
             cutedsl_fused_sigmoid_gating_delta_rule_update


### PR DESCRIPTION
## Motivation

This PR fixes two startup failures encountered when serving Qwen 3.5 MoE on AMD ROCm:

RoPE config parsing failure in Qwen3.5:
Some checkpoints provide RoPE settings in text_config.rope_parameters.
In current Qwen3_5TextConfig init, these values can be lost, leading to:
ValueError: Unknown RoPE scaling type
ROCm import-time failure in hybrid linear attention backend:
hybrid_linear_attn_backend.py unconditionally imports CuTe DSL kernel code.
CuTe DSL depends on cuda.bindings (CUDA-specific), unavailable on ROCm.
This causes:
ModuleNotFoundError: No module named 'cuda'

## Modifications

qwen3_5.py
In Qwen3_5TextConfig.__init__:
Read rope_parameters from kwargs.
If rope_scaling is not set, populate it from rope_parameters before parent init.
Ensure both self.rope_scaling and self.rope_parameters are populated and consistent for downstream compatibility.

hybrid_linear_attn_backend.py
Make CuTe DSL import optional with try/except ModuleNotFoundError.
If SGLANG_USE_CUTEDSL_GDN_DECODE=1 but CuTe deps are unavailable, log a fallback message and use the existing non-CuTe FLA decode kernel instead of failing.

## Accuracy Tests

No kernel math or model forward computation logic was changed.
Changes are limited to:
config normalization (rope_parameters/rope_scaling mapping)
backend import/fallback behavior
Therefore, no expected accuracy delta.

Validation performed:

Confirmed Qwen3_5MoeTextConfig(**text_config) now preserves:
rope_parameters["rope_type"] == "default"
mirrored rope_scaling content
Confirmed the previous RoPE-scaling initialization failure path is removed.

## Benchmarking and Profiling

No intended performance optimization in this PR.
CuTe path is still used when available and enabled.
On environments without CuTe dependencies (e.g., ROCm), this PR avoids import-time crash and uses existing fallback kernel path.

