### PR TITLE
Fix flashinfer autotune to only wrap run_once()

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -152,6 +152,7 @@ from sglang.srt.utils import (
     MultiprocessingSerializer,
     cpu_has_amx_support,
     dynamic_import,
+    empty_context,
     enable_show_time_cost,
     get_available_gpu_memory,
     get_cpu_ids_by_node,
@@ -1858,12 +1859,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         logger.info("Running FlashInfer autotune...")
 
-        with torch.inference_mode(), autotune():
-            self._dummy_run(batch_size=self.req_to_token_pool.size)
+        self._dummy_run(
+            batch_size=self.req_to_token_pool.size,
+            run_ctx=autotune(),
+        )
 
         logger.info("FlashInfer autotune completed.")
 
-    def _dummy_run(self, batch_size: int):
+    def _dummy_run(self, batch_size: int, run_ctx=None):
         """Run a dummy forward pass for warmup/profiling."""
         if self.is_generation:
             capture_forward_mode = ForwardMode.DECODE
@@ -2103,7 +2106,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         torch.get_device_module(self.device).synchronize()
         self.tp_group.barrier()
-        run_once()
+        with torch.inference_mode(), run_ctx or empty_context():
+            run_once()
 
     def init_device_graphs(self):
         """Capture device graphs."""


### PR DESCRIPTION
## Motivation

The `_flashinfer_autotune` method previously wrapped the entire `_dummy_run` call inside the `autotune()` context. This meant that buffer creation, `ForwardBatch` construction, and `attn_backend.init_forward_metadata()` (which calls flashinfer's `.plan()` / `.begin_forward()` metadata operations) were all unnecessarily wrapped by the autotuner.

Only the actual attention kernel execution inside `run_once()` → `self.model.forward(...)` should be autotuned.

## Modifications

- Added a `run_ctx` parameter to `_dummy_run()` that accepts an optional context manager.
- The `autotune()` context is now applied **only** around `run_once()`, not the entire `_dummy_run`.
- Uses the existing `empty_context()` utility as the no-op fallback when `run_ctx` is not provided.
- No changes to other callers of `_dummy_run` (warmup/profiling paths are unaffected).

## Accuracy Tests

N/A — no change to model outputs; this only narrows the scope of the autotune context.

## Benchmarking and Profiling

N/A — no expected performance change; the same kernels are autotuned, just with a more precise context boundary.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.