### PR TITLE
[Qwen3.5] Set full attn_backend to trtllm_mha on SM100 by default when possible

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1575,20 +1575,19 @@ class ServerArgs:
             ]:
                 sm100_default_attn_backend = "triton"
                 if is_sm100_supported():
-                    # trtllm_mha requires speculative_eagle_topk == 1 and page_size > 1
-                    # Use trtllm_mha only if radix cache is disabled because MambaRadixCache
-                    # requires page_size = 1 which trtllm_mha does not support. Radix cache
-                    # is also disabled when there is no extra buffer and spec decoding is enabled.
+                    # trtllm_mha requires speculative_eagle_topk == 1 and page_size > 1.
+                    # _get_default_attn_backend handles the eagle_topk check.
+                    # There is only one case where page_size=1 is required,
+                    # which is when radix cache is enabled and both extra_buffer
+                    # and spec decoding are disabled.
                     default_attn_backend = self._get_default_attn_backend(
                         use_mla_backend=self.use_mla_backend(),
                         model_config=self.get_model_config(),
                     )
-                    if default_attn_backend == "trtllm_mha" and (
-                        self.disable_radix_cache
-                        or (
-                            not self.enable_mamba_extra_buffer()
-                            and self.speculative_algorithm
-                        )
+                    if default_attn_backend == "trtllm_mha" and not (
+                        not self.enable_mamba_extra_buffer()
+                        and not self.disable_radix_cache
+                        and self.speculative_algorithm is None
                     ):
                         sm100_default_attn_backend = "trtllm_mha"
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1546,25 +1546,6 @@ class ServerArgs:
         elif model_arch in [
             "Qwen3MoeForCausalLM",
             "Qwen3VLMoeForConditionalGeneration",
-        ]:
-            if is_sm100_supported():
-                quant_method = get_quantization_config(hf_config)
-                if self.quantization is None and quant_method is not None:
-                    self.quantization = quant_method
-                if (
-                    (
-                        self.quantization in ("fp8", "modelopt_fp4")
-                        or self.quantization is None
-                    )
-                    and self.moe_a2a_backend == "none"
-                    and self.moe_runner_backend == "auto"
-                ):
-                    self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on sm100 for "
-                        f"{model_arch}"
-                    )
-        elif model_arch in [
             "Qwen3NextForCausalLM",
             "Qwen3_5MoeForConditionalGeneration",
             "Qwen3_5ForConditionalGeneration",
@@ -1583,14 +1564,40 @@ class ServerArgs:
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
-                        f"Use flashinfer_trtllm as MoE runner backend on sm100 for {model_arch}"
+                        "Use flashinfer_trtllm as MoE runner backend on sm100 for "
+                        f"{model_arch}"
                     )
-            self._handle_mamba_radix_cache(
-                model_arch=model_arch,
-                support_mamba_cache=True,
-                support_mamba_cache_extra_buffer=True,
-                sm100_default_attention_backend="triton",
-            )
+
+            if model_arch in [
+                "Qwen3NextForCausalLM",
+                "Qwen3_5MoeForConditionalGeneration",
+                "Qwen3_5ForConditionalGeneration",
+            ]:
+                sm100_default_attn_backend = "triton"
+                if is_sm100_supported():
+                    # trtllm_mha requires speculative_eagle_topk == 1 and page_size > 1
+                    # Use trtllm_mha only if radix cache is disabled because MambaRadixCache
+                    # requires page_size = 1 which trtllm_mha does not support. Radix cache
+                    # is also disabled when there is no extra buffer and spec decoding is enabled.
+                    default_attn_backend = self._get_default_attn_backend(
+                        use_mla_backend=self.use_mla_backend(),
+                        model_config=self.get_model_config(),
+                    )
+                    if default_attn_backend == "trtllm_mha" and (
+                        self.disable_radix_cache
+                        or (
+                            not self.enable_mamba_extra_buffer()
+                            and self.speculative_algorithm
+                        )
+                    ):
+                        sm100_default_attn_backend = "trtllm_mha"
+
+                self._handle_mamba_radix_cache(
+                    model_arch=model_arch,
+                    support_mamba_cache=True,
+                    support_mamba_cache_extra_buffer=True,
+                    sm100_default_attention_backend=sm100_default_attn_backend,
+                )
 
         elif model_arch in ["Glm4MoeForCausalLM"]:
             if is_sm100_supported():
@@ -1757,6 +1764,56 @@ class ServerArgs:
                 "flashinfer" if is_flashinfer_available() else "pytorch"
             )
 
+    def _get_default_attn_backend(self, use_mla_backend: bool, model_config):
+        """
+        Auto select the fastest attention backend.
+
+        1. Models with MHA Architecture (e.g: Llama, QWen)
+            1.1 We will turn on FA3 on hopper unless user use spec decode with topk > 1 or page_size > 1.
+            1.2 Use trtllm_mha for SM100/SM103 (Blackwell B200/GB200/B300) excluding spec with topk > 1.
+               Note: trtllm_mha does not support SM120, which will fall back to flashinfer.
+            1.3 In other cases, we will use flashinfer if available, otherwise use triton.
+        2. Models with MLA Architecture and using FA3
+            2.1 We will use FA3 backend on hopper.
+            2.2 We will use Flashinfer backend on blackwell.
+            2.3 Otherwise, we will use triton backend.
+        """
+        if not use_mla_backend:
+            # MHA architecture
+            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(self):
+                # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
+                # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA
+                # ref: https://github.com/sgl-project/sglang/issues/17411
+                return "fa3"
+            elif (
+                is_sm100_supported()
+                and is_no_spec_infer_or_topk_one(self)
+                and (
+                    self.speculative_algorithm is None
+                    or self.speculative_eagle_topk is not None
+                )
+            ):
+                return "trtllm_mha"
+            elif is_hip():
+                return "aiter"
+            else:
+                return "flashinfer" if is_flashinfer_available() else "triton"
+        else:
+            # MLA architecture
+            if is_hopper_with_cuda_12_3():
+                return "fa3"
+            elif is_sm100_supported():
+                return "flashinfer"
+            elif is_hip():
+                head_num = model_config.get_num_kv_heads(self.tp_size)
+                # TODO current aiter only support head number 16 or 128 head number
+                if head_num == 128 or head_num == 16:
+                    return "aiter"
+                else:
+                    return "triton"
+            else:
+                return "triton"
+
     def _handle_attention_backend_compatibility(self):
         model_config = self.get_model_config()
         use_mla_backend = self.use_mla_backend()
@@ -1768,57 +1825,9 @@ class ServerArgs:
 
         # Pick the default attention backend if not specified
         if self.attention_backend is None:
-            """
-            Auto select the fastest attention backend.
-
-            1. Models with MHA Architecture (e.g: Llama, QWen)
-                1.1 We will turn on FA3 on hopper unless user use spec decode with topk > 1 or page_size > 1.
-                1.2 Use trtllm_mha for SM100/SM103 (Blackwell B200/GB200/B300) excluding spec with topk > 1.
-                   Note: trtllm_mha does not support SM120, which will fall back to flashinfer.
-                1.3 In other cases, we will use flashinfer if available, otherwise use triton.
-            2. Models with MLA Architecture and using FA3
-                2.1 We will use FA3 backend on hopper.
-                2.2 We will use Flashinfer backend on blackwell.
-                2.3 Otherwise, we will use triton backend.
-            """
-
-            if not use_mla_backend:
-                # MHA architecture
-                if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(self):
-                    # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
-                    # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA
-                    # ref: https://github.com/sgl-project/sglang/issues/17411
-                    self.attention_backend = "fa3"
-                elif (
-                    is_sm100_supported()
-                    and is_no_spec_infer_or_topk_one(self)
-                    and (
-                        self.speculative_algorithm is None
-                        or self.speculative_eagle_topk is not None
-                    )
-                ):
-                    self.attention_backend = "trtllm_mha"
-                elif is_hip():
-                    self.attention_backend = "aiter"
-                else:
-                    self.attention_backend = (
-                        "flashinfer" if is_flashinfer_available() else "triton"
-                    )
-            else:
-                # MLA architecture
-                if is_hopper_with_cuda_12_3():
-                    self.attention_backend = "fa3"
-                elif is_sm100_supported():
-                    self.attention_backend = "flashinfer"
-                elif is_hip():
-                    head_num = model_config.get_num_kv_heads(self.tp_size)
-                    # TODO current aiter only support head number 16 or 128 head number
-                    if head_num == 128 or head_num == 16:
-                        self.attention_backend = "aiter"
-                    else:
-                        self.attention_backend = "triton"
-                else:
-                    self.attention_backend = "triton"
+            self.attention_backend = self._get_default_attn_backend(
+                use_mla_backend, model_config
+            )
 
             logger.info(
                 f"Attention backend not specified. Use {self.attention_backend} backend by default."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The default mha backend for hybrid qwen models is set to triton, which leads to worse performance when trtllm_mha can be used. 

## Modifications

- Refactor out `_get_default_attn_backend` so it can be called in `_handle_model_specific_adjustments`
- Remove the duplicated logic to set default MoE backend for qwen family models
- Get the default attn_backend by calling `_get_default_attn_backend` and pass it to `_handle_mamba_radix_cache` via `sm100_default_attention_backend`. 

## Accuracy Tests

gpqa with the fp8 checkpoint
```
python3 -m sglang.launch_server --model-path /models/Qwen3.5-397B-A17B-FP8 --tp-size 8 --ep-size 8 --mamba-ssm-dtype bfloat16 --enable-multimodal --max-mamba-cache-size 128 --max-running-requests 128 --chunked-prefill-size 2048 --disable-radix-cache --reasoning-parser qwen3 --host 0.0.0.0 --port 8001  --quantization fp8  

python3 -m sglang.test.run_eval --port 8001 --eval-name gpqa --num-examples 198 --max-tokens 81920 --repeat 8 --temperature 0.6 --top-p 0.95 --top-k 20

Repeat: 8, mean: 0.877
Scores: ['0.869', '0.874', '0.879', '0.879', '0.899', '0.864', '0.879', '0.874']
```

## Benchmarking and Profiling

tp=4, ep=4

similar ttft
tpot 35.00 ms vs 33.49 ms, 4.3% improvement
triton
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    256.0     
Max request concurrency:                 256       
Successful requests:                     1280      
Benchmark duration (s):                  197.13    
Total input tokens:                      1310720   
Total input text tokens:                 1310720   
Total generated tokens:                  1310720   
Total generated tokens (retokenized):    1307308   
Request throughput (req/s):              6.49      
Input token throughput (tok/s):          6649.14   
Output token throughput (tok/s):         6649.14   
Peak output token throughput (tok/s):    8121.00   
Peak concurrent requests:                512       
Total token throughput (tok/s):          13298.28  
Concurrency:                             254.90    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   39255.67  
Median E2E Latency (ms):                 39278.08  
P90 E2E Latency (ms):                    39518.20  
P99 E2E Latency (ms):                    39543.97  
---------------Time to First Token----------------
Mean TTFT (ms):                          3446.54   
Median TTFT (ms):                        3286.46   
P99 TTFT (ms):                           5501.00   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.00     
Median TPOT (ms):                        34.93     
P99 TPOT (ms):                           37.52     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           35.00     
Median ITL (ms):                         33.10     
P95 ITL (ms):                            33.98     
P99 ITL (ms):                            34.80     
Max ITL (ms):                            5195.80   
==================================================
```
trtllm_mha
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    256.0     
Max request concurrency:                 256       
Successful requests:                     1280      
Benchmark duration (s):                  189.34    
Total input tokens:                      1310720   
Total input text tokens:                 1310720   
Total generated tokens:                  1310720   
Total generated tokens (retokenized):    1307369   
Request throughput (req/s):              6.76      
Input token throughput (tok/s):          6922.42   
Output token throughput (tok/s):         6922.42   
Peak output token throughput (tok/s):    8192.00   
Peak concurrent requests:                512       
Total token throughput (tok/s):          13844.84  
Concurrency:                             254.86    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   37700.63  
Median E2E Latency (ms):                 37726.00  
P90 E2E Latency (ms):                    37917.82  
P99 E2E Latency (ms):                    37944.22  
---------------Time to First Token----------------
Mean TTFT (ms):                          3443.87   
Median TTFT (ms):                        3295.53   
P99 TTFT (ms):                           5590.22   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.49     
Median TPOT (ms):                        33.51     
P99 TPOT (ms):                           36.09     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           33.49     
Median ITL (ms):                         31.58     
P95 ITL (ms):                            32.16     
P99 ITL (ms):                            32.88     
Max ITL (ms):                            5187.85   
==================================================
```
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
