### PR TITLE
[feat] feat: support swa in trtllm_mha

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.attention.triton_ops.trtllm_fp8_kv_kernel import (
     fused_fp8_set_kv_buffer,
 )
 from sglang.srt.layers.attention.utils import canonicalize_stride
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.utils import is_flashinfer_available
 
@@ -56,6 +57,8 @@ class TRTLLMMHAMetadata:
     cu_seqlens_k: torch.Tensor = None
     # Page table, the index of KV Cache Tables/Blocks
     page_table: torch.Tensor = None
+    # Page table for SWA layers (translated from full pool indices to SWA pool indices)
+    swa_page_table: torch.Tensor = None
 
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
@@ -120,8 +123,71 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             model_runner.server_args.speculative_num_draft_tokens
         )
 
+        # SWA hybrid model support.
+        self._swa_allocator: Optional[SWATokenToKVPoolAllocator] = (
+            model_runner.token_to_kv_pool_allocator
+            if isinstance(
+                model_runner.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator
+            )
+            else None
+        )
+
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
+
+    def _maybe_translate_swa(
+        self, token_indices: torch.Tensor
+    ) -> Optional[torch.Tensor]:
+        """Translate full-pool token indices to SWA-pool indices, or return None."""
+        if self._swa_allocator is None:
+            return None
+        shape = token_indices.shape
+        return self._swa_allocator.translate_loc_from_full_to_swa(
+            token_indices.reshape(-1)
+        ).reshape(shape)
+
+    def _alloc_swa_page_table(
+        self, max_bs: int, max_num_pages: int
+    ) -> Optional[torch.Tensor]:
+        """Allocate a SWA page_table buffer, or return None for non-SWA models."""
+        if self._swa_allocator is None:
+            return None
+        return torch.zeros(
+            max_bs, max_num_pages, dtype=torch.int32, device=self.device
+        )
+
+    def _copy_swa_page_table(
+        self,
+        metadata: TRTLLMMHAMetadata,
+        page_indices: torch.Tensor,
+        num_pages: int,
+    ):
+        """Translate and copy SWA page indices into metadata. No-op for non-SWA."""
+        if metadata.swa_page_table is None:
+            return
+        swa_indices = self._maybe_translate_swa(page_indices)
+        metadata.swa_page_table[:, :num_pages].copy_(swa_indices // self.page_size)
+
+    def _bind_swa_page_table(
+        self, metadata: TRTLLMMHAMetadata, source: dict, key: str, bs: int
+    ):
+        """Bind a pre-allocated SWA page_table slice to metadata for CUDA graph."""
+        buf = source.get(key)
+        if buf is not None:
+            metadata.swa_page_table = buf[:bs, :]
+
+    def _get_layer_page_table(
+        self, layer: RadixAttention, forward_batch: ForwardBatch
+    ) -> torch.Tensor:
+        """Return the correct page_table for the given layer (SWA or full)."""
+        swa_pt = self.forward_metadata.swa_page_table
+        if swa_pt is not None and isinstance(
+            forward_batch.token_to_kv_pool, SWAKVPool
+        ):
+            _, is_swa = forward_batch.token_to_kv_pool.layers_mapping[layer.layer_id]
+            if is_swa:
+                return swa_pt
+        return self.forward_metadata.page_table
 
     def init_cuda_graph_state(
         self,
@@ -139,6 +205,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 dtype=torch.int32,
                 device=self.device,
             ),
+            "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             "strided_indices": torch.arange(
                 0, self.max_context_len, self.page_size, device=self.device
             ),
@@ -160,6 +227,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 dtype=torch.int32,
                 device=self.device,
             )
+            self.decode_cuda_graph_metadata[
+                "swa_page_table_draft_decode"
+            ] = self._alloc_swa_page_table(max_bs, max_num_pages)
+
             self.target_verify_metadata = {
                 "cache_seqlens": torch.zeros(
                     max_bs, dtype=torch.int32, device=self.device
@@ -180,6 +251,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     dtype=torch.int32,
                     device=self.device,
                 ),
+                "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
                 "strided_indices": torch.arange(
                     0, self.max_context_len, self.page_size, device=self.device
                 ),
@@ -203,6 +275,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     dtype=torch.int32,
                     device=self.device,
                 ),
+                "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
                 "strided_indices": torch.arange(
                     0, self.max_context_len, self.page_size, device=self.device
                 ),
@@ -244,6 +317,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.page_table = self.decode_cuda_graph_metadata[
                     "page_table_draft_decode"
                 ][:bs, :]
+                self._bind_swa_page_table(
+                    metadata, self.decode_cuda_graph_metadata,
+                    "swa_page_table_draft_decode", bs,
+                )
                 self.decode_cuda_graph_metadata[bs] = metadata
             else:
                 # Normal Decode
@@ -264,6 +341,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
                     :bs, :
                 ]
+                self._bind_swa_page_table(
+                    metadata, self.decode_cuda_graph_metadata, "swa_page_table", bs,
+                )
                 self.decode_cuda_graph_metadata[bs] = metadata
         elif forward_mode.is_target_verify():
             # Target Verify
@@ -293,6 +373,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
 
             metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
+            self._bind_swa_page_table(
+                metadata, self.target_verify_metadata, "swa_page_table", bs,
+            )
 
             self.target_verify_metadata[bs] = metadata
         elif forward_mode.is_draft_extend():
@@ -317,6 +400,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata.max_seq_len_k = seq_lens.max().item()
 
             metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
+            self._bind_swa_page_table(
+                metadata, self.draft_extend_metadata, "swa_page_table", bs,
+            )
 
             self.draft_extend_metadata[bs] = metadata
         self.forward_metadata = metadata
@@ -371,6 +457,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ],
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
+            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
         elif forward_mode.is_target_verify():
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
@@ -392,8 +479,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 req_pool_indices[:, None],
                 self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
             ]
-            page_indices //= self.page_size
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices)
+            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
+            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
             metadata.max_seq_len_q = self.speculative_num_draft_tokens
         elif forward_mode.is_draft_extend():
             metadata = self.draft_extend_metadata[bs]
@@ -422,6 +509,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 self.draft_extend_metadata["strided_indices"][:max_seq_pages],
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
+            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
         self.forward_metadata = metadata
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:
@@ -553,7 +641,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.max_seq_len_q = metadata.max_seq_len_k
                 metadata.cu_seqlens_q = metadata.cu_seqlens_k
 
-        # Convert the page table to a strided format
+        # Compute SWA page table (None for non-SWA models)
+        metadata.swa_page_table = self._maybe_translate_swa(metadata.page_table)
+
+        # Convert the page tables to a strided format
         if self.page_size > 1:
             self.strided_indices = torch.arange(
                 0, metadata.page_table.shape[1], self.page_size, device=self.device
@@ -561,6 +652,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata.page_table = (
                 metadata.page_table[:, self.strided_indices] // self.page_size
             )
+            if metadata.swa_page_table is not None:
+                metadata.swa_page_table = (
+                    metadata.swa_page_table[:, self.strided_indices] // self.page_size
+                )
 
         self.forward_metadata = metadata
 
@@ -629,19 +724,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # sink: additional value per head in the denominator of the softmax.
         attention_sink = kwargs.get("sinks", None)
 
+        page_table = self._get_layer_page_table(layer, forward_batch)
+
         # Call TRT-LLM kernel
         # raw_out: like q, [bs, acc_q_len, num_q_heads, head_dim] but with output dtype
         o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
             query=q,
             kv_cache=kv_cache,
             workspace_buffer=self.workspace_buffer,
-            block_tables=self.forward_metadata.page_table,
+            block_tables=page_table,
             seq_lens=self.forward_metadata.cache_seqlens_int32,
             max_seq_len=self.max_context_len,
             bmm1_scale=bmm1_scale,
             bmm2_scale=bmm2_scale,
             window_left=layer.sliding_window_size,
-            # TODO: add attention_sink operation or nvfp4 scale factor if needed
             sinks=attention_sink,
             out_dtype=self.q_data_type,  # model_runner.dtype
         )
@@ -711,29 +807,29 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         bmm1_scale = q_scale * k_scale * layer.scaling
         bmm2_scale = 1.0
 
+        page_table = self._get_layer_page_table(layer, forward_batch)
+
         if forward_batch.forward_mode.is_target_verify():
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,
                 workspace_buffer=self.workspace_buffer,
-                block_tables=self.forward_metadata.page_table,
+                block_tables=page_table,
                 seq_lens=self.forward_metadata.cache_seqlens_int32,
                 max_seq_len=self.max_context_len,
                 bmm1_scale=bmm1_scale,
                 bmm2_scale=bmm2_scale,
                 window_left=layer.sliding_window_size,
-                # TODO: add attention_sink operation or nvfp4 scale factor if needed
                 sinks=attention_sink,
                 out_dtype=self.q_data_type,  # model_runner.dtype
                 q_len_per_req=self.forward_metadata.max_seq_len_q,
             )
         else:
-
             o = flashinfer.prefill.trtllm_batch_context_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,
                 workspace_buffer=self.workspace_buffer,
-                block_tables=self.forward_metadata.page_table,
+                block_tables=page_table,
                 seq_lens=self.forward_metadata.cache_seqlens_int32,
                 max_q_len=self.forward_metadata.max_seq_len_q,
                 max_kv_len=self.max_context_len,
@@ -743,7 +839,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 cum_seq_lens_q=self.forward_metadata.cu_seqlens_q,
                 cum_seq_lens_kv=self.forward_metadata.cu_seqlens_k,
                 window_left=layer.sliding_window_size,
-                # TODO: add attention_sink operation or nvfp4 scale factor if needed
                 sinks=attention_sink,
                 out_dtype=self.q_data_type,  # model_runner.dtype
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Recent findings during the adaptation of step3.5-flash reveal that on the B200 platform, the default use of the trtllm_mha kernel lacks the implementation of SWA, resulting in incorrect output after generating a certain number of tokens.

## Modifications

1. add some helper function in `python/sglang/srt/layers/attention/trtllm_mha_backend.py`
2. add swa translate in trtllm_mha

## Accuracy Tests

using  [Step-3.5-Flash](https://huggingface.co/stepfun-ai/Step-3.5-Flash) to Test

In B200
```bash
4188fc30b06b% python -m sglang.test.few_shot_gsm8k \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 200 \
  --num-shots 5

Accuracy: 0.875
Invalid: 0.005
Latency: 9.289 s
Output throughput: 2154.766 token/s
```

In H20-3e
```bash
root@aba9b8cd2ed9:/sgl-workspace/sglang# python -m sglang.test.few_shot_gsm8k   --host http://127.0.0.1   --port 8000  --num-questions 200 --num-shots 5

Accuracy: 0.835
Invalid: 0.005
Latency: 11.075 s
Output throughput: 1789.372 token/s
```

GPQA-Diamond:

B200: 0.8316498316498316
H200: 0.835016835016835


### Detail Case

Pre Test:
```
4188fc30b06b% uv run test-scripts/chat.py '写一个python的快排' --temperature 0
.....
def quick_sort(arr, low=0, high=None):
    """原地快速排序（升序）"""
    if high is None:
        high = len(arr) - 1
    if low < high:
        # 分区操作，返回基准元素的正确位置
        pivot_index = partition(arr, low, high)
        # 递归排序左半部分和右半部分
        quick_sort(arr, low, pivot_index - 1)
        quick_sort(arr, pivot_index + 1, high)

def partition(arr, low, high):
    """分区函数：将数组分为小于基准和大于基准的两部分"""
    # 选择最后一个元素作为基准（可优化为随机选择）
    pivot = arr[high]
    i = low - 1  # 指向小于基准的区域的最后一个元素
    for j in range(low, high):
        if arr[j] <= pivot:
            i += 1
            i, arr[i], arr[i], arr[i], 交换 arr[i], 交换 arr[i] 交换 arr[i] 1 1 1, 1 1, 1:
    # 1:
                # 1
    # 1:
            arr[j] 1:
    # 1:
    # 1:
            arr[j] # 1:
    # 1:
            # 交换 arr[j]：
    # 1:
                # 1:
            arr[j] # 交换 arr[i] # 1:
            arr[i] # 交换 arr[i] # 交换 arr[i] # 交换 arr[j] # 交换 arr:
            arr[i] # 1:
            arr[j] # 1:
        arr[j] #  partition arr:
        # 1:
            arr:
            arr:
            arr:
            # 交换 arr[1:
            arr:
        arr:
        # 交换
    for _1:
        #  partition 1:
        #  partition 1:
        #  partition 1:
        # 1:
        # 1:
        #  partition 1:
            # 1:
        # 1, arr    #  partition  partition  partition 1:
        # 1,  partition arr    # 1:
    #  partition] = pivot_index = []
    ]:
    ]:
    # 1:
    ]:
        for j in range(:
    # 1    partition] # 1:
    # 升序）：
    partition 1  partition]    partition 越 partition 1 排序    # 排序    # 排序1    # 1]    # 1]    # 排序后的元素交换    partition2, arr    partition 的    partition  partition 的 partition]   交换    #  partition 2, 1    # 的    ]    ]   交换的 partition  partition 1]:
    }
```
After Test:
```
4188fc30b06b% uv run test-scripts/chat.py '写一个python的快排' --temperature 0

[Thinking]
我们来实现一个快速排序（Quick Sort）的Python函数。
 快速排序的基本思想是选择一个基准元素，通过一趟排序将数组分成两部分，其中一部分的所有数据都比另一部分的所有数据小，然后再按此方法对这两部分数据分别进行快速排序，整个过程可以递归进行。

 步骤：
 1. 选择一个基准元素（通常选择第一个元素，但也可以选择最后一个或中间的元素）。
 2. 通过一趟排序将数组分成两部分，使得左边的元素都小于等于基准，右边的元素都大于等于基准。
 3. 递归地对左右两部分进行快速排序。

 注意：这里我们实现一个原地排序的版本，但为了简单起见，也可以使用额外的列表。不过，原地排序更节省空间。

 我们这里实现一个原地排序的版本，使用两个指针（左右指针）进行划分。

 但是，注意：原地排序的快速排序在划分时需要注意细节，我们这里采用《算法导论》中的划分方法，即使用最后一个元素作为基准，然后维护一个索引i，使得[0, i-1]都是小于等于基准的，然后遍历j从0到high-1，如果当前元素小于等于基准，就交换到i的位置，然后i++。最后将基准（最后一个元素）与i位置的元素交换，这样基准就放在了正确的位置。

 然而，我们也可以选择第一个元素作为基准，但那样需要调整。这里我们选择最后一个元素作为基准。

 但是，为了通用性，我们可以让用户指定基准的选择方式，但这里我们固定使用最后一个元素。

 我们写一个函数，参数是数组arr，以及排序的起始和结束索引（low和high）。如果low小于high，则进行划分，然后递归排序。

 注意：我们这里实现的是升序排序。

 步骤：
 1. 如果low < high，则：
     a. 调用partition函数，返回基准元素的位置pivot_index。
     b. 递归排序low到pivot_index-1。
     c. 递归排序pivot_index+1到high。

 2. partition函数：
    选择最后一个元素作为基准（pivot = arr[high]）。
    初始化一个索引i = low - 1，表示小于等于基准的区域的最后一个元素的下标。
    遍历j从low到high-1：
        如果arr[j] <= pivot，则i++，交换arr[i]和arr[j]。
    最后，交换arr[i+1]和arr[high]（将基准放到正确位置）。
    返回i+1，即基准的位置。

 注意：这个划分方法会使得基准左边的元素都小于等于基准，右边的元素都大于等于基准。

 但是，快速排序的平均时间复杂度是O(nlogn)，最坏情况（已经有序）是O(n^2)。我们可以通过随机选择基准来避免最坏情况，但这里我们固定使用最后一个元素。

 我们也可以实现一个随机选择基准的版本，但题目没有要求，我们就先实现这个简单的。

 另外，注意递归深度，对于大数组可能会递归很深，但Python的递归深度有限，对于大数组可能会栈溢出。我们可以使用迭代方式，但这里我们先用递归。

 我们写一个函数，然后测试一下。

 但是，注意：我们这里实现的是原地排序，所以不需要返回新的列表，而是直接修改传入的列表。

 我们写两个函数：quick_sort和partition。

 但是，为了用户方便，我们可以提供一个对外的接口，只传入列表，然后内部调用递归函数。

 我们这样设计：

 定义一个内部递归函数_quick_sort(arr, low, high)，然后对外暴露一个quick_sort(arr)函数，它调用_quick_sort(arr, 0, len(arr)-1)。

 但是，注意：如果列表为空或只有一个元素，则直接返回。

 我们开始写代码。

[/Thinking]


以下是 Python 中快速排序（Quick Sort）的几种实现方式，包括**原地排序版本**（节省内存）和**易读版本**（使用额外列表）：

---

### 1. **原地排序版本（推荐）**
直接在原数组上操作，空间复杂度为 O(log n)（递归栈），时间复杂度平均 O(n log n)，最坏 O(n²)。

\```python
def quick_sort(arr, low=0, high=None):
    """原地快速排序（升序）"""
    if high is None:
        high = len(arr) - 1
    if low < high:
        # 分区操作，返回基准元素的正确位置
        pivot_index = partition(arr, low, high)
        # 递归排序左半部分和右半部分
        quick_sort(arr, low, pivot_index - 1)
        quick_sort(arr, pivot_index + 1, high)

def partition(arr, low, high):
    """分区函数：将数组分为小于基准和大于基准的两部分"""
    # 选择最后一个元素作为基准（可优化为随机选择）
    pivot = arr[high]
    i = low - 1  # 指向小于基准的区域的最后一个元素
    for j in range(low, high):
        if arr[j] <= pivot:
            i += 1
            arr[i], arr[j] = arr[j], arr[i]  # 交换元素
    # 将基准元素放到正确位置
    arr[i + 1], arr[high] = arr[high], arr[i + 1]
    return i + 1

# 示例
if __name__ == "__main__":
    data = [3, 6, 8, 10, 1, 2, 1]
    quick_sort(data)
    print("排序后:", data)  # 输出: [1, 1, 2, 3, 6, 8, 10]
\```

---

### 2. **易读版本（使用额外列表）**
逻辑清晰，适合理解快速排序原理，但空间复杂度 O(n)。

\```python
def quick_sort_readable(arr):
    """易读的快速排序（返回新列表）"""
    if len(arr) <= 1:
        return arr
    pivot = arr[-1]  # 选择最后一个元素作为基准
    left = [x for x in arr[:-1] if x <= pivot]  # 小于等于基准的子列表
    right = [x for x in arr[:-1] if x > pivot]   # 大于基准的子列表
    return quick_sort_readable(left) + [pivot] + quick_sort_readable(right)

# 示例
if __name__ == "__main__":
    data = [3, 6, 8, 10, 1, 2, 1]
    sorted_data = quick_sort_readable(data)
    print("排序后:", sorted_data)  # 输出: [1, 1, 2, 3, 6, 8, 10]
\```

---

### 3. **优化版本（随机选择基准 + 三数取中）**
避免最坏情况（如数组已排序），提升性能：

\```python
import random

def quick_sort_optimized(arr, low=0, high=None):
    """优化版快速排序：随机选择基准"""
    if high is None:
        high = len(arr) - 1
    if low < high:
        # 随机选择基准并交换到末尾
        random_index = random.randint(low, high)
        arr[random_index], arr[high] = arr[high], arr[random_index]
        pivot_index = partition(arr, low, high)
        quick_sort_optimized(arr, low, pivot_index - 1)
        quick_sort_optimized(arr, pivot_index + 1, high)

# partition 函数同上（使用 arr[high] 作为基准）
\```

---

### 关键点说明：
1. **基准选择**：固定选择最后一个元素简单但可能退化；随机选择可避免最坏情况。
2. **稳定性**：快速排序是**不稳定**的（相同元素的相对位置可能改变）。
3. **适用场景**：适合大规模无序数据；小数组可切换到插入排序优化。
4. **递归深度**：最坏情况递归深度 O(n)，可能栈溢出；可改用迭代+栈模拟递归。

---

### 测试建议：
\```python
# 测试不同情况
test_cases = [
    [], [1], [2, 1], [1, 2, 3], [3, 2, 1],
    [5, 2, 9, 1, 5, 6], [1, 1, 1, 1]
]
for case in test_cases:
    arr = case.copy()
    quick_sort(arr)
    print(f"{case} -> {arr}")
\```

选择版本建议：
- **生产环境**：使用原地排序版本（`quick_sort`），注意随机化基准。
- **教学/理解**：使用易读版本（`quick_sort_readable`）。
- **避免最坏情况**：使用优化版本（`quick_sort_optimized`）。
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [X] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
