### PR TITLE
fix: handle None extra_request_body in bench_serving

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2490,7 +2490,7 @@ async def benchmark(
 
         # Merge global extra_request_body with per-request extras
         # Per-request parameters take precedence over global ones
-        merged_extra_body = {**extra_request_body, **request.extra_request_body}
+        merged_extra_body = {**(extra_request_body or {}), **(request.extra_request_body or {})}
 
         request_func_input = RequestFuncInput(
             model=model_id,

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2490,7 +2490,10 @@ async def benchmark(
 
         # Merge global extra_request_body with per-request extras
         # Per-request parameters take precedence over global ones
-        merged_extra_body = {**(extra_request_body or {}), **(request.extra_request_body or {})}
+        merged_extra_body = {
+            **(extra_request_body or {}),
+            **(request.extra_request_body or {}),
+        }
 
         request_func_input = RequestFuncInput(
             model=model_id,


### PR DESCRIPTION
## Motivation

When `--extra-request-body` is not provided, the global `extra_request_body` is `None`. PR #17219 introduced a merge step `{**extra_request_body, **request.extra_request_body}` but did not guard against `None`, causing a `TypeError` crash.

## Modifications

In `bench_serving.py`, use `or {}` to safely fall back to empty dicts before merging:

`merged_extra_body = {**(extra_request_body or {}), **(request.extra_request_body or {})}`

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
