### PR TITLE
[jit kernel] Support per_token_group_quant_8bit jit kernel

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/benchmark/bench_per_token_group_quant_8bit.py
@@ -1,0 +1,317 @@
+import itertools
+import os
+
+import torch
+import triton
+from sgl_kernel.test_utils import create_per_token_group_quant_test_data
+
+from sglang.jit_kernel.per_token_group_quant_8bit import (
+    per_token_group_quant_8bit as sglang_per_token_group_quant_8bit,
+)
+from sglang.srt.layers.quantization.fp8_kernel import (
+    create_per_token_group_quant_fp8_output_scale,
+)
+from sglang.srt.layers.quantization.fp8_kernel import (
+    per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
+)
+from sglang.srt.utils import is_hip
+from sglang.srt.utils.bench_utils import bench_kineto
+
+# CI environment detection
+IS_CI = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+_is_hip = is_hip()
+fp8_type_ = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn
+
+
+mode_concentrated = IS_CI or (os.environ.get("SGLANG_BENCH_MODE", "") == "concentrated")
+
+if int(os.environ.get("SGLANG_NSYS_PROFILING", "0")):
+    configs = [
+        [
+            768 * 8,
+            2048,
+            128,
+            48,
+            fp8_type_,
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+                fuse_silu_and_mul=True,
+                # masked_layout_mode=None,
+                masked_layout_mode="balanced",
+                # masked_layout_mode="extreme",
+            ),
+        ]
+    ]
+elif mode_concentrated:
+    configs = list(
+        itertools.product(
+            [768],
+            [1536, 7168, 16384],
+            [128],
+            [None],
+            [fp8_type_],
+            [
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=False,
+                    masked_layout_mode=None,
+                ),
+            ],
+        )
+    ) + list(
+        itertools.product(
+            [768 * 8],
+            [2048],
+            [128],
+            [48],
+            [fp8_type_],
+            [
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode=None,
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode="balanced",
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode="imbalanced",
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode="extreme",
+                ),
+            ],
+        )
+    )
+else:
+    configs = list(
+        itertools.product(
+            [1, 4, 16, 64, 256, 768, 2048, 8192, 16384],
+            [1536, 7168, 16384],
+            [128],
+            [None],
+            [fp8_type_],
+            [
+                dict(
+                    column_major_scales=False,
+                    scale_tma_aligned=False,
+                    scale_ue8m0=False,
+                    fuse_silu_and_mul=False,
+                    masked_layout_mode=None,
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=False,
+                    scale_ue8m0=False,
+                    fuse_silu_and_mul=False,
+                    masked_layout_mode=None,
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=False,
+                    fuse_silu_and_mul=False,
+                    masked_layout_mode=None,
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=False,
+                    masked_layout_mode=None,
+                ),
+            ],
+        )
+    ) + list(
+        itertools.product(
+            [1 * 8, 4 * 8, 64 * 8, 256 * 8, 768 * 8],
+            [2048],
+            [128],
+            [8, 16, 32, 48],
+            [fp8_type_],
+            [
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode=None,
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode="balanced",
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode="imbalanced",
+                ),
+                dict(
+                    column_major_scales=True,
+                    scale_tma_aligned=True,
+                    scale_ue8m0=True,
+                    fuse_silu_and_mul=True,
+                    masked_layout_mode="extreme",
+                ),
+            ],
+        )
+    )
+
+
+def _flatten_to_2d(t: torch.Tensor) -> torch.Tensor:
+    """Reshape a tensor with 3+ dims to 2D by merging all leading dims."""
+    if t.ndim <= 2:
+        return t
+    return t.reshape(-1, t.shape[-1])
+
+
+def _make_sglang_bench_fn(
+    x: torch.Tensor,
+    group_size: int,
+    dst_dtype: torch.dtype,
+    flags: dict,
+):
+    """
+    Adapter that pre-allocates output tensors and returns a zero-arg callable
+    matching the JIT kernel's signature.
+
+    The JIT kernel does not support fuse_silu_and_mul, so when enabled we
+    pre-compute silu+mul on the input. bench_kineto only times the kernel
+    matching the given name, so the pre-processing is not included.
+
+    The JIT kernel expects 2D tensors, so any higher-dimensional inputs
+    (e.g. from masked_layout_mode) are flattened to 2D.
+    """
+    fuse_silu_and_mul = flags.get("fuse_silu_and_mul", False)
+    column_major_scales = flags.get("column_major_scales", False)
+    scale_tma_aligned = flags.get("scale_tma_aligned", False)
+    scale_ue8m0 = flags.get("scale_ue8m0", False)
+
+    # JIT kernel does not support fuse_silu_and_mul; pre-compute it
+    if fuse_silu_and_mul:
+        half = x.shape[-1] // 2
+        x_input = torch.nn.functional.silu(x[..., :half]) * x[..., half:]
+    else:
+        x_input = x
+
+    # JIT kernel expects 2D (num_tokens, hidden_dim); flatten if needed
+    x_input = _flatten_to_2d(x_input.contiguous())
+
+    out_shape = x_input.shape
+    output_q = torch.empty(out_shape, device=x.device, dtype=dst_dtype)
+
+    fp8_max = torch.finfo(dst_dtype).max
+    fp8_min = -fp8_max
+
+    output_s = create_per_token_group_quant_fp8_output_scale(
+        x_shape=out_shape,
+        device=x.device,
+        group_size=group_size,
+        column_major_scales=column_major_scales,
+        scale_tma_aligned=scale_tma_aligned,
+        scale_ue8m0=scale_ue8m0,
+    )
+
+    def _run():
+        sglang_per_token_group_quant_8bit(
+            input=x_input,
+            output_q=output_q,
+            output_s=output_s,
+            group_size=group_size,
+            eps=1e-10,
+            fp8_min=fp8_min,
+            fp8_max=fp8_max,
+            scale_ue8m0=scale_ue8m0,
+        )
+
+    return _run
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=[
+            "num_tokens",
+            "hidden_dim",
+            "group_size",
+            "num_ranks",
+            "dst_dtype",
+            "flags",
+        ],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["triton", "sglang"],
+        # Triton has multi kernels and we only report the time for the core one
+        line_names=["Triton (Inaccurate)", "SGL Kernel"],
+        styles=[("blue", "-"), ("green", "-")],
+        ylabel="us",
+        plot_name="per-token-group-quant-8bit-performance",
+        args={},
+    )
+)
+def benchmark(
+    num_tokens, hidden_dim, group_size, num_ranks, dst_dtype, flags, provider
+):
+    print(
+        f"Testing: {num_tokens=} {hidden_dim=} {group_size=} {num_ranks=} {dst_dtype=} {flags=} {provider=}"
+    )
+
+    x, masked_m = create_per_token_group_quant_test_data(
+        num_tokens=num_tokens, hidden_dim=hidden_dim, num_ranks=num_ranks, flags=flags
+    )
+
+    if provider == "triton":
+        fn = triton_per_token_group_quant_8bit
+        kernel_names = "_per_token_group_quant_8bit|_silu_and_mul_post_quant_kernel"
+        bench_fn = lambda: fn(
+            x=x,
+            masked_m=masked_m,
+            group_size=group_size,
+            dst_dtype=dst_dtype,
+            **{k: v for k, v in flags.items() if k not in ["masked_layout_mode"]},
+        )
+    elif provider == "sglang":
+        kernel_names = "per_token_group_quant_8bit_kernel"
+        bench_fn = _make_sglang_bench_fn(
+            x=x,
+            group_size=group_size,
+            dst_dtype=dst_dtype,
+            flags=flags,
+        )
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    time_s = bench_kineto(
+        bench_fn, kernel_names=kernel_names, num_tests=300 if mode_concentrated else 30
+    )
+    return time_s * 1e6
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_group_quant_8bit.cuh
@@ -1,0 +1,203 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/atomic.cuh>
+#include <sgl_kernel/cta.cuh>
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/tile.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+constexpr int kThreadsPerGroup = 16;
+
+__device__ __forceinline__ float GroupReduceMax(float val, const int tid) {
+  unsigned mask = threadIdx.x % 32 >= 16 ? 0xffff0000 : 0x0000ffff;
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 8));
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 4));
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 2));
+  val = fmaxf(val, __shfl_xor_sync(mask, val, 1));
+  return val;
+}
+
+template <bool kScaleUE8M0>
+using scale_packed_t = std::conditional_t<kScaleUE8M0, uint32_t, float>;
+
+template <bool kScaleUE8M0>
+using scale_element_t = std::conditional_t<kScaleUE8M0, uint8_t, float>;
+
+template <typename T, typename DST_DTYPE, bool kIsColumnMajor, bool kScaleUE8M0>
+__global__ void per_token_group_quant_8bit_kernel(
+    const T* __restrict__ input,
+    DST_DTYPE* __restrict__ output_q,
+    scale_packed_t<kScaleUE8M0>* __restrict__ output_s,
+    const int group_size,
+    const int num_groups,
+    const int groups_per_block,
+    const float eps,
+    const float min_8bit,
+    const float max_8bit,
+    const int num_groups_per_row = 0,
+    const int scale_stride = 0) {
+  using namespace device;
+  namespace math = device::math;
+
+  (void)num_groups;
+
+  const int local_group_id = static_cast<int>(threadIdx.x / kThreadsPerGroup);
+  const int lane_id = threadIdx.x % kThreadsPerGroup;
+
+  const int64_t block_group_id = blockIdx.x * groups_per_block;
+  const int64_t global_group_id = block_group_id + local_group_id;
+  const int64_t block_group_offset = global_group_id * group_size;
+
+  float local_absmax = eps;
+
+  using scale_element_t = std::conditional_t<kScaleUE8M0, uint8_t, float>;
+  static_assert(sizeof(scale_packed_t) % sizeof(scale_element_t) == 0);
+
+  const T* group_input = input + block_group_offset;
+  DST_DTYPE* group_output = static_cast<DST_DTYPE*>(output_q) + block_group_offset;
+  scale_element_t* scale_output = nullptr;
+
+  if constexpr (kIsColumnMajor) {
+    constexpr kElemsPerPack = static_cast<int>(sizeof(scale_packed_t) / sizeof(scale_element_t));
+    const int row_idx = global_group_id / num_groups_per_row;
+    const int col_idx_unpacked = global_group_id % num_groups_per_row;
+    const int col_idx = col_idx_unpacked / kElemsPerPack;
+    const int pack_idx = col_idx_unpacked % kElemsPerPack;
+    scale_output = reinterpret_cast<scale_element_t*>(output_s) +
+                   (col_idx * scale_stride * kElemsPerPack + row_idx * kElemsPerPack + pack_idx);
+  } else {
+    static_assert(!kScaleUE8M0);
+    scale_output = output_s + global_group_id;
+  }
+
+  constexpr uint32_t kVecSize = 16 / sizeof(T);
+  using vec_t = AlignedVector<T, kVecSize>;
+  const auto gmem_in = tile::Memory<vec_t>::thread();
+
+  const int32_t num_vec_elems = group_size / kVecSize;
+
+  for (int32_t i = lane_id; i < num_vec_elems; i += kThreadsPerGroup) {
+    const vec_t input_vec = gmem_in.load(group_input, i);
+
+#pragma unroll
+    for (uint32_t j = 0; j < kVecSize; ++j) {
+      const float val = static_cast<float>(input_vec[j]);
+      local_absmax = math::max(local_absmax, math::abs(val));
+    }
+  }
+
+  local_absmax = GroupReduceMax(local_absmax, lane_id);
+
+  float y_s = local_absmax / max_8bit;
+  if constexpr (kScaleUE8M0) {
+    y_s = exp2f(ceilf(log2f(math::max(y_s, 1e-10f))));
+  }
+
+  scale_element_t y_s_quant;
+  if constexpr (kScaleUE8M0) {
+    y_s_quant = static_cast<uint8_t>(((int)log2f(y_s)) + 127);
+  } else {
+    y_s_quant = y_s;
+  }
+
+  if (lane_id == 0) {
+    *scale_output = y_s_quant;
+  }
+
+  for (int32_t i = lane_id; i < num_vec_elems; i += kThreadsPerGroup) {
+    const vec_t input_vec = gmem_in.load(group_input, i);
+
+#pragma unroll
+    for (uint32_t j = 0; j < kVecSize; ++j) {
+      const float val = static_cast<float>(input_vec[j]);
+      const float q_val = math::min(math::max(val / y_s, min_8bit), max_8bit);
+      group_output[i * kVecSize + j] = DST_DTYPE(q_val);
+    }
+  }
+}
+
+void per_token_group_quant_8bit(
+    tvm::ffi::TensorView input,
+    tvm::ffi::TensorView output_q,
+    tvm::ffi::TensorView output_s,
+    int64_t group_size,
+    double eps,
+    double min_8bit,
+    double max_8bit,
+    bool scale_ue8m0) {
+  using namespace host;
+
+  const int64_t num_elements = 1;
+  // Compute total number of elements from the input tensor
+  int64_t total_elements = 1;
+  for (int i = 0; i < input.ndim(); ++i) {
+    total_elements *= input.shape()[i];
+  }
+
+  const int num_groups = total_elements / group_size;
+  const int groups_per_block = compute_groups_per_block(num_groups);
+  const int num_blocks = num_groups / groups_per_block;
+  const int num_threads = groups_per_block * kThreadsPerGroup;
+  const bool is_column_major = output_s.stride(0) < output_s.stride(1);
+  const int num_groups_per_row = hidden_dim / group_size;
+  const int scale_stride = output_s.stride(1);
+
+  auto device = input.device();
+
+  using scale_packed_t = std::conditional_t<kScaleUE8M0, uint32_t, float>;
+
+  if (is_column_major) {
+    if (scale_ue8m0) {
+      LaunchKernel(num_blocks, num_threads, device.unwrap())(
+          per_token_group_quant_8bit_kernel<DType, OutType, true, true>,
+          static_cast<const DType*>(input.data_ptr()),
+          static_cast<OutType*>(output_q.data_ptr()),
+          static_cast<uint32_t*>(output_s.data_ptr()),
+          static_cast<int>(group_size),
+          static_cast<int>(num_groups),
+          static_cast<int>(groups_per_block),
+          eps,
+          min_8bit,
+          max_8bit,
+          static_cast<int>(num_groups_per_row),
+          scale_stride);
+    } else {
+      LaunchKernel(num_blocks, num_threads, device.unwrap())(
+          per_token_group_quant_8bit_kernel<DType, OutType, true, false>,
+          static_cast<const DType*>(input.data_ptr()),
+          static_cast<OutType*>(output_q.data_ptr()),
+          static_cast<float*>(output_s.data_ptr()),
+          static_cast<int>(group_size),
+          static_cast<int>(num_groups),
+          static_cast<int>(groups_per_block),
+          eps,
+          min_8bit,
+          max_8bit,
+          static_cast<int>(num_groups_per_row),
+          scale_stride);
+    }
+  } else {
+    LaunchKernel(num_blocks, num_threads, device.unwrap())(
+        per_token_group_quant_8bit_kernel<DType, OutType, false, false>,
+        static_cast<const DType*>(input.data_ptr()),
+        static_cast<OutType*>(output_q.data_ptr()),
+        static_cast<float*>(output_s.data_ptr()),
+        static_cast<int>(group_size),
+        static_cast<int>(num_groups),
+        static_cast<int>(groups_per_block),
+        eps,
+        min_8bit,
+        max_8bit,
+        0,
+        0);
+  }
+}
+}  // namespace

--- a/python/sglang/jit_kernel/per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/per_token_group_quant_8bit.py
@@ -9,10 +9,7 @@ from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
-_OUTPUT_DTYPE_MAP = {
-    torch.float8_e4m3fn: "fp8_e4m3_t",
-    torch.int8: "int8_t",
-}
+from sglang.jit_kernel.utils import CPP_DTYPE_MAP as OUTPUT_DTYPE_MAP
 
 
 @cache_once
@@ -20,7 +17,7 @@ def _jit_per_token_group_quant_8bit_module(
     dtype: torch.dtype, output_type: torch.dtype
 ) -> Module:
     input_args = make_cpp_args(dtype)
-    out_cpp = _OUTPUT_DTYPE_MAP[output_type]
+    out_cpp = OUTPUT_DTYPE_MAP[output_type]
     return load_jit(
         "per_token_group_quant_8bit",
         cuda_files=["gemm/per_token_group_quant_8bit.cuh"],

--- a/python/sglang/jit_kernel/per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/per_token_group_quant_8bit.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_per_token_group_quant_8bit_module() -> Module:
+    return load_jit(
+        "per_tensor_quant_fp8",
+        cuda_files=["gemm/per_token_group_quant_8bit.cuh"],
+        cuda_wrappers=[("per_token_group_quant_8bit", f"per_token_group_quant_8bit")],
+    )
+
+
+def per_token_group_quant_8bit(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    fp8_min: float,
+    fp8_max: float,
+    scale_ue8m0: bool = False,
+) -> None:
+    """
+    Per-tensor quantization to FP8 format.
+
+    Args:
+        input: Input tensor to quantize (float, half, or bfloat16)
+        output_q: Output quantized tensor (fp8_e4m3)
+        output_s: Output scale tensor (float scalar or 1D tensor with 1 element)
+    """
+    module = _jit_per_token_group_quant_8bit_module()
+    module.per_token_group_quant_8bit(
+        input.view(-1),
+        output_q.view(-1),
+        output_s.view(-1),
+        group_size,
+        eps,
+        fp8_min,
+        fp8_max,
+        scale_ue8m0,
+    )

--- a/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
@@ -113,10 +113,6 @@ def test_per_token_group_quant_with_column_major(
     dst_dtype,
     flags,
 ):
-    print(
-        f"{num_tokens=} {hidden_dim=} {group_size=} {num_ranks=} {dst_dtype=} {flags=}"
-    )
-
     arch_major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
     if flags["scale_ue8m0"] and (arch_major <= 9):
         pytest.skip("Only Blackwell need ue8m0 fusion")

--- a/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
@@ -29,7 +29,7 @@ configs = list(
         [128, 256, 384, 512, 1024, 1536, 1664, 2048, 4096, 7168, 16384],  # hidden_dim
         [16, 32, 64, 128],  # group_size
         [None],  # num_ranks
-        [fp8_type_, torch.int8],  # dtype
+        [fp8_type_],  # dtype
         [
             dict(
                 column_major_scales=False,
@@ -64,7 +64,6 @@ configs = list(
 ) + list(
     itertools.product(
         [1, 4, 1 * 8, 4 * 8, 64 * 8, 256 * 8, 768 * 8],
-        # TODO support more
         [2048],
         [128],
         [8, 16, 32, 48],

--- a/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
@@ -1,0 +1,210 @@
+import itertools
+
+import pytest
+import torch
+
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
+fp8_type_ = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn
+
+from sgl_kernel.test_utils import (
+    assert_all_close_or_tiny_diff,
+    create_per_token_group_quant_test_data,
+)
+
+from sglang.jit_kernel.per_token_group_quant_8bit import (
+    per_token_group_quant_8bit as sglang_per_token_group_quant_8bit,
+)
+from sglang.srt.layers.quantization.fp8_kernel import (
+    create_per_token_group_quant_fp8_output_scale,
+)
+from sglang.srt.layers.quantization.fp8_kernel import (
+    per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
+)
+
+configs = list(
+    itertools.product(
+        [1, 4, 16, 64, 127, 128, 512, 1024, 4096, 8192],  # num_tokens
+        [128, 256, 384, 512, 1024, 1536, 1664, 2048, 4096, 7168, 16384],  # hidden_dim
+        [16, 32, 64, 128],  # group_size
+        [None],  # num_ranks
+        [fp8_type_, torch.int8],  # dtype
+        [
+            dict(
+                column_major_scales=False,
+                scale_tma_aligned=False,
+                scale_ue8m0=False,
+                fuse_silu_and_mul=False,
+                masked_layout_mode=None,
+            ),
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=False,
+                scale_ue8m0=False,
+                fuse_silu_and_mul=False,
+                masked_layout_mode=None,
+            ),
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=False,
+                fuse_silu_and_mul=False,
+                masked_layout_mode=None,
+            ),
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+                fuse_silu_and_mul=False,
+                masked_layout_mode=None,
+            ),
+        ],
+    )
+) + list(
+    itertools.product(
+        [1, 4, 1 * 8, 4 * 8, 64 * 8, 256 * 8, 768 * 8],
+        # TODO support more
+        [2048],
+        [128],
+        [8, 16, 32, 48],
+        [fp8_type_],
+        [
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+                fuse_silu_and_mul=True,
+                masked_layout_mode=None,
+            ),
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+                fuse_silu_and_mul=True,
+                masked_layout_mode="balanced",
+            ),
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+                fuse_silu_and_mul=True,
+                masked_layout_mode="imbalanced",
+            ),
+            dict(
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+                fuse_silu_and_mul=True,
+                masked_layout_mode="extreme",
+            ),
+        ],
+    )
+)
+
+
+@pytest.mark.parametrize(
+    "num_tokens, hidden_dim, group_size, num_ranks, dst_dtype, flags", configs
+)
+def test_per_token_group_quant_with_column_major(
+    num_tokens,
+    hidden_dim,
+    group_size,
+    num_ranks,
+    dst_dtype,
+    flags,
+):
+    print(
+        f"{num_tokens=} {hidden_dim=} {group_size=} {num_ranks=} {dst_dtype=} {flags=}"
+    )
+
+    arch_major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
+    if flags["scale_ue8m0"] and (arch_major <= 9):
+        pytest.skip("Only Blackwell need ue8m0 fusion")
+        return
+
+    if (flags["scale_ue8m0"] and (group_size != 128)) or (
+        (dst_dtype == torch.int8) and flags["column_major_scales"]
+    ):
+        pytest.skip()
+        return
+
+    x, masked_m = create_per_token_group_quant_test_data(
+        num_tokens=num_tokens, hidden_dim=hidden_dim, num_ranks=num_ranks, flags=flags
+    )
+
+    execute_kwargs = dict(
+        x=x,
+        masked_m=masked_m,
+        group_size=group_size,
+        eps=1e-10,
+        dst_dtype=dst_dtype,
+        **{k: v for k, v in flags.items() if k not in ["masked_layout_mode"]},
+    )
+
+    def _postprocess(x_q, x_s):
+        if masked_m is not None:
+            print(f"Mask tokens after {masked_m} to be zero")
+            for i in range(len(masked_m)):
+                x_q[i, masked_m[i] :, :] = 0
+                x_s[i, masked_m[i] :, :] = 0
+        return x_q, x_s
+
+    x_q_triton, x_s_triton = _postprocess(
+        *triton_per_token_group_quant_8bit(**execute_kwargs)
+    )
+
+    fuse_silu_and_mul = False
+    out_shape = (*x.shape[:-1], x.shape[-1] // (2 if fuse_silu_and_mul else 1))
+
+    fp8_dtype = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8_dtype).max
+    fp8_min = -fp8_max
+    x_q = torch.empty(out_shape, device=x.device, dtype=fp8_dtype)
+    x_s = create_per_token_group_quant_fp8_output_scale(
+        x_shape=out_shape,
+        device=x.device,
+        group_size=group_size,
+        column_major_scales=False,
+        scale_tma_aligned=False,
+        scale_ue8m0=False,
+    )
+
+    execute_kwargs = dict(
+        input=x,
+        output_q=x_q,
+        output_s=x_s,
+        group_size=group_size,
+        eps=1e-10,
+        fp8_max=fp8_max,
+        fp8_min=fp8_min,
+    )
+    x_q_sglang, x_s_sglang = _postprocess(
+        *sglang_per_token_group_quant_8bit(**execute_kwargs)
+    )
+
+    try:
+        assert_all_close_or_tiny_diff(x_q_triton, x_q_sglang)
+        torch.testing.assert_close(
+            x_s_triton.contiguous(),
+            x_s_sglang.contiguous(),
+            rtol=1e-3,
+            atol=1e-5,
+            msg=lambda message: message + f" {x_s_triton=} {x_s_sglang=}",
+        )
+    except AssertionError:
+        print(
+            f"{x.shape=} {x_q_triton.shape=} {x_s_triton.shape=} {x_q_sglang.shape=} {x_s_sglang.shape=}"
+        )
+        print(f"{x=}")
+        print(f"{masked_m=}")
+        print(f"{x_q_triton=}")
+        print(f"{x_s_triton=}")
+        print(f"{x_q_sglang=}")
+        print(f"{x_s_sglang=}")
+
+        raise
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -10,7 +10,6 @@ import torch
 if TYPE_CHECKING:
     from tvm_ffi import Module
 
-
 F = TypeVar("F", bound=Callable[..., Any])
 
 
@@ -73,7 +72,9 @@ class CPPArgList(list[str]):
 CPP_DTYPE_MAP = {
     torch.float: "fp32_t",
     torch.float16: "fp16_t",
+    torch.float8_e4m3fn: "fp8_e4m3_t",
     torch.bfloat16: "bf16_t",
+    torch.int8: "int8_t",
 }
 
 

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -63,6 +63,10 @@ if _is_cuda:
 
         enable_sgl_per_token_group_quant_8bit = False
 
+    from sglang.jit_kernel.per_token_group_quant_8bit import (
+        per_token_group_quant_8bit as sgl_per_token_group_quant_8bit_jit,
+    )
+
 if _is_hip:
     _has_vllm = False
     if _use_aiter:
@@ -501,19 +505,31 @@ def sglang_per_token_group_quant_fp8(
     if x.shape[0] > 0:
         # Temporary
         if enable_sgl_per_token_group_quant_8bit:
-            sgl_per_token_group_quant_8bit(
-                x,
-                x_q,
-                x_s,
-                group_size,
-                eps,
-                fp8_min,
-                fp8_max,
-                scale_ue8m0,
-                fuse_silu_and_mul,
-                masked_m,
-                enable_v2=enable_v2,
-            )
+            if enable_v2:
+                sgl_per_token_group_quant_8bit(
+                    x,
+                    x_q,
+                    x_s,
+                    group_size,
+                    eps,
+                    fp8_min,
+                    fp8_max,
+                    scale_ue8m0,
+                    fuse_silu_and_mul,
+                    masked_m,
+                    enable_v2=True,
+                )
+            else:
+                sgl_per_token_group_quant_8bit_jit(
+                    input=x,
+                    output_q=x_q,
+                    output_s=x_s,
+                    group_size=group_size,
+                    eps=eps,
+                    fp8_min=fp8_min,
+                    fp8_max=fp8_max,
+                    scale_ue8m0=scale_ue8m0,
+                )
         else:
             assert not enable_v2
             sgl_per_token_group_quant_fp8(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Support per_token_group_quant_8bit jit kernel.
Main:
<img width="2922" height="884" alt="image" src="https://github.com/user-attachments/assets/0598f7a8-4486-46da-9970-b0219ed240d6" />

PR:
<img width="2520" height="1198" alt="image" src="https://github.com/user-attachments/assets/de562073-203b-45bf-9d78-1770f8548278" />
<img width="2740" height="1362" alt="image" src="https://github.com/user-attachments/assets/18f60fe1-f8af-4f7f-90c0-18b9cf5348f9" />


UT:
```
root@c7e9bb6a6789:/sgl-workspace/sglang_dev3# python ./python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
[2026-02-17 02:49:12] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-17 02:49:12] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-17 02:49:12] INFO utils.py:164: NumExpr defaulting to 16 threads.
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /sgl-workspace/sglang_dev3/python
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, typeguard-4.4.4
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1872 items                                                                                                                                                                                                                  

python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py ...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s. [  8%]
..s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s [ 20%]
...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s... [ 32%]
s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s.. [ 44%]
.s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s. [ 56%]
..s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s [ 67%]
...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s... [ 79%]
s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s...s.. [ 91%]
.s...s...s...s...s...s...s...s...s...s...sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss                                                                      [100%]

========================================================================================================== warnings summary ===========================================================================================================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1303
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1303: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; anyio
    self._mark_plugins_for_rewrite(hook, disable_autoload)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================ 1320 passed, 552 skipped, 1 warning in 4.46s =============================================================================================
```

Benchmark:

```
root@c7e9bb6a6789:/sgl-workspace/sglang_dev3# python python/sglang/jit_kernel/benchmark/bench_per_token_group_quant_8bit.py 

......
per-token-group-quant-8bit-performance:
     num_tokens  hidden_dim  group_size num_ranks            dst_dtype                                                                                                                                         flags  Triton (Inaccurate)  SGL Kernel
0             1        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.043       2.396
1             1        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.050       2.412
2             1        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.062       2.531
3             1        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.098       2.693
4             1        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.128       2.557
5             1        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.187       2.547
6             1        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.143       2.722
7             1        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.183       2.823
8             1       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.167       2.609
9             1       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.190       2.603
10            1       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.175       2.785
11            1       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.247       2.937
12            4        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.097       2.599
13            4        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.136       2.730
14            4        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.112       2.777
15            4        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.198       2.883
16            4        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.209       2.639
17            4        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.263       2.803
18            4        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.249       2.768
19            4        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.290       2.885
20            4       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.411       2.707
21            4       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.455       2.903
22            4       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.414       2.944
23            4       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.498       2.995
24           16        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.189       2.616
25           16        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.227       2.811
26           16        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.207       2.762
27           16        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.300       2.868
28           16        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.485       2.779
29           16        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.540       2.957
30           16        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.509       2.963
31           16        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.596       3.082
32           16       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.172       2.972
33           16       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.208       3.166
34           16       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.212       3.198
35           16       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.313       3.327
36           64        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.445       2.779
37           64        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.479       2.920
38           64        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.479       2.954
39           64        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                2.526       3.057
40           64        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                4.086       3.709
41           64        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                4.161       3.847
42           64        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                4.169       3.890
43           64        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                4.221       3.988
44           64       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                6.856       5.435
45           64       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                6.954       5.718
46           64       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                6.957       5.650
47           64       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                7.015       5.698
48          256        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.813       3.466
49          256        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.842       3.721
50          256        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.853       3.702
51          256        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                3.915       3.812
52          256        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               10.527       7.749
53          256        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               10.635       9.002
54          256        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               10.654       8.930
55          256        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               10.699       8.038
56          256       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               21.622      14.800
57          256       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               21.745      15.989
58          256       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               21.727      15.920
59          256       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               21.815      15.004
60          768        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                7.477       5.842
61          768        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                7.564       6.166
62          768        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                7.575       6.143
63          768        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}                7.663       6.107
64          768        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               27.809      18.694
65          768        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               27.879      19.604
66          768        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               27.871      19.564
67          768        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               27.975      18.907
68          768       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.065      39.095
69          768       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.133      40.392
70          768       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.171      40.326
71          768       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.216      39.018
72         2048        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               16.693      11.638
73         2048        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               16.825      12.417
74         2048        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               16.806      12.367
75         2048        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               16.892      11.952
76         2048        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               70.897      45.047
77         2048        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               71.005      46.228
78         2048        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               70.993      46.307
79         2048        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               71.115      45.015
80         2048       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              159.583      99.404
81         2048       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              159.702     101.584
82         2048       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              159.687     101.807
83         2048       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              159.787      98.211
84         8192        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.034      39.023
85         8192        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.146      40.125
86         8192        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.160      40.141
87         8192        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}               61.249      38.938
88         8192        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              277.850     171.682
89         8192        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              277.943     175.706
90         8192        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              277.960     175.763
91         8192        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              277.772     169.681
92         8192       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              632.665     389.103
93         8192       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              632.763     397.270
94         8192       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              632.773     397.362
95         8192       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              632.867     383.703
96        16384        1536         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              120.134      75.228
97        16384        1536         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              120.267      77.015
98        16384        1536         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              120.291      76.906
99        16384        1536         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              120.349      74.654
100       16384        7168         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              553.748     340.575
101       16384        7168         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              553.890     347.350
102       16384        7168         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              553.909     347.446
103       16384        7168         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}              554.074     335.985
104       16384       16384         128      None  torch.float8_e4m3fn      {'column_major_scales': False, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}             1263.000     774.731
105       16384       16384         128      None  torch.float8_e4m3fn       {'column_major_scales': True, 'scale_tma_aligned': False, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}             1264.000     790.398
106       16384       16384         128      None  torch.float8_e4m3fn        {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': False, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}             1264.000     790.300
107       16384       16384         128      None  torch.float8_e4m3fn         {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': False, 'masked_layout_mode': None}             1264.000     763.256
108           8        2048         128         8  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.615       2.908
109           8        2048         128         8  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               13.015    1289.000
110           8        2048         128         8  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               13.067    1289.000
111           8        2048         128         8  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               13.057    1289.000
112           8        2048         128        16  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.655       2.910
113           8        2048         128        16  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                7.509    1289.000
114           8        2048         128        16  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                7.461    1289.000
115           8        2048         128        16  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                7.433    1289.000
116           8        2048         128        32  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.635       2.919
117           8        2048         128        32  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                4.678    1288.000
118           8        2048         128        32  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                4.772    1289.000
119           8        2048         128        32  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                4.749    1289.000
120           8        2048         128        48  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.648       2.912
121           8        2048         128        48  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                3.844    1289.000
122           8        2048         128        48  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                3.755    1289.000
123           8        2048         128        48  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                3.743    1288.000
124          32        2048         128         8  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.831       3.019
125          32        2048         128         8  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               12.997    1289.000
126          32        2048         128         8  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               13.066    1289.000
127          32        2048         128         8  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               13.217    1289.000
128          32        2048         128        16  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.852       3.028
129          32        2048         128        16  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                7.518    1289.000
130          32        2048         128        16  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                7.466    1289.000
131          32        2048         128        16  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                7.633    1289.000
132          32        2048         128        32  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.819       3.034
133          32        2048         128        32  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                4.682    1289.000
134          32        2048         128        32  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                4.778    1289.000
135          32        2048         128        32  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                4.874    1289.000
136          32        2048         128        48  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                2.854       3.052
137          32        2048         128        48  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                3.801    1288.000
138          32        2048         128        48  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                3.773    1289.000
139          32        2048         128        48  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                3.933    1289.000
140         512        2048         128         8  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                6.558       5.671
141         512        2048         128         8  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               13.266    1289.000
142         512        2048         128         8  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               13.509    1289.000
143         512        2048         128         8  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               13.154    1289.000
144         512        2048         128        16  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                6.581       5.651
145         512        2048         128        16  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                8.337    1289.000
146         512        2048         128        16  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                7.694    1289.000
147         512        2048         128        16  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                9.591    1289.000
148         512        2048         128        32  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                6.570       5.669
149         512        2048         128        32  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                6.062    1289.000
150         512        2048         128        32  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                6.782    1289.000
151         512        2048         128        32  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                9.003    1289.000
152         512        2048         128        48  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}                6.603       5.671
153         512        2048         128        48  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}                5.882    1289.000
154         512        2048         128        48  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}                6.634    1289.000
155         512        2048         128        48  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}                8.805    1288.000
156        2048        2048         128         8  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               15.751      15.011
157        2048        2048         128         8  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               14.840    1289.000
158        2048        2048         128         8  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               16.473    1289.000
159        2048        2048         128         8  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               29.118    1289.000
160        2048        2048         128        16  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               15.806      14.940
161        2048        2048         128        16  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               13.846    1289.000
162        2048        2048         128        16  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               17.267    1289.000
163        2048        2048         128        16  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               27.476    1289.000
164        2048        2048         128        32  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               15.696      14.935
165        2048        2048         128        32  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               14.534    1288.000
166        2048        2048         128        32  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               15.711    1289.000
167        2048        2048         128        32  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               26.902    1289.000
168        2048        2048         128        48  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               15.731      15.021
169        2048        2048         128        48  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               13.742    1288.000
170        2048        2048         128        48  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               23.188    1288.000
171        2048        2048         128        48  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               26.604    1288.000
172        6144        2048         128         8  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               39.847      38.908
173        6144        2048         128         8  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               31.793    1289.000
174        6144        2048         128         8  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               34.743    1289.000
175        6144        2048         128         8  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               77.850    1289.000
176        6144        2048         128        16  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               39.926      38.914
177        6144        2048         128        16  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               31.172    1289.000
178        6144        2048         128        16  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               39.292    1289.000
179        6144        2048         128        16  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               75.004    1288.000
180        6144        2048         128        32  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               39.824      39.066
181        6144        2048         128        32  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               35.384    1289.000
182        6144        2048         128        32  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               60.427    1288.000
183        6144        2048         128        32  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               74.285    1289.000
184        6144        2048         128        48  torch.float8_e4m3fn          {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': None}               39.914      38.950
185        6144        2048         128        48  torch.float8_e4m3fn    {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'balanced'}               32.346    1289.000
186        6144        2048         128        48  torch.float8_e4m3fn  {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'imbalanced'}               62.767    1289.000
187        6144        2048         128        48  torch.float8_e4m3fn     {'column_major_scales': True, 'scale_tma_aligned': True, 'scale_ue8m0': True, 'fuse_silu_and_mul': True, 'masked_layout_mode': 'extreme'}               74.102    1289.000
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

DeepSeek V3.2
```
➜  sglang git:(main) python3 -m sglang.launch_server \
  --model-path deepseek-ai/DeepSeek-V3.2-Exp \
  --trust-remote-code \
  --tp-size 8 --dp-size 8 --enable-dp-attention \
  --tool-call-parser deepseekv31 \
  --reasoning-parser deepseek-v3 \
  --chat-template ./examples/chat_template/tool_chat_template_deepseekv32.jinja
```

Main:
```
➜  sglang git:(main) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 14.1MB/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:22<00:00,  8.75it/s]
Accuracy: 0.985
Invalid: 0.000
Latency: 22.849 s
Output throughput: 862.559 token/s
```

PR:
```
➜  sglang_dev git:(jit_per_token_group_quant) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:18<00:00, 11.00it/s]
Accuracy: 0.985
Invalid: 0.000
Latency: 18.186 s
Output throughput: 1088.236 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
