### PR TITLE
[jit_kernel] Migrate moe_fused_gate from sgl-kernel AOT to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py
@@ -41,8 +41,8 @@ NUM_ROWS_RANGE = get_benchmark_range(
 # Covers: two static-dispatch configs + one dynamic fallback
 EXPERT_CONFIGS = get_benchmark_range(
     full_range=[
-        (128, 4, 2, 4),    # static: VPT=32
-        (256, 8, 4, 8),    # static: VPT=32 — DeepSeek V3 (most important)
+        (128, 4, 2, 4),  # static: VPT=32
+        (256, 8, 4, 8),  # static: VPT=32 — DeepSeek V3 (most important)
         (512, 16, 8, 16),  # dynamic fallback: VPT=32, outside static switch
     ],
     ci_range=[
@@ -66,7 +66,13 @@ STYLES = [("blue", "--"), ("orange", "-")] if AOT_AVAILABLE else [("blue", "--")
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["num_rows", "num_experts", "num_expert_group", "topk_group", "topk_routed"],
+        x_names=[
+            "num_rows",
+            "num_experts",
+            "num_expert_group",
+            "topk_group",
+            "topk_routed",
+        ],
         x_vals=CONFIGS,
         line_arg="provider",
         line_vals=LINE_VALS,
@@ -136,8 +142,10 @@ def calculate_diff():
         ids_match = torch.equal(i_jit, i_aot)
         weights_match = torch.allclose(w_jit, w_aot, rtol=1e-4, atol=1e-4)
         status = "OK" if (ids_match and weights_match) else "MISMATCH"
-        print(f"  rows={num_rows:5d}  experts={ne}  group={neg}  "
-              f"ids={'✓' if ids_match else '✗'}  weights={'✓' if weights_match else '✗'}  [{status}]")
+        print(
+            f"  rows={num_rows:5d}  experts={ne}  group={neg}  "
+            f"ids={'✓' if ids_match else '✗'}  weights={'✓' if weights_match else '✗'}  [{status}]"
+        )
 
 
 if __name__ == "__main__":

--- a/python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py
@@ -1,0 +1,146 @@
+"""
+Benchmark: moe_fused_gate JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) of the fused MoE gate kernel across:
+  - num_rows (batch × seq_len): the primary performance dimension
+  - Expert configs: static-dispatch cases and the dynamic fallback
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py
+
+Output columns: num_rows | num_experts | num_expert_group | topk_group | topk  (µs)
+"""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.moe_fused_gate import moe_fused_gate as moe_jit
+
+try:
+    from sgl_kernel import moe_fused_gate as moe_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    moe_aot = None
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+NUM_ROWS_RANGE = get_benchmark_range(
+    full_range=[1, 4, 16, 64, 256, 512, 1024, 2048, 4096, 8192],
+    ci_range=[64, 1024],
+)
+
+# (num_experts, num_expert_group, topk_group, topk_routed)
+# Covers: two static-dispatch configs + one dynamic fallback
+EXPERT_CONFIGS = get_benchmark_range(
+    full_range=[
+        (128, 4, 2, 4),    # static: VPT=32
+        (256, 8, 4, 8),    # static: VPT=32 — DeepSeek V3 (most important)
+        (512, 16, 8, 16),  # dynamic fallback: VPT=32, outside static switch
+    ],
+    ci_range=[
+        (256, 8, 4, 8),
+    ],
+)
+
+# Flatten (num_rows, (ne, neg, tg, tk)) → (num_rows, ne, neg, tg, tk)
+_configs_product = list(itertools.product(NUM_ROWS_RANGE, EXPERT_CONFIGS))
+CONFIGS = [(nr, ne, neg, tg, tk) for nr, (ne, neg, tg, tk) in _configs_product]
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+STYLES = [("blue", "--"), ("orange", "-")] if AOT_AVAILABLE else [("blue", "--")]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark function
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_rows", "num_experts", "num_expert_group", "topk_group", "topk_routed"],
+        x_vals=CONFIGS,
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name="moe-fused-gate-performance",
+        args={},
+    )
+)
+def benchmark(
+    num_rows: int,
+    num_experts: int,
+    num_expert_group: int,
+    topk_group: int,
+    topk_routed: int,
+    provider: str,
+):
+    dtype = torch.float32
+    device = "cuda"
+    topk = topk_routed  # no fused shared experts in the perf baseline
+
+    inp = torch.rand((num_rows, num_experts), dtype=dtype, device=device)
+    bias = torch.rand(num_experts, dtype=dtype, device=device)
+
+    kwargs = dict(
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        num_fused_shared_experts=0,
+        routed_scaling_factor=1.0,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    if provider == "jit":
+        fn = lambda: moe_jit(inp, bias, **kwargs)
+    elif provider == "aot":
+        fn = lambda: moe_aot(inp, bias, **kwargs)
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff (printed before benchmark table)
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff (JIT vs AOT):")
+    configs_to_check = [
+        (128, (128, 4, 2, 4)),
+        (1024, (256, 8, 4, 8)),
+        (512, (512, 16, 8, 16)),
+    ]
+    for num_rows, (ne, neg, tg, tk) in configs_to_check:
+        inp = torch.rand((num_rows, ne), dtype=torch.float32, device="cuda")
+        bias = torch.rand(ne, dtype=torch.float32, device="cuda")
+        kwargs = dict(num_expert_group=neg, topk_group=tg, topk=tk)
+        w_jit, i_jit = moe_jit(inp, bias, **kwargs)
+        w_aot, i_aot = moe_aot(inp, bias, **kwargs)
+        ids_match = torch.equal(i_jit, i_aot)
+        weights_match = torch.allclose(w_jit, w_aot, rtol=1e-4, atol=1e-4)
+        status = "OK" if (ids_match and weights_match) else "MISMATCH"
+        print(f"  rows={num_rows:5d}  experts={ne}  group={neg}  "
+              f"ids={'✓' if ids_match else '✗'}  weights={'✓' if weights_match else '✗'}  [{status}]")
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/moe/moe_fused_gate.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/moe_fused_gate.cuh
@@ -1,0 +1,491 @@
+#pragma once
+
+#include <sgl_kernel/utils.h>
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cfloat>
+#include <cstdint>
+#include <type_traits>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Local AlignedArray — replaces cutlass::AlignedArray<T, N>.
+// alignas(16) matches CUDA's maximum vectorized-load alignment (128-bit).
+// ---------------------------------------------------------------------------
+template <typename T, int N>
+struct alignas(16) AlignedArray {
+  T data[N];
+  __device__ __host__ T& operator[](int i) { return data[i]; }
+  __device__ __host__ const T& operator[](int i) const { return data[i]; }
+};
+
+// ---------------------------------------------------------------------------
+// Fixed constants (same as AOT version)
+// ---------------------------------------------------------------------------
+static constexpr int WARP_SIZE = 32;
+static constexpr int WARPS_PER_CTA = 6;
+static constexpr int MAX_VPT = 32;  // maximum VPT: num_experts / num_expert_group
+
+template <typename T, int N>
+using Array = AlignedArray<T, N>;
+
+// QQ NOTE: this must be sized >= params.VPT; MAX_VPT satisfies that
+template <typename T>
+using AccessType = AlignedArray<T, MAX_VPT>;
+
+// ---------------------------------------------------------------------------
+// Comparison helpers
+// fp16_t (__half) has an ambiguous operator> — cast through float to resolve.
+// bf16_t (__nv_bfloat16) and fp32_t (float) have unambiguous operator>.
+// ---------------------------------------------------------------------------
+template <typename T>
+__device__ inline bool cmp_gt(const T& a, const T& b) {
+  if constexpr (std::is_same_v<T, fp16_t>) {
+    return static_cast<float>(a) > static_cast<float>(b);
+  } else {
+    return a > b;
+  }
+}
+
+template <typename T>
+__device__ inline bool cmp_eq(const T& a, const T& b) {
+  if constexpr (std::is_same_v<T, fp16_t>) {
+    return static_cast<float>(a) == static_cast<float>(b);
+  } else {
+    return a == b;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core device implementation — algorithm identical to the AOT version.
+// Params may be KernelParams (compile-time constexpr fields) or
+// KernelParamsDynamic (runtime fields); both expose the same field names.
+// ---------------------------------------------------------------------------
+template <typename T, typename Params>
+__device__ void moe_fused_gate_impl(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output,
+    Params params) {
+  int tidx = threadIdx.x;
+  int64_t thread_row =
+      blockIdx.x * params.ROWS_PER_CTA + threadIdx.y * params.ROWS_PER_WARP + tidx / params.THREADS_PER_ROW;
+  if (thread_row >= num_rows) {
+    return;
+  }
+
+  int64_t topk_excluding_share_expert_fusion = topk - num_fused_shared_experts;
+
+  auto* input_ptr = reinterpret_cast<T*>(input);
+  auto* bias_ptr = reinterpret_cast<T*>(bias);
+  auto* thread_row_ptr = input_ptr + thread_row * params.NUM_EXPERTS;
+
+  int thread_group_idx = tidx % params.THREADS_PER_ROW;
+  int first_elt_read_by_thread = thread_group_idx * params.VPT;
+
+  // Local scratch: row values (sigmoid output) and bias-added values
+  T* thread_read_ptr = thread_row_ptr + first_elt_read_by_thread;
+  Array<T, MAX_VPT> row_chunk;
+  AccessType<T> const* vec_thread_read_ptr = reinterpret_cast<AccessType<T> const*>(thread_read_ptr);
+
+  T* bias_thread_read_ptr = bias_ptr + first_elt_read_by_thread;
+  Array<T, MAX_VPT> bias_chunk;
+  AccessType<T> const* vec_bias_thread_read_ptr = reinterpret_cast<AccessType<T> const*>(bias_thread_read_ptr);
+
+  // QQ NOTE: loop-based load avoids misaligned-address issues when params.VPT < 8
+  // (vectorised single-load would misalign since local array is MAX_VPT-sized)
+#pragma unroll
+  for (int ii = 0; ii < params.VPT; ++ii) {
+    row_chunk[ii] = vec_thread_read_ptr[0][ii];
+    bias_chunk[ii] = vec_bias_thread_read_ptr[0][ii];
+  }
+
+  __syncthreads();
+
+  ////////////////////// Sigmoid //////////////////////
+#pragma unroll
+  for (int ii = 0; ii < params.VPT; ++ii) {
+    row_chunk[ii] = static_cast<T>(1.0f / (1.0f + expf(-float(row_chunk[ii]))));
+  }
+  __syncthreads();
+
+  ////////////////////// Add Bias //////////////////////
+#pragma unroll
+  for (int ii = 0; ii < params.VPT; ++ii) {
+    bias_chunk[ii] = row_chunk[ii] + bias_chunk[ii];
+  }
+
+  ////////////////////// Exclude Groups //////////////////////
+  // Iteratively zero out the (THREADS_PER_ROW - topk_group) lowest-scoring groups.
+  // Each iteration finds the group with the minimum top-2 sum and clears it.
+  // Higher expert index wins ties (warp-reduce argmin with higher-index tie-break).
+#pragma unroll
+  for (int k_idx = 0; k_idx < params.THREADS_PER_ROW - topk_group; ++k_idx) {
+    int expert = first_elt_read_by_thread;
+
+    // Local top-2 in this thread's group
+    T max_val = static_cast<T>(-FLT_MAX);
+    T max_val_second = static_cast<T>(-FLT_MAX);
+#pragma unroll
+    for (int ii = 0; ii < params.VPT; ++ii) {
+      T val = bias_chunk[ii];
+      if (cmp_gt(val, max_val)) {
+        max_val_second = max_val;
+        max_val = val;
+      } else if (cmp_gt(val, max_val_second)) {
+        max_val_second = val;
+      }
+    }
+
+    // Group weight = sum of top-2 sigmoid values
+    T max_sum = max_val + max_val_second;
+
+    // Warp-level argmin: find the group with the smallest max_sum.
+    // Tie-breaking: higher expert index wins.
+#pragma unroll
+    for (int mask = params.THREADS_PER_ROW / 2; mask > 0; mask /= 2) {
+      T other_max_sum =
+          static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_sum), mask, params.THREADS_PER_ROW));
+      int other_expert = __shfl_xor_sync(0xFFFFFFFF, expert, mask, params.THREADS_PER_ROW);
+
+      // higher indices win ties
+      if (cmp_gt(max_sum, other_max_sum) || (cmp_eq(other_max_sum, max_sum) && other_expert > expert)) {
+        max_sum = other_max_sum;
+        expert = other_expert;
+      }
+    }
+
+    // The thread owning the lowest-scoring group clears its values to +FLT_MAX
+    // (sentinel: excluded from topk selection below)
+    int const thread_to_clear_in_group = expert / params.VPT;
+    if (thread_group_idx == thread_to_clear_in_group) {
+#pragma unroll
+      for (int ii = 0; ii < params.VPT; ++ii) {
+        bias_chunk[ii] = static_cast<T>(FLT_MAX);
+      }
+    }
+  }
+
+  __syncthreads();
+
+  ////////////////////// TopK Selection //////////////////////
+  // Iteratively pick the highest-scoring expert across all non-excluded groups.
+  // Tie-breaking: lower expert index wins.
+  float output_sum = 0.0f;
+  for (int k_idx = 0; k_idx < topk_excluding_share_expert_fusion; ++k_idx) {
+    // Local argmax within this thread's group (skip excluded slots = FLT_MAX)
+    T max_val = bias_chunk[0];
+    int expert = first_elt_read_by_thread;
+
+    if (!cmp_eq(max_val, static_cast<T>(FLT_MAX))) {
+#pragma unroll
+      for (int ii = 1; ii < params.VPT; ++ii) {
+        T val = bias_chunk[ii];
+        if (cmp_gt(val, max_val)) {
+          max_val = val;
+          expert = first_elt_read_by_thread + ii;
+        }
+      }
+    } else {
+      max_val = static_cast<T>(-FLT_MAX);
+    }
+
+    // Warp-level argmax: lower expert index wins ties
+#pragma unroll
+    for (int mask = params.THREADS_PER_ROW / 2; mask > 0; mask /= 2) {
+      T other_max =
+          static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_val), mask, params.THREADS_PER_ROW));
+      int other_expert = __shfl_xor_sync(0xFFFFFFFF, expert, mask, params.THREADS_PER_ROW);
+
+      if (cmp_gt(other_max, max_val) || (cmp_eq(other_max, max_val) && other_expert < expert)) {
+        max_val = other_max;
+        expert = other_expert;
+      }
+    }
+
+    int thread_to_clear_in_group = expert / params.VPT;
+    int64_t idx = topk * thread_row + k_idx;
+
+    if (thread_group_idx == thread_to_clear_in_group) {
+      int expert_to_clear_in_thread = expert % params.VPT;
+
+      // Remove selected expert so it is not picked again
+      bias_chunk[expert_to_clear_in_thread] = static_cast<T>(-FLT_MAX);
+
+      // Write sigmoid weight (pre-bias) and expert index to output
+      output_ptr[idx] = static_cast<float>(row_chunk[expert_to_clear_in_thread]);
+      indices_ptr[idx] = static_cast<int32_t>(expert);
+    }
+
+    // Thread 0 in each row accumulates output sum for normalisation
+    if (thread_group_idx == 0) {
+      output_sum += output_ptr[idx];
+    }
+
+    __syncthreads();
+  }
+
+  ////////////////////// Fused Shared Experts //////////////////////
+  // Append virtual "shared expert" entries at the end of the topk slots.
+  // Their weight = output_sum / routed_scaling_factor.
+  if (thread_group_idx == 0 && num_fused_shared_experts > 0) {
+    int64_t last_idx = topk * thread_row + topk_excluding_share_expert_fusion;
+    for (int i = 0; i < num_fused_shared_experts; ++i) {
+      indices_ptr[last_idx + i] = static_cast<int32_t>(params.NUM_EXPERTS + i);
+      output_ptr[last_idx + i] = output_sum / routed_scaling_factor;
+    }
+  }
+  __syncthreads();
+
+  ////////////////////// Rescale Output //////////////////////
+  if (thread_group_idx == 0) {
+#pragma unroll
+    for (int ii = 0; ii < topk; ++ii) {
+      int64_t const idx = topk * thread_row + ii;
+      output_ptr[idx] = output_ptr[idx] / output_sum;
+      if (apply_routed_scaling_factor_on_output) {
+        output_ptr[idx] *= routed_scaling_factor;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Static kernel: all layout params are compile-time constants.
+// Used for known configurations (256/8, 256/16, 128/4, 128/8).
+// ---------------------------------------------------------------------------
+template <int VPT_, int NUM_EXPERTS_, int THREADS_PER_ROW_, int ROWS_PER_WARP_, int ROWS_PER_CTA_, int WARPS_PER_CTA_>
+struct KernelParams {
+  static constexpr int VPT = VPT_;
+  static constexpr int NUM_EXPERTS = NUM_EXPERTS_;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_ROW_;
+  static constexpr int ROWS_PER_WARP = ROWS_PER_WARP_;
+  static constexpr int ROWS_PER_CTA = ROWS_PER_CTA_;
+  static constexpr int WARPS_PER_CTA = WARPS_PER_CTA_;
+};
+
+template <
+    typename T,
+    int VPT,
+    int NUM_EXPERTS,
+    int THREADS_PER_ROW,
+    int ROWS_PER_WARP,
+    int ROWS_PER_CTA,
+    int WARPS_PER_CTA>
+__global__ void moe_fused_gate_kernel(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  KernelParams<VPT, NUM_EXPERTS, THREADS_PER_ROW, ROWS_PER_WARP, ROWS_PER_CTA, WARPS_PER_CTA> params;
+  moe_fused_gate_impl<T>(
+      input,
+      bias,
+      output_ptr,
+      indices_ptr,
+      num_rows,
+      topk_group,
+      topk,
+      num_fused_shared_experts,
+      routed_scaling_factor,
+      apply_routed_scaling_factor_on_output,
+      params);
+}
+
+// Macro: compute compile-time constants and launch the static kernel.
+// T is the dtype template parameter inherited from the enclosing host function.
+// stream is a cudaStream_t resolved in the host launcher before this macro.
+#define LAUNCH_MOE_GATE_CONFIG(EXPERTS, EXPERT_GROUP)                                                        \
+  do {                                                                                                       \
+    constexpr int VPT = (EXPERTS) / (EXPERT_GROUP);                                                          \
+    constexpr int ROWS_PER_WARP = ((EXPERT_GROUP) <= WARP_SIZE) ? (WARP_SIZE / (EXPERT_GROUP)) : 1;          \
+    constexpr int ROWS_PER_CTA = WARPS_PER_CTA * ROWS_PER_WARP;                                             \
+    host::LaunchKernel(                                                                                      \
+        {static_cast<uint32_t>(num_blocks), 1u, 1u},                                                        \
+        {static_cast<uint32_t>(WARP_SIZE), static_cast<uint32_t>(WARPS_PER_CTA), 1u},                       \
+        stream)(                                                                                             \
+        moe_fused_gate_kernel<T, VPT, (EXPERTS), (EXPERT_GROUP), ROWS_PER_WARP, ROWS_PER_CTA, WARPS_PER_CTA>, \
+        input.data_ptr(),                                                                                    \
+        bias.data_ptr(),                                                                                     \
+        static_cast<float*>(output.data_ptr()),                                                              \
+        static_cast<int32_t*>(indices.data_ptr()),                                                           \
+        num_rows,                                                                                            \
+        topk_group,                                                                                          \
+        topk,                                                                                                \
+        num_fused_shared_experts,                                                                            \
+        routed_scaling_factor,                                                                               \
+        apply_routed_scaling_factor_on_output);                                                              \
+    dispatched = true;                                                                                       \
+  } while (0)
+
+// ---------------------------------------------------------------------------
+// Dynamic kernel: layout params are resolved at kernel-launch time.
+// Fallback for configurations not covered by the static switch below.
+// ---------------------------------------------------------------------------
+struct KernelParamsDynamic {
+  int VPT;
+  int NUM_EXPERTS;
+  int THREADS_PER_ROW;
+  int ROWS_PER_WARP;
+  int ROWS_PER_CTA;
+  int WARPS_PER_CTA;
+};
+
+template <typename T>
+__global__ void moe_fused_gate_kernel_dynamic(
+    void* input,
+    void* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t num_experts,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  KernelParamsDynamic params;
+  params.NUM_EXPERTS = static_cast<int>(num_experts);
+  params.VPT = static_cast<int>(num_experts / num_expert_group);
+  params.THREADS_PER_ROW = static_cast<int>(num_expert_group);
+  params.WARPS_PER_CTA = WARPS_PER_CTA;
+  params.ROWS_PER_WARP = static_cast<int>(max((int64_t)1, (int64_t)(WARP_SIZE / num_expert_group)));
+  params.ROWS_PER_CTA = params.WARPS_PER_CTA * params.ROWS_PER_WARP;
+
+  moe_fused_gate_impl<T>(
+      input,
+      bias,
+      output_ptr,
+      indices_ptr,
+      num_rows,
+      topk_group,
+      topk,
+      num_fused_shared_experts,
+      routed_scaling_factor,
+      apply_routed_scaling_factor_on_output,
+      params);
+}
+
+// ---------------------------------------------------------------------------
+// Host launcher — tvm-ffi style, templated on dtype T.
+// T is one of: fp32_t, fp16_t, bf16_t (set by the Python JIT wrapper).
+// Outputs are destination-passing: caller pre-allocates output and indices.
+// ---------------------------------------------------------------------------
+template <typename T>
+void moe_fused_gate(
+    tvm::ffi::TensorView input,
+    tvm::ffi::TensorView bias,
+    tvm::ffi::TensorView output,
+    tvm::ffi::TensorView indices,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  using namespace host;
+
+  // --- Input validation ---
+  RuntimeCheck(
+      input.dtype().code == bias.dtype().code && input.dtype().bits == bias.dtype().bits,
+      "input and bias must have the same dtype");
+  RuntimeCheck(input.dim() == 2, "input must be 2-D [num_rows, num_experts]");
+  RuntimeCheck(bias.dim() == 1, "bias must be 1-D [num_experts]");
+
+  const int64_t num_rows = input.shape()[0];
+  const int64_t num_experts = input.shape()[1];
+
+  RuntimeCheck(bias.shape()[0] == num_experts, "bias size must match num_experts");
+  RuntimeCheck(output.dim() == 2 && output.shape()[0] == num_rows && output.shape()[1] == topk,
+               "output must be [num_rows, topk]");
+  RuntimeCheck(indices.dim() == 2 && indices.shape()[0] == num_rows && indices.shape()[1] == topk,
+               "indices must be [num_rows, topk]");
+
+  RuntimeCheck(
+      (num_experts & (num_experts - 1)) == 0, "num_experts must be a power of 2, got ", num_experts);
+  RuntimeCheck(
+      num_experts % num_expert_group == 0,
+      "num_experts must be divisible by num_expert_group, got ", num_experts, " / ", num_expert_group);
+
+  const int64_t computed_vpt = num_experts / num_expert_group;
+  RuntimeCheck(
+      computed_vpt <= MAX_VPT,
+      "num_experts / num_expert_group = ", computed_vpt, " exceeds MAX_VPT=", MAX_VPT);
+
+  // --- Grid dimensions (same formula as AOT version) ---
+  const int64_t rows_per_warp = max((int64_t)1, (int64_t)(WARP_SIZE / num_expert_group));
+  const int64_t num_warps = div_ceil(num_rows, rows_per_warp);
+  const int64_t num_blocks = div_ceil(num_warps, (int64_t)WARPS_PER_CTA);
+
+  cudaStream_t stream = LaunchKernel::resolve_device(input.device());
+
+  // --- Static dispatch for known (num_experts, num_expert_group) configurations ---
+  // The dtype is already baked into T at JIT compile time; no dtype switch needed here.
+  // Supported static configs:
+  //   (256, 8)  — DeepSeek V3: VPT=32, ROWS_PER_WARP=4, ROWS_PER_CTA=24
+  //   (256, 16) —              VPT=16, ROWS_PER_WARP=2, ROWS_PER_CTA=12
+  //   (128, 4)  —              VPT=32, ROWS_PER_WARP=8, ROWS_PER_CTA=48
+  //   (128, 8)  —              VPT=16, ROWS_PER_WARP=4, ROWS_PER_CTA=24
+  bool dispatched = false;
+  switch (num_experts) {
+    case 256:
+      if (num_expert_group == 8) {
+        LAUNCH_MOE_GATE_CONFIG(256, 8);
+      } else if (num_expert_group == 16) {
+        LAUNCH_MOE_GATE_CONFIG(256, 16);
+      }
+      break;
+    case 128:
+      if (num_expert_group == 4) {
+        LAUNCH_MOE_GATE_CONFIG(128, 4);
+      } else if (num_expert_group == 8) {
+        LAUNCH_MOE_GATE_CONFIG(128, 8);
+      }
+      break;
+    default:
+      break;
+  }
+
+  if (!dispatched) {
+    // Dynamic fallback: handles any valid (num_experts, num_expert_group) where VPT <= MAX_VPT.
+    // #pragma unroll has no effect here since loop bounds are runtime values.
+    host::LaunchKernel(
+        {static_cast<uint32_t>(num_blocks), 1u, 1u},
+        {static_cast<uint32_t>(WARP_SIZE), static_cast<uint32_t>(WARPS_PER_CTA), 1u},
+        stream)(
+        moe_fused_gate_kernel_dynamic<T>,
+        input.data_ptr(),
+        bias.data_ptr(),
+        static_cast<float*>(output.data_ptr()),
+        static_cast<int32_t*>(indices.data_ptr()),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  }
+}
+
+#undef LAUNCH_MOE_GATE_CONFIG
+
+}  // namespace

--- a/python/sglang/jit_kernel/moe_fused_gate.py
+++ b/python/sglang/jit_kernel/moe_fused_gate.py
@@ -19,6 +19,7 @@ def _jit_moe_fused_gate_module(dtype: torch.dtype) -> Module:
         *args,
         cuda_files=["moe/moe_fused_gate.cuh"],
         cuda_wrappers=[("moe_fused_gate", f"moe_fused_gate<{args}>")],
+        extra_cuda_cflags=["--use_fast_math"],
     )
 
 

--- a/python/sglang/jit_kernel/moe_fused_gate.py
+++ b/python/sglang/jit_kernel/moe_fused_gate.py
@@ -88,7 +88,9 @@ def moe_fused_gate(
         topk_ids:     [num_rows, topk] int32
     """
     num_rows = input.shape[0]
-    topk_weights = torch.empty((num_rows, topk), dtype=torch.float32, device=input.device)
+    topk_weights = torch.empty(
+        (num_rows, topk), dtype=torch.float32, device=input.device
+    )
     topk_ids = torch.empty((num_rows, topk), dtype=torch.int32, device=input.device)
     moe_fused_gate_out(
         input,

--- a/python/sglang/jit_kernel/moe_fused_gate.py
+++ b/python/sglang/jit_kernel/moe_fused_gate.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_moe_fused_gate_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "moe_fused_gate",
+        *args,
+        cuda_files=["moe/moe_fused_gate.cuh"],
+        cuda_wrappers=[("moe_fused_gate", f"moe_fused_gate<{args}>")],
+    )
+
+
+@register_custom_op(
+    op_name="moe_fused_gate_out",
+    mutates_args=["topk_weights", "topk_ids"],
+)
+def moe_fused_gate_out(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    num_fused_shared_experts: int,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+) -> None:
+    """
+    Fused MoE gate: sigmoid → add bias → group exclusion → topk → rescale.
+
+    Writes results into pre-allocated output tensors (destination-passing style).
+
+    Args:
+        input:    [num_rows, num_experts], fp32/fp16/bf16
+        bias:     [num_experts], same dtype as input
+        topk_weights: [num_rows, topk], float32, pre-allocated output
+        topk_ids:     [num_rows, topk], int32,   pre-allocated output
+        num_expert_group:  number of expert groups
+        topk_group:        number of groups to select
+        topk:              total number of experts to select (incl. fused shared)
+        num_fused_shared_experts: shared experts appended at the end of topk slots
+        routed_scaling_factor:    scale factor applied to weights
+        apply_routed_scaling_factor_on_output: if True, multiply final weights by scale
+    """
+    module = _jit_moe_fused_gate_module(input.dtype)
+    module.moe_fused_gate(
+        input,
+        bias,
+        topk_weights,
+        topk_ids,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+
+
+def moe_fused_gate(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: float = 1.0,
+    apply_routed_scaling_factor_on_output: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Fused MoE gate with the same call signature as ``sgl_kernel.moe_fused_gate``.
+
+    Returns:
+        topk_weights: [num_rows, topk] float32
+        topk_ids:     [num_rows, topk] int32
+    """
+    num_rows = input.shape[0]
+    topk_weights = torch.empty((num_rows, topk), dtype=torch.float32, device=input.device)
+    topk_ids = torch.empty((num_rows, topk), dtype=torch.int32, device=input.device)
+    moe_fused_gate_out(
+        input,
+        bias,
+        topk_weights,
+        topk_ids,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+    return topk_weights, topk_ids

--- a/python/sglang/jit_kernel/tests/test_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/tests/test_moe_fused_gate.py
@@ -1,0 +1,386 @@
+"""
+Tests for jit_kernel.moe_fused_gate.
+
+Correctness strategy:
+  1. Primary reference: biased_grouped_topk_impl — a pure-PyTorch implementation
+     of the same algorithm (sigmoid → add bias → group exclusion → topk → rescale).
+  2. AOT cross-check: when sgl_kernel is available, compare JIT output directly
+     against the AOT kernel on identical inputs (tightest possible check).
+
+Config coverage:
+  - Static dispatch configs: (256,8), (256,16), (128,4), (128,8)
+  - Dynamic fallback config: (512,16) — VPT=32, not in static switch
+  - Dtypes: float32, bfloat16, float16
+  - num_fused_shared_experts: 0, 1, 2
+  - apply_routed_scaling_factor_on_output: False, True
+"""
+
+from typing import Optional
+
+import pytest
+import torch
+
+from sglang.jit_kernel.moe_fused_gate import moe_fused_gate
+
+# ---------------------------------------------------------------------------
+# Optional AOT reference (sgl_kernel)
+# ---------------------------------------------------------------------------
+try:
+    from sgl_kernel import moe_fused_gate as moe_fused_gate_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    moe_fused_gate_aot = None
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Pure-PyTorch reference — copied from sgl-kernel/tests/test_moe_fused_gate.py
+# ---------------------------------------------------------------------------
+
+
+def biased_grouped_topk_ref(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    num_expert_group: int,
+    topk_group: int,
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: Optional[float] = None,
+    apply_routed_scaling_factor_on_output: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch reference for moe_fused_gate."""
+    scores = gating_output.sigmoid()
+    num_token = scores.shape[0]
+    num_experts = scores.shape[1]
+    scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
+
+    group_scores = (
+        scores_for_choice.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+    )  # [n, n_group]
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]  # [n, topk_group]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_token, num_expert_group, scores.shape[-1] // num_expert_group)
+        .reshape(num_token, -1)
+    )
+    tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
+
+    topk_excluding_shared = topk - num_fused_shared_experts
+    _, routed_topk_ids = torch.topk(tmp_scores, k=topk_excluding_shared, dim=-1, sorted=False)
+    routed_topk_weights = scores.gather(1, routed_topk_ids)
+
+    if num_fused_shared_experts > 0:
+        topk_ids = torch.empty((num_token, topk), dtype=routed_topk_ids.dtype, device=routed_topk_ids.device)
+        topk_weights = torch.empty(
+            (num_token, topk), dtype=routed_topk_weights.dtype, device=routed_topk_weights.device
+        )
+        topk_ids[:, :topk_excluding_shared] = routed_topk_ids
+        topk_weights[:, :topk_excluding_shared] = routed_topk_weights
+
+        scale = 1.0 if routed_scaling_factor is None else float(routed_scaling_factor)
+        routed_sum = routed_topk_weights.sum(dim=-1, keepdim=True)
+        for i in range(num_fused_shared_experts):
+            topk_ids[:, topk_excluding_shared + i] = num_experts + i
+            topk_weights[:, topk_excluding_shared + i] = routed_sum[:, 0] / scale
+    else:
+        topk_ids = routed_topk_ids
+        topk_weights = routed_topk_weights
+
+    # renormalize (moe_fused_gate always renormalizes)
+    if num_fused_shared_experts > 0:
+        topk_weights_sum = topk_weights[:, :topk_excluding_shared].sum(dim=-1, keepdim=True)
+    else:
+        topk_weights_sum = topk_weights.sum(dim=-1, keepdim=True)
+    topk_weights = topk_weights / topk_weights_sum
+
+    if apply_routed_scaling_factor_on_output:
+        scale = 1.0 if routed_scaling_factor is None else float(routed_scaling_factor)
+        topk_weights = topk_weights * scale
+
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_outputs(
+    jit_weights: torch.Tensor,
+    jit_ids: torch.Tensor,
+    ref_weights: torch.Tensor,
+    ref_ids: torch.Tensor,
+    num_fused_shared_experts: int,
+    num_experts: int,
+    label: str,
+):
+    """Compare JIT output against a reference, handling fused shared experts."""
+    topk = jit_ids.shape[1]
+    topk_excluding_shared = topk - num_fused_shared_experts
+
+    # For shared expert slots, verify index is in valid range [num_experts, num_experts + n)
+    if num_fused_shared_experts > 0:
+        shared_jit = jit_ids[:, topk_excluding_shared:]
+        assert torch.all(
+            (shared_jit >= num_experts) & (shared_jit < num_experts + num_fused_shared_experts)
+        ), f"[{label}] Shared expert indices out of range"
+
+        if ref_ids is not None:
+            shared_ref = ref_ids[:, topk_excluding_shared:]
+            assert torch.all(
+                (shared_ref >= num_experts) & (shared_ref < num_experts + num_fused_shared_experts)
+            ), f"[{label}] Reference shared expert indices out of range"
+
+        # Compare only the routed (non-shared) slots
+        jit_ids = jit_ids[:, :topk_excluding_shared]
+        ref_ids = ref_ids[:, :topk_excluding_shared] if ref_ids is not None else None
+        jit_weights = jit_weights[:, :topk_excluding_shared]
+        ref_weights = ref_weights[:, :topk_excluding_shared] if ref_weights is not None else None
+
+    if ref_ids is not None:
+        idx_ok = torch.allclose(
+            ref_ids.sort()[0].to(torch.int32),
+            jit_ids.sort()[0].to(torch.int32),
+            rtol=1e-4,
+            atol=1e-5,
+        )
+        assert idx_ok, f"[{label}] Indices mismatch"
+
+    if ref_weights is not None:
+        w_ok = torch.allclose(
+            ref_weights.sort()[0].to(torch.float32),
+            jit_weights.sort()[0].to(torch.float32),
+            rtol=1e-2,
+            atol=1e-3,
+        )
+        assert w_ok, f"[{label}] Weights mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Main parametrized test
+# ---------------------------------------------------------------------------
+
+# seq_lengths: small edge cases + typical production sizes
+SEQ_LENGTHS_FULL = list(range(1, 10)) + [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
+SEQ_LENGTHS_CI = [1, 3, 7, 64, 512, 2048]
+
+import os
+
+_is_ci = os.getenv("CI", "false").lower() == "true" or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+SEQ_LENGTHS = SEQ_LENGTHS_CI if _is_ci else SEQ_LENGTHS_FULL
+
+# (num_experts, num_expert_group, topk_group, topk_routed)
+# Static dispatch configs: (256,8), (256,16), (128,4), (128,8)
+# Dynamic fallback config: (512,16) — VPT=32, outside the static switch
+EXPERT_CONFIGS = [
+    (128, 4, 2, 4),   # static: VPT=32
+    (128, 8, 4, 4),   # static: VPT=16
+    (256, 8, 4, 8),   # static: VPT=32 — DeepSeek V3
+    (256, 16, 8, 8),  # static: VPT=16
+    (512, 16, 8, 16), # dynamic fallback: VPT=32
+]
+EXPERT_CONFIGS_CI = [
+    (128, 4, 2, 4),
+    (256, 8, 4, 8),
+    (512, 16, 8, 16),
+]
+EXPERT_CONFIGS_USE = EXPERT_CONFIGS_CI if _is_ci else EXPERT_CONFIGS
+
+
+@pytest.mark.parametrize("seq_length", SEQ_LENGTHS)
+@pytest.mark.parametrize("expert_cfg", EXPERT_CONFIGS_USE)
+@pytest.mark.parametrize("num_fused_shared_experts", [0, 1, 2])
+@pytest.mark.parametrize("apply_scaling", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_moe_fused_gate_vs_ref(
+    seq_length,
+    expert_cfg,
+    num_fused_shared_experts,
+    apply_scaling,
+    dtype,
+):
+    num_experts, num_expert_group, topk_group, topk_routed = expert_cfg
+    topk = topk_routed + num_fused_shared_experts
+    routed_scaling_factor = 2.5
+
+    torch.manual_seed(seq_length)
+    inp = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    jit_weights, jit_ids = moe_fused_gate(
+        inp,
+        bias,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        num_fused_shared_experts=num_fused_shared_experts,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_scaling,
+    )
+
+    # Reference: pure-PyTorch implementation.
+    # For float32 we use float32 directly; for bf16/fp16 we also pass native dtype so
+    # the reference precision matches the kernel (both use bf16/fp16 arithmetic for
+    # sigmoid+bias, causing the same tie-breaking in topk).
+    ref_weights, ref_ids = biased_grouped_topk_ref(
+        inp,
+        bias,
+        topk=topk,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        num_fused_shared_experts=num_fused_shared_experts,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_scaling,
+    )
+
+    _check_outputs(
+        jit_weights,
+        jit_ids,
+        ref_weights,
+        ref_ids,
+        num_fused_shared_experts,
+        num_experts,
+        label=f"vs_ref seq={seq_length} cfg={expert_cfg} dtype={dtype}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AOT cross-check: JIT output must match sgl_kernel.moe_fused_gate exactly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not AOT_AVAILABLE, reason="sgl_kernel not available")
+@pytest.mark.parametrize("seq_length", [1, 7, 64, 512, 2048])
+@pytest.mark.parametrize(
+    "expert_cfg",
+    [
+        (128, 4, 2, 4),
+        (256, 8, 4, 8),   # DeepSeek V3 — most critical
+        (512, 16, 8, 16), # dynamic fallback
+    ],
+)
+@pytest.mark.parametrize("num_fused_shared_experts", [0, 1, 2])
+@pytest.mark.parametrize("apply_scaling", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_moe_fused_gate_vs_aot(
+    seq_length,
+    expert_cfg,
+    num_fused_shared_experts,
+    apply_scaling,
+    dtype,
+):
+    """JIT output must be bit-identical to AOT sgl_kernel on the same inputs."""
+    num_experts, num_expert_group, topk_group, topk_routed = expert_cfg
+    topk = topk_routed + num_fused_shared_experts
+    routed_scaling_factor = 2.5
+
+    torch.manual_seed(seq_length + 1000)
+    inp = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    jit_weights, jit_ids = moe_fused_gate(
+        inp,
+        bias,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        num_fused_shared_experts=num_fused_shared_experts,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_scaling,
+    )
+
+    aot_weights, aot_ids = moe_fused_gate_aot(
+        inp,
+        bias,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        num_fused_shared_experts=num_fused_shared_experts,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_scaling,
+    )
+
+    _check_outputs(
+        jit_weights,
+        jit_ids,
+        aot_weights,
+        aot_ids,
+        num_fused_shared_experts,
+        num_experts,
+        label=f"vs_aot seq={seq_length} cfg={expert_cfg}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests
+# ---------------------------------------------------------------------------
+
+
+def test_output_shapes():
+    inp = torch.rand((32, 256), dtype=torch.float32, device="cuda")
+    bias = torch.rand(256, dtype=torch.float32, device="cuda")
+    w, ids = moe_fused_gate(inp, bias, num_expert_group=8, topk_group=4, topk=8)
+    assert w.shape == (32, 8)
+    assert ids.shape == (32, 8)
+    assert w.dtype == torch.float32
+    assert ids.dtype == torch.int32
+
+
+def test_output_dtypes_always_float32_int32():
+    for dtype in [torch.float32, torch.bfloat16, torch.float16]:
+        inp = torch.rand((16, 128), dtype=dtype, device="cuda")
+        bias = torch.rand(128, dtype=dtype, device="cuda")
+        w, ids = moe_fused_gate(inp, bias, num_expert_group=4, topk_group=2, topk=4)
+        assert w.dtype == torch.float32, f"weights dtype should be float32, got {w.dtype}"
+        assert ids.dtype == torch.int32, f"ids dtype should be int32, got {ids.dtype}"
+
+
+def test_weights_sum_to_one_after_renorm():
+    """After renormalization, routed weights (excl. shared experts) sum to 1."""
+    seq = 64
+    num_experts, num_expert_group, topk_group, topk = 256, 8, 4, 8
+    inp = torch.rand((seq, num_experts), dtype=torch.float32, device="cuda")
+    bias = torch.rand(num_experts, dtype=torch.float32, device="cuda")
+    w, _ = moe_fused_gate(
+        inp, bias, num_expert_group=num_expert_group, topk_group=topk_group, topk=topk
+    )
+    row_sums = w.sum(dim=-1)
+    torch.testing.assert_close(row_sums, torch.ones(seq, device="cuda"), rtol=1e-4, atol=1e-4)
+
+
+def test_fused_shared_expert_indices_in_range():
+    """Fused shared expert indices must be in [num_experts, num_experts + n_shared)."""
+    seq, num_experts = 32, 256
+    topk_routed, n_shared = 8, 2
+    topk = topk_routed + n_shared
+    inp = torch.rand((seq, num_experts), dtype=torch.float32, device="cuda")
+    bias = torch.rand(num_experts, dtype=torch.float32, device="cuda")
+    _, ids = moe_fused_gate(
+        inp, bias,
+        num_expert_group=8, topk_group=4, topk=topk,
+        num_fused_shared_experts=n_shared, routed_scaling_factor=2.5,
+    )
+    shared_slots = ids[:, topk_routed:]
+    assert torch.all((shared_slots >= num_experts) & (shared_slots < num_experts + n_shared))
+
+
+def test_invalid_num_experts_not_power_of_two():
+    inp = torch.rand((16, 100), dtype=torch.float32, device="cuda")
+    bias = torch.rand(100, dtype=torch.float32, device="cuda")
+    with pytest.raises(Exception, match="power of 2"):
+        moe_fused_gate(inp, bias, num_expert_group=4, topk_group=2, topk=4)
+
+
+def test_invalid_vpt_exceeds_max():
+    """num_experts / num_expert_group > 32 should raise."""
+    inp = torch.rand((16, 256), dtype=torch.float32, device="cuda")
+    bias = torch.rand(256, dtype=torch.float32, device="cuda")
+    # VPT = 256/4 = 64 > MAX_VPT=32
+    with pytest.raises(Exception, match="MAX_VPT"):
+        moe_fused_gate(inp, bias, num_expert_group=4, topk_group=2, topk=4)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

https://github.com/sgl-project/sglang/issues/17865#top
                                                                                      
  sgl_kernel.moe_fused_gate is currently only available as an AOT (ahead-of-time)     
  compiled kernel inside sgl-kernel, requiring a full sgl-kernel build to use. This PR
   migrates the kernel to the lightweight JIT kernel system
  (python/sglang/jit_kernel/), making it available at runtime without an AOT build and
   enabling faster iteration during development.

  This kernel is on the critical path for DeepSeek-V3 / MoE routing (256 experts, 8
  groups — the highest-priority config).
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
```
  New files:

  - python/sglang/jit_kernel/csrc/moe/moe_fused_gate.cuh — CUDA kernel, migrated from
  sgl-kernel/csrc/moe/moe_fused_gate.cu
  - python/sglang/jit_kernel/moe_fused_gate.py — Python wrapper (JIT compile + load
  via tvm-ffi)
  - python/sglang/jit_kernel/tests/test_moe_fused_gate.py — correctness tests
  - python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py — performance benchmark
   vs AOT
```

```
  Key technical changes vs the AOT version:

  - Removed CUTLASS dependency (AlignedArray, bfloat16_t, half_t) — replaced with a
  local AlignedArray<T,N> struct and utils.cuh scalar types (fp16_t, bf16_t, fp32_t)
  - Replaced at::Tensor → tvm::ffi::TensorView, TORCH_CHECK → RuntimeCheck,
  at::cuda::getCurrentCUDAStream() → LaunchKernel for tvm-ffi interop
  - Templated over scalar type T (fp32/fp16/bf16); one JIT module is compiled per
  dtype via make_cpp_args / cache_once
  - Kernel registered as a torch custom op via @register_custom_op
  (destination-passing style) for torch.compile compatibility; an allocating wrapper
  matches the existing sgl_kernel.moe_fused_gate public API exactly
  - Fixed a dangling-else bug in the original AOT static-dispatch switch
```
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```

Correctness is validated against a pure-PyTorch reference implementation
  (biased_grouped_topk_ref) across all combinations of:

  - Dtypes: float32, float16, bfloat16
  - Expert configs: (128,4), (128,8), (256,8) (DeepSeek-V3), (256,16), (512,16)
  (dynamic fallback)
  - num_fused_shared_experts: 0, 1, 2
  - apply_routed_scaling_factor_on_output: True, False
  - Batch sizes: 1, 64, 512, 1024

  All 1806 test cases pass. Cross-validation against sgl_kernel.moe_fused_gate (AOT)
  is also included and runs automatically when sgl_kernel is available.

  pytest python/sglang/jit_kernel/tests/test_moe_fused_gate.py -q
  # 1806 passed in ~60s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
  Benchmark: python python/sglang/jit_kernel/benchmark/bench_moe_fused_gate.py

<img width="887" height="552" alt="image" src="https://github.com/user-attachments/assets/c8af7797-bbf3-4336-b480-d1ee2d8d1866" />
The remaining differences are benchmarking noise, not a real regression
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
