### PR TITLE
[Feature] Add logprob support for overlap spec v2 (EAGLE)

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_a2a_backend_context,
     speculative_moe_backend_context,
 )
+from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v2
 from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -35,7 +36,6 @@ from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
 )
-from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v2
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_info_v2 import (
     assign_extend_cache_locs,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -20,6 +20,7 @@ import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
+from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v2
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -37,7 +38,6 @@ from sglang.srt.speculative.multi_layer_eagle_utils import (
     rotate_input_ids_triton,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v2
 from sglang.srt.speculative.spec_utils import (
     detect_nan,
     draft_tp_context,

--- a/test/registered/layers/test_logprob_spec_v2.py
+++ b/test/registered/layers/test_logprob_spec_v2.py
@@ -46,7 +46,13 @@ def _make_mock_batch(
     top_logprobs_nums: list = None,
     device: str = "cpu",
 ):
-    reqs = [_make_mock_req(return_logprob=True, top_logprobs_num=top_logprobs_nums[i] if top_logprobs_nums else 0) for i in range(bs)]
+    reqs = [
+        _make_mock_req(
+            return_logprob=True,
+            top_logprobs_num=top_logprobs_nums[i] if top_logprobs_nums else 0,
+        )
+        for i in range(bs)
+    ]
     temperatures = torch.ones(bs, device=device)
     sampling_info = SimpleNamespace(temperatures=temperatures)
     batch = SimpleNamespace()

--- a/test/registered/layers/test_logprob_spec_v2.py
+++ b/test/registered/layers/test_logprob_spec_v2.py
@@ -1,0 +1,163 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for add_output_logprobs_for_spec_v2 (overlap spec v2 logprob support)."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v2
+
+
+def _make_logits_output(next_token_logits):
+    """Minimal mock for LogitsProcessorOutput to avoid pulling heavy deps (e.g. sgl_kernel)."""
+    out = SimpleNamespace()
+    out.next_token_logits = next_token_logits
+    return out
+
+
+def _make_mock_req(return_logprob: bool = True, top_logprobs_num: int = 0):
+    req = SimpleNamespace()
+    req.return_logprob = return_logprob
+    req.top_logprobs_num = top_logprobs_num
+    req.output_token_logprobs_val = []
+    req.output_token_logprobs_idx = []
+    req.output_top_logprobs_val = []
+    req.output_top_logprobs_idx = []
+    return req
+
+
+def _make_mock_batch(
+    bs: int,
+    stride: int,
+    num_tokens_per_req: list,
+    top_logprobs_nums: list = None,
+    device: str = "cpu",
+):
+    reqs = [_make_mock_req(return_logprob=True, top_logprobs_num=top_logprobs_nums[i] if top_logprobs_nums else 0) for i in range(bs)]
+    temperatures = torch.ones(bs, device=device)
+    sampling_info = SimpleNamespace(temperatures=temperatures)
+    batch = SimpleNamespace()
+    batch.reqs = reqs
+    batch.top_logprobs_nums = top_logprobs_nums or [0] * bs
+    batch.sampling_info = sampling_info
+    return batch
+
+
+class TestAddOutputLogprobsForSpecV2(unittest.TestCase):
+    """Test add_output_logprobs_for_spec_v2 with mock batch and logits."""
+
+    def test_empty_accept_index_returns_early(self):
+        """When no token is accepted (all -1), function returns without modifying reqs."""
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        bs, stride, vocab = 2, 4, 8
+        batch = _make_mock_batch(bs, stride, [0, 0], device=device)
+        logits_output = _make_logits_output(
+            torch.randn(bs * stride, vocab, device=device)
+        )
+        predict = torch.zeros(bs * stride, dtype=torch.long, device=device)
+        accept_length = torch.zeros(bs, dtype=torch.int32, device=device)
+        accept_index = torch.full((bs, stride), -1, dtype=torch.int32, device=device)
+
+        add_output_logprobs_for_spec_v2(
+            batch, logits_output, predict, accept_length, accept_index, stride
+        )
+
+        for req in batch.reqs:
+            self.assertEqual(len(req.output_token_logprobs_val), 0)
+            self.assertEqual(len(req.output_token_logprobs_idx), 0)
+
+    def test_single_token_per_req_appends_correctly(self):
+        """Two reqs, each with 1 accepted token; logprobs and token ids appended."""
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        bs, stride, vocab = 2, 4, 8
+        # accept_index: req0 accepts position 0, req1 accepts position stride (4).
+        accept_index = torch.full((bs, stride), -1, dtype=torch.int32, device=device)
+        accept_index[0, 0] = 0
+        accept_index[1, 0] = stride
+        accept_length = torch.tensor([1, 1], dtype=torch.int32, device=device)
+        # Predict token ids at accepted positions: 2 and 5.
+        predict = torch.zeros(bs * stride, dtype=torch.long, device=device)
+        predict[0] = 2
+        predict[stride] = 5
+        logits = torch.randn(bs * stride, vocab, device=device)
+        logits[0, 2] = 10.0
+        logits[stride, 5] = 10.0
+        logits_output = _make_logits_output(logits)
+        batch = _make_mock_batch(bs, stride, [1, 1], device=device)
+
+        add_output_logprobs_for_spec_v2(
+            batch, logits_output, predict, accept_length, accept_index, stride
+        )
+
+        self.assertEqual(len(batch.reqs[0].output_token_logprobs_val), 1)
+        self.assertEqual(len(batch.reqs[0].output_token_logprobs_idx), 1)
+        self.assertEqual(batch.reqs[0].output_token_logprobs_idx[0], 2)
+        self.assertIsInstance(batch.reqs[0].output_token_logprobs_val[0], (float,))
+
+        self.assertEqual(len(batch.reqs[1].output_token_logprobs_val), 1)
+        self.assertEqual(len(batch.reqs[1].output_token_logprobs_idx), 1)
+        self.assertEqual(batch.reqs[1].output_token_logprobs_idx[0], 5)
+
+    def test_multiple_tokens_per_req_order(self):
+        """One req with 3 accepted tokens; order and count match accept_length."""
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        bs, stride, vocab = 1, 4, 16
+        accept_index = torch.full((bs, stride), -1, dtype=torch.int32, device=device)
+        accept_index[0, 0] = 0
+        accept_index[0, 1] = 1
+        accept_index[0, 2] = 2
+        accept_length = torch.tensor([3], dtype=torch.int32, device=device)
+        predict = torch.arange(stride, dtype=torch.long, device=device)
+        for i in range(3):
+            predict[i] = i + 1
+        logits = torch.randn(bs * stride, vocab, device=device)
+        for i in range(3):
+            logits[i, i + 1] = 5.0
+        logits_output = _make_logits_output(logits)
+        batch = _make_mock_batch(bs, stride, [3], device=device)
+
+        add_output_logprobs_for_spec_v2(
+            batch, logits_output, predict, accept_length, accept_index, stride
+        )
+
+        self.assertEqual(len(batch.reqs[0].output_token_logprobs_val), 3)
+        self.assertEqual(batch.reqs[0].output_token_logprobs_idx, [1, 2, 3])
+
+    def test_top_logprobs_nums_none_uses_zeros(self):
+        """batch.top_logprobs_nums is None => treated as [0]*bs, no top append."""
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        bs, stride, vocab = 2, 2, 4
+        accept_index = torch.full((2, 2), -1, dtype=torch.int32, device=device)
+        accept_index[0, 0], accept_index[0, 1] = 0, 1
+        accept_length = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        predict = torch.tensor([1, 2, 0, 0], dtype=torch.long, device=device)
+        logits = torch.randn(4, vocab, device=device)
+        logits[0, 1] = 1.0
+        logits[1, 2] = 1.0
+        batch = _make_mock_batch(2, stride, [2, 0], device=device)
+        batch.top_logprobs_nums = None
+        logits_output = _make_logits_output(logits)
+
+        add_output_logprobs_for_spec_v2(
+            batch, logits_output, predict, accept_length, accept_index, stride
+        )
+
+        self.assertEqual(len(batch.reqs[0].output_token_logprobs_val), 2)
+        self.assertEqual(len(batch.reqs[0].output_top_logprobs_val), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

[Feature] Overlap Spec Support #11762

## Motivation

This PR adds **logprob support for overlap spec v2 (EAGLE)**. When `return_logprob=True`, the server should return `output_token_logprobs` (and optionally `output_top_logprobs`) for each generated token. Previously this path did not populate logprobs on the verify branch; this change fills them from the verify-step logits so that clients get correct per-token logprobs when using speculative decoding with spec v2.

## Modifications

- **logprob.py**  
  Add `add_output_logprobs_for_spec_v2(batch, logits_output, predict, accept_length, accept_index, stride)`, which takes the full verify logits, selects positions according to `accept_index`, applies temperature and log_softmax, and writes results into `req.output_token_logprobs_val/idx` and (when requested) top_logprobs. Handles `batch.top_logprobs_nums is None`.

- **multi_layer_eagle_worker_v2.py**  
  In the verify path, after `verify_input.sample()` and when `batch.return_logprob` and not idle, call `add_output_logprobs_for_spec_v2(...)` so that accepted tokens get logprobs before building `next_draft_input`.

- **eagle_worker_v2.py**  
  Same as above for the single-layer EAGLE v2 verify path.

- **test_logprob_spec_v2.py** (new)  
  Unit tests for `add_output_logprobs_for_spec_v2`: empty accept_index early return, single/multiple tokens per request, ordering, and `top_logprobs_nums is None` (uses zeros).

- **test_eagle_infer_beta.py**  
  Integration tests: `test_logprob_spec_v2` (return_logprob, check `output_token_logprobs` length and shape) and `test_logprob_spec_v2_top_logprobs` (with `top_logprobs_num`).

## Accuracy Tests

N/A — no changes to kernel or model forward; only logprob wiring and tests.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
