### PR TITLE
Add Qwen3-Omni to Qwen MoE architecture handling in fused_moe_triton

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -67,6 +67,7 @@ def get_model_config(
         "Qwen3NextForCausalLM",
         "Qwen3VLMoeForConditionalGeneration",
         "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3OmniMoeForConditionalGeneration",
     ]:
         E = config.num_experts // ep_size
         topk = config.num_experts_per_tok


### PR DESCRIPTION
### What This PR Does

This PR simply adds:

    "Qwen3OmniMoeForConditionalGeneration"

to the existing Qwen MoE architecture list.

Since Qwen3-Omni follows the same configuration schema as other Qwen
MoE variants (`num_experts`, `num_experts_per_tok`,
`intermediate_size`), it is correct to reuse the same logic branch.
The modification has been tested and works correctly for Qwen3-Omni on L20 GPUs.

### Impact

- Fixes runtime errors when tuning Qwen3-Omni models
- Keeps logic consistent across Qwen MoE variants
- No impact on existing architectures
- Fully backward compatible

Include "Qwen3OmniMoeForConditionalGeneration" in the existing Qwen MoE architecture handling logic in
benchmark/kernels/fused_moe_triton/common_utils.py.

The current implementation already supports several Qwen MoE variants:

- Qwen2MoeForCausalLM
- Qwen3MoeForCausalLM
- Qwen3NextForCausalLM
- Qwen3VLMoeForConditionalGeneration
- Qwen3_5MoeForConditionalGeneration

However, Qwen3OmniMoeForConditionalGeneration was not included in this list. As a result, the code falls back to the default branch, which assumes `num_local_experts` exists and raises an error.

Since Qwen3-Omni follows the same MoE config schema (`num_experts`, `num_experts_per_tok`, `intermediate_size`) as other Qwen MoE models, it should be handled by the same branch.

This patch adds the missing architecture string to ensure proper config parsing and prevent runtime failures during Triton fused MoE tuning.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ yes ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ yes ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ yes ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
