### PR TITLE
Expose priority parameter in Engine.generate() and Engine.async_generate()

### DIFF
--- a/python/sglang/srt/entrypoints/EngineBase.py
+++ b/python/sglang/srt/entrypoints/EngineBase.py
@@ -30,6 +30,7 @@ class EngineBase(ABC):
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
         rid: Optional[Union[List[str], str]] = None,
+        priority: Optional[int] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """Generate outputs based on given inputs."""
         pass

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -236,6 +236,7 @@ class Engine(EngineBase):
         external_trace_header: Optional[Dict] = None,
         rid: Optional[Union[List[str], str]] = None,
         session_params: Optional[Dict] = None,
+        priority: Optional[int] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -274,6 +275,7 @@ class Engine(EngineBase):
             external_trace_header=external_trace_header,
             rid=rid,
             session_params=session_params,
+            priority=priority,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 
@@ -325,6 +327,7 @@ class Engine(EngineBase):
         external_trace_header: Optional[Dict] = None,
         rid: Optional[Union[List[str], str]] = None,
         session_params: Optional[Dict] = None,
+        priority: Optional[int] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -364,6 +367,7 @@ class Engine(EngineBase):
             external_trace_header=external_trace_header,
             rid=rid,
             session_params=session_params,
+            priority=priority,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -108,6 +108,7 @@ class HttpServerEngineAdapter(EngineBase):
         token_ids_logprob=None,
         lora_path=None,
         custom_logit_processor=None,
+        priority=None,
     ):
         payload = {
             "text": prompt,
@@ -120,6 +121,7 @@ class HttpServerEngineAdapter(EngineBase):
             "token_ids_logprob": token_ids_logprob,
             "lora_path": lora_path,
             "custom_logit_processor": custom_logit_processor,
+            "priority": priority,
         }
         # Filter out None values
         payload = {k: v for k, v in payload.items() if v is not None}


### PR DESCRIPTION
## Motivation

`GenerateReqInput` already has a `priority: Optional[int] = None` field, and it is used by the HTTP serving path (`serving_chat`, `serving_completions`, `serving_embedding`, etc.) to pass per-request priority to the scheduler. However, the programmatic `Engine.generate()` and `Engine.async_generate()` APIs never exposed this parameter.

This means embedders that call these methods directly (e.g. [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo)) cannot set per-request priority — the field is silently dropped because neither method accepts it and therefore never passes it to `GenerateReqInput`.

## Changes

Add `priority: Optional[int] = None` to:
- `EngineBase.generate()` (abstract base class)
- `Engine.generate()` (sync) and `Engine.async_generate()` (async)
- `HttpServerEngineAdapter.generate()` (HTTP adapter)

and forward it to `GenerateReqInput` in all implementations.

Default behavior is unchanged (`None` → no priority set).

## Test plan

- Existing priority scheduling tests (`test/registered/scheduler/test_priority_scheduling.py`) continue to pass since they go through the HTTP path.
- Both the sync and async programmatic paths now correctly forward priority to the scheduler when set.