### PR TITLE
Revert "[diffusion]: Improve layerwise offload buffer reuse and shared-storage handling"

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -65,30 +65,8 @@ class LayerwiseOffloadManager:
         self._named_buffers: Dict[str, torch.Tensor] = {}
         # Store forward hooks for removal
         self._forward_hooks: List[Any] = []
-        # GPU buffer pool: dtype -> numel -> [buffers]
-        self._gpu_buffer_pool: Dict[torch.dtype, Dict[int, List[torch.Tensor]]] = {}
-        # layer_idx -> {dtype: gpu_buffer}
-        self._layer_gpu_buffers: Dict[int, Dict[torch.dtype, torch.Tensor]] = {}
-        self._gpu_buffer_pool_max = max(2, 2 * self.prefetch_size)
-        # Keep layer 0 resident during the forward pass to avoid redundant reloads
-        self._resident_window = 1
 
         self._initialize()
-
-    def _acquire_gpu_buffer(self, dtype: torch.dtype, numel: int) -> torch.Tensor:
-        pool_by_dtype = self._gpu_buffer_pool.setdefault(dtype, {})
-        bucket = pool_by_dtype.get(numel)
-        if bucket:
-            return bucket.pop()
-        return torch.empty((numel,), dtype=dtype, device=self.device)
-
-    def _release_gpu_buffer(
-        self, dtype: torch.dtype, numel: int, buffer: torch.Tensor
-    ) -> None:
-        pool_by_dtype = self._gpu_buffer_pool.setdefault(dtype, {})
-        bucket = pool_by_dtype.setdefault(numel, [])
-        if len(bucket) < self._gpu_buffer_pool_max:
-            bucket.append(buffer)
 
     def _match_layer_idx(self, name: str) -> int | None:
         m = self._layer_name_re.search(name)
@@ -104,14 +82,12 @@ class LayerwiseOffloadManager:
         if not self.enabled:
             return
 
-        named_parameters = list(self.model.named_parameters())
-        named_buffers = list(self.model.named_buffers())
-        self._named_parameters = dict(named_parameters)
-        self._named_buffers = dict(named_buffers)
+        self._named_parameters = dict(self.model.named_parameters())
+        self._named_buffers = dict(self.model.named_buffers())
 
         # 1. collect and group tensors by layer and dtype
         layer_groups: Dict[int, Dict[torch.dtype, List[Tuple[str, torch.Tensor]]]] = {}
-        all_tensors = list(chain(named_parameters, named_buffers))
+        all_tensors = chain(self._named_parameters.items(), self._named_buffers.items())
         for name, tensor in all_tensors:
             layer_idx = self._match_layer_idx(name)
             if layer_idx is None or layer_idx >= self.num_layers:
@@ -197,7 +173,9 @@ class LayerwiseOffloadManager:
         gpu_buffers: Dict[torch.dtype, torch.Tensor] = {}
         with torch.cuda.stream(self.copy_stream):
             for dtype, cpu_buffer in self._consolidated_cpu_weights[layer_idx].items():
-                gpu_buffer = self._acquire_gpu_buffer(dtype, cpu_buffer.numel())
+                gpu_buffer = torch.empty(
+                    cpu_buffer.shape, dtype=dtype, device=self.device
+                )
                 gpu_buffer.copy_(cpu_buffer, non_blocking=non_blocking)
                 gpu_buffers[dtype] = gpu_buffer
 
@@ -218,10 +196,9 @@ class LayerwiseOffloadManager:
             ].view(meta["shape"])
 
         self._gpu_layers.add(layer_idx)
-        self._layer_gpu_buffers[layer_idx] = gpu_buffers
 
     @torch.compiler.disable
-    def release_layer(self, layer_idx: int, force: bool = False) -> None:
+    def release_layer(self, layer_idx: int) -> None:
         """
         lightweight release layer weights
         Basically set the reference count to the gpu weight tensor to zero. The weights on cpu is untouched
@@ -232,7 +209,7 @@ class LayerwiseOffloadManager:
         # clear prefetch event, since it's useless and needs to be reset
         self._prefetch_events.pop(layer_idx, None)
 
-        if layer_idx < self._resident_window and not force:
+        if layer_idx <= 0:
             return
 
         if layer_idx not in self._gpu_layers:
@@ -241,11 +218,6 @@ class LayerwiseOffloadManager:
         for name, meta in self._weight_metadata.get(layer_idx, {}).items():
             target = self.get_target_with_name(name)
             target.data = torch.empty((1,), device=self.device, dtype=meta["dtype"])
-
-        layer_buffers = self._layer_gpu_buffers.pop(layer_idx, None)
-        if layer_buffers is not None:
-            for dtype, buffer in layer_buffers.items():
-                self._release_gpu_buffer(dtype, buffer.numel(), buffer)
 
         self._gpu_layers.discard(layer_idx)
 
@@ -257,9 +229,7 @@ class LayerwiseOffloadManager:
             torch.cuda.current_stream().wait_stream(self.copy_stream)
 
         for layer_idx in list(self._gpu_layers):
-            self.release_layer(layer_idx, force=True)
-
-        self._gpu_buffer_pool.clear()
+            self.release_layer(layer_idx)
 
     @torch.compiler.disable
     def load_all_layers(self) -> None:


### PR DESCRIPTION
Reverts sgl-project/sglang#18611

## Reverts #18611

### Summary

This reverts the buffer pool optimization introduced in #18611. While the original PR reported decreased "Peak GPU memory" metrics, this reduction is misleading as it only reflects PyTorch's **allocated memory** tracking, not actual VRAM consumption.

### Issue with Original PR

PR #18611 introduced a GPU buffer pool mechanism to `LayerwiseOffloadManager`. However, this creates a discrepancy between reported and actual memory usage:

- **What decreased**: `torch.cuda.max_memory_allocated()` - memory PyTorch tracks as "actively allocated"
- **What actually increased**: `torch.cuda.max_memory_reserved()` - actual physical VRAM held by the process

The buffer pool keeps pre-allocated GPU buffers in a cache (up to `2 × prefetch_size` buffers per unique tensor size). While these buffers occupy VRAM continuously, they are not counted in the `allocated` metric after being returned to the pool, leading to artificially lower reported memory usage.

### Real-World Impact

1. **Increased baseline VRAM usage**: The buffer pool maintains a constant pool of GPU buffers (~hundreds of MB to GB range depending on model size and `prefetch_size`)
2. **Potential fragmentation**: Models with varying layer sizes create multiple buffer buckets, each maintaining its own pool, multiplying VRAM overhead
3. **Misleading metrics**: Users relying on the "Peak GPU memory" log may incorrectly believe they have more available VRAM than actually exists


### Evidence

After switching from `torch.cuda.max_memory_allocated()` to 
`torch.cuda.max_memory_reserved()` in memory reporting, the peak 
GPU memory usage is **identical** between versions with and without 
the buffer pool (60.94 GB in both cases).

This proves that PR #18611 did not actually reduce VRAM usage - it 
only reduced the `allocated` metric by reusing tensor objects, while 
the actual VRAM held by PyTorch's CUDA allocator (shown by `reserved`) 
remains unchanged.

The buffer pool essentially reimplements what PyTorch's allocator 
already does internally, providing no real benefit while adding 
complexity and potential fragmentation issues.
### Verification

To verify actual VRAM consumption, use:
- `torch.cuda.max_memory_reserved()` instead of `max_memory_allocated()`
- `nvidia-smi` to monitor real GPU memory usage
- CUDA memory profiling tools

### Conclusion

The "decreased VRAM" claim in #18611 is based on an incomplete metric. This revert restores the original behavior where memory statistics accurately reflect actual VRAM pressure, allowing users to make informed decisions about offloading configurations.

I've drafted a pr #18865 to better reflect the actually VRAM usage