### PR TITLE
[AMD] Enable ROCm kvcache JIT path and add AMD CI coverage.

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -65,6 +65,7 @@ jobs:
     outputs:
       main_package: ${{ steps.filter.outputs.main_package || steps.run-mode.outputs.run_all_tests }}
       sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.run-mode.outputs.run_all_tests }}
+      jit_kernel: ${{ steps.filter.outputs.jit_kernel || steps.run-mode.outputs.run_all_tests }}
       multimodal_gen: ${{ steps.filter.outputs.multimodal_gen || steps.run-mode.outputs.run_all_tests }}
     steps:
       - name: Checkout code
@@ -101,6 +102,9 @@ jobs:
               - ".github/workflows/pr-test-amd-rocm720.yml"
             sgl_kernel:
               - "sgl-kernel/**"
+              - ".github/workflows/pr-test-amd-rocm720.yml"
+            jit_kernel:
+              - "python/sglang/jit_kernel/**"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             multimodal_gen:
               - "python/sglang/multimodal_gen/**"
@@ -237,6 +241,45 @@ jobs:
         timeout-minutes: 10
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-amd --continue-on-error
+
+  jit-kernel-unit-test-amd:
+    needs: [check-changes]
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'jit-kernel-unit-test-amd') ||
+        (
+          !inputs.target_stage &&
+          needs.check-changes.outputs.jit_kernel == 'true'
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-mi325-gpu-1]
+    runs-on: ${{matrix.runner}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build
+
+      - name: Run JIT kernel unit tests
+        timeout-minutes: 10
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" python3 -m pytest -q python/sglang/jit_kernel/tests/test_store_cache.py
 
   stage-b-test-small-1-gpu-amd:
     needs: [check-changes]
@@ -756,6 +799,7 @@ jobs:
         multimodal-gen-test-2-gpu-amd,
 
         stage-a-test-1-amd,
+        jit-kernel-unit-test-amd,
         stage-b-test-small-1-gpu-amd,
         stage-b-test-small-1-gpu-amd-mi35x,
         stage-b-test-large-1-gpu-amd,

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -62,6 +62,7 @@ jobs:
     outputs:
       main_package: ${{ steps.filter.outputs.main_package || steps.run-mode.outputs.run_all_tests }}
       sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.run-mode.outputs.run_all_tests }}
+      jit_kernel: ${{ steps.filter.outputs.jit_kernel || steps.run-mode.outputs.run_all_tests }}
       multimodal_gen: ${{ steps.filter.outputs.multimodal_gen || steps.run-mode.outputs.run_all_tests }}
     steps:
       - name: Checkout code
@@ -98,6 +99,9 @@ jobs:
               - ".github/workflows/pr-test-amd.yml"
             sgl_kernel:
               - "sgl-kernel/**"
+              - ".github/workflows/pr-test-amd.yml"
+            jit_kernel:
+              - "python/sglang/jit_kernel/**"
               - ".github/workflows/pr-test-amd.yml"
             multimodal_gen:
               - "python/sglang/multimodal_gen/**"
@@ -234,6 +238,45 @@ jobs:
         timeout-minutes: 10
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-amd
+
+  jit-kernel-unit-test-amd:
+    needs: [check-changes]
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'jit-kernel-unit-test-amd') ||
+        (
+          !inputs.target_stage &&
+          needs.check-changes.outputs.jit_kernel == 'true'
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-mi325-gpu-1]
+    runs-on: ${{matrix.runner}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Run JIT kernel unit tests
+        timeout-minutes: 10
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" python3 -m pytest -q python/sglang/jit_kernel/tests/test_store_cache.py
 
   stage-b-test-small-1-gpu-amd:
     needs: [check-changes, stage-a-test-1-amd]
@@ -845,6 +888,7 @@ jobs:
         multimodal-gen-test-2-gpu-amd,
 
         stage-a-test-1-amd,
+        jit-kernel-unit-test-amd,
         stage-b-test-small-1-gpu-amd,
         stage-b-test-small-1-gpu-amd-mi35x,
         stage-b-test-large-1-gpu-amd,

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -280,7 +280,7 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   \
   # TVM Python bits need Cython + z3 before configure.
   # Pin z3-solver==4.15.4.0: 4.15.4.0 has a manylinux wheel; 4.15.5.0 has no wheel and builds from source (fails: C++20 <format> needs GCC 14+, image has GCC 11).
-  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi>=0.1.6" "z3-solver==4.15.4.0"; \
+  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@v0.1.9-rc1" "z3-solver==4.15.4.0"; \
   \
   # Clone + pin TileLang (bundled TVM), then build
   git clone --recursive "${TILELANG_REPO}" /opt/tilelang && \

--- a/docker/rocm720.Dockerfile
+++ b/docker/rocm720.Dockerfile
@@ -309,7 +309,7 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   \
   # TVM Python bits need Cython + z3 before configure.
   # Pin z3-solver==4.15.4.0: 4.15.4.0 has a manylinux wheel; 4.15.5.0 has no wheel and builds from source (fails: C++20 <format> needs GCC 14+, image has GCC 11).
-  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi>=0.1.6" "z3-solver==4.15.4.0"; \
+  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@v0.1.9-rc1" "z3-solver==4.15.4.0"; \
   \
   # Clone + pin TileLang (bundled TVM), then build
   git clone --recursive "${TILELANG_REPO}" /opt/tilelang && \

--- a/python/sglang/jit_kernel/csrc/elementwise/kvcache.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/kvcache.cuh
@@ -10,6 +10,12 @@
 
 #include <cstdint>
 
+#ifdef USE_ROCM
+#ifndef __grid_constant__
+#define __grid_constant__
+#endif
+#endif
+
 namespace {
 
 struct StoreKVCacheParams {
@@ -149,7 +155,7 @@ struct StoreKVCacheKernel {
     auto dtype = SymbolicDType{};
     auto device = SymbolicDevice{};
     auto indice_dtype = SymbolicDType{};
-    device.set_options<kDLCUDA>();
+    device.set_options<kDLCUDA, kDLROCM>();
 
     TensorMatcher({B, D})  //
         .with_strides({KS, 1})

--- a/python/sglang/jit_kernel/csrc/elementwise/kvcache.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/kvcache.cuh
@@ -10,12 +10,6 @@
 
 #include <cstdint>
 
-#ifdef USE_ROCM
-#ifndef __grid_constant__
-#define __grid_constant__
-#endif
-#endif
-
 namespace {
 
 struct StoreKVCacheParams {

--- a/python/sglang/jit_kernel/include/sgl_kernel/tile.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/tile.cuh
@@ -13,10 +13,10 @@ struct Memory {
     return Memory{0, 1};
   }
   SGL_DEVICE static Memory warp(int warp_threads = kWarpThreads) {
-    return Memory{threadIdx.x % warp_threads, warp_threads};
+    return Memory{static_cast<uint32_t>(threadIdx.x % warp_threads), static_cast<uint32_t>(warp_threads)};
   }
   SGL_DEVICE static Memory cta(int cta_threads = blockDim.x) {
-    return Memory{threadIdx.x, cta_threads};
+    return Memory{static_cast<uint32_t>(threadIdx.x), static_cast<uint32_t>(cta_threads)};
   }
   SGL_DEVICE T load(const void* ptr, int64_t offset = 0) const {
     return static_cast<const T*>(ptr)[tid + offset * tsize];

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -25,8 +25,10 @@ using cudaStream_t = hipStream_t;
 using cudaLaunchConfig_t = hipLaunchConfig_t;
 using cudaLaunchAttribute = hipLaunchAttribute;
 inline constexpr auto cudaSuccess = hipSuccess;
+#define cudaStreamPerThread hipStreamPerThread
 #define cudaGetErrorString hipGetErrorString
 #define cudaGetLastError hipGetLastError
+#define cudaLaunchKernel hipLaunchKernel
 #endif
 
 #ifndef USE_ROCM
@@ -44,21 +46,6 @@ using fp8x2_e5m2_t = __nv_fp8x2_e5m2;
 
 using fp32x4_t = float4;
 #else
-#include <hip/hip_bf16.h>
-#include <hip/hip_fp16.h>
-#include <hip/hip_runtime.h>
-#ifndef __grid_constant__
-#define __grid_constant__
-#endif
-using cudaError_t = hipError_t;
-using cudaStream_t = hipStream_t;
-using cudaLaunchConfig_t = hipLaunchConfig_t;
-using cudaLaunchAttribute = hipLaunchAttribute;
-inline constexpr auto cudaSuccess = hipSuccess;
-#define cudaStreamPerThread hipStreamPerThread
-#define cudaGetErrorString hipGetErrorString
-#define cudaGetLastError hipGetLastError
-#define cudaLaunchKernel hipLaunchKernel
 using fp32_t = float;
 using fp16_t = __half;
 using bf16_t = __hip_bfloat16;

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -7,11 +7,27 @@
 
 #include <concepts>
 #include <cstddef>
+#include <type_traits>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
-#include <type_traits>
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#ifndef __grid_constant__
+#define __grid_constant__
+#endif
+using cudaError_t = hipError_t;
+using cudaStream_t = hipStream_t;
+using cudaLaunchConfig_t = hipLaunchConfig_t;
+using cudaLaunchAttribute = hipLaunchAttribute;
+inline constexpr auto cudaSuccess = hipSuccess;
+#define cudaGetErrorString hipGetErrorString
+#define cudaGetLastError hipGetLastError
+#endif
 
 #ifndef USE_ROCM
 using fp32_t = float;
@@ -26,6 +42,18 @@ using bf16x2_t = __nv_bfloat162;
 using fp8x2_e4m3_t = __nv_fp8x2_e4m3;
 using fp8x2_e5m2_t = __nv_fp8x2_e5m2;
 
+using fp32x4_t = float4;
+#else
+using fp32_t = float;
+using fp16_t = __half;
+using bf16_t = __hip_bfloat16;
+using fp8_e4m3_t = uint8_t;
+using fp8_e5m2_t = uint8_t;
+using fp32x2_t = float2;
+using fp16x2_t = half2;
+using bf16x2_t = __hip_bfloat162;
+using fp8x2_e4m3_t = uint16_t;
+using fp8x2_e5m2_t = uint16_t;
 using fp32x4_t = float4;
 #endif
 
@@ -146,6 +174,10 @@ struct LaunchKernel {
   }
 
   auto enable_pdl(bool enabled = true) -> LaunchKernel& {
+#ifdef USE_ROCM
+    (void)enabled;
+    m_config.numAttrs = 0;
+#else
     if (enabled) {
       m_attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
       m_attrs[0].val.programmaticStreamSerializationAllowed = true;
@@ -154,12 +186,24 @@ struct LaunchKernel {
     } else {
       m_config.numAttrs = 0;
     }
+#endif
     return *this;
   }
 
   template <typename T, typename... Args>
   auto operator()(T&& kernel, Args&&... args) const -> void {
+#ifdef USE_ROCM
+    hipLaunchKernelGGL(
+        std::forward<T>(kernel),
+        m_config.gridDim,
+        m_config.blockDim,
+        m_config.dynamicSmemBytes,
+        m_config.stream,
+        std::forward<Args>(args)...);
+    RuntimeDeviceCheck(m_location);
+#else
     RuntimeDeviceCheck(::cudaLaunchKernelEx(&m_config, kernel, std::forward<Args>(args)...), m_location);
+#endif
   }
 
  private:

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -44,6 +44,21 @@ using fp8x2_e5m2_t = __nv_fp8x2_e5m2;
 
 using fp32x4_t = float4;
 #else
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#ifndef __grid_constant__
+#define __grid_constant__
+#endif
+using cudaError_t = hipError_t;
+using cudaStream_t = hipStream_t;
+using cudaLaunchConfig_t = hipLaunchConfig_t;
+using cudaLaunchAttribute = hipLaunchAttribute;
+inline constexpr auto cudaSuccess = hipSuccess;
+#define cudaStreamPerThread hipStreamPerThread
+#define cudaGetErrorString hipGetErrorString
+#define cudaGetLastError hipGetLastError
+#define cudaLaunchKernel hipLaunchKernel
 using fp32_t = float;
 using fp16_t = __half;
 using bf16_t = __hip_bfloat16;

--- a/python/sglang/jit_kernel/kvcache.py
+++ b/python/sglang/jit_kernel/kvcache.py
@@ -7,12 +7,10 @@ import torch
 
 from sglang.jit_kernel.utils import (
     cache_once,
-    hip_ensure_tvm_ffi_stream,
     is_arch_support_pdl,
     is_hip_runtime,
     load_jit,
     make_cpp_args,
-    to_tvm_tensor_cached,
 )
 
 if TYPE_CHECKING:
@@ -80,19 +78,6 @@ def store_cache(
             num_split = 2
         else:
             num_split = 1
-    if _is_hip:
-        # HIP-only fast path: avoid per-call Python stream context-manager overhead.
-        hip_ensure_tvm_ffi_stream(k)
-        module.store_cache(
-            to_tvm_tensor_cached(k),
-            to_tvm_tensor_cached(v),
-            to_tvm_tensor_cached(k_cache),
-            to_tvm_tensor_cached(v_cache),
-            to_tvm_tensor_cached(indices),
-            num_split,
-        )
-        return
-
     module.store_cache(
         k,
         v,

--- a/python/sglang/jit_kernel/kvcache.py
+++ b/python/sglang/jit_kernel/kvcache.py
@@ -8,16 +8,12 @@ import torch
 from sglang.jit_kernel.utils import (
     cache_once,
     is_arch_support_pdl,
-    is_hip_runtime,
     load_jit,
     make_cpp_args,
 )
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
-
-
-_is_hip = is_hip_runtime()
 
 
 @cache_once

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import functools
 import os
 import pathlib
+import stat
+import weakref
 from typing import TYPE_CHECKING, Any, Callable, List, Tuple, TypeAlias, TypeVar, Union
 
 import torch
+from torch.utils.dlpack import to_dlpack
 
 if TYPE_CHECKING:
     from tvm_ffi import Module
@@ -76,6 +79,114 @@ CPP_DTYPE_MAP = {
     torch.bfloat16: "bf16_t",
 }
 
+# AMD/ROCm note:
+# tvm_ffi's generic Python torch fallback path can break HIP graph capture and
+# add avoidable per-call overhead. We keep a cached torch->tvm_ffi bridge and a
+# HIP stream cache here so all HIP-enabled JIT kernels can share the same fix.
+_tvm_tensor_cache: dict[int, tuple[weakref.ReferenceType[torch.Tensor], Any]] = {}
+_hip_tvm_stream_cache: dict[tuple[int, int], int] = {}
+
+
+@cache_once
+def is_hip_runtime() -> bool:
+    return bool(torch.version.hip)
+
+
+@cache_once
+def _prepare_rocm_cuda_shim() -> str:
+    """Create a CUDA-home-compatible shim that forwards nvcc to hipcc."""
+    shim_root = pathlib.Path.home() / ".cache" / "sglang_jit_rocm_cuda_shim"
+    bin_dir = shim_root / "bin"
+    lib64_dir = shim_root / "lib64"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    lib64_dir.mkdir(parents=True, exist_ok=True)
+
+    libcudart = lib64_dir / "libcudart.so"
+    if libcudart.exists() or libcudart.is_symlink():
+        libcudart.unlink()
+    libcudart.symlink_to("/opt/rocm/lib/libamdhip64.so")
+
+    nvcc_path = bin_dir / "nvcc"
+    wrapper = """#!/usr/bin/env bash
+set -euo pipefail
+
+depfile=""
+out=""
+src=""
+args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --generate-dependencies-with-compile)
+      shift
+      ;;
+    --dependency-output)
+      depfile="$2"
+      shift 2
+      ;;
+    -gencode=*)
+      shift
+      ;;
+    --expt-relaxed-constexpr)
+      shift
+      ;;
+    -Xcompiler)
+      # Keep the wrapped compiler flag, drop only the nvcc forwarding token.
+      if [[ $# -ge 2 ]]; then
+        args+=("$2")
+      fi
+      shift 2
+      ;;
+    -o)
+      out="$2"
+      args+=("$1" "$2")
+      shift 2
+      ;;
+    -c)
+      args+=("$1")
+      if [[ $# -ge 2 ]]; then
+        src="$2"
+      fi
+      shift
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${src}" ]]; then
+  hip_src="${src}.hip.cu"
+  /opt/rocm/bin/hipify-perl "${src}" > "${hip_src}"
+  for i in "${!args[@]}"; do
+    if [[ "${args[$i]}" == "${src}" ]]; then
+      args[$i]="${hip_src}"
+      break
+    fi
+  done
+fi
+
+/opt/rocm/bin/hipcc -DUSE_ROCM "${args[@]}"
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  exit $rc
+fi
+
+if [[ -n "${depfile}" ]]; then
+  if [[ -n "${out}" && -n "${src}" ]]; then
+    echo "${out}: ${src}" > "${depfile}"
+  else
+    : > "${depfile}"
+  fi
+fi
+"""
+    nvcc_path.write_text(wrapper)
+    nvcc_path.chmod(
+        nvcc_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    return str(shim_root)
+
 
 def make_cpp_args(*args: CPP_TEMPLATE_TYPE) -> CPPArgList:
     def _convert(arg: CPP_TEMPLATE_TYPE) -> str:
@@ -88,6 +199,38 @@ def make_cpp_args(*args: CPP_TEMPLATE_TYPE) -> CPPArgList:
         raise TypeError(f"Unsupported argument type for cpp template: {type(arg)}")
 
     return CPPArgList(_convert(arg) for arg in args)
+
+
+def to_tvm_tensor_cached(tensor: torch.Tensor):
+    """AMD/ROCm helper: cached torch->tvm_ffi conversion for HIP capture safety."""
+    key = id(tensor)
+    entry = _tvm_tensor_cache.get(key)
+    if entry is not None:
+        ref, cached = entry
+        if ref() is tensor:
+            return cached
+        _tvm_tensor_cache.pop(key, None)
+    from tvm_ffi import from_dlpack
+
+    tvm_tensor = from_dlpack(to_dlpack(tensor))
+    _tvm_tensor_cache[key] = (weakref.ref(tensor), tvm_tensor)
+    return tvm_tensor
+
+
+def hip_ensure_tvm_ffi_stream(tensor: torch.Tensor) -> None:
+    """AMD/ROCm helper: keep tvm_ffi stream aligned with the current HIP stream."""
+    from tvm_ffi.core import _env_set_current_stream
+
+    dl_device_type, dl_device_id = tensor.__dlpack_device__()
+    device_type = int(dl_device_type)
+    device_id = int(dl_device_id)
+    # Faster than constructing torch.cuda.current_stream(...) Python object.
+    current_stream = int(torch._C._cuda_getCurrentRawStream(device_id))
+    key = (device_type, device_id)
+    if _hip_tvm_stream_cache.get(key) == current_stream:
+        return
+    _env_set_current_stream(device_type, device_id, current_stream)
+    _hip_tvm_stream_cache[key] = current_stream
 
 
 def load_jit(
@@ -156,6 +299,13 @@ def load_jit(
     # Override TVM_FFI_CUDA_ARCH_LIST if it does not exist.
     env_key = "TVM_FFI_CUDA_ARCH_LIST"
     env_existed = env_key in os.environ
+    cuda_home_existed = "CUDA_HOME" in os.environ
+    old_cuda_home = os.environ.get("CUDA_HOME")
+
+    # tvm_ffi currently assumes a CUDA-style toolchain. On ROCm, provide a shim.
+    if is_hip_runtime():
+        os.environ["CUDA_HOME"] = _prepare_rocm_cuda_shim()
+        extra_cuda_cflags = ["-DUSE_ROCM"] + extra_cuda_cflags
     if not env_existed:
         os.environ[env_key] = _get_cuda_arch_list()
     try:
@@ -173,6 +323,12 @@ def load_jit(
         # Reset TVM_FFI_CUDA_ARCH_LIST to original state (not exist)
         if not env_existed:
             del os.environ[env_key]
+        if is_hip_runtime():
+            if cuda_home_existed:
+                assert old_cuda_home is not None
+                os.environ["CUDA_HOME"] = old_cuda_home
+            else:
+                os.environ.pop("CUDA_HOME", None)
 
 
 @cache_once

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -61,6 +61,9 @@ KERNEL_PATH = _resolve_kernel_path()
 DEFAULT_INCLUDE = [str(KERNEL_PATH / "include")]
 DEFAULT_CFLAGS = ["-std=c++20", "-O3"]
 DEFAULT_CUDA_CFLAGS = ["-std=c++20", "-O3", "--expt-relaxed-constexpr"]
+DEFAULT_HIP_CFLAGS = [
+    flag for flag in DEFAULT_CUDA_CFLAGS if flag != "--expt-relaxed-constexpr"
+]
 DEFAULT_LDFLAGS = []
 CPP_TEMPLATE_TYPE: TypeAlias = Union[int, float, bool, torch.dtype]
 
@@ -162,12 +165,9 @@ def load_jit(
     # Override TVM_FFI_CUDA_ARCH_LIST if it does not exist.
     env_key = "TVM_FFI_CUDA_ARCH_LIST"
     env_existed = env_key in os.environ
-    base_cuda_cflags = DEFAULT_CUDA_CFLAGS
+    selected_cuda_cflags = DEFAULT_CUDA_CFLAGS
     if is_hip_runtime():
-        # HIP clang does not support this nvcc-only flag.
-        base_cuda_cflags = [
-            flag for flag in DEFAULT_CUDA_CFLAGS if flag != "--expt-relaxed-constexpr"
-        ]
+        selected_cuda_cflags = DEFAULT_HIP_CFLAGS
         extra_cuda_cflags = ["-DUSE_ROCM"] + extra_cuda_cflags
     if not env_existed:
         os.environ[env_key] = _get_cuda_arch_list()
@@ -177,7 +177,7 @@ def load_jit(
             cpp_sources=cpp_sources,
             cuda_sources=cuda_sources,
             extra_cflags=DEFAULT_CFLAGS + extra_cflags,
-            extra_cuda_cflags=base_cuda_cflags + extra_cuda_cflags,
+            extra_cuda_cflags=selected_cuda_cflags + extra_cuda_cflags,
             extra_ldflags=DEFAULT_LDFLAGS + extra_ldflags,
             extra_include_paths=DEFAULT_INCLUDE + extra_include_paths,
             build_directory=build_directory,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -99,7 +99,7 @@ def _set_kv_buffer_impl(
     same_kv_dim: bool = True,
 ) -> None:
     row_bytes = row_dim * store_dtype.itemsize
-    if _is_cuda and same_kv_dim and can_use_store_cache(row_bytes):
+    if (_is_cuda or _is_hip) and same_kv_dim and can_use_store_cache(row_bytes):
         return store_cache(
             k.view(-1, row_dim),
             v.view(-1, row_dim),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
# updated
This PR needs to wait for this PR being fixed in tvm-ffi: https://github.com/apache/tvm-ffi/pull/466.
Then, I will refactor the tvm-ffi build in AMD dockerfile.

## Motivation

Enable KV-cache JIT kernel support on AMD GPUs (ROCm/HIP).
This unblocks AMD from using the same JIT kernel path used for `store_cache`, improves kernel execution cost, and keeps an explicit ON/OFF gate for A/B validation.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Enabled HIP to use the JIT `store_cache` path in `python/sglang/srt/mem_cache/memory_pool.py` by allowing `(_is_cuda or _is_hip)` in the JIT condition.
- Added HIP-only stream integration fast path in `python/sglang/jit_kernel/kvcache.py`:
- Updated `python/sglang/jit_kernel/benchmark/bench_store_cache.py`:
- ROCm JIT build/compat updates:
- Added the jit unit tests to AMD CI
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

- GSM8K gating was run for JIT ON and JIT OFF in prior validation workflow.
- Result: no observed accuracy compromise from JIT ON (both satisfy target threshold > 0.91).
- Repro command:
  - `python3 benchmark/gsm8k/bench_sglang.py --parallel 1319 --num-questions 1319`

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
# TODO
### 1) Microbenchmark
```
python python/sglang/jit_kernel/benchmark/bench_store_cache.py
---
store-kvcache-performance:
    item_size  batch_size  SGL JIT Kernel (us)  PyTorch Compile (us)  PyTorch 2 Stream (us)
0        64.0         1.0             1.530878              3.609001              13.910070
1        64.0         2.0             1.703583              1.701716              13.858375
2        64.0         4.0             1.525286              1.867752              13.834843
3        64.0         8.0             1.531984              1.856150              13.689956
4        64.0        16.0             1.702780              1.877719              13.939247
5        64.0        32.0             1.688343              1.898396              14.127501
6        64.0        64.0             1.700108              1.937117              14.493856
7        64.0       128.0             1.694447              1.906943              14.317665
8        64.0       256.0             1.712055              1.928936              14.269250
9        64.0       512.0             1.706658              1.988316              14.163227
10       64.0      1024.0             1.793236              1.914411              14.669482
11       64.0      2048.0             1.809130              2.067852              14.731377
12       64.0      4096.0             1.854543              2.775640              14.734177
13       64.0      8192.0             2.085342              4.244159              14.854081
14       64.0     16384.0             3.008147              9.428949              14.927790
15      128.0         1.0             1.526669              3.514099              15.224013
16      128.0         2.0             1.535702              3.380252              15.147796
17      128.0         4.0             1.532870              3.664049              15.174286
18      128.0         8.0             1.719195              3.639942              14.944473
19      128.0        16.0             1.747598              3.615295              15.019272
20      128.0        32.0             1.704128              3.758425              14.957170
21      128.0        64.0             1.709244              3.797895              15.043297
22      128.0       128.0             1.711217              3.826283              15.006878
23      128.0       256.0             1.734482              3.776173              14.947106
24      128.0       512.0             1.729476              3.769170              14.949036
25      128.0      1024.0             1.842618              4.162795              15.051123
26      128.0      2048.0             1.853122              5.915263              15.099389
27      128.0      4096.0             1.952395              9.327450              15.212351
28      128.0      8192.0             3.031015             20.726408              15.101812
29      128.0     16384.0             4.129458             39.449223              17.790274
30      256.0         1.0             1.524900              3.366259              15.007313
31      256.0         2.0             1.697072              3.601874              14.358390
32      256.0         4.0             1.524115              3.642532              14.357902
33      256.0         8.0             1.701475              3.683006              14.492978
34      256.0        16.0             1.701067              3.770033              14.623994
35      256.0        32.0             1.656125              3.800853              14.610519
36      256.0        64.0             1.724383              3.792146              14.569413
37      256.0       128.0             1.706427              3.790939              14.674269
38      256.0       256.0             1.732788              3.795366              14.428102
39      256.0       512.0             1.751780              4.184433              14.474892
40      256.0      1024.0             1.803404              5.892339              14.544748
41      256.0      2048.0             1.935257              9.308089              14.548281
42      256.0      4096.0             2.905640             20.732901              15.058139
43      256.0      8192.0             4.498064             39.478779              17.816505
44      256.0     16384.0             8.112202             89.219853              31.794805
45      512.0         1.0             1.524197              3.612409              14.563521
46      512.0         2.0             1.663075              3.661642              14.930169
47      512.0         4.0             1.538497              3.696966              14.765168
48      512.0         8.0             1.681958              3.793007              14.876653
49      512.0        16.0             1.684035              3.774594              14.866497
50      512.0        32.0             1.700258              3.821656              14.915637
51      512.0        64.0             1.702615              3.780679              15.000013
52      512.0       128.0             1.729654              3.754058              14.999363
53      512.0       256.0             1.755475              4.250167              14.923662
54      512.0       512.0             1.852408              6.005787              14.975765
55      512.0      1024.0             1.972089              9.485988              15.289171
56      512.0      2048.0             2.999174             20.683673              14.857239
57      512.0      4096.0             4.199431             39.554034              17.805115
58      512.0      8192.0             8.208252             90.155694              31.607517
59      512.0     16384.0            16.733556            187.789156              58.645830
60     1024.0         1.0             1.541506              3.573637              14.170540
61     1024.0         2.0             1.530745              3.703955              13.375077
62     1024.0         4.0             1.690164              3.785208              14.212782
63     1024.0         8.0             1.698685              3.793955              14.672082
64     1024.0        16.0             1.692635              3.789463              14.322547
65     1024.0        32.0             1.652687              3.784861              14.286241
66     1024.0        64.0             1.744674              3.725506              14.137428
67     1024.0       128.0             1.815641              4.239821              14.525985
68     1024.0       256.0             1.794034              6.090140              14.464665
69     1024.0       512.0             1.940442              9.497890              14.513952
70     1024.0      1024.0             2.941427             20.758252              14.296894
71     1024.0      2048.0             4.350285             39.668899              17.829414
72     1024.0      4096.0             8.109168             89.481054              31.885688
73     1024.0      8192.0            16.955048            189.105309              59.694808
74     1024.0     16384.0            29.589396            373.102844             109.242929
```
### 2) E2E A/B (Llama-3.1-8B, send_one/bench_serving)

- A/B toggle:
  - ON: `SGLANG_DISABLE_STORE_CACHE_JIT=0`
  - OFF: `SGLANG_DISABLE_STORE_CACHE_JIT=1`
- Example stable high-load result (`bench_serving`, `max-concurrency=16`, random `512->64`):
  - ON total throughput: `4225.85 tok/s`
  - OFF total throughput: `4222.38 tok/s`
  - ON mean E2E latency: `360.60 ms`
  - OFF mean E2E latency: `373.09 ms`
  - Interpretation: ON has clearer latency win with neutral-to-positive throughput delta.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

CC: @HaiShaw 