### PR TITLE
Skip flaky test_tool_choice_required_non_streaming for Mistral

### DIFF
--- a/test/registered/openai_server/function_call/test_tool_choice.py
+++ b/test/registered/openai_server/function_call/test_tool_choice.py
@@ -816,6 +816,11 @@ class TestToolChoiceMistral(TestToolChoiceLlama32):
         cls.tokenizer = get_tokenizer(cls.model)
 
     @unittest.skip("Fails due to whitespace issue with Mistral - skipping")
+    def test_tool_choice_required_non_streaming(self):
+        """Test tool_choice='required' in non-streaming mode"""
+        super().test_tool_choice_required_non_streaming()
+
+    @unittest.skip("Fails due to whitespace issue with Mistral - skipping")
     def test_multi_tool_scenario_required(self):
         """Test multi-tool scenario with tool_choice='required'"""
         super().test_multi_tool_scenario_required()


### PR DESCRIPTION
## Summary
- Skip `test_tool_choice_required_non_streaming` in `TestToolChoiceMistral` due to a known whitespace parsing issue where the Mistral model intermittently fails to produce tool calls in required non-streaming mode
- Matches the existing skip pattern for `test_multi_tool_scenario_required` and `test_complex_parameters_required_non_streaming` in the same class

Failure example: https://github.com/sgl-project/sglang/actions/runs/22021304301/job/63679261788

## Test plan
- [ ] Verify CI passes with the skipped test (no more flaky failures in `stage-b-test-small-1-gpu`)