### PR TITLE
Fix GLM-4V processor registration when glm_ocr is unavailable

### DIFF
--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -3,7 +3,6 @@ from typing import List, Union
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
 from sglang.srt.models.glm4v import Glm4vForConditionalGeneration
 from sglang.srt.models.glm4v_moe import Glm4vMoeForConditionalGeneration
-from sglang.srt.models.glm_ocr import GlmOcrForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
@@ -11,12 +10,21 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 
+try:
+    from sglang.srt.models.glm_ocr import GlmOcrForConditionalGeneration
+except ImportError:
+    GlmOcrForConditionalGeneration = None
+
 
 class Glm4vImageProcessor(SGLangBaseProcessor):
     models = [
-        Glm4vForConditionalGeneration,
-        Glm4vMoeForConditionalGeneration,
-        GlmOcrForConditionalGeneration,
+        m
+        for m in [
+            Glm4vForConditionalGeneration,
+            Glm4vMoeForConditionalGeneration,
+            GlmOcrForConditionalGeneration,
+        ]
+        if m is not None
     ]
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):


### PR DESCRIPTION
## Motivation

Fix nightly test failures where GLM-4V models fail with "No processor registered for architecture" or show "Model not evaluated".

Affected tests:
- **4-GPU**: `test_encoder_dp.py` — `zai-org/GLM-4.1V-9B-Thinking` fails with exit code 1 ([failure](https://github.com/sgl-project/sglang/actions/runs/22026980777))
- **VLM accuracy 2-GPU**: `test_vlms_mmmu_eval.py` — both `zai-org/GLM-4.1V-9B-Thinking` and `zai-org/GLM-4.5V-FP8` show "Model not evaluated" ([failure](https://github.com/sgl-project/sglang/actions/runs/22026980777))

## Modifications

Make the `GlmOcrForConditionalGeneration` import conditional in `python/sglang/srt/multimodal/processors/glm4v.py`.

**Root cause:** PR #17582 added `glm_ocr.py` model support which imports from `transformers.models.glm_ocr`. When this transformers module is unavailable (e.g., CI environment), the unconditional import at the top of `glm4v.py` causes the **entire** processor module to fail to load. The `import_processors` safety net in `multimodal_processor.py` catches this but drops ALL three model registrations, not just the OCR one:
- `Glm4vForConditionalGeneration` — used by **GLM-4.1V-9B-Thinking** 
- `Glm4vMoeForConditionalGeneration` — used by **GLM-4.5V-FP8**
- `GlmOcrForConditionalGeneration` — the actual model requiring the new transformers module

**Fix:** Wrap the `GlmOcrForConditionalGeneration` import in `try/except ImportError` and filter `None` from the models list. When `glm_ocr` is unavailable, GLM-4V and GLM-4V-MOE processors still register correctly. When it is available, all three register as before.