### PR TITLE
[Spec] Move forward timeout before verify to fix Eagle v1 filter mismatch

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1062,6 +1062,28 @@ class Scheduler(
             ]
         )
 
+    def _check_forward_timeout_for_running_batch(self):
+        """Check forward timeout for the running batch and set to_finish.
+
+        Called at the start of the event loop (same timing as abort) so
+        that check_finished() in subsequent forward passes handles timeout
+        together with abort. This avoids creating finished_reason after
+        verify has already set topk_p, which would cause a length mismatch
+        in EagleDraftInput.filter_batch().
+        """
+        timeout_ms = envs.SGLANG_FORWARD_TIMEOUT_MS.get()
+        if timeout_ms <= 0:
+            return
+        if self.running_batch.is_empty():
+            return
+
+        deadline = time.perf_counter() - timeout_ms / 1000.0
+        for req in self.running_batch.reqs:
+            if not req.finished() and 0 < req.time_stats.forward_entry_time < deadline:
+                req.to_finish = FINISH_ABORT(
+                    "Forward timeout.", HTTPStatus.SERVICE_UNAVAILABLE
+                )
+
     @DynamicGradMode()
     def event_loop_normal(self):
         """A normal scheduler loop."""
@@ -1823,6 +1845,7 @@ class Scheduler(
 
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
         self._abort_on_queued_timeout()
+        self._check_forward_timeout_for_running_batch()
         if self.dllm_config is not None:
             self.dllm_manager.filter_finished_reqs()
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1063,14 +1063,8 @@ class Scheduler(
         )
 
     def _check_forward_timeout_for_running_batch(self):
-        """Check forward timeout for the running batch and set to_finish.
-
-        Called at the start of the event loop (same timing as abort) so
-        that check_finished() in subsequent forward passes handles timeout
-        together with abort. This avoids creating finished_reason after
-        verify has already set topk_p, which would cause a length mismatch
-        in EagleDraftInput.filter_batch().
-        """
+        # NOTE: this should be called before a batch is launched,
+        # as current spec-v1 still filters batch inside verify stage.
         timeout_ms = envs.SGLANG_FORWARD_TIMEOUT_MS.get()
         if timeout_ms <= 0:
             return

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -159,8 +159,6 @@ class SchedulerOutputProcessorMixin:
             hidden_state_offset = 0
 
             # Check finish conditions
-            # Forward timeout is checked at the start of the event loop
-            # (same timing as abort). See _check_forward_timeout_for_running_batch().
             logprob_pt = 0
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
@@ -445,8 +443,6 @@ class SchedulerOutputProcessorMixin:
 
         # NOTE: in any case, we should check finish here
         # if finished, also clean up committed kv cache and over-allocated kv cache here
-        # Forward timeout is checked at the start of the event loop (same
-        # timing as abort), not here. See _check_forward_timeout_for_running_batch().
 
         # Check finish condition
         for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import time
-from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import torch
@@ -17,7 +16,6 @@ from sglang.srt.managers.io_struct import (
     BatchTokenIDOutput,
 )
 from sglang.srt.managers.schedule_batch import (
-    FINISH_ABORT,
     BaseFinishReason,
     Req,
     RequestStage,
@@ -161,21 +159,11 @@ class SchedulerOutputProcessorMixin:
             hidden_state_offset = 0
 
             # Check finish conditions
+            # Forward timeout is checked at the start of the event loop
+            # (same timing as abort). See _check_forward_timeout_for_running_batch().
             logprob_pt = 0
 
-            deadline = -1
-            if (timeout_ms := envs.SGLANG_FORWARD_TIMEOUT_MS.get()) > 0:
-                deadline = time.perf_counter() - timeout_ms / 1000.0
-
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
-                if (
-                    not req.finished()
-                    and 0 < req.time_stats.forward_entry_time < deadline
-                ):
-                    req.to_finish = FINISH_ABORT(
-                        "Forward timeout.", HTTPStatus.SERVICE_UNAVAILABLE
-                    )
-
                 if req.finished() or req.is_retracted:
                     # decode req in mixed batch or retracted req
                     continue
@@ -457,20 +445,12 @@ class SchedulerOutputProcessorMixin:
 
         # NOTE: in any case, we should check finish here
         # if finished, also clean up committed kv cache and over-allocated kv cache here
-
-        deadline = -1
-        if (timeout_ms := envs.SGLANG_FORWARD_TIMEOUT_MS.get()) > 0:
-            deadline = time.perf_counter() - timeout_ms / 1000.0
+        # Forward timeout is checked at the start of the event loop (same
+        # timing as abort), not here. See _check_forward_timeout_for_running_batch().
 
         # Check finish condition
         for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
             req: Req
-
-            if not req.finished() and 0 < req.time_stats.forward_entry_time < deadline:
-                # req.set_finish_with_abort()
-                req.to_finish = FINISH_ABORT(
-                    "Forward timeout.", HTTPStatus.SERVICE_UNAVAILABLE
-                )
 
             if self.enable_overlap and (req.finished() or req.is_retracted):
                 # NOTE: This (req.finished() or req.is_retracted) should only happen when overlap scheduling is enabled.

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -638,21 +638,6 @@ class MultiLayerEagleWorker(TpModelWorker):
         assert forward_batch.spec_info is batch.spec_info
         forward_batch.spec_info.topk_p = torch.cat(topk_p_list, dim=1)
         forward_batch.spec_info.topk_index = torch.cat(topk_index_list, dim=1)
-        has_finished, unfinished_req_index = False, []
-        for i, req in enumerate(batch.reqs):
-            if req.finished():
-                has_finished = True
-            else:
-                unfinished_req_index.append(i)
-        if has_finished:
-            unfinished_index_device = torch.tensor(
-                unfinished_req_index,
-                dtype=torch.int64,
-                device=batch.spec_info.topk_p.device,
-            )
-            batch.spec_info.filter_batch(
-                unfinished_index_device, has_been_filtered=False
-            )
 
     def forward_draft_extend_after_decode(self, batch: ScheduleBatch):
         assert isinstance(batch.spec_info, EagleDraftInput)


### PR DESCRIPTION
## Motivation

Fixes `ValueError: length of new_indices != length of topk_p` in Eagle speculative decoding v1.

Related: #14742, #17831

## Root Cause

Forward timeout was checked in `process_batch_result_decode`, which runs AFTER verify has already set `topk_p` to N-K entries. The timeout set `req.to_finish` and `check_finished()` immediately converted it to `finished_reason`, causing M additional requests to finish. The next iteration's `filter_batch(v1_spec_info_filtered=True)` then found N-K-M active requests but `topk_p` still had N-K entries — length mismatch.

Abort doesn't have this problem because it only sets `to_finish` (in `process_input_requests`), and `filter_batch` only checks `finished_reason`. The pending `to_finish` is caught by verify's `check_finished()` in the next forward pass, keeping it consistent with `topk_p`.

## Fix

- Move forward timeout detection from `process_batch_result_decode` / `process_batch_result_prefill` to `get_next_batch_to_run()`, next to `_abort_on_queued_timeout()`. Forward timeout now follows the same pattern as abort: only set `to_finish`, let verify's `check_finished()` handle conversion.
- Remove dead code filter in `forward_draft_extend` — `req.finished()` always returned False there since `check_finished()` was never called before that point.