### PR TITLE
Fix test_lora_qwen3 nightly failure: replace adapter with added_tokens

### DIFF
--- a/python/sglang/test/lora_utils.py
+++ b/python/sglang/test/lora_utils.py
@@ -126,7 +126,7 @@ LORA_MODELS_QWEN3 = [
                 prefill_tolerance=3e-1,
             ),
             LoRAAdaptor(
-                name="y9760210/Qwen3-4B-lora_model",
+                name="TanXS/Qwen3-4B-LoRA-ZH-WebNovelty-v0.0",
                 prefill_tolerance=3e-1,
             ),
         ],


### PR DESCRIPTION
## Motivation

Fix nightly 1-GPU test failure for `test_lora_qwen3.py` (exit code -9).

Failure: https://github.com/sgl-project/sglang/actions/runs/22026980777/job/63645203194

## Modifications

Replace LoRA test adapter `y9760210/Qwen3-4B-lora_model` with `TanXS/Qwen3-4B-LoRA-ZH-WebNovelty-v0.0` in `LORA_MODELS_QWEN3`.

**Root cause:** PR #18046 added validation in `lora_manager.py` that rejects LoRA adapters with `added_tokens.json`. The test adapter `y9760210/Qwen3-4B-lora_model` contains `added_tokens.json`, causing the server to crash during adapter loading.

**Fix:** Replace with `TanXS/Qwen3-4B-LoRA-ZH-WebNovelty-v0.0`, a valid Qwen3-4B LoRA adapter (rank 16, targets all attention + MLP modules) that does not have `added_tokens.json`.