### PR TITLE
[CI] Revive 8-GPU trace upload in nightly test workflow

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -120,6 +120,25 @@ jobs:
           cd test
           python3 run_suite.py --hw cuda --suite nightly-8-gpu-common --nightly --timeout-per-file=18000 --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
 
+      - name: Publish traces to storage repo
+        if: always()
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          TRACE_ARGS=""
+          for dir in test/performance_profiles_*/; do
+            [ -d "$dir" ] && TRACE_ARGS="$TRACE_ARGS --traces-dir $dir"
+          done
+          if [ -n "$TRACE_ARGS" ]; then
+            python3 scripts/ci/utils/publish_traces.py $TRACE_ARGS
+            find test/performance_profiles_*/ -name '*.json.gz' -delete
+          else
+            echo "No trace directories found, skipping publish"
+          fi
+
       - name: Run test
         timeout-minutes: 30
         env:
@@ -200,6 +219,25 @@ jobs:
         run: |
           cd test
           IS_BLACKWELL=1 python3 run_suite.py --hw cuda --suite nightly-8-gpu-common --nightly --timeout-per-file=12000 --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
+
+      - name: Publish traces to storage repo
+        if: always()
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          TRACE_ARGS=""
+          for dir in test/performance_profiles_*/; do
+            [ -d "$dir" ] && TRACE_ARGS="$TRACE_ARGS --traces-dir $dir"
+          done
+          if [ -n "$TRACE_ARGS" ]; then
+            python3 scripts/ci/utils/publish_traces.py $TRACE_ARGS
+            find test/performance_profiles_*/ -name '*.json.gz' -delete
+          else
+            echo "No trace directories found, skipping publish"
+          fi
 
       - name: Collect performance metrics
         if: always()


### PR DESCRIPTION
## Summary
- Restore trace uploading for 8-GPU H200 and B200 nightly jobs, which was dropped during the nightly test revamp (#15324)
- Extend `publish_traces.py` to accept multiple `--traces-dir` arguments so each partition can upload all its model traces in a single commit
- Use `continue-on-error: true` so trace upload failures don't fail the workflow
- Clean up only `.json.gz` trace files after upload, preserving `results_*.json` for the subsequent metrics collection step

## Test plan
- [ ] Verify `publish_traces.py --help` shows updated usage with repeatable `--traces-dir`
- [ ] Verify existing 2-GPU trace publish steps are unaffected (backward compatible single `--traces-dir`)
- [ ] Trigger a nightly test run and confirm 8-GPU traces appear in `sglang-bot/sglang-ci-data`
- [ ] Confirm metrics collection still works after trace cleanup (only `.json.gz` removed, not `results_*.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)