### PR TITLE
[VLM] Optimize Ernie4.5-VL rotary embedding with fused triton kernel

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -2787,8 +2787,237 @@ class YaRNScalingMRotaryEmbedding(MRotaryEmbedding):
         return cache
 
 
+@triton.jit
+def _triton_ernie45_rope_qk_fused(
+    q_ptr,
+    k_ptr,
+    cos_sin_cache_ptr,
+    positions_ptr,  # [3, num_tokens]  (t/h/w)
+    q_stride0: tl.constexpr,
+    k_stride0: tl.constexpr,
+    pos_stride0: tl.constexpr,  # positions.stride(0)
+    n_qh: tl.constexpr,
+    n_kh: tl.constexpr,
+    hd: tl.constexpr,
+    rd: tl.constexpr,  # rotary_dim
+    pad_n_qh: tl.constexpr,
+    pad_n_kh: tl.constexpr,
+    pad_hd: tl.constexpr,
+    section_hw: tl.constexpr,  # section_h + section_w (Ernie: 2*section_h)
+    is_neox_style: tl.constexpr,
+):
+    pid = tl.program_id(0)  # token id
+    q_ptr = q_ptr + pid * q_stride0
+    k_ptr = k_ptr + pid * k_stride0
+
+    half_rd = rd // 2
+
+    # positions: [3, num_tokens] => (t, h, w)
+    tpos = tl.load(positions_ptr + 0 * pos_stride0 + pid).to(tl.int32)
+    hpos = tl.load(positions_ptr + 1 * pos_stride0 + pid).to(tl.int32)
+    wpos = tl.load(positions_ptr + 2 * pos_stride0 + pid).to(tl.int32)
+
+    # rotary pair index vector [0 .. pad_hd/2)
+    ridx = tl.arange(0, pad_hd // 2)
+    rmask = ridx < half_rd
+
+    # Choose which axis position to use for each ridx
+    # ridx < section_hw: even->hpos, odd->wpos ; else -> tpos
+    use_hw = ridx < section_hw
+    use_h = (ridx & 1) == 0
+    pos = tl.where(use_hw, tl.where(use_h, hpos, wpos), tpos)
+
+    # Load cos/sin for each ridx from cache[pos, :]
+    # cache row stride is rd (cos first half, sin second half)
+    cos = tl.load(cos_sin_cache_ptr + pos * rd + ridx, mask=rmask, other=0.0)
+    sin = tl.load(
+        cos_sin_cache_ptr + pos * rd + (ridx + half_rd),
+        mask=rmask,
+        other=0.0,
+    )
+
+    # Apply to Q/K in-place.
+    # Q: [n_qh, hd], K: [n_kh, hd], but stored flattened [num_heads * hd]
+    if is_neox_style:
+        # Load first half / second half of rotary dim (size half_rd)
+        q_head = tl.arange(0, pad_n_qh)[:, None]
+        k_head = tl.arange(0, pad_n_kh)[:, None]
+
+        d = tl.arange(0, pad_hd // 2)[None, :]
+
+        q_mask = (q_head < n_qh) & (d < half_rd)
+        k_mask = (k_head < n_kh) & (d < half_rd)
+
+        # offsets for first half within each head
+        q_off0 = q_head * hd + d
+        k_off0 = k_head * hd + d
+
+        # offsets for second half within each head (shift by half_rd within rotary dim)
+        q_off1 = q_off0 + half_rd
+        k_off1 = k_off0 + half_rd
+
+        # Load
+        q0 = tl.load(q_ptr + q_off0, mask=q_mask, other=0.0).to(cos.dtype)
+        q1 = tl.load(q_ptr + q_off1, mask=q_mask, other=0.0).to(cos.dtype)
+        k0 = tl.load(k_ptr + k_off0, mask=k_mask, other=0.0).to(cos.dtype)
+        k1 = tl.load(k_ptr + k_off1, mask=k_mask, other=0.0).to(cos.dtype)
+
+        # Broadcast cos/sin to [heads, half_rd]
+        cos_b = cos[None, :]
+        sin_b = sin[None, :]
+
+        # Rotate
+        nq0 = q0 * cos_b - q1 * sin_b
+        nq1 = q1 * cos_b + q0 * sin_b
+        nk0 = k0 * cos_b - k1 * sin_b
+        nk1 = k1 * cos_b + k0 * sin_b
+
+        # Store back
+        tl.store(q_ptr + q_off0, nq0, mask=q_mask)
+        tl.store(q_ptr + q_off1, nq1, mask=q_mask)
+        tl.store(k_ptr + k_off0, nk0, mask=k_mask)
+        tl.store(k_ptr + k_off1, nk1, mask=k_mask)
+
+    else:
+        # GPT-J style: pairs are (even, odd) within rotary_dim
+        q_head = tl.arange(0, pad_n_qh)[:, None]
+        k_head = tl.arange(0, pad_n_kh)[:, None]
+        p = tl.arange(0, pad_hd // 2)[None, :]  # pair index
+
+        q_mask = (q_head < n_qh) & (p < half_rd)
+        k_mask = (k_head < n_kh) & (p < half_rd)
+
+        even = 2 * p
+        odd = even + 1
+
+        q_even_off = q_head * hd + even
+        q_odd_off = q_head * hd + odd
+        k_even_off = k_head * hd + even
+        k_odd_off = k_head * hd + odd
+
+        q_even = tl.load(q_ptr + q_even_off, mask=q_mask, other=0.0).to(cos.dtype)
+        q_odd = tl.load(q_ptr + q_odd_off, mask=q_mask, other=0.0).to(cos.dtype)
+        k_even = tl.load(k_ptr + k_even_off, mask=k_mask, other=0.0).to(cos.dtype)
+        k_odd = tl.load(k_ptr + k_odd_off, mask=k_mask, other=0.0).to(cos.dtype)
+
+        cos_b = cos[None, :]
+        sin_b = sin[None, :]
+
+        nq_even = q_even * cos_b - q_odd * sin_b
+        nq_odd = q_odd * cos_b + q_even * sin_b
+        nk_even = k_even * cos_b - k_odd * sin_b
+        nk_odd = k_odd * cos_b + k_even * sin_b
+
+        tl.store(q_ptr + q_even_off, nq_even, mask=q_mask)
+        tl.store(q_ptr + q_odd_off, nq_odd, mask=q_mask)
+        tl.store(k_ptr + k_even_off, nk_even, mask=k_mask)
+        tl.store(k_ptr + k_odd_off, nk_odd, mask=k_mask)
+
+
+def triton_ernie45_rope_fused_inplace(
+    q: torch.Tensor,  # [num_tokens, n_qh*hd], contiguous
+    k: torch.Tensor,  # [num_tokens, n_kh*hd], contiguous
+    cos_sin_cache: torch.Tensor,  # [max_pos, rd], contiguous
+    positions: torch.Tensor,  # [3, num_tokens], contiguous, stride(1)==1
+    mrope_section: list[int],  # [h, w, t]  (Ernie expects h==w)
+    head_size: int,
+    rotary_dim: int,
+    is_neox_style: bool,
+) -> None:
+    assert q.is_cuda and k.is_cuda and cos_sin_cache.is_cuda and positions.is_cuda
+    assert q.dim() == 2 and k.dim() == 2
+    assert positions.dim() == 2 and positions.shape[0] == 3
+    assert q.stride(1) == 1 and k.stride(1) == 1
+    assert positions.stride(1) == 1
+    assert cos_sin_cache.dim() == 2 and cos_sin_cache.is_contiguous()
+
+    num_tokens = q.shape[0]
+    assert positions.shape[1] == num_tokens
+    assert q.shape[0] == k.shape[0] == num_tokens
+
+    n_q_dim = q.shape[1]
+    n_k_dim = k.shape[1]
+    assert n_q_dim % head_size == 0 and n_k_dim % head_size == 0
+
+    n_qh = n_q_dim // head_size
+    n_kh = n_k_dim // head_size
+
+    rd = rotary_dim
+    assert rd % 2 == 0
+    assert rd <= head_size
+
+    # Ernie section sanity
+    section_h, section_w, section_t = mrope_section
+    assert section_h == section_w, "Ernie4.5 layout assumes section_h == section_w"
+    assert section_h + section_w + section_t == (
+        rd // 2
+    ), "mrope_section must sum to rotary_dim//2"
+
+    # Ensure cache dtype matches q/k dtype for best perf (avoid implicit casts)
+    if cos_sin_cache.dtype != q.dtype or cos_sin_cache.device != q.device:
+        cos_sin_cache = cos_sin_cache.to(device=q.device, dtype=q.dtype)
+
+    pad_n_qh = triton.next_power_of_2(n_qh)
+    pad_n_kh = triton.next_power_of_2(n_kh)
+    pad_hd = triton.next_power_of_2(head_size)
+
+    # Heuristic warps
+    num_warps = 4 if (pad_n_qh * pad_hd) <= 8192 else 8
+
+    _triton_ernie45_rope_qk_fused[(num_tokens,)](
+        q,
+        k,
+        cos_sin_cache,
+        positions,
+        q.stride(0),
+        k.stride(0),
+        positions.stride(0),
+        n_qh=n_qh,
+        n_kh=n_kh,
+        hd=head_size,
+        rd=rd,
+        pad_n_qh=pad_n_qh,
+        pad_n_kh=pad_n_kh,
+        pad_hd=pad_hd,
+        section_hw=section_h + section_w,
+        is_neox_style=is_neox_style,
+        num_warps=num_warps,
+    )
+
+
 class Ernie4_5_VLRotaryEmbedding(MRotaryEmbedding):
     """3D rotary positional embedding. [h w h w h w h w... t t t...]"""
+
+    def __init__(
+        self,
+        head_size: int,
+        rotary_dim: int,
+        max_position_embeddings: int,
+        base: int,
+        is_neox_style: bool,
+        dtype: torch.dtype,
+        mrope_section: Optional[List[int]] = None,
+        mrope_interleaved: bool = False,
+    ) -> None:
+        super().__init__(
+            head_size,
+            rotary_dim,
+            max_position_embeddings,
+            base,
+            is_neox_style,
+            dtype,
+            mrope_section=mrope_section,
+            mrope_interleaved=mrope_interleaved,
+        )
+        self.head_size = head_size
+        self.rotary_dim = rotary_dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        self.is_neox_style = is_neox_style
+        self.dtype = dtype
+        self.mrope_section = mrope_section
+        self.mrope_interleaved = mrope_interleaved
+        self._apply_rotary_emb_wrapped = torch.compile(dynamic=True)(_apply_rotary_emb)
 
     def forward_native(  # type: ignore[override]
         self,
@@ -2834,14 +3063,16 @@ class Ernie4_5_VLRotaryEmbedding(MRotaryEmbedding):
         query = query.view(num_tokens, -1, self.head_size)
         query_rot = query[..., : self.rotary_dim]
         query_pass = query[..., self.rotary_dim :]
-        query_rot = _apply_rotary_emb(query_rot, cos, sin, self.is_neox_style)
+        query_rot = self._apply_rotary_emb_wrapped(
+            query_rot, cos, sin, self.is_neox_style
+        )
         query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
 
         key_shape = key.shape
         key = key.view(num_tokens, -1, self.head_size)
         key_rot = key[..., : self.rotary_dim]
         key_pass = key[..., self.rotary_dim :]
-        key_rot = _apply_rotary_emb(key_rot, cos, sin, self.is_neox_style)
+        key_rot = self._apply_rotary_emb_wrapped(key_rot, cos, sin, self.is_neox_style)
         key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
         return query, key
 
@@ -2851,6 +3082,40 @@ class Ernie4_5_VLRotaryEmbedding(MRotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        assert key is not None
+        assert positions.ndim in (1, 2)
+
+        # Ensure cache dtype/device matches q/k to avoid extra casts
+        self._match_cos_sin_cache_dtype(query)
+
+        if positions.ndim == 2:
+            assert self.mrope_section is not None
+            # positions: [3, num_tokens]
+            triton_ernie45_rope_fused_inplace(
+                q=query,
+                k=key,
+                cos_sin_cache=self.cos_sin_cache,
+                positions=positions,
+                mrope_section=self.mrope_section,  # [h, w, t]
+                head_size=self.head_size,
+                rotary_dim=self.rotary_dim,
+                is_neox_style=self.is_neox_style,
+            )
+            return query, key
+
+        # positions.ndim == 1 (text-only): use existing fused kernel if available
+        if _is_cuda and (apply_rope_with_cos_sin_cache_inplace is not None):
+            apply_rope_with_cos_sin_cache_inplace(
+                positions=positions,
+                query=query,
+                key=key,
+                head_size=self.head_size,
+                cos_sin_cache=self.cos_sin_cache,
+                is_neox=self.is_neox_style,
+            )
+            return query, key
+
+        # fallback
         return self.forward_native(positions, query, key)
 
     def forward(
@@ -2869,7 +3134,7 @@ class Ernie4_5_VLRotaryEmbedding(MRotaryEmbedding):
             key: [num_tokens, num_kv_heads * head_size]
         """
         assert positions.ndim == 1 or positions.ndim == 2
-        return self.forward_native(positions, query, key)
+        return self.forward_cuda(positions, query, key)
 
 
 class DualChunkRotaryEmbedding(MultiPlatformOp):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Current Ernie4.5VL MRoPE occupies a major portion in inference time. It has many small ops which introduces quite a lot of GPU bubbles.

```
python3 -m sglang.launch_server --model-path baidu/ERNIE-4.5-VL-28B-A3B-PT \
 --served-model-name ERNIE-45-VL-28B \ 
 --port 30000 \ 
 --trust-remote-code
```

<img width="2886" height="1358" alt="image" src="https://github.com/user-attachments/assets/afc7e8a8-1dea-421f-8163-fcff2d3fda24" />
<img width="2822" height="1408" alt="image" src="https://github.com/user-attachments/assets/addb39d0-ef45-4fc3-883a-7f96cc364f6e" />

This PR is to introduce a fused Triton kernel for Ernie4.5 VL MRoPE (THW) rotary embedding. It applies rotary positional embeddings to both Q and K in-place for Ernie4.5 VL’s 3D MRoPE layout. The kernel fuses two previously separate steps:

One of the tricky parts of this enhancement is Ernie adopts specific frequency reordering ([h, w, h, w, ..., t, t, t]) from THW positions, which was previously implemented via multiple PyTorch ops (index_select/chunk/stack/reshape/cat) and materialized intermediate tensors. So we can't leverage the existing fused rotary embedding triton kernel for the traditional [t, h, w, t, h, w, ... ] layout.

Instead of constructing (cos, sin) tensors on the Python side, the kernel selects the appropriate position (h vs w interleaved for the spatial section, and t for the temporal tail) per rotary pair index and directly gathers cos/sin from the cache. This eliminates intermediate allocations, reduces kernel launches, and improves memory locality by keeping the entire operation within a single Triton launch.


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
**In our profiling, the fused kernel reduces the Ernie4.5 VL rotary embedding time from 670µs to 123µs, RotaryEmbedding kernel wise 5.4x speedup. (≈17% end-to-end improvement for the measured workload)**

Before PR: 
<img width="2880" height="1566" alt="image" src="https://github.com/user-attachments/assets/aca1b9dc-d86b-4db3-b061-6ed4c7914384" />

After PR:
<img width="2872" height="1460" alt="image" src="https://github.com/user-attachments/assets/86367f75-f3df-47ff-8f2d-05875a2af4fb" />
zoom in:
<img width="3112" height="1426" alt="image" src="https://github.com/user-attachments/assets/d6c5a1bd-17df-471e-a231-16c404f00a0f" />

Without PR:
root@c7e9bb6a6789:/sgl-workspace/bench_script# bash bench_n_image.sh 
{"id":"804d220f0f3a43feb9de208b67289ed9","object":"chat.completion","created":1771144593,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中植物是刺芹，属于伞形科刺芹属的多年生草本植物。其茎直立，有刺，叶片羽状分裂，边缘有尖锐的刺齿。刺芹常见于野外，具有一定的观赏价值，同时它也是一些动物的食物来源。\n刺芹含有挥发油等化学成分，具有一定的香气。需要注意的是，虽然刺芹本身不是传统意义上的有毒植物，但其茎叶上的刺可能对皮肤造成机械性刺激或损伤，接触后可能会引起不适。此外，对于某些特定人群（如过敏体质者）来说，接触或食用刺芹可能会引发过敏反应。\n在野外遇到刺芹时，建议不要随意采摘或食用，以免发生意外。如果需要了解某种植物是否可食用或具有药用价值，最好咨询专业的植物学家或相关领域的专家。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":2}],"usage":{"prompt_tokens":973,"total_tokens":1143,"completion_tokens":170,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m1.317s
user    0m0.002s
sys     0m0.004s

With PR:
root@c7e9bb6a6789:/sgl-workspace/bench_script# bash bench_n_image.sh 
{"id":"5c2afe89093346e48bfc153baeafbf56","object":"chat.completion","created":1771145589,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中植物是刺芹，属于伞形科刺芹属的多年生草本植物。其茎直立，有刺，叶片羽状分裂，边缘有尖锐的刺齿。刺芹常见于野外，具有一定的观赏价值，同时它也是一些动物的食物来源。\n刺芹含有挥发油等化学成分，具有一定的香气。需要注意的是，虽然刺芹本身不是传统意义上的有毒植物，但其茎叶上的刺可能会对皮肤造成机械性损伤，接触后可能引起不适。此外，对于某些特定人群（如过敏体质者）来说，接触或误食刺芹可能会引发过敏反应或其他不良反应。因此，在野外遇到刺芹时，应避免随意触摸或采摘食用。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":2}],"usage":{"prompt_tokens":973,"total_tokens":1119,"completion_tokens":146,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m1.085s
user    0m0.003s
sys     0m0.002s


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Main:
```
root@c7e9bb6a6789:/sgl-workspace/sglang# python3 -m lmms_eval --model openai_compatible   --model_args model_version=baidu/ERNIE-4.5-VL-28B-A3B-PT   --tasks mmmu_val   --batch_size 16
2026-02-15 10:53:36 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2026-02-15 10:53:38 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2026-02-15 10:53:38 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2026-02-15 10:53:38 | INFO     | lmms_eval.evaluator:simple_evaluate:162 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-15 10:53:41 | INFO     | lmms_eval.evaluator:evaluate:403 - Running on rank 0 (local rank 0)
2026-02-15 10:53:41 | INFO     | lmms_eval.api.task:build_all_requests:431 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 14077.68it/s]
2026-02-15 10:53:41 | INFO     | lmms_eval.evaluator:evaluate:496 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [11:47<00:00,  9.84s/it]2026-02-15 11:05:29 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 8564.083s, Total tokens: 112885, Avg speed: 13.2 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [11:47<00:00, 12.42s/it]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 9288.82it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.26667}, 'Art': {'num': 30, 'acc': 0.23333}, 'Art_Theory': {'num': 30, 'acc': 0.23333}, 'Design': {'num': 30, 'acc': 0.36667}, 'Music': {'num': 30, 'acc': 0.23333}, 'Overall-Business': {'num': 150, 'acc': 0.22667}, 'Accounting': {'num': 30, 'acc': 0.16667}, 'Economics': {'num': 30, 'acc': 0.26667}, 'Finance': {'num': 30, 'acc': 0.23333}, 'Manage': {'num': 30, 'acc': 0.2}, 'Marketing': {'num': 30, 'acc': 0.26667}, 'Overall-Science': {'num': 150, 'acc': 0.27333}, 'Biology': {'num': 30, 'acc': 0.33333}, 'Chemistry': {'num': 30, 'acc': 0.13333}, 'Geography': {'num': 30, 'acc': 0.26667}, 'Math': {'num': 30, 'acc': 0.36667}, 'Physics': {'num': 30, 'acc': 0.26667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.26667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.3}, 'Clinical_Medicine': {'num': 30, 'acc': 0.23333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.26667}, 'Pharmacy': {'num': 30, 'acc': 0.23333}, 'Public_Health': {'num': 30, 'acc': 0.3}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.275}, 'History': {'num': 30, 'acc': 0.5}, 'Literature': {'num': 30, 'acc': 0.4}, 'Sociology': {'num': 30, 'acc': 0.13333}, 'Psychology': {'num': 30, 'acc': 0.06667}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.27619}, 'Agriculture': {'num': 30, 'acc': 0.33333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.2}, 'Computer_Science': {'num': 30, 'acc': 0.3}, 'Electronics': {'num': 30, 'acc': 0.23333}, 'Energy_and_Power': {'num': 30, 'acc': 0.3}, 'Materials': {'num': 30, 'acc': 0.23333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.33333}, 'Overall': {'num': 900, 'acc': 0.26444}}
2026-02-15 11:05:30 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=baidu/ERNIE-4.5-VL-28B-A3B-PT), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|Stderr_CLT|Stderr_Clustered|
|--------|------:|------|-----:|--------|---|-----:|---|------|----------|----------------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.2644|±  |N/A   |N/A       |N/A             |
```

PR:
```
root@c7e9bb6a6789:/sgl-workspace/bench_script# python3 -m lmms_eval --model openai_compatible   --model_args model_version=baidu/ERNIE-4.5-VL-28B-A3B-PT   --tasks mmmu_val   --batch_size 16
2026-02-16 02:20:12 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2026-02-16 02:20:14 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2026-02-16 02:20:14 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2026-02-16 02:20:14 | INFO     | lmms_eval.evaluator:simple_evaluate:162 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-16 02:20:17 | INFO     | lmms_eval.evaluator:evaluate:403 - Running on rank 0 (local rank 0)
2026-02-16 02:20:17 | INFO     | lmms_eval.api.task:build_all_requests:431 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13926.80it/s]
2026-02-16 02:20:17 | INFO     | lmms_eval.evaluator:evaluate:496 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [12:38<00:00, 10.69s/it]2026-02-16 02:32:56 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 10344.727s, Total tokens: 112510, Avg speed: 10.9 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [12:38<00:00, 13.31s/it]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 9167.37it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.25833}, 'Art': {'num': 30, 'acc': 0.16667}, 'Art_Theory': {'num': 30, 'acc': 0.26667}, 'Design': {'num': 30, 'acc': 0.43333}, 'Music': {'num': 30, 'acc': 0.16667}, 'Overall-Business': {'num': 150, 'acc': 0.18667}, 'Accounting': {'num': 30, 'acc': 0.13333}, 'Economics': {'num': 30, 'acc': 0.16667}, 'Finance': {'num': 30, 'acc': 0.16667}, 'Manage': {'num': 30, 'acc': 0.23333}, 'Marketing': {'num': 30, 'acc': 0.23333}, 'Overall-Science': {'num': 150, 'acc': 0.29333}, 'Biology': {'num': 30, 'acc': 0.3}, 'Chemistry': {'num': 30, 'acc': 0.3}, 'Geography': {'num': 30, 'acc': 0.26667}, 'Math': {'num': 30, 'acc': 0.26667}, 'Physics': {'num': 30, 'acc': 0.33333}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.32667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.4}, 'Clinical_Medicine': {'num': 30, 'acc': 0.3}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.26667}, 'Pharmacy': {'num': 30, 'acc': 0.26667}, 'Public_Health': {'num': 30, 'acc': 0.4}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.25}, 'History': {'num': 30, 'acc': 0.33333}, 'Literature': {'num': 30, 'acc': 0.43333}, 'Sociology': {'num': 30, 'acc': 0.13333}, 'Psychology': {'num': 30, 'acc': 0.1}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.25714}, 'Agriculture': {'num': 30, 'acc': 0.2}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.16667}, 'Computer_Science': {'num': 30, 'acc': 0.26667}, 'Electronics': {'num': 30, 'acc': 0.1}, 'Energy_and_Power': {'num': 30, 'acc': 0.6}, 'Materials': {'num': 30, 'acc': 0.2}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.26667}, 'Overall': {'num': 900, 'acc': 0.26222}}
fatal: not a git repository (or any of the parent directories): .git
2026-02-16 02:32:57 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=baidu/ERNIE-4.5-VL-28B-A3B-PT), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|Stderr_CLT|Stderr_Clustered|
|--------|------:|------|-----:|--------|---|-----:|---|------|----------|----------------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.2622|±  |N/A   |N/A       |N/A             |
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
