### PR TITLE
[jit_kernel] Migrate kimi_k2_moe_fused_gate from sgl-kernel AOT to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
@@ -1,0 +1,126 @@
+"""
+Benchmark: kimi_k2_moe_fused_gate JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) of the Kimi K2 fused MoE gate kernel across
+num_rows spanning both the small-token path (≤512) and large-token path (>512).
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+
+Output columns: num_rows  (µs)
+"""
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.kimi_k2_moe_fused_gate import (
+    kimi_k2_moe_fused_gate as kimi_k2_jit,
+)
+
+try:
+    from sgl_kernel import kimi_k2_moe_fused_gate as kimi_k2_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    kimi_k2_aot = None
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+# Covers both the small-token (≤512) and large-token (>512) kernel paths
+NUM_ROWS_RANGE = get_benchmark_range(
+    full_range=[1, 4, 16, 64, 128, 256, 512, 513, 1024, 2048, 4096, 8192],
+    ci_range=[64, 512, 1024],
+)
+
+NUM_EXPERTS = 384
+TOPK = 6  # Kimi K2 uses topk=6
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+STYLES = [("blue", "--"), ("orange", "-")] if AOT_AVAILABLE else [("blue", "--")]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark function
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_rows"],
+        x_vals=NUM_ROWS_RANGE,
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name="kimi-k2-moe-fused-gate-performance",
+        args={},
+    )
+)
+def benchmark(num_rows: int, provider: str):
+    device = "cuda"
+    routed_scaling_factor = 2.872
+
+    inp = torch.rand((num_rows, NUM_EXPERTS), dtype=torch.float32, device=device)
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device=device)
+
+    kwargs = dict(
+        topk=TOPK,
+        renormalize=True,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    if provider == "jit":
+        fn = lambda: kimi_k2_jit(inp, bias, **kwargs)
+    elif provider == "aot":
+        fn = lambda: kimi_k2_aot(inp, bias, **kwargs)
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff (printed before benchmark table)
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff (JIT vs AOT):")
+    for num_rows in [1, 64, 512, 513, 1024, 4096]:
+        inp = torch.rand((num_rows, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+        bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+        kwargs = dict(
+            topk=TOPK,
+            renormalize=True,
+            routed_scaling_factor=2.872,
+            apply_routed_scaling_factor_on_output=False,
+        )
+        w_jit, _ = kimi_k2_jit(inp, bias, **kwargs)
+        w_aot, _ = kimi_k2_aot(inp, bias, **kwargs)
+        weights_match = torch.allclose(
+            w_jit.sort(dim=-1)[0], w_aot.sort(dim=-1)[0].float(), rtol=1e-3, atol=1e-4
+        )
+        kernel_used = "small" if num_rows <= 512 else "large"
+        status = "OK" if weights_match else "MISMATCH"
+        print(
+            f"  rows={num_rows:5d}  kernel={kernel_used:5s}  "
+            f"weights={'✓' if weights_match else '✗'}  [{status}]"
+        )
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
@@ -107,8 +107,8 @@ def calculate_diff():
             routed_scaling_factor=2.872,
             apply_routed_scaling_factor_on_output=False,
         )
-        w_jit, _ = kimi_k2_jit(inp, bias, **kwargs)
-        w_aot, _ = kimi_k2_aot(inp, bias, **kwargs)
+        w_jit, i_jit = kimi_k2_jit(inp, bias, **kwargs)
+        w_aot, i_aot = kimi_k2_aot(inp, bias, **kwargs)
         weights_match = torch.allclose(
             w_jit.sort(dim=-1)[0], w_aot.sort(dim=-1)[0].float(), rtol=1e-3, atol=1e-4
         )

--- a/python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
@@ -1,0 +1,339 @@
+#pragma once
+
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cfloat>
+#include <cstdint>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Kimi K2 constants (hard-coded for 384 experts)
+// ---------------------------------------------------------------------------
+static constexpr int K2_WARP_SIZE = 32;
+static constexpr int K2_WARPS_PER_CTA = 6;
+static constexpr int K2_NUM_EXPERTS = 384;
+static constexpr int K2_VPT = K2_NUM_EXPERTS / K2_WARP_SIZE;  // 12
+
+// Small-token kernel constants
+static constexpr int K2_SMALL_TOKEN_THRESHOLD = 512;
+static constexpr int K2_WARPS_PER_TOKEN_SMALL = 12;
+static constexpr int K2_THREADS_PER_BLOCK_SMALL = K2_WARPS_PER_TOKEN_SMALL * K2_WARP_SIZE;  // 384
+
+// Vectorised-load constants (large-token kernel)
+static constexpr int K2_VEC_SIZE = 4;  // float4
+static constexpr int K2_VEC_PER_LANE = K2_VPT / K2_VEC_SIZE;  // 3
+
+// ---------------------------------------------------------------------------
+// Small-token kernel: one CTA per row, 12 warps collaborate on a single row.
+// ---------------------------------------------------------------------------
+__global__ void kimi_k2_moe_fused_gate_kernel_small_token(
+    const float* __restrict__ input,
+    const float* __restrict__ bias,
+    float* __restrict__ output_ptr,
+    int32_t* __restrict__ indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  int64_t row_idx = blockIdx.x;
+  if (row_idx >= num_rows) return;
+
+  int tid = threadIdx.x;
+  int warp_id = tid / K2_WARP_SIZE;
+  int lane_id = tid % K2_WARP_SIZE;
+
+  __shared__ float shared_scores[K2_NUM_EXPERTS];
+  __shared__ float shared_original_scores[K2_NUM_EXPERTS];
+  __shared__ int selected_experts[8];  // topk <= 6; 8 for alignment
+  __shared__ float selected_vals[8];
+  __shared__ float warp_maxs[K2_WARPS_PER_TOKEN_SMALL];
+  __shared__ int warp_experts[K2_WARPS_PER_TOKEN_SMALL];
+
+  // Load: every thread handles one expert.
+  if (tid < K2_NUM_EXPERTS) {
+    float inp = input[row_idx * K2_NUM_EXPERTS + tid];
+    float b = bias[tid];
+    float sigmoid_val = 1.0f / (1.0f + expf(-inp));
+    shared_scores[tid] = sigmoid_val + b;
+    shared_original_scores[tid] = sigmoid_val;
+  }
+
+  __syncthreads();
+
+  // Iterative top-k: each iteration extracts the global maximum.
+  for (int k = 0; k < topk; k++) {
+    float my_val = (tid < K2_NUM_EXPERTS) ? shared_scores[tid] : -FLT_MAX;
+    int my_expert = tid;
+
+    // Warp-level reduction.
+    float warp_max_val = my_val;
+    int warp_max_expert = my_expert;
+#pragma unroll
+    for (int offset = 16; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, warp_max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, warp_max_expert, offset);
+      if (other_val > warp_max_val) {
+        warp_max_val = other_val;
+        warp_max_expert = other_expert;
+      }
+    }
+
+    if (lane_id == 0) {
+      warp_maxs[warp_id] = warp_max_val;
+      warp_experts[warp_id] = warp_max_expert;
+    }
+
+    __syncthreads();
+
+    // Reduce across warps (first warp only).
+    if (warp_id == 0) {
+      float final_max = (lane_id < K2_WARPS_PER_TOKEN_SMALL) ? warp_maxs[lane_id] : -FLT_MAX;
+      int final_expert = (lane_id < K2_WARPS_PER_TOKEN_SMALL) ? warp_experts[lane_id] : -1;
+#pragma unroll
+      for (int offset = 16; offset > 0; offset /= 2) {
+        float other_val = __shfl_down_sync(0xFFFFFFFF, final_max, offset);
+        int other_expert = __shfl_down_sync(0xFFFFFFFF, final_expert, offset);
+        if (other_val > final_max) {
+          final_max = other_val;
+          final_expert = other_expert;
+        }
+      }
+      if (lane_id == 0) {
+        selected_experts[k] = final_expert;
+        selected_vals[k] = final_max;
+      }
+    }
+
+    __syncthreads();
+
+    // Mask out the selected expert so the next iteration skips it.
+    if (tid == selected_experts[k]) {
+      shared_scores[tid] = -FLT_MAX;
+    }
+
+    __syncthreads();
+  }
+
+  // Write outputs (thread 0 only).
+  if (tid == 0) {
+    for (int k = 0; k < topk; k++) {
+      int expert_id = selected_experts[k];
+      if (expert_id >= 0 && expert_id < K2_NUM_EXPERTS) {
+        output_ptr[row_idx * topk + k] = shared_original_scores[expert_id];
+        indices_ptr[row_idx * topk + k] = expert_id;
+      } else {
+        output_ptr[row_idx * topk + k] = 0.0f;
+        indices_ptr[row_idx * topk + k] = 0;
+      }
+    }
+
+    if (renormalize) {
+      float sum = 0.0f;
+      for (int k = 0; k < topk; k++) sum += output_ptr[row_idx * topk + k];
+      if (sum > 0.0f) {
+        for (int k = 0; k < topk; k++) {
+          int64_t idx = row_idx * topk + k;
+          output_ptr[idx] /= sum;
+          if (apply_routed_scaling_factor_on_output) {
+            output_ptr[idx] *= static_cast<float>(routed_scaling_factor);
+          }
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Large-token kernel: WARPS_PER_CTA rows per CTA, vectorised loads.
+// ---------------------------------------------------------------------------
+__global__ void kimi_k2_moe_fused_gate_kernel(
+    const float* __restrict__ input,
+    const float* __restrict__ bias,
+    float* __restrict__ output_ptr,
+    int32_t* __restrict__ indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  int64_t row_idx = blockIdx.x * K2_WARPS_PER_CTA + threadIdx.y;
+  if (row_idx >= num_rows) return;
+
+  int lane_id = threadIdx.x;
+  int warp_id = threadIdx.y;
+
+  __shared__ float shared_scores[K2_NUM_EXPERTS * K2_WARPS_PER_CTA];
+  __shared__ float shared_original_scores[K2_NUM_EXPERTS * K2_WARPS_PER_CTA];
+
+  float* warp_scores = shared_scores + warp_id * K2_NUM_EXPERTS;
+  float* warp_original_scores = shared_original_scores + warp_id * K2_NUM_EXPERTS;
+
+  // Vectorised load: each lane loads K2_VEC_PER_LANE float4 chunks.
+  const float4* input_vec =
+      reinterpret_cast<const float4*>(input + row_idx * K2_NUM_EXPERTS);
+  const float4* bias_vec = reinterpret_cast<const float4*>(bias);
+
+#pragma unroll
+  for (int i = 0; i < K2_VEC_PER_LANE; i++) {
+    int vec_idx = lane_id * K2_VEC_PER_LANE + i;
+    float4 input_val = input_vec[vec_idx];
+    float4 bias_val = bias_vec[vec_idx];
+#pragma unroll
+    for (int j = 0; j < K2_VEC_SIZE; j++) {
+      int expert = vec_idx * K2_VEC_SIZE + j;
+      float inp = reinterpret_cast<const float*>(&input_val)[j];
+      float b = reinterpret_cast<const float*>(&bias_val)[j];
+      float sigmoid_val = 1.0f / (1.0f + expf(-inp));
+      warp_scores[expert] = sigmoid_val + b;
+      warp_original_scores[expert] = sigmoid_val;
+    }
+  }
+
+  __syncthreads();
+
+  for (int k = 0; k < topk; k++) {
+    float max_val = -FLT_MAX;
+    int max_expert = -1;
+
+    for (int expert = lane_id; expert < K2_NUM_EXPERTS; expert += K2_WARP_SIZE) {
+      if (warp_scores[expert] > max_val) {
+        max_val = warp_scores[expert];
+        max_expert = expert;
+      }
+    }
+
+    for (int offset = K2_WARP_SIZE / 2; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, max_expert, offset);
+      if (other_val > max_val || (other_val == max_val && other_expert < max_expert)) {
+        max_val = other_val;
+        max_expert = other_expert;
+      }
+    }
+
+    if (lane_id == 0) {
+      int64_t output_idx = row_idx * topk + k;
+      if (max_expert != -1) {
+        output_ptr[output_idx] = warp_original_scores[max_expert];
+        indices_ptr[output_idx] = max_expert;
+        warp_scores[max_expert] = -FLT_MAX;
+      } else {
+        output_ptr[output_idx] = 0.0f;
+        indices_ptr[output_idx] = 0;
+      }
+    }
+
+    __syncwarp();
+  }
+
+  __syncthreads();
+
+  if (renormalize && lane_id == 0) {
+    float sum = 0.0f;
+    for (int k = 0; k < topk; k++) sum += output_ptr[row_idx * topk + k];
+    if (sum > 0.0f) {
+      for (int k = 0; k < topk; k++) {
+        int64_t idx = row_idx * topk + k;
+        output_ptr[idx] /= sum;
+        if (apply_routed_scaling_factor_on_output) {
+          output_ptr[idx] *= static_cast<float>(routed_scaling_factor);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Host launcher
+// ---------------------------------------------------------------------------
+void kimi_k2_moe_fused_gate(
+    tvm::ffi::TensorView input,
+    tvm::ffi::TensorView bias,
+    tvm::ffi::TensorView output,
+    tvm::ffi::TensorView indices,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  using namespace host;
+
+  // --- Input validation ---
+  RuntimeCheck(input.dim() == 2, "input must be 2-D, got dim=", input.dim());
+  RuntimeCheck(bias.dim() == 1, "bias must be 1-D, got dim=", bias.dim());
+
+  const int64_t num_rows = input.shape()[0];
+  const int64_t num_experts = input.shape()[1];
+
+  RuntimeCheck(
+      num_experts == K2_NUM_EXPERTS,
+      "kimi_k2_moe_fused_gate only supports ",
+      K2_NUM_EXPERTS,
+      " experts, got ",
+      num_experts);
+  RuntimeCheck(bias.shape()[0] == num_experts, "bias size must match num_experts");
+  RuntimeCheck(
+      output.dim() == 2 && output.shape()[0] == num_rows && output.shape()[1] == topk,
+      "output must be [num_rows, topk]");
+  RuntimeCheck(
+      indices.dim() == 2 && indices.shape()[0] == num_rows && indices.shape()[1] == topk,
+      "indices must be [num_rows, topk]");
+  RuntimeCheck(topk > 0 && topk <= K2_NUM_EXPERTS, "topk out of range");
+
+  // Dtype checks (float32 only)
+  RuntimeCheck(
+      input.dtype().code == DLDataTypeCode::kDLFloat && input.dtype().bits == 32,
+      "input must be float32");
+  RuntimeCheck(
+      bias.dtype().code == DLDataTypeCode::kDLFloat && bias.dtype().bits == 32,
+      "bias must be float32");
+
+  const float* inp_ptr = static_cast<const float*>(input.data_ptr());
+  const float* bias_ptr = static_cast<const float*>(bias.data_ptr());
+  float* out_ptr = static_cast<float*>(output.data_ptr());
+  int32_t* idx_ptr = static_cast<int32_t*>(indices.data_ptr());
+
+  cudaStream_t stream = LaunchKernel::resolve_device(input.device());
+
+  if (num_rows <= K2_SMALL_TOKEN_THRESHOLD) {
+    // Small-token kernel: one CTA per row, 384 threads per CTA.
+    LaunchKernel(
+        {static_cast<uint32_t>(num_rows), 1u, 1u},
+        {static_cast<uint32_t>(K2_THREADS_PER_BLOCK_SMALL), 1u, 1u},
+        stream)(
+        kimi_k2_moe_fused_gate_kernel_small_token,
+        inp_ptr,
+        bias_ptr,
+        out_ptr,
+        idx_ptr,
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  } else {
+    // Large-token kernel: K2_WARPS_PER_CTA rows per CTA.
+    int64_t num_blocks = (num_rows + K2_WARPS_PER_CTA - 1) / K2_WARPS_PER_CTA;
+    LaunchKernel(
+        {static_cast<uint32_t>(num_blocks), 1u, 1u},
+        {static_cast<uint32_t>(K2_WARP_SIZE), static_cast<uint32_t>(K2_WARPS_PER_CTA), 1u},
+        stream)(
+        kimi_k2_moe_fused_gate_kernel,
+        inp_ptr,
+        bias_ptr,
+        out_ptr,
+        idx_ptr,
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  }
+}

--- a/python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
@@ -17,6 +17,7 @@ def _jit_kimi_k2_moe_fused_gate_module() -> Module:
         "kimi_k2_moe_fused_gate",
         cuda_files=["moe/kimi_k2_moe_fused_gate.cuh"],
         cuda_wrappers=[("kimi_k2_moe_fused_gate", "kimi_k2_moe_fused_gate")],
+        extra_cuda_cflags=["--use_fast_math"],
     )
 
 

--- a/python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_kimi_k2_moe_fused_gate_module() -> Module:
+    return load_jit(
+        "kimi_k2_moe_fused_gate",
+        cuda_files=["moe/kimi_k2_moe_fused_gate.cuh"],
+        cuda_wrappers=[("kimi_k2_moe_fused_gate", "kimi_k2_moe_fused_gate")],
+    )
+
+
+@register_custom_op(
+    op_name="kimi_k2_moe_fused_gate_out",
+    mutates_args=["topk_weights", "topk_ids"],
+)
+def kimi_k2_moe_fused_gate_out(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+) -> None:
+    """
+    Kimi K2 fused MoE gate: sigmoid → add bias → top-k → renormalize.
+
+    Writes results into pre-allocated output tensors (destination-passing style).
+
+    Args:
+        input:      [num_rows, 384], float32
+        bias:       [384], float32
+        topk_weights: [num_rows, topk], float32, pre-allocated output
+        topk_ids:     [num_rows, topk], int32,   pre-allocated output
+        topk:         number of experts to select
+        renormalize:  whether to renormalize weights to sum to 1
+        routed_scaling_factor: scale factor applied after renormalization
+        apply_routed_scaling_factor_on_output: if True, multiply weights by scale
+    """
+    module = _jit_kimi_k2_moe_fused_gate_module()
+    module.kimi_k2_moe_fused_gate(
+        input,
+        bias,
+        topk_weights,
+        topk_ids,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+
+
+def kimi_k2_moe_fused_gate(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    renormalize: bool = True,
+    routed_scaling_factor: float = 1.0,
+    apply_routed_scaling_factor_on_output: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Kimi K2 fused MoE gate with the same call signature as
+    ``sgl_kernel.kimi_k2_moe_fused_gate``.
+
+    Hard-coded for 384 experts (Kimi K2 architecture).
+
+    Args:
+        input:      [num_rows, 384], float32
+        bias:       [384], float32
+        topk:       number of experts to select (Kimi K2 uses topk=6)
+        renormalize: whether to renormalize weights to sum to 1
+        routed_scaling_factor: scale factor applied after renormalization
+        apply_routed_scaling_factor_on_output: if True, multiply weights by scale
+
+    Returns:
+        topk_weights: [num_rows, topk] float32
+        topk_ids:     [num_rows, topk] int32
+    """
+    num_rows = input.shape[0]
+    topk_weights = torch.empty(
+        (num_rows, topk), dtype=torch.float32, device=input.device
+    )
+    topk_ids = torch.empty((num_rows, topk), dtype=torch.int32, device=input.device)
+    kimi_k2_moe_fused_gate_out(
+        input,
+        bias,
+        topk_weights,
+        topk_ids,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+    return topk_weights, topk_ids

--- a/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
@@ -1,0 +1,297 @@
+"""
+Correctness tests for the kimi_k2_moe_fused_gate JIT kernel.
+
+Validates against a pure-PyTorch reference (kimi_k2_biased_topk_ref) and,
+when sgl_kernel is available, also cross-checks against the AOT implementation.
+"""
+
+import os
+
+import pytest
+import torch
+
+from sglang.jit_kernel.kimi_k2_moe_fused_gate import kimi_k2_moe_fused_gate
+
+try:
+    from sgl_kernel import kimi_k2_moe_fused_gate as kimi_k2_moe_fused_gate_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Pure-PyTorch reference
+# ---------------------------------------------------------------------------
+
+NUM_EXPERTS = 384  # Kimi K2 is hard-coded to 384 experts
+
+
+def kimi_k2_biased_topk_ref(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Pure-PyTorch reference for kimi_k2_moe_fused_gate.
+
+    Algorithm (matches kernel):
+      1. sigmoid(input) → scores
+      2. scores + bias  → biased_scores
+      3. topk on biased_scores → indices
+      4. gather scores[indices] → weights
+      5. renormalize and optionally scale
+    """
+    scores = input.sigmoid()
+    biased_scores = scores + bias.unsqueeze(0)
+
+    _, topk_ids = torch.topk(biased_scores, k=topk, dim=-1, sorted=False)
+    topk_weights = scores.gather(1, topk_ids)
+
+    if renormalize:
+        topk_weights_sum = topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights = topk_weights / topk_weights_sum
+        if apply_routed_scaling_factor_on_output:
+            topk_weights = topk_weights * routed_scaling_factor
+
+    return topk_weights.float(), topk_ids.int()
+
+
+# ---------------------------------------------------------------------------
+# CI / full-range selection
+# ---------------------------------------------------------------------------
+
+_is_ci = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+SEQ_LENGTHS_FULL = list(range(1, 10)) + [
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+]
+SEQ_LENGTHS_CI = [1, 3, 7, 64, 512, 2048]
+SEQ_LENGTHS = SEQ_LENGTHS_CI if _is_ci else SEQ_LENGTHS_FULL
+
+# ---------------------------------------------------------------------------
+# Main correctness test: JIT vs PyTorch reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_length", SEQ_LENGTHS)
+@pytest.mark.parametrize("topk", [6])  # Kimi K2 uses topk=6
+@pytest.mark.parametrize("renormalize", [True, False])
+@pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [True, False])
+def test_kimi_k2_moe_fused_gate_vs_ref(
+    seq_length,
+    topk,
+    renormalize,
+    apply_routed_scaling_factor_on_output,
+):
+    routed_scaling_factor = 2.872  # Kimi K2's scaling factor
+
+    torch.manual_seed(seq_length)
+    inp = torch.rand((seq_length, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+    jit_weights, jit_ids = kimi_k2_moe_fused_gate(
+        inp,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+    ref_weights, ref_ids = kimi_k2_biased_topk_ref(
+        inp,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+
+    # Compare sorted weights (indices may differ for ties, weights must agree)
+    assert torch.allclose(
+        jit_weights.sort(dim=-1)[0],
+        ref_weights.sort(dim=-1)[0],
+        rtol=1e-3,
+        atol=1e-4,
+    ), (
+        f"Weight mismatch: seq={seq_length}, topk={topk}, renorm={renormalize}, "
+        f"scale_out={apply_routed_scaling_factor_on_output}"
+    )
+
+    # Verify that selected indices are valid expert IDs
+    assert torch.all((jit_ids >= 0) & (jit_ids < NUM_EXPERTS)), "Expert indices out of range"
+
+
+# ---------------------------------------------------------------------------
+# Output shape and dtype checks
+# ---------------------------------------------------------------------------
+
+
+def test_output_shapes_and_dtypes():
+    seq, topk = 64, 6
+    inp = torch.rand((seq, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+    weights, ids = kimi_k2_moe_fused_gate(inp, bias, topk=topk)
+
+    assert weights.shape == (seq, topk), f"weights shape: {weights.shape}"
+    assert ids.shape == (seq, topk), f"ids shape: {ids.shape}"
+    assert weights.dtype == torch.float32, f"weights dtype: {weights.dtype}"
+    assert ids.dtype == torch.int32, f"ids dtype: {ids.dtype}"
+
+
+# ---------------------------------------------------------------------------
+# Renormalization check: weights must sum to 1 per row when renormalize=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_length", [1, 64, 512, 1024])
+def test_weights_sum_to_one_when_renormalize(seq_length):
+    topk = 6
+    inp = torch.rand((seq_length, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+    weights, _ = kimi_k2_moe_fused_gate(inp, bias, topk=topk, renormalize=True)
+    row_sums = weights.sum(dim=-1)
+    torch.testing.assert_close(
+        row_sums, torch.ones(seq_length, device="cuda"), rtol=1e-4, atol=1e-4
+    )
+
+
+# ---------------------------------------------------------------------------
+# Kernel boundary: test both sides of the small/large-token threshold (512)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_length", [511, 512, 513, 1024])
+def test_small_large_token_boundary(seq_length):
+    """Verify consistent results across the small/large-token kernel boundary."""
+    topk = 6
+    torch.manual_seed(seq_length)
+    inp = torch.rand((seq_length, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+    weights, ids = kimi_k2_moe_fused_gate(inp, bias, topk=topk, renormalize=True)
+    ref_weights, _ = kimi_k2_biased_topk_ref(
+        inp,
+        bias,
+        topk=topk,
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    assert torch.allclose(
+        weights.sort(dim=-1)[0],
+        ref_weights.sort(dim=-1)[0],
+        rtol=1e-3,
+        atol=1e-4,
+    ), f"Boundary mismatch at seq_length={seq_length}"
+
+
+# ---------------------------------------------------------------------------
+# Routed scaling factor check
+# ---------------------------------------------------------------------------
+
+
+def test_routed_scaling_factor_applied():
+    seq, topk = 32, 6
+    scale = 2.872
+    inp = torch.rand((seq, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+    weights_no_scale, _ = kimi_k2_moe_fused_gate(
+        inp,
+        bias,
+        topk=topk,
+        renormalize=True,
+        routed_scaling_factor=scale,
+        apply_routed_scaling_factor_on_output=False,
+    )
+    weights_scaled, _ = kimi_k2_moe_fused_gate(
+        inp,
+        bias,
+        topk=topk,
+        renormalize=True,
+        routed_scaling_factor=scale,
+        apply_routed_scaling_factor_on_output=True,
+    )
+
+    # scaled weights should be ≈ scale × unscaled weights
+    torch.testing.assert_close(
+        weights_scaled,
+        weights_no_scale * scale,
+        rtol=1e-4,
+        atol=1e-5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invalid input checks
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_num_experts():
+    inp = torch.rand((16, 128), dtype=torch.float32, device="cuda")  # wrong: not 384
+    bias = torch.rand(128, dtype=torch.float32, device="cuda")
+    with pytest.raises(Exception):
+        kimi_k2_moe_fused_gate(inp, bias, topk=6)
+
+
+def test_invalid_dtype():
+    inp = torch.rand((16, NUM_EXPERTS), dtype=torch.float16, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float16, device="cuda")
+    with pytest.raises(Exception):
+        kimi_k2_moe_fused_gate(inp, bias, topk=6)
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation against AOT sgl_kernel (skipped when not available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not AOT_AVAILABLE, reason="sgl_kernel not available")
+@pytest.mark.parametrize("seq_length", [1, 64, 512, 1024, 4096])
+@pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [False, True])
+def test_kimi_k2_moe_fused_gate_vs_aot(seq_length, apply_routed_scaling_factor_on_output):
+    topk = 6
+    routed_scaling_factor = 2.872
+    torch.manual_seed(seq_length)
+    inp = torch.rand((seq_length, NUM_EXPERTS), dtype=torch.float32, device="cuda")
+    bias = torch.rand(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+
+    kwargs = dict(
+        topk=topk,
+        renormalize=True,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+
+    jit_weights, jit_ids = kimi_k2_moe_fused_gate(inp, bias, **kwargs)
+    aot_weights, aot_ids = kimi_k2_moe_fused_gate_aot(inp, bias, **kwargs)
+
+    # Compare sorted (indices may differ for ties)
+    assert torch.allclose(
+        jit_weights.sort(dim=-1)[0],
+        aot_weights.sort(dim=-1)[0].float(),
+        rtol=1e-3,
+        atol=1e-4,
+    ), f"JIT vs AOT weight mismatch at seq={seq_length}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
@@ -133,7 +133,9 @@ def test_kimi_k2_moe_fused_gate_vs_ref(
     )
 
     # Verify that selected indices are valid expert IDs
-    assert torch.all((jit_ids >= 0) & (jit_ids < NUM_EXPERTS)), "Expert indices out of range"
+    assert torch.all(
+        (jit_ids >= 0) & (jit_ids < NUM_EXPERTS)
+    ), "Expert indices out of range"
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +269,9 @@ def test_invalid_dtype():
 @pytest.mark.skipif(not AOT_AVAILABLE, reason="sgl_kernel not available")
 @pytest.mark.parametrize("seq_length", [1, 64, 512, 1024, 4096])
 @pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [False, True])
-def test_kimi_k2_moe_fused_gate_vs_aot(seq_length, apply_routed_scaling_factor_on_output):
+def test_kimi_k2_moe_fused_gate_vs_aot(
+    seq_length, apply_routed_scaling_factor_on_output
+):
     topk = 6
     routed_scaling_factor = 2.872
     torch.manual_seed(seq_length)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
https://github.com/sgl-project/sglang/issues/17865
  sgl_kernel.kimi_k2_moe_fused_gate is currently only available as an AOT             
  (ahead-of-time) compiled kernel inside sgl-kernel, requiring a full sgl-kernel build
   to use. This PR migrates the kernel to the lightweight JIT kernel system           
  (python/sglang/jit_kernel/), making it available at runtime without an AOT build and
   enabling faster iteration during development.

  This kernel is on the critical path for Kimi K2 MoE routing (384 experts, topk=6).

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
```
Ports sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu into the lightweight JIT kernel
  system under python/sglang/jit_kernel/.

  Key characteristics of this kernel vs moe_fused_gate:
  - Hard-coded for 384 experts (Kimi K2 architecture), no expert grouping
  - Float32 only — no templating over dtype needed
  - Two CUDA kernel variants selected at runtime:
    - Small-token (num_rows <= 512): one CTA per row, 12 warps x 32 threads
  collaborate per row using iterative warp-level top-k reduction
    - Large-token (num_rows > 512): 6 rows per CTA with vectorised float4 loads

  Migration changes vs AOT:
  - Replace ATen / PyTorch headers with tvm-ffi TensorView
  - Replace TORCH_CHECK with RuntimeCheck (host::)
  - Replace at::cuda::getCurrentCUDAStream() with LaunchKernel::resolve_device()
  - Destination-passing kernel registered as torch custom op via @register_custom_op;
  allocating wrapper matches sgl_kernel API

  New files:
  - python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
  - python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
  - python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
  - python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
```
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
`pytest python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py -q`

<img width="895" height="130" alt="image" src="https://github.com/user-attachments/assets/13275525-498f-4cb6-bfec-b0b4ca8f05f4" />

## Benchmarking and Profiling
`python python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py`
<img width="906" height="332" alt="image" src="https://github.com/user-attachments/assets/e492ee80-487e-47e0-8dd1-fad2e4dcb344" />

  Correctness: All 6 spot-checks pass (small and large kernel paths).                    
                                                                                         
  Performance: JIT is at parity with AOT across all 12 configurations. Max deviation is  
  ~0.6%, within measurement noise.                                                       
  No regressions. The --use_fast_math fix fully closed the 7–16% gap seen before.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
