### PR TITLE
[Diffusion][Kernel] dual_norm_fusion

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_fused_norm_scale_shift.py
+++ b/python/sglang/jit_kernel/benchmark/bench_fused_norm_scale_shift.py
@@ -66,8 +66,8 @@ def bench_fused_norm_scale_shift(
     B: int, S: int, D: int, norm_type, affine: bool, provider: str
 ) -> Tuple[float, float, float]:
     x = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
-    scale = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
-    shift = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
+    scale = torch.randn(B, 1, D, dtype=DTYPE, device=DEVICE)
+    shift = torch.randn(B, 1, D, dtype=DTYPE, device=DEVICE)
     if norm_type == "layer":
         layer = LayerNormScaleShift(D, EPS, affine, dtype=DTYPE)
     else:
@@ -104,8 +104,8 @@ def bench_fused_scale_residual_norm_scale_shift(
 ) -> Tuple[float, float, float]:
     residual = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
     x = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
-    scale = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
-    shift = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
+    scale = torch.randn(B, 1, D, dtype=DTYPE, device=DEVICE)
+    shift = torch.randn(B, 1, D, dtype=DTYPE, device=DEVICE)
     gate = torch.randn(B, 1, D, dtype=DTYPE, device=DEVICE)
     if norm_type == "layer":
         layer = ScaleResidualLayerNormScaleShift(D, EPS, affine, dtype=DTYPE).to(DEVICE)

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -47,6 +47,10 @@ from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
+from sglang.jit_kernel.diffusion.cutedsl.scale_residual_norm_scale_shift import (
+    fused_dual_scale_residual_norm_scale_shift
+)
+
 logger = init_logger(__name__)  # pylint: disable=invalid-name
 
 
@@ -366,6 +370,11 @@ class FluxTransformerBlock(nn.Module):
             attn_output, context_attn_output, ip_attn_output = attention_outputs
 
         # Process attention outputs for the `hidden_states`.
+        # norm_hidden_states, hidden_states, norm_encoder_hidden_states, encoder_hidden_states= fused_dual_scale_residual_norm_scale_shift(
+        #     hidden_states, attn_output, gate_msa.unsqueeze(1), None, None, scale_mlp[:, None], shift_mlp[:, None],
+        #     encoder_hidden_states, context_attn_output, c_gate_msa.unsqueeze(1), None, None, c_scale_mlp[:, None], c_shift_mlp[:, None],
+        #     "layer", 1e-6,
+        # )
         attn_output = gate_msa.unsqueeze(1) * attn_output
         hidden_states = hidden_states + attn_output
         norm_hidden_states = self.norm2(hidden_states)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## [WIP]

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR fuses the image and text norm–scale–shift kernels in Flux into a single kernel. Since the text branch typically has a smaller shape and cannot fully utilize memory bandwidth on its own, merging the two improves bandwidth utilization.

```
y1, res_out1 = norm(gate_1 * x + res_1) * (1 + scale_1) + shift_1 # image_path: [4096, 3072]
y2, res_out2 = norm(gate_2 * x + res_2) * (1 + scale_2) + shift_2 # txt_path: [512, 3072]
```

nsys profiling shows the fused kernel is **~5** µs faster than the torch.compile auto-fused version. Given that one layer takes **~2200** µs, this corresponds to about **0.2%** speedup. Submitting as a draft for now.

After fusion: single kernel, 29us
<img width="932" height="342" alt="image" src="https://github.com/user-attachments/assets/f0c324ca-170b-4d8f-ad1b-f88d437d7437" />

triton kernel generated by torch.compile: two kernels, 34us
<img width="808" height="264" alt="image" src="https://github.com/user-attachments/assets/fd37471e-611b-4afa-9271-95280d3ea24d" />

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
