### PR TITLE
[HiCache] feat: L3 prefetch prometheus metrics

### DIFF
--- a/docs/references/production_metrics.md
+++ b/docs/references/production_metrics.md
@@ -125,6 +125,22 @@ sglang:gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct"} 86.50814177
 sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 2826.0
 ```
 
+## HiCache Storage Metrics
+
+These metrics are emitted when HiCache storage is enabled and metrics are turned on:
+
+- `sglang:prefetch_requests_total`: Number of prefetch requests by status (`ok`, `failed`, `timeout`).
+- `sglang:prefetch_request_latency_seconds`: End-to-end prefetch latency per request (seconds).
+- `sglang:prefetch_page_latency_seconds`: End-to-end per-page prefetch latency (request latency divided by delivered pages).
+- `sglang:prefetch_page_io_latency_seconds`: L3 -> L2 prefetch I/O latency per page (transport/service time).
+- `sglang:prefetch_queue_wait_seconds`: Time spent waiting in the prefetch I/O queue before I/O starts.
+- `sglang:prefetch_io_queue_size`: Current size of the prefetch I/O queue.
+- `sglang:prefetch_inflight`: Number of in-flight prefetch I/O operations.
+- `sglang:prefetch_pages_per_request`: Pages delivered per prefetch request.
+- `sglang:prefetched_tokens_total`: Number of prefetched prompt tokens.
+- `sglang:prefetch_pgs`: Histogram of prefetch batch sizes (pages).
+- `sglang:prefetch_bandwidth`: Histogram of prefetch bandwidth in GB/s.
+
 ## Setup Guide
 
 This section describes how to set up the monitoring stack (Prometheus + Grafana) provided in the `examples/monitoring` directory.

--- a/python/sglang/run_bench.sh
+++ b/python/sglang/run_bench.sh
@@ -1,0 +1,11 @@
+python3 bench_serving.py \
+    --backend vllm-chat \
+    --model deepseek-ai/DeepSeek-V3.2 \
+    --base-url https://dsv32.ml-models.cloud.yandex.net:443 \
+    --dataset-name random \
+    --seed 1 \
+    --random-input-len 2560 \
+    --random-output-len 1024 \
+    --random-range-ratio 1.0 \
+    --request-rate 40 \
+    --num-prompts 10000

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1157,7 +1157,7 @@ class HiRadixCache(RadixCache):
                 )
             if timeout_terminated:
                 status = "timeout"
-            elif min_completed_tokens == expected_tokens and expected_tokens > 0:
+            elif min_completed_tokens == expected_tokens:
                 status = "ok"
             else:
                 status = "failed"

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -473,6 +473,8 @@ class HiRadixCache(RadixCache):
                     cc.prefetch_tokens_occupied -= len(token_ids)
                     if cc.prefetch_tokens_occupied < 0:
                         cc.prefetch_tokens_occupied = 0
+                    if log_metrics and self.enable_storage_metrics:
+                        self.storage_metrics_collector.log_prefetch_request("failed")
 
         def _drain_backup():
             for operation in _drain_queue(cc.ack_backup_queue, n_backup):
@@ -963,6 +965,12 @@ class HiRadixCache(RadixCache):
         if self.enable_storage:
             self.drain_storage_control_queues()
         if self.enable_storage_metrics:
+            self.storage_metrics_collector.set_prefetch_io_queue_size(
+                self.cache_controller.get_prefetch_io_queue_size()
+            )
+            self.storage_metrics_collector.set_prefetch_inflight(
+                self.cache_controller.get_prefetch_inflight()
+            )
             self.storage_metrics_collector.log_storage_metrics(
                 self.cache_controller.storage_backend.get_stats()
             )
@@ -1043,6 +1051,18 @@ class HiRadixCache(RadixCache):
         can_terminate = can_terminate or operation_terminated
         return can_terminate
 
+    def _is_prefetch_timeout_distributed(self, operation: PrefetchOperation) -> bool:
+        timed_out = self.is_prefetch_timeout(operation)
+        if self.tp_world_size > 1:
+            timeout_tensor = torch.tensor(int(timed_out), dtype=torch.int)
+            torch.distributed.all_reduce(
+                timeout_tensor,
+                op=torch.distributed.ReduceOp.MAX,
+                group=self.tp_group,
+            )
+            timed_out = timeout_tensor.item() == 1
+        return timed_out
+
     def check_prefetch_progress(self, req_id: str) -> bool:
         if req_id not in self.ongoing_prefetch:
             # there is no ongoing prefetch for this request or it has been revoked
@@ -1060,6 +1080,16 @@ class HiRadixCache(RadixCache):
 
         if not self.can_terminate_prefetch(operation):
             return False
+
+        expected_tokens = len(operation.hash_value) * self.page_size
+        completed = (
+            expected_tokens > 0 and operation.completed_tokens == expected_tokens
+        )
+        timeout_terminated = (
+            self.prefetch_stop_policy == "timeout"
+            and not completed
+            and self._is_prefetch_timeout_distributed(operation)
+        )
 
         completed_tokens, hash_value = self.cache_controller.terminate_prefetch(
             operation
@@ -1103,6 +1133,35 @@ class HiRadixCache(RadixCache):
 
         if self.enable_storage_metrics:
             self.storage_metrics_collector.log_prefetched_tokens(loaded_from_storage)
+            for page_latency_seconds, count in operation.get_page_latency_samples():
+                self.storage_metrics_collector.log_prefetch_page_io_latency(
+                    page_latency_seconds, count
+                )
+            delivered_pages = min_completed_tokens // self.page_size
+            e2e_request_latency_seconds = time.monotonic() - operation.start_time
+            self.storage_metrics_collector.log_prefetch_request_latency(
+                e2e_request_latency_seconds
+            )
+            self.storage_metrics_collector.log_prefetch_pages_per_request(
+                delivered_pages
+            )
+            if delivered_pages > 0:
+                e2e_page_latency_seconds = e2e_request_latency_seconds / delivered_pages
+                self.storage_metrics_collector.log_prefetch_page_latency(
+                    e2e_page_latency_seconds, delivered_pages
+                )
+            queue_wait_seconds = operation.get_prefetch_queue_wait_seconds()
+            if queue_wait_seconds is not None:
+                self.storage_metrics_collector.log_prefetch_queue_wait_seconds(
+                    queue_wait_seconds
+                )
+            if timeout_terminated:
+                status = "timeout"
+            elif min_completed_tokens == expected_tokens and expected_tokens > 0:
+                status = "ok"
+            else:
+                status = "failed"
+            self.storage_metrics_collector.log_prefetch_request(status)
 
         return True
 
@@ -1392,3 +1451,5 @@ class HiRadixCache(RadixCache):
         del self.ongoing_prefetch[rid]
         self.cache_controller.append_host_mem_release(host_indices[:completed_tokens])
         self.cache_controller.prefetch_tokens_occupied -= len(token_ids)
+        if self.enable_storage_metrics:
+            self.storage_metrics_collector.log_prefetch_request("failed")

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -1405,7 +1405,7 @@ class StorageMetricsCollector:
         self,
         labels: Dict[str, str],
     ):
-        from prometheus_client import Counter, Histogram
+        from prometheus_client import Counter, Gauge, Histogram
 
         self.labels = labels
 
@@ -1419,6 +1419,26 @@ class StorageMetricsCollector:
             name="sglang:backuped_tokens_total",
             documentation="Number of backuped tokens.",
             labelnames=labels.keys(),
+        )
+
+        self.prefetch_requests_total = Counter(
+            name="sglang:prefetch_requests_total",
+            documentation="Number of prefetch requests by status.",
+            labelnames=list(labels.keys()) + ["status"],
+        )
+
+        self.prefetch_io_queue_size = Gauge(
+            name="sglang:prefetch_io_queue_size",
+            documentation="Current size of prefetch I/O queue.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.prefetch_inflight = Gauge(
+            name="sglang:prefetch_inflight",
+            documentation="Number of in-flight prefetch I/O operations.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
         )
 
         bucket_io = [
@@ -1437,6 +1457,21 @@ class StorageMetricsCollector:
             10,
             50,
             100,
+        ]
+
+        bucket_prefetch_request_latency = [
+            0.01,
+            0.02,
+            0.05,
+            0.1,
+            0.2,
+            0.5,
+            1,
+            2,
+            5,
+            10,
+            20,
+            30,
         ]
 
         self.histogram_prefetch_pgs = Histogram(
@@ -1467,6 +1502,56 @@ class StorageMetricsCollector:
             buckets=bucket_bandwidth,
         )
 
+        self.histogram_prefetch_request_latency = Histogram(
+            name="sglang:prefetch_request_latency_seconds",
+            documentation="Histogram of end-to-end prefetch request latency in seconds.",
+            labelnames=labels.keys(),
+            buckets=bucket_prefetch_request_latency,
+        )
+
+        self.histogram_prefetch_pages_per_request = Histogram(
+            name="sglang:prefetch_pages_per_request",
+            documentation="Histogram of pages delivered per prefetch request.",
+            labelnames=labels.keys(),
+            buckets=bucket_io,
+        )
+
+        self.histogram_prefetch_queue_wait_seconds = Histogram(
+            name="sglang:prefetch_queue_wait_seconds",
+            documentation="Histogram of prefetch queue wait time in seconds.",
+            labelnames=labels.keys(),
+            buckets=bucket_prefetch_request_latency,
+        )
+
+        # Covers expected range from a few milliseconds to a few seconds.
+        bucket_prefetch_page_latency = [
+            0.002,
+            0.005,
+            0.01,
+            0.02,
+            0.05,
+            0.1,
+            0.2,
+            0.5,
+            1,
+            2,
+            3,
+            5,
+        ]
+        self.histogram_prefetch_page_io_latency = Histogram(
+            name="sglang:prefetch_page_io_latency_seconds",
+            documentation="Histogram of L3->L2 prefetch page I/O latency in seconds.",
+            labelnames=labels.keys(),
+            buckets=bucket_prefetch_page_latency,
+        )
+
+        self.histogram_prefetch_page_latency = Histogram(
+            name="sglang:prefetch_page_latency_seconds",
+            documentation="Histogram of end-to-end L3->L2 prefetch page latency in seconds.",
+            labelnames=labels.keys(),
+            buckets=bucket_prefetch_page_latency,
+        )
+
     def log_prefetched_tokens(self, prefetched_tokens: int):
         if prefetched_tokens > 0:
             self.prefetched_tokens_total.labels(**self.labels).inc(prefetched_tokens)
@@ -1474,6 +1559,48 @@ class StorageMetricsCollector:
     def log_backuped_tokens(self, backuped_tokens: int):
         if backuped_tokens > 0:
             self.backuped_tokens_total.labels(**self.labels).inc(backuped_tokens)
+
+    def log_prefetch_request(self, status: str):
+        self.prefetch_requests_total.labels(**self.labels, status=status).inc(1)
+
+    def set_prefetch_io_queue_size(self, queue_size: int):
+        self.prefetch_io_queue_size.labels(**self.labels).set(queue_size)
+
+    def set_prefetch_inflight(self, inflight: int):
+        self.prefetch_inflight.labels(**self.labels).set(max(0, inflight))
+
+    def log_prefetch_request_latency(self, latency_seconds: float):
+        if latency_seconds < 0:
+            return
+        self.histogram_prefetch_request_latency.labels(**self.labels).observe(
+            latency_seconds
+        )
+
+    def log_prefetch_pages_per_request(self, pages: int):
+        if pages <= 0:
+            return
+        self.histogram_prefetch_pages_per_request.labels(**self.labels).observe(pages)
+
+    def log_prefetch_queue_wait_seconds(self, wait_seconds: float):
+        if wait_seconds < 0:
+            return
+        self.histogram_prefetch_queue_wait_seconds.labels(**self.labels).observe(
+            wait_seconds
+        )
+
+    def log_prefetch_page_io_latency(self, page_latency_seconds: float, count: int = 1):
+        if count <= 0:
+            return
+        histogram = self.histogram_prefetch_page_io_latency.labels(**self.labels)
+        for _ in range(count):
+            histogram.observe(page_latency_seconds)
+
+    def log_prefetch_page_latency(self, page_latency_seconds: float, count: int = 1):
+        if count <= 0:
+            return
+        histogram = self.histogram_prefetch_page_latency.labels(**self.labels)
+        for _ in range(count):
+            histogram.observe(page_latency_seconds)
 
     def _log_histogram(self, histogram, data: Union[int, float]):
         histogram.labels(**self.labels).observe(data)


### PR DESCRIPTION
## Motivation

 Add production observability for HiCache L3 prefetch behavior so we can track reliability and latency end-to-end, including queue pressure and timeout/failure modes.

## Modifications

- Added new HiCache prefetch Prometheus metrics in `python/sglang/srt/metrics/collector.py`
- Extended prefetch operation lifecycle tracking in `python/sglang/srt/managers/cache_controller.py`
- Wired metric emission into HiRadix flow in `python/sglang/srt/mem_cache/hiradix_cache.py`
- Updated metric docs in `docs/references/production_metrics.md`

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A