### PR TITLE
Fix dev Docker build OOM on ARM64 cu13 by adding docker system prune

### DIFF
--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -69,6 +69,11 @@ jobs:
           large-packages: true
           swap-storage: true
 
+      - name: Prune Docker to reclaim disk space
+        run: |
+          docker buildx prune --filter "until=72h" -f
+          docker system prune -af --volumes --filter "until=72h"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- The `arm64-cu13` dev Docker build was failing with `No space left on device` (13 MB free) while installing `flashinfer-jit-cache` (1.8 GB wheel)
- The existing `jlumbroso/free-disk-space` action only prunes unused Docker images, but stale containers, build cache, and volumes were consuming additional space on the self-hosted ARM64 runner
- Added `docker system prune -af --volumes` step before the build to aggressively reclaim disk space

## Test plan
- [ ] Re-run the [dev Docker build workflow](https://github.com/sgl-project/sglang/actions/workflows/release-docker-dev.yml) and verify the `arm64-cu13` job completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)