### PR TITLE
Fix/mova cfg parallel

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -156,8 +156,8 @@ class MOVADenoisingStage(PipelineStage):
 
     @property
     def parallelism_type(self) -> StageParallelismType:
-        if get_global_server_args().enable_cfg_parallel:
-            return StageParallelismType.CFG_PARALLEL
+        # Always REPLICATED: CFG parallel is handled internally (pos/neg split
+        # + cfg_model_parallel_all_reduce), matching the Wan/SGLang paradigm.
         return StageParallelismType.REPLICATED
 
     def _predict(
@@ -703,7 +703,7 @@ class MOVADenoisingStage(PipelineStage):
         - Before unpatchify, sequences are gathered back
         """
         model_dtype = visual_dit.time_embedding.fc_in.weight.dtype
-        device = visual_latents.device
+        device = get_local_torch_device()
 
         visual_context = context.to(device=device, dtype=model_dtype)
         audio_context = context.to(device=device, dtype=model_dtype)


### PR DESCRIPTION
## Motivation

This PR enables and stabilizes CFG parallel execution in MOVA denoising with minimal and interface-preserving changes.

Previously, the CFG-parallel path in `MOVADenoisingStage` did not correctly combine rank-local predictions, which could lead to undefined `visual_noise_pred/audio_noise_pred` in the denoising loop. In multi-GPU runs, there were also device-placement mismatches in the denoising forward path. This PR fixes these issues while keeping the existing stage interfaces unchanged.

## Modifications

- Updated `MOVADenoisingStage.forward()` CFG logic to properly support CFG parallel:
  - Rank 0 computes conditional (`pos`) branch.
  - Rank 1 computes unconditional (`neg`) branch.
  - Final predictions are combined via `_cfg_combine()` using `cfg_model_parallel_all_reduce`.
- Kept serial CFG behavior unchanged when `enable_cfg_parallel=False`.
- Added `partial = partial.contiguous()` in `_cfg_combine()` before all-reduce for communication safety/consistency.
- Adjusted denoising device placement to use local worker device:
  - In `inference_single_step()`, use `get_local_torch_device()` for context/timestep preparation to avoid cross-device tensor mismatches.
- Set `MOVADenoisingStage.parallelism_type` to `REPLICATED`:
  - CFG parallel is handled inside stage forward (Wan/SGLang-style), not by executor-level CFG-parallel stage broadcast.
- Added lightweight logging to clarify whether CFG parallel or serial CFG path is active.

## Accuracy Tests


## Benchmarking and Profiling

- No dedicated performance benchmarking attached yet.
- This PR is primarily a correctness/stability fix for CFG parallel execution path.
- Basic sample tests were performed to confirm that the implementation works as expected and that CFG parallel can be enabled and executed correctly.
<img width="806" height="234" alt="cfg-parallel" src="https://github.com/user-attachments/assets/ef2e6231-1750-4990-bcce-56a410a8755d" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).