### PR TITLE
Refactor sampler: Use a better hash function for deterministic sampling and clear dispatch for probs/logprobs/logits sampling paths

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -126,9 +126,7 @@ class Sampler(nn.Module):
             # Post process logits
             logits.div_(sampling_info.temperatures)
             # For ascend backend, softmax is not needed before sampling
-            if not get_global_server_args().sampling_backend == "ascend" or (
-                return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB
-            ):
+            if not get_global_server_args().sampling_backend == "ascend":
                 probs = torch.softmax(logits, dim=-1)
             else:
                 probs = logits

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -192,7 +192,7 @@ class Sampler(nn.Module):
     ) -> torch.Tensor:
         """Sample from probability distribution (after softmax).
 
-        Used for standard sampling on CUDA with flashinfer/pytorch backends.
+        Used for standard sampling with flashinfer/pytorch backends.
         Handles both simple (direct multinomial) and complex (top-k/top-p/min-p) cases.
         """
         if simple_sampling_case:

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -126,7 +126,7 @@ class Sampler(nn.Module):
             # Post process logits
             logits.div_(sampling_info.temperatures)
             # For ascend backend, softmax is not needed before sampling
-            if not get_global_server_args().sampling_backend == "ascend":
+            if get_global_server_args().sampling_backend != "ascend":
                 probs = torch.softmax(logits, dim=-1)
             else:
                 probs = logits

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -121,7 +121,7 @@ class Sampler(nn.Module):
 
             # In RL on-policy mode, we use log_softmax to compute logprobs to match the trainer.
             logprobs_via_logsoftmax_kernel = None
-            if get_global_server_args().rl_on_policy_target is not None:
+            if self.rl_on_policy_target is not None:
                 # TODO: use more inplace ops to save memory
                 logits_div_temperature = (
                     logits.bfloat16().div(sampling_info.temperatures).bfloat16()

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -163,7 +163,7 @@ class Sampler(nn.Module):
                     logprobs = (
                         logprobs_via_logsoftmax_kernel
                         if logprobs_via_logsoftmax_kernel is not None
-                        else torch.log(probs, dim=-1)
+                        else torch.log(probs)
                     )
 
         # Attach logprobs to logits_output (in-place modification)

--- a/python/sglang/srt/layers/utils/hash.py
+++ b/python/sglang/srt/layers/utils/hash.py
@@ -1,0 +1,121 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def rotl32(x, r: tl.constexpr) -> tl.uint32:
+    """
+    rotate left 32-bit integer x by r bits
+    e.g. x = 01110001, r = 2 -> 11000101
+    """
+    x = x.to(tl.uint64)
+    return ((x << r) | (x >> (32 - r))) & 0xFFFFFFFF
+
+
+@triton.jit
+def fmix32(h: tl.uint32) -> tl.uint32:
+    """
+    final mix of 32-bit hash value for MurmurHash
+    """
+    h ^= h >> 16
+    h = (h * 0x85EBCA6B) & 0xFFFFFFFF
+    h ^= h >> 13
+    h = (h * 0xC2B2AE35) & 0xFFFFFFFF
+    h ^= h >> 16
+    return h
+
+
+@triton.jit
+def murmur3_mix(h: tl.uint32, k: tl.uint32) -> tl.uint32:
+    """
+    Mixes a 32-bit key into the hash state.
+    """
+    c1: tl.uint32 = 0xCC9E2D51
+    c2: tl.uint32 = 0x1B873593
+    r1: tl.constexpr = 15
+    r2: tl.constexpr = 13
+    mm: tl.uint32 = 5
+    nn: tl.uint32 = 0xE6546B64
+
+    k = (k * c1) & 0xFFFFFFFF
+    k = rotl32(k, r1)
+    k = (k * c2) & 0xFFFFFFFF
+    h ^= k
+    h = rotl32(h, r2)
+    h = (h * mm + nn) & 0xFFFFFFFF
+    return h
+
+
+@triton.jit
+def murmur_hash32_kernel(
+    seed_ptr,
+    positions_ptr,
+    col_indices_ptr,
+    output_ptr,
+    num_rows,
+    num_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    MurmurHash 32-bit implementation for Triton.
+    Reference:
+    - https://medium.com/@thealonemusk/murmurhash-the-scrappy-algorithm-that-secretly-powers-half-the-internet-2d3f79b4509b
+    - https://en.wikipedia.org/wiki/MurmurHash
+
+    We treat 64-bit seed, 32-bit position, and 32-bit col_index as 4 4-byte blocks, and bit-blend them together.
+    """
+    pid_row = tl.program_id(0)
+    pid_col = tl.program_id(1)
+
+    row_idx = pid_row
+    col_offsets = pid_col * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < num_cols
+
+    # Load inputs
+    seed = tl.load(seed_ptr + row_idx).to(tl.uint64)
+    pos = tl.load(positions_ptr + row_idx).to(tl.uint32)
+    col = tl.load(col_indices_ptr + col_offsets, mask=mask, other=0).to(tl.uint32)
+
+    h: tl.uint32 = 0  # hash accumulator
+
+    # Process seed_low
+    k: tl.uint32 = (seed & 0xFFFFFFFF).to(tl.uint32)
+    h = murmur3_mix(h, k)
+
+    # Process seed_high
+    k = ((seed >> 32) & 0xFFFFFFFF).to(tl.uint32)
+    h = murmur3_mix(h, k)
+
+    # Process position block starting from seed32
+    h = murmur3_mix(h, pos)
+
+    # Process col block
+    h = murmur3_mix(h, col)
+
+    # Finalize (len=16 for seed + pos + col)
+    h ^= 16
+    h = fmix32(h)
+
+    # Store result as uint32
+    tl.store(output_ptr + row_idx * num_cols + col_offsets, h, mask=mask)
+
+
+def murmur_hash32(seed, positions, col_indices):
+    assert (
+        seed.shape == positions.shape
+    ), "Seed and positions must have the same shape (n,)"
+    assert (
+        len(seed.shape) == 1 and len(col_indices.shape) == 1
+    ), f"Inputs must be 1D tensors {seed.shape=} {col_indices.shape=}"
+    n = seed.shape[0]
+    m = col_indices.shape[0]
+    device = seed.device
+    hashed = torch.empty((n, m), dtype=torch.uint32, device=device)
+
+    BLOCK_SIZE = 1024
+    grid = (n, triton.cdiv(m, BLOCK_SIZE))
+    murmur_hash32_kernel[grid](
+        seed, positions, col_indices, hashed, n, m, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return hashed

--- a/python/sglang/test/send_one.py
+++ b/python/sglang/test/send_one.py
@@ -24,6 +24,7 @@ class BenchArgs:
     port: int = 30000
     batch_size: int = 1
     different_prompts: bool = False
+    seed: Optional[int] = None
     temperature: float = 0.0
     max_new_tokens: int = 512
     frequency_penalty: float = 0.0
@@ -51,6 +52,7 @@ class BenchArgs:
             action="store_true",
             default=BenchArgs.different_prompts,
         )
+        parser.add_argument("--seed", type=int, default=BenchArgs.seed)
         parser.add_argument("--temperature", type=float, default=BenchArgs.temperature)
         parser.add_argument(
             "--max-new-tokens", type=int, default=BenchArgs.max_new_tokens
@@ -127,6 +129,7 @@ def send_one_prompt(args: BenchArgs):
         "text": prompt,
         "image_data": image_data,
         "sampling_params": {
+            "sampling_seed": args.seed,
             "temperature": args.temperature,
             "max_new_tokens": args.max_new_tokens,
             "frequency_penalty": args.frequency_penalty,


### PR DESCRIPTION
## Summary

Refactors `sampler.py` to make the sampling dispatch logic clear and self-documenting. The previous code had a single `_sample_from_probs` method that confusingly accepted probs, logits, or logprobs depending on the context. This PR splits it into three well-named methods with explicit dispatch.

## Changes


### 1. Improved `multinomial_with_seed` (Gumbel-trick sampling)

- Now uses MurmurHash3 (via a new Triton kernel in `layers/utils/hash.py`) for better hash quality instead of the ad-hoc hash.
- Uses float64 throughout the Gumbel noise computation for numerical stability.
- Decorated with `@torch.compile(dynamic=True)` for performance.
- Input parameter renamed from `inputs` to `logprobs` to clarify the expected input.

### 2. Three-way sampling dispatch (`_sample_from_probs`, `_sample_from_logprobs`, `_sample_from_logits`)

The old monolithic `_sample_from_probs` is split into three methods, each with a clear contract:

- **`_sample_from_probs(probs, ...)`** — Samples from a softmax probability distribution. Used for standard CUDA sampling with flashinfer/pytorch backends. Handles both simple (direct multinomial) and complex (top-k/top-p/min-p) cases.

- **`_sample_from_logprobs(logprobs, ...)`** — Samples from log-probabilities using the Gumbel trick. Used for deterministic RL on-policy sampling with simple cases (no top-k/top-p/min-p). Requires `sampling_seed`.

- **`_sample_from_logits(logits, ...)`** — Samples from temperature-scaled logits without prior softmax. Used for the Ascend NPU backend which handles softmax internally in its fused kernels.

### 3. Clear dispatch in `forward()`

The dispatch logic in `forward()` is now an explicit three-way branch:

```python
if self.use_ascend_backend:
    # Ascend: sample from logits (no softmax needed)
    batch_next_token_ids, logprobs = self._forward_ascend_backend(...)
elif self.use_log_softmax_logprob and self.enable_deterministic and simple_sampling_case:
    # RL on-policy: sample from logprobs via gumbel trick
    batch_next_token_ids = self._sample_from_logprobs(...)
else:
    # Standard: softmax then sample from probs
    batch_next_token_ids = self._sample_from_probs(...)
```

### 4. Ascend backend extracted to `_forward_ascend_backend`

The Ascend-specific path (temperature scaling → logits sampling → optional logprob computation) is encapsulated in a standalone method for clarity.

### 5. Renames for clarity

- `can_sample_directly_from_probs` → `simple_sampling_case` (more general and accurate)
- `top_k_top_p_min_p_sampling_from_probs_ascend` → `top_k_top_p_min_p_sampling_from_logits_ascend` (accurately reflects that this function takes logits, not probs, as input). Parameter also renamed from `probs` to `logits`.

```
Co-authored-by: Sehoon Kim <sehoon@x.ai>
```