### PR TITLE
[jit_kernel] Add JIT tree_speculative_sampling_target_only kernel

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_speculative_sampling.py
+++ b/python/sglang/jit_kernel/benchmark/bench_speculative_sampling.py
@@ -1,0 +1,203 @@
+"""
+Benchmark: tree_speculative_sampling_target_only JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) for tree speculative sampling across typical
+LLM configurations.
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_speculative_sampling.py
+"""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.speculative_sampling import (
+    tree_speculative_sampling_target_only as tree_spec_sampling_jit,
+)
+
+try:
+    from sgl_kernel import (
+        tree_speculative_sampling_target_only as tree_spec_sampling_aot,
+    )
+
+    AOT_AVAILABLE = True
+except ImportError:
+    tree_spec_sampling_aot = None
+    AOT_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+BATCH_SIZE_RANGE = get_benchmark_range(
+    full_range=[1, 4, 8, 16],
+    ci_range=[4],
+)
+
+# (num_draft_tokens, num_spec_step, vocab_size)
+MODEL_CONFIGS = get_benchmark_range(
+    full_range=[
+        (8, 5, 32000),  # typical LLaMA
+        (16, 8, 32000),  # wider tree
+        (8, 5, 128000),  # large vocabulary
+    ],
+    ci_range=[(8, 5, 32000)],
+)
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+STYLES = [(("blue", "--"), ("orange", "-"))] if AOT_AVAILABLE else [("blue", "--")]
+
+DEVICE = "cuda"
+
+
+def make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size):
+    tot_draft = bs * num_draft_tokens
+
+    predicts = torch.zeros(tot_draft, dtype=torch.int32, device=DEVICE)
+    accept_index = torch.zeros(bs, num_spec_step, dtype=torch.int32, device=DEVICE)
+    accept_token_num = torch.zeros(bs, dtype=torch.int32, device=DEVICE)
+
+    # Linear chain tree
+    retrive_index = torch.stack(
+        [torch.arange(num_draft_tokens, dtype=torch.int64, device=DEVICE)] * bs
+    )
+    next_token = torch.arange(1, num_draft_tokens + 1, dtype=torch.int64, device=DEVICE)
+    next_token[-1] = -1
+    retrive_next_token = next_token.unsqueeze(0).expand(bs, -1).contiguous()
+    retrive_next_sibling = torch.full(
+        (bs, num_draft_tokens), -1, dtype=torch.int64, device=DEVICE
+    )
+    candidates = (
+        (torch.arange(num_draft_tokens, dtype=torch.int64, device=DEVICE) % vocab_size)
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+
+    uniform_samples = torch.rand(
+        bs, num_draft_tokens, dtype=torch.float32, device=DEVICE
+    )
+    uniform_samples_for_final_sampling = torch.rand(
+        bs, dtype=torch.float32, device=DEVICE
+    )
+
+    raw = torch.rand(
+        bs, num_draft_tokens, vocab_size, dtype=torch.float32, device=DEVICE
+    )
+    target_probs = raw / raw.sum(dim=-1, keepdim=True)
+    draft_probs = target_probs.clone()
+
+    return dict(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        uniform_samples=uniform_samples,
+        uniform_samples_for_final_sampling=uniform_samples_for_final_sampling,
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+    )
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["bs", "num_draft_tokens", "num_spec_step", "vocab_size"],
+        x_vals=[
+            (bs, ndt, nss, vs)
+            for bs, (ndt, nss, vs) in itertools.product(BATCH_SIZE_RANGE, MODEL_CONFIGS)
+        ],
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=[("blue", "--"), ("orange", "-")][: len(LINE_VALS)],
+        ylabel="us",
+        plot_name="tree-speculative-sampling-performance",
+        args={},
+    )
+)
+def bench_speculative_sampling(
+    bs: int,
+    num_draft_tokens: int,
+    num_spec_step: int,
+    vocab_size: int,
+    provider: str,
+):
+    inputs = make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size)
+    common_kwargs = dict(
+        threshold_single=0.9,
+        threshold_acc=0.9,
+        deterministic=True,
+    )
+
+    if provider == "jit":
+
+        def fn():
+            inp = {
+                k: v.clone() if isinstance(v, torch.Tensor) else v
+                for k, v in inputs.items()
+            }
+            tree_spec_sampling_jit(**inp, **common_kwargs)
+
+    elif provider == "aot":
+
+        def fn():
+            inp = {
+                k: v.clone() if isinstance(v, torch.Tensor) else v
+                for k, v in inputs.items()
+            }
+            tree_spec_sampling_aot(**inp, **common_kwargs)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff (JIT vs AOT):")
+    for bs, num_draft_tokens, num_spec_step, vocab_size in [
+        (1, 4, 4, 32),
+        (2, 8, 5, 32000),
+        (4, 16, 8, 128000),
+    ]:
+        inputs_jit = make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size)
+        inputs_aot = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in inputs_jit.items()
+        }
+
+        tree_spec_sampling_jit(**inputs_jit, threshold_single=0.9, threshold_acc=0.9)
+        tree_spec_sampling_aot(**inputs_aot, threshold_single=0.9, threshold_acc=0.9)
+
+        match_predicts = torch.equal(inputs_jit["predicts"], inputs_aot["predicts"])
+        match_accept_num = torch.equal(
+            inputs_jit["accept_token_num"], inputs_aot["accept_token_num"]
+        )
+        status = "OK" if (match_predicts and match_accept_num) else "MISMATCH"
+        print(
+            f"  bs={bs:2d} num_draft={num_draft_tokens:2d} num_spec={num_spec_step:2d} "
+            f"vocab={vocab_size:6d}  [{status}]"
+        )
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    bench_speculative_sampling.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/speculative/speculative_sampling.cuh
+++ b/python/sglang/jit_kernel/csrc/speculative/speculative_sampling.cuh
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2025 by SGLang team.
+ * Copyright (c) 2024-2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Adapted from
+// https://github.com/sgl-project/sglang/blob/main/sgl-kernel/csrc/speculative/speculative_sampling.cuh
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <flashinfer/sampling.cuh>
+#include <tvm/ffi/container/tensor.h>
+
+#include <assert.h>
+
+namespace flashinfer {
+
+namespace sampling {
+
+using namespace cub;
+
+template <
+    uint32_t BLOCK_THREADS,
+    BlockScanAlgorithm SCAN_ALGORITHM,
+    BlockReduceAlgorithm REDUCE_ALGORITHM,
+    uint32_t VEC_SIZE,
+    bool DETERMINISTIC,
+    typename DType,
+    typename IdType,
+    typename IdType2>
+__global__ void TreeSpeculativeSamplingTargetOnly(
+    IdType* predicts,          // mutable
+    IdType* accept_index,      // mutable
+    IdType* accept_token_num,  // mutable
+    IdType2* candidates,
+    IdType2* retrive_index,
+    IdType2* retrive_next_token,
+    IdType2* retrive_next_sibling,
+    DType* uniform_samples,
+    DType* uniform_samples_for_final_sampling,
+    DType* target_probs,
+    DType* draft_probs,
+    uint32_t batch_size,
+    uint32_t num_speculative_tokens,
+    uint32_t num_draft_tokens,
+    uint32_t d,
+    DType threshold_single,
+    DType threshold_acc) {
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+  DType prob_acc = 0.0;
+  uint32_t cur_prob_offset = bx * num_draft_tokens * d;
+  DType coin = uniform_samples[bx * num_draft_tokens];
+  IdType2 last_accepted_retrive_idx = retrive_index[bx * num_draft_tokens];
+  accept_index[bx * num_speculative_tokens] = last_accepted_retrive_idx;
+  uint32_t num_accepted_tokens = 0;
+  IdType2 cur_index = 0;
+
+  for (uint32_t j = 1; j < num_speculative_tokens; ++j) {
+    cur_index = retrive_next_token[bx * num_draft_tokens + cur_index];
+    while (cur_index != -1) {
+      IdType2 draft_index = retrive_index[bx * num_draft_tokens + cur_index];
+      IdType2 draft_token_id = candidates[bx * num_draft_tokens + cur_index];
+      DType target_prob_single = target_probs[cur_prob_offset + draft_token_id];
+      prob_acc += target_prob_single;
+
+      if (coin <= prob_acc / threshold_acc || target_prob_single >= threshold_single) {
+        // accept token
+        prob_acc = 0.;
+        cur_prob_offset = (bx * num_draft_tokens + cur_index) * d;
+        coin = uniform_samples[bx * num_draft_tokens + cur_index];
+        predicts[last_accepted_retrive_idx] = draft_token_id;
+        ++num_accepted_tokens;
+        accept_index[bx * num_speculative_tokens + num_accepted_tokens] = draft_index;
+        last_accepted_retrive_idx = draft_index;
+        break;
+      } else {
+        // FIXME: leverage draft probs
+        draft_probs[cur_prob_offset + draft_token_id] = target_probs[cur_prob_offset + draft_token_id];
+        cur_index = retrive_next_sibling[bx * num_draft_tokens + cur_index];
+      }
+    }
+    if (cur_index == -1) break;
+  }
+  accept_token_num[bx] = num_accepted_tokens;
+
+  // we need a different coin for the final sampling
+  coin = uniform_samples_for_final_sampling[bx];
+
+  // sample from relu(target_probs - draft_probs)
+  DType sum_relu_q_minus_p(0);
+  vec_t<DType, VEC_SIZE> q_vec, p_vec;
+  DType relu_q_minus_p[VEC_SIZE];
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    q_vec.fill(DType(0));
+    p_vec.fill(DType(0));
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      q_vec.load(target_probs + cur_prob_offset + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      if (num_accepted_tokens != num_speculative_tokens - 1) {
+        // there is no draft_probs for the bonus token
+        p_vec.load(draft_probs + cur_prob_offset + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      }
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], DType(0));
+    }
+    sum_relu_q_minus_p += BlockReduce<DType, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                              .Sum<VEC_SIZE>(relu_q_minus_p);
+    __syncthreads();
+  }
+  if (tx == 0) {
+    temp_storage.block_aggregate.value = sum_relu_q_minus_p;
+  }
+  // init the first rejected token to (d - 1)
+  temp_storage.sampled_id = d - 1;
+  __syncthreads();
+  sum_relu_q_minus_p = temp_storage.block_aggregate.value;
+  DType u = coin * sum_relu_q_minus_p;
+
+  DType aggregate_relu_q_minus_p(0);
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    q_vec.fill(DType(0));
+    p_vec.fill(DType(0));
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      q_vec.load(target_probs + cur_prob_offset + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      if (num_accepted_tokens != num_speculative_tokens - 1) {
+        // there is no draft_probs for the bonus token
+        p_vec.load(draft_probs + cur_prob_offset + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      }
+    }
+
+    vec_t<DType, VEC_SIZE> relu_q_minus_p_vec;
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], DType(0));
+    }
+
+    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+        i, d, [&](DType x) { return x > 0; }, u, relu_q_minus_p_vec, aggregate_relu_q_minus_p, &temp_storage);
+    if (aggregate_relu_q_minus_p > u) {
+      break;
+    }
+  }
+  __syncthreads();
+  // set the first rejected token
+  predicts[last_accepted_retrive_idx] = temp_storage.sampled_id;
+  // value at not used indices are undefined
+}
+
+template <typename DType, typename IdType, typename IdType2>
+cudaError_t TreeSpeculativeSamplingTargetOnlyLauncher(
+    IdType* predicts,                   // mutable
+    IdType* output_token_ids,           // mutable
+    IdType* output_accepted_token_num,  // mutable
+    IdType2* candidates,
+    IdType2* retrive_index,
+    IdType2* retrive_next_token,
+    IdType2* retrive_next_sibling,
+    DType* uniform_samples,
+    DType* uniform_samples_for_final_sampling,
+    DType* target_probs,
+    DType* draft_probs,
+    uint32_t batch_size,
+    uint32_t num_speculative_tokens,
+    uint32_t num_draft_tokens,
+    uint32_t d,
+    DType threshold_single = 1,
+    DType threshold_acc = 1,
+    bool deterministic = true,
+    cudaStream_t stream = 0) {
+  constexpr uint32_t BLOCK_THREADS = 1024;
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+
+  const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+  dim3 nblks(batch_size);
+  dim3 nthrs(BLOCK_THREADS);
+  float capped_threshold_acc = fmaxf(threshold_acc, 1e-9f);
+  void* args[] = {
+      &predicts,
+      &output_token_ids,
+      &output_accepted_token_num,
+      &candidates,
+      &retrive_index,
+      &retrive_next_token,
+      &retrive_next_sibling,
+      &uniform_samples,
+      &uniform_samples_for_final_sampling,
+      &target_probs,
+      &draft_probs,
+      &batch_size,
+      &num_speculative_tokens,
+      &num_draft_tokens,
+      &d,
+      &threshold_single,
+      &capped_threshold_acc};
+  DISPATCH_ALIGNED_VEC_SIZE(
+      vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+        auto kernel = TreeSpeculativeSamplingTargetOnly<
+            BLOCK_THREADS,
+            SCAN_ALGO,
+            REDUCE_ALGO,
+            VEC_SIZE,
+            DETERMINISTIC,
+            DType,
+            IdType,
+            IdType2>;
+        FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+        FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+      })});
+  return cudaSuccess;
+}
+
+}  // namespace sampling
+
+}  // namespace flashinfer
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// tvm-ffi entry point
+// ---------------------------------------------------------------------------
+
+void tree_speculative_sampling_target_only(
+    tvm::ffi::TensorView predicts,                            // [tot_num_draft_tokens] int32, mutable
+    tvm::ffi::TensorView accept_index,                        // [bs, num_spec_step] int32, mutable
+    tvm::ffi::TensorView accept_token_num,                    // [bs] int32, mutable
+    tvm::ffi::TensorView candidates,                          // [bs, num_draft_tokens] int64
+    tvm::ffi::TensorView retrive_index,                       // [bs, num_draft_tokens] int64
+    tvm::ffi::TensorView retrive_next_token,                  // [bs, num_draft_tokens] int64
+    tvm::ffi::TensorView retrive_next_sibling,                // [bs, num_draft_tokens] int64
+    tvm::ffi::TensorView uniform_samples,                     // [bs, num_draft_tokens] float32
+    tvm::ffi::TensorView uniform_samples_for_final_sampling,  // [bs] float32
+    tvm::ffi::TensorView target_probs,                        // [bs, num_draft_tokens, vocab_size] float32
+    tvm::ffi::TensorView draft_probs,                         // [bs, num_draft_tokens, vocab_size] float32, mutable
+    float threshold_single,
+    float threshold_acc,
+    int deterministic) {
+  using namespace host;
+
+  RuntimeCheck(target_probs.device().device_type == kDLCUDA, "target_probs must be a CUDA tensor");
+  RuntimeCheck(target_probs.ndim() == 3, "target_probs must be 3D: [bs, num_draft_tokens, vocab_size]");
+  RuntimeCheck(target_probs.is_contiguous(), "target_probs must be contiguous");
+  RuntimeCheck(
+      target_probs.dtype().code == kDLFloat && target_probs.dtype().bits == 32, "target_probs must be float32");
+
+  uint32_t batch_size = static_cast<uint32_t>(target_probs.size(0));
+  uint32_t num_draft_tokens = static_cast<uint32_t>(target_probs.size(1));
+  uint32_t vocab_size = static_cast<uint32_t>(target_probs.size(2));
+
+  RuntimeCheck(accept_index.ndim() == 2, "accept_index must be 2D: [bs, num_spec_step]");
+  uint32_t num_spec_step = static_cast<uint32_t>(accept_index.size(1));
+  RuntimeCheck(static_cast<uint32_t>(accept_index.size(0)) == batch_size, "accept_index batch_size mismatch");
+
+  RuntimeCheck(predicts.ndim() == 1, "predicts must be 1D");
+  RuntimeCheck(predicts.dtype().code == kDLInt && predicts.dtype().bits == 32, "predicts must be int32");
+  RuntimeCheck(predicts.is_contiguous(), "predicts must be contiguous");
+
+  RuntimeCheck(accept_index.dtype().code == kDLInt && accept_index.dtype().bits == 32, "accept_index must be int32");
+  RuntimeCheck(accept_index.is_contiguous(), "accept_index must be contiguous");
+
+  RuntimeCheck(accept_token_num.ndim() == 1, "accept_token_num must be 1D");
+  RuntimeCheck(
+      accept_token_num.dtype().code == kDLInt && accept_token_num.dtype().bits == 32, "accept_token_num must be int32");
+  RuntimeCheck(accept_token_num.is_contiguous(), "accept_token_num must be contiguous");
+  RuntimeCheck(static_cast<uint32_t>(accept_token_num.size(0)) == batch_size, "accept_token_num batch_size mismatch");
+
+  RuntimeCheck(candidates.ndim() == 2, "candidates must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(candidates.dtype().code == kDLInt && candidates.dtype().bits == 64, "candidates must be int64");
+  RuntimeCheck(candidates.is_contiguous(), "candidates must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(candidates.size(0)) == batch_size &&
+          static_cast<uint32_t>(candidates.size(1)) == num_draft_tokens,
+      "candidates shape mismatch");
+
+  RuntimeCheck(retrive_index.ndim() == 2, "retrive_index must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(retrive_index.dtype().code == kDLInt && retrive_index.dtype().bits == 64, "retrive_index must be int64");
+  RuntimeCheck(retrive_index.is_contiguous(), "retrive_index must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(retrive_index.size(0)) == batch_size &&
+          static_cast<uint32_t>(retrive_index.size(1)) == num_draft_tokens,
+      "retrive_index shape mismatch");
+
+  RuntimeCheck(retrive_next_token.ndim() == 2, "retrive_next_token must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(
+      retrive_next_token.dtype().code == kDLInt && retrive_next_token.dtype().bits == 64,
+      "retrive_next_token must be int64");
+  RuntimeCheck(retrive_next_token.is_contiguous(), "retrive_next_token must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(retrive_next_token.size(0)) == batch_size &&
+          static_cast<uint32_t>(retrive_next_token.size(1)) == num_draft_tokens,
+      "retrive_next_token shape mismatch");
+
+  RuntimeCheck(retrive_next_sibling.ndim() == 2, "retrive_next_sibling must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(
+      retrive_next_sibling.dtype().code == kDLInt && retrive_next_sibling.dtype().bits == 64,
+      "retrive_next_sibling must be int64");
+  RuntimeCheck(retrive_next_sibling.is_contiguous(), "retrive_next_sibling must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(retrive_next_sibling.size(0)) == batch_size &&
+          static_cast<uint32_t>(retrive_next_sibling.size(1)) == num_draft_tokens,
+      "retrive_next_sibling shape mismatch");
+
+  RuntimeCheck(uniform_samples.ndim() == 2, "uniform_samples must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(
+      uniform_samples.dtype().code == kDLFloat && uniform_samples.dtype().bits == 32,
+      "uniform_samples must be float32");
+  RuntimeCheck(uniform_samples.is_contiguous(), "uniform_samples must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(uniform_samples.size(0)) == batch_size &&
+          static_cast<uint32_t>(uniform_samples.size(1)) == num_draft_tokens,
+      "uniform_samples shape mismatch");
+
+  RuntimeCheck(uniform_samples_for_final_sampling.ndim() == 1, "uniform_samples_for_final_sampling must be 1D: [bs]");
+  RuntimeCheck(
+      uniform_samples_for_final_sampling.dtype().code == kDLFloat &&
+          uniform_samples_for_final_sampling.dtype().bits == 32,
+      "uniform_samples_for_final_sampling must be float32");
+  RuntimeCheck(
+      uniform_samples_for_final_sampling.is_contiguous(), "uniform_samples_for_final_sampling must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(uniform_samples_for_final_sampling.size(0)) == batch_size,
+      "uniform_samples_for_final_sampling batch_size mismatch");
+
+  RuntimeCheck(draft_probs.ndim() == 3, "draft_probs must be 3D: [bs, num_draft_tokens, vocab_size]");
+  RuntimeCheck(draft_probs.dtype().code == kDLFloat && draft_probs.dtype().bits == 32, "draft_probs must be float32");
+  RuntimeCheck(draft_probs.is_contiguous(), "draft_probs must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(draft_probs.size(0)) == batch_size &&
+          static_cast<uint32_t>(draft_probs.size(1)) == num_draft_tokens &&
+          static_cast<uint32_t>(draft_probs.size(2)) == vocab_size,
+      "draft_probs shape mismatch");
+
+  RuntimeCheck(threshold_single >= 0.0f && threshold_single <= 1.0f, "threshold_single must be in [0, 1]");
+  RuntimeCheck(threshold_acc >= 0.0f && threshold_acc <= 1.0f, "threshold_acc must be in [0, 1]");
+
+  cudaStream_t stream = LaunchKernel::resolve_device(target_probs.device());
+
+  cudaError_t status = flashinfer::sampling::TreeSpeculativeSamplingTargetOnlyLauncher<float, int32_t, int64_t>(
+      static_cast<int32_t*>(predicts.data_ptr()),
+      static_cast<int32_t*>(accept_index.data_ptr()),
+      static_cast<int32_t*>(accept_token_num.data_ptr()),
+      static_cast<int64_t*>(candidates.data_ptr()),
+      static_cast<int64_t*>(retrive_index.data_ptr()),
+      static_cast<int64_t*>(retrive_next_token.data_ptr()),
+      static_cast<int64_t*>(retrive_next_sibling.data_ptr()),
+      static_cast<float*>(uniform_samples.data_ptr()),
+      static_cast<float*>(uniform_samples_for_final_sampling.data_ptr()),
+      static_cast<float*>(target_probs.data_ptr()),
+      static_cast<float*>(draft_probs.data_ptr()),
+      batch_size,
+      num_spec_step,
+      num_draft_tokens,
+      vocab_size,
+      threshold_single,
+      threshold_acc,
+      static_cast<bool>(deterministic),
+      stream);
+
+  RuntimeCheck(status == cudaSuccess, "TreeSpeculativeSamplingTargetOnly failed: ", cudaGetErrorString(status));
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/speculative/speculative_sampling.cuh
+++ b/python/sglang/jit_kernel/csrc/speculative/speculative_sampling.cuh
@@ -26,6 +26,7 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <assert.h>
+#include <numeric>
 
 namespace flashinfer {
 

--- a/python/sglang/jit_kernel/speculative_sampling.py
+++ b/python/sglang/jit_kernel/speculative_sampling.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING
+
+import flashinfer
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_speculative_sampling_module() -> Module:
+    flashinfer_dir = pathlib.Path(flashinfer.__file__).parent.resolve()
+    assert (
+        flashinfer_dir / "data" / "include"
+    ).exists(), (
+        f"flashinfer headers are missing: {str(flashinfer_dir / 'data' / 'include')}"
+    )
+    flashinfer_include_path = (flashinfer_dir / "data" / "include").resolve()
+    return load_jit(
+        "speculative_sampling",
+        cuda_files=["speculative/speculative_sampling.cuh"],
+        cuda_wrappers=[
+            (
+                "tree_speculative_sampling_target_only",
+                "tree_speculative_sampling_target_only",
+            )
+        ],
+        extra_include_paths=[str(flashinfer_include_path)],
+    )
+
+
+@register_custom_op(
+    op_name="tree_speculative_sampling_target_only_out",
+    mutates_args=["predicts", "accept_index", "accept_token_num", "draft_probs"],
+)
+def tree_speculative_sampling_target_only(
+    predicts: torch.Tensor,
+    accept_index: torch.Tensor,
+    accept_token_num: torch.Tensor,
+    candidates: torch.Tensor,
+    retrive_index: torch.Tensor,
+    retrive_next_token: torch.Tensor,
+    retrive_next_sibling: torch.Tensor,
+    uniform_samples: torch.Tensor,
+    uniform_samples_for_final_sampling: torch.Tensor,
+    target_probs: torch.Tensor,
+    draft_probs: torch.Tensor,
+    threshold_single: float,
+    threshold_acc: float,
+    deterministic: bool = True,
+) -> None:
+    """
+    Tree-based speculative sampling (target-only variant).
+
+    Performs tree speculative decoding acceptance/rejection in-place.
+
+    Args:
+        predicts:              [tot_num_draft_tokens] int32 — filled with accepted/sampled tokens
+        accept_index:          [bs, num_spec_step] int32 — filled with accepted token indices
+        accept_token_num:      [bs] int32 — filled with number of accepted tokens per sequence
+        candidates:            [bs, num_draft_tokens] int64 — draft token IDs
+        retrive_index:         [bs, num_draft_tokens] int64 — tree node indices
+        retrive_next_token:    [bs, num_draft_tokens] int64 — next token in tree path
+        retrive_next_sibling:  [bs, num_draft_tokens] int64 — next sibling in tree
+        uniform_samples:       [bs, num_draft_tokens] float32 — uniform random samples
+        uniform_samples_for_final_sampling: [bs] float32 — uniform sample for bonus token
+        target_probs:          [bs, num_draft_tokens, vocab_size] float32
+        draft_probs:           [bs, num_draft_tokens, vocab_size] float32 — modified in-place
+        threshold_single:      float in [0, 1] — per-token acceptance threshold
+        threshold_acc:         float in [0, 1] — cumulative acceptance threshold
+        deterministic:         bool — deterministic sampling (default True)
+    """
+    module = _jit_speculative_sampling_module()
+    module.tree_speculative_sampling_target_only(
+        predicts,
+        accept_index,
+        accept_token_num,
+        candidates,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+        uniform_samples,
+        uniform_samples_for_final_sampling,
+        target_probs,
+        draft_probs,
+        threshold_single,
+        threshold_acc,
+        1 if deterministic else 0,
+    )

--- a/python/sglang/jit_kernel/tests/test_speculative_sampling.py
+++ b/python/sglang/jit_kernel/tests/test_speculative_sampling.py
@@ -1,0 +1,295 @@
+"""
+Tests for the JIT tree_speculative_sampling_target_only kernel.
+
+Correctness is validated by:
+1. Comparing against the AOT sgl_kernel implementation (bitwise identical
+   for deterministic=True, since the same algorithm + same inputs are used).
+2. Smoke tests and boundary checks.
+"""
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Helper: build a simple linear-chain tree
+# ---------------------------------------------------------------------------
+
+
+def make_linear_chain(bs, num_draft_tokens, num_spec_step, vocab_size, device):
+    """
+    Construct tree tensors for a simple linear chain (no branching).
+
+    Tree layout (per batch element):
+      slot 0: initial context anchor
+      slot 1..num_draft_tokens-1: draft tokens in sequence
+
+    retrive_index[b, i] = i   (slot i writes to predicts[i])
+    retrive_next_token[b, i] = i+1  (sequential chain), last = -1
+    retrive_next_sibling[b, i] = -1 (no siblings)
+    candidates[b, i] = i % vocab_size
+    """
+    retrive_index = torch.stack(
+        [torch.arange(num_draft_tokens, dtype=torch.int64, device=device)] * bs
+    )  # [bs, num_draft_tokens]
+
+    next_token = torch.arange(1, num_draft_tokens + 1, dtype=torch.int64, device=device)
+    next_token[-1] = -1
+    retrive_next_token = next_token.unsqueeze(0).expand(bs, -1).contiguous()
+
+    retrive_next_sibling = torch.full(
+        (bs, num_draft_tokens), -1, dtype=torch.int64, device=device
+    )
+
+    candidates = (
+        torch.arange(num_draft_tokens, dtype=torch.int64, device=device) % vocab_size
+    )
+    candidates = candidates.unsqueeze(0).expand(bs, -1).contiguous()
+
+    return retrive_index, retrive_next_token, retrive_next_sibling, candidates
+
+
+# ---------------------------------------------------------------------------
+# JIT and AOT wrappers
+# ---------------------------------------------------------------------------
+
+
+def run_jit(
+    predicts,
+    accept_index,
+    accept_token_num,
+    candidates,
+    retrive_index,
+    retrive_next_token,
+    retrive_next_sibling,
+    uniform_samples,
+    uniform_samples_for_final_sampling,
+    target_probs,
+    draft_probs,
+    threshold_single,
+    threshold_acc,
+    deterministic=True,
+):
+    from sglang.jit_kernel.speculative_sampling import (
+        tree_speculative_sampling_target_only,
+    )
+
+    tree_speculative_sampling_target_only(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        uniform_samples=uniform_samples,
+        uniform_samples_for_final_sampling=uniform_samples_for_final_sampling,
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+        threshold_single=threshold_single,
+        threshold_acc=threshold_acc,
+        deterministic=deterministic,
+    )
+
+
+def run_aot(
+    predicts,
+    accept_index,
+    accept_token_num,
+    candidates,
+    retrive_index,
+    retrive_next_token,
+    retrive_next_sibling,
+    uniform_samples,
+    uniform_samples_for_final_sampling,
+    target_probs,
+    draft_probs,
+    threshold_single,
+    threshold_acc,
+    deterministic=True,
+):
+    from sgl_kernel import tree_speculative_sampling_target_only
+
+    tree_speculative_sampling_target_only(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        uniform_samples=uniform_samples,
+        uniform_samples_for_final_sampling=uniform_samples_for_final_sampling,
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+        threshold_single=threshold_single,
+        threshold_acc=threshold_acc,
+        deterministic=deterministic,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+DEVICE = "cuda"
+
+
+def make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size, seed=42):
+    """Create all tensors needed for one kernel call."""
+    torch.manual_seed(seed)
+    device = DEVICE
+
+    tot_draft = bs * num_draft_tokens
+    predicts = torch.zeros(tot_draft, dtype=torch.int32, device=device)
+    accept_index = torch.zeros(bs, num_spec_step, dtype=torch.int32, device=device)
+    accept_token_num = torch.zeros(bs, dtype=torch.int32, device=device)
+
+    retrive_index, retrive_next_token, retrive_next_sibling, candidates = (
+        make_linear_chain(bs, num_draft_tokens, num_spec_step, vocab_size, device)
+    )
+
+    uniform_samples = torch.rand(
+        bs, num_draft_tokens, dtype=torch.float32, device=device
+    )
+    uniform_samples_for_final_sampling = torch.rand(
+        bs, dtype=torch.float32, device=device
+    )
+
+    # Uniform probabilities (each token equally likely)
+    raw = torch.rand(
+        bs, num_draft_tokens, vocab_size, dtype=torch.float32, device=device
+    )
+    target_probs = raw / raw.sum(dim=-1, keepdim=True)
+    draft_probs = target_probs.clone()
+
+    return dict(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        uniform_samples=uniform_samples,
+        uniform_samples_for_final_sampling=uniform_samples_for_final_sampling,
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — just verify it runs without errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bs,num_draft_tokens,num_spec_step,vocab_size",
+    [
+        (1, 4, 4, 32),
+        (2, 8, 5, 64),
+        (4, 16, 8, 128),
+        (1, 1, 1, 32),
+    ],
+)
+def test_smoke(bs, num_draft_tokens, num_spec_step, vocab_size):
+    inputs = make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size)
+    run_jit(**inputs, threshold_single=0.9, threshold_acc=0.9)
+
+    # Outputs must be non-negative and in range
+    assert inputs["accept_token_num"].min() >= 0
+    assert inputs["accept_token_num"].max() < num_spec_step
+
+
+# ---------------------------------------------------------------------------
+# JIT vs AOT cross-validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bs,num_draft_tokens,num_spec_step,vocab_size",
+    [
+        (1, 4, 4, 32),
+        (2, 8, 5, 64),
+        (4, 16, 8, 128),
+        (1, 1, 1, 32),
+        (8, 32, 8, 256),
+    ],
+)
+def test_vs_aot(bs, num_draft_tokens, num_spec_step, vocab_size):
+    try:
+        from sgl_kernel import (  # noqa: F401
+            tree_speculative_sampling_target_only as _aot_fn,
+        )
+    except ImportError:
+        pytest.skip("sgl_kernel not available")
+
+    inputs_jit = make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size, seed=0)
+    # Deep-copy all mutable tensors for AOT
+    inputs_aot = {
+        k: v.clone() if isinstance(v, torch.Tensor) else v
+        for k, v in inputs_jit.items()
+    }
+    # Use same probabilities (from JIT input) for AOT
+    inputs_aot["target_probs"] = inputs_jit["target_probs"].clone()
+    inputs_aot["draft_probs"] = inputs_jit["draft_probs"].clone()
+
+    run_jit(**inputs_jit, threshold_single=0.9, threshold_acc=0.9, deterministic=True)
+    run_aot(**inputs_aot, threshold_single=0.9, threshold_acc=0.9, deterministic=True)
+
+    # Mutable outputs should be identical (deterministic=True, same algorithm)
+    assert torch.equal(
+        inputs_jit["predicts"], inputs_aot["predicts"]
+    ), "predicts mismatch"
+    assert torch.equal(
+        inputs_jit["accept_index"], inputs_aot["accept_index"]
+    ), "accept_index mismatch"
+    assert torch.equal(
+        inputs_jit["accept_token_num"], inputs_aot["accept_token_num"]
+    ), "accept_token_num mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary: threshold_single=1.0 means no token is auto-accepted
+# via single-token check (must rely on cumulative).
+# threshold_acc=0.0 is floored to 1e-9 by the kernel, so coin <= prob/1e-9
+# is almost always true (accept all).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bs", [1, 2])
+def test_accept_all_when_threshold_acc_zero(bs):
+    """With threshold_acc very small, all draft tokens should be accepted."""
+    num_draft_tokens = 4
+    num_spec_step = 4
+    vocab_size = 32
+
+    inputs = make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size, seed=123)
+    # Force coins to 0 so coin <= prob / 1e-9 is always satisfied
+    inputs["uniform_samples"].fill_(0.0)
+
+    run_jit(**inputs, threshold_single=0.0, threshold_acc=0.0)
+    # All num_spec_step - 1 draft tokens should be accepted (+ 1 bonus always)
+    assert (inputs["accept_token_num"] == num_spec_step - 1).all()
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary: threshold_single=0.0 means auto-accept first token
+# with prob >= 0, which is always true for non-negative probs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bs", [1, 2])
+def test_accept_all_when_threshold_single_zero(bs):
+    """With threshold_single=0.0 and positive target probs, all tokens accepted."""
+    num_draft_tokens = 4
+    num_spec_step = 4
+    vocab_size = 32
+
+    inputs = make_inputs(bs, num_draft_tokens, num_spec_step, vocab_size, seed=456)
+    # threshold_single=0.0 means target_prob_single >= 0 always passes
+    run_jit(**inputs, threshold_single=0.0, threshold_acc=1.0)
+    assert (inputs["accept_token_num"] == num_spec_step - 1).all()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Motivation

Part of the ongoing effort to migrate `sgl-kernel` AOT kernels to the `jit_kernel` system (tracking issue #17865). This PR ports `sgl-kernel/csrc/speculative/speculative_sampling.cu` to a JIT kernel, making tree speculative sampling available without the heavyweight AOT compilation path.

## Key Design Decisions

- **FlashInfer headers via `extra_include_paths`**: The kernel depends on `flashinfer/sampling.cuh` for `vec_t`, `SamplingTempStorage`, `DeviceSamplingFromProb`, and dispatch macros (`DISPATCH_ALIGNED_VEC_SIZE`, `DISPATCH_DETERMINISTIC`). Following the pattern from `rope.py`, these headers are included via `extra_include_paths` at JIT compile time.
- **Self-contained kernel**: The `__global__` kernel and host launcher are copied verbatim from `sgl-kernel/csrc/speculative/speculative_sampling.cuh` (renamed to `TreeSpeculativeSamplingTargetOnlyLauncher` to avoid symbol conflicts). A thin tvm-ffi wrapper validates inputs and resolves the CUDA stream.
- **Fixed types**: The kernel is instantiated with `DType=float`, `IdType=int32_t`, `IdType2=int64_t` matching the AOT implementation.
- **API compatibility**: The Python wrapper matches `sgl_kernel.tree_speculative_sampling_target_only` exactly (same keyword argument names and types).

## Changes

- `python/sglang/jit_kernel/csrc/speculative/speculative_sampling.cuh` — CUDA kernel + tvm-ffi host wrapper
- `python/sglang/jit_kernel/speculative_sampling.py` — Python API with `@register_custom_op` and `@cache_once`
- `python/sglang/jit_kernel/tests/test_speculative_sampling.py` — 13 tests (smoke, AOT cross-validation, boundary)
- `python/sglang/jit_kernel/benchmark/bench_speculative_sampling.py` — JIT vs AOT throughput benchmark

## Test Results

All 13 tests pass:
```
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_smoke[1-4-4-32] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_smoke[2-8-5-64] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_smoke[4-16-8-128] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_smoke[1-1-1-32] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_vs_aot[1-4-4-32] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_vs_aot[2-8-5-64] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_vs_aot[4-16-8-128] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_vs_aot[1-1-1-32] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_vs_aot[8-32-8-256] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_accept_all_when_threshold_acc_zero[1] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_accept_all_when_threshold_acc_zero[2] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_accept_all_when_threshold_single_zero[1] PASSED
python/sglang/jit_kernel/tests/test_speculative_sampling.py::test_accept_all_when_threshold_single_zero[2] PASSED
13 passed in 17.09s
```

Benchmark (JIT vs AOT, µs, A100):
Correctness:
<img width="884" height="79" alt="image" src="https://github.com/user-attachments/assets/6ad1e6c7-df72-48b3-9588-dc658e5813ab" />

<img width="884" height="283" alt="image" src="https://github.com/user-attachments/assets/56a4af68-7ff2-43a4-ba6b-2fc35682108f" />

Performance: JIT is at parity or faster than AOT across all 12 configurations.         
 <img width="523" height="98" alt="image" src="https://github.com/user-attachments/assets/bbce8e0d-db32-45ef-9b89-d03630e86667" />                                                                             
 No regressions. No further tuning needed.
