### PR TITLE
fix: nightly whl dev date suffix

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -54,28 +54,26 @@ jobs:
           cd python
           cp ../README.md ../LICENSE .
 
-          # Parse git describe output to detect exact tag builds (distance=0)
+          # Parse git describe output to get latest tag
           # Use same command as pyproject.toml to ensure version consistency
           DESC=$(git tag --list --sort=-version:refname 'v*.*.*' | head -1 | xargs git describe --tags --long 2>/dev/null || echo 'v0.0.0-0-g0000000')
-          DIST=$(echo "$DESC" | cut -d- -f2)
+          TAG=$(echo "$DESC" | cut -d- -f1)
+          HASH="g$(git rev-parse --short HEAD)"
+          BUILD_DATE=$(date -u +%Y%m%d)
 
-          # If building at exact tag (distance=0), force dev0 version for unique wheel names
-          if [ "$DIST" = "0" ]; then
-            TAG=$(echo "$DESC" | cut -d- -f1)
-            HASH="g$(git rev-parse --short HEAD)"
+          # Increment patch version for nightlies (e.g., v0.5.8 -> 0.5.9)
+          VERSION=${TAG#v}  # Remove 'v' prefix
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
 
-            # Increment patch version for nightlies (e.g., v0.5.8 -> 0.5.9.dev0)
-            VERSION=${TAG#v}  # Remove 'v' prefix
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            PATCH=$(echo "$VERSION" | cut -d. -f3)
-            NEXT_PATCH=$((PATCH + 1))
-            NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
-
-            FORCE_VERSION="${NEXT_VERSION}.dev0+${HASH}"
-            echo "Building at exact tag $TAG, forcing nightly version to: $FORCE_VERSION"
-            export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"
-          fi
+          # Use date-based dev number for correct chronological sorting
+          # e.g., 0.5.9.dev20260215+g4cf4f0859 > 0.5.9.dev20260214+g45a4697d4
+          FORCE_VERSION="${NEXT_VERSION}.dev${BUILD_DATE}+${HASH}"
+          echo "Forcing nightly version to: $FORCE_VERSION"
+          export SETUPTOOLS_SCM_PRETEND_VERSION="$FORCE_VERSION"
 
           # Build wheel
           python3 -m build --wheel


### PR DESCRIPTION
## Motivation

The original nightly whl suffix was based on the version.postx versioning, but accounting for this caused a lot of edge cases in indexing and hashing. Currently, the formatting of dev0 causes pip to pick the lexicographically largest hash, so the incorrect (not latest) whl version would be selected. 

We follow the standard `next_version.dev{date}+g{hash}` format similar to pytorch nightlies.

## Modifications

Remove dev(number) tagging and the edge cases around it, and replaced it with a date based tagging in release-nightly-pypi.yml.

## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/22047691908

```
uv pip install -U sglang sgl-kernel --pre \
  --index-url https://sgl-project.github.io/whl/cu129/ \
  --extra-index-url https://pypi.org/simple \
  --extra-index-url https://download.pytorch.org/whl/cu129 \
  --index-strategy unsafe-best-match
```
<img width="675" height="70" alt="Screenshot 2026-02-15 at 9 12 03 PM" src="https://github.com/user-attachments/assets/5d84e744-9216-4632-8d75-3346d5f5d868" />


## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
