### PR TITLE
[VLM] Introduce FlashInfer CUDNN Prefill as ViT Backend

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -65,6 +65,24 @@ ROTARY_EMBED_CLASSES = {
     "normal": apply_rotary_pos_emb,
 }
 
+# === Vision Encoder === #
+FLASHINFER_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
+
+# Batch buckets for cuDNN graph caching - graphs are cached per bucket size
+# This avoids creating a new graph for each unique batch size at runtime
+BATCH_BUCKETS = [8, 16, 32, 64]
+
+# Bucketized max seqlens to reduce cuDNN recompilation frequency while
+# preserving a tighter upper bound than a single fixed max seqlen.
+FLASHINFER_MAX_SEQLEN_BUCKETS = [
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+]
+
 
 @dataclasses.dataclass
 class SingletonCache:
@@ -483,28 +501,69 @@ class VisionFlashInferAttention(nn.Module):
         """
         if "sequence_lengths" not in kwargs:
             raise RuntimeError(
-                "sequence_lengths should be prepared for flashinfer backend"
+                "sequence_lengths should be prepared for vision flashinfer_cudnn attention backend"
             )
         if "max_seqlen" not in kwargs:
-            raise RuntimeError("max_seqlen should be prepared for flashinfer backend")
-        sequence_lengths = kwargs["sequence_lengths"]
+            raise RuntimeError(
+                "max_seqlen should be prepared for vision flashinfer_cudnn attention backend"
+            )
+
+        sequence_lengths = kwargs["sequence_lengths"]  # (B_padded,) or (B_padded,1,1,1)
         max_seqlen = kwargs["max_seqlen"]
 
+        # max_seqlen must be python int
+        if isinstance(max_seqlen, torch.Tensor):
+            if max_seqlen.is_cuda:
+                max_seqlen = int(max_seqlen.detach().cpu().item())
+            else:
+                max_seqlen = int(max_seqlen.item())
+        else:
+            max_seqlen = int(max_seqlen)
+
+        # flatten if caller gives (b, s, h, d)
         is_reshaped = q.dim() == 4
         if is_reshaped:
             reshape_batch_size = q.shape[0]
             q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
 
-        assert len(cu_seqlens) % 3 == 0, "cu_seqlens must be divisible by 3"
-        cu_seqlength = len(cu_seqlens) // 3
-        cu_qk = cu_seqlens[:cu_seqlength]
-        cu_v = cu_seqlens[cu_seqlength : cu_seqlength * 2]
-        cu_o = cu_seqlens[cu_seqlength * 2 :]
-        batch_offsets_qk = cu_qk.view(-1, 1, 1, 1)
-        batch_offsets_v = cu_v.view(-1, 1, 1, 1)
-        batch_offsets_o = cu_o.view(-1, 1, 1, 1)
-        sequence_lengths = sequence_lengths.view(-1, 1, 1, 1)
-        max_seqlen = max_seqlen.item()
+        if not isinstance(cu_seqlens, torch.Tensor):
+            raise RuntimeError(
+                "flashinfer_cudnn expects packed indptrs as a torch.Tensor"
+            )
+
+        # sequence_lengths -> (B,)
+        if not isinstance(sequence_lengths, torch.Tensor):
+            raise RuntimeError("sequence_lengths must be a torch.Tensor")
+        seq_lens_1d = sequence_lengths.view(-1).to(device=q.device, dtype=torch.int32)
+        B = int(seq_lens_1d.numel())
+
+        # cu_seqlens contains packed *element indptrs*:
+        # [qk_indptr(B+1), v_indptr(B+1), o_indptr(B+1)] => total 3*(B+1)
+        cu_seqlens_1d = cu_seqlens.view(-1).to(device=q.device, dtype=torch.int32)
+        expected = 3 * (B + 1)
+        if int(cu_seqlens_1d.numel()) != expected:
+            raise RuntimeError(
+                f"packed indptr numel mismatch: got {cu_seqlens_1d.numel()}, expected {expected} (= 3*(B+1))"
+            )
+
+        split = B + 1
+        indptr_qk = cu_seqlens_1d[:split].view(split, 1, 1, 1)
+        indptr_v = cu_seqlens_1d[split : 2 * split].view(split, 1, 1, 1)
+        indptr_o = cu_seqlens_1d[2 * split :].view(split, 1, 1, 1)
+
+        # cuDNN style: (B,1,1,1)
+        seq_lens_4d = seq_lens_1d.view(B, 1, 1, 1)
+
+        # indptr are in ELEMENT offsets (not token offsets)
+        token_width_q = int(q.shape[1] * q.shape[2])  # heads * head_dim on this rank
+        total_elems_q = int(q.numel())
+
+        # check each real sequence fits
+        # (skip padded tail where seq_len==0)
+        start_elems = indptr_qk.view(-1)[:-1]  # (B,)
+        end_elems = start_elems + seq_lens_1d * token_width_q
+        if (end_elems > total_elems_q).any():
+            raise RuntimeError("offset + len out of bounds; packed indptr is wrong")
 
         _, _, head_size = q.shape
         scale = head_size**-0.5
@@ -517,14 +576,14 @@ class VisionFlashInferAttention(nn.Module):
             self.workspace_buffer,
             max_token_per_sequence=max_seqlen,
             max_sequence_kv=max_seqlen,
-            actual_seq_lens_q=sequence_lengths,
-            actual_seq_lens_kv=sequence_lengths,
+            actual_seq_lens_q=seq_lens_4d,
+            actual_seq_lens_kv=seq_lens_4d,
             causal=False,
-            return_lse=False,
-            batch_offsets_q=batch_offsets_qk,
-            batch_offsets_k=batch_offsets_qk,
-            batch_offsets_v=batch_offsets_v,
-            batch_offsets_o=batch_offsets_o,
+            return_lse=True,
+            batch_offsets_q=indptr_qk,
+            batch_offsets_k=indptr_qk,
+            batch_offsets_v=indptr_v,
+            batch_offsets_o=indptr_o,
             is_cuda_graph_compatible=True,
         )
 
@@ -634,7 +693,7 @@ QKV_BACKEND_IMPL = {
     "sdpa": VisionSdpaAttention,
     "fa3": VisionFlash3Attention,
     "fa4": VisionFlash4Attention,
-    "fi": VisionFlashInferAttention,
+    "flashinfer_cudnn": VisionFlashInferAttention,
     "ascend_attn": VisionAscendAttention,
     "aiter_attn": VisionAiterAttention,
 }

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -66,13 +66,29 @@ from sglang.srt.models.utils import (
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
 from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix, get_int_env_var, is_npu
+from sglang.srt.utils import add_prefix, get_int_env_var, is_npu, round_up
 from sglang.srt.utils.hf_transformers_utils import get_processor
 
 logger = logging.getLogger(__name__)
 
 
 # === Vision Encoder === #
+FLASHINFER_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
+
+# Batch buckets for cuDNN graph caching - graphs are cached per bucket size
+# This avoids creating a new graph for each unique batch size at runtime
+BATCH_BUCKETS = [8, 16, 32, 64]
+
+# Bucketized max seqlens to reduce cuDNN recompilation frequency while
+# preserving a tighter upper bound than a single fixed max seqlen.
+FLASHINFER_MAX_SEQLEN_BUCKETS = [
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+]
 
 
 class Qwen3_VisionMLP(nn.Module):
@@ -161,6 +177,7 @@ class Qwen3_VisionBlock(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         use_data_parallel: bool = False,
+        workspace_buffer: torch.Tensor | None = None,
     ) -> None:
         super().__init__()
         if norm_layer is None:
@@ -179,6 +196,7 @@ class Qwen3_VisionBlock(nn.Module):
             prefix=add_prefix("attn", prefix),
             use_data_parallel=use_data_parallel,
             use_dp_attention_reduce=is_dp_attention_enabled(),
+            workspace_buffer=workspace_buffer,
         )
         self.mlp = Qwen3_VisionMLP(
             dim,
@@ -197,6 +215,8 @@ class Qwen3_VisionBlock(nn.Module):
         rotary_pos_emb_cos: torch.Tensor,
         rotary_pos_emb_sin: torch.Tensor,
         output_ws: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[torch.Tensor] = None,
+        sequence_lengths: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         hidden_states = self.norm1(x)
         hidden_states = rearrange(hidden_states, "s b ... -> b s ...")
@@ -206,6 +226,8 @@ class Qwen3_VisionBlock(nn.Module):
             rotary_pos_emb_cos=rotary_pos_emb_cos,
             rotary_pos_emb_sin=rotary_pos_emb_sin,
             output_ws=output_ws,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
         attn = rearrange(attn, "b s ... -> s b ...")
         x += attn
@@ -325,6 +347,14 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             is_neox_style=True,
         )
 
+        workspace_buffer = (
+            None
+            if get_global_server_args().mm_attention_backend != "fi"
+            else torch.zeros(
+                FLASHINFER_WORKSPACE_SIZE_BYTES, dtype=torch.uint8, device=self.device
+            )
+        )
+
         self.blocks = nn.ModuleList(
             [
                 Qwen3_VisionBlock(
@@ -336,6 +366,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                     quant_config=quant_config,
                     prefix=add_prefix(f"blocks.{layer_idx}", prefix),
                     use_data_parallel=use_data_parallel,
+                    workspace_buffer=workspace_buffer,
                 )
                 for layer_idx in range(vision_config.depth)
             ]
@@ -468,6 +499,122 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
         return torch.cat(result_parts, dim=0)
 
+    def fast_pos_embed_interpolate_from_list(self, grid_thw):
+        num_grid_per_side = self.num_grid_per_side
+        m_size = self.spatial_merge_size
+        hidden_dim = self.pos_embed.embedding_dim
+
+        outputs = []
+        for t, h, w in grid_thw:
+            h_idxs = torch.linspace(
+                0, num_grid_per_side - 1, h, dtype=torch.float32, device=self.device
+            )
+            w_idxs = torch.linspace(
+                0, num_grid_per_side - 1, w, dtype=torch.float32, device=self.device
+            )
+
+            h_floor = h_idxs.to(torch.long)
+            w_floor = w_idxs.to(torch.long)
+            h_ceil = torch.clamp(h_floor + 1, max=num_grid_per_side - 1)
+            w_ceil = torch.clamp(w_floor + 1, max=num_grid_per_side - 1)
+
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+
+            # Create meshgrid view for all h, w vars
+            dh_grid, dw_grid = torch.meshgrid(dh, dw, indexing="ij")
+            h_floor_grid, w_floor_grid = torch.meshgrid(h_floor, w_floor, indexing="ij")
+            h_ceil_grid, w_ceil_grid = torch.meshgrid(h_ceil, w_ceil, indexing="ij")
+
+            # original computation of weights
+            # w00 = (1 - dh_grid) * (1 - dw_grid)
+            # w01 = (1 - dh_grid) * dw_grid
+            # w10 = dh_grid * (1 - dw_grid)
+            # w11 = dh_grid * dw_grid
+            # we reuse w11 here to avoid duplicate
+            # dh_grid * dw_grid computation
+            w11 = dh_grid * dw_grid
+            w10 = dh_grid - w11
+            w01 = dw_grid - w11
+            w00 = 1 - dh_grid - w01
+
+            h_grid = torch.stack([h_floor_grid, h_floor_grid, h_ceil_grid, h_ceil_grid])
+            w_grid = torch.stack([w_floor_grid, w_ceil_grid, w_floor_grid, w_ceil_grid])
+            h_grid_idx = h_grid * num_grid_per_side
+
+            indices = (h_grid_idx + w_grid).reshape(4, -1)
+            weights = torch.stack([w00, w01, w10, w11], dim=0).reshape(4, -1, 1)
+            weights = weights.to(dtype=self.dtype)
+
+            embeds = self.pos_embed(indices)
+            embeds *= weights
+            combined = embeds.sum(dim=0)
+
+            combined = combined.reshape(
+                h // m_size, m_size, w // m_size, m_size, hidden_dim
+            )
+            combined = combined.permute(0, 2, 1, 3, 4).reshape(1, -1, hidden_dim)
+            repeated = combined.expand(t, -1, -1).reshape(-1, hidden_dim)
+            outputs.append(repeated)
+
+        return torch.cat(outputs, dim=0)
+
+    def add_padding_to_fi_seqlens(
+        self, seq: np.ndarray, batch_size: int, padding_value: int
+    ) -> np.ndarray:
+        batch_size_padded = next(
+            (b for b in BATCH_BUCKETS if b >= batch_size),
+            # For large batches (> max bucket), round up to a multiple of
+            # the base bucket size to avoid negative pad length.
+            round_up(batch_size, BATCH_BUCKETS[0]),
+        )
+        if batch_size_padded == batch_size:
+            return seq
+        return np.concatenate(
+            [
+                seq,
+                np.full(
+                    (batch_size_padded - batch_size,), padding_value, dtype=seq.dtype
+                ),
+            ]
+        )
+
+    def compute_flashinfer_cu_seqlens(
+        self,
+        cu_seqlens: np.ndarray,
+        rotary_pos_emb_cos: torch.Tensor | None = None,
+        rotary_pos_emb_sin: torch.Tensor | None = None,
+    ) -> np.ndarray:
+        batch_size = len(cu_seqlens) - 1
+        scale = self.hidden_size // self.tp_size
+        cu_seqlens = cu_seqlens * scale
+        if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
+            cu_seqlens_qk = cu_seqlens
+        else:
+            cu_seqlens_qk = cu_seqlens * 3
+        cu_seqlens_v = cu_seqlens * 3
+        cu_seqlens_o = cu_seqlens
+        cu_seqlens_qk = self.add_padding_to_fi_seqlens(
+            cu_seqlens_qk, batch_size, cu_seqlens_qk[-1]
+        )
+        cu_seqlens_v = self.add_padding_to_fi_seqlens(
+            cu_seqlens_v, batch_size, cu_seqlens_v[-1]
+        )
+        cu_seqlens_o = self.add_padding_to_fi_seqlens(
+            cu_seqlens_o, batch_size, cu_seqlens_o[-1]
+        )
+        return np.concatenate([cu_seqlens_qk, cu_seqlens_v, cu_seqlens_o])
+
+    def bucket_flashinfer_max_seqlen(self, real_max_seqlen: int) -> int:
+        if real_max_seqlen <= 0:
+            return FLASHINFER_MAX_SEQLEN_BUCKETS[0]
+        return next(
+            (s for s in FLASHINFER_MAX_SEQLEN_BUCKETS if s >= real_max_seqlen),
+            # For large sequences (> max bucket), round up to a multiple of
+            # the largest bucket to avoid under-estimation.
+            round_up(real_max_seqlen, FLASHINFER_MAX_SEQLEN_BUCKETS[-1]),
+        )
+
     def fast_pos_embed_interpolate(self, grid_thw):
         """Interpolate position embeddings for (batch, 3) size input dimensions.
 
@@ -536,22 +683,53 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
         if isinstance(grid_thw, list):
             grid_thw_list = grid_thw
-            grid_thw = torch.tensor(grid_thw, dtype=torch.int32)
+            grid_thw = np.array(grid_thw, dtype=np.int32)
         else:
             grid_thw_list = grid_thw.tolist()
+            grid_thw = grid_thw.numpy()
 
-        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        pos_embeds = self.fast_pos_embed_interpolate_from_list(grid_thw_list)
         x += pos_embeds
 
         rotary_pos_emb_cos, rotary_pos_emb_sin = self.rot_pos_emb(grid_thw_list)
 
         # compute cu_seqlens
-        cu_seqlens = compute_cu_seqlens_from_grid_numpy(grid_thw)
+        cu_seqlens = np.repeat(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]).cumsum(
+            axis=0, dtype=np.int32
+        )
+        cu_seqlens = np.concatenate([np.zeros(1, dtype=np.int32), cu_seqlens])
+
+        flashinfer_max_seqlen = 0
+        if get_global_server_args().mm_attention_backend == "fi":
+            sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+            flashinfer_max_seqlen = self.bucket_flashinfer_max_seqlen(
+                int(sequence_lengths.max()) if sequence_lengths.size > 0 else 0
+            )
+            sequence_lengths = self.add_padding_to_fi_seqlens(
+                sequence_lengths, len(sequence_lengths), 0
+            )
+            cu_seqlens = self.compute_flashinfer_cu_seqlens(
+                cu_seqlens, rotary_pos_emb_cos, rotary_pos_emb_sin
+            )
+            sequence_lengths = torch.from_numpy(sequence_lengths).to(
+                device=self.device,
+                dtype=torch.int32,
+                non_blocking=True,
+            )
+        else:
+            sequence_lengths = None
+
+        cu_seqlens = torch.from_numpy(cu_seqlens)
         # cu_seqlens must be on cpu because of npu_flash_attention_unpad operator restriction
         if not is_npu():
             cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
         else:
             cu_seqlens = cu_seqlens.to("cpu")
+
+        max_seqlen = torch.tensor(
+            flashinfer_max_seqlen, device=self.device, dtype=torch.int32
+        )
+
         x = x.unsqueeze(1)
 
         deepstack_feature_lists = []
@@ -563,6 +741,8 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                 cu_seqlens=cu_seqlens,
                 rotary_pos_emb_cos=rotary_pos_emb_cos,
                 rotary_pos_emb_sin=rotary_pos_emb_sin,
+                max_seqlen=max_seqlen,
+                sequence_lengths=sequence_lengths,
             )
 
             if layer_num in self.deepstack_visual_indexes:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3866,7 +3866,7 @@ class ServerArgs:
                 "triton_attn",
                 "ascend_attn",
                 "aiter_attn",
-                "fi",
+                "flashinfer_cudnn",
             ],
             default=ServerArgs.mm_attention_backend,
             help="Set multimodal attention backend.",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3859,7 +3859,15 @@ class ServerArgs:
         parser.add_argument(
             "--mm-attention-backend",
             type=str,
-            choices=["sdpa", "fa3", "fa4", "triton_attn", "ascend_attn", "aiter_attn"],
+            choices=[
+                "sdpa",
+                "fa3",
+                "fa4",
+                "triton_attn",
+                "ascend_attn",
+                "aiter_attn",
+                "fi",
+            ],
             default=ServerArgs.mm_attention_backend,
             help="Set multimodal attention backend.",
         )

--- a/test/manual/nightly/test_vlms_vit_flashinfer_cudnn.py
+++ b/test/manual/nightly/test_vlms_vit_flashinfer_cudnn.py
@@ -1,0 +1,258 @@
+import argparse
+import glob
+import json
+import os
+import random
+import sys
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+)
+
+MODELS = [
+    SimpleNamespace(model="Qwen/Qwen3-VL-30B-A3B-Instruct", mmmu_accuracy=0.51),
+]
+
+
+# Set default mem_fraction_static to 0.8
+DEFAULT_MEM_FRACTION_STATIC = 0.8
+
+
+class TestVLMViTFlashinferCudnn(CustomTestCase):
+    parsed_args = None  # Class variable to store args
+
+    @classmethod
+    def setUpClass(cls):
+        # Removed argument parsing from here
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.time_out = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+        if cls.parsed_args is None:
+            cls.parsed_args = SimpleNamespace(
+                mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC
+            )
+
+        # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
+        os.environ["OPENAI_API_KEY"] = cls.api_key
+        os.environ["OPENAI_API_BASE"] = f"{cls.base_url}/v1"
+
+    def run_mmmu_eval(
+        self,
+        model_version: str,
+        output_path: str,
+        *,
+        env: dict | None = None,
+    ):
+        """
+        Evaluate a VLM on the MMMU validation set with lmms‑eval.
+        Only `model_version` (checkpoint) and `chat_template` vary;
+        We are focusing only on the validation set due to resource constraints.
+        """
+        # -------- fixed settings --------
+        model = "openai_compatible"
+        tp = 1
+        tasks = "mmmu_val"
+        batch_size = 32
+        log_suffix = "openai_compatible"
+        os.makedirs(output_path, exist_ok=True)
+
+        # -------- compose --model_args --------
+        model_args = f'model_version="{model_version}",' f"tp={tp}"
+
+        # -------- build command list --------
+        cmd = [
+            "python3",
+            "-m",
+            "lmms_eval",
+            "--model",
+            model,
+            "--model_args",
+            model_args,
+            "--tasks",
+            tasks,
+            "--batch_size",
+            str(batch_size),
+            "--output_path",
+            str(output_path),
+        ]
+
+        _run_lmms_eval_with_retry(cmd, timeout=3600)
+
+    def _run_vlm_mmmu_test(
+        self,
+        model,
+        output_path,
+        test_name="",
+        custom_env=None,
+        log_level="info",
+        capture_output=False,
+    ):
+        """
+        Common method to run VLM MMMU benchmark test.
+        Args:
+            model: Model to test
+            output_path: Path for output logs
+            test_name: Optional test name for logging
+            custom_env: Optional custom environment variables
+            log_level: Log level for server (default: "info")
+            capture_output: Whether to capture server stdout/stderr
+        """
+        print(f"\nTesting model: {model.model}{test_name}")
+
+        process = None
+        mmmu_accuracy = 0  # Initialize to handle potential exceptions
+        server_output = ""
+
+        try:
+            # Prepare environment variables
+            process_env = os.environ.copy()
+            if custom_env:
+                process_env.update(custom_env)
+            # if test vlm with cuda_ipc feature, open this env_var
+            process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
+
+            # Prepare stdout/stderr redirection if needed
+            stdout_file = None
+            stderr_file = None
+            if capture_output:
+                stdout_file = open("/tmp/server_stdout.log", "w")
+                stderr_file = open("/tmp/server_stderr.log", "w")
+
+            # Launch server for testing
+            process = popen_launch_server(
+                model.model,
+                base_url=self.base_url,
+                timeout=self.time_out,
+                api_key=self.api_key,
+                other_args=[
+                    "--mm-attention-backend",
+                    "flashinfer_cudnn",
+                    "--chunked-prefill-size",
+                    "8192",
+                    "--disable-radix-cache",
+                ],
+                env=process_env,
+                return_stdout_stderr=(
+                    (stdout_file, stderr_file) if capture_output else None
+                ),
+            )
+
+            # Run evaluation
+            self.run_mmmu_eval(model.model, output_path)
+
+            # Get the result file
+            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories)
+            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
+            if not result_files:
+                result_files = glob.glob(f"{output_path}/*.json")
+
+            if not result_files:
+                raise FileNotFoundError(f"No JSON result files found in {output_path}")
+
+            result_file_path = result_files[0]
+
+            with open(result_file_path, "r") as f:
+                result = json.load(f)
+                print(f"Result{test_name}\n: {result}")
+
+            # Process the result
+            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
+            print(
+                f"Model {model.model} achieved accuracy{test_name}: {mmmu_accuracy:.4f}"
+            )
+
+            # Capture server output if requested
+            if capture_output and process:
+                server_output = self._read_output_from_files()
+
+            # Assert performance meets expected threshold
+            self.assertGreaterEqual(
+                mmmu_accuracy,
+                model.mmmu_accuracy,
+                f"Model {model.model} accuracy ({mmmu_accuracy:.4f}) below expected threshold ({model.mmmu_accuracy:.4f}){test_name}",
+            )
+
+            return server_output
+
+        except Exception as e:
+            print(f"Error testing {model.model}{test_name}: {e}")
+            self.fail(f"Test failed for {model.model}{test_name}: {e}")
+
+        finally:
+            # Ensure process cleanup happens regardless of success/failure
+            if process is not None and process.poll() is None:
+                print(f"Cleaning up process {process.pid}")
+                try:
+                    kill_process_tree(process.pid)
+                except Exception as e:
+                    print(f"Error killing process: {e}")
+
+            # clean up temporary files
+            if capture_output:
+                if stdout_file:
+                    stdout_file.close()
+                if stderr_file:
+                    stderr_file.close()
+                for filename in ["/tmp/server_stdout.log", "/tmp/server_stderr.log"]:
+                    try:
+                        if os.path.exists(filename):
+                            os.remove(filename)
+                    except Exception as e:
+                        print(f"Error removing {filename}: {e}")
+
+    def _read_output_from_files(self):
+        output_lines = []
+
+        log_files = [
+            ("/tmp/server_stdout.log", "[STDOUT]"),
+            ("/tmp/server_stderr.log", "[STDERR]"),
+        ]
+        for filename, tag in log_files:
+            try:
+                if os.path.exists(filename):
+                    with open(filename, "r") as f:
+                        for line in f:
+                            output_lines.append(f"{tag} {line.rstrip()}")
+            except Exception as e:
+                print(f"Error reading {tag.lower()} file: {e}")
+
+        return "\n".join(output_lines)
+
+    def test_vlm_mmmu_benchmark(self):
+        """Test VLM models against MMMU benchmark."""
+        models_to_test = MODELS
+
+        if is_in_ci():
+            models_to_test = [random.choice(MODELS)]
+
+        for model in models_to_test:
+            self._run_vlm_mmmu_test(model, "./logs")
+
+
+if __name__ == "__main__":
+    # Define and parse arguments here, before unittest.main
+    parser = argparse.ArgumentParser(description="Test VLM models")
+    parser.add_argument(
+        "--mem-fraction-static",
+        type=float,
+        help="Static memory fraction for the model",
+        default=DEFAULT_MEM_FRACTION_STATIC,
+    )
+
+    # Parse args intended for unittest
+    args = parser.parse_args()
+
+    # Store the parsed args object on the class
+    TestVLMViTFlashinferCudnn.parsed_args = args
+
+    # Pass args to unittest
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
FlashInfer CUDNN Prefill demonstrates strong performance. This PR is to introduce it to SGLang as one of VLM ViT attention backends. A new "flashinfer" mm attention backend is added. This PR supports Qwen3-VL. In the next PRs we will adapt more VLMs to support this backend.

**The performance improved 11.6% vs FA3. (TTFT reduce)** 
1054ms vs 931ms.

```
Server:
➜  sglang_dev2 git:(support_vit_fi_backend) ✗ CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server --model Qwen/Qwen3-VL-30B-A3B-Instruct --tp 4 --mm-attention-backend flashinfer_cudnn --disable-radix-cache

Client:
➜  sglang git:(main) python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 256 \
  --apply-chat-template \
  --random-input-len 128 \
  --random-output-len 32 \
  --image-resolution 560x560 \
  --image-format jpeg \
  --image-count 1 \
  --image-content random \
  --random-range-ratio 0.1 \
  --port 30000 \
  --max-concurrency 32

FlashInfer CUDNN:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 32
Successful requests:                     256
Benchmark duration (s):                  19.08
Total input tokens:                      104048
Total input text tokens:                 20592
Total input vision tokens:               83456
Total generated tokens:                  4541
Total generated tokens (retokenized):    4540
Request throughput (req/s):              13.42
Input token throughput (tok/s):          5452.43
Output token throughput (tok/s):         237.96
Peak output token throughput (tok/s):    453.00
Peak concurrent requests:                53
Total token throughput (tok/s):          5690.39
Concurrency:                             31.67
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2360.65
Median E2E Latency (ms):                 2366.75
P90 E2E Latency (ms):                    3779.53
P99 E2E Latency (ms):                    4930.41
---------------Time to First Token----------------
Mean TTFT (ms):                          931.84
Median TTFT (ms):                        742.34
P99 TTFT (ms):                           2560.43
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          77.37
Median TPOT (ms):                        87.15
P99 TPOT (ms):                           128.54
---------------Inter-Token Latency----------------
Mean ITL (ms):                           85.31
Median ITL (ms):                         10.76
P95 ITL (ms):                            602.59
P99 ITL (ms):                            715.00
Max ITL (ms):                            2025.51
==================================================

FA3
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 32
Successful requests:                     256
Benchmark duration (s):                  19.21
Total input tokens:                      103973
Total input text tokens:                 20517
Total input vision tokens:               83456
Total generated tokens:                  4541
Total generated tokens (retokenized):    4540
Request throughput (req/s):              13.33
Input token throughput (tok/s):          5413.28
Output token throughput (tok/s):         236.42
Peak output token throughput (tok/s):    492.00
Peak concurrent requests:                54
Total token throughput (tok/s):          5649.71
Concurrency:                             31.76
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2382.67
Median E2E Latency (ms):                 2262.79
P90 E2E Latency (ms):                    3848.96
P99 E2E Latency (ms):                    5391.16
---------------Time to First Token----------------
Mean TTFT (ms):                          1054.52
Median TTFT (ms):                        819.71
P99 TTFT (ms):                           3271.18
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          71.16
Median TPOT (ms):                        78.08
P99 TPOT (ms):                           127.13
---------------Inter-Token Latency----------------
Mean ITL (ms):                           79.37
Median ITL (ms):                         9.42
P95 ITL (ms):                            559.35
P99 ITL (ms):                            831.08
Max ITL (ms):                            1503.12
==================================================
```

```
➜  python git:(support_vit_fi_backend) ✗ python3 -m sglang.launch_server --model Qwen/Qwen3-VL-30B-A3B-Instruct --tp 4 --mm-attention-backend flashinfer_cudnn --disable-radix-cache
[2026-02-21 10:47:35] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-21 10:47:35] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-21 10:47:35] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2026-02-21 10:47:37] INFO server_args.py:1830: Attention backend not specified. Use fa3 backend by default.
[2026-02-21 10:47:38] server_args=ServerArgs(model_path='Qwen/Qwen3-VL-30B-A3B-Instruct', tokenizer_path='Qwen/Qwen3-VL-30B-A3B-Instruct', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=False, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, rl_quant_profile=None, mem_fraction_static=0.8322890624999999, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, enable_dynamic_chunking=False, max_prefill_tokens=16384, prefill_max_requests=None, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', enable_prefill_delayer=False, prefill_delayer_max_delay_passes=30, prefill_delayer_token_usage_low_watermark=None, prefill_delayer_forward_passes_buckets=None, prefill_delayer_wait_seconds_buckets=None, device='cuda', tp_size=4, pp_size=1, pp_max_micro_batch_size=None, pp_async_batch_depth=0, stream_interval=1, stream_output=False, random_seed=812334462, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, soft_watchdog_timeout=None, dist_timeout=None, download_dir=None, model_checksum=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, custom_sigquit_handler=None, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, log_requests_format='text', log_requests_target=None, uvicorn_access_log_exclude_prefixes=[], crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, extra_metric_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, admin_api_key=None, served_model_name='Qwen/Qwen3-VL-30B-A3B-Instruct', weight_version='default', chat_template=None, hf_chat_template_name=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', attn_cp_size=1, moe_dp_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, enable_lora_overlap_loading=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend='flashinfer_cudnn', fp8_gemm_runner_backend='auto', fp4_gemm_runner_backend='flashinfer_cutlass', nsa_prefill_backend=None, nsa_decode_backend=None, disable_flashinfer_autotune=False, speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_draft_attention_backend=None, speculative_moe_runner_backend='auto', speculative_moe_a2a_backend=None, speculative_draft_model_quantization=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, enable_multi_layer_eagle=False, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype=None, mamba_full_memory_ratio=0.9, mamba_scheduler_strategy='no_buffer', mamba_track_interval=256, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', disable_hicache_numa_detect=False, hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, hierarchical_sparse_attention_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_algorithm_config=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=True, cuda_graph_max_bs=512, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=False, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 832, 896, 960, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840, 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, enable_return_routed_experts=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, enable_nsa_prefill_context_parallel=False, nsa_prefill_cp_mode='round-robin-split', enable_fused_qk_norm_rope=False, enable_precise_embedding_interpolation=False, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, encoder_only=False, language_only=False, encoder_transfer_backend='zmq_to_scheduler', encoder_urls=[], custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, remote_instance_weight_loader_backend='nccl', remote_instance_weight_loader_start_seed_via_transfer_engine=False, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, enable_broadcast_mm_inputs_process=False, enable_prefix_mm_cache=False, mm_enable_dp_encoder=False, mm_process_config={}, limit_mm_data_per_request=None, decrypted_config_file=None, decrypted_draft_config_file=None, forward_hooks=None)
[2026-02-21 10:47:40] Ignore import error when loading sglang.srt.multimodal.processors.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-02-21 10:47:42] Using default HuggingFace chat template with detected content format: openai
[2026-02-21 10:47:45] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-21 10:47:45] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-21 10:47:45] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2026-02-21 10:47:45] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-21 10:47:45] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-21 10:47:45] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2026-02-21 10:47:45] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-21 10:47:45] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-21 10:47:45] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2026-02-21 10:47:45] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-21 10:47:45] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-21 10:47:45] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2026-02-21 10:47:45] INFO utils.py:148: Note: detected 224 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2026-02-21 10:47:45] INFO utils.py:151: Note: NumExpr detected 224 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2026-02-21 10:47:45] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2026-02-21 10:47:49 TP1] Init torch distributed begin.
[2026-02-21 10:47:49 TP3] Init torch distributed begin.
[2026-02-21 10:47:49 TP2] Init torch distributed begin.
[2026-02-21 10:47:49 TP0] Init torch distributed begin.
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[2026-02-21 10:47:50 TP0] sglang is using nccl==2.27.5
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-02-21 10:47:52 TP0] Init torch distributed ends. elapsed=2.57 s, mem usage=1.24 GB
[2026-02-21 10:47:52 TP3] Init torch distributed ends. elapsed=2.80 s, mem usage=1.06 GB
[2026-02-21 10:47:52 TP2] Init torch distributed ends. elapsed=2.63 s, mem usage=1.29 GB
[2026-02-21 10:47:52 TP1] Init torch distributed ends. elapsed=2.84 s, mem usage=1.29 GB
[2026-02-21 10:47:54 TP3] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP3] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP3] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-02-21 10:47:54 TP2] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP2] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP2] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-02-21 10:47:54 TP1] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP1] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP1] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-02-21 10:47:54 TP0] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP0] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-02-21 10:47:54 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/usr/local/lib/python3.12/dist-packages/transformers/__init__.py)
[2026-02-21 10:47:54 TP2] Load weight begin. avail mem=137.99 GB
[2026-02-21 10:47:54 TP3] Load weight begin. avail mem=138.23 GB
[2026-02-21 10:47:54 TP1] Load weight begin. avail mem=137.99 GB
[2026-02-21 10:47:54 TP2] Using flashinfer_cudnn as multimodal attention backend.
[2026-02-21 10:47:54 TP3] Using flashinfer_cudnn as multimodal attention backend.
[2026-02-21 10:47:54 TP1] Using flashinfer_cudnn as multimodal attention backend.
[2026-02-21 10:47:54 TP0] Load weight begin. avail mem=138.04 GB
[2026-02-21 10:47:54 TP0] Using flashinfer_cudnn as multimodal attention backend.
[2026-02-21 10:47:54 TP0] Found local HF snapshot for Qwen/Qwen3-VL-30B-A3B-Instruct at /root/.cache/huggingface/hub/models--Qwen--Qwen3-VL-30B-A3B-Instruct/snapshots/9c4b90e1e4ba969fd3b5378b57d966d725f1b86c; skipping download.
Loading safetensors checkpoint shards:   0% Completed | 0/13 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   8% Completed | 1/13 [00:01<00:14,  1.18s/it]
Loading safetensors checkpoint shards:  15% Completed | 2/13 [00:02<00:15,  1.42s/it]
Loading safetensors checkpoint shards:  23% Completed | 3/13 [00:04<00:15,  1.52s/it]
Loading safetensors checkpoint shards:  31% Completed | 4/13 [00:06<00:14,  1.58s/it]
Loading safetensors checkpoint shards:  38% Completed | 5/13 [00:07<00:12,  1.60s/it]
Loading safetensors checkpoint shards:  46% Completed | 6/13 [00:09<00:11,  1.61s/it]
Loading safetensors checkpoint shards:  54% Completed | 7/13 [00:10<00:09,  1.61s/it]
Loading safetensors checkpoint shards:  62% Completed | 8/13 [00:12<00:08,  1.61s/it]
Loading safetensors checkpoint shards:  69% Completed | 9/13 [00:14<00:06,  1.61s/it]
Loading safetensors checkpoint shards:  77% Completed | 10/13 [00:15<00:04,  1.61s/it]
Loading safetensors checkpoint shards:  85% Completed | 11/13 [00:17<00:03,  1.61s/it]
Loading safetensors checkpoint shards:  92% Completed | 12/13 [00:19<00:01,  1.62s/it]
Loading safetensors checkpoint shards: 100% Completed | 13/13 [00:19<00:00,  1.30s/it]
Loading safetensors checkpoint shards: 100% Completed | 13/13 [00:19<00:00,  1.51s/it]

[2026-02-21 10:48:14 TP0] Load weight end. elapsed=19.88 s, type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=123.26 GB, mem usage=14.78 GB.
[2026-02-21 10:48:15 TP3] Load weight end. elapsed=21.17 s, type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=123.44 GB, mem usage=14.78 GB.
[2026-02-21 10:48:15 TP2] Load weight end. elapsed=21.19 s, type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=123.21 GB, mem usage=14.78 GB.
[2026-02-21 10:48:15 TP1] Load weight end. elapsed=21.16 s, type=Qwen3VLMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=123.21 GB, mem usage=14.78 GB.
[2026-02-21 10:48:15 TP0] Using KV cache dtype: torch.bfloat16
[2026-02-21 10:48:16 TP1] KV Cache is allocated. #tokens: 4370273, K size: 50.01 GB, V size: 50.01 GB
[2026-02-21 10:48:16 TP1] Memory pool end. avail mem=19.01 GB
[2026-02-21 10:48:16 TP0] KV Cache is allocated. #tokens: 4370273, K size: 50.01 GB, V size: 50.01 GB
[2026-02-21 10:48:16 TP0] Memory pool end. avail mem=19.06 GB
[2026-02-21 10:48:16 TP3] KV Cache is allocated. #tokens: 4370273, K size: 50.01 GB, V size: 50.01 GB
[2026-02-21 10:48:16 TP3] Memory pool end. avail mem=19.24 GB
[2026-02-21 10:48:16 TP2] KV Cache is allocated. #tokens: 4370273, K size: 50.01 GB, V size: 50.01 GB
[2026-02-21 10:48:16 TP2] Memory pool end. avail mem=19.01 GB
[2026-02-21 10:48:16 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=18.92 GB
[2026-02-21 10:48:16 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=18.96 GB
[2026-02-21 10:48:16 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]
[2026-02-21 10:48:16 TP3] Capture cuda graph begin. This can take up to several minutes. avail mem=19.15 GB
[2026-02-21 10:48:16 TP2] Capture cuda graph begin. This can take up to several minutes. avail mem=18.92 GB
Capturing batches (bs=512 avail_mem=18.17 GB):   0%|                                                                                                                                                                        | 0/52 [00:00<?, ?it/s][2026-02-21 10:48:17 TP3] Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200.json. Fallback to triton version 3.2.0 and use MoE kernel config from /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=128,N=192,device_name=NVIDIA_H200.json. Performance might be sub-optimal!
[2026-02-21 10:48:17 TP3] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2026-02-21 10:48:18 TP2] Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200.json. Fallback to triton version 3.2.0 and use MoE kernel config from /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=128,N=192,device_name=NVIDIA_H200.json. Performance might be sub-optimal!
[2026-02-21 10:48:18 TP2] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2026-02-21 10:48:18 TP0] Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200.json. Fallback to triton version 3.2.0 and use MoE kernel config from /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=128,N=192,device_name=NVIDIA_H200.json. Performance might be sub-optimal!
[2026-02-21 10:48:18 TP0] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2026-02-21 10:48:18 TP1] Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200.json. Fallback to triton version 3.2.0 and use MoE kernel config from /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=128,N=192,device_name=NVIDIA_H200.json. Performance might be sub-optimal!
[2026-02-21 10:48:18 TP1] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang_dev2/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=192,device_name=NVIDIA_H200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
Capturing batches (bs=1 avail_mem=17.16 GB): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 52/52 [00:10<00:00,  5.20it/s]
[2026-02-21 10:48:27 TP0] Registering 5044 cuda graph addresses
[2026-02-21 10:48:27 TP0] Capture cuda graph end. Time elapsed: 10.73 s. mem usage=1.81 GB. avail mem=17.15 GB.
[2026-02-21 10:48:27 TP1] Capture cuda graph end. Time elapsed: 10.81 s. mem usage=1.81 GB. avail mem=17.10 GB.
[2026-02-21 10:48:27 TP2] Capture cuda graph end. Time elapsed: 10.69 s. mem usage=1.81 GB. avail mem=17.10 GB.
[2026-02-21 10:48:27 TP3] Capture cuda graph end. Time elapsed: 10.71 s. mem usage=1.81 GB. avail mem=17.34 GB.
[2026-02-21 10:48:29 TP0] max_total_num_tokens=4370273, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4096, context_len=262144, available_gpu_mem=17.15 GB
[2026-02-21 10:48:29] INFO:     Started server process [278206]
[2026-02-21 10:48:29] INFO:     Waiting for application startup.
[2026-02-21 10:48:29] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
[2026-02-21 10:48:29] INFO:     Application startup complete.
[2026-02-21 10:48:29] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-02-21 10:48:30] INFO:     127.0.0.1:39446 - "GET /model_info HTTP/1.1" 200 OK
[2026-02-21 10:48:33 TP0] Prefill batch, #new-seq: 1, #new-token: 78, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, cuda graph: False
[2026-02-21 10:48:33] INFO:     127.0.0.1:39448 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-02-21 10:48:33] The server is fired up and ready to roll!
[2026-02-21 10:48:36 TP0] Prefill batch, #new-seq: 1, #new-token: 764, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 20.35, cuda graph: False
[2026-02-21 10:48:37 TP0] Decode batch, #running-req: 1, #token: 797, token usage: 0.00, cuda graph: True, gen throughput (token/s): 0.81, #queue-req: 0
[2026-02-21 10:48:37 TP0] Decode batch, #running-req: 1, #token: 837, token usage: 0.00, cuda graph: True, gen throughput (token/s): 264.06, #queue-req: 0
[2026-02-21 10:48:37 TP0] Decode batch, #running-req: 1, #token: 877, token usage: 0.00, cuda graph: True, gen throughput (token/s): 263.86, #queue-req: 0
[2026-02-21 10:48:37 TP0] Decode batch, #running-req: 1, #token: 917, token usage: 0.00, cuda graph: True, gen throughput (token/s): 263.92, #queue-req: 0
[2026-02-21 10:48:37 TP0] Decode batch, #running-req: 1, #token: 957, token usage: 0.00, cuda graph: True, gen throughput (token/s): 264.28, #queue-req: 0
[2026-02-21 10:48:37 TP0] Decode batch, #running-req: 1, #token: 997, token usage: 0.00, cuda graph: True, gen throughput (token/s): 264.60, #queue-req: 0
[2026-02-21 10:48:38 TP0] Decode batch, #running-req: 1, #token: 1037, token usage: 0.00, cuda graph: True, gen throughput (token/s): 263.88, #queue-req: 0
[2026-02-21 10:48:38 TP0] Decode batch, #running-req: 1, #token: 1077, token usage: 0.00, cuda graph: True, gen throughput (token/s): 263.52, #queue-req: 0
[2026-02-21 10:48:38 TP0] Decode batch, #running-req: 1, #token: 1117, token usage: 0.00, cuda graph: True, gen throughput (token/s): 262.94, #queue-req: 0
[2026-02-21 10:48:38] INFO:     127.0.0.1:39458 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

Client:
```
➜  bench_script bash test_image.sh
{"id":"44c35817d91d4242be93a6f91a440d57","object":"chat.completion","created":1771670918,"model":"nvidia/Eagle2.5-8B","choices":[{"index":0,"message":{"role":"assistant","content":"好的，这张图片描绘了一个宁静而专注的场景。\n\n图中主要人物是一位正在拍照的人，我们只能看到其背影和侧面。以下是图片的详细描述：\n\n- **人物与穿着**:\n  - 这个人戴着一顶深灰色的针织帽，帽檐压得很低，遮住了部分脸庞。\n  - 他们有一头深色的卷发，从帽子边缘露出来。\n  - 他们穿着一件蓝色的牛仔夹克。\n\n- **动作与设备**:\n  - 人物正用双手举着一台相机，镜头对准前方，似乎正在拍摄。\n  - 他们的眼睛正通过相机的取景器观察。\n  - 这台相机是一台经典的单反相机，从机身上可以清晰地看到“Canon”（佳能）的品牌标志。\n  - 相机的镜头是黑色的，上面印有“CANON LENS FD 50mm 1:1.8”的字样，表明这是一支佳能FD卡口的50mm f/1.8镜头。\n  - 人物的右手无名指上戴着一枚简单的金属戒指。\n\n- **背景与环境**:\n  - 背景是一个模糊的户外自然景观，可能是一片田野或开阔地。\n  - 远处的树木和地平线都处于焦外，形成了柔和的虚化效果。\n  - 天空呈现出温暖的色调，像是日出或日落时分的金色或橙色光芒，为整个画面增添了一种温暖、宁静的氛围。\n\n总的来说，这张照片捕捉了一个摄影爱好者在黄昏或黎明时分，沉浸于摄影创作中的瞬间。画面构图将焦点集中在人物和相机上，背景的虚化和温暖的光线共同营造出一种专注、宁静且富有艺术感的氛围。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":764,"total_tokens":1149,"completion_tokens":385,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}

➜  bench_script bash test_video.sh
{"id":"6398c2d085e345a380417283ebf57860","object":"chat.completion","created":1771670971,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频中描述的是史蒂夫·乔布斯在一次产品发布会上介绍iPod Nano的场景。他站在舞台上，背景是一个巨大的屏幕，屏幕上显示着一个手从牛仔裤口袋中拿出一个白色的小设备。乔布斯用幽默的方式提问：“有人知道这个口袋是干什么用的吗？”然后他解释说，这个口袋是用来放iPod Nano的。接着，他从自己的口袋里拿出一个iPod Nano，展示给观众看，并说：“这就是新的iPod Nano。”整个场景充满了科技感和幽默感，展示了苹果公司产品的创新和设计。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":9948,"total_tokens":10072,"completion_tokens":124,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}

```

## Key Technical Notes

### CUDNN Attention Parameters
| Parameter          | Description                                                                 |
|-------------------|-----------------------------------------------------------------------------|
| cu_seqlens       | Split into 3 sections: Q/K offsets, V offsets, O offsets                    |
| sequence_lengths | Padded to batch size 8                                                      |
| max_seqlen       | Fixed at 128K for FlashInfer                                                |
| workspace_buffer | 128MB pre-allocated buffer                                                  |
</body></html>

### cu_seqlens Format
```
cu_seqlength = len(cu_seqlens) // 3
batch_offsets_qk = cu_seqlens[:cu_seqlength] # Q/K batch offsets
batch_offsets_v = cu_seqlens[cu_seqlength:cu_seqlength2] # V batch offsets
batch_offsets_o = cu_seqlens[cu_seqlength2:] # O batch offset
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
lmms_eval mmm_val acc no drop.

```
Main:
➜  bench_script python3 -m lmms_eval --model openai_compatible --model_args model_version=Qwen/Qwen3-VL-30B-A3B-Instruct --tasks mmmu_val --batch_size 16
2026-02-21 07:09:16 | INFO     | __main__:cli_evaluate:476 - Verbosity set to INFO
2026-02-21 07:09:19 | INFO     | __main__:cli_evaluate_single:565 - Evaluation tracker args: {}
2026-02-21 07:09:19 | INFO     | __main__:cli_evaluate_single:649 - Selected Tasks: ['mmmu_val']
2026-02-21 07:09:19 | INFO     | lmms_eval.evaluator:simple_evaluate:170 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-21 07:09:20 | INFO     | lmms_eval.evaluator:evaluate:515 - Running on rank 0 (local rank 0)
2026-02-21 07:09:20 | INFO     | lmms_eval.api.task:build_all_requests:428 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13988.47it/s]
2026-02-21 07:09:20 | INFO     | lmms_eval.evaluator:evaluate:609 - Running generate_until requests
Model Responding:  99%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ | 891/900 [01:59<00:00,  9.04it/s]2026-02-21 07:11:20 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:136 - Metric summary - Total elapsed time: 2292.603s, Total gen tokens: 42108, Avg speed: 18.4 tokens/s
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [01:59<00:00,  7.52it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 9522.77it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.75}, 'Art': {'num': 30, 'acc': 0.7}, 'Art_Theory': {'num': 30, 'acc': 0.93333}, 'Design': {'num': 30, 'acc': 0.9}, 'Music': {'num': 30, 'acc': 0.46667}, 'Overall-Business': {'num': 150, 'acc': 0.41333}, 'Accounting': {'num': 30, 'acc': 0.4}, 'Economics': {'num': 30, 'acc': 0.46667}, 'Finance': {'num': 30, 'acc': 0.3}, 'Manage': {'num': 30, 'acc': 0.5}, 'Marketing': {'num': 30, 'acc': 0.4}, 'Overall-Science': {'num': 150, 'acc': 0.48667}, 'Biology': {'num': 30, 'acc': 0.5}, 'Chemistry': {'num': 30, 'acc': 0.33333}, 'Geography': {'num': 30, 'acc': 0.63333}, 'Math': {'num': 30, 'acc': 0.46667}, 'Physics': {'num': 30, 'acc': 0.5}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.52667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.6}, 'Clinical_Medicine': {'num': 30, 'acc': 0.6}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.33333}, 'Pharmacy': {'num': 30, 'acc': 0.6}, 'Public_Health': {'num': 30, 'acc': 0.5}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.725}, 'History': {'num': 30, 'acc': 0.73333}, 'Literature': {'num': 30, 'acc': 0.9}, 'Sociology': {'num': 30, 'acc': 0.6}, 'Psychology': {'num': 30, 'acc': 0.66667}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.37143}, 'Agriculture': {'num': 30, 'acc': 0.63333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.33333}, 'Computer_Science': {'num': 30, 'acc': 0.5}, 'Electronics': {'num': 30, 'acc': 0.2}, 'Energy_and_Power': {'num': 30, 'acc': 0.33333}, 'Materials': {'num': 30, 'acc': 0.33333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.26667}, 'Overall': {'num': 900, 'acc': 0.52111}}
fatal: not a git repository (or any of the parent directories): .git
2026-02-21 07:11:20 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:238 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-30B-A3B-Instruct), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5211|±  |N/A   |
                                                                           
Throughput Summary

|      Metric      |  Value   |  Unit  |
|------------------|---------:|--------|
|total_gen_tokens  |42108.0000|tokens  |
|total_elapsed_time| 2292.6026|seconds |
|avg_speed         |   18.3669|tokens/s|


PR:
➜  sglang_dev2 git:(support_vit_fi_backend) ✗ python3 -m lmms_eval --model openai_compatible --model_args model_version=Qwen/Qwen3-VL-30B-A3B-Instruct --tasks mmmu_val --batch_size 16
2026-02-21 10:42:28 | INFO     | __main__:cli_evaluate:476 - Verbosity set to INFO
2026-02-21 10:42:31 | INFO     | __main__:cli_evaluate_single:565 - Evaluation tracker args: {}
2026-02-21 10:42:31 | INFO     | __main__:cli_evaluate_single:649 - Selected Tasks: ['mmmu_val']
2026-02-21 10:42:31 | INFO     | lmms_eval.evaluator:simple_evaluate:170 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-21 10:42:32 | INFO     | lmms_eval.evaluator:evaluate:515 - Running on rank 0 (local rank 0)
2026-02-21 10:42:32 | INFO     | lmms_eval.api.task:build_all_requests:428 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13231.29it/s]
2026-02-21 10:42:32 | INFO     | lmms_eval.evaluator:evaluate:609 - Running generate_until requests
Model Responding:  99%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ | 891/900 [01:55<00:00,  9.69it/s]2026-02-21 10:44:28 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:136 - Metric summary - Total elapsed time: 2079.956s, Total gen tokens: 42078, Avg speed: 20.2 tokens/s
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [01:55<00:00,  7.80it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 9581.04it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.74167}, 'Art': {'num': 30, 'acc': 0.73333}, 'Art_Theory': {'num': 30, 'acc': 0.9}, 'Design': {'num': 30, 'acc': 0.86667}, 'Music': {'num': 30, 'acc': 0.46667}, 'Overall-Business': {'num': 150, 'acc': 0.42667}, 'Accounting': {'num': 30, 'acc': 0.43333}, 'Economics': {'num': 30, 'acc': 0.53333}, 'Finance': {'num': 30, 'acc': 0.23333}, 'Manage': {'num': 30, 'acc': 0.46667}, 'Marketing': {'num': 30, 'acc': 0.46667}, 'Overall-Science': {'num': 150, 'acc': 0.49333}, 'Biology': {'num': 30, 'acc': 0.56667}, 'Chemistry': {'num': 30, 'acc': 0.33333}, 'Geography': {'num': 30, 'acc': 0.63333}, 'Math': {'num': 30, 'acc': 0.46667}, 'Physics': {'num': 30, 'acc': 0.46667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.54}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.63333}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.33333}, 'Pharmacy': {'num': 30, 'acc': 0.6}, 'Public_Health': {'num': 30, 'acc': 0.5}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.725}, 'History': {'num': 30, 'acc': 0.73333}, 'Literature': {'num': 30, 'acc': 0.9}, 'Sociology': {'num': 30, 'acc': 0.6}, 'Psychology': {'num': 30, 'acc': 0.66667}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.35238}, 'Agriculture': {'num': 30, 'acc': 0.6}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.3}, 'Computer_Science': {'num': 30, 'acc': 0.43333}, 'Electronics': {'num': 30, 'acc': 0.16667}, 'Energy_and_Power': {'num': 30, 'acc': 0.23333}, 'Materials': {'num': 30, 'acc': 0.43333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.3}, 'Overall': {'num': 900, 'acc': 0.52111}}
2026-02-21 10:44:28 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:238 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-30B-A3B-Instruct), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5211|±  |N/A   |


Throughput Summary

|      Metric      |  Value   |  Unit  |
|------------------|---------:|--------|
|total_gen_tokens  |42078.0000|tokens  |
|total_elapsed_time| 2079.9561|seconds |
|avg_speed         |   20.2302|tokens/s|
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
