### PR TITLE
[DSv32] Fix MTP and CP compatability

### DIFF
--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -34,8 +34,8 @@ from sglang.srt.layers.attention.nsa.utils import (
     prepare_input_dp_with_cp_dsa,
 )
 from sglang.srt.layers.dp_attention import (
-    get_attention_tp_rank,
-    get_attention_tp_size,
+    get_attention_cp_rank,
+    get_attention_cp_size,
     is_dp_attention_enabled,
 )
 from sglang.srt.layers.layernorm import RMSNorm
@@ -123,7 +123,7 @@ class DeepseekModelNextN(nn.Module):
         self.shared_head.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
-            self.cp_size = get_attention_tp_size()
+            self.cp_size = get_attention_cp_size()
         else:
             self.cp_size = None
 
@@ -206,8 +206,8 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         self.use_nsa = is_deepseek_nsa(config)
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
-            self.cp_rank = get_attention_tp_rank()
-            self.cp_size = get_attention_tp_size()
+            self.cp_rank = get_attention_cp_rank()
+            self.cp_size = get_attention_cp_size()
         else:
             self.cp_rank = None
             self.cp_size = None


### PR DESCRIPTION
## Motivation

PR https://github.com/sgl-project/sglang/pull/17213 introduced separate
`get_attention_cp_size()` / `get_attention_cp_rank()` APIs and migrated the main model in `deepseek_v2.py` to use them, but missed `deepseek_nextn.py`.

Here is the assigns:

https://github.com/sgl-project/sglang/blob/0d20cf5a66531eed4db554589dd80c045b5c9e17/python/sglang/srt/models/deepseek_nextn.py#L208-L210

Before the refactor this returned 8 (the combined TP+CP group size). After the refactor it returns 1 (pure attention TP size), so the MTP model operates with cp_size=1, skips CP logic, and produces tensors with wrong shapes. Any request crashes with:

```
RuntimeError: seqlens_k must have shape (batch_size)
```

## Accuracy Tests

Run config
```
export SGLANG_ENABLE_JIT_DEEPGEMM=1
export SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1

export SGLANG_USE_FUSED_METADATA_COPY=0
export SGLANG_ENABLE_SPEC_V2=0

python3 -m sglang.launch_server \
      --model-path deepseek-ai/DeepSeek-V3.2 \
      --trust-remote-code \
      --port 30031 \
      --host "::" \
      --context-length 65536 \
      --chunked-prefill-size 65536 \
      --watchdog-timeout 3600 \
      --tp-size 8 \
      --attn-cp-size 8 \
      --enable-nsa-prefill-context-parallel \
      --cuda-graph-max-bs 75 \
      --chat-template examples/chat_template/tool_chat_template_deepseekv32.jinja \
      --page-size 64 \
      --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}' \
      --mem-fraction-static 0.8 \
      --speculative-algorithm EAGLE \
      --kv-cache-dtype fp8_e4m3
```

Bench
```
python benchmark/gsm8k/bench_sglang.py --port 30031 --num-questions 500 --num-shots 48 --parallel 100

```

Results
```
Accuracy: 0.966
Invalid: 0.000
Latency: 99.841 s
Output throughput: 478.503 token/s
```