### PR TITLE
[PD-Disagg] Fix double free when prebuilt batch is aborted.

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 
@@ -119,6 +118,8 @@ class ScheduleBatchDisaggregationDecodeMixin:
                     if req.grammar.current_token is None:
                         req.grammar.accept_token(req.output_ids[-1])
                 except ValueError as e:
+                    from sglang.srt.managers.schedule_batch import FINISH_ABORT
+
                     # Grammar accept_token can raise ValueError if the token is not in the grammar.
                     # This can happen if the grammar is not set correctly or the token is invalid.
                     # Use to_finish (not finished_reason) so that process_batch_result_prebuilt

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from sglang.srt.disaggregation.utils import prepare_abort
-from sglang.srt.mem_cache.common import release_kv_cache
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 
@@ -122,10 +121,11 @@ class ScheduleBatchDisaggregationDecodeMixin:
                 except ValueError as e:
                     # Grammar accept_token can raise ValueError if the token is not in the grammar.
                     # This can happen if the grammar is not set correctly or the token is invalid.
+                    # Use to_finish (not finished_reason) so that process_batch_result_prebuilt
+                    # handles the release via check_finished -> release_kv_cache in one place.
                     error_message = f"Grammar accept_token failed for req {req.rid} with token {req.output_ids[-1]}: {e}"
-                    release_kv_cache(req, self.tree_cache)
-                    prepare_abort(
-                        req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                    req.to_finish = FINISH_ABORT(
+                        error_message, HTTPStatus.INTERNAL_SERVER_ERROR
                     )
                 req.grammar.finished = req.finished()
         self.output_ids = torch.tensor(self.output_ids, device=self.device)


### PR DESCRIPTION
Fix the issue: #17797

How to reproduce this bug (it only happens when grammar hit exception):

```patch
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -110,6 +110,14 @@ class ScheduleBatchDisaggregationDecodeMixin:
         for req in self.reqs:
             self.output_ids.append(req.output_ids[-1])
             self.tree_cache.cache_unfinished_req(req)
+            from mock import Mock
+
+            # mock a exception grammar
+            req.grammar = Mock()
+            req.grammar.current_token = None
+            req.grammar.accept_token = Mock()
+            req.grammar.accept_token.side_effect = ValueError("Test Grammar Failures")
+            req.grammar.finished = Mock()
             if req.grammar is not None:
                 # FIXME: this try-except block is for handling unexpected xgrammar issue.
                 try:
```

Do this custom patch to the code base and launch a PD-disaggregation server, then it will enter the double free code path (but now it will raise another error of by mamba check)