### PR TITLE
Fix DataParallelController and BatchTokenizedGenerateReqInput API

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -30,9 +30,9 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.managers.io_struct import (
     ActiveRanksOutput,
-    BlockReqInput,
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
+    BlockReqInput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     WatchLoadUpdateReq,

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -31,6 +31,8 @@ from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.managers.io_struct import (
     ActiveRanksOutput,
     BlockReqInput,
+    BatchTokenizedEmbeddingReqInput,
+    BatchTokenizedGenerateReqInput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     WatchLoadUpdateReq,
@@ -212,6 +214,8 @@ class DataParallelController:
             [
                 (TokenizedGenerateReqInput, self.dispatching_with_trace),
                 (TokenizedEmbeddingReqInput, self.dispatching_with_trace),
+                (BatchTokenizedGenerateReqInput, self.dispatching_with_trace),
+                (BatchTokenizedEmbeddingReqInput, self.dispatching_with_trace),
                 (BlockReqInput, self.send_to_all_workers),
                 (WatchLoadUpdateReq, self.handle_load_update_req),
                 (ActiveRanksOutput, self.update_active_ranks),

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -786,6 +786,9 @@ class BatchTokenizedGenerateReqInput(BaseBatchReq):
     def __iter__(self):
         return iter(self.batch)
 
+    # For data parallel rank routing
+    data_parallel_rank: Optional[int] = None
+
 
 @dataclass
 class EmbeddingReqInput(BaseReq, APIServingTimingMixin):
@@ -975,6 +978,9 @@ class BatchTokenizedEmbeddingReqInput(BaseBatchReq):
 
     def __iter__(self):
         return iter(self.batch)
+
+    # For data parallel rank routing
+    data_parallel_rank: Optional[int] = None
 
 
 @dataclass


### PR DESCRIPTION
If you start a server with a DP size of 2 (or more) and send a BatchTokenizedGenerateReqInput request this request will be broadcast to every Scheduler of each data parallel worker.