### PR TITLE
[Fix] Enable Pipeline Parallelism support for Kimi K2.5

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1132,7 +1132,7 @@ def general_mm_embed_routine(
         input_embeds = None
 
     hidden_states = language_model(
-        input_ids=None,
+        input_ids=input_ids,
         forward_batch=forward_batch,
         input_embeds=input_embeds,
         **kwargs,

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -30,7 +30,7 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputs,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.deepseek_v2 import DeepseekV3ForCausalLM
 from sglang.srt.models.kimi_vl_moonvit import MLP2
@@ -705,9 +705,11 @@ class KimiK25ForConditionalGeneration(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
         get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
-        hidden_states = general_mm_embed_routine(
+        return general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,
             language_model=self.language_model,
@@ -715,9 +717,8 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 Modality.IMAGE: self.get_image_feature,
             },
             positions=positions,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
-
-        return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load weights for the model, separating vision and language weights"""

--- a/test/registered/8-gpu-models/test_kimi_k25_pp.py
+++ b/test/registered/8-gpu-models/test_kimi_k25_pp.py
@@ -1,0 +1,42 @@
+import unittest
+
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings
+
+register_cuda_ci(est_time=1800, suite="nightly-8-gpu-common", nightly=True)
+
+KIMI_K25_MODEL_PATH = "moonshotai/Kimi-K2.5"
+
+
+class TestKimiK25PP(unittest.TestCase):
+    """Test Kimi-K2.5 with Pipeline Parallelism (TP4 PP2) on 8 GPUs."""
+
+    def test_kimi_k25_pp(self):
+        base_args = [
+            "--tp-size=4",
+            "--pp-size=2",
+            "--chunked-prefill-size=8192",
+            "--tool-call-parser=kimi_k2",
+            "--reasoning-parser=kimi_k2",
+        ]
+
+        variants = [
+            ModelLaunchSettings(
+                KIMI_K25_MODEL_PATH,
+                tp_size=4,
+                extra_args=base_args,
+                variant="TP4_PP2",
+            ),
+        ]
+
+        run_combined_tests(
+            models=variants,
+            test_name="Kimi-K2.5-PP",
+            accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.90),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The PR adds a support to use pipeline parallelism with Kimi k2.5 model. This is helpful for those who use the model for multi-node deployment on H100 GPUs. One common setup is 8TP + 2PP. Such a set up works in vllm but I discovered it didn't work in sglang.

Below is the command I used to start sglang on 2 nodes.
```
python3 -m sglang.launch_server \
  --model-path $MODEL_PATH \
  --trust-remote-code \
  --dist-init-addr $MASTER_IP:$MASTER_PORT \
  --nnodes 2 \
  --node-rank $RANK \
  --tp-size 8 \
  --pp-size 2 \
  --tool-call-parser kimi_k2 \
  --reasoning-parser kimi_k2
```

Before my fix I caught `AssertionError: Pipeline Parallel is not compatible with this model.` with this command. Moreover, this assertion appeared not in the beginning but after about one hour of trying to set up the server (loading weigths, etc). 

## Modifications

1. **python/sglang/srt/models/kimi_k25.py**
   - Added `PPProxyTensors` import from `forward_batch_info`
   - Added `pp_proxy_tensors` parameter to the `forward()` method signature
   - Passed `pp_proxy_tensors` through to `general_mm_embed_routine()`

2. **python/sglang/srt/managers/mm_utils.py**
   - Fixed `general_mm_embed_routine()` to pass `input_ids` parameter to the language model instead of `None`
   - This ensures non-first PP ranks have access to `input_ids` for device inference


After the fix the server successfully starts and I tested it with a few requests. Let me know if you need more details.



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
