### PR TITLE
[Fix] Defer req_to_token pool-index free in overlap scheduling to prevent cross-stream data race

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1004,6 +1004,13 @@ class Scheduler(
         self.batch_record_buf = [None] * 2
         self.batch_record_ct = 0
 
+        # Deferred KV cache release list: requests whose pool slots should not
+        # be freed immediately because the next batch (already launched on the
+        # forward stream) may still be reading their req_to_token rows when overlap
+        # schedule is enabled. They are flushed at the start of the next
+        # process_batch_result_decode, after copy_done.synchronize().
+        self._deferred_kv_release_reqs = []
+
     def init_deterministic_inference_config(self):
         """Initialize deterministic inference configuration for different attention backends."""
         if not self.server_args.enable_deterministic_inference:

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -329,6 +329,11 @@ class SchedulerRuntimeCheckerMixin:
             if queue_size:
                 return
 
+        # Flush any deferred KV releases. During idle, no batch is running on
+        # the forward stream, so it is always safe.
+        if self.enable_overlap:
+            self._flush_deferred_kv_releases()
+
         self.check_memory()
         self.check_tree_cache()
         self.new_token_ratio = self.init_new_token_ratio


### PR DESCRIPTION
## Motivation

Fixes #18744

With MTPv2 overlap scheduling enabled (`SGLANG_ENABLE_SPEC_V2=1`), we see intermittent device-side assertion failures:

```
/pytorch/aten/src/ATen/native/cuda/IndexKernel.cu:111: operator(): block: [0,0,0], thread: [0,0,0]
Assertion `-sizes[i] <= index && index < sizes[i] && "index out of bounds"` failed.
```

**Root cause:** In overlap scheduling, `process_batch_result(N-1)` runs on the default stream concurrently with `forward(N)` draft extend on the forward stream. When a request finishes, `release_kv_cache` immediately returns its `req_pool_idx` to the free list. A new request can then recycle that pool index and `prepare_for_decode` overwrites the `req_to_token` row on the default stream while the draft extend attention`forward(N)` still reads it.

```
Iteration N:
  forward stream: forward(N) reads req_to_token[pool_idx=1] for req A     ← still running
  default stream: process_batch_result(N-1) → A finished → free pool_idx=1

Iteration N+1:
  default stream: new req B gets pool_idx=1 (recycled)
  default stream: prepare_for_decode writes req_to_token[pool_idx=1] for B ← RACE!
```

## Modifications

Instead of freeing immediately, append finished requests to a deferred list (`_deferred_kv_release_reqs`). The list is flushed at the start of the next `process_batch_result_decode`, right after `copy_done.synchronize()` -- which guarantees the forward stream has finished reading those rows. An additional flush during idle ensures slots aren't held unnecessarily when no more batches are running.
