### PR TITLE
Add support for FlashInfer mxfp8

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -50,8 +50,11 @@ from sglang.srt.layers.quantization.fp8_utils import (
     cutlass_fp8_supported,
     dispatch_w8a8_block_fp8_linear,
     dispatch_w8a8_mxfp8_linear,
+    flashinfer_mxfp8_blockscaled_linear,
+    flashinfer_mxfp8_quantize,
     input_to_float8,
     mxfp8_group_quantize,
+    mxfp8_scale_linear_to_swizzled,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_weight_ue8m0_inplace,
 )
@@ -262,6 +265,10 @@ class Fp8LinearMethod(LinearMethodBase):
             self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
         else:
             self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
+        self.use_flashinfer_mxfp8_linear = (
+            self.use_mxfp8
+            and self.w8a8_mxfp8_linear is flashinfer_mxfp8_blockscaled_linear
+        )
         self.is_checkpoint_fp8_serialized = (
             self.quant_config.is_checkpoint_fp8_serialized
         )
@@ -434,6 +441,7 @@ class Fp8LinearMethod(LinearMethodBase):
             # Keep parameter object to preserve weight_loader attrs for hot reload.
             layer.weight_scale_inv.requires_grad_(False)
             layer.weight_scale_inv.format_ue8m0 = True
+            self._maybe_prepare_flashinfer_mxfp8_weight_scale(layer)
             return
         else:
             # For fp8 linear weights run with deepgemm, the weights and scales need be requantized to ue8m0
@@ -467,6 +475,42 @@ class Fp8LinearMethod(LinearMethodBase):
         layer.weight.data = weight.data
         layer.weight_scale_inv.data = weight_scale.data
 
+    def _maybe_prepare_flashinfer_mxfp8_weight_scale(self, layer: Module) -> None:
+        if not self.use_flashinfer_mxfp8_linear:
+            return
+        new_swizzled = mxfp8_scale_linear_to_swizzled(layer.weight_scale_inv.data)
+        cached_swizzled = getattr(layer, "weight_scale_inv_swizzled", None)
+        # Keep storage address stable when possible so CUDA graph captures remain valid.
+        if (
+            cached_swizzled is not None
+            and cached_swizzled.shape == new_swizzled.shape
+            and cached_swizzled.device == new_swizzled.device
+            and cached_swizzled.dtype == new_swizzled.dtype
+        ):
+            cached_swizzled.copy_(new_swizzled)
+        else:
+            layer.weight_scale_inv_swizzled = new_swizzled
+        layer._weight_scale_inv_swizzled_src_version = layer.weight_scale_inv._version
+        layer._weight_scale_inv_swizzled_src_data_ptr = (
+            layer.weight_scale_inv.data_ptr()
+        )
+
+    def _get_mxfp8_weight_scale(self, layer: Module) -> torch.Tensor:
+        if self.use_flashinfer_mxfp8_linear:
+            swizzled = getattr(layer, "weight_scale_inv_swizzled", None)
+            src_version = getattr(layer, "_weight_scale_inv_swizzled_src_version", -1)
+            src_data_ptr = getattr(layer, "_weight_scale_inv_swizzled_src_data_ptr", -1)
+            if (
+                swizzled is None
+                or swizzled.device != layer.weight_scale_inv.device
+                or swizzled.dtype != torch.uint8
+                or src_version != layer.weight_scale_inv._version
+                or src_data_ptr != layer.weight_scale_inv.data_ptr()
+            ):
+                self._maybe_prepare_flashinfer_mxfp8_weight_scale(layer)
+            return layer.weight_scale_inv_swizzled
+        return layer.weight_scale_inv
+
     def _quantize_mxfp8_weights(self, layer: Module) -> None:
         weight = layer.weight.data
         qweight, weight_scale = mxfp8_group_quantize(weight)
@@ -482,6 +526,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 "weight_scale_inv", Parameter(weight_scale, requires_grad=False)
             )
         layer.weight_scale_inv.format_ue8m0 = True
+        self._maybe_prepare_flashinfer_mxfp8_weight_scale(layer)
         layer.input_scale = None
 
     def process_weights_after_loading(self, layer: Module) -> None:
@@ -614,18 +659,19 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
+            weight_scale = self._get_mxfp8_weight_scale(layer)
             if isinstance(x, tuple):
                 return self.w8a8_mxfp8_linear(
                     input=x[0],
                     weight=layer.weight,
-                    weight_scale=layer.weight_scale_inv,
+                    weight_scale=weight_scale,
                     input_scale=x[1],
                     bias=bias,
                 )
             return self.w8a8_mxfp8_linear(
                 input=x,
                 weight=layer.weight,
-                weight_scale=layer.weight_scale_inv,
+                weight_scale=weight_scale,
                 input_scale=None,
                 bias=bias,
             )
@@ -691,12 +737,30 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.block_quant = (
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
-        if get_moe_runner_backend().is_cutlass():
+        moe_runner_backend = get_moe_runner_backend()
+        self._moe_runner_backend = moe_runner_backend
+        self._use_cutlass_backend = moe_runner_backend.is_cutlass()
+        self._use_flashinfer_cutlass_backend = (
+            moe_runner_backend.is_flashinfer_cutlass()
+        )
+        if self._use_cutlass_backend:
             assert (
                 cutlass_fp8_supported()
             ), "cutlass_fp8 MoE requires CUDA 12.0+ with SM90 or CUDA 12.4+ with SM89"
             assert self.block_quant, "cutlass_fp8 MoE requires block quantization"
             assert is_sm100_supported() or is_sm90_supported()
+        if self._use_flashinfer_cutlass_backend:
+            assert self.use_mxfp8, (
+                "flashinfer_cutlass FP8 MoE currently requires MXFP8 "
+                "(quantization=mxfp8)."
+            )
+            assert is_sm100_supported(), "flashinfer_cutlass MXFP8 MoE requires SM100."
+            assert (
+                flashinfer_cutlass_fused_moe is not None
+            ), "flashinfer_cutlass backend requires flashinfer.fused_moe.cutlass_fused_moe."
+            assert (
+                flashinfer_mxfp8_quantize is not None
+            ), "flashinfer_cutlass MXFP8 MoE requires flashinfer.mxfp8_quantize."
 
     @property
     def load_up_proj_weight_first(self) -> bool:
@@ -705,7 +769,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         is_gated = moe_runner_config is None or moe_runner_config.is_gated
         return (
             self.use_mxfp8
-            and get_moe_runner_backend().is_flashinfer_cutlass()
+            and self._use_flashinfer_cutlass_backend
             and flashinfer_cutlass_fused_moe is not None
             and is_gated
         )
@@ -836,7 +900,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.register_parameter("w13_weight_scale_inv", w13_weight_scale)
             layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
             assert self.quant_config.activation_scheme == "dynamic"
-            if get_moe_runner_backend().is_cutlass():
+            if self._use_cutlass_backend:
                 self._ensure_cutlass_buffers_initialized(layer)
 
         else:
@@ -1085,7 +1149,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             return qweight, scale
 
         if quantize:
-            if get_moe_runner_backend().is_cutlass():
+            if self._use_cutlass_backend or self._use_flashinfer_cutlass_backend:
                 w13_q, w13_s = _quantize_and_swizzle_with_cutlass_es_kernel(
                     layer.w13_weight.data
                 )
@@ -1368,7 +1432,17 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         moe_runner_config: MoeRunnerConfig,
+        output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if flashinfer_cutlass_fused_moe is None or flashinfer_mxfp8_quantize is None:
+            raise RuntimeError(
+                "FlashInfer MXFP8 MoE requires flashinfer.fused_moe.cutlass_fused_moe "
+                "and flashinfer.mxfp8_quantize."
+            )
+        if layer.w13_weight_scale_inv.dtype != torch.uint8:
+            raise TypeError("w13_weight_scale_inv must be uint8 UE8M0 for MXFP8.")
+        if layer.w2_weight_scale_inv.dtype != torch.uint8:
+            raise TypeError("w2_weight_scale_inv must be uint8 UE8M0 for MXFP8.")
         if layer.w13_weight_scale_inv.shape[-1] % 4 != 0:
             raise ValueError(
                 "MXFP8 FlashInfer MoE requires w13 scale last dim divisible by 4."
@@ -1389,24 +1463,48 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 "FlashInfer MXFP8 MoE supports only silu-gated or gelu-nongated "
                 f"activation, but got activation={activation!r}, is_gated={is_gated}."
             )
+        if moe_runner_config.apply_router_weight_on_input:
+            raise ValueError(
+                "apply_router_weight_on_input is not supported for FlashInfer MXFP8 MoE."
+            )
+
+        x_2d = x.contiguous()
+        x_mxfp8, x_sf = flashinfer_mxfp8_quantize(
+            x_2d, is_sf_swizzled_layout=True, alignment=32
+        )
+        x_mxfp8 = x_mxfp8[:, : x_2d.shape[1]].contiguous()
+        x_sf = x_sf.contiguous()
 
         w13_scale_block = layer.w13_weight_scale_inv.contiguous().view(torch.int32)
         w2_scale_block = layer.w2_weight_scale_inv.contiguous().view(torch.int32)
-
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
+        num_experts = layer.w13_weight.shape[0]
+        global_scale = getattr(layer, "_flashinfer_mxfp8_global_scale", None)
+        if (
+            global_scale is None
+            or global_scale.shape != (num_experts,)
+            or global_scale.device != x.device
+            or global_scale.dtype != torch.float32
         ):
-            symm_output = torch.empty_like(x)
+            global_scale = torch.ones(num_experts, dtype=torch.float32, device=x.device)
+            layer._flashinfer_mxfp8_global_scale = global_scale
+
+        if output is None:
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                output = torch.empty_like(x)
 
         return flashinfer_cutlass_fused_moe(
-            output=symm_output,
-            input=x,
+            output=output,
+            input=x_mxfp8,
             token_selected_experts=topk_ids.to(torch.int),
             token_final_scales=topk_weights,
             fc1_expert_weights=layer.w13_weight,
             fc2_expert_weights=layer.w2_weight,
             output_dtype=x.dtype,
-            quant_scales=[w13_scale_block, w2_scale_block],
+            quant_scales=[w13_scale_block, global_scale, w2_scale_block, global_scale],
+            input_sf=x_sf,
+            use_mxfp8_act_scaling=True,
             ep_size=layer.moe_ep_size,
             ep_rank=layer.moe_ep_rank,
             tp_size=layer.moe_tp_size,
@@ -1462,18 +1560,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             if ret is not None:
                 return StandardCombineInput(hidden_states=ret)
 
-        if get_moe_runner_backend().is_flashinfer_cutlass():
+        if self.use_mxfp8 and self._use_flashinfer_cutlass_backend:
+            from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
+
             topk_weights, topk_ids, _ = dispatch_output.topk_output
+            preallocated_output = (
+                dispatch_output.moe_output
+                if DispatchOutputChecker.format_is_flashinfer(dispatch_output)
+                else None
+            )
             output = self._apply_flashinfer_cutlass_mxfp8(
                 layer=layer,
                 x=x,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
                 moe_runner_config=moe_runner_config,
+                output=preallocated_output,
             )
             return StandardCombineInput(hidden_states=output)
 
-        if get_moe_runner_backend().is_cutlass():
+        if self._use_cutlass_backend:
             from sglang.srt.layers.moe.cutlass_moe import cutlass_fused_experts_fp8
 
             with use_symmetric_memory(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -54,7 +54,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     flashinfer_mxfp8_quantize,
     input_to_float8,
     mxfp8_group_quantize,
-    mxfp8_scale_linear_to_swizzled,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_weight_ue8m0_inplace,
 )
@@ -108,11 +107,9 @@ if _use_aiter or _use_hip_int4:
     from aiter.ops.shuffle import shuffle_weight
 
 if is_flashinfer_available():
+    from flashinfer import block_scale_interleave as flashinfer_block_scale_interleave
     from flashinfer.fused_moe import cutlass_fused_moe as flashinfer_cutlass_fused_moe
     from flashinfer.fused_moe.core import ActivationType as FlashInferActivationType
-else:
-    flashinfer_cutlass_fused_moe = None
-    FlashInferActivationType = Any
 
 
 ACTIVATION_SCHEMES = ["static", "dynamic"]
@@ -478,7 +475,23 @@ class Fp8LinearMethod(LinearMethodBase):
     def _maybe_prepare_flashinfer_mxfp8_weight_scale(self, layer: Module) -> None:
         if not self.use_flashinfer_mxfp8_linear:
             return
-        new_swizzled = mxfp8_scale_linear_to_swizzled(layer.weight_scale_inv.data)
+
+        if not is_sm100_supported() or not is_flashinfer_available():
+            raise RuntimeError(
+                "FlashInfer MXFP8 weight-scale swizzle requires SM100 and FlashInfer."
+            )
+
+        scale_u8 = layer.weight_scale_inv.data
+        if scale_u8.dtype != torch.uint8:
+            raise TypeError(f"Expected uint8 scale tensor, got {scale_u8.dtype}.")
+        if scale_u8.ndim != 2:
+            raise ValueError(
+                f"Expected 2D scale tensor, got shape {tuple(scale_u8.shape)}."
+            )
+        new_swizzled = flashinfer_block_scale_interleave(
+            scale_u8.contiguous()
+        ).contiguous()
+
         cached_swizzled = getattr(layer, "weight_scale_inv_swizzled", None)
         # Keep storage address stable when possible so CUDA graph captures remain valid.
         if (
@@ -659,6 +672,7 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
+            assert self.w8a8_mxfp8_linear is not None
             weight_scale = self._get_mxfp8_weight_scale(layer)
             if isinstance(x, tuple):
                 return self.w8a8_mxfp8_linear(
@@ -738,26 +752,21 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
         moe_runner_backend = get_moe_runner_backend()
-        self._moe_runner_backend = moe_runner_backend
-        self._use_cutlass_backend = moe_runner_backend.is_cutlass()
-        self._use_flashinfer_cutlass_backend = (
-            moe_runner_backend.is_flashinfer_cutlass()
-        )
-        if self._use_cutlass_backend:
+        if moe_runner_backend.is_cutlass():
             assert (
                 cutlass_fp8_supported()
             ), "cutlass_fp8 MoE requires CUDA 12.0+ with SM90 or CUDA 12.4+ with SM89"
             assert self.block_quant, "cutlass_fp8 MoE requires block quantization"
             assert is_sm100_supported() or is_sm90_supported()
-        if self._use_flashinfer_cutlass_backend:
+        if moe_runner_backend.is_flashinfer_cutlass():
             assert self.use_mxfp8, (
                 "flashinfer_cutlass FP8 MoE currently requires MXFP8 "
                 "(quantization=mxfp8)."
             )
             assert is_sm100_supported(), "flashinfer_cutlass MXFP8 MoE requires SM100."
             assert (
-                flashinfer_cutlass_fused_moe is not None
-            ), "flashinfer_cutlass backend requires flashinfer.fused_moe.cutlass_fused_moe."
+                is_flashinfer_available()
+            ), "flashinfer_cutlass backend requires FlashInfer."
             assert (
                 flashinfer_mxfp8_quantize is not None
             ), "flashinfer_cutlass MXFP8 MoE requires flashinfer.mxfp8_quantize."
@@ -767,10 +776,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         # FlashInfer CUTLASS kernel assumes [Up, Gate] order for gated W13.
         moe_runner_config = getattr(self, "moe_runner_config", None)
         is_gated = moe_runner_config is None or moe_runner_config.is_gated
+        moe_runner_backend = get_moe_runner_backend()
         return (
             self.use_mxfp8
-            and self._use_flashinfer_cutlass_backend
-            and flashinfer_cutlass_fused_moe is not None
+            and moe_runner_backend.is_flashinfer_cutlass()
+            and is_flashinfer_available()
             and is_gated
         )
 
@@ -900,7 +910,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.register_parameter("w13_weight_scale_inv", w13_weight_scale)
             layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
             assert self.quant_config.activation_scheme == "dynamic"
-            if self._use_cutlass_backend:
+            if get_moe_runner_backend().is_cutlass():
                 self._ensure_cutlass_buffers_initialized(layer)
 
         else:
@@ -1149,7 +1159,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             return qweight, scale
 
         if quantize:
-            if self._use_cutlass_backend or self._use_flashinfer_cutlass_backend:
+            moe_runner_backend = get_moe_runner_backend()
+            if (
+                moe_runner_backend.is_cutlass()
+                or moe_runner_backend.is_flashinfer_cutlass()
+            ):
                 w13_q, w13_s = _quantize_and_swizzle_with_cutlass_es_kernel(
                     layer.w13_weight.data
                 )
@@ -1434,7 +1448,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         moe_runner_config: MoeRunnerConfig,
         output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if flashinfer_cutlass_fused_moe is None or flashinfer_mxfp8_quantize is None:
+        if not is_flashinfer_available() or flashinfer_mxfp8_quantize is None:
             raise RuntimeError(
                 "FlashInfer MXFP8 MoE requires flashinfer.fused_moe.cutlass_fused_moe "
                 "and flashinfer.mxfp8_quantize."
@@ -1523,6 +1537,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         x = dispatch_output.hidden_states
         moe_runner_config = self.moe_runner_config
+        moe_runner_backend = get_moe_runner_backend()
 
         if use_intel_amx_backend(layer):
             from sglang.srt.layers.moe.topk import apply_topk_weights_cpu
@@ -1560,26 +1575,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             if ret is not None:
                 return StandardCombineInput(hidden_states=ret)
 
-        if self.use_mxfp8 and self._use_flashinfer_cutlass_backend:
-            from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
-
-            topk_weights, topk_ids, _ = dispatch_output.topk_output
-            preallocated_output = (
-                dispatch_output.moe_output
-                if DispatchOutputChecker.format_is_flashinfer(dispatch_output)
-                else None
-            )
-            output = self._apply_flashinfer_cutlass_mxfp8(
-                layer=layer,
-                x=x,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                moe_runner_config=moe_runner_config,
-                output=preallocated_output,
-            )
-            return StandardCombineInput(hidden_states=output)
-
-        if self._use_cutlass_backend:
+        if get_moe_runner_backend().is_cutlass():
             from sglang.srt.layers.moe.cutlass_moe import cutlass_fused_experts_fp8
 
             with use_symmetric_memory(
@@ -1616,6 +1612,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 enable_es=(use_mxfp8, use_mxfp8),
             )
             return StandardCombineInput(hidden_states=output)
+
+        if self.use_mxfp8 and get_moe_runner_backend().is_flashinfer_cutlass():
+            from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
+
+            topk_weights, topk_ids, _ = dispatch_output.topk_output
+            preallocated_output = (
+                dispatch_output.moe_output
+                if DispatchOutputChecker.format_is_flashinfer(dispatch_output)
+                else None
+            )
+            output = self._apply_flashinfer_cutlass_mxfp8(
+                layer=layer,
+                x=x,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                moe_runner_config=moe_runner_config,
+                output=preallocated_output,
+            )
+            return StandardCombineInput(hidden_states=output)
+
 
         if self.runner.runner_backend.is_deep_gemm():
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -805,11 +805,13 @@ def flashinfer_mxfp8_blockscaled_linear(
         else:
             output_dtype = torch.bfloat16
 
+    # flashinfer.mm_mxfp8 runner transposes B internally before launching the
+    # CUDA op; passing weight.t() here keeps the internal mat2 contiguous.
     output = flashinfer_mm_mxfp8(
         q_input,
-        weight.t().contiguous(),
+        weight.t(),
         x_scale_u8,
-        weight_scale.t().contiguous(),
+        weight_scale.t(),
         out_dtype=output_dtype,
         backend="auto",
     )

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -172,10 +172,14 @@ def _check_cutlass_block_fp8_hardware_support() -> bool:
 
 
 if is_blackwell_supported() and is_flashinfer_available():
+    from flashinfer import block_scale_interleave as flashinfer_block_scale_interleave
     from flashinfer import mm_mxfp8 as flashinfer_mm_mxfp8
+    from flashinfer import mxfp8_quantize as flashinfer_mxfp8_quantize
     from flashinfer.gemm import gemm_fp8_nt_groupwise
 else:
+    flashinfer_block_scale_interleave = None
     flashinfer_mm_mxfp8 = None
+    flashinfer_mxfp8_quantize = None
 
 if is_sm90_supported() and is_flashinfer_available():
     # FlashInfer SM90 DeepGEMM with automatic swapAB optimization for small M
@@ -647,6 +651,23 @@ def mxfp8_group_quantize(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     return q_input.contiguous(), scale_u8.contiguous()
 
 
+def mxfp8_scale_linear_to_swizzled(scale_u8: torch.Tensor) -> torch.Tensor:
+    """Convert MXFP8 2D linear scale layout [rows, cols] to swizzled 1D layout."""
+    if scale_u8.dtype != torch.uint8:
+        raise TypeError(f"Expected uint8 scale tensor, got {scale_u8.dtype}.")
+    if scale_u8.ndim != 2:
+        raise ValueError(
+            f"Expected 2D scale tensor, got shape {tuple(scale_u8.shape)}."
+        )
+
+    scale_u8 = scale_u8.contiguous()
+    if flashinfer_block_scale_interleave is None:
+        raise RuntimeError(
+            "mxfp8_scale_linear_to_swizzled requires FlashInfer block_scale_interleave."
+        )
+    return flashinfer_block_scale_interleave(scale_u8).contiguous()
+
+
 def _pack_mxfp8_scales(scale_u8: torch.Tensor) -> torch.Tensor:
     # Pack (M, K//32) UE8M0 scales into the layout expected by tl.dot_scaled.
     assert scale_u8.dim() == 2, f"Expected 2D scale tensor, got {scale_u8.dim()}D"
@@ -750,6 +771,31 @@ def triton_mxfp8_blockscaled_linear(
     return output.to(dtype=output_dtype).view(*output_shape)
 
 
+def _validate_mxfp8_scale_tensor(
+    scale: torch.Tensor, *, rows: int, k_scales: int, name: str
+) -> None:
+    if scale.dtype != torch.uint8:
+        raise TypeError(f"{name} must be UE8M0 uint8.")
+
+    if scale.ndim == 2:
+        expected_shape = (rows, k_scales)
+        if scale.shape != expected_shape:
+            raise ValueError(
+                f"Expected {name} shape {expected_shape}, got {scale.shape}."
+            )
+        return
+
+    if scale.ndim == 1:
+        expected_len = ceil_div(rows, 128) * 128 * ceil_div(k_scales, 4) * 4
+        if scale.numel() != expected_len:
+            raise ValueError(
+                f"Expected swizzled {name} length {expected_len}, got {scale.numel()}."
+            )
+        return
+
+    raise ValueError(f"Expected {name} to be 1D or 2D, got {scale.ndim}D.")
+
+
 def flashinfer_mxfp8_blockscaled_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -778,26 +824,31 @@ def flashinfer_mxfp8_blockscaled_linear(
         raise ValueError(f"K={k} must be divisible by 32 for MXFP8.")
     if weight.dtype != torch.float8_e4m3fn:
         raise TypeError("MXFP8 weight must be FP8 E4M3.")
-    if weight_scale.dtype != torch.uint8:
-        raise TypeError("MXFP8 weight_scale must be UE8M0 uint8.")
-    expected_weight_scale_shape = (n, k // 32)
-    if weight_scale.shape != expected_weight_scale_shape:
-        raise ValueError(
-            f"Expected weight_scale shape {expected_weight_scale_shape}, got {weight_scale.shape}."
-        )
+    k_scales = k // 32
+    _validate_mxfp8_scale_tensor(
+        weight_scale, rows=n, k_scales=k_scales, name="weight_scale"
+    )
 
     if input_scale is None:
-        q_input, x_scale_u8 = mxfp8_group_quantize(input_2d)
+        if flashinfer_mxfp8_quantize is not None:
+            q_input, x_scale_u8 = flashinfer_mxfp8_quantize(
+                input_2d, is_sf_swizzled_layout=True, alignment=32
+            )
+            q_input = q_input[:, :k].contiguous()
+            x_scale_u8 = x_scale_u8.contiguous()
+        else:
+            q_input, x_scale_u8 = mxfp8_group_quantize(input_2d)
     else:
         q_input = input_2d
         x_scale_u8 = input_scale
-        if x_scale_u8.dtype != torch.uint8:
-            raise TypeError("MXFP8 input_scale must be UE8M0 uint8.")
-        expected_input_scale_shape = (m, k // 32)
-        if x_scale_u8.shape != expected_input_scale_shape:
-            raise ValueError(
-                f"Expected input_scale shape {expected_input_scale_shape}, got {x_scale_u8.shape}."
+        if q_input.dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "When input_scale is provided, input must be MXFP8 tensor "
+                "(torch.float8_e4m3fn)."
             )
+        _validate_mxfp8_scale_tensor(
+            x_scale_u8, rows=m, k_scales=k_scales, name="input_scale"
+        )
 
     if output_dtype is None:
         if input_2d.dtype in (torch.float16, torch.bfloat16, torch.float32):
@@ -805,13 +856,18 @@ def flashinfer_mxfp8_blockscaled_linear(
         else:
             output_dtype = torch.bfloat16
 
-    # flashinfer.mm_mxfp8 runner transposes B internally before launching the
-    # CUDA op; passing weight.t() here keeps the internal mat2 contiguous.
+    # Ensure transposed tensors are contiguous for FlashInfer's internal runner.
+    weight_t = weight.contiguous().t()
+    weight_scale_t = (
+        weight_scale.contiguous().t()
+        if weight_scale.ndim == 2
+        else weight_scale.contiguous()
+    )
     output = flashinfer_mm_mxfp8(
         q_input,
-        weight.t(),
+        weight_t,
         x_scale_u8,
-        weight_scale.t(),
+        weight_scale_t,
         out_dtype=output_dtype,
         backend="auto",
     )

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -172,14 +172,9 @@ def _check_cutlass_block_fp8_hardware_support() -> bool:
 
 
 if is_blackwell_supported() and is_flashinfer_available():
-    from flashinfer import block_scale_interleave as flashinfer_block_scale_interleave
     from flashinfer import mm_mxfp8 as flashinfer_mm_mxfp8
     from flashinfer import mxfp8_quantize as flashinfer_mxfp8_quantize
     from flashinfer.gemm import gemm_fp8_nt_groupwise
-else:
-    flashinfer_block_scale_interleave = None
-    flashinfer_mm_mxfp8 = None
-    flashinfer_mxfp8_quantize = None
 
 if is_sm90_supported() and is_flashinfer_available():
     # FlashInfer SM90 DeepGEMM with automatic swapAB optimization for small M
@@ -651,23 +646,6 @@ def mxfp8_group_quantize(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     return q_input.contiguous(), scale_u8.contiguous()
 
 
-def mxfp8_scale_linear_to_swizzled(scale_u8: torch.Tensor) -> torch.Tensor:
-    """Convert MXFP8 2D linear scale layout [rows, cols] to swizzled 1D layout."""
-    if scale_u8.dtype != torch.uint8:
-        raise TypeError(f"Expected uint8 scale tensor, got {scale_u8.dtype}.")
-    if scale_u8.ndim != 2:
-        raise ValueError(
-            f"Expected 2D scale tensor, got shape {tuple(scale_u8.shape)}."
-        )
-
-    scale_u8 = scale_u8.contiguous()
-    if flashinfer_block_scale_interleave is None:
-        raise RuntimeError(
-            "mxfp8_scale_linear_to_swizzled requires FlashInfer block_scale_interleave."
-        )
-    return flashinfer_block_scale_interleave(scale_u8).contiguous()
-
-
 def _pack_mxfp8_scales(scale_u8: torch.Tensor) -> torch.Tensor:
     # Pack (M, K//32) UE8M0 scales into the layout expected by tl.dot_scaled.
     assert scale_u8.dim() == 2, f"Expected 2D scale tensor, got {scale_u8.dim()}D"
@@ -805,7 +783,7 @@ def flashinfer_mxfp8_blockscaled_linear(
     output_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
     """MXFP8 dense linear via FlashInfer mm_mxfp8."""
-    if flashinfer_mm_mxfp8 is None:
+    if not (is_blackwell_supported() and is_flashinfer_available()):
         raise RuntimeError(
             "MXFP8 FlashInfer GEMM requested, but flashinfer.mm_mxfp8 is unavailable."
         )
@@ -830,17 +808,14 @@ def flashinfer_mxfp8_blockscaled_linear(
     )
 
     if input_scale is None:
-        if flashinfer_mxfp8_quantize is not None:
-            q_input, x_scale_u8 = flashinfer_mxfp8_quantize(
-                input_2d, is_sf_swizzled_layout=True, alignment=32
-            )
-            q_input = q_input[:, :k].contiguous()
-            x_scale_u8 = x_scale_u8.contiguous()
-        else:
-            q_input, x_scale_u8 = mxfp8_group_quantize(input_2d)
+        q_input, x_scale_u8 = flashinfer_mxfp8_quantize(
+            input_2d, is_sf_swizzled_layout=True, alignment=32
+        )
+        q_input = q_input[:, :k].contiguous()
+        x_scale_u8 = x_scale_u8.contiguous()
     else:
         q_input = input_2d
-        x_scale_u8 = input_scale
+        x_scale_u8 = input_scale.contiguous()
         if q_input.dtype != torch.float8_e4m3fn:
             raise TypeError(
                 "When input_scale is provided, input must be MXFP8 tensor "

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2105,19 +2105,26 @@ class ServerArgs:
 
     def _handle_moe_kernel_config(self):
         if self.quantization == "mxfp8":
-            if self.moe_runner_backend not in ["auto", "cutlass"]:
-                logger.warning(
-                    "mxfp8 quantization forces --moe-runner-backend=cutlass. "
-                    f"Overriding {self.moe_runner_backend!r}."
+            if self.moe_runner_backend not in [
+                "auto",
+                "cutlass",
+                "flashinfer_cutlass",
+            ]:
+                raise ValueError(
+                    "mxfp8 quantization supports --moe-runner-backend in "
+                    "{'auto', 'cutlass', 'flashinfer_cutlass'}, but got "
+                    f"{self.moe_runner_backend!r}."
                 )
-            self.moe_runner_backend = "cutlass"
+            if self.moe_runner_backend == "auto":
+                self.moe_runner_backend = "cutlass"
 
         if self.moe_runner_backend == "flashinfer_cutlass":
             assert self.quantization in [
                 "modelopt_fp4",
                 "modelopt_fp8",
+                "mxfp8",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', or bfloat16 (None)."
+            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'mxfp8', or bfloat16 (None)."
             assert self.ep_size in [
                 1,
                 self.tp_size,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2105,26 +2105,28 @@ class ServerArgs:
 
     def _handle_moe_kernel_config(self):
         if self.quantization == "mxfp8":
-            if self.moe_runner_backend not in [
-                "auto",
-                "cutlass",
-                "flashinfer_cutlass",
-            ]:
+            allowed_mxfp8_backends = ("auto", "cutlass", "flashinfer_cutlass")
+            if self.moe_runner_backend not in allowed_mxfp8_backends:
                 raise ValueError(
                     "mxfp8 quantization supports --moe-runner-backend in "
-                    "{'auto', 'cutlass', 'flashinfer_cutlass'}, but got "
+                    f"{allowed_mxfp8_backends}, but got "
                     f"{self.moe_runner_backend!r}."
                 )
             if self.moe_runner_backend == "auto":
                 self.moe_runner_backend = "cutlass"
 
         if self.moe_runner_backend == "flashinfer_cutlass":
-            assert self.quantization in [
+            flashinfer_cutlass_quantizations = (
                 "modelopt_fp4",
                 "modelopt_fp8",
                 "mxfp8",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'mxfp8', or bfloat16 (None)."
+            )
+            assert self.quantization in flashinfer_cutlass_quantizations, (
+                f"Invalid quantization '{self.quantization}'.\n"
+                "FlashInfer Cutlass MOE supports only "
+                f"{flashinfer_cutlass_quantizations}."
+            )
             assert self.ep_size in [
                 1,
                 self.tp_size,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
@humansand

WIP.

FlashInfer has very good mxfp8 kernels.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Dependency
Dense linear requires https://github.com/sgl-project/sglang/pull/19005
MoE requires https://github.com/flashinfer-ai/flashinfer/pull/2581

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
# Preparation

# Install this sglang branch
cd /sgl-workspace/
rm -rf sglang
git clone -b flashinfer-mxfp8 https://github.com/zianglih/sglang.git && \
cd sglang && \
pip install --upgrade pip && \
pip install -e "python"

# Install miles for converting HF models to MXFP8
cd /root/
rm -rf miles
git clone -b main https://github.com/zianglih/miles.git
cd /root/miles
pip install -e . --no-deps

# Install flashinfer from source
pip uninstall -y flashinfer-jit-cache flashinfer-python flashinfer-cubin
cd /root
git clone -b mxfp8 https://github.com/zianglih/flashinfer.git --recursive flashinfer-src
cd flashinfer-src
python -m pip install --no-build-isolation -e . -v


# Download and convert the model to MXFP8
hf download Qwen/Qwen3-30B-A3B-Instruct-2507 --local-dir /data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507
python /root/miles/tools/convert_hf_to_mxfp8.py --model-dir /data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507 --save-dir /data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507-MXFP8

```

```
# Previous working baseline
pkill -9 sglang ; pkill -9 python
cd /sgl-workspace/sglang
python -m sglang.launch_server --kv-cache-dtype bf16 --model /data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507-MXFP8 --fp8-gemm-backend triton --moe-runner-backend cutlass &
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.963
Invalid: 0.000
Latency: 16.731 s
Output throughput: 10141.918 token/s
curl -sS http://localhost:30000/update_weights_from_disk \
  -H 'Content-Type: application/json' \
  -d '{
    "model_path": "/data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507-MXFP8",
    "flush_cache": true,
    "abort_all_requests": false
  }'
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.963
Invalid: 0.000
Latency: 17.151 s
Output throughput: 9893.989 token/s
```

```
# With FlashInfer MXFP8
pkill -9 sglang ; pkill -9 python
cd /sgl-workspace/sglang
python -m sglang.launch_server --kv-cache-dtype bf16 --model /data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507-MXFP8 --fp8-gemm-backend flashinfer_trtllm --moe-runner-backend flashinfer_cutlass &
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.964
Invalid: 0.000
Latency: 9.902 s
Output throughput: 17213.156 token/s
curl -sS http://localhost:30000/update_weights_from_disk \
  -H 'Content-Type: application/json' \
  -d '{
    "model_path": "/data/home/ziangli/models/Qwen3-30B-A3B-Instruct-2507-MXFP8",
    "flush_cache": true,
    "abort_all_requests": false
  }'
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
Accuracy: 0.964
Invalid: 0.000
Latency: 9.740 s
Output throughput: 17493.374 token/s

```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
On B200 TP1 Qwen3-30B-A3B-Instruct-2507-MXFP8, `python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum` throughput is 1.7x

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
