### PR TITLE
fix: disable structural_tag for function_call_parser.GptOssDetector to fix 500error when using tools + streaming

### DIFF
--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -237,5 +237,8 @@ class GptOssDetector(BaseFormatDetector):
             parameters=json.dumps(arguments, ensure_ascii=False),
         )
 
+    def supports_structural_tag(self) -> bool:
+        return False
+
     def structure_info(self) -> _GetInfoFunc:
         raise NotImplementedError("structure_info not used with HarmonyParser")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using gpt-oss (e.g. gpt-oss-120b) with tools and `tool_choice="auto"`, the server returns **500 Internal Server Error**. Reproduced with **chat completions streaming** (`chat.completions.stream`); non-streaming was not tested.

The failure happens in the request path: `serving_chat.py` -> `get_structure_constraint()` -> `get_structure_tag()` -> `detector.structure_info()`. For gpt-oss, tool calls are handled by `GptOssDetector` + HarmonyParser; `structure_info()` is intentionally not implemented (raises `NotImplementedError`). The serving layer still tried to build a structural_tag because the base detector returns `supports_structural_tag() == True`, so requests with tools and strict tools triggered the error. This fix prevents that path from being used for gpt-oss.

```
NotImplementedError: structure_info not used with HarmonyParser
```

## Modifications

- **`python/sglang/srt/function_call/gpt_oss_detector.py`**: Override `supports_structural_tag()` to return `False`. The server then no longer calls `get_structure_tag()` / `structure_info()` for gpt-oss when `tool_choice="auto"`. Tool-call parsing continues to use HarmonyParser in `detect_and_parse` / `parse_streaming_increment`; only the constraint-construction path is skipped.

## Accuracy Tests

N/A — no changes to model forward, kernels, or sampling logic. Only the condition for applying structural_tag to gpt-oss is changed (disabled).

## Benchmarking and Profiling

N/A — no impact on inference speed; same parsing path as before for gpt-oss tool calls.

## Reproduction

Our service calls the SGLang backend via the OpenAI-compatible API with tools and streaming. Simplified pattern that triggers the bug:

```
async with client.chat.completions.stream(
    model="openai/gpt-oss-120b",
    messages=[...],
    tools=[{"type": "function", "function": {"name": "fetch_db", "description": "...", "parameters": {...}, "strict": True}}],
    tool_choice="auto",
    stream_options={"include_usage": True},
) as stream:
    async for chunk in stream:
        ...
```

### Error in our service (client side):

<details>
<summary>Click to expand</summary>

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/fedor/Desktop/work/evotor-ai/src/services/llm/agents/main_agent.py", line 246, in <module>
    
  File "/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.13/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/fedor/Desktop/work/evotor-ai/src/services/llm/agents/main_agent.py", line 240, in main
    
  File "/Users/fedor/Desktop/work/evotor-ai/src/services/llm/agents/main_agent.py", line 32, in run
    response = await self.llm.invoke(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fedor/Desktop/work/evotor-ai/src/services/llm/engine.py", line 45, in invoke
    async with self.allm_client.chat.completions.stream(**request_params) as stream:
  File "/Users/fedor/Desktop/work/evotor-ai/.venv/lib/python3.11/site-packages/openai/lib/streaming/chat/_completions.py", line 273, in __aenter__
    raw_stream = await self.__api_request
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fedor/Desktop/work/evotor-ai/.venv/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 2585, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
  File "/Users/fedor/Desktop/work/evotor-ai/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1794, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fedor/Desktop/work/evotor-ai/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 1594, in request
    raise self._make_status_error_from_response(err.response) from None
openai.InternalServerError: Error code: 500 - {'object': 'error', 'message': 'Internal server error: structure_info not used with HarmonyParser', 'type': 'InternalServerError', 'param': None, 'code': 500}
```

</details>

### Error on the inference server (SGLang):

<details>
<summary>Click to expand</summary>

```
...
File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 182, in _process_messages
    tool_call_constraint = parser.get_structure_constraint(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 172, in get_structure_constraint
    strict_tag = self.get_structure_tag()
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 126, in get_structure_tag
    get_structure_info = self.detector.structure_info()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/gpt_oss_detector.py", line 216, in structure_info
    raise NotImplementedError("structure_info not used with HarmonyParser")
NotImplementedError: structure_info not used with HarmonyParser
[2026-01-25 19:05:28] INFO:     10.0.11.6:36290 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
[2026-01-25 19:05:29] Error in request: structure_info not used with HarmonyParser
Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_base.py", line 39, in handle_request
    adapted_request, processed_request = self._convert_to_internal_request(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 112, in _convert_to_internal_request
    processed_messages = self._process_messages(request, is_multimodal)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 182, in _process_messages
    tool_call_constraint = parser.get_structure_constraint(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 172, in get_structure_constraint
    strict_tag = self.get_structure_tag()
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 126, in get_structure_tag
    get_structure_info = self.detector.structure_info()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/gpt_oss_detector.py", line 216, in structure_info
    raise NotImplementedError("structure_info not used with HarmonyParser")
NotImplementedError: structure_info not used with HarmonyParser
[2026-01-25 19:05:29] INFO:     10.0.11.6:36290 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
[2026-01-25 19:05:31] Error in request: structure_info not used with HarmonyParser
Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_base.py", line 39, in handle_request
    adapted_request, processed_request = self._convert_to_internal_request(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 112, in _convert_to_internal_request
    processed_messages = self._process_messages(request, is_multimodal)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 182, in _process_messages
    tool_call_constraint = parser.get_structure_constraint(
[2026-01-25 19:05:31] INFO:     10.0.11.6:37016 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 172, in get_structure_constraint
    strict_tag = self.get_structure_tag()
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 126, in get_structure_tag
    get_structure_info = self.detector.structure_info()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/gpt_oss_detector.py", line 216, in structure_info
    raise NotImplementedError("structure_info not used with HarmonyParser")
NotImplementedError: structure_info not used with HarmonyParser
[2026-01-25 19:05:34] Error in request: structure_info not used with HarmonyParser
Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_base.py", line 39, in handle_request
    adapted_request, processed_request = self._convert_to_internal_request(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 112, in _convert_to_internal_request
    processed_messages = self._process_messages(request, is_multimodal)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 182, in _process_messages
    tool_call_constraint = parser.get_structure_constraint(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2026-01-25 19:05:34] INFO:     10.0.11.6:37022 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 172, in get_structure_constraint
    strict_tag = self.get_structure_tag()
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 126, in get_structure_tag
    get_structure_info = self.detector.structure_info()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/gpt_oss_detector.py", line 216, in structure_info
    raise NotImplementedError("structure_info not used with HarmonyParser")
NotImplementedError: structure_info not used with HarmonyParser
[2026-01-25 19:05:34] Error in request: structure_info not used with HarmonyParser
Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_base.py", line 39, in handle_request
    adapted_request, processed_request = self._convert_to_internal_request(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 112, in _convert_to_internal_request
    processed_messages = self._process_messages(request, is_multimodal)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 182, in _process_messages
    tool_call_constraint = parser.get_structure_constraint(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 172, in get_structure_constraint
    strict_tag = self.get_structure_tag()
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/function_call_parser.py", line 126, in get_structure_tag
    get_structure_info = self.detector.structure_info()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/function_call/gpt_oss_detector.py", line 216, in structure_info
    raise NotImplementedError("structure_info not used with HarmonyParser")
NotImplementedError: structure_info not used with HarmonyParser
```

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).