### PR TITLE
feat: Enhance flush_cache functionality to support empty_cache

### DIFF
--- a/python/sglang/lang/api.py
+++ b/python/sglang/lang/api.py
@@ -50,9 +50,7 @@ def set_default_backend(backend: BaseBackend):
     global_config.default_backend = backend
 
 
-def flush_cache(
-    backend: Optional[BaseBackend] = None, empty_cache: bool = True
-):
+def flush_cache(backend: Optional[BaseBackend] = None, empty_cache: bool = True):
     backend = backend or global_config.default_backend
     if backend is None:
         return False

--- a/python/sglang/lang/api.py
+++ b/python/sglang/lang/api.py
@@ -50,7 +50,9 @@ def set_default_backend(backend: BaseBackend):
     global_config.default_backend = backend
 
 
-def flush_cache(backend: Optional[BaseBackend] = None):
+def flush_cache(
+    backend: Optional[BaseBackend] = None, empty_cache: bool = True
+):
     backend = backend or global_config.default_backend
     if backend is None:
         return False
@@ -58,7 +60,7 @@ def flush_cache(backend: Optional[BaseBackend] = None):
     # If backend is Runtime
     if hasattr(backend, "endpoint"):
         backend = backend.endpoint
-    return backend.flush_cache()
+    return backend.flush_cache(empty_cache=empty_cache)
 
 
 def get_server_info(backend: Optional[BaseBackend] = None):

--- a/python/sglang/lang/backend/base_backend.py
+++ b/python/sglang/lang/backend/base_backend.py
@@ -75,7 +75,7 @@ class BaseBackend:
     def shutdown(self):
         pass
 
-    def flush_cache(self):
+    def flush_cache(self, empty_cache: bool = True):
         pass
 
     def get_server_info(self):

--- a/python/sglang/lang/backend/runtime_endpoint.py
+++ b/python/sglang/lang/backend/runtime_endpoint.py
@@ -56,9 +56,10 @@ class RuntimeEndpoint(BaseBackend):
     def get_model_name(self):
         return self.model_info["model_path"]
 
-    def flush_cache(self):
+    def flush_cache(self, empty_cache: bool = True):
         res = http_request(
             self.base_url + "/flush_cache",
+            json={"empty_cache": empty_cache},
             api_key=self.api_key,
             verify=self.verify,
             method="POST",

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -769,8 +769,10 @@ class Engine(EngineScoreMixin, EngineBase):
         self.shutdown()
         return False
 
-    def flush_cache(self):
-        return self.loop.run_until_complete(self.tokenizer_manager.flush_cache())
+    def flush_cache(self, empty_cache: bool = True):
+        return self.loop.run_until_complete(
+            self.tokenizer_manager.flush_cache(empty_cache=empty_cache)
+        )
 
     def open_session(
         self,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -118,6 +118,7 @@ from sglang.srt.managers.io_struct import (
     DestroyWeightsUpdateGroupReqInput,
     DumperControlReqInput,
     EmbeddingReqInput,
+    FlushCacheReqInput,
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
@@ -717,9 +718,14 @@ async def classify_request(obj: EmbeddingReqInput, request: Request):
 
 @app.api_route("/flush_cache", methods=["GET", "POST"])
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
-async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
+async def flush_cache(
+    timeout: float = Query(0.0, ge=0.0),
+    empty_cache: bool = True,
+):
     """Flush the radix cache."""
-    ret = await _global_state.tokenizer_manager.flush_cache(timeout_s=timeout)
+    ret = await _global_state.tokenizer_manager.flush_cache(
+        timeout_s=timeout, empty_cache=empty_cache
+    )
     if ret.success:
         content = (
             "Cache flushed.\nPlease check backend logs for more details. "

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1123,6 +1123,7 @@ class ClearHiCacheReqOutput(BaseReq):
 @dataclass
 class FlushCacheReqInput(BaseReq):
     timeout_s: Optional[float] = None
+    empty_cache: bool = True
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2846,7 +2846,7 @@ class Scheduler(
         pending_req, deadline = self._pending_flush
 
         if self.is_fully_idle():
-            success = self.flush_cache()
+            success = self.flush_cache(empty_cache=pending_req.empty_cache)
             self._pending_flush = None
             self.send_to_tokenizer.send_output(
                 FlushCacheReqOutput(success=success), pending_req
@@ -2876,10 +2876,14 @@ class Scheduler(
 
         timeout_s = float(recv_req.timeout_s or 0.0)
         if timeout_s <= 0.0:
-            return FlushCacheReqOutput(success=self.flush_cache())
+            return FlushCacheReqOutput(
+                success=self.flush_cache(empty_cache=recv_req.empty_cache)
+            )
 
         if self.is_fully_idle():
-            return FlushCacheReqOutput(success=self.flush_cache())
+            return FlushCacheReqOutput(
+                success=self.flush_cache(empty_cache=recv_req.empty_cache)
+            )
 
         self._pending_flush = (recv_req, time.monotonic() + timeout_s)
         return None
@@ -3035,7 +3039,7 @@ class Scheduler(
 
         return DetachHiCacheStorageReqOutput(success=False, message=msg)
 
-    def flush_cache(self):
+    def flush_cache(self, empty_cache: bool = True):
         """Flush the memory pool and cache."""
         if self.is_fully_idle():
             self.cur_batch = None
@@ -3049,8 +3053,8 @@ class Scheduler(
             if self.draft_worker:
                 self.draft_worker.clear_cache_pool()
 
-            # TODO: allow optional empty cache
-            torch.cuda.empty_cache()
+            if empty_cache:
+                torch.cuda.empty_cache()
             logger.info("Cache flushed successfully!")
             success = True
         else:

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -344,11 +344,15 @@ class TokenizerCommunicatorMixin:
         )
 
     async def flush_cache(
-        self: TokenizerManager, timeout_s: Optional[float] = None
+        self: TokenizerManager,
+        timeout_s: Optional[float] = None,
+        empty_cache: bool = True,
     ) -> FlushCacheReqOutput:
         self.auto_create_handle_loop()
         return (
-            await self.flush_cache_communicator(FlushCacheReqInput(timeout_s=timeout_s))
+            await self.flush_cache_communicator(
+                FlushCacheReqInput(timeout_s=timeout_s, empty_cache=empty_cache)
+            )
         )[0]
 
     async def clear_hicache_storage(self: TokenizerManager) -> ClearHiCacheReqOutput:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`flush_cache` currently couples two different operations:
1. Clearing SGLang runtime cache/state (radix tree, pools,
metrics, etc.).
2. Calling `torch.cuda.empty_cache()`.

Before this PR, users could not clear runtime cache without
also emptying the CUDA allocator cache. This made cache-flush
behavior less controllable for performance-sensitive workflows
where allocator eviction is unnecessary.

## Modifications

Optional `empty_cache` flag (default to be True) and propagates it across the full flush path:
- public API:
    - `python/sglang/lang/api.py`: `flush_cache
    - `python/sglang/lang/backend/base_backend.py`
    - `python/sglang/lang/backend/runtime_endpoint.py`



## Accuracy Tests

N/A. Doesn't modify model's forward/kernels or decoding logics.

## Benchmarking and Profiling

No default-path performance change is expected (`empty_cache=True` keeps prior behavior).

This PR enables an opt-out path (`empty_cache=False`) to avoid allocator eviction overhead in workflows that only need logical

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
