### PR TITLE
[jit_kernel] Migrate moe_topk_sigmoid from sgl-kernel AOT to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py
@@ -1,0 +1,129 @@
+"""
+Benchmark: moe_topk_sigmoid JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) across num_tokens and num_experts configurations,
+covering static-dispatch (power-of-2) and dynamic-fallback paths.
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py
+
+Output columns: num_tokens | num_experts | topk  (µs)
+"""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.moe_topk_sigmoid import topk_sigmoid as topk_sigmoid_jit
+
+try:
+    from sgl_kernel import topk_sigmoid as topk_sigmoid_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    topk_sigmoid_aot = None
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+NUM_TOKENS_RANGE = get_benchmark_range(
+    full_range=[1, 16, 64, 128, 256, 512, 1024, 2048, 4096],
+    ci_range=[64, 512, 2048],
+)
+
+# (num_experts, topk) — static dispatch + dynamic fallback
+EXPERT_CONFIGS = get_benchmark_range(
+    full_range=[
+        (64, 2),   # static: small expert count
+        (128, 4),  # static: common config
+        (256, 4),  # static: large power-of-2
+    ],
+    ci_range=[(128, 4)],
+)
+
+_configs_product = list(itertools.product(NUM_TOKENS_RANGE, EXPERT_CONFIGS))
+CONFIGS = [(nt, ne, tk) for nt, (ne, tk) in _configs_product]
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+STYLES = [("blue", "--"), ("orange", "-")] if AOT_AVAILABLE else [("blue", "--")]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark function
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_tokens", "num_experts", "topk"],
+        x_vals=CONFIGS,
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name="moe-topk-sigmoid-performance",
+        args={},
+    )
+)
+def benchmark(num_tokens: int, num_experts: int, topk: int, provider: str):
+    dtype = torch.float32
+    device = "cuda"
+
+    gating = torch.randn((num_tokens, num_experts), dtype=dtype, device=device)
+    topk_w = torch.empty((num_tokens, topk), dtype=torch.float32, device=device)
+    topk_i = torch.empty((num_tokens, topk), dtype=torch.int32, device=device)
+
+    if provider == "jit":
+        fn = lambda: topk_sigmoid_jit(topk_w, topk_i, gating)
+    elif provider == "aot":
+        fn = lambda: topk_sigmoid_aot(topk_w, topk_i, gating)
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff (JIT vs AOT):")
+    for num_tokens, num_experts, topk in [(64, 128, 4), (512, 256, 4), (1024, 64, 2)]:
+        gating = torch.randn(
+            (num_tokens, num_experts), dtype=torch.float32, device="cuda"
+        )
+        topk_w_jit = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+        topk_i_jit = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+        topk_w_aot = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+        topk_i_aot = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+
+        topk_sigmoid_jit(topk_w_jit, topk_i_jit, gating)
+        topk_sigmoid_aot(topk_w_aot, topk_i_aot, gating)
+
+        weights_match = torch.allclose(topk_w_jit, topk_w_aot, atol=1e-3, rtol=1e-3)
+        indices_match = torch.equal(topk_i_jit, topk_i_aot)
+        status = "OK" if (weights_match and indices_match) else "MISMATCH"
+        print(
+            f"  tokens={num_tokens:5d}  experts={num_experts:3d}  topk={topk}  "
+            f"weights={'✓' if weights_match else '✗'}  "
+            f"indices={'✓' if indices_match else '✗'}  [{status}]"
+        )
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py
@@ -39,7 +39,7 @@ NUM_TOKENS_RANGE = get_benchmark_range(
 # (num_experts, topk) — static dispatch + dynamic fallback
 EXPERT_CONFIGS = get_benchmark_range(
     full_range=[
-        (64, 2),   # static: small expert count
+        (64, 2),  # static: small expert count
         (128, 4),  # static: common config
         (256, 4),  # static: large power-of-2
     ],

--- a/python/sglang/jit_kernel/csrc/moe/moe_topk_sigmoid.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/moe_topk_sigmoid.cuh
@@ -1,0 +1,502 @@
+// Adapt from https://github.com/vllm-project/vllm/blob/v0.7.3/csrc/moe/topk_softmax_kernels.cu
+// which is originally adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/v0.7.1/cpp/tensorrt_llm/kernels/mixtureOfExperts/moe_kernels.cu
+#pragma once
+
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/optional.h>
+
+#include <cub/cub.cuh>
+#include <cub/util_type.cuh>
+
+// CUDA 12.9+ deprecated cub::Max/Min in favour of cuda::maximum/minimum
+#if CUDA_VERSION >= 12090
+#include <cuda/functional>
+using MaxReduceOp = cuda::maximum<>;
+using MinReduceOp = cuda::minimum<>;
+#else
+using MaxReduceOp = cub::Max;
+using MinReduceOp = cub::Min;
+#endif
+
+#include <cfloat>
+#include <cstdint>
+#include <type_traits>
+
+using tvm::ffi::TensorView;
+
+#ifndef MOE_TOPK_SIGMOID_WARP_SIZE
+#define MOE_TOPK_SIGMOID_WARP_SIZE 32
+#endif
+
+namespace {
+
+static constexpr int WARP_SIZE = MOE_TOPK_SIGMOID_WARP_SIZE;
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+// ---------------------------------------------------------------------------
+// Aligned array — avoids CUTLASS dependency; identical semantics.
+// ---------------------------------------------------------------------------
+template <typename T, int N, int Alignment = static_cast<int>(sizeof(T) * N)>
+class alignas(Alignment) AlignedArray {
+  T data[N];
+};
+
+// ---------------------------------------------------------------------------
+// Type conversion helper
+// ---------------------------------------------------------------------------
+template <typename T>
+__device__ float convert_to_float(T x) {
+  if constexpr (std::is_same_v<T, __half>) {
+    return __half2float(x);
+  } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    return __bfloat162float(x);
+  } else {
+    return static_cast<float>(x);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// moeSigmoid — fallback sigmoid kernel (used for non-power-of-2 experts)
+// ---------------------------------------------------------------------------
+template <typename T, int TPB>
+__launch_bounds__(TPB) __global__ void moeSigmoid(
+    const T* input,
+    const bool* finished,
+    float* output,
+    const int num_cols,
+    const float* correction_bias) {
+  const int thread_row_offset = blockIdx.x * num_cols;
+
+  if ((finished != nullptr) && finished[blockIdx.x]) {
+    return;
+  }
+
+  for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
+    const int idx = thread_row_offset + ii;
+    float val = convert_to_float<T>(input[idx]);
+    val = 1.0f / (1.0f + expf(-val));
+    if (correction_bias != nullptr) {
+      val = val + correction_bias[ii];
+    }
+    output[idx] = val;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// moeTopK — fallback top-k kernel (used for non-power-of-2 experts)
+// ---------------------------------------------------------------------------
+template <int TPB>
+__launch_bounds__(TPB) __global__ void moeTopK(
+    const float* inputs_after_sigmoid,
+    const bool* finished,
+    float* output,
+    int* indices,
+    const int num_experts,
+    const int k,
+    const int start_expert,
+    const int end_expert,
+    const bool renormalize,
+    const float* correction_bias) {
+  using cub_kvp = cub::KeyValuePair<int, float>;
+  using BlockReduce = cub::BlockReduce<cub_kvp, TPB>;
+  __shared__ typename BlockReduce::TempStorage tmpStorage;
+
+  cub_kvp thread_kvp;
+  cub::ArgMax arg_max;
+
+  const int block_row = blockIdx.x;
+  const bool row_is_active = finished ? !finished[block_row] : true;
+  const int thread_read_offset = blockIdx.x * num_experts;
+  float row_sum_for_renormalize = 0;
+
+  for (int k_idx = 0; k_idx < k; ++k_idx) {
+    thread_kvp.key = 0;
+    thread_kvp.value = -1.f;
+
+    cub_kvp inp_kvp;
+    for (int expert = threadIdx.x; expert < num_experts; expert += TPB) {
+      const int idx = thread_read_offset + expert;
+      inp_kvp.key = expert;
+      inp_kvp.value = inputs_after_sigmoid[idx];
+
+      for (int prior_k = 0; prior_k < k_idx; ++prior_k) {
+        const int prior_winning_expert = indices[k * block_row + prior_k];
+        if (prior_winning_expert == expert) {
+          inp_kvp = thread_kvp;
+        }
+      }
+
+      thread_kvp = arg_max(inp_kvp, thread_kvp);
+    }
+
+    const cub_kvp result_kvp = BlockReduce(tmpStorage).Reduce(thread_kvp, arg_max);
+    if (threadIdx.x == 0) {
+      const int expert = result_kvp.key;
+      const bool node_uses_expert = expert >= start_expert && expert < end_expert;
+      const bool should_process_row = row_is_active && node_uses_expert;
+
+      const int idx = k * block_row + k_idx;
+      float val = result_kvp.value;
+      if (correction_bias != nullptr) {
+        val -= correction_bias[expert];
+      }
+      output[idx] = val;
+      indices[idx] = should_process_row ? (expert - start_expert) : num_experts;
+      assert(indices[idx] >= 0);
+      row_sum_for_renormalize += val;
+    }
+    __syncthreads();
+  }
+
+  if (renormalize && threadIdx.x == 0) {
+    float row_sum_for_renormalize_inv = 1.f / row_sum_for_renormalize;
+    for (int k_idx = 0; k_idx < k; ++k_idx) {
+      const int idx = k * block_row + k_idx;
+      output[idx] = output[idx] * row_sum_for_renormalize_inv;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// topkGatingSigmoid — optimised kernel for power-of-2 expert counts
+// ---------------------------------------------------------------------------
+template <typename T, int VPT, int NUM_EXPERTS, int WARPS_PER_CTA, int BYTES_PER_LDG>
+__launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__ void topkGatingSigmoid(
+    const T* input,
+    const bool* finished,
+    float* output,
+    const int num_rows,
+    int* indices,
+    const int k,
+    const int start_expert,
+    const int end_expert,
+    const bool renormalize,
+    const float* correction_bias) {
+  static_assert(VPT == (VPT & -VPT), "VPT must be power of 2");
+  static_assert(NUM_EXPERTS == (NUM_EXPERTS & -NUM_EXPERTS), "NUM_EXPERTS must be power of 2");
+  static_assert(BYTES_PER_LDG == (BYTES_PER_LDG & -BYTES_PER_LDG), "BYTES_PER_LDG must be power of 2");
+  static_assert(BYTES_PER_LDG <= 16, "BYTES_PER_LDG must be leq 16");
+
+  static constexpr int ELTS_PER_LDG = BYTES_PER_LDG / sizeof(T);
+  static constexpr int ELTS_PER_ROW = NUM_EXPERTS;
+  static constexpr int THREADS_PER_ROW = ELTS_PER_ROW / VPT;
+  static constexpr int LDG_PER_THREAD = VPT / ELTS_PER_LDG;
+
+  static_assert(VPT % ELTS_PER_LDG == 0, "");
+  static_assert(WARP_SIZE % THREADS_PER_ROW == 0, "");
+  static_assert(THREADS_PER_ROW == (THREADS_PER_ROW & -THREADS_PER_ROW), "");
+  static_assert(THREADS_PER_ROW <= WARP_SIZE, "");
+
+  static constexpr int ELTS_PER_WARP = WARP_SIZE * VPT;
+  static constexpr int ROWS_PER_WARP = ELTS_PER_WARP / ELTS_PER_ROW;
+  static constexpr int ROWS_PER_CTA = WARPS_PER_CTA * ROWS_PER_WARP;
+
+  static_assert(ELTS_PER_WARP % ELTS_PER_ROW == 0, "");
+
+  const int cta_base_row = blockIdx.x * ROWS_PER_CTA;
+  const int warp_base_row = cta_base_row + threadIdx.y * ROWS_PER_WARP;
+  const int thread_row_in_warp = threadIdx.x / THREADS_PER_ROW;
+  const int thread_row = warp_base_row + thread_row_in_warp;
+
+  if (thread_row >= num_rows) {
+    return;
+  }
+  const bool row_is_active = finished ? !finished[thread_row] : true;
+
+  const T* thread_row_ptr = input + thread_row * ELTS_PER_ROW;
+  const int thread_group_idx = threadIdx.x % THREADS_PER_ROW;
+  const int first_elt_read_by_thread = thread_group_idx * ELTS_PER_LDG;
+  const T* thread_read_ptr = thread_row_ptr + first_elt_read_by_thread;
+
+  using AccessType = AlignedArray<T, ELTS_PER_LDG>;
+
+  T row_chunk_temp[VPT];
+  AccessType* row_chunk_vec_ptr = reinterpret_cast<AccessType*>(&row_chunk_temp);
+  const AccessType* vec_thread_read_ptr = reinterpret_cast<const AccessType*>(thread_read_ptr);
+#pragma unroll
+  for (int ii = 0; ii < LDG_PER_THREAD; ++ii) {
+    row_chunk_vec_ptr[ii] = vec_thread_read_ptr[ii * THREADS_PER_ROW];
+  }
+
+  float row_chunk[VPT];
+#pragma unroll
+  for (int ii = 0; ii < VPT; ++ii) {
+    float val = convert_to_float<T>(row_chunk_temp[ii]);
+    val = 1.0f / (1.0f + expf(-val));
+    if (correction_bias != nullptr) {
+      const int group_id = ii / ELTS_PER_LDG;
+      const int local_id = ii % ELTS_PER_LDG;
+      const int expert_idx =
+          first_elt_read_by_thread + group_id * THREADS_PER_ROW * ELTS_PER_LDG + local_id;
+      val = val + correction_bias[expert_idx];
+    }
+    row_chunk[ii] = val;
+  }
+
+  int start_col = first_elt_read_by_thread;
+  static constexpr int COLS_PER_GROUP_LDG = ELTS_PER_LDG * THREADS_PER_ROW;
+
+  float row_sum_for_renormalize = 0;
+
+  for (int k_idx = 0; k_idx < k; ++k_idx) {
+    float max_val = row_chunk[0];
+    int expert = start_col;
+#pragma unroll
+    for (int ldg = 0, col = start_col; ldg < LDG_PER_THREAD; ++ldg, col += COLS_PER_GROUP_LDG) {
+#pragma unroll
+      for (int ii = 0; ii < ELTS_PER_LDG; ++ii) {
+        float val = row_chunk[ldg * ELTS_PER_LDG + ii];
+        if (val > max_val) {
+          max_val = val;
+          expert = col + ii;
+        }
+      }
+    }
+
+#pragma unroll
+    for (int mask = THREADS_PER_ROW / 2; mask > 0; mask /= 2) {
+      float other_max = __shfl_xor_sync(0xffffffff, max_val, mask, THREADS_PER_ROW);
+      int other_expert = __shfl_xor_sync(0xffffffff, expert, mask, THREADS_PER_ROW);
+      if (other_max > max_val || (other_max == max_val && other_expert < expert)) {
+        max_val = other_max;
+        expert = other_expert;
+      }
+    }
+
+    if (thread_group_idx == 0) {
+      const bool node_uses_expert = expert >= start_expert && expert < end_expert;
+      const bool should_process_row = row_is_active && node_uses_expert;
+
+      const int idx = k * thread_row + k_idx;
+      if (correction_bias != nullptr) {
+        max_val -= correction_bias[expert];
+      }
+      output[idx] = max_val;
+      indices[idx] = should_process_row ? (expert - start_expert) : NUM_EXPERTS;
+      row_sum_for_renormalize += max_val;
+    }
+
+    if (k_idx + 1 < k) {
+      const int ldg_group_for_expert = expert / COLS_PER_GROUP_LDG;
+      const int thread_to_clear_in_group = (expert / ELTS_PER_LDG) % THREADS_PER_ROW;
+      if (thread_group_idx == thread_to_clear_in_group) {
+        const int offset_for_expert = expert % ELTS_PER_LDG;
+        row_chunk[ldg_group_for_expert * ELTS_PER_LDG + offset_for_expert] = -10000.f;
+      }
+    }
+  }
+
+  if (renormalize && thread_group_idx == 0) {
+    float row_sum_for_renormalize_inv = 1.f / row_sum_for_renormalize;
+#pragma unroll
+    for (int k_idx = 0; k_idx < k; ++k_idx) {
+      const int idx = k * thread_row + k_idx;
+      output[idx] = output[idx] * row_sum_for_renormalize_inv;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time constants helper
+// ---------------------------------------------------------------------------
+namespace detail {
+template <typename T, int EXPERTS, int BYTES_PER_LDG>
+struct TopkConstants {
+  static constexpr int ELTS_PER_LDG = BYTES_PER_LDG / sizeof(T);
+  static_assert(
+      EXPERTS / (ELTS_PER_LDG * WARP_SIZE) == 0 || EXPERTS % (ELTS_PER_LDG * WARP_SIZE) == 0, "");
+  static constexpr int VECs_PER_THREAD = MAX(1, EXPERTS / (ELTS_PER_LDG * WARP_SIZE));
+  static constexpr int VPT = VECs_PER_THREAD * ELTS_PER_LDG;
+  static constexpr int THREADS_PER_ROW = EXPERTS / VPT;
+  static constexpr int ROWS_PER_WARP = WARP_SIZE / THREADS_PER_ROW;
+};
+}  // namespace detail
+
+// ---------------------------------------------------------------------------
+// Per-expert-count launcher helper
+// ---------------------------------------------------------------------------
+template <typename T, int EXPERTS, int WARPS_PER_TB>
+void topkGatingSigmoidLauncherHelper(
+    const T* input,
+    const bool* finished,
+    float* output,
+    int* indices,
+    const int num_rows,
+    const int k,
+    const int start_expert,
+    const int end_expert,
+    const bool renormalize,
+    const float* correction_bias,
+    cudaStream_t stream) {
+  static constexpr std::size_t MAX_BYTES_PER_LDG = 16;
+  static constexpr int BYTES_PER_LDG = MIN(MAX_BYTES_PER_LDG, sizeof(T) * EXPERTS);
+  using Constants = detail::TopkConstants<T, EXPERTS, BYTES_PER_LDG>;
+  static constexpr int VPT = Constants::VPT;
+  static constexpr int ROWS_PER_WARP = Constants::ROWS_PER_WARP;
+  const int num_warps = (num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
+  const int num_blocks = (num_warps + WARPS_PER_TB - 1) / WARPS_PER_TB;
+
+  dim3 block_dim(WARP_SIZE, WARPS_PER_TB);
+  topkGatingSigmoid<T, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG>
+      <<<num_blocks, block_dim, 0, stream>>>(
+          input, finished, output, num_rows, indices, k, start_expert, end_expert,
+          renormalize, correction_bias);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch macro — used inside topkGatingSigmoidKernelLauncher
+// ---------------------------------------------------------------------------
+#define LAUNCH_SIGMOID(TYPE, NUM_EXPERTS, WARPS_PER_TB)       \
+  topkGatingSigmoidLauncherHelper<TYPE, NUM_EXPERTS, WARPS_PER_TB>( \
+      gating_output,                                          \
+      nullptr,                                                \
+      topk_weights,                                           \
+      topk_indices,                                           \
+      num_tokens,                                             \
+      topk,                                                   \
+      0,                                                      \
+      num_experts,                                            \
+      renormalize,                                            \
+      correction_bias,                                        \
+      stream)
+
+// ---------------------------------------------------------------------------
+// Main launcher: dispatches on num_experts
+// ---------------------------------------------------------------------------
+template <typename T>
+void topkGatingSigmoidKernelLauncher(
+    const T* gating_output,
+    float* topk_weights,
+    int* topk_indices,
+    float* sigmoid_workspace,
+    const int num_tokens,
+    const int num_experts,
+    const int topk,
+    const bool renormalize,
+    const float* correction_bias,
+    cudaStream_t stream) {
+  static constexpr int WARPS_PER_TB = 4;
+  switch (num_experts) {
+    case 1:
+      LAUNCH_SIGMOID(T, 1, WARPS_PER_TB);
+      break;
+    case 2:
+      LAUNCH_SIGMOID(T, 2, WARPS_PER_TB);
+      break;
+    case 4:
+      LAUNCH_SIGMOID(T, 4, WARPS_PER_TB);
+      break;
+    case 8:
+      LAUNCH_SIGMOID(T, 8, WARPS_PER_TB);
+      break;
+    case 16:
+      LAUNCH_SIGMOID(T, 16, WARPS_PER_TB);
+      break;
+    case 32:
+      LAUNCH_SIGMOID(T, 32, WARPS_PER_TB);
+      break;
+    case 64:
+      LAUNCH_SIGMOID(T, 64, WARPS_PER_TB);
+      break;
+    case 128:
+      LAUNCH_SIGMOID(T, 128, WARPS_PER_TB);
+      break;
+    case 256:
+      LAUNCH_SIGMOID(T, 256, WARPS_PER_TB);
+      break;
+    default: {
+      // Fallback: non-power-of-2 or >256 experts
+      using namespace host;
+      RuntimeCheck(
+          sigmoid_workspace != nullptr,
+          "sigmoid_workspace must be provided for num_experts that are not a power of 2");
+      static constexpr int TPB = 256;
+      moeSigmoid<T, TPB>
+          <<<num_tokens, TPB, 0, stream>>>(gating_output, nullptr, sigmoid_workspace, num_experts, correction_bias);
+      moeTopK<TPB><<<num_tokens, TPB, 0, stream>>>(
+          sigmoid_workspace,
+          nullptr,
+          topk_weights,
+          topk_indices,
+          num_experts,
+          topk,
+          0,
+          num_experts,
+          renormalize,
+          correction_bias);
+    }
+  }
+}
+
+#undef LAUNCH_SIGMOID
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Host launcher (tvm-ffi interface)
+// ---------------------------------------------------------------------------
+template <typename T>
+void topk_sigmoid(
+    TensorView gating_output,
+    TensorView topk_weights,
+    TensorView topk_ids,
+    TensorView workspace,
+    bool renormalize,
+    tvm::ffi::Optional<TensorView> correction_bias) {
+  using namespace host;
+
+  // --- Input validation ---
+  RuntimeCheck(gating_output.dim() == 2, "gating_output must be 2-D");
+  RuntimeCheck(topk_weights.dim() == 2, "topk_weights must be 2-D");
+  RuntimeCheck(topk_ids.dim() == 2, "topk_ids must be 2-D");
+
+  const int64_t num_tokens = gating_output.shape()[0];
+  const int64_t num_experts = gating_output.shape()[1];
+  const int64_t topk = topk_weights.shape()[1];
+
+  RuntimeCheck(
+      topk_weights.shape()[0] == num_tokens && topk_ids.shape()[0] == num_tokens,
+      "topk_weights and topk_ids must have num_tokens rows");
+  RuntimeCheck(topk_ids.shape()[1] == topk, "topk_ids second dim must match topk_weights");
+  RuntimeCheck(topk <= num_experts, "topk must be <= num_experts");
+
+  // correction_bias validation
+  if (correction_bias.has_value()) {
+    const auto& bias = correction_bias.value();
+    RuntimeCheck(bias.dim() == 1, "correction_bias must be 1-D");
+    RuntimeCheck(bias.shape()[0] == num_experts, "correction_bias size must equal num_experts");
+    RuntimeCheck(
+        bias.dtype().code == DLDataTypeCode::kDLFloat && bias.dtype().bits == 32,
+        "correction_bias must be float32");
+  }
+
+  const T* gating_ptr = static_cast<const T*>(gating_output.data_ptr());
+  float* weights_ptr = static_cast<float*>(topk_weights.data_ptr());
+  int* indices_ptr = static_cast<int*>(topk_ids.data_ptr());
+  float* workspace_ptr = static_cast<float*>(workspace.data_ptr());
+  const float* bias_ptr =
+      correction_bias.has_value()
+          ? static_cast<const float*>(correction_bias.value().data_ptr())
+          : nullptr;
+
+  cudaStream_t stream = LaunchKernel::resolve_device(gating_output.device());
+
+  topkGatingSigmoidKernelLauncher<T>(
+      gating_ptr,
+      weights_ptr,
+      indices_ptr,
+      workspace_ptr,
+      static_cast<int>(num_tokens),
+      static_cast<int>(num_experts),
+      static_cast<int>(topk),
+      renormalize,
+      bias_ptr,
+      stream);
+}

--- a/python/sglang/jit_kernel/moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/moe_topk_sigmoid.py
@@ -81,7 +81,9 @@ def topk_sigmoid(
     is_pow2 = num_experts != 0 and (num_experts & (num_experts - 1)) == 0
     needs_workspace = not is_pow2 or num_experts > 256
     workspace_size = num_tokens * num_experts if needs_workspace else 1
-    workspace = torch.empty(workspace_size, dtype=torch.float32, device=gating_output.device)
+    workspace = torch.empty(
+        workspace_size, dtype=torch.float32, device=gating_output.device
+    )
 
     moe_topk_sigmoid_out(
         gating_output,

--- a/python/sglang/jit_kernel/moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/moe_topk_sigmoid.py
@@ -19,6 +19,7 @@ def _jit_moe_topk_sigmoid_module(dtype: torch.dtype) -> Module:
         *args,
         cuda_files=["moe/moe_topk_sigmoid.cuh"],
         cuda_wrappers=[("topk_sigmoid", f"topk_sigmoid<{args}>")],
+        extra_cuda_cflags=["--use_fast_math"],
     )
 
 

--- a/python/sglang/jit_kernel/moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/moe_topk_sigmoid.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_moe_topk_sigmoid_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "moe_topk_sigmoid",
+        *args,
+        cuda_files=["moe/moe_topk_sigmoid.cuh"],
+        cuda_wrappers=[("topk_sigmoid", f"topk_sigmoid<{args}>")],
+    )
+
+
+@register_custom_op(
+    op_name="moe_topk_sigmoid_out",
+    mutates_args=["topk_weights", "topk_ids"],
+)
+def moe_topk_sigmoid_out(
+    gating_output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    workspace: torch.Tensor,
+    renormalize: bool,
+    correction_bias: Optional[torch.Tensor],
+) -> None:
+    """
+    Fused sigmoid top-k MoE gate (destination-passing style).
+
+    Args:
+        gating_output: [num_tokens, num_experts], fp32/fp16/bf16
+        topk_weights:  [num_tokens, topk], float32, pre-allocated output
+        topk_ids:      [num_tokens, topk], int32,   pre-allocated output
+        workspace:     [num_tokens * num_experts] float32 scratch (may be size 1
+                       when num_experts is a supported power-of-2 ≤ 256)
+        renormalize:   whether to renormalize weights to sum to 1 per row
+        correction_bias: [num_experts] float32 per-expert bias, or None
+    """
+    module = _jit_moe_topk_sigmoid_module(gating_output.dtype)
+    module.topk_sigmoid(
+        gating_output,
+        topk_weights,
+        topk_ids,
+        workspace,
+        renormalize,
+        correction_bias,
+    )
+
+
+def topk_sigmoid(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    correction_bias: Optional[torch.Tensor] = None,
+) -> None:
+    """
+    Fused sigmoid top-k MoE gate with the same call signature as
+    ``sgl_kernel.topk_sigmoid`` (destination-passing, in-place).
+
+    Args:
+        topk_weights:  [num_tokens, topk] float32, written in-place
+        topk_ids:      [num_tokens, topk] int32,   written in-place
+        gating_output: [num_tokens, num_experts] fp32/fp16/bf16
+        renormalize:   whether to renormalize weights to sum to 1 per row
+        correction_bias: [num_experts] float32 per-expert bias, or None
+    """
+    num_tokens = gating_output.shape[0]
+    num_experts = gating_output.shape[1]
+
+    is_pow2 = num_experts != 0 and (num_experts & (num_experts - 1)) == 0
+    needs_workspace = not is_pow2 or num_experts > 256
+    workspace_size = num_tokens * num_experts if needs_workspace else 1
+    workspace = torch.empty(workspace_size, dtype=torch.float32, device=gating_output.device)
+
+    moe_topk_sigmoid_out(
+        gating_output,
+        topk_weights,
+        topk_ids,
+        workspace,
+        renormalize,
+        correction_bias,
+    )

--- a/python/sglang/jit_kernel/tests/test_moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/tests/test_moe_topk_sigmoid.py
@@ -106,9 +106,9 @@ def test_topk_sigmoid_vs_ref(num_tokens, num_experts, topk, dtype, renormalize):
     ), f"Weight mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk}, renorm={renormalize})"
     # Exact index match is only reliable for float32 (fp16/bf16 tie-breaking may differ)
     if dtype == torch.float32:
-        assert torch.equal(topk_i, ref_i), (
-            f"Index mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
-        )
+        assert torch.equal(
+            topk_i, ref_i
+        ), f"Index mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
 
 
 # ---------------------------------------------------------------------------
@@ -138,9 +138,9 @@ def test_topk_sigmoid_with_correction_bias(num_tokens, num_experts, topk, renorm
     assert torch.allclose(
         topk_w, ref_w, atol=1e-3, rtol=1e-3
     ), f"Weight mismatch with bias (n_exp={num_experts}, topk={topk}, renorm={renormalize})"
-    assert torch.equal(topk_i, ref_i), (
-        f"Index mismatch with bias (n_exp={num_experts}, topk={topk})"
-    )
+    assert torch.equal(
+        topk_i, ref_i
+    ), f"Index mismatch with bias (n_exp={num_experts}, topk={topk})"
 
 
 # ---------------------------------------------------------------------------
@@ -228,9 +228,9 @@ def test_topk_sigmoid_vs_aot(num_tokens, num_experts, topk, dtype, renormalize):
     assert torch.allclose(
         topk_w_jit, topk_w_aot, atol=1e-3, rtol=1e-3
     ), f"JIT vs AOT weight mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
-    assert torch.equal(topk_i_jit, topk_i_aot), (
-        f"JIT vs AOT index mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
-    )
+    assert torch.equal(
+        topk_i_jit, topk_i_aot
+    ), f"JIT vs AOT index mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
 
 
 if __name__ == "__main__":

--- a/python/sglang/jit_kernel/tests/test_moe_topk_sigmoid.py
+++ b/python/sglang/jit_kernel/tests/test_moe_topk_sigmoid.py
@@ -1,0 +1,237 @@
+"""
+Correctness tests for the moe_topk_sigmoid JIT kernel.
+
+Validates against a pure-PyTorch reference and, when sgl_kernel is available,
+cross-checks against the AOT implementation.
+"""
+
+import itertools
+import os
+
+import pytest
+import torch
+
+from sglang.jit_kernel.moe_topk_sigmoid import topk_sigmoid
+
+try:
+    from sgl_kernel import topk_sigmoid as topk_sigmoid_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# CI / full-range helpers
+# ---------------------------------------------------------------------------
+
+_is_ci = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+# Power-of-2 configs covered by static dispatch (num_experts 1–256)
+# Plus 48 (non-power-of-2) to exercise the fallback path
+NUM_TOKENS_FULL = [1, 16, 128, 512, 1024, 2048]
+NUM_TOKENS_CI = [1, 128, 1024]
+
+NUM_EXPERTS_FULL = [4, 8, 16, 32, 64, 128, 256, 48]  # 48 = fallback path
+NUM_EXPERTS_CI = [8, 64, 48]
+
+TOPK_FULL = [1, 2, 4]
+TOPK_CI = [1, 4]
+
+DTYPES_FULL = [torch.float32, torch.float16, torch.bfloat16]
+DTYPES_CI = [torch.float32, torch.bfloat16]
+
+NUM_TOKENS = NUM_TOKENS_CI if _is_ci else NUM_TOKENS_FULL
+NUM_EXPERTS = NUM_EXPERTS_CI if _is_ci else NUM_EXPERTS_FULL
+TOPK_LIST = TOPK_CI if _is_ci else TOPK_FULL
+DTYPES = DTYPES_CI if _is_ci else DTYPES_FULL
+
+
+# ---------------------------------------------------------------------------
+# Pure-PyTorch reference
+# ---------------------------------------------------------------------------
+
+
+def topk_sigmoid_ref(
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    correction_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reference: sigmoid → (add bias) → topk → (renormalize).
+    Indices are selected on biased scores; weights are the unbiased sigmoid values.
+    """
+    scores = gating_output.float().sigmoid()
+    biased = scores if correction_bias is None else scores + correction_bias.float()
+    _, ref_ids = torch.topk(biased, k=topk, dim=-1)
+    ref_weights = scores.gather(1, ref_ids)
+    if renormalize:
+        ref_weights = ref_weights / ref_weights.sum(dim=-1, keepdim=True)
+    return ref_weights.float(), ref_ids.int()
+
+
+# ---------------------------------------------------------------------------
+# Correctness: JIT vs PyTorch reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, topk",
+    list(itertools.product(NUM_TOKENS, NUM_EXPERTS, TOPK_LIST)),
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_topk_sigmoid_vs_ref(num_tokens, num_experts, topk, dtype, renormalize):
+    if topk > num_experts:
+        pytest.skip("topk > num_experts")
+
+    torch.manual_seed(num_tokens * num_experts)
+    gating = torch.randn((num_tokens, num_experts), dtype=dtype, device="cuda")
+
+    topk_w = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid(topk_w, topk_i, gating, renormalize=renormalize)
+
+    ref_w, ref_i = topk_sigmoid_ref(gating, topk, renormalize, correction_bias=None)
+
+    # Compare sorted weights (indices may differ for ties when dtype != float32)
+    assert torch.allclose(
+        topk_w.sort(dim=-1)[0],
+        ref_w.sort(dim=-1)[0],
+        atol=1e-3,
+        rtol=1e-3,
+    ), f"Weight mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk}, renorm={renormalize})"
+    # Exact index match is only reliable for float32 (fp16/bf16 tie-breaking may differ)
+    if dtype == torch.float32:
+        assert torch.equal(topk_i, ref_i), (
+            f"Index mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Correctness: with correction_bias
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, topk",
+    list(itertools.product(NUM_TOKENS, NUM_EXPERTS, TOPK_LIST)),
+)
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_topk_sigmoid_with_correction_bias(num_tokens, num_experts, topk, renormalize):
+    if topk > num_experts:
+        pytest.skip("topk > num_experts")
+
+    torch.manual_seed(num_tokens + num_experts)
+    gating = torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda")
+    bias = torch.randn(num_experts, dtype=torch.float32, device="cuda")
+
+    topk_w = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid(topk_w, topk_i, gating, renormalize=renormalize, correction_bias=bias)
+
+    ref_w, ref_i = topk_sigmoid_ref(gating, topk, renormalize, correction_bias=bias)
+
+    assert torch.allclose(
+        topk_w, ref_w, atol=1e-3, rtol=1e-3
+    ), f"Weight mismatch with bias (n_exp={num_experts}, topk={topk}, renorm={renormalize})"
+    assert torch.equal(topk_i, ref_i), (
+        f"Index mismatch with bias (n_exp={num_experts}, topk={topk})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Renormalization: weights should sum to 1 per row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_tokens, num_experts, topk", [(128, 64, 4), (1, 8, 2)])
+def test_renormalize_sums_to_one(num_tokens, num_experts, topk):
+    gating = torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda")
+    topk_w = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid(topk_w, topk_i, gating, renormalize=True)
+    row_sums = topk_w.sum(dim=-1)
+    torch.testing.assert_close(
+        row_sums, torch.ones(num_tokens, device="cuda"), rtol=1e-4, atol=1e-4
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output shape and dtype
+# ---------------------------------------------------------------------------
+
+
+def test_output_shapes_and_dtypes():
+    num_tokens, num_experts, topk = 64, 128, 4
+    gating = torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda")
+    topk_w = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid(topk_w, topk_i, gating)
+
+    assert topk_w.shape == (num_tokens, topk)
+    assert topk_i.shape == (num_tokens, topk)
+    assert topk_w.dtype == torch.float32
+    assert topk_i.dtype == torch.int32
+
+
+# ---------------------------------------------------------------------------
+# Fallback path (non-power-of-2 experts)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_experts", [48, 96])
+def test_fallback_non_power_of_two(num_experts):
+    num_tokens, topk = 64, 2
+    gating = torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda")
+    topk_w = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid(topk_w, topk_i, gating, renormalize=True)
+
+    # Weights should be positive and sum to 1
+    assert torch.all(topk_w > 0)
+    torch.testing.assert_close(
+        topk_w.sum(dim=-1), torch.ones(num_tokens, device="cuda"), rtol=1e-4, atol=1e-4
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation against AOT sgl_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not AOT_AVAILABLE, reason="sgl_kernel not available")
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, topk",
+    list(itertools.product([1, 128, 1024], [8, 64, 128], [1, 4])),
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_topk_sigmoid_vs_aot(num_tokens, num_experts, topk, dtype, renormalize):
+    if topk > num_experts:
+        pytest.skip("topk > num_experts")
+
+    torch.manual_seed(42)
+    gating = torch.randn((num_tokens, num_experts), dtype=dtype, device="cuda")
+
+    topk_w_jit = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i_jit = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid(topk_w_jit, topk_i_jit, gating, renormalize=renormalize)
+
+    topk_w_aot = torch.empty((num_tokens, topk), dtype=torch.float32, device="cuda")
+    topk_i_aot = torch.empty((num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_sigmoid_aot(topk_w_aot, topk_i_aot, gating, renormalize=renormalize)
+
+    assert torch.allclose(
+        topk_w_jit, topk_w_aot, atol=1e-3, rtol=1e-3
+    ), f"JIT vs AOT weight mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
+    assert torch.equal(topk_i_jit, topk_i_aot), (
+        f"JIT vs AOT index mismatch (dtype={dtype}, n_exp={num_experts}, topk={topk})"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -805,6 +805,7 @@ class _RpcBroadcastBase:
     def __init__(self, handles: List[_ZmqRpcHandle]):
         self._handles = handles
 
+
 class _LocalOnlyBroadcast(_RpcBroadcastBase):
     """Calls methods directly on the local dumper, wrapping the result in a list."""
 


### PR DESCRIPTION
## Motivation
https://github.com/sgl-project/sglang/issues/17865
sgl_kernel.topk_sigmoid is currently only available as an AOT (ahead-of-time) compiled kernel inside sgl-kernel,       requiring a full sgl-kernel build to use. This PR migrates the kernel to the lightweight JIT kernel system               (python/sglang/jit_kernel/), making it available at runtime without an AOT build and enabling faster iteration during development.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications
  Ports sgl-kernel/csrc/moe/moe_topk_sigmoid_kernels.cu into the lightweight JIT kernel system under
  python/sglang/jit_kernel/.

  Key characteristics:
  - Supports fp32, fp16, bf16 via template T (one JIT module compiled per dtype)
  - Static dispatch for power-of-2 expert counts (1–256) using the optimised warp-shuffle topkGatingSigmoid kernel
  - Fallback path for non-power-of-2 or >256 experts via moeSigmoid + moeTopK (uses CUB BlockReduce, which ships with CUDA
  — no extra dependency)
  - Optional correction_bias support (float32, per-expert)
  - Optional renormalization fused into the kernel
  - Destination-passing API matching sgl_kernel.topk_sigmoid exactly

  Migration changes vs AOT:
  - Replace ATen/PyTorch headers with tvm-ffi TensorView
  - Replace TORCH_CHECK with RuntimeCheck (host::)
  - Replace SGLANG_SHFL_XOR_SYNC_WIDTH macro with __shfl_xor_sync directly
  - Replace at::cuda::getCurrentCUDAStream() with LaunchKernel::resolve_device()
  - correction_bias passed as tvm::ffi::Optional<TensorView>
  - sigmoid_workspace allocated in Python wrapper, passed as TensorView

  New files:
  - python/sglang/jit_kernel/csrc/moe/moe_topk_sigmoid.cuh
  - python/sglang/jit_kernel/moe_topk_sigmoid.py
  - python/sglang/jit_kernel/tests/test_moe_topk_sigmoid.py
  - python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py
  
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
  Correctness is validated against a pure-PyTorch reference (sigmoid → topk → renormalize) across all combinations of:

  - dtypes: float32, float16, bfloat16
  - num_experts: 4, 8, 16, 32, 64, 128, 256 (static dispatch) + 48, 96 (fallback path)
  - num_tokens: 1, 16, 128, 512, 1024, 2048
  - topk: 1, 2, 4
  - renormalize: True, False
  - correction_bias: with and without

  All 1229 test cases pass. Cross-validation against sgl_kernel.topk_sigmoid (AOT) passes on all spot-checked configs
  (weights ✓, indices ✓).

  pytest python/sglang/jit_kernel/tests/test_moe_topk_sigmoid.py -q
  1229 passed in 5.33s

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
  Benchmark: python python/sglang/jit_kernel/benchmark/bench_moe_topk_sigmoid.py

<img width="870" height="493" alt="image" src="https://github.com/user-attachments/assets/db76daed-a07c-4900-917f-3345858d166b" />
  Performance: JIT is at parity with AOT across all 27 configurations. Max deviation is ~0.3%, within measurement noise.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
