### PR TITLE
feature: docker patch workflow

### DIFF
--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -3,8 +3,8 @@ name: Patch Docker Image
 on:
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: "PR number to patch (leave empty to patch with latest main)"
+      pr_numbers:
+        description: "Comma-separated PR numbers to apply (e.g. 18962,19010)"
         required: false
         default: ""
       image_tag:
@@ -37,26 +37,30 @@ jobs:
           echo "Image built from commit: ${BASE_SHA}"
           echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_ENV"
 
-      - name: Generate patch
+      - name: Generate patches
         run: |
-          # Fetch the exact commit the image was built from (branch-agnostic)
           git fetch origin "${BASE_SHA}"
+          mkdir -p /tmp/patch-ctx
 
-          if [ -n "${{ inputs.pr_number }}" ]; then
-            echo "Generating diff: image ${BASE_SHA} → PR #${{ inputs.pr_number }}"
-            git fetch origin "pull/${{ inputs.pr_number }}/head:pr-${{ inputs.pr_number }}"
-            git diff "${BASE_SHA}..pr-${{ inputs.pr_number }}" > /tmp/sglang.patch
+          if [ -n "${{ inputs.pr_numbers }}" ]; then
+            IFS=',' read -ra PRS <<< "${{ inputs.pr_numbers }}"
+            for pr in "${PRS[@]}"; do
+              pr=$(echo "${pr}" | xargs)
+              echo "Fetching PR #${pr}"
+              git fetch origin "pull/${pr}/head:pr-${pr}"
+              git diff "${BASE_SHA}..pr-${pr}" > "/tmp/patch-ctx/${pr}.patch"
+              echo "  PR #${pr}: $(wc -l < /tmp/patch-ctx/${pr}.patch) lines"
+            done
           else
             echo "Generating diff: image ${BASE_SHA} → latest main"
             git fetch origin main
-            git diff "${BASE_SHA}..origin/main" > /tmp/sglang.patch
+            git diff "${BASE_SHA}..origin/main" > /tmp/patch-ctx/main.patch
+            echo "  main: $(wc -l < /tmp/patch-ctx/main.patch) lines"
           fi
 
-          LINES=$(wc -l < /tmp/sglang.patch)
-          echo "Patch: ${LINES} lines"
-
-          if [ "${LINES}" -eq 0 ]; then
-            echo "::warning::Patch is empty — image is already up to date"
+          TOTAL=$(cat /tmp/patch-ctx/*.patch | wc -l)
+          if [ "${TOTAL}" -eq 0 ]; then
+            echo "::warning::All patches are empty — image is already up to date"
             echo "SKIP_BUILD=true" >> "$GITHUB_ENV"
           fi
 
@@ -65,17 +69,17 @@ jobs:
         run: |
           IMAGE="lmsysorg/sglang:${{ inputs.image_tag }}"
 
-          mkdir -p /tmp/patch-ctx
-          cp /tmp/sglang.patch /tmp/patch-ctx/
-
           cat <<'DOCKERFILE' > /tmp/patch-ctx/Dockerfile
           ARG BASE_IMAGE
           FROM ${BASE_IMAGE}
-          COPY sglang.patch /tmp/sglang.patch
+          COPY *.patch /tmp/patches/
           RUN cd /sgl-workspace/sglang \
-              && git apply --verbose --stat /tmp/sglang.patch \
-              && git apply /tmp/sglang.patch \
-              && rm /tmp/sglang.patch
+              && for p in /tmp/patches/*.patch; do \
+                   echo "Applying ${p}..." \
+                   && git apply --stat "${p}" \
+                   && git apply "${p}"; \
+                 done \
+              && rm -rf /tmp/patches
           DOCKERFILE
 
           docker build \
@@ -90,6 +94,6 @@ jobs:
           IMAGE="lmsysorg/sglang:${{ inputs.image_tag }}"
           docker push "${IMAGE}"
 
-          echo "### Patched Docker Image" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Image:** \`${IMAGE}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Source:** ${{ inputs.pr_number && format('PR #{0}', inputs.pr_number) || 'latest main' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Patched \`${IMAGE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Base commit:** \`${BASE_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Source:** ${{ inputs.pr_numbers && format('PRs: {0}', inputs.pr_numbers) || 'latest main' }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -1,0 +1,90 @@
+name: Patch Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to patch (leave empty to patch with latest main)"
+        required: false
+        default: ""
+      image_tag:
+        description: "Base image tag to patch (e.g. dev-x86, dev-x86-cu13)"
+        required: true
+
+concurrency:
+  group: patch-docker-${{ inputs.image_tag }}
+  cancel-in-progress: true
+
+jobs:
+  patch:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: x64-docker-build-node
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate patch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          IMAGE="lmsysorg/sglang:${{ inputs.image_tag }}"
+
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            echo "Generating diff from PR #${{ inputs.pr_number }}"
+            gh pr diff ${{ inputs.pr_number }} > /tmp/sglang.patch
+          else
+            echo "Generating diff from image commit to latest main"
+            docker pull "${IMAGE}"
+            BASE_SHA=$(docker run --rm "${IMAGE}" git -C /sgl-workspace/sglang rev-parse HEAD)
+            echo "Image built from commit: ${BASE_SHA}"
+            git fetch origin main
+            git diff "${BASE_SHA}..origin/main" > /tmp/sglang.patch
+          fi
+
+          LINES=$(wc -l < /tmp/sglang.patch)
+          echo "Patch: ${LINES} lines"
+
+          if [ "${LINES}" -eq 0 ]; then
+            echo "::warning::Patch is empty — image is already up to date"
+            echo "SKIP_BUILD=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build patched image
+        if: env.SKIP_BUILD != 'true'
+        run: |
+          IMAGE="lmsysorg/sglang:${{ inputs.image_tag }}"
+
+          mkdir -p /tmp/patch-ctx
+          cp /tmp/sglang.patch /tmp/patch-ctx/
+
+          cat <<'DOCKERFILE' > /tmp/patch-ctx/Dockerfile
+          ARG BASE_IMAGE
+          FROM ${BASE_IMAGE}
+          COPY sglang.patch /tmp/sglang.patch
+          RUN cd /sgl-workspace/sglang \
+              && git apply --verbose --stat /tmp/sglang.patch \
+              && git apply /tmp/sglang.patch \
+              && rm /tmp/sglang.patch
+          DOCKERFILE
+
+          docker build \
+            --no-cache \
+            --build-arg BASE_IMAGE="${IMAGE}" \
+            -t "${IMAGE}" \
+            /tmp/patch-ctx/
+
+      - name: Push patched image
+        if: env.SKIP_BUILD != 'true'
+        run: |
+          IMAGE="lmsysorg/sglang:${{ inputs.image_tag }}"
+          docker push "${IMAGE}"
+
+          echo "### Patched Docker Image" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image:** \`${IMAGE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Source:** ${{ inputs.pr_number && format('PR #{0}', inputs.pr_number) || 'latest main' }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -29,20 +29,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Generate patch
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Pull base image and extract commit
         run: |
           IMAGE="lmsysorg/sglang:${{ inputs.image_tag }}"
+          docker pull "${IMAGE}"
+          BASE_SHA=$(docker run --rm "${IMAGE}" git -C /sgl-workspace/sglang rev-parse HEAD)
+          echo "Image built from commit: ${BASE_SHA}"
+          echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_ENV"
+
+      - name: Generate patch
+        run: |
+          # Fetch the exact commit the image was built from (branch-agnostic)
+          git fetch origin "${BASE_SHA}"
 
           if [ -n "${{ inputs.pr_number }}" ]; then
-            echo "Generating diff from PR #${{ inputs.pr_number }}"
-            gh pr diff ${{ inputs.pr_number }} > /tmp/sglang.patch
+            echo "Generating diff: image ${BASE_SHA} → PR #${{ inputs.pr_number }}"
+            git fetch origin "pull/${{ inputs.pr_number }}/head:pr-${{ inputs.pr_number }}"
+            git diff "${BASE_SHA}..pr-${{ inputs.pr_number }}" > /tmp/sglang.patch
           else
-            echo "Generating diff from image commit to latest main"
-            docker pull "${IMAGE}"
-            BASE_SHA=$(docker run --rm "${IMAGE}" git -C /sgl-workspace/sglang rev-parse HEAD)
-            echo "Image built from commit: ${BASE_SHA}"
+            echo "Generating diff: image ${BASE_SHA} → latest main"
             git fetch origin main
             git diff "${BASE_SHA}..origin/main" > /tmp/sglang.patch
           fi


### PR DESCRIPTION
## Motivation

Currently, updating a custom docker image requires a complete rebuild, and this is inconvenient especially if the base docker image is custom. This workflow is designed to patch custom images efficiently using git diff.

## Modifications

Pull the specified image first, git diff, and then git apply to patch within.

## Accuracy Tests

As this is a new workflow, need an initial merge to test via workflow dispatch.

## Benchmarking and Profiling

N/A

## Checklist

- [ Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
