### PR TITLE
[Fix] Fix rank used in parallel executor when enable_cfg_parallel is false

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -60,7 +60,26 @@ class ParallelExecutor(PipelineExecutor):
         """
         Execute all pipeline stages respecting their declared parallelism type.
         """
+        # if server_args.enable_cfg_parallel:
+        #     rank = get_classifier_free_guidance_rank()
+        # else:
+        #     rank = (
+        #         torch.distributed.get_rank()
+        #         if torch.distributed.is_initialized()
+        #         else 0
+        #     )
         rank = get_classifier_free_guidance_rank()
+        cfg_rank = get_classifier_free_guidance_rank()
+        world_rank = (
+            torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        )
+        logger.info(
+            "parallel_executor rank: enable_cfg_parallel=%s cfg_rank=%s world_rank=%s rank_used=%s",
+            server_args.enable_cfg_parallel,
+            cfg_rank,
+            world_rank,
+            rank,
+        )
         cfg_group = get_cfg_group()
 
         # TODO: decide when to gather on main when CFG_PARALLEL -> MAIN_RANK_ONLY

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -8,6 +8,7 @@ from sglang.multimodal_gen.runtime.distributed import get_sp_group
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_cfg_group,
     get_classifier_free_guidance_rank,
+    get_world_rank,
 )
 from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.executors.pipeline_executor import (
@@ -63,11 +64,7 @@ class ParallelExecutor(PipelineExecutor):
         if server_args.enable_cfg_parallel:
             rank = get_classifier_free_guidance_rank()
         else:
-            rank = (
-                torch.distributed.get_rank()
-                if torch.distributed.is_initialized()
-                else 0
-            )
+            rank = get_world_rank()
         cfg_group = get_cfg_group()
 
         # TODO: decide when to gather on main when CFG_PARALLEL -> MAIN_RANK_ONLY

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py
@@ -60,26 +60,14 @@ class ParallelExecutor(PipelineExecutor):
         """
         Execute all pipeline stages respecting their declared parallelism type.
         """
-        # if server_args.enable_cfg_parallel:
-        #     rank = get_classifier_free_guidance_rank()
-        # else:
-        #     rank = (
-        #         torch.distributed.get_rank()
-        #         if torch.distributed.is_initialized()
-        #         else 0
-        #     )
-        rank = get_classifier_free_guidance_rank()
-        cfg_rank = get_classifier_free_guidance_rank()
-        world_rank = (
-            torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-        )
-        logger.info(
-            "parallel_executor rank: enable_cfg_parallel=%s cfg_rank=%s world_rank=%s rank_used=%s",
-            server_args.enable_cfg_parallel,
-            cfg_rank,
-            world_rank,
-            rank,
-        )
+        if server_args.enable_cfg_parallel:
+            rank = get_classifier_free_guidance_rank()
+        else:
+            rank = (
+                torch.distributed.get_rank()
+                if torch.distributed.is_initialized()
+                else 0
+            )
         cfg_group = get_cfg_group()
 
         # TODO: decide when to gather on main when CFG_PARALLEL -> MAIN_RANK_ONLY


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
When enable_cfg_parallel is false, the executor uses get_classifier_free_guidance_rank() as the execution rank. With CFG disabled the CFG group has size 1, so every worker gets rank 0. In multi-GPU runs, world_rank is 0, 1, 2, … but the effective rank stays 0 on all workers. That breaks logic that should run only on the main rank (e.g. MAIN_RANK_ONLY): either all workers run or behavior is wrong. 

A PR from https://github.com/sgl-project/sglang/pull/18170/

I add logs to show the bug:
```python

logger.info(
            "parallel_executor rank: enable_cfg_parallel=%s cfg_rank=%s world_rank=%s rank_used=%s", \
            server_args.enable_cfg_parallel, \
            cfg_rank, \
            world_rank, \
            rank, \
            main_process_only=False, \
            local_main_process_only=False, \
        )
```

```bash
sglang generate   --model-path Qwen/Qwen-Image   --num-gpus 2   --prompt "A logo with bold text: SGL"   --num-inference-steps 4
```

> [02-18 13:20:15] parallel_executor rank: enable_cfg_parallel=False cfg_rank=0 world_rank=0 rank_used=0
> [02-18 13:20:15] parallel_executor rank: enable_cfg_parallel=False cfg_rank=0 world_rank=1 rank_used=0 


after the fix:

> [02-18 13:27:19] parallel_executor rank: enable_cfg_parallel=False cfg_rank=0 world_rank=0 rank_used=0
> [02-18 13:27:19] parallel_executor rank: enable_cfg_parallel=False cfg_rank=0 world_rank=1 rank_used=1


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
