### PR TITLE
Fix invalid import paths in glm_image.py

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass, field
 import torch
 from diffusers.image_processor import VaeImageProcessor
 
-from python.sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
-from python.sglang.multimodal_gen.configs.models.encoders.t5 import T5Config
+from sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
+from sglang.multimodal_gen.configs.models.encoders.t5 import T5Config
 from sglang.multimodal_gen.configs.models import DiTConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.glmimage import GlmImageDitConfig
 from sglang.multimodal_gen.configs.models.vaes.glmimage import GlmImageVAEConfig

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass, field
 import torch
 from diffusers.image_processor import VaeImageProcessor
 
-from sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
-from sglang.multimodal_gen.configs.models.encoders.t5 import T5Config
 from sglang.multimodal_gen.configs.models import DiTConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.glmimage import GlmImageDitConfig
+from sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
+from sglang.multimodal_gen.configs.models.encoders.t5 import T5Config
 from sglang.multimodal_gen.configs.models.vaes.glmimage import GlmImageVAEConfig
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ImagePipelineConfig,


### PR DESCRIPTION
## Summary
- Fix `from python.sglang...` imports to `from sglang...` in `glm_image.py` — the `python.` prefix is a filesystem path, not a valid Python module path
- Broke `multimodal-gen-test-1-gpu` CI on all runners

Introduced in #18704.

**Failure example**: https://github.com/sgl-project/sglang/actions/runs/21969599115/job/63467788436

## Test plan
- [ ] `multimodal-gen-test-1-gpu` CI passes (no longer hits `ModuleNotFoundError: No module named 'python'`)