### PR TITLE
fix(remote): add device default and distributed streaming for RunAI S3 loading

### DIFF
--- a/python/sglang/srt/connector/__init__.py
+++ b/python/sglang/srt/connector/__init__.py
@@ -22,7 +22,7 @@ class ConnectorType(str, enum.Enum):
     INSTANCE = "instance"
 
 
-def create_remote_connector(url, device, **kwargs) -> BaseConnector:
+def create_remote_connector(url, device: str = "cpu", **kwargs) -> BaseConnector:
     connector_type = parse_connector_type(url)
     if connector_type == "redis":
         return RedisConnector(url)


### PR DESCRIPTION
## Motivation

When using `--load-format remote --model-path s3://...`, two issues prevent correct and efficient model loading:

1. **`create_remote_connector()` requires `device` but 3 call-sites omit it** — causes `TypeError` at startup for any S3/Redis remote path (`ModelConfig._maybe_pull_model_tokenizer_from_remote`, `get_config`, `get_tokenizer`).

2. **RunAI Model Streamer defaults to `device="cpu", is_distributed=False`** — on a multi-GPU node (TP=8), every rank reads the full model from S3 independently (8x I/O), and weights land on CPU causing a large async H2D copy backlog.

## Modifications

### `python/sglang/srt/connector/__init__.py` (+1 line)
- Add `device: str = "cpu"` default to `create_remote_connector()`. Only `instance://` uses `device`; S3 and Redis ignore it.

### `python/sglang/srt/model_loader/weight_utils.py` (+28 / -4 lines)
- **`runai_safetensors_weights_iterator()`**: read `SGLANG_RUNAI_STREAMER_DEVICE` (default `"auto"` → `"cuda"`) and `SGLANG_RUNAI_STREAMER_DISTRIBUTED` (default `"auto"` → `True` when distributed+GPU), pass to `streamer.stream_file()`.
- **`set_runai_streamer_env()`**: add `AWS_ENDPOINT_URL_S3` as fallback for `RUNAI_STREAMER_S3_ENDPOINT`.

With `device="cuda"`, `should_async_load()` returns `False` for GPU tensors, so the CPU async-copy backlog is also eliminated.

## Accuracy Tests

No changes to model forward code. Weight loading path only.

## Benchmarking and Profiling

Tested on 8×GPU node with DeepSeek-V3-0324 (600 GB) from S3:
- Before: 8× full S3 reads, ~45 min, CPU OOM risk
- After: 1× distributed read to GPU, ~6 min

## Checklist

- [x] Format code with pre-commit
- [x] Follow SGLang code style guidance
- [ ] Add unit tests (no existing infra for remote/RunAI path; tested manually)
- [ ] Update documentation