### PR TITLE
fix: Fix false-positive mamba memory leak check (safe follow-up to #16067)

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -116,10 +116,11 @@ class SchedulerRuntimeCheckerMixin:
         # must not be counted as leaked; they will be reused on the next scheduling
         # round without re-copying from the radix cache (preserving numerical
         # determinism for mamba models).
-        waiting_mamba_slots = set()
-        for req in self.waiting_queue:
-            if req.mamba_pool_idx is not None:
-                waiting_mamba_slots.add(int(req.mamba_pool_idx))
+        waiting_mamba_slots = {
+            int(req.mamba_pool_idx)
+            for req in self.waiting_queue
+            if req.mamba_pool_idx is not None
+        }
 
         memory_leak = (
             full_num_used != self.tree_cache.full_protected_size()


### PR DESCRIPTION
## Motivation

#16067 attempted to improve the mamba memory leak check, but the change interacted with slot lifecycle/scheduling and was later reverted in #18910 due to KL divergence instability.

The original issue still exists: `_check_mamba_memory` may report false-positive leaks when a request has already allocated a mamba slot but is still in the scheduler `waiting_queue`. These slots are valid and will be reused in the next scheduling round.

This PR fixes that checker logic in a safer way, without touching scheduling behavior.

## Changes

* Track mamba slots held by requests in `waiting_queue`
* Count them as valid allocations in the expected used size
* Exclude them from `leaked_mamba_pages`

## Notes

Only refines the runtime checker. No scheduling or model behavior changes.

Related: #16067, #18910



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
