### PR TITLE
Fix flaky Qwen3-Next KL divergence tests by reverting mamba slot release

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2091,8 +2091,6 @@ class Scheduler(
                 running_loras.add(req.lora_id)
 
             if res != AddReqResult.CONTINUE:
-                self.maybe_release_mamba_cache(req)
-
                 if res == AddReqResult.NO_TOKEN:
                     if self.enable_hierarchical_cache:
                         # Set batch_is_full after making sure there are requests that can be served
@@ -2189,25 +2187,6 @@ class Scheduler(
             new_batch.decoding_reqs = None
 
         return new_batch
-
-    def maybe_release_mamba_cache(self, req: Req) -> None:
-        """Release mamba slot if allocated via COW but scheduling failed.
-
-        Without this, the slot remains held by a waiting request, causing
-        check_memory() to detect a "memory leak" and crash the server.
-        The next schedule round will re-allocate safely via match_prefix().
-
-        Note: In disaggregation DECODE mode, mamba state is transferred from PREFILL and
-        is not recoverable if freed, so we do not free it here. To avoid false-positive
-        leak checks in this situation, self_check_during_idle skips memory checking when
-        the waiting queue is not empty.
-        """
-        if (
-            req.mamba_pool_idx is not None
-            and self.disaggregation_mode != DisaggregationMode.DECODE
-        ):
-            self.req_to_token_pool.mamba_pool.free(req.mamba_pool_idx.unsqueeze(-1))
-            req.mamba_pool_idx = None
 
     def update_running_batch(self, batch: ScheduleBatch) -> Optional[ScheduleBatch]:
         """Update the current running decoding batch."""


### PR DESCRIPTION
## Summary
- Reverts the mamba slot release logic on scheduling failure that was causing non-deterministic KL divergence in Qwen3-Next tests
- When scheduling fails after `init_next_round_input` has already performed COW allocation, freeing the mamba pool slot causes states to be reconstructed from the radix cache on rescheduling, introducing numerical differences that manifest as outlier KL values

## Root Cause Analysis
CI data confirms the correlation:
- **Before the slot release change**: Qwen3-Next KL tests had ~90% pass rate (18/20 H100 runs, Feb 7-13)
- **After the slot release change**: pass rate dropped to ~35% (7/20 runs, Feb 13-18)
- Same commit `fd5a45d5c` on Feb 15 produced both PASS and FAIL, confirming the test became non-deterministic

The mamba state reconstruction from the radix cache (at the last tracking point) introduces slight numerical differences for some samples, causing outlier KL divergence values (0.12-0.27) that pull the arithmetic mean above the test threshold.

## Test plan
- [ ] Verify Qwen3-Next KL tests pass: `test_qwen3_next_models_mtp.py`, `test_qwen3_next_models.py`
- [ ] Verify no mamba slot leak regressions under normal workloads