### PR TITLE
Fix CI concurrency collision between scheduled runs and fork PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,10 +54,12 @@ on:
 concurrency:
   # Concurrency group structure: pr-test-{branch}-{pr_sha}-{stage}
   # - github.head_ref (pull_request) or github.ref_name (workflow_dispatch) normalizes to branch name
+  # - For schedule events, use 'scheduled-main' to avoid collision with fork PRs whose branch is named 'main'
+  #   (both would otherwise resolve to pr-test-main-current-all, causing the scheduled run to block the PR)
   # - pr_head_sha isolates /rerun-stage from main branch runs
   # - target_stage allows parallel stage dispatches to run independently
   # This ensures pull_request and workflow_dispatch on same branch cancel each other
-  group: pr-test-${{ github.head_ref || github.ref_name || 'default' }}-${{ inputs.pr_head_sha || 'current' }}-${{ inputs.target_stage || inputs.ref || 'all' }}
+  group: pr-test-${{ github.head_ref || (github.event_name == 'schedule' && 'scheduled-main') || github.ref_name || 'default' }}-${{ inputs.pr_head_sha || 'current' }}-${{ inputs.target_stage || inputs.ref || 'all' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
 
 env:


### PR DESCRIPTION
## Summary
- Scheduled PR Test runs (every 6h) and fork PRs whose branch is named `main` resolve to the **same concurrency group** (`pr-test-main-current-all`), causing the scheduled run to block the PR's CI indefinitely
- Fix by using `scheduled-main` instead of `main` for the branch segment when `event_name == 'schedule'`, giving scheduled runs their own group (`pr-test-scheduled-main-current-all`)

## Root Cause
The concurrency group formula:
```
pr-test-${{ github.head_ref || github.ref_name || 'default' }}-...
```
- **Schedule**: `github.head_ref` is empty → falls to `github.ref_name` = `main` → group `pr-test-main-...`
- **Fork PR (branch `main`)**: `github.head_ref` = `main` → group `pr-test-main-...`

Both resolve to `pr-test-main-current-all`. The scheduled run gets queued first, and since `cancel-in-progress` only cancels `in_progress` runs (not `queued` ones), the PR run waits indefinitely.

**Example**: [PR #18821](https://github.com/sgl-project/sglang/pull/18821) was blocked by [scheduled run #22007397565](https://github.com/sgl-project/sglang/actions/runs/22007397565)

## Fix
```yaml
# Before:
group: pr-test-${{ github.head_ref || github.ref_name || 'default' }}-...

# After:
group: pr-test-${{ github.head_ref || (github.event_name == 'schedule' && 'scheduled-main') || github.ref_name || 'default' }}-...
```

This preserves all existing behavior (PR + workflow_dispatch cancellation on same branch) while ensuring scheduled runs never collide with PR runs.

## Test plan
- [ ] Verify PR CI runs without being blocked by scheduled runs
- [ ] Verify scheduled runs still cancel each other (newer cancels older)
- [ ] Verify /rerun-stage (workflow_dispatch) still cancels existing PR runs on the same branch