### PR TITLE
[Fix] Qwen3-VL-MoE hangs at VocabParallelEmbedding during inference

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -540,6 +540,13 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             grid_thw_list = grid_thw.tolist()
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        if x.shape[0] == 0:
+            empty_image_embeds_local = torch.empty(
+                (0, self.out_hidden_size),
+                device=x.device,
+                dtype=x.dtype,
+            )
+            return empty_image_embeds_local
         x += pos_embeds
 
         rotary_pos_emb_cos, rotary_pos_emb_sin = self.rot_pos_emb(grid_thw_list)
@@ -592,6 +599,13 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             grid_thw_list = grid_thw.tolist()
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        if x.shape[0] == 0:
+            empty_image_embeds_local = torch.empty(
+                (0, self.out_hidden_size),
+                device=x.device,
+                dtype=x.dtype,
+            )
+            return empty_image_embeds_local
         x += pos_embeds
 
         # rotary embedding -> (cos, sin)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When I ran this script, an error was triggered, indicating that different ranks were executing different communication primitives.

```bash
python -m sglang.launch_server \
    --model-path /***/Qwen3-VL-30B-A3B-Instruct \
    --host *** \
    --port 9596 \
    --tp 4 \
    --max-prefill-tokens 40960 \
    --chunked-prefill-size 40960 \
    --attention-backend ascend \
    --mem-fraction-static 0.8 \
    --mm-attention-backend ascend_attn \
    --max-running-requests 256 \
    --disable-radix-cache \
    --cuda-graph-bs 40 60 80 120 160 200 256 \
    --trust-remote-code \
    --enable-multimodal \
    --sampling-backend ascend \
    --mm-enable-dp-encoder \
    --enable-dp-attention --dp-size 2
```
After debugging, I found that in mm_utils.py, different ranks took divergent code paths. Further investigation revealed that, under the combined effects of [PR #14636](https://github.com/sgl-project/sglang/pull/14636) and [PR #17570](https://github.com/sgl-project/sglang/pull/17570), the `Qwen3VLMoeVisionModel` now uses pos_embed implemented as a `VocabParallelEmbedding`. When dp_attn is enabled, this introduces inter-group communication, which conflicts with the logic in mm_utils.py's `run_dp_sharded_mrope_vision_model` for handling empty pixel_values_local. **Specifically, whether to enter the vision model for computation is determined by `pixel_values_local.shape[0] != 0`, causing inconsistent communication patterns across different ranks and leading to an error.**

## Modifications

- All branches inside `run_dp_sharded_mrope_vision_model` should proceed to execute the vision_model's forward pass to ensure consistent subsequent communication operations.
- Since Qwen3-VL is the only model that uses both `VocabParallelEmbedding` and `run_dp_sharded_mrope_vision_model`, I apply this handling exclusively to Qwen3-VL’s forward pass—after performing the necessary communication operations for compatibility, it returns an empty tensor.

## Accuracy Tests

```bash
evalscope eval  --model Qwen3-VL-30B-A3B-Instruct   --api-url http://127.0.0.1:23388/v1  --api-key EMPTY  --eval-type openai_api  --generation-config '{"do_sample": true, "max_tokens": 20000, "seed": 3407 ,"top_p":0.8, "top_k":20, "temperature": 0.7, "n":1, "presence_penalty": 1.5,"repetition_penalty": 1, "timeout": 60, "stream": true, "extra_body": {"chat_template_kwargs": {"enable_thinking": false}}}'  --datasets mm_bench  --dataset-hub Local  --dataset-args '{"mm_bench": {"dataset_id": "/home/xjw/datasets/MMBench","subset_list": ["cn"]}}'  --eval-batch-size 30 --ignore-errors --limit 500
```

```
mm_bench report table:
+---------------------------+-----------+----------+----------+-------+---------+---------+
| Model                     | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===========================+===========+==========+==========+=======+=========+=========+
| Qwen3-VL-30B-A3B-Instruct | mm_bench  | mean_acc | cn       |   500 |   0.848 | default |
+---------------------------+-----------+----------+----------+-------+---------+---------+ 

2026-02-14 11:01:20 - evalscope - INFO: Skipping report analysis (`analysis_report=False`).
2026-02-14 11:01:20 - evalscope - INFO: Dump report to: ./outputs/20260214_105544/reports/Qwen3-VL-30B-A3B-Instruct/mm_bench.json 

2026-02-14 11:01:20 - evalscope - INFO: Benchmark mm_bench evaluation finished.
2026-02-14 11:01:20 - evalscope - INFO: Overall report table: 
+---------------------------+-----------+----------+----------+-------+---------+---------+
| Model                     | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===========================+===========+==========+==========+=======+=========+=========+
| Qwen3-VL-30B-A3B-Instruct | mm_bench  | mean_acc | cn       |   500 |   0.848 | default |
+---------------------------+-----------+----------+----------+-------+---------+---------+ 

2026-02-14 11:01:20 - evalscope - INFO: Finished evaluation for Qwen3-VL-30B-A3B-Instruct on ['mm_bench']
2026-02-14 11:01:20 - evalscope - INFO: Output directory: ./outputs/20260214_105544
```

## Benchmarking and Profiling

```bash
vllm bench serve --backend openai-chat --model /home/xjw/weights/Qwen3-VL-30B-A3B-Instruct --tokenizer /home/xjw/weights/Qwen3-VL-30B-A3B-Instruct --served-model-name Qwen3-VL-30B-A3B-Instruct --dataset-name random-mm --random-input-len 1024 --random-output-len 100 --random-mm-base-items-per-request 1 --random-mm-limit-mm-per-prompt '{"image": 1}' --random-mm-bucket-config '{(1024,1024,1): 1}' --request-rate 15 --num-prompts 512 --endpoint /v1/chat/completions --host 127.0.0.1 --port 23388 --seed 1000 --percentile-metrics ttft,tpot,itl,e2el --ignore-eos --trust-remote-code --temperature 0.01 --max-concurrency 256
```

```
============ Serving Benchmark Result ============
Successful requests:                     512       
Failed requests:                         0         
Maximum request concurrency:             256       
Request rate configured (RPS):           15.00     
Benchmark duration (s):                  217.77    
Total input tokens:                      524288    
Total generated tokens:                  51200     
Request throughput (req/s):              2.35      
Output token throughput (tok/s):         235.11    
Peak output token throughput (tok/s):    4061.00   
Peak concurrent requests:                512.00    
Total token throughput (tok/s):          2642.64   
---------------Time to First Token----------------
Mean TTFT (ms):                          63792.59  
Median TTFT (ms):                        65092.39  
P99 TTFT (ms):                           105704.79 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          412.26    
Median TPOT (ms):                        408.92    
P99 TPOT (ms):                           994.80    
---------------Inter-token Latency----------------
Mean ITL (ms):                           412.75    
Median ITL (ms):                         63.57     
P99 ITL (ms):                            436.83    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          104606.13 
Median E2EL (ms):                        108677.47 
P99 E2EL (ms):                           112634.63 
==================================================
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
