### PR TITLE
[NPU] [DLLM] Support openPangu_Diffusion DLLM model

### DIFF
--- a/python/sglang/srt/dllm/algorithm/shift_confidence.py
+++ b/python/sglang/srt/dllm/algorithm/shift_confidence.py
@@ -1,0 +1,136 @@
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+try:
+    import torch_npu
+except ImportError:
+    pass
+
+def sample_tokens(logits, neg_entropy=False):
+    probs = torch.softmax(logits, dim=-1)
+    confidence, x0 = probs.max(dim=-1)
+
+    if neg_entropy:
+        epsilon = 1e-10
+        log_probs = torch.log(probs + epsilon)
+        confidence = torch.sum(probs * log_probs, dim=-1)
+
+    return confidence, x0
+
+class ShiftConfidence(DllmAlgorithm):
+    def __init__(
+        self,
+        config: DllmConfig,
+    ):
+        super().__init__(config)
+        self.threshold = config.algorithm_config.get("threshold", 0.9)
+        self.num_small_blocks = config.algorithm_config.get("num_small_blocks", 4)
+        self.alg = config.algorithm_config.get("alg", "confidence_threshold")
+        self.eos_token_id = config.algorithm_config.get("eos_token_id")
+        self.next_token_cache = None
+        self.pad_len = 0
+        self.pad_id = config.pad_id
+        self.fia_length = 32768
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[
+        Union[LogitsProcessorOutput, torch.Tensor], Optional[torch.Tensor], bool
+    ]:
+        prompt_flag = forward_batch.input_ids[0].item() != self.mask_id
+        is_first_block = forward_batch.positions[0] == 1 or forward_batch.positions[0] == 0
+        small_block_length = self.block_size // self.num_small_blocks
+
+        if self.block_size % self.num_small_blocks != 0:
+            raise ValueError(f"block_size ({self.block_size}) must be divisible by num_small_blocks ({self.num_small_blocks})")
+        
+        mask_index = forward_batch.input_ids == self.mask_id
+        mask_count = torch.sum(mask_index).item()
+
+        if forward_batch.model_specific_states is None:
+            forward_batch.model_specific_states = {}
+
+        if is_first_block:
+            pad_len = torch.sum(forward_batch.input_ids == self.pad_id).item()
+            if pad_len!=self.pad_len:
+                self.pad_len = pad_len
+        forward_batch.model_specific_states["pad_len"] = self.pad_len
+
+        if self.pad_len:
+            padding_mask = torch.ones(self.fia_length, dtype=torch.bool, device=forward_batch.input_ids.device)
+            padding_mask[:self.pad_len] = False
+            padding_mask = torch.logical_and(
+                padding_mask.unsqueeze(-2),
+                padding_mask.unsqueeze(-1),
+            )
+            padding_mask = padding_mask[forward_batch.seq_lens[0]-forward_batch.input_ids.shape[0]:forward_batch.seq_lens[0]]
+        
+        if not prompt_flag:
+            if self.next_token_cache is not None:
+                forward_batch.input_ids[0] = self.next_token_cache
+                self.next_token_cache = None
+
+            forward_batch.model_specific_states["attention_mask"] = padding_mask if self.pad_len>0 else None
+
+            for small_block_idx in range(self.num_small_blocks):
+                small_block_start = small_block_idx * small_block_length
+                small_block_end = small_block_start + small_block_length
+
+                while True:
+                    mask_index = forward_batch.input_ids[small_block_start:small_block_end] == self.mask_id
+                    mask_count = torch.sum(mask_index).item()
+                    if mask_count == 0:
+                        break
+
+                    out = model_runner.forward(
+                        forward_batch, pp_proxy_tensors=None
+                    )
+                    logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+
+                    original_logits = logits_output.full_logits 
+                    shifted_logits = torch.cat([original_logits[:1, :], original_logits[:-1, :]], dim=0)
+                    shifted_logits = shifted_logits[small_block_start:small_block_end]
+
+                    confidence, x = sample_tokens(shifted_logits, neg_entropy=(self.alg == 'entropy'))
+                    confidence = torch.where(mask_index, confidence, -np.inf)
+
+                    transfer_index = (F.one_hot(torch.max(confidence, dim=0)[1], num_classes=small_block_length) == 1)
+                    if self.alg == 'confidence_threshold':
+                        transfer_index |= (confidence > self.threshold)
+
+                    forward_batch.input_ids[small_block_start:small_block_end][transfer_index] = x[transfer_index]
+                
+                if self.eos_token_id and (forward_batch.input_ids[small_block_start:small_block_end] == self.eos_token_id).any():
+                    break  
+
+        causal_mask = torch.tril(torch.ones(self.fia_length, self.fia_length, device=forward_batch.input_ids.device, dtype=torch.bool))
+        causal_mask = causal_mask[forward_batch.seq_lens[0]-forward_batch.input_ids.shape[0]:forward_batch.seq_lens[0]]
+        forward_batch.model_specific_states["attention_mask"] = (padding_mask & causal_mask) if self.pad_len > 0 else causal_mask
+        
+        out = model_runner.forward(
+            forward_batch, pp_proxy_tensors=None
+        )
+        logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+        
+        last_logits = logits_output.full_logits[len(forward_batch.input_ids)-mask_count-1, :]
+        self.next_token_cache = torch.argmax(last_logits, dim=-1)
+
+        if prompt_flag:
+            next_token_ids = []
+        else :
+            next_token_ids = [forward_batch.input_ids]
+
+        return logits_output, next_token_ids, can_run_cuda_graph
+
+Algorithm = ShiftConfidence

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -12,12 +12,16 @@ class DllmConfig:
         block_size: int,
         mask_id: int,
         max_running_requests: int,
+        pad_id: int,
+        use_lpadding: bool,
     ):
         self.algorithm = algorithm
         self.algorithm_config = algorithm_config
         self.block_size = block_size
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
+        self.pad_id = pad_id
+        self.use_lpadding = use_lpadding
 
     @staticmethod
     def from_server_args(
@@ -32,9 +36,15 @@ class DllmConfig:
             model_revision=server_args.revision,
         )
 
+        pad_id = 0
+        use_lpadding = False
         if model_config.hf_config.architectures[0] == "LLaDA2MoeModelLM":
             block_size = 32
             mask_id = 156895
+        elif model_config.hf_config.architectures[0] == "PanguEmbeddedForCausalLM":
+            block_size = 32
+            mask_id = 45830
+            use_lpadding = True
         else:
             raise RuntimeError(
                 f"Unknown diffusion LLM: {model_config.hf_config.architectures[0]}"
@@ -67,4 +77,6 @@ class DllmConfig:
             block_size=block_size,
             mask_id=mask_id,
             max_running_requests=max_running_requests,
+            pad_id=pad_id,
+            use_lpadding=use_lpadding,
         )

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -24,6 +24,15 @@ class SchedulerDllmMixin:
             else None
         )
         self.dllm_manager = DllmManager(dllm_config=self.dllm_config)
+        if self.dllm_config and self.server_args.attention_backend == "ascend":
+            # make sure the page size is not larger than block_size and chunked_prefill_size
+            if self.dllm_config.block_size < self.page_size:
+                logger.warning(
+                    "WARNING: "
+                    f"The page size {self.page_size} should not be larger than dllm block size {self.dllm_config.block_size}."
+                    f"Page size now falls back to {self.dllm_config.block_size}"
+                )
+                self.page_size = self.dllm_config.block_size
 
     def get_new_batch_dllm(self: Scheduler) -> Optional[ScheduleBatch]:
         """Generate a new batch for DLLM (Diffusion LLM) scheduling."""

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -305,6 +305,9 @@ class RotaryEmbedding(MultiPlatformOp):
         assert (
             fused_set_kv_buffer_arg is None
         ), "fused_set_kv_buffer_arg is not supported for npu implementation"
+        # cast the position dtype to int64 for npu_mrope call
+        if positions.dtype != torch.int64:
+            positions = positions.to(torch.int64)
         if query.dtype == torch.bfloat16 and self.cos_sin_cache.dtype == torch.float:
             return self.forward_native(positions, query, key, offsets)
         if self.is_neox_style:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2231,6 +2231,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             is_prefill_only=self.is_prefill_only,
             dimensions=self.dimensions,
             dllm_block_offsets=[req.dllm_block_offset for req in self.reqs],
+            dllm_prompt_paddings=[req.dllm_prompt_padding for req in self.reqs],
             dllm_config=self.dllm_config,
             reqs=self.reqs,
             has_grammar=self.has_grammar,
@@ -2410,6 +2411,7 @@ class ModelWorkerBatch:
 
     # Diffusion LLM
     dllm_block_offsets: Optional[List[int]] = None
+    dllm_prompt_paddings: Optional[List[int]] = None
     dllm_config: Optional[DllmConfig] = None
 
     # For constrained decoding

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -432,6 +432,17 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             ret.num_token_non_padded = torch.tensor(
                 len(batch.input_ids), dtype=torch.int32
             ).to(device, non_blocking=True)
+            if hasattr(batch.dllm_config, "use_lpadding") and batch.dllm_config.use_lpadding:
+                start_idx = 0
+                for prompt_padding, block_offset in zip(batch.dllm_prompt_paddings, batch.dllm_block_offsets):
+                    if block_offset==0:
+                        ret.positions[start_idx:start_idx + prompt_padding] = 1
+                        ret.positions[start_idx + prompt_padding: start_idx + block_size] = ret.positions[
+                            start_idx + prompt_padding: start_idx + block_size] - prompt_padding
+                    else:
+                        ret.positions[start_idx: start_idx + block_size] = ret.positions[
+                            start_idx: start_idx + block_size] - prompt_padding
+                    start_idx += block_size
         ret.num_token_non_padded_cpu = len(batch.input_ids)
 
         # For MLP sync

--- a/python/sglang/srt/models/openPangu_diffusion.py
+++ b/python/sglang/srt/models/openPangu_diffusion.py
@@ -1,0 +1,503 @@
+"""Inference-only PanguEmbedded model compatible with SGLang."""
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+from sglang.srt.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+
+from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.pooler import Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import (
+    default_weight_loader,
+    kv_cache_scales_loader,
+)
+
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
+
+class PanguEmbeddedMLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("gate_up_proj", prefix),
+        )
+
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("down_proj", prefix),
+        )
+        if hidden_act != "silu":
+            raise ValueError(f"Unsupported activation: {hidden_act}. Only silu is supported for PanguEmbeddedMLP.")
+        self.act_fn = SiluAndMul()
+    def forward(self, x):
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+    
+class PanguEmbeddedAttention(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        layer_id: int = 0,
+        rope_theta: float = 16000000.0,
+        rope_scaling: Optional[Dict[str, Any]] = None,
+        max_position_embeddings: int = 32768,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+
+        super().__init__()
+        self.hidden_size = hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = getattr(config, "head_dim", self.hidden_size // self.total_num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.rope_theta = rope_theta
+        self.max_position_embeddings = max_position_embeddings
+        use_bias = getattr(config, "bias", False)
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=use_bias,
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=use_bias,
+            quant_config=quant_config,
+            prefix=add_prefix("o_proj", prefix),
+        )
+
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position_embeddings,
+            base=rope_theta,
+            rope_scaling=rope_scaling,
+        )
+
+        self.attn = RadixAttention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            quant_config=quant_config,
+            prefix=add_prefix("attn", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v, forward_batch)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+
+class PanguEmbeddedDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
+    ) -> None:
+
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        rope_theta = getattr(config, "rope_theta", 16000000.0)
+        rope_scaling = getattr(config, "rope_scaling", None)
+        max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+        self.self_attn = PanguEmbeddedAttention(
+            config=config,
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            layer_id=layer_id,
+            rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
+            max_position_embeddings=max_position_embeddings,
+            quant_config=quant_config,
+            prefix=add_prefix("self_attn", prefix),
+        )
+        self.mlp = PanguEmbeddedMLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+
+        )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+        )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)    
+        return hidden_states, residual
+
+class PanguEmbeddedModel(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        decoder_layer_type: type[nn.Module] = PanguEmbeddedDecoderLayer,
+        alt_stream: Optional[torch.cuda.Stream] = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.pp_group = get_pp_group()
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                enable_tp=not is_dp_attention_enabled(),
+                prefix=add_prefix("embed_tokens", prefix),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+        decoder_layer_type = decoder_layer_type or PanguEmbeddedDecoderLayer
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: decoder_layer_type(
+                layer_id=idx,
+                config=config,
+                quant_config=quant_config,
+                prefix=prefix,
+                alt_stream=alt_stream,
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=add_prefix("layers", prefix),
+        )
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer(return_tuple=True)  
+
+        self.layers_to_capture = []
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+
+        if self.pp_group.is_first_rank:
+            if input_embeds is None:
+                hidden_states = self.embed_tokens(input_ids)
+            else:
+                hidden_states = input_embeds
+            residual = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        aux_hidden_states = []
+        for i in range(self.start_layer, self.end_layer):
+            if i in self.layers_to_capture:
+                aux_hidden_states.append(
+                    hidden_states + residual if residual is not None else hidden_states
+                )
+            layer = self.layers[i]
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                forward_batch,
+                residual,
+            )
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors({"hidden_states": hidden_states, "residual": residual})
+        else:
+            if hidden_states.shape[0] != 0:
+                if residual is None:
+                    hidden_states = self.norm(hidden_states)
+                else:
+                    hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) == 0:
+            return hidden_states
+
+        return hidden_states, aux_hidden_states
+
+    def load_kv_cache_scales(self, quantization_param_path: str) -> None:
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+
+        for layer_idx, scaling_factor in kv_cache_scales_loader(
+            quantization_param_path,
+            tp_rank,
+            tp_size,
+            self.config.num_hidden_layers,
+            self.config.__class__.model_type,
+        ):
+
+            if not isinstance(self.layers[layer_idx], nn.Identity):
+                layer_self_attn = self.layers[layer_idx].self_attn
+            if hasattr(layer_self_attn.attn, "k_scale"):
+                layer_self_attn.attn.k_scale = scaling_factor
+                layer_self_attn.attn.v_scale = scaling_factor
+            else:
+                raise RuntimeError(
+                    "Self attention has no KV cache scaling factor attribute!"
+                )
+
+class PanguEmbeddedForCausalLM(nn.Module):
+    stacked_params_mapping = [
+        ("qkv_proj", "q_proj", "q"),
+        ("qkv_proj", "k_proj", "k"),
+        ("qkv_proj", "v_proj", "v"),
+        ("gate_up_proj", "gate_proj", 0),
+        ("gate_up_proj", "up_proj", 1),
+    ]
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+        self.config = config
+        self.quant_config = quant_config
+        self.model = PanguEmbeddedModel(
+            config, quant_config=quant_config, prefix=add_prefix("model", prefix)
+        )
+
+        if self.pp_group.is_last_rank:
+            if getattr(config, "tie_word_embeddings", False):
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config, return_full_logits=True)
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+        self.capture_aux_hidden_states = False
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+
+        if self.pp_group.is_last_rank:
+            if not get_embedding:
+                return self.logits_processor(
+                    input_ids,
+                    hidden_states,
+                    self.lm_head,
+                    forward_batch,
+                    aux_hidden_states,
+                )
+            else:
+                return self.pooler(hidden_states, forward_batch)
+        else:
+            return hidden_states
+        
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        start, end = split_interval
+
+        if start == 0:
+            if input_embeds is None:
+                forward_batch.hidden_states = self.model.embed_tokens(input_ids)
+            else:
+                forward_batch.hidden_states = input_embeds
+
+        for i in range(start, end):
+            layer = self.model.layers[i]
+            forward_batch.hidden_states, forward_batch.residual = layer(
+                positions,
+                forward_batch.hidden_states,
+                forward_batch,
+                forward_batch.residual,
+            )
+
+        if end == self.model.config.num_hidden_layers:
+            hidden_states, _ = self.model.norm(
+                forward_batch.hidden_states, forward_batch.residual
+            )
+            forward_batch.hidden_states = hidden_states
+            result = self.logits_processor(
+                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+            )
+        else:
+            result = None
+        return result
+
+    def get_num_params(self):
+        params_dict = dict(self.named_parameters())
+        return len(params_dict)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name: continue
+            if "word_embeddings" in name: name = name.replace("word_embeddings", "embed_tokens")
+            if "output_layer" in name: name = name.replace("output_layer", "lm_head")
+            is_stacked = False
+            for param_name, weight_name, shard_id in self.stacked_params_mapping:
+                if weight_name in name:
+                    name = name.replace(weight_name, param_name)
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight, shard_id)
+                    is_stacked = True
+                    break
+
+            if is_stacked:
+                continue
+            if name in params_dict:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            else:
+                if f"model.{name}" in params_dict:
+                    param = params_dict[f"model.{name}"]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight)
+                else:
+                    pass
+
+    def load_kv_cache_scales(self, quantization_param_path: str) -> None:
+        self.model.load_kv_cache_scales(quantization_param_path)
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        if not self.pp_group.is_last_rank:
+            return
+        self.capture_aux_hidden_states = True
+        if layer_ids is None:
+            num_layers = self.config.num_hidden_layers
+            self.model.layers_to_capture = [2, num_layers // 2, num_layers - 3]
+        else:
+            self.model.layers_to_capture = [val + 1 for val in layer_ids]
+
+EntryClass = PanguEmbeddedForCausalLM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2745,7 +2745,13 @@ class ServerArgs:
                 )
                 self.attention_backend = "triton"
         elif not self.disable_cuda_graph:
-            if self.attention_backend != "flashinfer":
+            if self.device == "npu":
+                if self.attention_backend != "ascend":
+                    logger.warning(
+                        "Attention backend is set to ascend with npu because of enabling cuda graph in diffusion LLM inference"
+                    )
+                    self.attention_backend = "ascend"
+            elif self.attention_backend != "flashinfer":
                 logger.warning(
                     "Attention backend is set to flashinfer because of enabling cuda graph in diffusion LLM inference"
                 )


### PR DESCRIPTION
## Motivation

This PR introduces support for openPangu_Diffusion, a diffusion-based language model architecture, to SGLang's DLLM algorithm suite.

While sharing some conceptual similarities with Llada2.0, openPangu_Diffusion exhibits distinct architectural requirements regarding logit alignment and attention masking. This PR provides the necessary specialized implementation to ensure efficient and accurate inference for this model family.

These are the links related to the model：
https://ai.gitcode.com/ascend-tribe/openPangu-7B-Diffusion-Base?source_module=search_result_model
https://ai.gitcode.com/ascend-tribe/openPangu-R-7B-Diffusion?source_module=search_result_model

## Modifications

1. Logits Right Shift Logic
Unlike Llada2.0, the output logits of openPangu_Diffusion require an explicit right-shift operation. 

2. Causal Attention during KV Cache Saving
In the final stage of saving the KV Cache, we have enforced a Causal Attention Mask. 

3. Left Padding Strategy
To strictly decouple the Prefill and Decode phases, we implemented a Left Padding strategy. 

## How to run
1、To use this feature, create a configuration file and load it using the --dllm-algorithm-config flag.
Example: dllm_config.yaml
alg: "confidence_threshold"  # entropy or confidence_threshold 
threshold: 0.9          # Confidence threshold for token filtering
block_size: 32
num_small_blocks: 4     
pad_id: 0               # Model specific padding ID
eos_token_id: 2     # Set to 2 for Base model or 45892 for R model

2、Launch Command
python -m sglang.launch_server \
  --model-path /openPangu-7B-Diffusion-Base \
  --trust-remote-code \
  --attention-backend ascend \
  --device npu \
  --mem-fraction-static 0.8 \
  --host 0.0.0.0 \
  --port 30000 \
  --dllm-algorithm "ShiftConfidence" \
  --dllm-algorithm-config dllm_config.yaml \
  --skip-server-warmup \
  --max-running-requests 1 \
  --enable-tokenizer-batch-encode \
  --dtype bfloat16 \
  --kv-cache-dtype bfloat16 \
  --disable-radix-cache \
  --disable-cuda-graph

## Accuracy Tests
The test results are available for reference at the provided GitCode link.

Note: If you use /sglang/benchmark to test the accuracy of the openpangu-R-7B-Diffusion model, you need to add a chat template to the test script.


## Known Limitations
To ensure stability in the current implementation, please note the following constraints:

CUDA Graph / Graph Mode: Currently not supported. Please ensure --disable-cuda-graph is used (especially on Ascend NPU).

Batch Size: Currently supports Batch Size = 1 only (--max-running-requests 1). Requests with batch sizes greater than 1 may lead to unexpected behavior in the ShiftConfidence logic.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
