### PR TITLE
Fix CI: add flashinfer --download-cubin to install dependencies

### DIFF
--- a/scripts/ci/cuda/ci_download_flashinfer_cubin.sh
+++ b/scripts/ci/cuda/ci_download_flashinfer_cubin.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Download flashinfer cubins if the local set is incomplete.
+#
+# The flashinfer-cubin pip package may not include cubins for newer architectures
+# (e.g. sm_100, sm_120) due to PyPI size limits. This script checks the local
+# cubin status against the flashinfer artifact repository and downloads any
+# missing files.
+set -euxo pipefail
+
+CUBIN_STATUS=$(FLASHINFER_LOGGING_LEVEL=warning python3 -c "
+from flashinfer.artifacts import get_artifacts_status
+status = get_artifacts_status()
+total = len(status)
+downloaded = sum(1 for _, exists in status if exists)
+print(f'{downloaded}/{total}')
+" 2>/dev/null) || CUBIN_STATUS="unknown"
+
+echo "Flashinfer cubin status: ${CUBIN_STATUS}"
+
+if echo "$CUBIN_STATUS" | grep -qE '^[0-9]+/[0-9]+$'; then
+    CUBIN_DOWNLOADED="${CUBIN_STATUS%/*}"
+    CUBIN_TOTAL="${CUBIN_STATUS#*/}"
+    if [ "$CUBIN_DOWNLOADED" = "$CUBIN_TOTAL" ] && [ "$CUBIN_TOTAL" != "0" ]; then
+        echo "All flashinfer cubins already present (${CUBIN_STATUS}), skipping download"
+    else
+        echo "Cubins incomplete (${CUBIN_STATUS}), downloading..."
+        FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin
+    fi
+else
+    echo "Could not determine cubin status, downloading as fallback..."
+    FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin
+fi

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -289,6 +289,11 @@ if [ "$FLASHINFER_INSTALLED" = false ]; then
     exit 1
 fi
 
+# Download precompiled CUDA binaries for the current GPU architecture
+# Without this, flashinfer.fused_moe (trtllm_fp4_block_scale_moe) may not be available
+# on architectures like B200/sm_100 where PyPI cubins are missing
+FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin
+
 # Show current packages
 $PIP_CMD list
 python3 -c "import torch; print(torch.version.cuda)"

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -289,10 +289,8 @@ if [ "$FLASHINFER_INSTALLED" = false ]; then
     exit 1
 fi
 
-# Download precompiled CUDA binaries for the current GPU architecture
-# Without this, flashinfer.fused_moe (trtllm_fp4_block_scale_moe) may not be available
-# on architectures like B200/sm_100 where PyPI cubins are missing
-FLASHINFER_LOGGING_LEVEL=warning python3 -m flashinfer --download-cubin
+# Download flashinfer cubins if the local set is incomplete
+bash "${SCRIPT_DIR}/ci_download_flashinfer_cubin.sh"
 
 # Show current packages
 $PIP_CMD list


### PR DESCRIPTION
## Summary
- Add `python3 -m flashinfer --download-cubin` step to `scripts/ci/cuda/ci_install_dependency.sh` after flashinfer-jit-cache installation
- Fixes `TypeError: 'NoneType' object is not callable` for `trtllm_fp4_block_scale_moe` on B200 CI runner
- Mirrors the existing pattern in the Dockerfile (line 220)

failure example: https://github.com/sgl-project/sglang/actions/runs/22018874131/job/63624809610?pr=14105#logs

## Root Cause
The B200 (sm_100) CI runner fails on `test_deepseek_v3_fp4_mtp_small` because `flashinfer.fused_moe.trtllm_fp4_block_scale_moe` cannot be imported. The import is silently caught and set to `None`, which later causes a `TypeError` at runtime.

The Dockerfile already runs `python3 -m flashinfer --download-cubin` to download precompiled CUDA binaries for the current GPU architecture. The CI install script was missing this step, so the cubins needed for `flashinfer.fused_moe` were not available on B200/sm_100.

## Test plan
- [ ] Verify `stage-b-test-4-gpu-b200` CI passes, specifically `test_deepseek_v3_fp4_mtp_small`