### PR TITLE
Revert "Fix generated-shared-prefix bench_serving"

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1525,12 +1525,12 @@ def sample_custom_requests(
     return filtered_dataset
 
 
-def compute_random_lens(full_len: int, range_ratio: float, num: int) -> np.ndarray:
+def compute_random_lens(full_len: int, range_ratio: float, num: int) -> List[int]:
     return np.random.randint(
         max(int(full_len * range_ratio), 1),
         full_len + 1,
         size=num,
-    )
+    ).tolist()
 
 
 def sample_random_requests(


### PR DESCRIPTION
Reverts sgl-project/sglang#18769

#18769 tries to fix the np.array error, but this has actually been fixed in #18761

cc @sufeng-buaa @zminglei 