### PR TITLE
Fix corrupted JSONL metrics file due to concurrent writes

### DIFF
--- a/python/sglang/srt/managers/request_metrics_exporter.py
+++ b/python/sglang/srt/managers/request_metrics_exporter.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Union
 
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils.aio_rwlock import RWLock
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +87,7 @@ class FileRequestMetricsExporter(RequestMetricsExporter):
 
         # File handler state management
         self._current_file_handler = None
-        self._current_file_lock = RWLock()
+        self._current_file_lock = asyncio.Lock()
         self._current_hour_suffix = None
 
     def _ensure_file_handler(self, hour_suffix: str):
@@ -137,7 +136,7 @@ class FileRequestMetricsExporter(RequestMetricsExporter):
             current_time = datetime.now()
             hour_suffix = current_time.strftime("%Y%m%d_%H")
 
-            async with self._current_file_lock.writer_lock:
+            async with self._current_file_lock:
                 # Ensure correct file handler is open for current hour
                 self._ensure_file_handler(hour_suffix)
 

--- a/python/sglang/srt/managers/request_metrics_exporter.py
+++ b/python/sglang/srt/managers/request_metrics_exporter.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Union
 
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils.aio_rwlock import RWLock
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ class FileRequestMetricsExporter(RequestMetricsExporter):
 
         # File handler state management
         self._current_file_handler = None
-        self._current_file_lock = asyncio.Lock()
+        self._current_file_lock = RWLock()
         self._current_hour_suffix = None
 
     def _ensure_file_handler(self, hour_suffix: str):
@@ -136,7 +137,7 @@ class FileRequestMetricsExporter(RequestMetricsExporter):
             current_time = datetime.now()
             hour_suffix = current_time.strftime("%Y%m%d_%H")
 
-            async with self._current_file_lock:
+            async with self._current_file_lock.writer_lock:
                 # Ensure correct file handler is open for current hour
                 self._ensure_file_handler(hour_suffix)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using sglang server with `--export-metrics-to-file --export-metrics-to-file-dir /tmp/sglang-metrics`, concurrent writes can corrupt the jsonl file of the metrics.

Example of corrupted jsonl file with 32 concurrent requests:
```
, "id": "a9667994aff3400686d6d3eb95ee0235", "finish_reason": {"type": "stop", "matched": 128009}, "prompt_tokens": 3538, "weight_version": "default", "total_retractions": 0, "queue_time": 0.021411570953205228, "prefill_launch_delay": 0.0005364660173654556, "prefill_launch_latency": 0.06839973502792418, "prefill_finished_ts": 1771503801.2129033, "completion_tokens": 482, "cached_tokens": 45, "e2e_latency": 5.103912115097046, "spec_accept_rate": 0.9147286821705426, "spec_accept_length": 3.7364341085271318, "spec_accept_token_num": 354, "spec_draft_token_num": 387, "spec_verify_ct": 129, "request_received_ts": 1771503800.9961853, "request_sent_to_scheduler_ts": 1771503801.002038, "decode_finished_ts": 1771503806.1000974, "inference_time": 5.0451679839752614, "decode_throughput": 144.13696466037615, "response_sent_to_client_ts": 1771503806.1002116}
```

Write lock mechanism will prevent this from happening.

## Modifications

Added `RWLock` for the `FileRequestMetricsExporter`, which is acquired when we open the metrics file in `_write_record`.

## Accuracy Tests

Not expected to impact model output/accuracy.

## Benchmarking and Profiling

Not expected to impact latency/throughput.

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
