### PR TITLE
fix: add SM12x to JIT flash attention compute capability whitelist

### DIFF
--- a/python/sglang/jit_kernel/flash_attention/cute/interface.py
+++ b/python/sglang/jit_kernel/flash_attention/cute/interface.py
@@ -248,7 +248,7 @@ def _flash_attn_fwd(
         else _compute_capability
     )
 
-    assert compute_capability in [9, 10, 11], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x"
+    assert compute_capability in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
 
     use_block_sparsity = block_sparse_tensors is not None
 
@@ -271,7 +271,7 @@ def _flash_attn_fwd(
         if head_dim == head_dim_v == 128 and not causal and not local and not use_block_sparsity:
             n_block_size = 192
 
-    if compute_capability in [10, 11]:
+    if compute_capability in [10, 11, 12]:
         if (
             pack_gqa
             and (128 % qhead_per_kvhead != 0)
@@ -451,7 +451,7 @@ def _flash_attn_fwd(
                 score_mod=score_mod,
                 has_aux_tensors=aux_tensors is not None,
             )
-        elif compute_capability in [10, 11]:
+        elif compute_capability in [10, 11, 12]:
             fa_fwd = FlashAttentionForwardSm100(
                 head_dim,
                 head_dim_v,
@@ -477,7 +477,7 @@ def _flash_attn_fwd(
             )
         else:
             raise ValueError(
-                f"Unsupported compute capability: {compute_capability}. Supported: 9.x, 10.x, 11.x"
+                f"Unsupported compute capability: {compute_capability}. Supported: 9.x, 10.x, 11.x, 12.x"
             )
         # TODO: check @can_implement
         _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
@@ -578,7 +578,7 @@ def _flash_attn_bwd(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     compute_capability = _get_device_capability()
-    assert compute_capability in [9, 10, 11], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x"
+    assert compute_capability in [9, 10, 11, 12], "Unsupported compute capability. Supported: 9.x, 10.x, 11.x, 12.x"
 
     if compute_capability == 9:
         m_block_size = 80 if not causal else 64
@@ -701,8 +701,8 @@ def _flash_attn_bwd(
         pack_gqa = qhead_per_kvhead > 1
     # pack_gqa backward not yet supported in bwd
     pack_gqa = False
-    if compute_capability not in [10, 11]:
-        assert deterministic is False, "bwd deterministic only supported for sm100/sm110 for now"
+    if compute_capability not in [10, 11, 12]:
+        assert deterministic is False, "bwd deterministic only supported for sm100/sm110/sm120 for now"
 
     if score_mod is not None:
         assert score_mod_bwd is not None, "score_mod_bwd is required when score_mod is provided"


### PR DESCRIPTION
## Summary
- The JIT kernel flash attention interface rejects compute capability 12 (SM12x) in both forward and backward passes, causing an assertion crash on consumer Blackwell / DGX Spark GPUs
- SM12x uses the same tcgen05 instruction set as SM100/SM110 and should use `FlashAttentionForwardSm100`

## Changes (7 locations in `interface.py`)
| Line | Context | Change |
|------|---------|--------|
| 251 | Forward assertion | `[9, 10, 11]` → `[9, 10, 11, 12]` |
| 274 | GQA/SplitKV tuning | `[10, 11]` → `[10, 11, 12]` |
| 454 | Kernel selection dispatch | `[10, 11]` → `[10, 11, 12]` |
| 480 | Error message | Add `12.x` |
| 581 | Backward assertion | `[9, 10, 11]` → `[9, 10, 11, 12]` |
| 704 | Deterministic check | `[10, 11]` → `[10, 11, 12]` |
| 705 | Deterministic message | Add `sm120` |

## Context
This is the JIT kernel version of the same fix applied to sgl-kernel in #18748. The JIT kernel interface is the actively-used FA4 implementation (FA4 was moved from sgl-kernel to JIT kernel in Jan 2026).

`_get_device_capability()` returns the major version only (12 for SM121a). The `FlashAttentionForwardSm100` kernel uses Blackwell-wide tcgen05 instructions that are common to all Blackwell variants (SM100, SM110, SM120, SM121a).

## Test plan
- [ ] `_get_device_capability()` returns 12 on SM121a
- [ ] Forward pass assertion no longer crashes on SM12x
- [ ] Backward pass assertion no longer crashes on SM12x
- [ ] SM12x correctly dispatches to `FlashAttentionForwardSm100`
- [ ] Existing CI tests pass (SM90/SM100/SM110 unaffected)

*Tested on DGX Spark (GB10, SM121a, CUDA 13.0, aarch64) provided by [Second Nature Computing](https://secondnature.pro), an applied AI lab.*

Related: #18748, #15342

🤖 Generated with [Claude Code](https://claude.com/claude-code)