### PR TITLE
Fix KeyError when loading ModelOpt FP8 checkpoint for Falcon-H1R-7B

### DIFF
--- a/python/sglang/srt/models/falcon_h1.py
+++ b/python/sglang/srt/models/falcon_h1.py
@@ -559,6 +559,8 @@ class FalconH1ForCausalLM(nn.Module):
                     continue
                 # if is_pp_missing_parameter(name, self):
                 #     continue
+                if name not in params_dict:
+                    continue
 
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)


### PR DESCRIPTION
[FalconH1] Fix KeyError when loading FP8 checkpoint with mamba scale tensors      

The load_weights method in FalconH1ForCausalLM raised a KeyError when loading                                                                                                                                                                                              
  a ModelOpt FP8 checkpoint that contains quantization scale tensors (e.g.                                                                                                                                                                                                   
  mamba.in_proj.input_scale) with no corresponding registered model parameter.                                                        


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

  1. Only skip .output_scale, .k_scale, .v_scale (KV cache scales, no model params)
  2. Dequantize only when the target parameter is BF16 (param.dtype != float8_e4m3fn) — applies to mamba's BF16 in_proj/out_proj
  3. Load FP8 weights directly for attention/MLP layers (target params are FP8)
  4. Load weight_scale/input_scale through the normal path — for FP8 layers they land in the registered PerTensorScaleParameter; for mamba they fall through the name not in params_dict guard and get skipped naturally


## Accuracy Tests

```
  #!/usr/bin/env python3                                                                                                                                                                                    
  """                                                                        
  Test script for FalconH1 FP8 model loading fix.                                                                                                                                                           
  Start the server first:                                                                                                                                                                                   
    python -m sglang.launch_server \
      --model /path/to/Falcon-H1R-7B-FP8 \
      --quantization modelopt \
      --tensor-parallel-size 1 \
      --reasoning-parser deepseek-r1 \
      --port 30000
  """

  import openai

  client = openai.Client(base_url="http://127.0.0.1:30000/v1", api_key="EMPTY")

  def test(prompt, expected_substr):
      response = client.chat.completions.create(
          model="default",
          messages=[{"role": "user", "content": prompt}],
          max_tokens=256,
          temperature=0,
      )
      content = response.choices[0].message.content
      print(f"Q: {prompt}")
      print(f"A: {content}")
      assert expected_substr.lower() in content.lower(), \
          f"Expected '{expected_substr}' in response, got: {content}"
      print("PASS\n")

  # Basic factual question
  test("What is the capital of France?", "Paris")

  # Arithmetic — exercises reasoning parser
  test("What is 2+2? Answer with just the number.", "4")

  print("All tests passed.")
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
