### PR TITLE
fix: add SM110 (Jetson AGX Thor) to Blackwell capability check

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -245,7 +245,7 @@ is_hopper_with_cuda_12_3 = lru_cache(maxsize=1)(
 is_blackwell_supported = is_blackwell = lru_cache(maxsize=1)(
     partial(
         _check_cuda_device_version,
-        device_capability_majors=[10, 12],
+        device_capability_majors=[10, 11, 12],
         cuda_version=(12, 8),
     )
 )


### PR DESCRIPTION
Jetson AGX Thor uses Compute Capability 11.0 (SM110), which is a Blackwell-architecture device that supports NVFP4 quantization. However, is_blackwell_supported() only checked for majors [10, 12], causing NVFP4 models to fail with:
  ValueError: Current platform does not support NVFP4 quantization.

Add major 11 to the device_capability_majors list so SM110 devices are correctly recognized as Blackwell-compatible.