### PR TITLE
Migrate moe_sum_reduce from sgl-kernel AOT to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_moe_sum_reduce.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_sum_reduce.py
@@ -1,0 +1,122 @@
+"""
+Benchmark: moe_sum_reduce JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) across num_tokens × hidden_dim configurations,
+covering the BF16 vectorized fast path and the general warp-per-token path.
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_moe_sum_reduce.py
+
+Output columns: num_tokens | hidden_dim | topk  (µs)
+"""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.moe_sum_reduce import moe_sum_reduce as moe_sum_reduce_jit
+
+try:
+    from sgl_kernel import moe_sum_reduce as moe_sum_reduce_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    moe_sum_reduce_aot = None
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+NUM_TOKENS_RANGE = get_benchmark_range(
+    full_range=[1, 64, 128, 256, 512, 1024, 2048, 4096],
+    ci_range=[64, 512, 2048],
+)
+
+# (hidden_dim, topk)
+CONFIGS_EXPERT = get_benchmark_range(
+    full_range=[
+        (4096, 4),   # common: 4k hidden, topk=4
+        (7168, 8),   # DeepSeek-style: 7k hidden, topk=8
+        (2048, 2),   # smaller hidden
+    ],
+    ci_range=[(4096, 4)],
+)
+
+_configs_product = list(itertools.product(NUM_TOKENS_RANGE, CONFIGS_EXPERT))
+CONFIGS = [(nt, hd, tk) for nt, (hd, tk) in _configs_product]
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+STYLES = [("blue", "--"), ("orange", "-")] if AOT_AVAILABLE else [("blue", "--")]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark function
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["num_tokens", "hidden_dim", "topk"],
+        x_vals=CONFIGS,
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name="moe-sum-reduce-performance",
+        args={},
+    )
+)
+def benchmark(num_tokens: int, hidden_dim: int, topk: int, provider: str):
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    x = torch.randn((num_tokens, topk, hidden_dim), dtype=dtype, device=device)
+    out = torch.empty((num_tokens, hidden_dim), dtype=dtype, device=device)
+
+    if provider == "jit":
+        fn = lambda: moe_sum_reduce_jit(x, out, 1.0)
+    elif provider == "aot":
+        fn = lambda: moe_sum_reduce_aot(x, out, 1.0)
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff (JIT vs AOT):")
+    for num_tokens, hidden_dim, topk in [(64, 4096, 4), (512, 7168, 8), (1024, 2048, 2)]:
+        x = torch.randn((num_tokens, topk, hidden_dim), dtype=torch.bfloat16, device="cuda")
+        out_jit = torch.empty((num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda")
+        out_aot = torch.empty((num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda")
+
+        moe_sum_reduce_jit(x, out_jit, 1.0)
+        moe_sum_reduce_aot(x, out_aot, 1.0)
+
+        match = torch.allclose(out_jit, out_aot, atol=1e-2, rtol=1e-3)
+        status = "OK" if match else "MISMATCH"
+        print(
+            f"  tokens={num_tokens:5d}  hidden={hidden_dim:5d}  topk={topk}  "
+            f"output={'✓' if match else '✗'}  [{status}]"
+        )
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_moe_sum_reduce.py
+++ b/python/sglang/jit_kernel/benchmark/bench_moe_sum_reduce.py
@@ -39,9 +39,9 @@ NUM_TOKENS_RANGE = get_benchmark_range(
 # (hidden_dim, topk)
 CONFIGS_EXPERT = get_benchmark_range(
     full_range=[
-        (4096, 4),   # common: 4k hidden, topk=4
-        (7168, 8),   # DeepSeek-style: 7k hidden, topk=8
-        (2048, 2),   # smaller hidden
+        (4096, 4),  # common: 4k hidden, topk=4
+        (7168, 8),  # DeepSeek-style: 7k hidden, topk=8
+        (2048, 2),  # smaller hidden
     ],
     ci_range=[(4096, 4)],
 )
@@ -100,10 +100,20 @@ def calculate_diff():
         return
 
     print("Correctness diff (JIT vs AOT):")
-    for num_tokens, hidden_dim, topk in [(64, 4096, 4), (512, 7168, 8), (1024, 2048, 2)]:
-        x = torch.randn((num_tokens, topk, hidden_dim), dtype=torch.bfloat16, device="cuda")
-        out_jit = torch.empty((num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda")
-        out_aot = torch.empty((num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda")
+    for num_tokens, hidden_dim, topk in [
+        (64, 4096, 4),
+        (512, 7168, 8),
+        (1024, 2048, 2),
+    ]:
+        x = torch.randn(
+            (num_tokens, topk, hidden_dim), dtype=torch.bfloat16, device="cuda"
+        )
+        out_jit = torch.empty(
+            (num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda"
+        )
+        out_aot = torch.empty(
+            (num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda"
+        )
 
         moe_sum_reduce_jit(x, out_jit, 1.0)
         moe_sum_reduce_aot(x, out_aot, 1.0)

--- a/python/sglang/jit_kernel/csrc/moe/moe_sum_reduce.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/moe_sum_reduce.cuh
@@ -1,0 +1,357 @@
+// Adapt from sgl-kernel/csrc/moe/moe_sum_reduce.cu
+#pragma once
+
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+#include <type_traits>
+
+using tvm::ffi::TensorView;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Accumulation helpers — always accumulate in float
+// ---------------------------------------------------------------------------
+template <typename T>
+__device__ __forceinline__ float to_acc(T x) {
+  return static_cast<float>(x);
+}
+template <>
+__device__ __forceinline__ float to_acc<__half>(__half x) {
+  return __half2float(x);
+}
+template <>
+__device__ __forceinline__ float to_acc<__nv_bfloat16>(__nv_bfloat16 x) {
+  return __bfloat162float(x);
+}
+
+template <typename T>
+__device__ __forceinline__ T from_acc(float x) {
+  return static_cast<T>(x);
+}
+template <>
+__device__ __forceinline__ __half from_acc<__half>(float x) {
+  return __float2half_rn(x);
+}
+template <>
+__device__ __forceinline__ __nv_bfloat16 from_acc<__nv_bfloat16>(float x) {
+  return __float2bfloat16_rn(x);
+}
+
+template <typename T>
+__device__ __forceinline__ T ldg_cg(const T* p) {
+  return __ldg(p);
+}
+
+// ---------------------------------------------------------------------------
+// Vectorised BF16 kernel — 16 elements (2 × uint4) per iteration
+// Only instantiated when T == __nv_bfloat16
+// ---------------------------------------------------------------------------
+union Pack16B {
+  uint4 v;
+  __nv_bfloat16 u16[8];
+};
+
+template <int WARPS_PER_BLOCK>
+__global__ void moe_sum_reduce_warp_per_token_vec_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    __nv_bfloat16* __restrict__ y,
+    const int64_t token_num,
+    const int64_t hidden_dim,
+    const int64_t topk_num,
+    const int64_t stride_token,
+    const int64_t stride_topk,
+    const int64_t out_stride_token,
+    const float scale) {
+  constexpr int VEC = 16;
+  constexpr int PACKS = VEC / 8;
+
+  const int warp_id = threadIdx.x / 32;
+  const int lane = threadIdx.x % 32;
+  const int64_t t = (int64_t)blockIdx.y * WARPS_PER_BLOCK + warp_id;
+  if (t >= token_num) return;
+
+  const int64_t n_chunks = hidden_dim / VEC;
+
+  for (int64_t chunk = (int64_t)blockIdx.x * 32 + lane; chunk < n_chunks; chunk += (int64_t)gridDim.x * 32) {
+    const int64_t d = chunk * VEC;
+    const int64_t base = t * stride_token + d;
+
+    float acc[VEC];
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) acc[i] = 0.f;
+
+    for (int64_t k = 0; k < topk_num; ++k) {
+#pragma unroll
+      for (int p = 0; p < PACKS; ++p) {
+        const int64_t offset = base + k * stride_topk + p * 8;
+        Pack16B pack = {ldg_cg(reinterpret_cast<const uint4*>(x + offset))};
+#pragma unroll
+        for (int i = 0; i < 8; ++i) acc[p * 8 + i] += __bfloat162float(pack.u16[i]);
+      }
+    }
+
+#pragma unroll
+    for (int i = 0; i < VEC; ++i) acc[i] *= scale;
+
+#pragma unroll
+    for (int p = 0; p < PACKS; ++p) {
+      Pack16B outp;
+#pragma unroll
+      for (int i = 0; i < 8; ++i) outp.u16[i] = __float2bfloat16_rn(acc[p * 8 + i]);
+      *reinterpret_cast<uint4*>(y + t * out_stride_token + d + p * 8) = outp.v;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Warp-per-token kernels with compile-time TOPK
+// ---------------------------------------------------------------------------
+template <typename T, int TOPK, int WARPS_PER_BLOCK>
+__global__ void moe_sum_reduce_kernel_warp_token_topk(
+    const T* __restrict__ x,
+    T* __restrict__ y,
+    const int64_t token_num,
+    const int64_t hidden_dim,
+    const int64_t stride_token,
+    const int64_t stride_topk,
+    const int64_t out_stride_token,
+    const float scale) {
+  const int warp_id = threadIdx.x / 32;
+  const int lane = threadIdx.x % 32;
+  const int64_t t = (int64_t)blockIdx.y * WARPS_PER_BLOCK + warp_id;
+  if (t >= token_num) return;
+
+  for (int64_t d = (int64_t)blockIdx.x * 32 + lane; d < hidden_dim; d += (int64_t)gridDim.x * 32) {
+    float acc = 0.f;
+    const int64_t base = t * stride_token + d;
+#pragma unroll
+    for (int k = 0; k < TOPK; ++k) acc += to_acc<T>(x[base + (int64_t)k * stride_topk]);
+    acc *= scale;
+    y[t * out_stride_token + d] = from_acc<T>(acc);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small-token kernels with compile-time TOPK
+// ---------------------------------------------------------------------------
+template <typename T, int TOPK>
+__global__ void moe_sum_reduce_kernel(
+    const T* __restrict__ x,
+    T* __restrict__ y,
+    const int64_t token_num,
+    const int64_t hidden_dim,
+    const int64_t stride_token,
+    const int64_t stride_topk,
+    const int64_t out_stride_token,
+    const float scale) {
+  for (int t = blockIdx.y; t < token_num; t += gridDim.y) {
+    for (int d = blockIdx.x * blockDim.x + threadIdx.x; d < hidden_dim; d += blockDim.x * gridDim.x) {
+      const int64_t base = t * stride_token + d;
+      float acc = 0.f;
+#pragma unroll
+      for (int k = 0; k < TOPK; ++k) acc += to_acc<T>(x[base + (int64_t)k * stride_topk]);
+      acc *= scale;
+      y[t * out_stride_token + d] = from_acc<T>(acc);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// General fallback kernels (runtime topk_num)
+// ---------------------------------------------------------------------------
+template <typename T>
+__global__ void moe_sum_reduce_kernel_general(
+    const T* __restrict__ x,
+    T* __restrict__ y,
+    const int64_t token_num,
+    const int64_t hidden_dim,
+    const int64_t stride_token,
+    const int64_t stride_topk,
+    const int64_t out_stride_token,
+    const int topk_num,
+    const float scale) {
+  for (int t = blockIdx.y; t < token_num; t += gridDim.y) {
+    for (int d = blockIdx.x * blockDim.x + threadIdx.x; d < hidden_dim; d += blockDim.x * gridDim.x) {
+      const int64_t base = t * stride_token + d;
+      float acc = 0.f;
+#pragma unroll 1
+      for (int k = 0; k < topk_num; ++k) acc += to_acc<T>(x[base + (int64_t)k * stride_topk]);
+      acc *= scale;
+      y[t * out_stride_token + d] = from_acc<T>(acc);
+    }
+  }
+}
+
+template <typename T, int WARPS_PER_BLOCK>
+__global__ void moe_sum_reduce_kernel_warp_token_general(
+    const T* __restrict__ x,
+    T* __restrict__ y,
+    const int64_t token_num,
+    const int64_t hidden_dim,
+    const int64_t stride_token,
+    const int64_t stride_topk,
+    const int64_t out_stride_token,
+    const int topk_num,
+    const float scale) {
+  const int warp_id = threadIdx.x / 32;
+  const int lane = threadIdx.x % 32;
+  const int64_t t = (int64_t)blockIdx.y * WARPS_PER_BLOCK + warp_id;
+  if (t >= token_num) return;
+
+  for (int64_t d = (int64_t)blockIdx.x * 32 + lane; d < hidden_dim; d += (int64_t)gridDim.x * 32) {
+    float acc = 0.f;
+    const int64_t base = t * stride_token + d;
+#pragma unroll 1
+    for (int k = 0; k < topk_num; ++k) acc += to_acc<T>(x[base + (int64_t)k * stride_topk]);
+    acc *= scale;
+    y[t * out_stride_token + d] = from_acc<T>(acc);
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Host launcher (tvm-ffi interface)
+// ---------------------------------------------------------------------------
+template <typename T>
+void moe_sum_reduce(TensorView input, TensorView output, double routed_scaling_factor) {
+  using namespace host;
+
+  // --- Input validation ---
+  RuntimeCheck(input.dim() == 3, "input must be 3-D [token_num, topk_num, hidden_dim]");
+  RuntimeCheck(output.dim() == 2, "output must be 2-D [token_num, hidden_dim]");
+  RuntimeCheck(input.shape()[0] == output.shape()[0], "token dim mismatch");
+  RuntimeCheck(input.shape()[2] == output.shape()[1], "hidden_dim mismatch");
+  RuntimeCheck(input.is_contiguous(), "input must be contiguous");
+  RuntimeCheck(output.is_contiguous(), "output must be contiguous");
+
+  const int64_t token_num = input.shape()[0];
+  const int64_t topk_num = input.shape()[1];
+  const int64_t hidden_dim = input.shape()[2];
+
+  // Contiguous strides
+  const int64_t in_stride_token = topk_num * hidden_dim;
+  const int64_t in_stride_topk = hidden_dim;
+  const int64_t out_stride_token = hidden_dim;
+
+  const float scale = static_cast<float>(routed_scaling_factor);
+
+  const T* x_ptr = static_cast<const T*>(input.data_ptr());
+  T* y_ptr = static_cast<T*>(output.data_ptr());
+
+  cudaStream_t stream = LaunchKernel::resolve_device(input.device());
+
+  // ---------------------------------------------------------------------------
+  // Fast vectorised BF16 path: warp-per-token, 16-element loads
+  // Only compiled/entered when T == __nv_bfloat16
+  // ---------------------------------------------------------------------------
+  if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    if ((token_num > 256) && (hidden_dim % 8 == 0)) {
+      constexpr int WARPS_PER_BLOCK = 8;
+      constexpr int THREADS = WARPS_PER_BLOCK * 32;
+
+      int64_t grid_x = (hidden_dim / 8 + 32 - 1) / 32;
+      if (grid_x > 65535) grid_x = 65535;
+      int64_t grid_y = (token_num + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      if (grid_y > 65535) grid_y = 65535;
+
+      moe_sum_reduce_warp_per_token_vec_kernel<WARPS_PER_BLOCK>
+          <<<dim3(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y)), dim3(THREADS), 0, stream>>>(
+              reinterpret_cast<const __nv_bfloat16*>(x_ptr),
+              reinterpret_cast<__nv_bfloat16*>(y_ptr),
+              token_num,
+              hidden_dim,
+              topk_num,
+              in_stride_token,
+              in_stride_topk,
+              out_stride_token,
+              scale);
+      return;
+    }
+  }
+
+  const bool per_token_use_one_warp = (token_num > 128);
+
+  if (!per_token_use_one_warp) {
+    // -------------------------------------------------------------------------
+    // Small-token path: one CTA covers many tokens
+    // -------------------------------------------------------------------------
+    const int block_size = 256;
+    int64_t grid_x = (hidden_dim + block_size - 1) / block_size;
+    if (grid_x > 65535) grid_x = 65535;
+    int64_t grid_y = token_num < 65535 ? token_num : 65535;
+
+    dim3 block(block_size);
+    dim3 grid(static_cast<unsigned>(grid_x), static_cast<unsigned>(grid_y));
+
+#define LAUNCH_SMALL(TOPK)                                                                                 \
+  moe_sum_reduce_kernel<T, TOPK><<<grid, block, 0, stream>>>(x_ptr, y_ptr, token_num, hidden_dim,         \
+                                                              in_stride_token, in_stride_topk,             \
+                                                              out_stride_token, scale);
+
+    switch (topk_num) {
+      case 2:
+        LAUNCH_SMALL(2);
+        break;
+      case 4:
+        LAUNCH_SMALL(4);
+        break;
+      case 8:
+        LAUNCH_SMALL(8);
+        break;
+      case 9:
+        LAUNCH_SMALL(9);
+        break;
+      default:
+        moe_sum_reduce_kernel_general<T><<<grid, block, 0, stream>>>(
+            x_ptr, y_ptr, token_num, hidden_dim, in_stride_token, in_stride_topk, out_stride_token,
+            static_cast<int>(topk_num), scale);
+    }
+#undef LAUNCH_SMALL
+
+  } else {
+    // -------------------------------------------------------------------------
+    // Warp-per-token path: one warp handles one token
+    // -------------------------------------------------------------------------
+    constexpr int WARPS_PER_BLOCK = 4;
+    constexpr int THREADS = WARPS_PER_BLOCK * 32;
+
+    int64_t gx = (hidden_dim + 32 - 1) / 32;
+    if (gx > 65535) gx = 65535;
+    int64_t gy = (token_num + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    if (gy > 65535) gy = 65535;
+
+    dim3 block(THREADS);
+    dim3 grid(static_cast<unsigned>(gx), static_cast<unsigned>(gy));
+
+#define LAUNCH_WARP(TOPK)                                                                                         \
+  moe_sum_reduce_kernel_warp_token_topk<T, TOPK, WARPS_PER_BLOCK><<<grid, block, 0, stream>>>(                   \
+      x_ptr, y_ptr, token_num, hidden_dim, in_stride_token, in_stride_topk, out_stride_token, scale);
+
+    switch (topk_num) {
+      case 2:
+        LAUNCH_WARP(2);
+        break;
+      case 4:
+        LAUNCH_WARP(4);
+        break;
+      case 8:
+        LAUNCH_WARP(8);
+        break;
+      case 9:
+        LAUNCH_WARP(9);
+        break;
+      default:
+        moe_sum_reduce_kernel_warp_token_general<T, WARPS_PER_BLOCK><<<grid, block, 0, stream>>>(
+            x_ptr, y_ptr, token_num, hidden_dim, in_stride_token, in_stride_topk, out_stride_token,
+            static_cast<int>(topk_num), scale);
+    }
+#undef LAUNCH_WARP
+  }
+}

--- a/python/sglang/jit_kernel/moe_sum_reduce.py
+++ b/python/sglang/jit_kernel/moe_sum_reduce.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_moe_sum_reduce_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "moe_sum_reduce",
+        *args,
+        cuda_files=["moe/moe_sum_reduce.cuh"],
+        cuda_wrappers=[("moe_sum_reduce", f"moe_sum_reduce<{args}>")],
+    )
+
+
+@register_custom_op(
+    op_name="moe_sum_reduce_out",
+    mutates_args=["output"],
+)
+def moe_sum_reduce_out(
+    input: torch.Tensor,
+    output: torch.Tensor,
+    routed_scaling_factor: float,
+) -> None:
+    """
+    Fused weighted sum-reduce over the top-k expert dimension (destination-passing style).
+
+    Args:
+        input:  [token_num, topk_num, hidden_dim], fp32/fp16/bf16, contiguous
+        output: [token_num, hidden_dim], same dtype, pre-allocated output
+        routed_scaling_factor: scalar multiplied into each output element
+    """
+    module = _jit_moe_sum_reduce_module(input.dtype)
+    module.moe_sum_reduce(input, output, routed_scaling_factor)
+
+
+def moe_sum_reduce(
+    input_tensor: torch.Tensor,
+    output_tensor: torch.Tensor,
+    routed_scaling_factor: float = 0.0,
+) -> None:
+    """
+    Fused weighted sum-reduce over the top-k expert dimension.
+
+    Matches the call signature of ``sgl_kernel.moe_sum_reduce``.
+
+    Args:
+        input_tensor:  [token_num, topk_num, hidden_dim], fp32/fp16/bf16
+        output_tensor: [token_num, hidden_dim], written in-place
+        routed_scaling_factor: scalar multiplied into each output element
+    """
+    moe_sum_reduce_out(input_tensor, output_tensor, routed_scaling_factor)

--- a/python/sglang/jit_kernel/tests/test_moe_sum_reduce.py
+++ b/python/sglang/jit_kernel/tests/test_moe_sum_reduce.py
@@ -1,0 +1,165 @@
+"""
+Correctness tests for the moe_sum_reduce JIT kernel.
+
+Validates against a pure-PyTorch reference and, when sgl_kernel is available,
+cross-checks against the AOT implementation.
+"""
+
+import itertools
+import os
+
+import pytest
+import torch
+
+from sglang.jit_kernel.moe_sum_reduce import moe_sum_reduce
+
+try:
+    from sgl_kernel import moe_sum_reduce as moe_sum_reduce_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# CI / full-range helpers
+# ---------------------------------------------------------------------------
+
+_is_ci = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+NUM_TOKENS_FULL = [1, 16, 64, 128, 256, 512, 1024]
+NUM_TOKENS_CI = [1, 64, 512]
+
+# topk values: 2, 4, 8, 9 hit static-dispatch; 3 exercises general fallback
+TOPK_FULL = [2, 4, 8, 9, 3]
+TOPK_CI = [2, 4, 3]
+
+HIDDEN_DIM_FULL = [256, 1024, 4096]
+HIDDEN_DIM_CI = [256, 4096]
+
+DTYPES_FULL = [torch.float32, torch.float16, torch.bfloat16]
+DTYPES_CI = [torch.float32, torch.bfloat16]
+
+NUM_TOKENS = NUM_TOKENS_CI if _is_ci else NUM_TOKENS_FULL
+TOPK_LIST = TOPK_CI if _is_ci else TOPK_FULL
+HIDDEN_DIMS = HIDDEN_DIM_CI if _is_ci else HIDDEN_DIM_FULL
+DTYPES = DTYPES_CI if _is_ci else DTYPES_FULL
+
+
+# ---------------------------------------------------------------------------
+# Pure-PyTorch reference
+# ---------------------------------------------------------------------------
+
+
+def moe_sum_reduce_ref(
+    x: torch.Tensor,
+    routed_scaling_factor: float,
+) -> torch.Tensor:
+    """Sum over the topk dim (dim=1) and multiply by scale."""
+    return (x.float().sum(dim=1) * routed_scaling_factor).to(x.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Correctness: JIT vs PyTorch reference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_tokens, topk, hidden_dim",
+    list(itertools.product(NUM_TOKENS, TOPK_LIST, HIDDEN_DIMS)),
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("routed_scaling_factor", [1.0, 0.5])
+def test_moe_sum_reduce_vs_ref(num_tokens, topk, hidden_dim, dtype, routed_scaling_factor):
+    torch.manual_seed(num_tokens * topk * hidden_dim)
+    x = torch.randn((num_tokens, topk, hidden_dim), dtype=dtype, device="cuda")
+    out = torch.empty((num_tokens, hidden_dim), dtype=dtype, device="cuda")
+
+    moe_sum_reduce(x, out, routed_scaling_factor)
+    ref = moe_sum_reduce_ref(x, routed_scaling_factor)
+
+    # fp16/bf16 accumulation tolerance
+    atol = 1e-2 if dtype != torch.float32 else 1e-5
+    assert torch.allclose(out, ref, atol=atol, rtol=1e-3), (
+        f"Mismatch (dtype={dtype}, tokens={num_tokens}, topk={topk}, "
+        f"hidden={hidden_dim}, scale={routed_scaling_factor})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Correctness: scale=0 → all-zeros output
+# ---------------------------------------------------------------------------
+
+
+def test_zero_scale():
+    x = torch.randn((64, 4, 256), dtype=torch.float32, device="cuda")
+    out = torch.empty((64, 256), dtype=torch.float32, device="cuda")
+    moe_sum_reduce(x, out, 0.0)
+    assert torch.all(out == 0.0), "scale=0 should produce all-zeros output"
+
+
+# ---------------------------------------------------------------------------
+# Correctness: BF16 vectorized fast path (token_num > 256, hidden_dim % 8 == 0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hidden_dim", [256, 4096, 8192])
+@pytest.mark.parametrize("topk", [2, 4, 8])
+def test_bf16_vec_fast_path(hidden_dim, topk):
+    """token_num=512 > 256 triggers the vectorized BF16 path."""
+    num_tokens = 512
+    torch.manual_seed(42)
+    x = torch.randn((num_tokens, topk, hidden_dim), dtype=torch.bfloat16, device="cuda")
+    out = torch.empty((num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda")
+    moe_sum_reduce(x, out, 1.0)
+    ref = moe_sum_reduce_ref(x, 1.0)
+    assert torch.allclose(out, ref, atol=1e-2, rtol=1e-3), (
+        f"BF16 vec path mismatch (hidden={hidden_dim}, topk={topk})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output shape and dtype preserved
+# ---------------------------------------------------------------------------
+
+
+def test_output_shape_and_dtype():
+    num_tokens, topk, hidden_dim = 64, 4, 1024
+    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+        x = torch.randn((num_tokens, topk, hidden_dim), dtype=dtype, device="cuda")
+        out = torch.empty((num_tokens, hidden_dim), dtype=dtype, device="cuda")
+        moe_sum_reduce(x, out, 1.0)
+        assert out.shape == (num_tokens, hidden_dim)
+        assert out.dtype == dtype
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation against AOT sgl_kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not AOT_AVAILABLE, reason="sgl_kernel not available")
+@pytest.mark.parametrize(
+    "num_tokens, topk, hidden_dim",
+    list(itertools.product([1, 128, 512], [2, 4, 8], [256, 4096])),
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_moe_sum_reduce_vs_aot(num_tokens, topk, hidden_dim, dtype):
+    torch.manual_seed(42)
+    x = torch.randn((num_tokens, topk, hidden_dim), dtype=dtype, device="cuda")
+
+    out_jit = torch.empty((num_tokens, hidden_dim), dtype=dtype, device="cuda")
+    out_aot = torch.empty((num_tokens, hidden_dim), dtype=dtype, device="cuda")
+
+    moe_sum_reduce(x, out_jit, 1.0)
+    moe_sum_reduce_aot(x, out_aot, 1.0)
+
+    assert torch.allclose(out_jit, out_aot, atol=1e-5, rtol=1e-5), (
+        f"JIT vs AOT mismatch (dtype={dtype}, tokens={num_tokens}, topk={topk}, hidden={hidden_dim})"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/sglang/jit_kernel/tests/test_moe_sum_reduce.py
+++ b/python/sglang/jit_kernel/tests/test_moe_sum_reduce.py
@@ -72,7 +72,9 @@ def moe_sum_reduce_ref(
 )
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 0.5])
-def test_moe_sum_reduce_vs_ref(num_tokens, topk, hidden_dim, dtype, routed_scaling_factor):
+def test_moe_sum_reduce_vs_ref(
+    num_tokens, topk, hidden_dim, dtype, routed_scaling_factor
+):
     torch.manual_seed(num_tokens * topk * hidden_dim)
     x = torch.randn((num_tokens, topk, hidden_dim), dtype=dtype, device="cuda")
     out = torch.empty((num_tokens, hidden_dim), dtype=dtype, device="cuda")
@@ -115,9 +117,9 @@ def test_bf16_vec_fast_path(hidden_dim, topk):
     out = torch.empty((num_tokens, hidden_dim), dtype=torch.bfloat16, device="cuda")
     moe_sum_reduce(x, out, 1.0)
     ref = moe_sum_reduce_ref(x, 1.0)
-    assert torch.allclose(out, ref, atol=1e-2, rtol=1e-3), (
-        f"BF16 vec path mismatch (hidden={hidden_dim}, topk={topk})"
-    )
+    assert torch.allclose(
+        out, ref, atol=1e-2, rtol=1e-3
+    ), f"BF16 vec path mismatch (hidden={hidden_dim}, topk={topk})"
 
 
 # ---------------------------------------------------------------------------
@@ -156,9 +158,9 @@ def test_moe_sum_reduce_vs_aot(num_tokens, topk, hidden_dim, dtype):
     moe_sum_reduce(x, out_jit, 1.0)
     moe_sum_reduce_aot(x, out_aot, 1.0)
 
-    assert torch.allclose(out_jit, out_aot, atol=1e-5, rtol=1e-5), (
-        f"JIT vs AOT mismatch (dtype={dtype}, tokens={num_tokens}, topk={topk}, hidden={hidden_dim})"
-    )
+    assert torch.allclose(
+        out_jit, out_aot, atol=1e-5, rtol=1e-5
+    ), f"JIT vs AOT mismatch (dtype={dtype}, tokens={num_tokens}, topk={topk}, hidden={hidden_dim})"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
https://github.com/sgl-project/sglang/issues/17865  
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
  Migrate moe_sum_reduce from the AOT sgl-kernel build to the JIT kernel system (python/sglang/jit_kernel/), following the same pattern established for moe_topk_sigmoid and moe_topk_softmax.                                                      
                                                                                                                           
  New files:                                                                                                               
  - python/sglang/jit_kernel/csrc/moe/moe_sum_reduce.cuh — CUDA kernels ported from sgl-kernel/csrc/moe/moe_sum_reduce.cu:
    - moe_sum_reduce_warp_per_token_vec_kernel — vectorized BF16 fast path (16-element uint4 loads)
    - moe_sum_reduce_kernel<T, TOPK> — small-token path with compile-time topk unrolling
    - moe_sum_reduce_kernel_warp_token_topk<T, TOPK, WARPS> — warp-per-token path with compile-time topk unrolling
    - moe_sum_reduce_kernel_general<T> / moe_sum_reduce_kernel_warp_token_general<T, WARPS> — runtime-topk fallbacks
    - tvm-ffi host wrapper moe_sum_reduce<T> replacing PyTorch/ATen tensor handling
  - python/sglang/jit_kernel/moe_sum_reduce.py — Python wrapper with the same call signature as sgl_kernel.moe_sum_reduce
  - python/sglang/jit_kernel/tests/test_moe_sum_reduce.py — correctness tests
  - python/sglang/jit_kernel/benchmark/bench_moe_sum_reduce.py — benchmark

  Key implementation notes:
  - BF16 vectorized fast path (token_num > 256, hidden_dim % 8 == 0) is gated with if constexpr (std::is_same_v<T,
  __nv_bfloat16>) — zero overhead for fp16/fp32
  - Replaced at::opmath_type<T> with explicit float accumulator (same semantics for all three types)
  - Replaced AT_DISPATCH_FLOATING_TYPES_AND2 runtime dispatch with JIT-time template instantiation via make_cpp_args(dtype)
  - Dropped unused cutlass/array.h include from the original
  - Contiguous strides computed from shape; contiguity enforced via RuntimeCheck
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
  677 tests pass, covering:
  - All dtypes (fp32, fp16, bf16) across token counts (1–1024), topk values (2, 4, 8, 9, and general fallback with topk=3),
   hidden dims (256, 1024, 4096)
  - BF16 vectorized fast path explicitly tested with token_num=512 > 256
  - Scale=0 produces all-zeros output
  - Cross-validation against sgl_kernel.moe_sum_reduce (AOT): exact match on all tested configs

  677 passed in 17.80s

  Correctness diff (JIT vs AOT):
  tokens=   64  hidden= 4096  topk=4  output=✓  [OK]
  tokens=  512  hidden= 7168  topk=8  output=✓  [OK]
  tokens= 1024  hidden= 2048  topk=2  output=✓  [OK]
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
<img width="840" height="467" alt="image" src="https://github.com/user-attachments/assets/3d25855a-5e8a-43a0-a776-cbeb0a72578c" />
The max deviation across all 24 configs is ±1.8% — this is pure measurement noise, not  a real regression. JIT is faster than AOT in 10 configs and slower in 14 configs by the same tiny margin.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
