### PR TITLE
fix: enable MXFP8 dense linear on SM12x Blackwell GPUs

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -40,7 +40,6 @@ from sglang.srt.utils import (
     is_flashinfer_available,
     is_hip,
     is_sm90_supported,
-    is_sm100_supported,
     offloader,
 )
 
@@ -662,8 +661,8 @@ def triton_mxfp8_blockscaled_linear(
     bias: Optional[torch.Tensor] = None,
     output_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
-    if not (_is_cuda and is_sm100_supported()):
-        raise RuntimeError("MXFP8 dense linear requires Blackwell GPUs (SM100+).")
+    if not (_is_cuda and is_blackwell_supported()):
+        raise RuntimeError("MXFP8 dense linear requires Blackwell GPUs (SM100/SM12x).")
 
     input_2d = input.view(-1, input.shape[-1]).contiguous()
     output_shape = [*input.shape[:-1], weight.shape[0]]


### PR DESCRIPTION
## Summary
- `mxfp8_dense_linear()` used `is_sm100_supported()` which only checks SM100 (device capability major=10), blocking SM12x (consumer Blackwell, DGX Spark)
- Changed to `is_blackwell_supported()` which covers both SM100 and SM12x
- MXFP8 is a Blackwell-family feature supported on all Blackwell variants

## Changes
| File | Line | Before | After |
|------|------|--------|-------|
| `fp8_utils.py` | 665 | `is_sm100_supported()` | `is_blackwell_supported()` |
| `fp8_utils.py` | 666 | `"SM100+"` | `"SM100/SM12x"` |
| `fp8_utils.py` | 43 | Remove unused `is_sm100_supported` import | — |

## Context
`is_blackwell_supported()` in `common.py` already correctly checks `device_capability_majors=[10, 12]` with `cuda_version=(12, 8)`. The function was already imported in the file but not used for this check.

## Test plan
- [ ] MXFP8 dense linear no longer raises `RuntimeError` on SM12x
- [ ] MXFP8 still raises on non-Blackwell GPUs (SM90, etc.)
- [ ] Existing CI tests pass

*Identified on DGX Spark (GB10, SM121a, CUDA 13.0) provided by [Second Nature Computing](https://secondnature.pro), an applied AI lab.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)