### PR TITLE
fix: adding custom tag to prevent cleanups for designated docker images

### DIFF
--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -8,14 +8,9 @@ on:
         required: false
         default: ""
       tag:
-        description: "Custom tag suffix (overrides pr_number in tag). E.g. 'my-test' → dev-x86-my-test, dev-cu13-my-test, etc."
+        description: "Custom tag: creates '{tag}' (cu12.9) and 'cu13-{tag}' (cu13) multi-arch images"
         required: false
         default: ""
-      pin:
-        description: "Pin this image to prevent nightly cleanup from deleting it. Appends '-pin' to the tag."
-        type: boolean
-        required: false
-        default: false
   schedule:
     - cron: "0 0 * * *"
 
@@ -149,20 +144,27 @@ jobs:
             SUFFIX="-pr-${{ inputs.pr_number }}"
           fi
 
-          TAG="${{ matrix.variant.base }}${SUFFIX}"
           X86_TAG="dev-${{ matrix.variant.x86 }}${SUFFIX}"
           ARM64_TAG="dev-${{ matrix.variant.arm64 }}${SUFFIX}"
 
+          # Custom tag mode: clean tags like '{tag}' and 'cu13-{tag}'
+          # Normal mode: 'dev{suffix}' and 'dev-cu13{suffix}'
+          if [ -n "${{ inputs.tag }}" ]; then
+            if [ "${{ matrix.variant.base }}" = "dev" ]; then
+              TAG="${{ inputs.tag }}"
+            else
+              # dev-cu13 -> cu13-{tag}
+              TAG="cu13-${{ inputs.tag }}"
+            fi
+          else
+            TAG="${{ matrix.variant.base }}${SUFFIX}"
+          fi
+
           # For nightly (no suffix), also stamp a dated tag
-          # If pin is set, append -pin so the dated tag survives cleanup
           EXTRA_TAG=""
           if [ -z "${SUFFIX}" ]; then
             SHORT_SHA="${{ github.sha }}"
-            PIN_SUFFIX=""
-            if [ "${{ inputs.pin }}" = "true" ]; then
-              PIN_SUFFIX="-pin"
-            fi
-            EXTRA_TAG="-t lmsysorg/sglang:nightly-${TAG}-$(date +%Y%m%d)-${SHORT_SHA:0:8}${PIN_SUFFIX}"
+            EXTRA_TAG="-t lmsysorg/sglang:nightly-${TAG}-$(date +%Y%m%d)-${SHORT_SHA:0:8}"
           fi
 
           docker buildx imagetools create \
@@ -184,7 +186,7 @@ jobs:
             "https://hub.docker.com/v2/repositories/lmsysorg/sglang/tags/?page_size=100")
 
           TAGS=$(echo "$TAGS_RESPONSE" | jq -r \
-            '.results[] | select(.name | test("^nightly-${{ matrix.variant.base }}-[0-9]")) | select(.name | test("pin") | not) | "\(.last_updated)|\(.name)"' \
+            '.results[] | select(.name | test("^nightly-${{ matrix.variant.base }}-[0-9]")) | "\(.last_updated)|\(.name)"' \
             | sort -r | cut -d'|' -f2)
 
           TAG_COUNT=$(echo "$TAGS" | wc -l)

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -11,6 +11,11 @@ on:
         description: "Custom tag suffix (overrides pr_number in tag). E.g. 'my-test' → dev-x86-my-test, dev-cu13-my-test, etc."
         required: false
         default: ""
+      pin:
+        description: "Pin this image to prevent nightly cleanup from deleting it. Appends '-pin' to the tag."
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: "0 0 * * *"
 
@@ -149,10 +154,15 @@ jobs:
           ARM64_TAG="dev-${{ matrix.variant.arm64 }}${SUFFIX}"
 
           # For nightly (no suffix), also stamp a dated tag
+          # If pin is set, append -pin so the dated tag survives cleanup
           EXTRA_TAG=""
           if [ -z "${SUFFIX}" ]; then
             SHORT_SHA="${{ github.sha }}"
-            EXTRA_TAG="-t lmsysorg/sglang:nightly-${TAG}-$(date +%Y%m%d)-${SHORT_SHA:0:8}"
+            PIN_SUFFIX=""
+            if [ "${{ inputs.pin }}" = "true" ]; then
+              PIN_SUFFIX="-pin"
+            fi
+            EXTRA_TAG="-t lmsysorg/sglang:nightly-${TAG}-$(date +%Y%m%d)-${SHORT_SHA:0:8}${PIN_SUFFIX}"
           fi
 
           docker buildx imagetools create \
@@ -174,7 +184,7 @@ jobs:
             "https://hub.docker.com/v2/repositories/lmsysorg/sglang/tags/?page_size=100")
 
           TAGS=$(echo "$TAGS_RESPONSE" | jq -r \
-            '.results[] | select(.name | test("^nightly-${{ matrix.variant.base }}-[0-9]")) | "\(.last_updated)|\(.name)"' \
+            '.results[] | select(.name | test("^nightly-${{ matrix.variant.base }}-[0-9]")) | select(.name | test("pin") | not) | "\(.last_updated)|\(.name)"' \
             | sort -r | cut -d'|' -f2)
 
           TAG_COUNT=$(echo "$TAGS" | wc -l)


### PR DESCRIPTION
## Motivation

Currently, sglang model releases are pinned to a specific nightly image build. However, all nightly builds are cleaned up after 14 days. This PR enables a custom tag that won't be cleaned up, where the images will follow the format: lmsysorg/sglang:my-test and lmsysorg/sglang:cu13-my-test format.

## Modifications

Modified release-docker.dev.yml to accept new workflow dispatch parameter of custom tag.

## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/22127778603

https://hub.docker.com/layers/lmsysorg/sglang/dev-test/images/sha256-661456de37b236edfa636e31b2f25730119d43ed93b6880a65c46b5f237e063d

https://hub.docker.com/layers/lmsysorg/sglang/cu13-dev-test/images/sha256-b45dd398e4fc7aa989f7cc5082a124c9d4071147de2db5e29c8e5f5776ea41c0

## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
