### PR TITLE
feat: Add FP8 KV cache support for Triton attention backend

### DIFF
--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -251,6 +251,8 @@ class TestTritonAttention(CustomTestCase):
             True,
             mask_indptr,
             max_len_extend,
+            1.0,
+            1.0,
         )
 
         b_seq_mask_len = b_seq_len_extend * b_seq_len
@@ -286,6 +288,8 @@ class TestTritonAttention(CustomTestCase):
             True,
             mask_indptr,
             max_len_extend,
+            1.0,
+            1.0,
         )
 
         redundant_attention(
@@ -395,6 +399,8 @@ class TestTritonAttention(CustomTestCase):
             is_causal=True,
             mask_indptr=None,
             max_len_extend=max_len_extend,
+            k_scale=1.0,
+            v_scale=1.0,
             sliding_window_size=WINDOW_SIZE,
         )
 
@@ -517,6 +523,8 @@ class TestTritonAttention(CustomTestCase):
             num_kv_splits,
             max_kv_splits,
             sm_scale,
+            1.0,
+            1.0,
         )
 
         # Correctness reference (float32, stable softmax)
@@ -591,6 +599,7 @@ class TestTritonAttention(CustomTestCase):
             num_kv_splits,
             max_kv_splits,
             sm_scale,
+            1.0,
         )
 
         attn_logits1 = torch.empty(
@@ -616,6 +625,7 @@ class TestTritonAttention(CustomTestCase):
             num_kv_splits,
             max_kv_splits,
             sm_scale,
+            1.0,
         )
 
         cos_sim = torch.nn.functional.cosine_similarity(
@@ -722,6 +732,8 @@ class TestTritonAttention(CustomTestCase):
             is_causal=True,
             mask_indptr=None,
             max_len_extend=max_len_extend,
+            k_scale=1.0,
+            v_scale=1.0,
         )
 
         # Build unified KV indices
@@ -750,6 +762,8 @@ class TestTritonAttention(CustomTestCase):
             o_unified,
             k_buffer,
             v_buffer,
+            1.0,
+            1.0,
             qo_indptr,
             unified_kv_indptr,
             unified_kv_indices,

--- a/test/registered/attention/test_wave_attention_kernels.py
+++ b/test/registered/attention/test_wave_attention_kernels.py
@@ -155,6 +155,8 @@ class TestWaveAttention(unittest.TestCase):
             is_causal,
             mask_indptr,
             max_len_extend,
+            1.0,
+            1.0,
         )
 
         o_wave = torch.empty(
@@ -240,6 +242,7 @@ class TestWaveAttention(unittest.TestCase):
             num_kv_splits,
             max_kv_splits,
             sm_scale,
+            1.0,
             logit_cap,
         )
 

--- a/test/registered/quant/test_fp8kv_triton.py
+++ b/test/registered/quant/test_fp8kv_triton.py
@@ -1,0 +1,58 @@
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.few_shot_gsm8k import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=520, suite="stage-b-test-large-1-gpu")
+
+
+class TestFP8KVCacheTritonBackend(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--quantization",
+                "fp8",
+                "--kv-cache-dtype",
+                "fp8_e4m3",
+                "--attention-backend",
+                "triton",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        parsed_url = urlparse(self.base_url)
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=200,
+            host=f"{parsed_url.scheme}://{parsed_url.hostname}",
+            port=parsed_url.port,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["accuracy"], 0.70)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The Triton attention backend does not correctly handle FP8 KV cache. It does not pass k_scale/v_scale to set_kv_buffer, causing scales to default to 1.0. In addition, the Triton kernels lack dequantization support. Unlike FlashInfer which handles scales internally, the Triton kernels receive raw FP8 values without applying the corresponding scales.

This PR fuses FP8 dequantization scales directly into the Triton attention kernels, efficiently enabling FP8 KV cache to work correctly with the Triton backend.

Related: #15194

## Modifications

**Triton kernels (`decode_attention.py`, `extend_attention.py`):**
- `decode_attention_fwd`: accepts `k_scale` and `v_scale`, fuses `k_scale` into `sm_scale` (pre-softmax), applies `v_scale` at output store in stage 2 reduce kernel. Zero overhead — scalar multiply in registers.
- `extend_attention_fwd` (`_fwd_kernel`): accepts `k_scale` and `v_scale`. Stage 1 (prefix from FP8 buffer): applies `k_scale` via `sm_scale * k_scale` to QK scores, applies `v_scale` via `tl.dot(p, v) * v_scale` to V accumulator. Stage 2 (new extend tokens in BF16): uses unscaled `sm_scale` only. No `v_scale` needed since V_Extend is already in BF16.
- `extend_attention_fwd_unified` (`_fwd_kernel_unified`): all KV comes from buffer, so `k_scale` is fused into `sm_scale` and `v_scale` is applied at output store (same as decode).

**Backend (`triton_backend.py`):**
- `forward_extend`: passes `k.clone()` and `v.clone()` to `set_kv_buffer` to prevent in-place mutation `div_` from corrupting the original `k`/`v` tensors that are later passed to the extend kernel. Passes `layer.k_scale_float` and `layer.v_scale_float` to the kernel.
- `forward_decode`: passes `layer.k_scale_float` and `layer.v_scale_float` to the kernel. No clone needed since decode doesn't pass raw `k`/`v` to the kernel.
- `_forward_extend_unified`: passes scales to the unified kernel.
- Guard `k_scale`/`v_scale` with None check, default to 1.0 for non-quantized models (e.g. encoder models).
- Added detection logic for MLA. Skip passing `k_scale`/`v_scale` to MLA `set_kv_buffer` as MLA currently does not support FP8 KV cache.

**Tests:**

- `test_triton_attention_kernels.py`, `test_wave_attention_kernels.py`: Add required k_scale/v_scale args to match updated kernel signatures.
- `test_fp8kv_triton.py` (new): test with `neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV` (non-trivial kv scales) + triton backend, validates GSM8K accuracy > 0.70.

## Accuracy Tests

MMLU on 5090, server command:
```bash
python3 -m sglang.launch_server \
    --model-path neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV \
    --quantization fp8 \
    --kv-cache-dtype fp8_e4m3 \
   --attention-backend triton \
  --port 30000
```
Result:
```bash
root@8c8fc5fff53c:/workspace/sglang/benchmark/mmlu# python3 bench_sglang.py --nsub 10
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1369/1369 [00:02<00:00, 672.14it/s]
subject: abstract_algebra, #q:100, acc: 0.300
subject: anatomy, #q:135, acc: 0.689
subject: astronomy, #q:152, acc: 0.750
subject: business_ethics, #q:100, acc: 0.710
subject: clinical_knowledge, #q:265, acc: 0.758
subject: college_biology, #q:144, acc: 0.771
subject: college_chemistry, #q:100, acc: 0.470
subject: college_computer_science, #q:100, acc: 0.560
subject: college_mathematics, #q:100, acc: 0.380
subject: college_medicine, #q:173, acc: 0.642
Total latency: 2.047
Average accuracy: 0.637
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
