### PR TITLE
Fix symm-mem deadlock during autotune and CUDA graph capture

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -605,13 +605,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
             self.init_attention_backend()
-            # Pre-allocate symmetric memory pool before autotune and CUDA graph
-            # capture. This initializes the NCCL allocator (JIT compile +
-            # ncclMemAlloc/ncclCommWindowRegister) while all ranks are still
-            # synchronized. Autotune and CUDA graph capture then run with
-            # symm_mem disabled to avoid NCCL collective deadlocks during
-            # their divergent forward passes.
-            self.prealloc_symmetric_memory_pool()
             self.kernel_warmup()
             self.init_device_graphs()
         elif self.device in ["npu", "cpu"]:
@@ -632,6 +625,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Initialize piecewise CUDA graph
         self.init_piecewise_cuda_graphs()
+
+        self.prealloc_symmetric_memory_pool()
 
     def init_routed_experts_capturer(self):
         if not self.server_args.disable_shared_experts_fusion and hasattr(


### PR DESCRIPTION
## Summary
- Fix `TestDeepseekV3FP4SymmetricMemory` timeout in `stage-c-test-4-gpu-b200` caused by NCCL deadlocks when `--enable-symm-mem` is enabled
- Three-part fix for sequential NCCL collective deadlock points during server init:
  1. **Disable symm_mem during FlashInfer autotune** — different ranks may profile different kernel configs, causing NCCL collective divergence
  2. **Disable symm_mem during CUDA graph capture** (both regular and piecewise) — warmup forward passes may trigger NCCL collectives that deadlock across ranks
  3. **Synchronize NCCL allocator JIT compilation before prealloc** — the NCCL allocator C extension takes ~90s to JIT compile and different ranks finish at different times. Without a barrier, the first rank to finish calls `ncclMemAlloc`/`ncclCommWindowRegister` (collective ops) while other ranks are still compiling. Also keep the pre-allocated tensor alive to prevent `ncclMemFree` (another collective) from being called.
- Same disable pattern as the DeepGEMM compilation deadlock fix (commit 3a64844a1)

MoE forward passes wrap operations in `use_symmetric_memory()` which triggers NCCL collective operations (`ncclMemAlloc`/`ncclCommWindowRegister`). During warmup phases (autotune profiling, CUDA graph capture), different ranks may execute different kernel configurations or batch sizes, causing these collectives to deadlock. The `prealloc_symmetric_memory_pool` additionally requires synchronization because the NCCL allocator's JIT compilation has variable latency across ranks.

Example failures:
- Autotune deadlock: https://github.com/sgl-project/sglang/actions/runs/22079202405/attempts/2
- CUDA graph capture deadlock: https://github.com/sgl-project/sglang/actions/runs/22121740777/job/63943145435
- Prealloc hang (JIT compile desync): https://github.com/sgl-project/sglang/actions/runs/22154429047

## Test plan
- [ ] Verify `stage-c-test-4-gpu-b200` CI passes with `TestDeepseekV3FP4SymmetricMemory` completing without timeout