### PR TITLE
Add missing prefill batch log in disaggregation prefill mode

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -545,6 +545,14 @@ class SchedulerDisaggregationPrefillMixin:
                     RequestStage.PREFILL_CHUNKED_FORWARD, req.rid, auto_next_anon=True
                 )
 
+        if self.current_scheduler_metrics_enabled:
+            can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+            self.log_prefill_stats(
+                prefill_stats=batch.prefill_stats,
+                can_run_cuda_graph=can_run_cuda_graph,
+                dp_cooperation_info=batch.dp_cooperation_info,
+            )
+
         self.maybe_send_health_check_signal()
 
     def process_disagg_prefill_inflight_queue(


### PR DESCRIPTION
## Summary
- `process_batch_result_disagg_prefill` was missing the `log_prefill_stats` call that exists in the normal `process_batch_result_prefill` path
- This caused no "Prefill batch" log lines to be emitted for PD disaggregated prefill servers (e.g. `--disaggregation-mode prefill`)
- Added the same `log_prefill_stats` call, matching the pattern in `scheduler_output_processor_mixin.py`

## Test plan
- [ ] Deploy a disaggregated prefill server and verify "Prefill batch" log lines now appear
- [ ] Verify non-disaggregated serving is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)