### PR TITLE
Apply GraphInputBuffers to piecewise CUDA graph runner

### DIFF
--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Optional
+from dataclasses import dataclass, fields
+from typing import ClassVar, Dict, Optional
 
 import torch
 
@@ -12,25 +12,62 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 
 
+def _keep_larger(
+    existing: Optional[torch.Tensor],
+    new: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    if existing is None:
+        return new
+    if new is None:
+        return existing
+    return existing if existing.numel() >= new.numel() else new
+
+
 @dataclass
 class GraphInputBuffers:
     input_ids: torch.Tensor
-    input_embeds: torch.Tensor
+    input_embeds: Optional[torch.Tensor]
     req_pool_indices: torch.Tensor
     seq_lens: torch.Tensor
     seq_lens_cpu: torch.Tensor
     out_cache_loc: torch.Tensor
+    out_cache_loc_swa: Optional[torch.Tensor]
     positions: torch.Tensor
-    mrope_positions: torch.Tensor
+    mrope_positions: Optional[torch.Tensor]
     num_token_non_padded: torch.Tensor
     custom_mask: torch.Tensor
     next_token_logits_buffer: torch.Tensor
     mamba_track_indices: Optional[torch.Tensor]
     mamba_track_mask: Optional[torch.Tensor]
+    mamba_track_seqlens: Optional[torch.Tensor]
     global_num_tokens_gpu: torch.Tensor
     global_num_tokens_for_logprob_gpu: torch.Tensor
     encoder_lens: Optional[torch.Tensor]
     pp_proxy_tensors: Optional[Dict[str, torch.Tensor]]
+
+    # singleton
+    _graph_input_buffers: ClassVar[Optional["GraphInputBuffers"]] = None
+
+    @classmethod
+    def get_graph_input_buffers(cls) -> Optional["GraphInputBuffers"]:
+        return cls._graph_input_buffers
+
+    @classmethod
+    def _set_graph_input_buffers(cls, buffers: "GraphInputBuffers") -> None:
+        existing = cls._graph_input_buffers
+        if existing is not None:
+            for f in fields(cls):
+                old_val = getattr(existing, f.name)
+                new_val = getattr(buffers, f.name)
+                if isinstance(old_val, torch.Tensor) or isinstance(
+                    new_val, torch.Tensor
+                ):
+                    setattr(
+                        buffers,
+                        f.name,
+                        _keep_larger(old_val, new_val),
+                    )
+        cls._graph_input_buffers = buffers
 
     @classmethod
     def create(
@@ -51,23 +88,54 @@ class GraphInputBuffers:
         num_tokens_per_bs: int,
         cache_loc_dtype: torch.dtype,
         enable_mamba_track: bool,
+        enable_swa_out_cache: bool = False,
+        is_pcg: bool = False,
+        is_multimodal: bool = False,
     ) -> "GraphInputBuffers":
+
+        if is_pcg:
+            custom_mask_size = max_bs + max_num_token
+            pp_proxy_token_dim = max_num_token
+        else:
+            custom_mask_size = (
+                max_bs * seq_len_fill_value + max_num_token
+            ) * num_tokens_per_bs
+            pp_proxy_token_dim = max_bs
+
         with torch.device(device):
+            # For PCG, Only create input_embeds and mrope_positions for multimodal
+            # model to save memory
+            # 1. In multimodal, we only compile and capture the language model part.
+            # 2. The embedder is outside of the graph, but cuda graph requires the
+            # input embeds to have a fixed memory address.
+            # 3. Input embeds is a pre-allocated buffer. In model.forward, we copy
+            # the embed output to this buffer.
+            alloc_embeds = (not is_pcg) or is_multimodal
+
             input_ids = torch.zeros((max_num_token,), dtype=torch.int64)
-            input_embeds = torch.zeros((max_num_token, hidden_size), dtype=dtype)
+            input_embeds = (
+                torch.zeros((max_num_token, hidden_size), dtype=dtype)
+                if alloc_embeds
+                else None
+            )
             req_pool_indices = torch.zeros((max_bs,), dtype=torch.int32)
             seq_lens = torch.full((max_bs,), seq_len_fill_value, dtype=torch.int32)
             out_cache_loc = torch.zeros((max_num_token,), dtype=cache_loc_dtype)
-            positions = torch.zeros((max_num_token,), dtype=torch.int64)
-            mrope_positions = torch.zeros((3, max_num_token), dtype=torch.int64)
-            num_token_non_padded = torch.zeros((1,), dtype=torch.int32)
-            custom_mask = torch.ones(
-                (max_bs * seq_len_fill_value + max_num_token) * num_tokens_per_bs,
-                dtype=torch.bool,
+            out_cache_loc_swa = (
+                torch.zeros((max_num_token,), dtype=cache_loc_dtype)
+                if enable_swa_out_cache
+                else None
             )
+            positions = torch.zeros((max_num_token,), dtype=torch.int64)
+            mrope_positions = (
+                torch.zeros((3, max_num_token), dtype=torch.int64)
+                if alloc_embeds
+                else None
+            )
+            num_token_non_padded = torch.zeros((1,), dtype=torch.int32)
+            custom_mask = torch.ones((custom_mask_size,), dtype=torch.bool)
             next_token_logits_buffer = torch.zeros(
-                (max_num_token, vocab_size),
-                dtype=torch.float,
+                (max_num_token, vocab_size), dtype=torch.float
             )
             mamba_track_indices = (
                 torch.zeros((max_bs,), dtype=torch.int64)
@@ -77,21 +145,29 @@ class GraphInputBuffers:
             mamba_track_mask = (
                 torch.zeros((max_bs,), dtype=torch.bool) if enable_mamba_track else None
             )
+            mamba_track_seqlens = (
+                torch.zeros((max_bs,), dtype=torch.int32)
+                if enable_mamba_track
+                else None
+            )
 
             if pp_size > 1:
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hidden_size), dtype=dtype),
-                    "residual": torch.zeros((max_bs, hidden_size), dtype=dtype),
+                    "hidden_states": torch.zeros(
+                        (pp_proxy_token_dim, hidden_size), dtype=dtype
+                    ),
+                    "residual": torch.zeros(
+                        (pp_proxy_token_dim, hidden_size), dtype=dtype
+                    ),
                 }
             else:
                 pp_proxy_tensors = None
 
-            if is_encoder_decoder:
-                encoder_lens = torch.full(
-                    (max_bs,), encoder_len_fill_value, dtype=torch.int32
-                )
-            else:
-                encoder_lens = None
+            encoder_lens = (
+                torch.full((max_bs,), encoder_len_fill_value, dtype=torch.int32)
+                if is_encoder_decoder
+                else None
+            )
 
             if require_mlp_tp_gather:
                 global_num_tokens_gpu = torch.zeros((dp_size,), dtype=torch.int32)
@@ -104,19 +180,17 @@ class GraphInputBuffers:
 
         # Keep seq_lens_cpu as a true CPU tensor, like the old implementation.
         seq_lens_cpu = torch.full(
-            (max_bs,),
-            seq_len_fill_value,
-            dtype=torch.int32,
-            device="cpu",
+            (max_bs,), seq_len_fill_value, dtype=torch.int32, device="cpu"
         )
 
-        return cls(
+        buffers = cls(
             input_ids=input_ids,
             input_embeds=input_embeds,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens_cpu,
             out_cache_loc=out_cache_loc,
+            out_cache_loc_swa=out_cache_loc_swa,
             positions=positions,
             mrope_positions=mrope_positions,
             num_token_non_padded=num_token_non_padded,
@@ -124,11 +198,14 @@ class GraphInputBuffers:
             next_token_logits_buffer=next_token_logits_buffer,
             mamba_track_indices=mamba_track_indices,
             mamba_track_mask=mamba_track_mask,
+            mamba_track_seqlens=mamba_track_seqlens,
             encoder_lens=encoder_lens,
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
             pp_proxy_tensors=pp_proxy_tensors,
         )
+        cls._set_graph_input_buffers(buffers)
+        return buffers
 
     def populate_from_forward_batch(
         self,
@@ -180,7 +257,10 @@ class GraphInputBuffers:
         if self.encoder_lens is not None and forward_batch.encoder_lens is not None:
             self.encoder_lens[:raw_bs].copy_(forward_batch.encoder_lens)
 
-        if forward_batch.mrope_positions is not None:
+        if (
+            forward_batch.mrope_positions is not None
+            # and self.mrope_positions is not None
+        ):
             self.mrope_positions[:, :raw_num_token].copy_(forward_batch.mrope_positions)
 
         if require_gathered_buffer:

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -213,15 +213,19 @@ class PiecewiseCudaGraphRunner:
         )
 
         self.input_ids = self.buffers.input_ids
-        self.input_embeds = self.buffers.input_embeds
         self.out_cache_loc = self.buffers.out_cache_loc
         self.out_cache_loc_swa = self.buffers.out_cache_loc_swa
         self.mamba_track_indices = self.buffers.mamba_track_indices
         self.mamba_track_mask = self.buffers.mamba_track_mask
         self.mamba_track_seqlens = self.buffers.mamba_track_seqlens
         self.positions = self.buffers.positions
-        self.mrope_positions = self.buffers.mrope_positions
         self.custom_mask = self.buffers.custom_mask
+        if self.is_multimodal:
+            self.input_embeds = self.buffers.input_embeds
+            self.mrope_positions = self.buffers.mrope_positions
+        else:
+            self.input_embeds = None
+            self.mrope_positions = None
 
         self.tbo_plugin = TboCudaGraphRunnerPlugin()
 


### PR DESCRIPTION
## Summary

Apply the `GraphInputBuffers` pattern (from #13676) to `PiecewiseCudaGraphRunner`, so both `CudaGraphRunner` and `PiecewiseCudaGraphRunner` share the same buffer class with a class-level singleton.

## Changes

### `input_buffers.py`
- Add `is_pcg`, `is_multimodal`, `enable_swa_out_cache` parameters to `GraphInputBuffers.create()`.
- Add new fields: `mamba_track_seqlens`, `out_cache_loc_swa` (used by PCG).
- Make `input_embeds` and `mrope_positions` optional — only allocated for multimodal models in PCG mode, saving memory.
- Add class-level singleton (`_graph_input_buffers`) with `_set_graph_input_buffers()` that iterates over dataclass fields and keeps the larger tensor (by `numel()`) to prevent OOB from buffer size reduction.
- When `is_pcg=True`, `custom_mask` and `pp_proxy_tensors` are sized for token-centric extend semantics.

### `piecewise_cuda_graph_runner.py`
- Replace manual per-buffer allocation with `GraphInputBuffers.create(is_pcg=True, is_multimodal=...)`.
- All buffer aliases (`input_ids`, `positions`, `out_cache_loc`, `mamba_track_*`, etc.) now reference `self.buffers.*` directly.

## Design Decisions
- **No buffer shrinking**: The singleton merge logic (`_set_graph_input_buffers`) compares by `numel()` and always keeps the larger buffer.
- **Automatic field iteration**: Adding a new tensor field to the dataclass requires zero changes to the merge logic.
- **Memory-efficient for non-multimodal PCG**: `input_embeds` and `mrope_positions` are skipped when `is_pcg=True` and `is_multimodal=False`.

## Testing
- `TestPiecewiseCudaGraphCorrectness::test_mmlu` ✅
- `TestPiecewiseCudaGraphBenchmark::test_latency` ✅
- Unit tests for singleton, no-shrink, conditional allocation ✅
