### PR TITLE
Support resetting and enhance HTTP endpoints for dumper

### DIFF
--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -187,6 +187,11 @@ class _Dumper:
             k: v for k, v in (self._global_ctx | kwargs).items() if v is not None
         }
 
+    def reset(self) -> None:
+        self._dump_index = 0
+        self._forward_pass_id = 0
+        self._global_ctx = {}
+
     @contextmanager
     def capture_output(self):
         assert self._captured_output_data is None

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -265,12 +265,12 @@ class _Dumper:
             return
 
         captured_forward_pass_id = self._forward_pass_id
-        captured_extra = deepcopy(extra_kwargs)
+        captured_user_kwargs = dict(name=f"grad__{name}", **deepcopy(extra_kwargs))
 
         def grad_hook(grad: torch.Tensor) -> None:
             self._dump_single(
                 tag="Dumper.Grad",
-                user_kwargs=dict(name=f"grad__{name}", **captured_extra),
+                user_kwargs=captured_user_kwargs,
                 value=grad,
                 save=save,
                 forward_pass_id=captured_forward_pass_id,

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -4,13 +4,13 @@ import re
 import socket
 import threading
 import time
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, fields, replace
 from functools import cached_property
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from abc import ABC, abstractmethod
 from typing import List, Optional, Self, get_args, get_type_hints
 
 import torch

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -18,26 +18,6 @@ import torch.distributed as dist
 # -------------------------------------- dumper core ------------------------------------------
 
 
-_ENV_PREFIX = "SGLANG_DUMPER_"
-
-
-def _env_name(field_name: str) -> str:
-    return f"{_ENV_PREFIX}{field_name.upper()}"
-
-
-def _parse_env_field(env_name: str, default):
-    raw = os.getenv(env_name)
-    if raw is None or not raw.strip():
-        return default
-    if isinstance(default, bool):
-        return raw.lower() in ("true", "1")
-    if isinstance(default, int):
-        return int(raw)
-    if isinstance(default, Path):
-        return Path(raw)
-    return raw
-
-
 @dataclass(frozen=True)
 class _DumperConfig:
     enable: bool = False
@@ -68,6 +48,26 @@ class _DumperConfig:
             if os.getenv(_env_name(key)) is None
         }
         return replace(self, **actual) if actual else self
+
+
+_ENV_PREFIX = "SGLANG_DUMPER_"
+
+
+def _env_name(field_name: str) -> str:
+    return f"{_ENV_PREFIX}{field_name.upper()}"
+
+
+def _parse_env_field(env_name: str, default):
+    raw = os.getenv(env_name)
+    if raw is None or not raw.strip():
+        return default
+    if isinstance(default, bool):
+        return raw.lower() in ("true", "1")
+    if isinstance(default, int):
+        return int(raw)
+    if isinstance(default, Path):
+        return Path(raw)
+    return raw
 
 
 class _Dumper:

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -34,7 +34,7 @@ class _Dumper:
     `SGLANG_DUMPER_ENABLE=1 python ...`
 
     Auto-cleanup old dumps before first write:
-    `SGLANG_DUMPER_CLEANUP=1 python ...`
+    `SGLANG_DUMPER_CLEANUP_PREVIOUS=1 python ...`
 
     Alternatively, disable at startup and enable via HTTP:
     1. `python ...`
@@ -56,7 +56,7 @@ class _Dumper:
         enable_model_grad: bool = True,
         partial_name: Optional[str] = None,
         enable_http_server: bool = True,
-        cleanup: bool = False,
+        cleanup_previous: bool = False,
     ):
         # Config
         self._enable = enable
@@ -76,7 +76,7 @@ class _Dumper:
         self._global_ctx = {}
         self._override_enable = None
         self._http_server_handled = not enable_http_server
-        self._pending_cleanup = cleanup
+        self._pending_cleanup = cleanup_previous
 
     @classmethod
     def from_env(cls) -> "_Dumper":
@@ -95,7 +95,7 @@ class _Dumper:
             enable_http_server=get_bool_env_var(
                 "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
             ),
-            cleanup=get_bool_env_var("SGLANG_DUMPER_CLEANUP", "0"),
+            cleanup_previous=get_bool_env_var("SGLANG_DUMPER_CLEANUP_PREVIOUS", "0"),
         )
 
     def on_forward_pass_start(self):

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -109,10 +109,6 @@ class _Dumper:
         self._global_ctx: dict = {}
         self._captured_output_data: Optional[dict] = None
 
-    @classmethod
-    def from_env(cls) -> "_Dumper":
-        return cls(config=_DumperConfig.from_env())
-
     def on_forward_pass_start(self):
         """This should be called on all ranks."""
 
@@ -743,7 +739,7 @@ def _get_local_ip_by_remote() -> Optional[str]:
 # -------------------------------------- singleton ------------------------------------------
 
 
-dumper = _Dumper.from_env()
+dumper = _Dumper(config=_DumperConfig.from_env())
 
 
 # -------------------------------------- other utility functions ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -216,8 +216,8 @@ class _Dumper:
         if not (self._enable and (self._override_enable is not False)):
             return
 
-        user_kwargs = dict(name=name, **extra_kwargs, **self._global_ctx)
-        if (f := self._filter) is not None and re.search(f, _format_kwargs(user_kwargs)) is None:
+        tags = dict(name=name, **extra_kwargs, **self._global_ctx)
+        if (f := self._filter) is not None and re.search(f, _format_kwargs(tags)) is None:
             return
 
         if not (enable_value or enable_curr_grad or enable_future_grad):
@@ -231,7 +231,7 @@ class _Dumper:
         if enable_value:
             self._dump_single(
                 tag=value_tag,
-                user_kwargs=user_kwargs,
+                tags=tags,
                 value=value,
                 save=save,
             )
@@ -243,7 +243,7 @@ class _Dumper:
         ):
             self._dump_single(
                 tag=grad_tag,
-                user_kwargs={**user_kwargs, "name": f"grad__{name}"},
+                tags={**tags, "name": f"grad__{name}"},
                 value=g,
                 save=save,
             )
@@ -265,12 +265,12 @@ class _Dumper:
             return
 
         captured_forward_pass_id = self._forward_pass_id
-        captured_user_kwargs = dict(name=f"grad__{name}", **deepcopy(extra_kwargs))
+        captured_tags = dict(name=f"grad__{name}", **deepcopy(extra_kwargs))
 
         def grad_hook(grad: torch.Tensor) -> None:
             self._dump_single(
                 tag="Dumper.Grad",
-                user_kwargs=captured_user_kwargs,
+                tags=captured_tags,
                 value=grad,
                 save=save,
                 forward_pass_id=captured_forward_pass_id,
@@ -282,7 +282,7 @@ class _Dumper:
         self,
         *,
         tag: str,
-        user_kwargs: dict,
+        tags: dict,
         value,
         save: bool,
         forward_pass_id: Optional[int] = None,
@@ -299,7 +299,7 @@ class _Dumper:
             ),
             rank=rank,
             dump_index=self._dump_index,
-            **user_kwargs,
+            **tags,
         )
         full_filename = _format_kwargs(full_kwargs) + ".pt"
         path = self._base_dir / f"sglang_dump_{self._partial_name}" / full_filename
@@ -324,7 +324,7 @@ class _Dumper:
 
             if capturing:
                 output_data["value"] = _deepcopy_or_clone(output_data["value"])
-                self._captured_output_data[user_kwargs["name"]] = output_data
+                self._captured_output_data[tags["name"]] = output_data
             else:
                 if self._pending_cleanup:
                     self._pending_cleanup = False

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -61,6 +61,14 @@ class _DumperConfig:
             for f in fields(cls)
         })
 
+    def with_defaults(self, **kwargs) -> "_DumperConfig":
+        actual = {
+            key: value
+            for key, value in kwargs.items()
+            if os.getenv(_env_name(key)) is None
+        }
+        return replace(self, **actual) if actual else self
+
 
 class _Dumper:
     """Utility to dump tensors, which can be useful when comparison checking models.
@@ -157,6 +165,12 @@ class _Dumper:
             yield self._captured_output_data
         finally:
             self._captured_output_data = None
+
+    def configure(self, **kwargs) -> None:
+        self._config = replace(self._config, **kwargs)
+
+    def configure_default(self, **kwargs) -> None:
+        self._config = self._config.with_defaults(**kwargs)
 
     def override_enable(self, value: bool):
         self._override_enable = value
@@ -604,7 +618,7 @@ class _DumperRpcHandler:
 
     def set_enable(self, enable: bool):
         print(f"[DumperRpcHandler] set_enable {enable=}")
-        self._dumper._config = replace(self._dumper._config, enable=enable)
+        self._dumper.configure(enable=enable)
 
 
 # -------------------------------------- zmq rpc ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -85,10 +85,6 @@ class _FrozenConfig(ABC):
 
 @dataclass(frozen=True)
 class _DumperConfig(_FrozenConfig):
-    @classmethod
-    def _env_prefix(cls) -> str:
-        return "SGLANG_DUMPER_"
-
     enable: bool = False
     filter: Optional[str] = None
     dir: str = "/tmp"
@@ -102,6 +98,10 @@ class _DumperConfig(_FrozenConfig):
     enable_http_server: bool = True
     cleanup_previous: bool = False
     collective_timeout: int = 60
+
+    @classmethod
+    def _env_prefix(cls) -> str:
+        return "SGLANG_DUMPER_"
 
 
 # -------------------------------------- dumper core ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -4,6 +4,7 @@ import re
 import socket
 import threading
 import time
+from contextlib import contextmanager
 from copy import deepcopy
 from functools import cached_property
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -79,6 +80,7 @@ class _Dumper:
         self._forward_pass_id = 0
         self._global_ctx = {}
         self._override_enable = None
+        self._captured_output_data: Optional[dict] = None
         self._http_server_handled = not enable_http_server
         self._pending_cleanup = cleanup_previous
 
@@ -146,6 +148,15 @@ class _Dumper:
         self._global_ctx = {
             k: v for k, v in (self._global_ctx | kwargs).items() if v is not None
         }
+
+    @contextmanager
+    def capture_output(self):
+        assert self._captured_output_data is None
+        self._captured_output_data = {}
+        try:
+            yield self._captured_output_data
+        finally:
+            self._captured_output_data = None
 
     def override_enable(self, value: bool):
         self._override_enable = value
@@ -308,17 +319,23 @@ class _Dumper:
                 f"sample_value={get_truncated_value(value)}"
             )
 
-        if self._enable_output_file and save:
-            if self._pending_cleanup:
-                self._pending_cleanup = False
-                _cleanup_old_dumps(self._base_dir)
-
-            path.parent.mkdir(parents=True, exist_ok=True)
+        capturing = self._captured_output_data is not None
+        if save and (self._enable_output_file or capturing):
             output_data = {
                 "value": value.data if isinstance(value, torch.nn.Parameter) else value,
                 "meta": dict(**full_kwargs, **self._static_meta),
             }
-            _torch_save(output_data, str(path))
+
+            if capturing:
+                output_data["value"] = _deepcopy_or_clone(output_data["value"])
+                self._captured_output_data[name] = output_data
+            else:
+                if self._pending_cleanup:
+                    self._pending_cleanup = False
+                    _cleanup_old_dumps(self._base_dir)
+
+                path.parent.mkdir(parents=True, exist_ok=True)
+                _torch_save(output_data, str(path))
 
     @cached_property
     def _static_meta(self) -> dict:
@@ -422,6 +439,12 @@ def _materialize_value(value):
     if callable(value):
         value = value()
     return value
+
+
+def _deepcopy_or_clone(x):
+    if isinstance(x, torch.Tensor):
+        return x.clone()
+    return deepcopy(x)
 
 
 # -------------------------------------- static meta ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -623,17 +623,15 @@ def _start_maybe_http_server(dumper, timeout_seconds: int = 60):
     )
 
     if _get_rank() == 0:
-        handler_class = _make_dumper_http_handler(rpc_handles=rpc_handles)
+        handler_class = _make_rpc_http_handler(prefix="/dumper/", rpc_handles=rpc_handles)
         server = HTTPServer(("0.0.0.0", http_port), handler_class)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
         print(f"[Dumper] HTTP server started on port {http_port}")
 
 
-def _make_dumper_http_handler(rpc_handles):
-    prefix = "/dumper/"
-
-    class _DumperHTTPHandler(BaseHTTPRequestHandler):
+def _make_rpc_http_handler(*, prefix: str, rpc_handles):
+    class _RpcHTTPHandler(BaseHTTPRequestHandler):
         def do_POST(self):
             if not self.path.startswith(prefix):
                 self.send_error(404)
@@ -655,7 +653,7 @@ def _make_dumper_http_handler(rpc_handles):
                 return {}
             return json.loads(self.rfile.read(content_length))
 
-    return _DumperHTTPHandler
+    return _RpcHTTPHandler
 
 
 # -------------------------------------- zmq rpc ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -106,7 +106,6 @@ class _Dumper:
         self._dump_index = 0
         self._forward_pass_id = 0
         self._global_ctx: dict = {}
-        self._override_enable: Optional[bool] = None
         self._captured_output_data: Optional[dict] = None
 
     @classmethod
@@ -148,7 +147,7 @@ class _Dumper:
         """
         Example:
 
-        dumper.override_enable(self.layer_id <= 3)
+        dumper.configure_default(filter='layer_id=[0-3]')
         dumper.set_ctx(layer_id=self.layer_id)
         ...
         dumper.set_ctx(layer_id=None)
@@ -171,9 +170,6 @@ class _Dumper:
 
     def configure_default(self, **kwargs) -> None:
         self._config = self._config.with_defaults(**kwargs)
-
-    def override_enable(self, value: bool):
-        self._override_enable = value
 
     def dump_dict(self, name_prefix, data, save: bool = True, **kwargs):
         data = _obj_to_dict(data)
@@ -228,7 +224,7 @@ class _Dumper:
     ) -> None:
         self._ensure_http_server()
 
-        if not (self._config.enable and (self._override_enable is not False)):
+        if not self._config.enable:
             return
 
         tags = dict(name=name, **extra_kwargs, **self._global_ctx)

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -257,7 +257,12 @@ class _Dumper:
             )
 
     def _register_dump_grad_hook(
-        self, *, name: str, tensor, extra_kwargs: dict, save: bool,
+        self,
+        *,
+        name: str,
+        tensor,
+        extra_kwargs: dict,
+        save: bool,
     ) -> None:
         if not isinstance(tensor, torch.Tensor):
             return

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -126,7 +126,9 @@ class _Dumper:
 
     def _ensure_partial_name(self):
         if self._partial_name is None:
-            self._partial_name = _get_partial_name(timeout_seconds=self._collective_timeout)
+            self._partial_name = _get_partial_name(
+                timeout_seconds=self._collective_timeout
+            )
             print(f"[Dumper] Choose partial_name={self._partial_name}")
 
     def set_ctx(self, **kwargs):

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -15,14 +15,14 @@ from typing import List, Optional
 import torch
 import torch.distributed as dist
 
-# -------------------------------------- dumper core ------------------------------------------
+# -------------------------------------- dumper config ------------------------------------------
 
 
 @dataclass(frozen=True)
 class _DumperConfig:
     enable: bool = False
     filter: Optional[str] = None
-    dir: Path = Path("/tmp")
+    dir: str = "/tmp"
     enable_output_file: bool = True
     enable_output_console: bool = True
     enable_value: bool = True
@@ -65,9 +65,10 @@ def _parse_env_field(env_name: str, default):
         return raw.lower() in ("true", "1")
     if isinstance(default, int):
         return int(raw)
-    if isinstance(default, Path):
-        return Path(raw)
     return raw
+
+
+# -------------------------------------- dumper core ------------------------------------------
 
 
 class _Dumper:
@@ -313,7 +314,7 @@ class _Dumper:
             **tags,
         )
         full_filename = _format_tags(full_kwargs) + ".pt"
-        path = self._config.dir / f"sglang_dump_{self._config.partial_name}" / full_filename
+        path = Path(self._config.dir) / f"sglang_dump_{self._config.partial_name}" / full_filename
 
         if self._config.enable_output_console:
             print(
@@ -339,7 +340,7 @@ class _Dumper:
             else:
                 if not self._cleanup_previous_handled:
                     self._cleanup_previous_handled = True
-                    _cleanup_old_dumps(self._config.dir)
+                    _cleanup_old_dumps(Path(self._config.dir))
 
                 path.parent.mkdir(parents=True, exist_ok=True)
                 _torch_save(output_data, str(path))

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -6,7 +6,6 @@ import threading
 import time
 from contextlib import contextmanager
 from copy import deepcopy
-from dataclasses import dataclass, replace
 from functools import cached_property
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -16,47 +15,6 @@ import torch
 import torch.distributed as dist
 
 # -------------------------------------- dumper core ------------------------------------------
-
-
-@dataclass(frozen=True)
-class _DumperConfig:
-    enable: bool = False
-    filter: Optional[str] = None
-    base_dir: Path = Path("/tmp")
-    enable_output_file: bool = True
-    enable_output_console: bool = True
-    enable_value: bool = True
-    enable_grad: bool = False
-    enable_model_value: bool = True
-    enable_model_grad: bool = True
-    partial_name: Optional[str] = None
-    enable_http_server: bool = True
-    cleanup_previous: bool = False
-    collective_timeout: int = 60
-
-    @classmethod
-    def from_env(cls) -> "_DumperConfig":
-        return cls(
-            enable=get_bool_env_var("SGLANG_DUMPER_ENABLE", "0"),
-            filter=_get_str_env_var("SGLANG_DUMPER_FILTER"),
-            base_dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
-            enable_output_file=get_bool_env_var("SGLANG_DUMPER_OUTPUT_FILE", "1"),
-            enable_output_console=get_bool_env_var(
-                "SGLANG_DUMPER_OUTPUT_CONSOLE", "1"
-            ),
-            enable_value=get_bool_env_var("SGLANG_DUMPER_ENABLE_VALUE", "1"),
-            enable_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_GRAD", "0"),
-            enable_model_value=get_bool_env_var(
-                "SGLANG_DUMPER_ENABLE_MODEL_VALUE", "1"
-            ),
-            enable_model_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_MODEL_GRAD", "1"),
-            partial_name=_get_str_env_var("SGLANG_DUMPER_PARTIAL_NAME"),
-            enable_http_server=get_bool_env_var(
-                "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
-            ),
-            cleanup_previous=get_bool_env_var("SGLANG_DUMPER_CLEANUP_PREVIOUS", "0"),
-            collective_timeout=60,
-        )
 
 
 class _Dumper:
@@ -86,22 +44,67 @@ class _Dumper:
     Related: `sglang.srt.debug_utils.dump_comparator` for dump comparison
     """
 
-    def __init__(self, *, config: _DumperConfig):
+    def __init__(
+        self,
+        *,
+        enable: bool,
+        base_dir: Path,
+        filter: Optional[str] = None,
+        enable_output_file: bool = True,
+        enable_output_console: bool = True,
+        enable_value: bool = True,
+        enable_grad: bool = False,
+        enable_model_value: bool = True,
+        enable_model_grad: bool = True,
+        partial_name: Optional[str] = None,
+        enable_http_server: bool = True,
+        cleanup_previous: bool = False,
+        collective_timeout: int = 60,
+    ):
+        # Config
+        self._enable = enable
         # TODO (1) support filtering kv instead of name only (2) allow HTTP req change it
-        self._config = config
+        self._filter = filter
+        self._base_dir = base_dir
+        self._enable_output_file = enable_output_file
+        self._enable_output_console = enable_output_console
+        self._enable_value = enable_value
+        self._enable_grad = enable_grad
+        self._enable_model_value = enable_model_value
+        self._enable_model_grad = enable_model_grad
+        self._collective_timeout = collective_timeout
 
-        self._http_server_handled = not config.enable_http_server
-        self._cleanup_previous_handled = not config.cleanup_previous
-
+        # States
+        self._partial_name = partial_name
         self._dump_index = 0
         self._forward_pass_id = 0
-        self._global_ctx: dict = {}
-        self._override_enable: Optional[bool] = None
+        self._global_ctx = {}
+        self._override_enable = None
         self._captured_output_data: Optional[dict] = None
+        self._http_server_handled = not enable_http_server
+        self._pending_cleanup = cleanup_previous
 
     @classmethod
     def from_env(cls) -> "_Dumper":
-        return cls(config=_DumperConfig.from_env())
+        return cls(
+            enable=get_bool_env_var("SGLANG_DUMPER_ENABLE", "0"),
+            base_dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
+            filter=_get_str_env_var("SGLANG_DUMPER_FILTER"),
+            enable_output_file=get_bool_env_var("SGLANG_DUMPER_OUTPUT_FILE", "1"),
+            enable_output_console=get_bool_env_var("SGLANG_DUMPER_OUTPUT_CONSOLE", "1"),
+            enable_value=get_bool_env_var("SGLANG_DUMPER_ENABLE_VALUE", "1"),
+            enable_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_GRAD", "0"),
+            enable_model_value=get_bool_env_var(
+                "SGLANG_DUMPER_ENABLE_MODEL_VALUE", "1"
+            ),
+            enable_model_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_MODEL_GRAD", "1"),
+            partial_name=_get_str_env_var("SGLANG_DUMPER_PARTIAL_NAME"),
+            enable_http_server=get_bool_env_var(
+                "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
+            ),
+            cleanup_previous=get_bool_env_var("SGLANG_DUMPER_CLEANUP_PREVIOUS", "0"),
+            collective_timeout=60,
+        )
 
     def on_forward_pass_start(self):
         """This should be called on all ranks."""
@@ -109,7 +112,7 @@ class _Dumper:
         # Even if SGLANG_DUMPER_ENABLE=0, users may want to use HTTP endpoint to enable it
         self._ensure_http_server()
 
-        if not self._config.enable:
+        if not self._enable:
             return
 
         # Users may want to `dump` only on some ranks, thus determine name here
@@ -124,15 +127,14 @@ class _Dumper:
         if self._http_server_handled:
             return
         self._http_server_handled = True
-        _start_maybe_http_server(self, timeout_seconds=self._config.collective_timeout)
+        _start_maybe_http_server(self, timeout_seconds=self._collective_timeout)
 
     def _ensure_partial_name(self):
-        if self._config.partial_name is None:
-            name = _get_partial_name(
-                timeout_seconds=self._config.collective_timeout
+        if self._partial_name is None:
+            self._partial_name = _get_partial_name(
+                timeout_seconds=self._collective_timeout
             )
-            self._config = replace(self._config, partial_name=name)
-            print(f"[Dumper] Choose partial_name={name}")
+            print(f"[Dumper] Choose partial_name={self._partial_name}")
 
     def set_ctx(self, **kwargs):
         """
@@ -170,9 +172,9 @@ class _Dumper:
             value=value,
             extra_kwargs=kwargs,
             save=save,
-            enable_value=self._config.enable_value,
+            enable_value=self._enable_value,
             enable_curr_grad=False,
-            enable_future_grad=self._config.enable_grad,
+            enable_future_grad=self._enable_grad,
             value_tag="Dumper.Value",
             grad_tag="Dumper.Grad",
         )
@@ -190,8 +192,8 @@ class _Dumper:
                 value=param,
                 extra_kwargs=kwargs,
                 save=save,
-                enable_value=self._config.enable_model_value,
-                enable_curr_grad=self._config.enable_model_grad,
+                enable_value=self._enable_model_value,
+                enable_curr_grad=self._enable_model_grad,
                 enable_future_grad=False,
                 value_tag="Dumper.ParamValue",
                 grad_tag="Dumper.ParamGrad",
@@ -212,9 +214,9 @@ class _Dumper:
     ) -> None:
         self._ensure_http_server()
 
-        if not (self._config.enable and (self._override_enable is not False)):
+        if not (self._enable and (self._override_enable is not False)):
             return
-        if (f := self._config.filter) is not None and re.search(f, name) is None:
+        if (f := self._filter) is not None and re.search(f, name) is None:
             return
         if not (enable_value or enable_curr_grad or enable_future_grad):
             return
@@ -304,9 +306,9 @@ class _Dumper:
             **self._global_ctx,
         )
         full_filename = "___".join(f"{k}={v}" for k, v in full_kwargs.items()) + ".pt"
-        path = self._config.base_dir / f"sglang_dump_{self._config.partial_name}" / full_filename
+        path = self._base_dir / f"sglang_dump_{self._partial_name}" / full_filename
 
-        if self._config.enable_output_console:
+        if self._enable_output_console:
             print(
                 f"[{tag}] [{rank}, {time.time()}] {path} "
                 f"type={type(value)} "
@@ -318,7 +320,7 @@ class _Dumper:
             )
 
         capturing = self._captured_output_data is not None
-        if save and (self._config.enable_output_file or capturing):
+        if save and (self._enable_output_file or capturing):
             output_data = {
                 "value": value.data if isinstance(value, torch.nn.Parameter) else value,
                 "meta": dict(**full_kwargs, **self._static_meta),
@@ -328,9 +330,9 @@ class _Dumper:
                 output_data["value"] = _deepcopy_or_clone(output_data["value"])
                 self._captured_output_data[name] = output_data
             else:
-                if not self._cleanup_previous_handled:
-                    self._cleanup_previous_handled = True
-                    _cleanup_old_dumps(self._config.base_dir)
+                if self._pending_cleanup:
+                    self._pending_cleanup = False
+                    _cleanup_old_dumps(self._base_dir)
 
                 path.parent.mkdir(parents=True, exist_ok=True)
                 _torch_save(output_data, str(path))
@@ -601,7 +603,7 @@ class _DumperRpcHandler:
 
     def set_enable(self, enable: bool):
         print(f"[DumperRpcHandler] set_enable {enable=}")
-        self._dumper._config = replace(self._dumper._config, enable=enable)
+        self._dumper._enable = enable
 
 
 # -------------------------------------- zmq rpc ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -39,10 +39,12 @@ class _DumperConfig:
 
     @classmethod
     def from_env(cls) -> "_DumperConfig":
-        return cls(**{
-            f.name: _parse_env_field(_env_name(f.name), f.default)
-            for f in fields(cls)
-        })
+        return cls(
+            **{
+                f.name: _parse_env_field(_env_name(f.name), f.default)
+                for f in fields(cls)
+            }
+        )
 
     def with_defaults(self, **kwargs) -> "_DumperConfig":
         actual = {
@@ -159,9 +161,7 @@ class _Dumper:
 
     def _ensure_partial_name(self):
         if self._config.partial_name is None:
-            name = _get_partial_name(
-                timeout_seconds=self._config.collective_timeout
-            )
+            name = _get_partial_name(timeout_seconds=self._config.collective_timeout)
             self.configure(partial_name=name)
             print(f"[Dumper] Choose partial_name={name}")
 
@@ -250,7 +250,9 @@ class _Dumper:
             return
 
         tags = dict(name=name, **extra_kwargs, **self._global_ctx)
-        if (f := self._config.filter) is not None and re.search(f, _format_tags(tags)) is None:
+        if (f := self._config.filter) is not None and re.search(
+            f, _format_tags(tags)
+        ) is None:
             return
 
         if not (enable_value or enable_curr_grad or enable_future_grad):
@@ -290,7 +292,12 @@ class _Dumper:
             )
 
     def _register_dump_grad_hook(
-        self, *, name: str, tensor, extra_kwargs: dict, save: bool,
+        self,
+        *,
+        name: str,
+        tensor,
+        extra_kwargs: dict,
+        save: bool,
     ) -> None:
         if not isinstance(tensor, torch.Tensor):
             return
@@ -335,7 +342,11 @@ class _Dumper:
             **tags,
         )
         full_filename = _format_tags(full_kwargs) + ".pt"
-        path = Path(self._config.dir) / f"sglang_dump_{self._config.partial_name}" / full_filename
+        path = (
+            Path(self._config.dir)
+            / f"sglang_dump_{self._config.partial_name}"
+            / full_filename
+        )
 
         if self._config.enable_output_console:
             print(

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -217,7 +217,7 @@ class _Dumper:
             return
 
         tags = dict(name=name, **extra_kwargs, **self._global_ctx)
-        if (f := self._filter) is not None and re.search(f, _format_kwargs(tags)) is None:
+        if (f := self._filter) is not None and re.search(f, _format_tags(tags)) is None:
             return
 
         if not (enable_value or enable_curr_grad or enable_future_grad):
@@ -301,7 +301,7 @@ class _Dumper:
             dump_index=self._dump_index,
             **tags,
         )
-        full_filename = _format_kwargs(full_kwargs) + ".pt"
+        full_filename = _format_tags(full_kwargs) + ".pt"
         path = self._base_dir / f"sglang_dump_{self._partial_name}" / full_filename
 
         if self._enable_output_console:
@@ -437,7 +437,7 @@ def _materialize_value(value):
     return value
 
 
-def _format_kwargs(kwargs: dict) -> str:
+def _format_tags(kwargs: dict) -> str:
     return "___".join(f"{k}={v}" for k, v in kwargs.items())
 
 

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -636,7 +636,7 @@ def _make_http_handler(*, prefix: str, target):
             if not self.path.startswith(prefix):
                 self.send_error(404)
                 return
-            method = self.path[len(prefix):]
+            method = self.path[len(prefix) :]
             try:
                 kwargs = self._get_request_body()
                 print(f"[Dumper#{_get_rank()}] HTTP {self.path} {kwargs=}")

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -22,7 +22,7 @@ import torch.distributed as dist
 class _DumperConfig:
     enable: bool = False
     filter: Optional[str] = None
-    base_dir: Path = Path("/tmp")
+    dir: Path = Path("/tmp")
     enable_output_file: bool = True
     enable_output_console: bool = True
     enable_value: bool = True
@@ -39,10 +39,10 @@ class _DumperConfig:
         return cls(
             enable=get_bool_env_var("SGLANG_DUMPER_ENABLE", "0"),
             filter=_get_str_env_var("SGLANG_DUMPER_FILTER"),
-            base_dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
-            enable_output_file=get_bool_env_var("SGLANG_DUMPER_OUTPUT_FILE", "1"),
+            dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
+            enable_output_file=get_bool_env_var("SGLANG_DUMPER_ENABLE_OUTPUT_FILE", "1"),
             enable_output_console=get_bool_env_var(
-                "SGLANG_DUMPER_OUTPUT_CONSOLE", "1"
+                "SGLANG_DUMPER_ENABLE_OUTPUT_CONSOLE", "1"
             ),
             enable_value=get_bool_env_var("SGLANG_DUMPER_ENABLE_VALUE", "1"),
             enable_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_GRAD", "0"),
@@ -52,7 +52,7 @@ class _DumperConfig:
             enable_model_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_MODEL_GRAD", "1"),
             partial_name=_get_str_env_var("SGLANG_DUMPER_PARTIAL_NAME"),
             enable_http_server=get_bool_env_var(
-                "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
+                "SGLANG_DUMPER_ENABLE_HTTP_SERVER", "1"
             ),
             cleanup_previous=get_bool_env_var("SGLANG_DUMPER_CLEANUP_PREVIOUS", "0"),
             collective_timeout=60,
@@ -300,7 +300,7 @@ class _Dumper:
             **tags,
         )
         full_filename = _format_tags(full_kwargs) + ".pt"
-        path = self._config.base_dir / f"sglang_dump_{self._config.partial_name}" / full_filename
+        path = self._config.dir / f"sglang_dump_{self._config.partial_name}" / full_filename
 
         if self._config.enable_output_console:
             print(
@@ -326,7 +326,7 @@ class _Dumper:
             else:
                 if not self._cleanup_previous_handled:
                     self._cleanup_previous_handled = True
-                    _cleanup_old_dumps(self._config.base_dir)
+                    _cleanup_old_dumps(self._config.dir)
 
                 path.parent.mkdir(parents=True, exist_ok=True)
                 _torch_save(output_data, str(path))

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -217,9 +217,8 @@ class _Dumper:
             return
 
         user_kwargs = dict(name=name, **extra_kwargs, **self._global_ctx)
-        if (f := self._filter) is not None:
-            if re.search(f, _format_kwargs(user_kwargs)) is None:
-                return
+        if (f := self._filter) is not None and re.search(f, _format_kwargs(user_kwargs)) is None:
+            return
 
         if not (enable_value or enable_curr_grad or enable_future_grad):
             return

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -6,6 +6,7 @@ import threading
 import time
 from contextlib import contextmanager
 from copy import deepcopy
+from dataclasses import dataclass, replace
 from functools import cached_property
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -15,6 +16,47 @@ import torch
 import torch.distributed as dist
 
 # -------------------------------------- dumper core ------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DumperConfig:
+    enable: bool = False
+    filter: Optional[str] = None
+    base_dir: Path = Path("/tmp")
+    enable_output_file: bool = True
+    enable_output_console: bool = True
+    enable_value: bool = True
+    enable_grad: bool = False
+    enable_model_value: bool = True
+    enable_model_grad: bool = True
+    partial_name: Optional[str] = None
+    enable_http_server: bool = True
+    cleanup_previous: bool = False
+    collective_timeout: int = 60
+
+    @classmethod
+    def from_env(cls) -> "_DumperConfig":
+        return cls(
+            enable=get_bool_env_var("SGLANG_DUMPER_ENABLE", "0"),
+            filter=_get_str_env_var("SGLANG_DUMPER_FILTER"),
+            base_dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
+            enable_output_file=get_bool_env_var("SGLANG_DUMPER_OUTPUT_FILE", "1"),
+            enable_output_console=get_bool_env_var(
+                "SGLANG_DUMPER_OUTPUT_CONSOLE", "1"
+            ),
+            enable_value=get_bool_env_var("SGLANG_DUMPER_ENABLE_VALUE", "1"),
+            enable_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_GRAD", "0"),
+            enable_model_value=get_bool_env_var(
+                "SGLANG_DUMPER_ENABLE_MODEL_VALUE", "1"
+            ),
+            enable_model_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_MODEL_GRAD", "1"),
+            partial_name=_get_str_env_var("SGLANG_DUMPER_PARTIAL_NAME"),
+            enable_http_server=get_bool_env_var(
+                "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
+            ),
+            cleanup_previous=get_bool_env_var("SGLANG_DUMPER_CLEANUP_PREVIOUS", "0"),
+            collective_timeout=60,
+        )
 
 
 class _Dumper:
@@ -44,66 +86,21 @@ class _Dumper:
     Related: `sglang.srt.debug_utils.dump_comparator` for dump comparison
     """
 
-    def __init__(
-        self,
-        *,
-        enable: bool,
-        base_dir: Path,
-        filter: Optional[str] = None,
-        enable_output_file: bool = True,
-        enable_output_console: bool = True,
-        enable_value: bool = True,
-        enable_grad: bool = False,
-        enable_model_value: bool = True,
-        enable_model_grad: bool = True,
-        partial_name: Optional[str] = None,
-        enable_http_server: bool = True,
-        cleanup_previous: bool = False,
-        collective_timeout: int = 60,
-    ):
-        # Config
-        self._enable = enable
-        self._filter = filter
-        self._base_dir = base_dir
-        self._enable_output_file = enable_output_file
-        self._enable_output_console = enable_output_console
-        self._enable_value = enable_value
-        self._enable_grad = enable_grad
-        self._enable_model_value = enable_model_value
-        self._enable_model_grad = enable_model_grad
-        self._collective_timeout = collective_timeout
+    def __init__(self, *, config: _DumperConfig):
+        self._config = config
 
-        # States
-        self._partial_name = partial_name
+        self._http_server_handled = not config.enable_http_server
+        self._cleanup_previous_handled = not config.cleanup_previous
+
         self._dump_index = 0
         self._forward_pass_id = 0
-        self._global_ctx = {}
-        self._override_enable = None
+        self._global_ctx: dict = {}
+        self._override_enable: Optional[bool] = None
         self._captured_output_data: Optional[dict] = None
-        self._http_server_handled = not enable_http_server
-        self._pending_cleanup = cleanup_previous
 
     @classmethod
     def from_env(cls) -> "_Dumper":
-        return cls(
-            enable=get_bool_env_var("SGLANG_DUMPER_ENABLE", "0"),
-            base_dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
-            filter=_get_str_env_var("SGLANG_DUMPER_FILTER"),
-            enable_output_file=get_bool_env_var("SGLANG_DUMPER_OUTPUT_FILE", "1"),
-            enable_output_console=get_bool_env_var("SGLANG_DUMPER_OUTPUT_CONSOLE", "1"),
-            enable_value=get_bool_env_var("SGLANG_DUMPER_ENABLE_VALUE", "1"),
-            enable_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_GRAD", "0"),
-            enable_model_value=get_bool_env_var(
-                "SGLANG_DUMPER_ENABLE_MODEL_VALUE", "1"
-            ),
-            enable_model_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_MODEL_GRAD", "1"),
-            partial_name=_get_str_env_var("SGLANG_DUMPER_PARTIAL_NAME"),
-            enable_http_server=get_bool_env_var(
-                "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
-            ),
-            cleanup_previous=get_bool_env_var("SGLANG_DUMPER_CLEANUP_PREVIOUS", "0"),
-            collective_timeout=60,
-        )
+        return cls(config=_DumperConfig.from_env())
 
     def on_forward_pass_start(self):
         """This should be called on all ranks."""
@@ -111,7 +108,7 @@ class _Dumper:
         # Even if SGLANG_DUMPER_ENABLE=0, users may want to use HTTP endpoint to enable it
         self._ensure_http_server()
 
-        if not self._enable:
+        if not self._config.enable:
             return
 
         # Users may want to `dump` only on some ranks, thus determine name here
@@ -126,14 +123,15 @@ class _Dumper:
         if self._http_server_handled:
             return
         self._http_server_handled = True
-        _start_maybe_http_server(self, timeout_seconds=self._collective_timeout)
+        _start_maybe_http_server(self, timeout_seconds=self._config.collective_timeout)
 
     def _ensure_partial_name(self):
-        if self._partial_name is None:
-            self._partial_name = _get_partial_name(
-                timeout_seconds=self._collective_timeout
+        if self._config.partial_name is None:
+            name = _get_partial_name(
+                timeout_seconds=self._config.collective_timeout
             )
-            print(f"[Dumper] Choose partial_name={self._partial_name}")
+            self._config = replace(self._config, partial_name=name)
+            print(f"[Dumper] Choose partial_name={name}")
 
     def set_ctx(self, **kwargs):
         """
@@ -171,9 +169,9 @@ class _Dumper:
             value=value,
             extra_kwargs=kwargs,
             save=save,
-            enable_value=self._enable_value,
+            enable_value=self._config.enable_value,
             enable_curr_grad=False,
-            enable_future_grad=self._enable_grad,
+            enable_future_grad=self._config.enable_grad,
             value_tag="Dumper.Value",
             grad_tag="Dumper.Grad",
         )
@@ -191,8 +189,8 @@ class _Dumper:
                 value=param,
                 extra_kwargs=kwargs,
                 save=save,
-                enable_value=self._enable_model_value,
-                enable_curr_grad=self._enable_model_grad,
+                enable_value=self._config.enable_model_value,
+                enable_curr_grad=self._config.enable_model_grad,
                 enable_future_grad=False,
                 value_tag="Dumper.ParamValue",
                 grad_tag="Dumper.ParamGrad",
@@ -213,11 +211,11 @@ class _Dumper:
     ) -> None:
         self._ensure_http_server()
 
-        if not (self._enable and (self._override_enable is not False)):
+        if not (self._config.enable and (self._override_enable is not False)):
             return
 
         tags = dict(name=name, **extra_kwargs, **self._global_ctx)
-        if (f := self._filter) is not None and re.search(f, _format_tags(tags)) is None:
+        if (f := self._config.filter) is not None and re.search(f, _format_tags(tags)) is None:
             return
 
         if not (enable_value or enable_curr_grad or enable_future_grad):
@@ -302,9 +300,9 @@ class _Dumper:
             **tags,
         )
         full_filename = _format_tags(full_kwargs) + ".pt"
-        path = self._base_dir / f"sglang_dump_{self._partial_name}" / full_filename
+        path = self._config.base_dir / f"sglang_dump_{self._config.partial_name}" / full_filename
 
-        if self._enable_output_console:
+        if self._config.enable_output_console:
             print(
                 f"[{tag}] [{rank}, {time.time()}] {path} "
                 f"type={type(value)} "
@@ -316,7 +314,7 @@ class _Dumper:
             )
 
         capturing = self._captured_output_data is not None
-        if save and (self._enable_output_file or capturing):
+        if save and (self._config.enable_output_file or capturing):
             output_data = {
                 "value": value.data if isinstance(value, torch.nn.Parameter) else value,
                 "meta": dict(**full_kwargs, **self._static_meta),
@@ -326,9 +324,9 @@ class _Dumper:
                 output_data["value"] = _deepcopy_or_clone(output_data["value"])
                 self._captured_output_data[tags["name"]] = output_data
             else:
-                if self._pending_cleanup:
-                    self._pending_cleanup = False
-                    _cleanup_old_dumps(self._base_dir)
+                if not self._cleanup_previous_handled:
+                    self._cleanup_previous_handled = True
+                    _cleanup_old_dumps(self._config.base_dir)
 
                 path.parent.mkdir(parents=True, exist_ok=True)
                 _torch_save(output_data, str(path))
@@ -603,7 +601,7 @@ class _DumperRpcHandler:
 
     def set_enable(self, enable: bool):
         print(f"[DumperRpcHandler] set_enable {enable=}")
-        self._dumper._enable = enable
+        self._dumper._config = replace(self._dumper._config, enable=enable)
 
 
 # -------------------------------------- zmq rpc ------------------------------------------

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -49,7 +49,8 @@ class _Dumper:
         enable: bool,
         base_dir: Path,
         filter: Optional[str] = None,
-        enable_write_file: bool = True,
+        enable_output_file: bool = True,
+        enable_output_console: bool = True,
         enable_value: bool = True,
         enable_grad: bool = False,
         enable_model_value: bool = True,
@@ -64,7 +65,8 @@ class _Dumper:
         # TODO (1) support filtering kv instead of name only (2) allow HTTP req change it
         self._filter = filter
         self._base_dir = base_dir
-        self._enable_write_file = enable_write_file
+        self._enable_output_file = enable_output_file
+        self._enable_output_console = enable_output_console
         self._enable_value = enable_value
         self._enable_grad = enable_grad
         self._enable_model_value = enable_model_value
@@ -86,7 +88,8 @@ class _Dumper:
             enable=get_bool_env_var("SGLANG_DUMPER_ENABLE", "0"),
             base_dir=Path(_get_str_env_var("SGLANG_DUMPER_DIR", "/tmp")),
             filter=_get_str_env_var("SGLANG_DUMPER_FILTER"),
-            enable_write_file=get_bool_env_var("SGLANG_DUMPER_WRITE_FILE", "1"),
+            enable_output_file=get_bool_env_var("SGLANG_DUMPER_OUTPUT_FILE", "1"),
+            enable_output_console=get_bool_env_var("SGLANG_DUMPER_OUTPUT_CONSOLE", "1"),
             enable_value=get_bool_env_var("SGLANG_DUMPER_ENABLE_VALUE", "1"),
             enable_grad=get_bool_env_var("SGLANG_DUMPER_ENABLE_GRAD", "0"),
             enable_model_value=get_bool_env_var(
@@ -294,17 +297,18 @@ class _Dumper:
         full_filename = "___".join(f"{k}={v}" for k, v in full_kwargs.items()) + ".pt"
         path = self._base_dir / f"sglang_dump_{self._partial_name}" / full_filename
 
-        print(
-            f"[{tag}] [{rank}, {time.time()}] {path} "
-            f"type={type(value)} "
-            f"shape={value.shape if isinstance(value, torch.Tensor) else None} "
-            f"dtype={value.dtype if isinstance(value, torch.Tensor) else None} "
-            f"device={value.device if isinstance(value, torch.Tensor) else None} "
-            f"id={id(value)} "
-            f"sample_value={get_truncated_value(value)}"
-        )
+        if self._enable_output_console:
+            print(
+                f"[{tag}] [{rank}, {time.time()}] {path} "
+                f"type={type(value)} "
+                f"shape={value.shape if isinstance(value, torch.Tensor) else None} "
+                f"dtype={value.dtype if isinstance(value, torch.Tensor) else None} "
+                f"device={value.device if isinstance(value, torch.Tensor) else None} "
+                f"id={id(value)} "
+                f"sample_value={get_truncated_value(value)}"
+            )
 
-        if self._enable_write_file and save:
+        if self._enable_output_file and save:
             if self._pending_cleanup:
                 self._pending_cleanup = False
                 _cleanup_old_dumps(self._base_dir)

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -33,6 +33,9 @@ class _Dumper:
     Then run the program:
     `SGLANG_DUMPER_ENABLE=1 python ...`
 
+    Auto-cleanup old dumps before first write:
+    `SGLANG_DUMPER_CLEANUP=1 python ...`
+
     Alternatively, disable at startup and enable via HTTP:
     1. `python ...`
     2. `curl -X POST http://localhost:40000/dumper -d '{"enable": true}'`
@@ -53,6 +56,7 @@ class _Dumper:
         enable_model_grad: bool = True,
         partial_name: Optional[str] = None,
         enable_http_server: bool = True,
+        needs_cleanup: bool = False,
     ):
         # Config
         self._enable = enable
@@ -72,6 +76,7 @@ class _Dumper:
         self._global_ctx = {}
         self._override_enable = None
         self._http_server_handled = not enable_http_server
+        self._needs_cleanup = needs_cleanup
 
     @classmethod
     def from_env(cls) -> "_Dumper":
@@ -90,6 +95,7 @@ class _Dumper:
             enable_http_server=get_bool_env_var(
                 "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
             ),
+            needs_cleanup=get_bool_env_var("SGLANG_DUMPER_CLEANUP", "0"),
         )
 
     def on_forward_pass_start(self):
@@ -294,6 +300,10 @@ class _Dumper:
         )
 
         if self._enable_write_file and save:
+            if self._needs_cleanup:
+                self._needs_cleanup = False
+                _cleanup_old_dumps(self._base_dir)
+
             path.parent.mkdir(parents=True, exist_ok=True)
             output_data = {
                 "value": value.data if isinstance(value, torch.nn.Parameter) else value,
@@ -327,6 +337,19 @@ def _get_partial_name():
     if dist.is_initialized():
         dist.broadcast_object_list(object_list, device="cuda")
     return object_list[0]
+
+
+def _cleanup_old_dumps(base_dir: Path) -> None:
+    import shutil
+
+    if _get_rank() == 0:
+        for entry in base_dir.glob("sglang_dump_*"):
+            if entry.is_dir():
+                shutil.rmtree(entry)
+                print(f"[Dumper] Cleaned up {entry}")
+
+    if dist.is_initialized():
+        dist.barrier()
 
 
 def _get_rank():

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -56,7 +56,7 @@ class _Dumper:
         enable_model_grad: bool = True,
         partial_name: Optional[str] = None,
         enable_http_server: bool = True,
-        needs_cleanup: bool = False,
+        cleanup: bool = False,
     ):
         # Config
         self._enable = enable
@@ -76,7 +76,7 @@ class _Dumper:
         self._global_ctx = {}
         self._override_enable = None
         self._http_server_handled = not enable_http_server
-        self._needs_cleanup = needs_cleanup
+        self._pending_cleanup = cleanup
 
     @classmethod
     def from_env(cls) -> "_Dumper":
@@ -95,7 +95,7 @@ class _Dumper:
             enable_http_server=get_bool_env_var(
                 "SGLANG_ENABLE_DUMPER_HTTP_SERVER", "1"
             ),
-            needs_cleanup=get_bool_env_var("SGLANG_DUMPER_CLEANUP", "0"),
+            cleanup=get_bool_env_var("SGLANG_DUMPER_CLEANUP", "0"),
         )
 
     def on_forward_pass_start(self):
@@ -300,8 +300,8 @@ class _Dumper:
         )
 
         if self._enable_write_file and save:
-            if self._needs_cleanup:
-                self._needs_cleanup = False
+            if self._pending_cleanup:
+                self._pending_cleanup = False
                 _cleanup_old_dumps(self._base_dir)
 
             path.parent.mkdir(parents=True, exist_ok=True)

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -664,6 +664,7 @@ def _make_dumper_http_handler(rpc_handles):
 def _create_zmq_rpc_handles(
     handler, base_port: int, timeout_seconds: int = 60
 ) -> Optional[List["_ZmqRpcHandle"]]:
+    """A general-purpose minimal RPC to support broadcasting executions to multi processes"""
     import zmq
 
     rank = _get_rank()

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -137,7 +137,7 @@ class _Dumper:
             name = _get_partial_name(
                 timeout_seconds=self._config.collective_timeout
             )
-            self._config = replace(self._config, partial_name=name)
+            self.configure(partial_name=name)
             print(f"[Dumper] Choose partial_name={name}")
 
     def set_ctx(self, **kwargs):

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -97,9 +97,13 @@ class TestEndToEnd(CustomTestCase):
 
             dump_dirs = []
             for d, tensor in [(d1, baseline_tensor), (d2, target_tensor)]:
-                dumper = _Dumper(config=_DumperConfig(
-                    enable=True, dir=d, enable_http_server=False,
-                ))
+                dumper = _Dumper(
+                    config=_DumperConfig(
+                        enable=True,
+                        dir=d,
+                        enable_http_server=False,
+                    )
+                )
                 dumper.on_forward_pass_start()
                 dumper.dump("tensor_a", tensor)
                 dumper.on_forward_pass_start()

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -89,7 +89,7 @@ class TestEndToEnd(CustomTestCase):
         from argparse import Namespace
 
         from sglang.srt.debug_utils.dump_comparator import main
-        from sglang.srt.debug_utils.dumper import _Dumper, _DumperConfig
+        from sglang.srt.debug_utils.dumper import _Dumper
 
         with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
             baseline_tensor = torch.randn(10, 10)
@@ -97,14 +97,15 @@ class TestEndToEnd(CustomTestCase):
 
             dump_dirs = []
             for d, tensor in [(d1, baseline_tensor), (d2, target_tensor)]:
-                dumper = _Dumper(config=_DumperConfig(
-                    enable=True, base_dir=Path(d), enable_http_server=False,
-                ))
-                dumper.on_forward_pass_start()
-                dumper.dump("tensor_a", tensor)
-                dumper.on_forward_pass_start()
-                dumper.dump("tensor_b", tensor * 2)
-                dump_dirs.append(Path(d) / f"sglang_dump_{dumper._config.partial_name}")
+                with _with_env("SGLANG_DUMPER_DIR", d), _with_env(
+                    "SGLANG_DUMPER_SERVER_PORT", "-1"
+                ):
+                    dumper = _Dumper()
+                    dumper.on_forward_pass_start()
+                    dumper.dump("tensor_a", tensor)
+                    dumper.on_forward_pass_start()
+                    dumper.dump("tensor_b", tensor * 2)
+                    dump_dirs.append(Path(d) / f"sglang_dump_{dumper._partial_name}")
 
             args = Namespace(
                 baseline_path=str(dump_dirs[0]),

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -98,7 +98,7 @@ class TestEndToEnd(CustomTestCase):
             dump_dirs = []
             for d, tensor in [(d1, baseline_tensor), (d2, target_tensor)]:
                 dumper = _Dumper(config=_DumperConfig(
-                    enable=True, base_dir=Path(d), enable_http_server=False,
+                    enable=True, dir=Path(d), enable_http_server=False,
                 ))
                 dumper.on_forward_pass_start()
                 dumper.dump("tensor_a", tensor)

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -89,7 +89,7 @@ class TestEndToEnd(CustomTestCase):
         from argparse import Namespace
 
         from sglang.srt.debug_utils.dump_comparator import main
-        from sglang.srt.debug_utils.dumper import _Dumper
+        from sglang.srt.debug_utils.dumper import _Dumper, _DumperConfig
 
         with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
             baseline_tensor = torch.randn(10, 10)
@@ -97,15 +97,14 @@ class TestEndToEnd(CustomTestCase):
 
             dump_dirs = []
             for d, tensor in [(d1, baseline_tensor), (d2, target_tensor)]:
-                with _with_env("SGLANG_DUMPER_DIR", d), _with_env(
-                    "SGLANG_DUMPER_SERVER_PORT", "-1"
-                ):
-                    dumper = _Dumper()
-                    dumper.on_forward_pass_start()
-                    dumper.dump("tensor_a", tensor)
-                    dumper.on_forward_pass_start()
-                    dumper.dump("tensor_b", tensor * 2)
-                    dump_dirs.append(Path(d) / f"sglang_dump_{dumper._partial_name}")
+                dumper = _Dumper(config=_DumperConfig(
+                    enable=True, base_dir=Path(d), enable_http_server=False,
+                ))
+                dumper.on_forward_pass_start()
+                dumper.dump("tensor_a", tensor)
+                dumper.on_forward_pass_start()
+                dumper.dump("tensor_b", tensor * 2)
+                dump_dirs.append(Path(d) / f"sglang_dump_{dumper._config.partial_name}")
 
             args = Namespace(
                 baseline_path=str(dump_dirs[0]),

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -98,7 +98,7 @@ class TestEndToEnd(CustomTestCase):
             dump_dirs = []
             for d, tensor in [(d1, baseline_tensor), (d2, target_tensor)]:
                 dumper = _Dumper(config=_DumperConfig(
-                    enable=True, dir=Path(d), enable_http_server=False,
+                    enable=True, dir=d, enable_http_server=False,
                 ))
                 dumper.on_forward_pass_start()
                 dumper.dump("tensor_a", tensor)

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -47,21 +47,21 @@ class TestDumperConfig:
         assert _DumperConfig.from_env() == _DumperConfig()
 
     def test_from_env_bool(self):
-        with temp_set_env(SGLANG_DUMPER_ENABLE="1"):
+        with temp_set_env(allow_sglang=True, SGLANG_DUMPER_ENABLE="1"):
             assert _DumperConfig.from_env().enable is True
-        with temp_set_env(SGLANG_DUMPER_ENABLE="false"):
+        with temp_set_env(allow_sglang=True, SGLANG_DUMPER_ENABLE="false"):
             assert _DumperConfig.from_env().enable is False
 
     def test_from_env_str(self):
-        with temp_set_env(SGLANG_DUMPER_FILTER="layer_id=0"):
+        with temp_set_env(allow_sglang=True, SGLANG_DUMPER_FILTER="layer_id=0"):
             assert _DumperConfig.from_env().filter == "layer_id=0"
 
     def test_from_env_path(self):
-        with temp_set_env(SGLANG_DUMPER_DIR="/my/dir"):
+        with temp_set_env(allow_sglang=True, SGLANG_DUMPER_DIR="/my/dir"):
             assert _DumperConfig.from_env().dir == Path("/my/dir")
 
     def test_from_env_int(self):
-        with temp_set_env(SGLANG_DUMPER_COLLECTIVE_TIMEOUT="120"):
+        with temp_set_env(allow_sglang=True, SGLANG_DUMPER_COLLECTIVE_TIMEOUT="120"):
             assert _DumperConfig.from_env().collective_timeout == 120
 
     def test_configure_overrides(self):
@@ -72,7 +72,7 @@ class TestDumperConfig:
         assert d._config.enable is True
 
     def test_configure_default_skips_when_env_set(self):
-        with temp_set_env(SGLANG_DUMPER_FILTER="from_env"):
+        with temp_set_env(allow_sglang=True, SGLANG_DUMPER_FILTER="from_env"):
             d = _Dumper(config=_DumperConfig.from_env())
             d.configure_default(filter="from_code")
             assert d._config.filter == "from_env"

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -413,7 +413,7 @@ class TestDumpDictFormat:
 def _make_test_dumper(tmp_path: Path, **overrides) -> _Dumper:
     """Create a _Dumper for CPU testing without HTTP server or distributed."""
     config = _DumperConfig(
-        enable=True, base_dir=tmp_path, partial_name="test",
+        enable=True, dir=tmp_path, partial_name="test",
         enable_http_server=False, **overrides,
     )
     d = _Dumper(config=config)

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -558,5 +558,29 @@ class TestDumpModel:
         assert all("grad" in f for f in filenames)
 
 
+class TestCleanup:
+    def test_cleanup_removes_old_dumps(self, tmp_path):
+        old_dir = tmp_path / "sglang_dump_old"
+        old_dir.mkdir()
+        (old_dir / "dummy.pt").touch()
+
+        dumper = _make_test_dumper(tmp_path, needs_cleanup=True)
+        dumper.dump("new_tensor", torch.randn(3, 3))
+
+        assert not old_dir.exists()
+        _assert_files(_get_filenames(tmp_path), exist=["new_tensor"])
+
+    def test_no_cleanup_by_default(self, tmp_path):
+        old_dir = tmp_path / "sglang_dump_old"
+        old_dir.mkdir()
+        (old_dir / "dummy.pt").touch()
+
+        dumper = _make_test_dumper(tmp_path)
+        dumper.dump("new_tensor", torch.randn(3, 3))
+
+        assert old_dir.exists()
+        _assert_files(_get_filenames(tmp_path), exist=["new_tensor"])
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -307,7 +307,20 @@ class TestDumperFileWriteControl:
         assert len(_get_filenames(tmpdir)) == 0
 
 
-class TestOutputConsoleControl:
+class TestOutputControl:
+    def test_file_enabled_by_default(self, tmp_path):
+        d = _make_test_dumper(tmp_path)
+        d.dump("file_on", torch.randn(3, 3))
+
+        _assert_files(_get_filenames(tmp_path), exist=["file_on"])
+
+    def test_file_disabled(self, tmp_path, capsys):
+        d = _make_test_dumper(tmp_path, enable_output_file=False)
+        d.dump("file_off", torch.randn(3, 3))
+
+        assert len(_get_filenames(tmp_path)) == 0
+        assert "file_off" in capsys.readouterr().out
+
     def test_console_enabled_by_default(self, tmp_path, capsys):
         d = _make_test_dumper(tmp_path)
         d.dump("console_on", torch.randn(3, 3))
@@ -320,17 +333,8 @@ class TestOutputConsoleControl:
         d = _make_test_dumper(tmp_path, enable_output_console=False)
         d.dump("console_off", torch.randn(3, 3))
 
-        captured = capsys.readouterr()
-        assert "console_off" not in captured.out
+        assert "console_off" not in capsys.readouterr().out
         _assert_files(_get_filenames(tmp_path), exist=["console_off"])
-
-    def test_console_only_no_file(self, tmp_path, capsys):
-        d = _make_test_dumper(tmp_path, enable_output_file=False)
-        d.dump("console_only", torch.randn(3, 3))
-
-        captured = capsys.readouterr()
-        assert "console_only" in captured.out
-        assert len(_get_filenames(tmp_path)) == 0
 
 
 class TestDumpDictFormat:

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -56,16 +56,16 @@ class TestDumperConfig:
         with temp_set_env(allow_sglang=True, SGLANG_DUMPER_FILTER="layer_id=0"):
             assert _DumperConfig.from_env().filter == "layer_id=0"
 
-    def test_from_env_path(self):
+    def test_from_env_dir(self):
         with temp_set_env(allow_sglang=True, SGLANG_DUMPER_DIR="/my/dir"):
-            assert _DumperConfig.from_env().dir == Path("/my/dir")
+            assert _DumperConfig.from_env().dir == "/my/dir"
 
     def test_from_env_int(self):
         with temp_set_env(allow_sglang=True, SGLANG_DUMPER_COLLECTIVE_TIMEOUT="120"):
             assert _DumperConfig.from_env().collective_timeout == 120
 
     def test_configure_overrides(self):
-        d = _make_test_dumper(Path("/tmp"))
+        d = _make_test_dumper("/tmp")
         d.configure(enable=False)
         assert d._config.enable is False
         d.configure(enable=True)
@@ -446,10 +446,10 @@ class TestDumpDictFormat:
         assert torch.equal(raw["value"], tensor)
 
 
-def _make_test_dumper(tmp_path: Path, **overrides) -> _Dumper:
+def _make_test_dumper(tmp_path, **overrides) -> _Dumper:
     """Create a _Dumper for CPU testing without HTTP server or distributed."""
     config = _DumperConfig(
-        enable=True, dir=tmp_path, partial_name="test",
+        enable=True, dir=str(tmp_path), partial_name="test",
         enable_http_server=False, **overrides,
     )
     d = _Dumper(config=config)
@@ -525,7 +525,7 @@ class TestSaveValue:
 
 class TestStaticMetadata:
     def test_static_meta_contains_world_info(self):
-        dumper = _make_test_dumper(Path("/tmp"))
+        dumper = _make_test_dumper("/tmp")
         meta = dumper._static_meta
         assert "world_rank" in meta
         assert "world_size" in meta
@@ -533,7 +533,7 @@ class TestStaticMetadata:
         assert meta["world_size"] == 1
 
     def test_static_meta_caching(self):
-        dumper = _make_test_dumper(Path("/tmp"))
+        dumper = _make_test_dumper("/tmp")
         meta1 = dumper._static_meta
         meta2 = dumper._static_meta
         assert meta1 is meta2

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -15,6 +15,7 @@ from sglang.srt.debug_utils.dumper import (
     _collect_sglang_parallel_info,
     _collective_with_timeout,
     _Dumper,
+    _DumperConfig,
     _materialize_value,
     _obj_to_dict,
     _torch_save,
@@ -38,6 +39,11 @@ def _capture_stdout():
         yield captured
     finally:
         sys.stdout = old_stdout
+
+
+class TestDumperConfig:
+    def test_from_env_defaults_match_dataclass_defaults(self):
+        assert _DumperConfig.from_env() == _DumperConfig()
 
 
 class TestDumperPureFunctions:
@@ -175,11 +181,9 @@ class TestDumperDistributed:
     @staticmethod
     def _test_collective_timeout_func(rank):
         dumper = _Dumper(
-            enable=True,
-            base_dir=Path("/tmp"),
-            partial_name=None,
-            enable_http_server=False,
-            collective_timeout=3,
+            config=_DumperConfig(
+                enable=True, collective_timeout=3, enable_http_server=False,
+            ),
         )
 
         with _capture_stdout() as captured:
@@ -202,7 +206,7 @@ class TestDumperDistributed:
     def _test_http_func(rank):
         from sglang.srt.debug_utils.dumper import dumper
 
-        assert not dumper._enable
+        assert not dumper._config.enable
         dumper.on_forward_pass_start()
 
         for enable in [True, False]:
@@ -213,7 +217,7 @@ class TestDumperDistributed:
                     "http://localhost:40000/dumper", json={"enable": enable}
                 ).raise_for_status()
             dist.barrier()
-            assert dumper._enable == enable
+            assert dumper._config.enable == enable
 
     def test_file_content_correctness(self, tmp_path):
         with temp_set_env(
@@ -407,13 +411,11 @@ class TestDumpDictFormat:
 
 def _make_test_dumper(tmp_path: Path, **overrides) -> _Dumper:
     """Create a _Dumper for CPU testing without HTTP server or distributed."""
-    defaults: dict = dict(
-        enable=True,
-        base_dir=tmp_path,
-        partial_name="test",
-        enable_http_server=False,
+    config = _DumperConfig(
+        enable=True, base_dir=tmp_path, partial_name="test",
+        enable_http_server=False, **overrides,
     )
-    d = _Dumper(**{**defaults, **overrides})
+    d = _Dumper(config=config)
     d.on_forward_pass_start()
     return d
 

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -15,7 +15,7 @@ from sglang.srt.debug_utils.dumper import (
     _collect_sglang_parallel_info,
     _collective_with_timeout,
     _Dumper,
-    _format_kwargs,
+    _format_tags,
     _materialize_value,
     _obj_to_dict,
     _torch_save,
@@ -605,9 +605,9 @@ class TestDumpGrad:
 
 
 class TestKvFilter:
-    def test_format_kwargs(self):
-        assert _format_kwargs({"a": 1, "b": "hello"}) == "a=1___b=hello"
-        assert _format_kwargs({}) == ""
+    def test_format_tags(self):
+        assert _format_tags({"a": 1, "b": "hello"}) == "a=1___b=hello"
+        assert _format_tags({}) == ""
 
     def test_filter_matches_extra_kwargs(self, tmp_path):
         d = _make_test_dumper(tmp_path, filter="layer_id=0")

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -181,11 +181,9 @@ class TestDumperDistributed:
         sys.stdout = captured
 
         try:
-            if rank == 0:
-                dumper.on_forward_pass_start()
-            else:
+            if rank != 0:
                 time.sleep(6)
-                dumper.on_forward_pass_start()
+            dumper.on_forward_pass_start()
         finally:
             sys.stdout = old_stdout
 

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -269,25 +269,6 @@ class TestDumperFileWriteControl:
             not_exist=["skip_this", "not_keep_this"],
         )
 
-    def test_write_disabled(self, tmp_path):
-        with temp_set_env(
-            allow_sglang=True,
-            SGLANG_DUMPER_ENABLE="1",
-            SGLANG_DUMPER_DIR=str(tmp_path),
-            SGLANG_DUMPER_OUTPUT_FILE="0",
-        ):
-            run_distributed_test(self._test_write_disabled_func, tmpdir=str(tmp_path))
-
-    @staticmethod
-    def _test_write_disabled_func(rank, tmpdir):
-        from sglang.srt.debug_utils.dumper import dumper
-
-        dumper.on_forward_pass_start()
-        dumper.dump("no_write", torch.randn(5, device=f"cuda:{rank}"))
-
-        dist.barrier()
-        assert len(_get_filenames(tmpdir)) == 0
-
     def test_save_false(self, tmp_path):
         with temp_set_env(
             allow_sglang=True,

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -64,6 +64,24 @@ class TestDumperConfig:
         with temp_set_env(SGLANG_DUMPER_COLLECTIVE_TIMEOUT="120"):
             assert _DumperConfig.from_env().collective_timeout == 120
 
+    def test_configure_overrides(self):
+        d = _make_test_dumper(Path("/tmp"))
+        d.configure(enable=False)
+        assert d._config.enable is False
+        d.configure(enable=True)
+        assert d._config.enable is True
+
+    def test_configure_default_skips_when_env_set(self):
+        with temp_set_env(SGLANG_DUMPER_FILTER="from_env"):
+            d = _Dumper(config=_DumperConfig.from_env())
+            d.configure_default(filter="from_code")
+            assert d._config.filter == "from_env"
+
+    def test_configure_default_applies_when_no_env(self):
+        d = _Dumper(config=_DumperConfig.from_env())
+        d.configure_default(filter="from_code")
+        assert d._config.filter == "from_code"
+
 
 class TestDumperPureFunctions:
     def test_get_truncated_value(self):

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -74,7 +74,9 @@ class TestDumperConfig:
     def test_type_validation(self):
         with pytest.raises(TypeError, match="enable.*expected bool.*got str"):
             _DumperConfig(enable="yes")
-        with pytest.raises(TypeError, match="collective_timeout.*expected int.*got str"):
+        with pytest.raises(
+            TypeError, match="collective_timeout.*expected int.*got str"
+        ):
             _DumperConfig(collective_timeout="abc")
         with pytest.raises(TypeError, match="filter.*expected str.*got int"):
             _DumperConfig(filter=123)
@@ -227,7 +229,9 @@ class TestDumperDistributed:
     def _test_collective_timeout_func(rank):
         dumper = _Dumper(
             config=_DumperConfig(
-                enable=True, collective_timeout=3, enable_http_server=False,
+                enable=True,
+                collective_timeout=3,
+                enable_http_server=False,
             ),
         )
 
@@ -457,8 +461,11 @@ class TestDumpDictFormat:
 def _make_test_dumper(tmp_path, **overrides) -> _Dumper:
     """Create a _Dumper for CPU testing without HTTP server or distributed."""
     config = _DumperConfig(
-        enable=True, dir=str(tmp_path), partial_name="test",
-        enable_http_server=False, **overrides,
+        enable=True,
+        dir=str(tmp_path),
+        partial_name="test",
+        enable_http_server=False,
+        **overrides,
     )
     d = _Dumper(config=config)
     d.on_forward_pass_start()

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -247,26 +247,84 @@ class TestDumperDistributed:
             assert "WARNING" in output, f"Expected WARNING in rank 0 output: {output}"
             assert "has not completed after 3s" in output
 
-    def test_http_enable(self):
+    def test_http_configure(self):
         with temp_set_env(allow_sglang=True, SGLANG_DUMPER_ENABLE="0"):
-            run_distributed_test(self._test_http_func)
+            run_distributed_test(self._test_http_configure_func)
 
     @staticmethod
-    def _test_http_func(rank):
+    def _test_http_configure_func(rank):
         from sglang.srt.debug_utils.dumper import dumper
 
         assert not dumper._config.enable
         dumper.on_forward_pass_start()
 
+        base_url = "http://localhost:40000"
+
+        # (1) enable toggle
         for enable in [True, False]:
             dist.barrier()
             if rank == 0:
                 time.sleep(0.1)
                 requests.post(
-                    "http://localhost:40000/dumper", json={"enable": enable}
+                    f"{base_url}/dumper/configure", json={"enable": enable}
                 ).raise_for_status()
             dist.barrier()
             assert dumper._config.enable == enable
+
+        # (2) multi-field configure
+        dist.barrier()
+        if rank == 0:
+            time.sleep(0.1)
+            requests.post(
+                f"{base_url}/dumper/configure",
+                json={"enable": True, "filter": "layer_id=0", "dir": "/tmp/test_http"},
+            ).raise_for_status()
+        dist.barrier()
+        assert dumper._config.enable is True
+        assert dumper._config.filter == "layer_id=0"
+        assert dumper._config.dir == "/tmp/test_http"
+
+        # (3) clear optional field
+        dist.barrier()
+        if rank == 0:
+            time.sleep(0.1)
+            requests.post(
+                f"{base_url}/dumper/configure",
+                json={"filter": None},
+            ).raise_for_status()
+        dist.barrier()
+        assert dumper._config.filter is None
+
+        # (4) reset
+        dumper._dump_index = 42
+        dumper._forward_pass_id = 99
+        dist.barrier()
+        if rank == 0:
+            time.sleep(0.1)
+            requests.post(f"{base_url}/dumper/reset").raise_for_status()
+        dist.barrier()
+        assert dumper._dump_index == 0
+        assert dumper._forward_pass_id == 0
+
+        # (5) error: unknown field -> 400
+        dist.barrier()
+        if rank == 0:
+            time.sleep(0.1)
+            resp = requests.post(
+                f"{base_url}/dumper/configure",
+                json={"nonexistent_field": 123},
+            )
+            assert resp.status_code == 400
+
+        # (6) error: wrong type -> 400
+        dist.barrier()
+        if rank == 0:
+            time.sleep(0.1)
+            resp = requests.post(
+                f"{base_url}/dumper/configure",
+                json={"enable": "not_a_bool"},
+            )
+            assert resp.status_code == 400
 
     def test_file_content_correctness(self, tmp_path):
         with temp_set_env(

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -15,6 +15,7 @@ from sglang.srt.debug_utils.dumper import (
     _collect_sglang_parallel_info,
     _collective_with_timeout,
     _Dumper,
+    _DumperConfig,
     _format_tags,
     _materialize_value,
     _obj_to_dict,
@@ -39,6 +40,11 @@ def _capture_stdout():
         yield captured
     finally:
         sys.stdout = old_stdout
+
+
+class TestDumperConfig:
+    def test_from_env_defaults_match_dataclass_defaults(self):
+        assert _DumperConfig.from_env() == _DumperConfig()
 
 
 class TestDumperPureFunctions:
@@ -176,11 +182,9 @@ class TestDumperDistributed:
     @staticmethod
     def _test_collective_timeout_func(rank):
         dumper = _Dumper(
-            enable=True,
-            base_dir=Path("/tmp"),
-            partial_name=None,
-            enable_http_server=False,
-            collective_timeout=3,
+            config=_DumperConfig(
+                enable=True, collective_timeout=3, enable_http_server=False,
+            ),
         )
 
         with _capture_stdout() as captured:
@@ -203,7 +207,7 @@ class TestDumperDistributed:
     def _test_http_func(rank):
         from sglang.srt.debug_utils.dumper import dumper
 
-        assert not dumper._enable
+        assert not dumper._config.enable
         dumper.on_forward_pass_start()
 
         for enable in [True, False]:
@@ -214,7 +218,7 @@ class TestDumperDistributed:
                     "http://localhost:40000/dumper", json={"enable": enable}
                 ).raise_for_status()
             dist.barrier()
-            assert dumper._enable == enable
+            assert dumper._config.enable == enable
 
     def test_file_content_correctness(self, tmp_path):
         with temp_set_env(
@@ -408,13 +412,11 @@ class TestDumpDictFormat:
 
 def _make_test_dumper(tmp_path: Path, **overrides) -> _Dumper:
     """Create a _Dumper for CPU testing without HTTP server or distributed."""
-    defaults: dict = dict(
-        enable=True,
-        base_dir=tmp_path,
-        partial_name="test",
-        enable_http_server=False,
+    config = _DumperConfig(
+        enable=True, base_dir=tmp_path, partial_name="test",
+        enable_http_server=False, **overrides,
     )
-    d = _Dumper(**{**defaults, **overrides})
+    d = _Dumper(config=config)
     d.on_forward_pass_start()
     return d
 

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -359,6 +359,16 @@ class TestOutputControl:
         tensor.fill_(999.0)
         assert torch.equal(captured["clone_check"]["value"], torch.zeros(3, 3))
 
+    def test_capture_output_respects_filter(self, tmp_path):
+        d = _make_test_dumper(tmp_path, filter="^keep")
+
+        with d.capture_output() as captured:
+            d.dump("keep_this", torch.randn(3, 3))
+            d.dump("skip_this", torch.randn(3, 3))
+
+        assert "keep_this" in captured
+        assert "skip_this" not in captured
+
 
 class TestDumpDictFormat:
     """Verify that dump files use the dict output format: {"value": ..., "meta": {...}}."""

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -46,6 +46,24 @@ class TestDumperConfig:
     def test_from_env_defaults_match_dataclass_defaults(self):
         assert _DumperConfig.from_env() == _DumperConfig()
 
+    def test_from_env_bool(self):
+        with temp_set_env(SGLANG_DUMPER_ENABLE="1"):
+            assert _DumperConfig.from_env().enable is True
+        with temp_set_env(SGLANG_DUMPER_ENABLE="false"):
+            assert _DumperConfig.from_env().enable is False
+
+    def test_from_env_str(self):
+        with temp_set_env(SGLANG_DUMPER_FILTER="layer_id=0"):
+            assert _DumperConfig.from_env().filter == "layer_id=0"
+
+    def test_from_env_path(self):
+        with temp_set_env(SGLANG_DUMPER_DIR="/my/dir"):
+            assert _DumperConfig.from_env().dir == Path("/my/dir")
+
+    def test_from_env_int(self):
+        with temp_set_env(SGLANG_DUMPER_COLLECTIVE_TIMEOUT="120"):
+            assert _DumperConfig.from_env().collective_timeout == 120
+
 
 class TestDumperPureFunctions:
     def test_get_truncated_value(self):

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -564,7 +564,7 @@ class TestCleanup:
         old_dir.mkdir()
         (old_dir / "dummy.pt").touch()
 
-        dumper = _make_test_dumper(tmp_path, needs_cleanup=True)
+        dumper = _make_test_dumper(tmp_path, cleanup_previous=True)
         dumper.dump("new_tensor", torch.randn(3, 3))
 
         assert not old_dir.exists()

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -71,6 +71,14 @@ class TestDumperConfig:
         d.configure(enable=True)
         assert d._config.enable is True
 
+    def test_type_validation(self):
+        with pytest.raises(TypeError, match="enable.*expected bool.*got str"):
+            _DumperConfig(enable="yes")
+        with pytest.raises(TypeError, match="collective_timeout.*expected int.*got str"):
+            _DumperConfig(collective_timeout="abc")
+        with pytest.raises(TypeError, match="filter.*expected str.*got int"):
+            _DumperConfig(filter=123)
+
     def test_configure_default_skips_when_env_set(self):
         with temp_set_env(allow_sglang=True, SGLANG_DUMPER_FILTER="from_env"):
             d = _Dumper(config=_DumperConfig.from_env())

--- a/test/registered/debug_utils/test_dumper.py
+++ b/test/registered/debug_utils/test_dumper.py
@@ -196,9 +196,9 @@ class TestDumperDistributed:
         dumper.set_ctx(ctx_arg=None)
 
         dumper.on_forward_pass_start()
-        dumper.override_enable(False)
+        dumper.configure(filter=r"^$")
         dumper.dump("tensor_skip", tensor)
-        dumper.override_enable(True)
+        dumper.configure(filter=None)
 
         dumper.on_forward_pass_start()
         dumper.dump_dict("obj", {"a": torch.randn(3, device=f"cuda:{rank}"), "b": 42})


### PR DESCRIPTION
## Changes

- Add `_Dumper.reset()` method to clear runtime state (dump_index, forward_pass_id, global_ctx)
- Replace single `POST /dumper` endpoint (only supported `enable`) with generic URL-path-based dispatch:
  - `POST /dumper/configure` — accepts any `_DumperConfig` field as JSON kwargs
  - `POST /dumper/reset` — resets dumper runtime state across all ranks
- Remove `_DumperRpcHandler` indirection — ZMQ RPC now proxies `_Dumper` directly
- Extract `_ZmqRpcBroadcast` to encapsulate fan-out to all ranks (replaces for-loops at call sites)
- Generalize `_make_http_handler(prefix, target)` — dispatches `POST /<prefix>/<method>` to `target.<method>(**body)`

## Test plan

- Extended `test_http_configure` (distributed, 2-GPU): enable toggle, multi-field configure, clear optional fields, reset, unknown field -> 400, wrong type -> 400
- All 65 dumper tests pass
- All 8 dump_comparator tests pass
- pre-commit clean