### PR TITLE
[Fix][Qwen3.5] Pass max_mamba_cache_size to mamba pool in disaggregation decode path

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -173,7 +173,9 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         )
         self.enable_mamba_extra_buffer = enable_mamba_extra_buffer
         self.enable_memory_saver = enable_memory_saver
-        effective_mamba_size = (mamba_size if mamba_size is not None else size) + pre_alloc_size
+        effective_mamba_size = (
+            mamba_size if mamba_size is not None else size
+        ) + pre_alloc_size
         self._init_mamba_pool(
             size=effective_mamba_size,
             mamba_spec_state_size=size + pre_alloc_size,

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -158,6 +158,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         speculative_num_draft_tokens: int,
         enable_mamba_extra_buffer: bool,
         pre_alloc_size: int,
+        mamba_size: int = None,
     ):
         DecodeReqToTokenPool.__init__(
             self,
@@ -172,8 +173,9 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         )
         self.enable_mamba_extra_buffer = enable_mamba_extra_buffer
         self.enable_memory_saver = enable_memory_saver
+        effective_mamba_size = (mamba_size if mamba_size is not None else size) + pre_alloc_size
         self._init_mamba_pool(
-            size=size + pre_alloc_size,
+            size=effective_mamba_size,
             mamba_spec_state_size=size + pre_alloc_size,
             cache_params=cache_params,
             device=device,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -445,6 +445,7 @@ class ModelRunnerKVCacheMixin:
                         speculative_num_draft_tokens=self.server_args.speculative_num_draft_tokens,
                         enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
                         pre_alloc_size=pre_alloc_size,
+                        mamba_size=self.server_args.max_mamba_cache_size,
                     )
                 else:
                     self.req_to_token_pool = DecodeReqToTokenPool(


### PR DESCRIPTION
## Motivation

`HybridMambaDecodeReqToTokenPool` (used exclusively in PD disaggregation decode) ignores the `--max-mamba-cache-size` setting when initializing its mamba pool. The original code hardcodes `size` (= `max_num_reqs`) as the mamba pool capacity, whereas the non-disaggregation path (`HybridReqToTokenPool`) correctly accepts a separate `mamba_size` parameter (= `max_mamba_cache_size`).

With `mamba-scheduler-strategy: extra_buffer`, each request consumes 3 mamba pool slots (1 main + 2 ping-pong). Would set `max-mamba-cache-size = 3 × max-running-requests` to provide enough slots, but in disagg decode the configured value is silently discarded — the mamba pool is always allocated at `max_num_reqs` size, causing:

```
 File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/decode.py", line 667, in _pre_alloc
    req_pool_indices = self.req_to_token_pool.alloc([req])
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 526, in alloc
    req.mamba_ping_pong_track_buffer is not None
AssertionError: Not enough space for mamba ping pong idx, try to increase --mamba-full-memory-ratio.

```

For example, with `--max-mamba-cache-size 750 --max-running-requests 250`, the decode mamba pool is still created with only 250 slots (confirmed by logs: `Mamba Cache is allocated. max_mamba_cache_size: 250`), which can serve at most 83 concurrent requests before exhausting mamba slots.

## Modifications

- **`decode.py`**: Add `mamba_size` parameter to `HybridMambaDecodeReqToTokenPool.__init__`. Use it for the mamba pool capacity (`size`) in `_init_mamba_pool`, while keeping `mamba_spec_state_size` at `size + pre_alloc_size` (aligned with the non-disagg path where speculative intermediate buffers are sized by `max_num_reqs`, not `max_mamba_cache_size`).
- **`model_runner_kv_cache_mixin.py`**: Pass `mamba_size=self.server_args.max_mamba_cache_size` when constructing `HybridMambaDecodeReqToTokenPool`.

## Accuracy Tests

Qwen3.5-397B-A17B-FP8, 1P1D PD disaggregation, TP4, `extra_buffer` strategy, GB200:

| Run | `max-mamba-cache-size` | Code | Mamba Pool Allocated | Result |
|-----|----------------------|------|---------------------|--------|
| 948491 | Not set (`mamba-full-memory-ratio: 2.5`) | Before fix | 250 (ignores auto-calc) | **CRASH** |
| 949024 | 750 (explicit) | Before fix | 250 (ignores 750) | **CRASH** |
| 949062 | 750 (explicit) | **After fix** | **750** (expected) | **GPQA 0.875** |
```
====================
Repeat: 8, mean: 0.875
Scores: ['0.869', '0.874', '0.864', '0.879', '0.874', '0.874', '0.864', '0.904']
====================
```

Repro config (on GB200):
```
  prefill_environment:
    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
    PYTHONUNBUFFERED: "1"
    NCCL_MNNVL_ENABLE: "1"
    NCCL_CUMEM_ENABLE: "1"
    MC_FORCE_MNNVL: "1"
    SGLANG_DG_CACHE_DIR: "/configs/deepgemm-cache"
    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"

  decode_environment:
    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
    PYTHONUNBUFFERED: "1"
    NCCL_MNNVL_ENABLE: "1"
    NCCL_CUMEM_ENABLE: "1"
    MC_FORCE_MNNVL: "1"
    SGLANG_DG_CACHE_DIR: "/configs/deepgemm-cache"
    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
    SGLANG_DECODE_BOOTSTRAP_TIMEOUT: "1000"
    SGLANG_HACK_SEQ_BOOTSTRAP_ROOM: "1"
    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"

    prefill:
      served-model-name: "Qwen/Qwen3.5-397B-A17B-FP8"
      model-path: "/model/"
      trust-remote-code: true

      # Parallelism
      tensor-parallel-size: 4
      data-parallel-size: 1
      expert-parallel-size: 1

      # Mamba hybrid model settings
      mamba-scheduler-strategy: "extra_buffer"
      mamba-track-interval: 128
      mamba-ssm-dtype: "bfloat16"

      # PD disaggregation
      disaggregation-mode: "prefill"
      disable-radix-cache: true

      # Memory: match AGG config (0.75), let system auto-calculate max_running_requests
      mem-fraction-static: 0.75
      chunked-prefill-size: 2048
      context-length: 262144

      load-balance-method: "round_robin"
      watchdog-timeout: 1000000

    decode:
      served-model-name: "Qwen/Qwen3.5-397B-A17B-FP8"
      model-path: "/model/"
      trust-remote-code: true

      # Parallelism
      tensor-parallel-size: 4
      data-parallel-size: 1
      expert-parallel-size: 1

      # Mamba hybrid model settings
      mamba-scheduler-strategy: "extra_buffer"
      mamba-track-interval: 128
      mamba-ssm-dtype: "bfloat16"
      # extra_buffer needs 3 mamba pool slots per request (1 main + 2 ping-pong).
      max-mamba-cache-size: 750
      max-running-requests: 250

      # PD disaggregation
      disaggregation-mode: "decode"
      disable-radix-cache: true

      # Memory
      mem-fraction-static: 0.75
      chunked-prefill-size: 2048
      context-length: 262144

      watchdog-timeout: 1000000
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).