### PR TITLE
Fix KV offload flush-cache ordering and guard Mamba clear path

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2623,8 +2623,11 @@ class Scheduler(
             self.cur_batch = None
             self.last_batch = None
             self.tree_cache.reset()
-            self.req_to_token_pool.clear()
-            self.token_to_kv_pool_allocator.clear()
+            # Skip pool clear when KV cache memory is offloaded (freed by memory_saver),
+            # as the underlying CUDA memory is not on GPU.
+            if "kv_cache" not in self.offload_tags:
+                self.req_to_token_pool.clear()
+                self.token_to_kv_pool_allocator.clear()
             self.grammar_manager.clear()
             self.reset_metrics()
 


### PR DESCRIPTION
## Motivation

In RL/VERL workflows, memory release and weight update happen in different phases, and `flush_cache()` is reached from more than one call path.

The critical sequence is:

1. `release_memory_occupation(all tags)` pauses KV cache memory (`pause("kv_cache")`).
2. Training happens.
3. `rollout_mode` resumes only weights, then runs weight update.
4. `update_weights_from_tensor(..., flush_cache=True)` calls `Scheduler.flush_cache()` while KV cache is still offloaded.

Sample Error got from verl
```
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/managers/scheduler.py", line 2864, in run_scheduler_process
(WorkerDict pid=450741, ip=10.141.1.37)     scheduler.event_loop_overlap()
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/miniconda3/envs/sglang-verl-env-test/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(WorkerDict pid=450741, ip=10.141.1.37)     return func(*args, **kwargs)
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/managers/scheduler.py", line 1089, in event_loop_overlap
(WorkerDict pid=450741, ip=10.141.1.37)     self.process_input_requests(recv_reqs)
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/managers/scheduler.py", line 1294, in process_input_requests
(WorkerDict pid=450741, ip=10.141.1.37)     output = self._request_dispatcher(recv_req)
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/utils.py", line 507, in __call__
(WorkerDict pid=450741, ip=10.141.1.37)     return fn(obj)
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/managers/scheduler_update_weights_mixin.py", line 128, in release_memory_occupation
(WorkerDict pid=450741, ip=10.141.1.37)     self.flush_cache()
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/managers/scheduler.py", line 2379, in flush_cache
(WorkerDict pid=450741, ip=10.141.1.37)     self.req_to_token_pool.clear()
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 503, in clear
(WorkerDict pid=450741, ip=10.141.1.37)     self.mamba_pool.clear()
(WorkerDict pid=450741, ip=10.141.1.37)   File "/home/changyi/verl_tool_env/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 287, in clear
(WorkerDict pid=450741, ip=10.141.1.37)     self.mamba_cache.conv[i].zero_()
(WorkerDict pid=450741, ip=10.141.1.37) torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

Code-level path:

- `SchedulerUpdateWeightsMixin.update_weights_from_tensor()`
  - `python/sglang/srt/managers/scheduler_update_weights_mixin.py`
  - `if recv_req.flush_cache: self.flush_cache()`
- `Scheduler.flush_cache()`
  - `python/sglang/srt/managers/scheduler.py`
  - calls `self.req_to_token_pool.clear()` and `self.token_to_kv_pool_allocator.clear()`.

Why this can crash now (and why some old paths might not):

- In non-Mamba or normal serve paths, cache clearing is often metadata-only (free-slot reset, index bookkeeping), which not immediately touch offloaded device tensors.
- In Mamba/hybrid cache paths, clearing includes explicit tensor writes:
  - `HybridReqToTokenPool.clear()` -> `self.req_index_to_mamba_index_mapping.zero_()`
  - and optionally `self.req_index_to_mamba_ping_pong_track_buffer_mapping.zero_()`
  - in `python/sglang/srt/mem_cache/memory_pool.py`.
- These are real tensor ops on KV-related GPU tensors. If KV region has already been paused/offloaded, those writes can hit invalid/offloaded memory and trigger CUDA illegal memory access.

So the bug is not "flush_cache always unsafe". It is unsafe specifically when `flush_cache()` is executed while KV cache is offloaded, and the concrete failure surface is Mamba clear path doing `.zero_()`.

## Modifications

1. Reordered KV handling in `release_memory_occupation`:

- File: `python/sglang/srt/managers/scheduler_update_weights_mixin.py`
- Change:
  - before: `pause(kv_cache)` -> `flush_cache()`
  - after: `flush_cache()` -> `pause(kv_cache)`

Rationale:

- During release path itself, we should flush while pools/tensors are still live.
- Pausing KV after flush avoids writing to already-offloaded memory during release.

2. Added KV-offload guard in `flush_cache` for later call paths:

- File: `python/sglang/srt/managers/scheduler.py`
- Change:
  - guard `req_to_token_pool.clear()` and `token_to_kv_pool_allocator.clear()` behind:
    - `if "kv_cache" not in self.offload_tags:`

Rationale:

- Weight-update-triggered `flush_cache()` can run while KV is intentionally still offloaded.
- In that state, skip KV-pool clear to avoid tensor writes (`.zero_()`) into offloaded memory.
- Non-KV cache cleanup (tree cache, grammar manager, metrics, etc.) still runs.

3. Updated `offload_tags` timing to preserve intended semantics:

- File: `python/sglang/srt/managers/scheduler_update_weights_mixin.py`
- Change:
  - mark `offload_tags` at the end of release flow (single tail loop), after per-tag teardown.

Rationale:

- Ensures release-path `flush_cache()` still performs required clear (KV not yet marked offloaded).
- Ensures subsequent paths (e.g. update-weights flush) observe `"kv_cache" in offload_tags` and correctly skip KV clear.
