### PR TITLE
[Fix] Fix EAGLE speculative decoding CUDA crash from missing accept_length handling

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -346,9 +346,12 @@ class EAGLEDraftCudaGraphRunner:
             self.topk_p[raw_bs:bs].zero_()
             self.topk_index[raw_bs:bs].zero_()
             self.hidden_states[raw_bs:bs].zero_()
-            # Point padding slots to the first real request's pool entry
-            # so that the padding attention reads from a valid KV cache entry.
-            self.req_pool_indices[raw_bs:bs] = forward_batch.req_pool_indices[0]
+            # Point padding slots to a valid pool entry so that the padding
+            # attention reads from a valid KV cache entry.
+            if raw_bs > 0:
+                self.req_pool_indices[raw_bs:bs] = forward_batch.req_pool_indices[0]
+            else:
+                self.req_pool_indices[raw_bs:bs].fill_(0)
 
         num_tokens = bs * self.num_tokens_per_bs
 

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -341,6 +341,14 @@ class EAGLEDraftCudaGraphRunner:
             self.seq_lens.fill_(self.seq_len_fill_value)
             self.out_cache_loc.zero_()
             self.positions.zero_()
+            # Zero padding slots for safety: stale values from previous runs
+            # could contain out-of-range indices causing illegal memory access.
+            self.topk_p[raw_bs:bs].zero_()
+            self.topk_index[raw_bs:bs].zero_()
+            self.hidden_states[raw_bs:bs].zero_()
+            # Point padding slots to the first real request's pool entry
+            # so that the padding attention reads from a valid KV cache entry.
+            self.req_pool_indices[raw_bs:bs] = forward_batch.req_pool_indices[0]
 
         num_tokens = bs * self.num_tokens_per_bs
 


### PR DESCRIPTION
## Summary
- Fix `EagleDraftInput.filter_batch()` and `merge_batch()` to properly handle `accept_length` and `accept_length_cpu` fields. When retract filters the batch during speculative decoding, these fields were not updated, causing dimension mismatches with other batch tensors (`topk_p`, `hidden_states`, etc.) that could lead to CUDA illegal memory access.
- Zero stale CUDA graph padding slot values (`topk_p`, `topk_index`, `hidden_states`) and set `req_pool_indices` to a valid pool entry. Stale values from previous batch runs could contain out-of-range indices causing illegal memory access.

**Failure example**: https://github.com/sgl-project/sglang/actions/runs/22151968295/job/64045532930

This is a recurring intermittent issue with `test_eagle_infer_b.py` (tracked in #17050: Jan 6, Jan 12, Feb 2, Feb 18).

## Test plan
- [ ] CI `stage-b-test-large-1-gpu (0)` passes (`test_eagle_infer_b.py`)
- [ ] Other EAGLE tests in `test_eagle_infer_a.py` pass
- [ ] No regressions in other speculative decoding tests