### PR TITLE
Enable DeepGemm fast warmup in CI to prevent cold-cache timeouts

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -62,6 +62,7 @@ concurrency:
 
 env:
   SGLANG_IS_IN_CI: true
+  SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
 
 permissions:
   actions: write


### PR DESCRIPTION
## Summary
- Enable `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=true` globally in CI workflow to prevent DeepGemm compilation timeouts when runners restart and the JIT cache (`~/.cache/deep_gemm`) is lost
- Without this, a cold cache triggers full warmup compiling up to 128K kernel variants (~30 min), exceeding CI timeouts
- Fast warmup (from #18111) reduces compilation to ~3K variants (<3 min), with negligible perf impact for CI testing

## Context
Previously `SGLANG_DG_CACHE_DIR` was set so CI workers shared a single DeepGemm cache directory. When runners are reprovisioned, this cache is lost. Setting the fast warmup flag through the workflow env ensures this is handled in code without requiring machine-level configuration.

## Test plan
- [ ] Verify 8-GPU H200/H20 CI jobs (stage-c) that run DeepSeek models pass without timeout
- [ ] Confirm DeepGemm warmup completes in <3 min on cold cache