### PR TITLE
[jit_kernel] Add JIT eagle_utils kernel

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_eagle_utils.py
+++ b/python/sglang/jit_kernel/benchmark/bench_eagle_utils.py
@@ -1,0 +1,361 @@
+"""
+Benchmark: eagle_utils JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) for:
+  - build_tree_kernel_efficient
+  - verify_tree_greedy
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_eagle_utils.py
+"""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.eagle_utils import build_tree_kernel_efficient as build_tree_jit
+from sglang.jit_kernel.eagle_utils import verify_tree_greedy as verify_tree_greedy_jit
+
+try:
+    from sgl_kernel import build_tree_kernel_efficient as build_tree_aot
+    from sgl_kernel import verify_tree_greedy as verify_tree_greedy_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    build_tree_aot = None
+    verify_tree_greedy_aot = None
+    AOT_AVAILABLE = False
+
+# TreeMaskMode constants (must match eagle_utils.cuh)
+FULL_MASK = 0
+QLEN_ONLY = 1
+QLEN_ONLY_BITPACKING = 2
+
+DEVICE = "cuda"
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+BATCH_SIZE_RANGE = get_benchmark_range(
+    full_range=[1, 4, 8, 16],
+    ci_range=[4],
+)
+
+# (topk, depth) → draft_token_num = topk * (depth - 1) + 1
+TREE_CONFIGS = get_benchmark_range(
+    full_range=[
+        (4, 5),  # typical EAGLE: 17 draft tokens
+        (8, 4),  # wider: 25 draft tokens
+        (4, 8),  # deeper: 29 draft tokens
+    ],
+    ci_range=[(4, 5)],
+)
+
+# (num_draft_tokens, num_spec_step, vocab_size) for verify_tree_greedy
+VERIFY_CONFIGS = get_benchmark_range(
+    full_range=[
+        (16, 8, 32000),
+        (32, 8, 32000),
+        (16, 8, 128000),
+    ],
+    ci_range=[(16, 8, 32000)],
+)
+
+
+# ---------------------------------------------------------------------------
+# build_tree_kernel_efficient inputs
+# ---------------------------------------------------------------------------
+
+
+def make_build_tree_inputs(bs, topk, depth, tree_mask_mode):
+    draft_token_num = topk * (depth - 1) + 1
+    seq_len = 128
+
+    parent_list_size = topk * (depth - 1) + 1
+    parent_list = torch.zeros(bs, parent_list_size, dtype=torch.int64, device=DEVICE)
+    for i in range(1, parent_list_size):
+        parent_list[:, i] = i - 1
+
+    selected_index = (
+        torch.arange(draft_token_num - 1, dtype=torch.int64, device=DEVICE)
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+    verified_seq_len = torch.full((bs,), seq_len, dtype=torch.int64, device=DEVICE)
+
+    if tree_mask_mode == QLEN_ONLY_BITPACKING:
+        num_bytes = 4 if draft_token_num > 16 else (2 if draft_token_num > 8 else 1)
+        tree_mask = torch.zeros(
+            bs * draft_token_num * num_bytes, dtype=torch.uint8, device=DEVICE
+        )
+    else:
+        tree_mask = torch.zeros(
+            bs * draft_token_num * draft_token_num, dtype=torch.bool, device=DEVICE
+        )
+
+    positions = torch.zeros(bs, draft_token_num, dtype=torch.int64, device=DEVICE)
+    retrive_index = torch.zeros(bs, draft_token_num, dtype=torch.int64, device=DEVICE)
+    retrive_next_token = torch.full(
+        (bs, draft_token_num), -1, dtype=torch.int64, device=DEVICE
+    )
+    retrive_next_sibling = torch.full(
+        (bs, draft_token_num), -1, dtype=torch.int64, device=DEVICE
+    )
+
+    return dict(
+        parent_list=parent_list,
+        selected_index=selected_index,
+        verified_seq_len=verified_seq_len,
+        tree_mask=tree_mask,
+        positions=positions,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        topk=topk,
+        depth=depth,
+        draft_token_num=draft_token_num,
+        tree_mask_mode=tree_mask_mode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# verify_tree_greedy inputs
+# ---------------------------------------------------------------------------
+
+
+def make_verify_inputs(bs, num_draft_tokens, num_spec_step, vocab_size):
+    tot_draft = bs * num_draft_tokens
+
+    predicts = torch.zeros(tot_draft, dtype=torch.int32, device=DEVICE)
+    accept_index = torch.zeros(bs, num_spec_step, dtype=torch.int32, device=DEVICE)
+    accept_token_num = torch.zeros(bs, dtype=torch.int32, device=DEVICE)
+
+    retrive_index = torch.stack(
+        [torch.arange(num_draft_tokens, dtype=torch.int64, device=DEVICE)] * bs
+    )
+    next_token = torch.arange(1, num_draft_tokens + 1, dtype=torch.int64, device=DEVICE)
+    next_token[-1] = -1
+    retrive_next_token = next_token.unsqueeze(0).expand(bs, -1).contiguous()
+    retrive_next_sibling = torch.full(
+        (bs, num_draft_tokens), -1, dtype=torch.int64, device=DEVICE
+    )
+    candidates = (
+        (torch.arange(num_draft_tokens, dtype=torch.int64, device=DEVICE) % vocab_size)
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+    target_predict = candidates.clone()
+
+    return dict(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        target_predict=target_predict,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_tree_kernel_efficient benchmark
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["bs", "topk", "depth", "tree_mask_mode"],
+        x_vals=[
+            (bs, topk, depth, QLEN_ONLY)
+            for bs, (topk, depth) in itertools.product(BATCH_SIZE_RANGE, TREE_CONFIGS)
+        ],
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=[("blue", "--"), ("orange", "-")][: len(LINE_VALS)],
+        ylabel="us",
+        plot_name="build-tree-performance",
+        args={},
+    )
+)
+def bench_build_tree(
+    bs: int, topk: int, depth: int, tree_mask_mode: int, provider: str
+):
+    draft_token_num = topk * (depth - 1) + 1
+    inputs = make_build_tree_inputs(bs, topk, depth, tree_mask_mode)
+
+    mutated_keys = {
+        "positions",
+        "retrive_index",
+        "retrive_next_token",
+        "retrive_next_sibling",
+        "tree_mask",
+    }
+    backups = {k: inputs[k].clone() for k in mutated_keys}
+
+    if provider == "jit":
+
+        def fn():
+            for k in mutated_keys:
+                inputs[k].copy_(backups[k])
+            build_tree_jit(**inputs)
+
+    elif provider == "aot":
+
+        def fn():
+            for k in mutated_keys:
+                inputs[k].copy_(backups[k])
+            build_tree_aot(**inputs)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# verify_tree_greedy benchmark
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["bs", "num_draft_tokens", "num_spec_step", "vocab_size"],
+        x_vals=[
+            (bs, ndt, nss, vs)
+            for bs, (ndt, nss, vs) in itertools.product(
+                BATCH_SIZE_RANGE, VERIFY_CONFIGS
+            )
+        ],
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=[("blue", "--"), ("orange", "-")][: len(LINE_VALS)],
+        ylabel="us",
+        plot_name="verify-tree-greedy-performance",
+        args={},
+    )
+)
+def bench_verify_tree_greedy(
+    bs: int,
+    num_draft_tokens: int,
+    num_spec_step: int,
+    vocab_size: int,
+    provider: str,
+):
+    inputs = make_verify_inputs(bs, num_draft_tokens, num_spec_step, vocab_size)
+
+    mutated_keys = {"predicts", "accept_index", "accept_token_num"}
+    backups = {k: inputs[k].clone() for k in mutated_keys}
+
+    if provider == "jit":
+
+        def fn():
+            for k in mutated_keys:
+                inputs[k].copy_(backups[k])
+            verify_tree_greedy_jit(**inputs)
+
+    elif provider == "aot":
+
+        def fn():
+            for k in mutated_keys:
+                inputs[k].copy_(backups[k])
+            verify_tree_greedy_aot(**inputs)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff — verify_tree_greedy (JIT vs AOT):")
+    for bs, num_draft_tokens, num_spec_step, vocab_size in [
+        (1, 4, 4, 32),
+        (2, 8, 5, 32000),
+        (4, 16, 8, 128000),
+    ]:
+        inp_jit = make_verify_inputs(bs, num_draft_tokens, num_spec_step, vocab_size)
+        inp_aot = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in inp_jit.items()
+        }
+
+        verify_tree_greedy_jit(**inp_jit)
+        verify_tree_greedy_aot(**inp_aot)
+
+        match_predicts = torch.equal(inp_jit["predicts"], inp_aot["predicts"])
+        match_accept_num = torch.equal(
+            inp_jit["accept_token_num"], inp_aot["accept_token_num"]
+        )
+        status = "OK" if (match_predicts and match_accept_num) else "MISMATCH"
+        print(
+            f"  bs={bs:2d} num_draft={num_draft_tokens:2d} num_spec={num_spec_step:2d} "
+            f"vocab={vocab_size:6d}  [{status}]"
+        )
+
+    print()
+    print("Correctness diff — build_tree_kernel_efficient (JIT vs AOT):")
+    for bs, topk, depth, tree_mask_mode in [
+        (1, 4, 5, QLEN_ONLY),
+        (2, 4, 5, QLEN_ONLY_BITPACKING),
+        (4, 8, 4, QLEN_ONLY),
+    ]:
+        inp_jit = make_build_tree_inputs(bs, topk, depth, tree_mask_mode)
+        inp_aot = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in inp_jit.items()
+        }
+
+        build_tree_jit(**inp_jit)
+        build_tree_aot(**inp_aot)
+
+        match_positions = torch.equal(inp_jit["positions"], inp_aot["positions"])
+        match_retrive_index = torch.equal(
+            inp_jit["retrive_index"], inp_aot["retrive_index"]
+        )
+        match_next_token = torch.equal(
+            inp_jit["retrive_next_token"], inp_aot["retrive_next_token"]
+        )
+        match_sibling = torch.equal(
+            inp_jit["retrive_next_sibling"], inp_aot["retrive_next_sibling"]
+        )
+        status = (
+            "OK"
+            if all(
+                [match_positions, match_retrive_index, match_next_token, match_sibling]
+            )
+            else "MISMATCH"
+        )
+        draft_token_num = topk * (depth - 1) + 1
+        print(
+            f"  bs={bs:2d} topk={topk:2d} depth={depth:2d} draft_tokens={draft_token_num:2d} "
+            f"mode={tree_mask_mode}  [{status}]"
+        )
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    bench_build_tree.run(print_data=True)
+    print()
+    bench_verify_tree_greedy.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/speculative/eagle_utils.cuh
+++ b/python/sglang/jit_kernel/csrc/speculative/eagle_utils.cuh
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2025 by SGLang team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Adapted from
+// https://github.com/sgl-project/sglang/blob/main/sgl-kernel/csrc/speculative/eagle_utils.cu
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+typedef enum { FULL_MASK = 0, QLEN_ONLY = 1, QLEN_ONLY_BITPACKING = 2 } TreeMaskMode;
+
+// parent_list [bs, topk * (depth - 1) + 1)]
+// selected_index [bs, draft_token_num - 1]
+// verified_seq_len [bs]
+// tree_mask [draft_token*(seq_len[0]+draft_token) | draft_token*(seq_len[1]+draft_token) | ..] =
+// [sum(verified_seq_len)*draft_token+bs*draft_token*draft_token] positions [bs * draft_token] retrive_index [b,
+// draft_token] retrive_next_token [b, draft_token] retrive_next_sibling [b, draft_token]
+__global__ void build_tree_efficient(
+    int64_t* parent_list,
+    int64_t* selected_index,
+    int64_t* verified_seq_len,
+    bool* tree_mask,
+    int64_t* positions,
+    int64_t* retrive_index,
+    int64_t* retrive_next_token,
+    int64_t* retrive_next_sibling,
+    int topk,
+    int depth,
+    int draft_token_num,
+    int tree_mask_mode) {
+  int bid = blockIdx.x;
+  int tid = threadIdx.x;
+
+  if (tid >= draft_token_num) {
+    return;
+  }
+  int seq_tree_idx = draft_token_num * draft_token_num * bid;
+  for (int i = 0; i < bid; i++) {
+    seq_tree_idx += verified_seq_len[i] * draft_token_num;
+  }
+  int seq_len = verified_seq_len[bid];
+  int token_tree_idx;
+  if (tree_mask_mode == FULL_MASK) {
+    token_tree_idx = seq_tree_idx + (seq_len + draft_token_num) * tid + seq_len + 1;
+  } else {
+    token_tree_idx = draft_token_num * draft_token_num * bid + draft_token_num * tid + 1;
+  }
+  tree_mask[token_tree_idx - 1] = true;
+  for (int i = 0; i < draft_token_num - 1; i++) {
+    tree_mask[token_tree_idx + i] = false;
+  }
+
+  int position = 0;
+  if (tid == 0) {
+    positions[bid * draft_token_num] = seq_len;
+
+    int retrive_index_offset = bid * draft_token_num;
+    for (int i = draft_token_num - 1; i > 0; --i) {
+      int current_token_idx = retrive_index_offset + i;
+      retrive_index[bid * draft_token_num + i] = current_token_idx;
+      int parent_tb_idx = selected_index[bid * (draft_token_num - 1) + i - 1] / topk;
+      int parent_position = 0;
+      if (parent_tb_idx > 0) {
+        int parent_token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
+        for (; parent_position < draft_token_num; ++parent_position) {
+          if (selected_index[bid * (draft_token_num - 1) + parent_position] == parent_token_idx) {
+            ++parent_position;
+            break;
+          }
+        }
+      }
+      if (parent_position == draft_token_num) {
+        printf(
+            "WARNING: invalid eagle tree!!! Detected a token with no parent token selected. "
+            "Please check if the logprob has nan. The token will be ignored to keep proceeding.\n");
+        continue;
+      }
+
+      if (retrive_next_token[bid * draft_token_num + parent_position] == -1) {
+        retrive_next_token[bid * draft_token_num + parent_position] = i;
+      } else {
+        int origin_next_token = retrive_next_token[bid * draft_token_num + parent_position];
+        retrive_next_token[bid * draft_token_num + parent_position] = i;
+        retrive_next_sibling[bid * draft_token_num + i] = origin_next_token;
+      }
+    }
+    retrive_index[bid * draft_token_num] = bid * draft_token_num;
+  } else {
+    int cur_position = tid - 1;
+    while (true) {
+      position += 1;
+      tree_mask[token_tree_idx + cur_position] = true;
+      int parent_tb_idx = selected_index[bid * (draft_token_num - 1) + cur_position] / topk;
+      if (parent_tb_idx == 0) {
+        break;
+      }
+
+      int token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
+      for (cur_position = 0; cur_position < draft_token_num; ++cur_position) {
+        if (selected_index[bid * (draft_token_num - 1) + cur_position] == token_idx) {
+          break;
+        }
+      }
+    }
+    positions[bid * draft_token_num + tid] = position + seq_len;
+  }
+}
+
+// parent_list [bs, topk * (depth - 1) + 1)]
+// selected_index [bs, draft_token_num - 1]
+// verified_seq_len [bs]
+// tree_mask: [draft_token*num_bytes_per_item | .. ] = [bs*draft_token*num_bytes_per_item]
+// positions [bs * draft_token]
+// retrive_index [bs, draft_token]
+// retrive_next_token [bs, draft_token]
+// retrive_next_sibling [bs, draft_token]
+__global__ void build_tree_efficient_partial_packed(
+    int64_t* parent_list,
+    int64_t* selected_index,
+    int64_t* verified_seq_len,
+    uint8_t* tree_mask,
+    int64_t* positions,
+    int64_t* retrive_index,
+    int64_t* retrive_next_token,
+    int64_t* retrive_next_sibling,
+    int topk,
+    int depth,
+    int draft_token_num,
+    size_t num_bytes_per_item) {
+  int bid = blockIdx.x;
+  int tid = threadIdx.x;
+
+  if (tid >= draft_token_num) {
+    return;
+  }
+  int seq_len = verified_seq_len[bid];
+  int token_tree_idx = (bid * draft_token_num + tid) * num_bytes_per_item;
+  tree_mask[token_tree_idx] = 1;  // little endian
+
+  int position = 0;
+  if (tid == 0) {
+    positions[bid * draft_token_num] = seq_len;
+
+    int retrive_index_offset = bid * draft_token_num;
+    for (int i = draft_token_num - 1; i > 0; --i) {
+      int current_token_idx = retrive_index_offset + i;
+      retrive_index[bid * draft_token_num + i] = current_token_idx;
+      int parent_tb_idx = selected_index[bid * (draft_token_num - 1) + i - 1] / topk;
+      int parent_position = 0;
+      if (parent_tb_idx > 0) {
+        int parent_token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
+        for (; parent_position < draft_token_num; ++parent_position) {
+          if (selected_index[bid * (draft_token_num - 1) + parent_position] == parent_token_idx) {
+            ++parent_position;
+            break;
+          }
+        }
+      }
+      if (parent_position == draft_token_num) {
+        printf(
+            "WARNING: invalid eagle tree!!! Detected a token with no parent token selected. "
+            "Please check if the logprob has nan. The token will be ignored to keep proceeding.\n");
+        continue;
+      }
+
+      if (retrive_next_token[bid * draft_token_num + parent_position] == -1) {
+        retrive_next_token[bid * draft_token_num + parent_position] = i;
+      } else {
+        int origin_next_token = retrive_next_token[bid * draft_token_num + parent_position];
+        retrive_next_token[bid * draft_token_num + parent_position] = i;
+        retrive_next_sibling[bid * draft_token_num + i] = origin_next_token;
+      }
+    }
+    retrive_index[bid * draft_token_num] = bid * draft_token_num;
+  } else {
+    int cur_position = tid - 1;
+    while (true) {
+      position += 1;
+      int byte_idx = (cur_position + 1) / 8;
+      int bit_idx = (cur_position + 1) % 8;
+      tree_mask[token_tree_idx + byte_idx] |= (1 << bit_idx);
+      int parent_tb_idx = selected_index[bid * (draft_token_num - 1) + cur_position] / topk;
+      if (parent_tb_idx == 0) {
+        break;
+      }
+
+      int token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
+      for (cur_position = 0; cur_position < draft_token_num; ++cur_position) {
+        if (selected_index[bid * (draft_token_num - 1) + cur_position] == token_idx) {
+          break;
+        }
+      }
+    }
+    positions[bid * draft_token_num + tid] = position + seq_len;
+  }
+}
+
+template <typename IdType, typename IdType2>
+__global__ void VerifyTreeGreedy(
+    IdType* predicts,
+    IdType* accept_index,
+    IdType* accept_token_num,  // mutable
+    IdType2* candidates,
+    IdType2* retrive_index,
+    IdType2* retrive_next_token,
+    IdType2* retrive_next_sibling,
+    IdType2* target_predict,
+    uint32_t batch_size,
+    uint32_t num_speculative_tokens,
+    uint32_t num_draft_tokens) {
+  uint32_t bx = blockIdx.x;
+
+  IdType2 last_accepted_retrive_idx = retrive_index[bx * num_draft_tokens];
+  accept_index[bx * num_speculative_tokens] = last_accepted_retrive_idx;
+  uint32_t num_accepted_tokens = 0;
+  IdType2 cur_index = 0;
+
+  for (uint32_t j = 1; j < num_speculative_tokens; ++j) {
+    cur_index = retrive_next_token[bx * num_draft_tokens + cur_index];
+    while (cur_index != -1) {
+      IdType2 draft_index = retrive_index[bx * num_draft_tokens + cur_index];
+      IdType2 draft_token_id = candidates[bx * num_draft_tokens + cur_index];
+      IdType2 target_token_id = target_predict[last_accepted_retrive_idx];
+
+      if (draft_token_id == target_token_id) {
+        // accept token
+        predicts[last_accepted_retrive_idx] = target_token_id;
+        ++num_accepted_tokens;
+        accept_index[bx * num_speculative_tokens + num_accepted_tokens] = draft_index;
+        last_accepted_retrive_idx = draft_index;
+        break;
+      } else {
+        cur_index = retrive_next_sibling[bx * num_draft_tokens + cur_index];
+      }
+    }
+    if (cur_index == -1) break;
+  }
+  accept_token_num[bx] = num_accepted_tokens;
+  predicts[last_accepted_retrive_idx] = target_predict[last_accepted_retrive_idx];
+}
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// tvm-ffi entry points
+// ---------------------------------------------------------------------------
+
+// predicts:              [tot_num_draft_tokens] int32, mutable
+// accept_index:          [bs, num_spec_step] int32, mutable
+// accept_token_num:      [bs] int32, mutable
+// candidates:            [bs, num_draft_tokens] int64
+// retrive_index:         [bs, num_draft_tokens] int64
+// retrive_next_token:    [bs, num_draft_tokens] int64
+// retrive_next_sibling:  [bs, num_draft_tokens] int64
+// target_predict:        [bs, num_draft_tokens] int64
+void verify_tree_greedy(
+    tvm::ffi::TensorView predicts,
+    tvm::ffi::TensorView accept_index,
+    tvm::ffi::TensorView accept_token_num,
+    tvm::ffi::TensorView candidates,
+    tvm::ffi::TensorView retrive_index,
+    tvm::ffi::TensorView retrive_next_token,
+    tvm::ffi::TensorView retrive_next_sibling,
+    tvm::ffi::TensorView target_predict) {
+  using namespace host;
+
+  RuntimeCheck(candidates.device().device_type == kDLCUDA, "candidates must be a CUDA tensor");
+  RuntimeCheck(candidates.ndim() == 2, "candidates must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(candidates.is_contiguous(), "candidates must be contiguous");
+  RuntimeCheck(candidates.dtype().code == kDLInt && candidates.dtype().bits == 64, "candidates must be int64");
+
+  uint32_t batch_size = static_cast<uint32_t>(candidates.size(0));
+  uint32_t num_draft_tokens = static_cast<uint32_t>(candidates.size(1));
+
+  RuntimeCheck(accept_index.ndim() == 2, "accept_index must be 2D: [bs, num_spec_step]");
+  RuntimeCheck(accept_index.dtype().code == kDLInt && accept_index.dtype().bits == 32, "accept_index must be int32");
+  RuntimeCheck(accept_index.is_contiguous(), "accept_index must be contiguous");
+  RuntimeCheck(static_cast<uint32_t>(accept_index.size(0)) == batch_size, "accept_index batch_size mismatch");
+  uint32_t num_spec_step = static_cast<uint32_t>(accept_index.size(1));
+
+  RuntimeCheck(predicts.ndim() == 1, "predicts must be 1D");
+  RuntimeCheck(
+      static_cast<uint32_t>(predicts.size(0)) == batch_size * num_draft_tokens,
+      "predicts size must equal batch_size * num_draft_tokens");
+  RuntimeCheck(predicts.dtype().code == kDLInt && predicts.dtype().bits == 32, "predicts must be int32");
+  RuntimeCheck(predicts.is_contiguous(), "predicts must be contiguous");
+
+  RuntimeCheck(accept_token_num.ndim() == 1, "accept_token_num must be 1D");
+  RuntimeCheck(
+      accept_token_num.dtype().code == kDLInt && accept_token_num.dtype().bits == 32, "accept_token_num must be int32");
+  RuntimeCheck(accept_token_num.is_contiguous(), "accept_token_num must be contiguous");
+  RuntimeCheck(static_cast<uint32_t>(accept_token_num.size(0)) == batch_size, "accept_token_num batch_size mismatch");
+
+  RuntimeCheck(retrive_index.ndim() == 2, "retrive_index must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(retrive_index.dtype().code == kDLInt && retrive_index.dtype().bits == 64, "retrive_index must be int64");
+  RuntimeCheck(retrive_index.is_contiguous(), "retrive_index must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(retrive_index.size(0)) == batch_size &&
+          static_cast<uint32_t>(retrive_index.size(1)) == num_draft_tokens,
+      "retrive_index shape mismatch");
+
+  RuntimeCheck(retrive_next_token.ndim() == 2, "retrive_next_token must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(
+      retrive_next_token.dtype().code == kDLInt && retrive_next_token.dtype().bits == 64,
+      "retrive_next_token must be int64");
+  RuntimeCheck(retrive_next_token.is_contiguous(), "retrive_next_token must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(retrive_next_token.size(0)) == batch_size &&
+          static_cast<uint32_t>(retrive_next_token.size(1)) == num_draft_tokens,
+      "retrive_next_token shape mismatch");
+
+  RuntimeCheck(retrive_next_sibling.ndim() == 2, "retrive_next_sibling must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(
+      retrive_next_sibling.dtype().code == kDLInt && retrive_next_sibling.dtype().bits == 64,
+      "retrive_next_sibling must be int64");
+  RuntimeCheck(retrive_next_sibling.is_contiguous(), "retrive_next_sibling must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(retrive_next_sibling.size(0)) == batch_size &&
+          static_cast<uint32_t>(retrive_next_sibling.size(1)) == num_draft_tokens,
+      "retrive_next_sibling shape mismatch");
+
+  RuntimeCheck(target_predict.ndim() == 2, "target_predict must be 2D: [bs, num_draft_tokens]");
+  RuntimeCheck(
+      target_predict.dtype().code == kDLInt && target_predict.dtype().bits == 64, "target_predict must be int64");
+  RuntimeCheck(target_predict.is_contiguous(), "target_predict must be contiguous");
+  RuntimeCheck(
+      static_cast<uint32_t>(target_predict.size(0)) == batch_size &&
+          static_cast<uint32_t>(target_predict.size(1)) == num_draft_tokens,
+      "target_predict shape mismatch");
+
+  cudaStream_t stream = LaunchKernel::resolve_device(candidates.device());
+  dim3 grid(batch_size);
+  dim3 block(1);
+
+  LaunchKernel(grid, block, stream)(
+      VerifyTreeGreedy<int32_t, int64_t>,
+      static_cast<int32_t*>(predicts.data_ptr()),
+      static_cast<int32_t*>(accept_index.data_ptr()),
+      static_cast<int32_t*>(accept_token_num.data_ptr()),
+      static_cast<int64_t*>(candidates.data_ptr()),
+      static_cast<int64_t*>(retrive_index.data_ptr()),
+      static_cast<int64_t*>(retrive_next_token.data_ptr()),
+      static_cast<int64_t*>(retrive_next_sibling.data_ptr()),
+      static_cast<int64_t*>(target_predict.data_ptr()),
+      batch_size,
+      num_spec_step,
+      num_draft_tokens);
+}
+
+// parent_list:          [bs, topk * (depth - 1) + 1] int64
+// selected_index:       [bs, draft_token_num - 1] int64
+// verified_seq_len:     [bs] int64
+// tree_mask:            shape depends on tree_mask_mode; uint8 (bool or bitpacked)
+// positions:            [bs, draft_token_num] int64, mutable
+// retrive_index:        [bs, draft_token_num] int64, mutable
+// retrive_next_token:   [bs, draft_token_num] int64, mutable
+// retrive_next_sibling: [bs, draft_token_num] int64, mutable
+// topk, depth, draft_token_num, tree_mask_mode: scalars
+void build_tree_kernel_efficient(
+    tvm::ffi::TensorView parent_list,
+    tvm::ffi::TensorView selected_index,
+    tvm::ffi::TensorView verified_seq_len,
+    tvm::ffi::TensorView tree_mask,
+    tvm::ffi::TensorView positions,
+    tvm::ffi::TensorView retrive_index,
+    tvm::ffi::TensorView retrive_next_token,
+    tvm::ffi::TensorView retrive_next_sibling,
+    int64_t topk,
+    int64_t depth,
+    int64_t draft_token_num,
+    int64_t tree_mask_mode) {
+  using namespace host;
+
+  RuntimeCheck(parent_list.device().device_type == kDLCUDA, "parent_list must be a CUDA tensor");
+  RuntimeCheck(parent_list.ndim() == 2, "parent_list must be 2D: [bs, topk*(depth-1)+1]");
+  RuntimeCheck(parent_list.is_contiguous(), "parent_list must be contiguous");
+  RuntimeCheck(parent_list.dtype().code == kDLInt && parent_list.dtype().bits == 64, "parent_list must be int64");
+
+  int bs = static_cast<int>(parent_list.size(0));
+
+  RuntimeCheck(selected_index.ndim() == 2, "selected_index must be 2D: [bs, draft_token_num-1]");
+  RuntimeCheck(selected_index.is_contiguous(), "selected_index must be contiguous");
+  RuntimeCheck(
+      selected_index.dtype().code == kDLInt && selected_index.dtype().bits == 64, "selected_index must be int64");
+  RuntimeCheck(static_cast<int>(selected_index.size(0)) == bs, "selected_index batch_size mismatch");
+  RuntimeCheck(selected_index.size(1) == draft_token_num - 1, "selected_index dim1 must equal draft_token_num - 1");
+
+  RuntimeCheck(verified_seq_len.ndim() == 1, "verified_seq_len must be 1D: [bs]");
+  RuntimeCheck(verified_seq_len.is_contiguous(), "verified_seq_len must be contiguous");
+  RuntimeCheck(
+      verified_seq_len.dtype().code == kDLInt && verified_seq_len.dtype().bits == 64, "verified_seq_len must be int64");
+  RuntimeCheck(static_cast<int>(verified_seq_len.size(0)) == bs, "verified_seq_len batch_size mismatch");
+
+  RuntimeCheck(tree_mask.is_contiguous(), "tree_mask must be contiguous");
+  // tree_mask is bool (torch.bool → kDLBool) for FULL_MASK/QLEN_ONLY and
+  // uint8 (torch.uint8 → kDLUInt) for QLEN_ONLY_BITPACKING.  Both are 1-byte
+  // elements; check only the element size to accept either dtype.
+  RuntimeCheck(host::dtype_bytes(tree_mask.dtype()) == 1, "tree_mask element size must be 1 byte (bool or uint8)");
+
+  RuntimeCheck(positions.ndim() == 2, "positions must be 2D: [bs, draft_token_num]");
+  RuntimeCheck(positions.is_contiguous(), "positions must be contiguous");
+  RuntimeCheck(positions.dtype().code == kDLInt && positions.dtype().bits == 64, "positions must be int64");
+  RuntimeCheck(
+      static_cast<int>(positions.size(0)) == bs && positions.size(1) == draft_token_num, "positions shape mismatch");
+
+  RuntimeCheck(retrive_index.ndim() == 2, "retrive_index must be 2D: [bs, draft_token_num]");
+  RuntimeCheck(retrive_index.is_contiguous(), "retrive_index must be contiguous");
+  RuntimeCheck(retrive_index.dtype().code == kDLInt && retrive_index.dtype().bits == 64, "retrive_index must be int64");
+  RuntimeCheck(
+      static_cast<int>(retrive_index.size(0)) == bs && retrive_index.size(1) == draft_token_num,
+      "retrive_index shape mismatch");
+
+  RuntimeCheck(retrive_next_token.ndim() == 2, "retrive_next_token must be 2D: [bs, draft_token_num]");
+  RuntimeCheck(retrive_next_token.is_contiguous(), "retrive_next_token must be contiguous");
+  RuntimeCheck(
+      retrive_next_token.dtype().code == kDLInt && retrive_next_token.dtype().bits == 64,
+      "retrive_next_token must be int64");
+  RuntimeCheck(
+      static_cast<int>(retrive_next_token.size(0)) == bs && retrive_next_token.size(1) == draft_token_num,
+      "retrive_next_token shape mismatch");
+
+  RuntimeCheck(retrive_next_sibling.ndim() == 2, "retrive_next_sibling must be 2D: [bs, draft_token_num]");
+  RuntimeCheck(retrive_next_sibling.is_contiguous(), "retrive_next_sibling must be contiguous");
+  RuntimeCheck(
+      retrive_next_sibling.dtype().code == kDLInt && retrive_next_sibling.dtype().bits == 64,
+      "retrive_next_sibling must be int64");
+  RuntimeCheck(
+      static_cast<int>(retrive_next_sibling.size(0)) == bs && retrive_next_sibling.size(1) == draft_token_num,
+      "retrive_next_sibling shape mismatch");
+
+  cudaStream_t stream = LaunchKernel::resolve_device(parent_list.device());
+  dim3 grid(bs);
+  dim3 block(static_cast<unsigned>(draft_token_num));
+
+  if (tree_mask_mode == QLEN_ONLY_BITPACKING) {
+    size_t num_bytes_per_item = 1;
+    if (draft_token_num > 16) {
+      num_bytes_per_item = 4;
+    } else if (draft_token_num > 8) {
+      num_bytes_per_item = 2;
+    }
+    LaunchKernel(grid, block, stream)(
+        build_tree_efficient_partial_packed,
+        static_cast<int64_t*>(parent_list.data_ptr()),
+        static_cast<int64_t*>(selected_index.data_ptr()),
+        static_cast<int64_t*>(verified_seq_len.data_ptr()),
+        static_cast<uint8_t*>(tree_mask.data_ptr()),
+        static_cast<int64_t*>(positions.data_ptr()),
+        static_cast<int64_t*>(retrive_index.data_ptr()),
+        static_cast<int64_t*>(retrive_next_token.data_ptr()),
+        static_cast<int64_t*>(retrive_next_sibling.data_ptr()),
+        static_cast<int>(topk),
+        static_cast<int>(depth),
+        static_cast<int>(draft_token_num),
+        num_bytes_per_item);
+  } else {
+    LaunchKernel(grid, block, stream)(
+        build_tree_efficient,
+        static_cast<int64_t*>(parent_list.data_ptr()),
+        static_cast<int64_t*>(selected_index.data_ptr()),
+        static_cast<int64_t*>(verified_seq_len.data_ptr()),
+        static_cast<bool*>(tree_mask.data_ptr()),
+        static_cast<int64_t*>(positions.data_ptr()),
+        static_cast<int64_t*>(retrive_index.data_ptr()),
+        static_cast<int64_t*>(retrive_next_token.data_ptr()),
+        static_cast<int64_t*>(retrive_next_sibling.data_ptr()),
+        static_cast<int>(topk),
+        static_cast<int>(depth),
+        static_cast<int>(draft_token_num),
+        static_cast<int>(tree_mask_mode));
+  }
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/eagle_utils.py
+++ b/python/sglang/jit_kernel/eagle_utils.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_eagle_utils_module() -> Module:
+    return load_jit(
+        "eagle_utils",
+        cuda_files=["speculative/eagle_utils.cuh"],
+        cuda_wrappers=[
+            ("build_tree_kernel_efficient", "build_tree_kernel_efficient"),
+            ("verify_tree_greedy", "verify_tree_greedy"),
+        ],
+    )
+
+
+@register_custom_op(
+    op_name="build_tree_kernel_efficient_out",
+    mutates_args=[
+        "tree_mask",
+        "positions",
+        "retrive_index",
+        "retrive_next_token",
+        "retrive_next_sibling",
+    ],
+)
+def build_tree_kernel_efficient(
+    parent_list: torch.Tensor,
+    selected_index: torch.Tensor,
+    verified_seq_len: torch.Tensor,
+    tree_mask: torch.Tensor,
+    positions: torch.Tensor,
+    retrive_index: torch.Tensor,
+    retrive_next_token: torch.Tensor,
+    retrive_next_sibling: torch.Tensor,
+    topk: int,
+    depth: int,
+    draft_token_num: int,
+    tree_mask_mode: int,
+) -> None:
+    """
+    Build EAGLE speculative decoding tree in-place.
+
+    Args:
+        parent_list:          [bs, topk*(depth-1)+1] int64 — parent node indices in tree
+        selected_index:       [bs, draft_token_num-1] int64 — selected token indices
+        verified_seq_len:     [bs] int64 — verified sequence lengths
+        tree_mask:            tree attention mask tensor (shape depends on tree_mask_mode)
+        positions:            [bs, draft_token_num] int64 — filled with token positions
+        retrive_index:        [bs, draft_token_num] int64 — filled with retrieval indices
+        retrive_next_token:   [bs, draft_token_num] int64 — filled with next token links
+        retrive_next_sibling: [bs, draft_token_num] int64 — filled with sibling links
+        topk:                 number of top-k candidates per step
+        depth:                tree depth
+        draft_token_num:      total number of draft tokens per batch element
+        tree_mask_mode:       0=FULL_MASK, 1=QLEN_ONLY, 2=QLEN_ONLY_BITPACKING
+    """
+    module = _jit_eagle_utils_module()
+    module.build_tree_kernel_efficient(
+        parent_list,
+        selected_index,
+        verified_seq_len,
+        tree_mask,
+        positions,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+        topk,
+        depth,
+        draft_token_num,
+        tree_mask_mode,
+    )
+
+
+@register_custom_op(
+    op_name="verify_tree_greedy_out",
+    mutates_args=["predicts", "accept_index", "accept_token_num"],
+)
+def verify_tree_greedy(
+    predicts: torch.Tensor,
+    accept_index: torch.Tensor,
+    accept_token_num: torch.Tensor,
+    candidates: torch.Tensor,
+    retrive_index: torch.Tensor,
+    retrive_next_token: torch.Tensor,
+    retrive_next_sibling: torch.Tensor,
+    target_predict: torch.Tensor,
+) -> None:
+    """
+    Greedy tree verification for EAGLE speculative decoding.
+
+    Args:
+        predicts:              [tot_num_draft_tokens] int32 — filled with accepted/predicted tokens
+        accept_index:          [bs, num_spec_step] int32 — filled with accepted token indices
+        accept_token_num:      [bs] int32 — filled with number of accepted tokens per sequence
+        candidates:            [bs, num_draft_tokens] int64 — draft token IDs
+        retrive_index:         [bs, num_draft_tokens] int64 — tree node retrieval indices
+        retrive_next_token:    [bs, num_draft_tokens] int64 — next token links in tree
+        retrive_next_sibling:  [bs, num_draft_tokens] int64 — sibling links in tree
+        target_predict:        [bs, num_draft_tokens] int64 — target model token predictions
+    """
+    module = _jit_eagle_utils_module()
+    module.verify_tree_greedy(
+        predicts,
+        accept_index,
+        accept_token_num,
+        candidates,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+        target_predict,
+    )

--- a/python/sglang/jit_kernel/tests/test_eagle_utils.py
+++ b/python/sglang/jit_kernel/tests/test_eagle_utils.py
@@ -1,0 +1,366 @@
+"""
+Tests for the JIT eagle_utils kernels:
+  - build_tree_kernel_efficient
+  - verify_tree_greedy
+
+Correctness is validated by:
+1. Comparing against the AOT sgl_kernel implementation (bitwise identical outputs).
+2. Smoke tests and boundary checks.
+"""
+
+import pytest
+import torch
+
+DEVICE = "cuda"
+
+# TreeMaskMode constants (must match eagle_utils.cuh)
+FULL_MASK = 0
+QLEN_ONLY = 1
+QLEN_ONLY_BITPACKING = 2
+
+
+# ---------------------------------------------------------------------------
+# Helper: make inputs for build_tree_kernel_efficient
+# ---------------------------------------------------------------------------
+
+
+def make_build_tree_inputs(
+    bs, topk, depth, draft_token_num, seq_len, tree_mask_mode, device=DEVICE
+):
+    """
+    Create a minimal set of tensors for build_tree_kernel_efficient.
+
+    Uses a simple linear-chain tree (each node's parent is the previous one).
+    """
+    parent_list_size = topk * (depth - 1) + 1
+    parent_list = torch.zeros(bs, parent_list_size, dtype=torch.int64, device=device)
+    # Simple: parent_list[b, i] = i - 1 (previous node), 0 is root
+    for i in range(1, parent_list_size):
+        parent_list[:, i] = i - 1
+
+    selected_index = torch.arange(draft_token_num - 1, dtype=torch.int64, device=device)
+    selected_index = selected_index.unsqueeze(0).expand(bs, -1).contiguous()
+
+    verified_seq_len = torch.full((bs,), seq_len, dtype=torch.int64, device=device)
+
+    # Allocate tree_mask
+    if tree_mask_mode == QLEN_ONLY_BITPACKING:
+        if draft_token_num > 16:
+            num_bytes = 4
+        elif draft_token_num > 8:
+            num_bytes = 2
+        else:
+            num_bytes = 1
+        tree_mask = torch.zeros(
+            bs * draft_token_num * num_bytes, dtype=torch.uint8, device=device
+        )
+    elif tree_mask_mode == QLEN_ONLY:
+        tree_mask = torch.zeros(
+            bs * draft_token_num * draft_token_num, dtype=torch.bool, device=device
+        )
+    else:  # FULL_MASK
+        total_mask_size = (
+            sum([seq_len] * bs) * draft_token_num
+            + bs * draft_token_num * draft_token_num
+        )
+        tree_mask = torch.zeros(total_mask_size, dtype=torch.bool, device=device)
+
+    positions = torch.zeros(bs, draft_token_num, dtype=torch.int64, device=device)
+    retrive_index = torch.zeros(bs, draft_token_num, dtype=torch.int64, device=device)
+    retrive_next_token = torch.full(
+        (bs, draft_token_num), -1, dtype=torch.int64, device=device
+    )
+    retrive_next_sibling = torch.full(
+        (bs, draft_token_num), -1, dtype=torch.int64, device=device
+    )
+
+    return dict(
+        parent_list=parent_list,
+        selected_index=selected_index,
+        verified_seq_len=verified_seq_len,
+        tree_mask=tree_mask,
+        positions=positions,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: make inputs for verify_tree_greedy
+# ---------------------------------------------------------------------------
+
+
+def make_verify_tree_greedy_inputs(
+    bs, num_draft_tokens, num_spec_step, vocab_size, seed=42, device=DEVICE
+):
+    """Create tensors for verify_tree_greedy with a linear-chain tree.
+
+    retrive_index uses **absolute** flat indices (as produced by build_tree_efficient):
+      retrive_index[b, i] = b * num_draft_tokens + i
+    target_predict[b, i] contains the token the target model predicts from tree slot (b, i).
+    """
+    torch.manual_seed(seed)
+
+    tot_draft = bs * num_draft_tokens
+    predicts = torch.zeros(tot_draft, dtype=torch.int32, device=device)
+    accept_index = torch.zeros(bs, num_spec_step, dtype=torch.int32, device=device)
+    accept_token_num = torch.zeros(bs, dtype=torch.int32, device=device)
+
+    # Absolute retrive_index: retrive_index[b, i] = b * num_draft_tokens + i
+    retrive_index = torch.zeros(bs, num_draft_tokens, dtype=torch.int64, device=device)
+    for b in range(bs):
+        retrive_index[b] = torch.arange(
+            b * num_draft_tokens,
+            (b + 1) * num_draft_tokens,
+            dtype=torch.int64,
+            device=device,
+        )
+
+    # retrive_next_token[b, i] = i+1 (linear chain, last = -1)
+    next_token = torch.arange(1, num_draft_tokens + 1, dtype=torch.int64, device=device)
+    next_token[-1] = -1
+    retrive_next_token = next_token.unsqueeze(0).expand(bs, -1).contiguous()
+
+    retrive_next_sibling = torch.full(
+        (bs, num_draft_tokens), -1, dtype=torch.int64, device=device
+    )
+
+    candidates = (
+        (torch.arange(num_draft_tokens, dtype=torch.int64, device=device) % vocab_size)
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+
+    # target_predict[b, i] = what target predicts after accepting slot i.
+    # For a neutral baseline set it equal to candidates (greedy accepts all but last slot).
+    target_predict = candidates.clone()
+
+    return dict(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        target_predict=target_predict,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for build_tree_kernel_efficient
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bs", [1, 2, 4])
+@pytest.mark.parametrize("tree_mask_mode", [QLEN_ONLY, QLEN_ONLY_BITPACKING])
+def test_build_tree_smoke(bs, tree_mask_mode):
+    from sglang.jit_kernel.eagle_utils import build_tree_kernel_efficient
+
+    topk = 4
+    depth = 5
+    draft_token_num = topk * (depth - 1) + 1
+    seq_len = 10
+
+    inputs = make_build_tree_inputs(
+        bs, topk, depth, draft_token_num, seq_len, tree_mask_mode
+    )
+    build_tree_kernel_efficient(
+        **inputs,
+        topk=topk,
+        depth=depth,
+        draft_token_num=draft_token_num,
+        tree_mask_mode=tree_mask_mode,
+    )
+
+    # positions[b, 0] should equal seq_len (root position)
+    assert (
+        inputs["positions"][:, 0] == seq_len
+    ).all(), "Root position should equal seq_len"
+    # retrive_index[b, 0] should equal b * draft_token_num
+    for b in range(bs):
+        assert inputs["retrive_index"][b, 0].item() == b * draft_token_num
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for verify_tree_greedy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bs,num_draft_tokens,num_spec_step,vocab_size",
+    [
+        (1, 4, 4, 32),
+        (2, 8, 5, 64),
+        (4, 16, 8, 128),
+        (1, 1, 1, 32),
+    ],
+)
+def test_verify_tree_greedy_smoke(bs, num_draft_tokens, num_spec_step, vocab_size):
+    from sglang.jit_kernel.eagle_utils import verify_tree_greedy
+
+    inputs = make_verify_tree_greedy_inputs(
+        bs, num_draft_tokens, num_spec_step, vocab_size
+    )
+    verify_tree_greedy(**inputs)
+
+    # accept_token_num should be non-negative and < num_spec_step
+    assert inputs["accept_token_num"].min() >= 0
+    assert inputs["accept_token_num"].max() < num_spec_step
+
+
+def test_verify_tree_greedy_accept_all():
+    """When target_predict[b,i] == candidates[b,i+1], all draft tokens should be accepted."""
+    from sglang.jit_kernel.eagle_utils import verify_tree_greedy
+
+    bs = 2
+    num_draft_tokens = 4
+    num_spec_step = 4
+    vocab_size = 32
+
+    inputs = make_verify_tree_greedy_inputs(
+        bs, num_draft_tokens, num_spec_step, vocab_size
+    )
+    # The kernel accepts slot i+1 if target_predict[b, i] == candidates[b, i+1].
+    # Set target_predict[b, i] = candidates[b, i+1] to accept every step.
+    target_predict = inputs["candidates"].clone()
+    target_predict[:, :-1] = inputs["candidates"][:, 1:]
+    inputs["target_predict"] = target_predict
+
+    verify_tree_greedy(**inputs)
+
+    # All num_spec_step - 1 draft tokens should be accepted
+    assert (inputs["accept_token_num"] == num_spec_step - 1).all()
+
+
+def test_verify_tree_greedy_accept_none():
+    """When target_predict[b,0] != candidates[b,1], no tokens are accepted."""
+    from sglang.jit_kernel.eagle_utils import verify_tree_greedy
+
+    bs = 2
+    num_draft_tokens = 4
+    num_spec_step = 4
+    vocab_size = 32
+
+    inputs = make_verify_tree_greedy_inputs(
+        bs, num_draft_tokens, num_spec_step, vocab_size
+    )
+    # candidates[b, i] = i % vocab_size, so candidates[b, 1] = 1.
+    # Set target_predict to all zeros: target_predict[b, 0] = 0 != 1 = candidates[b, 1].
+    # The first candidate is rejected, sibling is -1, so the loop breaks immediately.
+    inputs["target_predict"] = torch.zeros_like(inputs["target_predict"])
+
+    verify_tree_greedy(**inputs)
+
+    # No draft tokens should be accepted
+    assert (inputs["accept_token_num"] == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# JIT vs AOT cross-validation: verify_tree_greedy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bs,num_draft_tokens,num_spec_step,vocab_size",
+    [
+        (1, 4, 4, 32),
+        (2, 8, 5, 64),
+        (4, 16, 8, 128),
+    ],
+)
+def test_verify_tree_greedy_vs_aot(bs, num_draft_tokens, num_spec_step, vocab_size):
+    try:
+        from sgl_kernel import verify_tree_greedy as verify_tree_greedy_aot
+    except ImportError:
+        pytest.skip("sgl_kernel not available")
+
+    from sglang.jit_kernel.eagle_utils import (
+        verify_tree_greedy as verify_tree_greedy_jit,
+    )
+
+    inputs_jit = make_verify_tree_greedy_inputs(
+        bs, num_draft_tokens, num_spec_step, vocab_size, seed=0
+    )
+    inputs_aot = {
+        k: v.clone() if isinstance(v, torch.Tensor) else v
+        for k, v in inputs_jit.items()
+    }
+
+    verify_tree_greedy_jit(**inputs_jit)
+    verify_tree_greedy_aot(**inputs_aot)
+
+    assert torch.equal(
+        inputs_jit["predicts"], inputs_aot["predicts"]
+    ), "predicts mismatch"
+    assert torch.equal(
+        inputs_jit["accept_index"], inputs_aot["accept_index"]
+    ), "accept_index mismatch"
+    assert torch.equal(
+        inputs_jit["accept_token_num"], inputs_aot["accept_token_num"]
+    ), "accept_token_num mismatch"
+
+
+# ---------------------------------------------------------------------------
+# JIT vs AOT cross-validation: build_tree_kernel_efficient
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bs", [1, 2])
+@pytest.mark.parametrize("tree_mask_mode", [QLEN_ONLY, QLEN_ONLY_BITPACKING])
+def test_build_tree_vs_aot(bs, tree_mask_mode):
+    try:
+        from sgl_kernel import build_tree_kernel_efficient as build_tree_aot
+    except ImportError:
+        pytest.skip("sgl_kernel not available")
+
+    from sglang.jit_kernel.eagle_utils import (
+        build_tree_kernel_efficient as build_tree_jit,
+    )
+
+    topk = 4
+    depth = 5
+    draft_token_num = topk * (depth - 1) + 1
+    seq_len = 8
+
+    inputs_jit = make_build_tree_inputs(
+        bs, topk, depth, draft_token_num, seq_len, tree_mask_mode
+    )
+    inputs_aot = {
+        k: v.clone() if isinstance(v, torch.Tensor) else v
+        for k, v in inputs_jit.items()
+    }
+
+    build_tree_jit(
+        **inputs_jit,
+        topk=topk,
+        depth=depth,
+        draft_token_num=draft_token_num,
+        tree_mask_mode=tree_mask_mode,
+    )
+    build_tree_aot(
+        **inputs_aot,
+        topk=topk,
+        depth=depth,
+        draft_token_num=draft_token_num,
+        tree_mask_mode=tree_mask_mode,
+    )
+
+    assert torch.equal(
+        inputs_jit["positions"], inputs_aot["positions"]
+    ), "positions mismatch"
+    assert torch.equal(
+        inputs_jit["retrive_index"], inputs_aot["retrive_index"]
+    ), "retrive_index mismatch"
+    assert torch.equal(
+        inputs_jit["retrive_next_token"], inputs_aot["retrive_next_token"]
+    ), "retrive_next_token mismatch"
+    assert torch.equal(
+        inputs_jit["retrive_next_sibling"], inputs_aot["retrive_next_sibling"]
+    ), "retrive_next_sibling mismatch"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
https://github.com/sgl-project/sglang/issues/17865
The eagle_utils kernels (build_tree_kernel_efficient and                   
verify_tree_greedy) are currently only available as AOT-compiled functions 
in sgl-kernel. Porting them to the JIT kernel framework allows SGLang to   
build and use these kernels without requiring a pre-compiled sgl-kernel    
package, improving portability and enabling faster iteration during
development.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
  - python/sglang/jit_kernel/csrc/speculative/eagle_utils.cuh: JIT port of
  sgl-kernel/csrc/speculative/eagle_utils.cu. Replaces PyTorch ATen tensor
  types with tvm::ffi::TensorView, at::cuda::getCurrentCUDAStream() with
  LaunchKernel::resolve_device(), and CHECK_* macros with RuntimeCheck. The
  two CUDA device kernels (build_tree_efficient,
  build_tree_efficient_partial_packed, VerifyTreeGreedy) are unchanged.
  - python/sglang/jit_kernel/eagle_utils.py: Python wrappers for
  build_tree_kernel_efficient and verify_tree_greedy using
  @register_custom_op, following the same pattern as speculative_sampling.py.
  - python/sglang/jit_kernel/tests/test_eagle_utils.py: Tests covering smoke
  runs across batch sizes and tree configurations, accept-all / accept-none
  boundary cases, and bitwise JIT vs AOT cross-validation for both kernels
  (19 tests, all passing).
  - python/sglang/jit_kernel/benchmark/bench_eagle_utils.py:
  triton.testing.perf_report benchmarks for both kernels comparing JIT vs AOT
   across typical EAGLE tree configurations and batch sizes.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
`python -m pytest python/sglang/jit_kernel/tests/test_eagle_utils.py -v`
<img width="1271" height="428" alt="image" src="https://github.com/user-attachments/assets/71286212-c1e2-413f-b8ea-b1951a761b4a" />

Correctness
<img width="828" height="156" alt="image" src="https://github.com/user-attachments/assets/d118f98e-5ef7-472c-80be-7b2e1d58f189" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

Performance Benchmark
<img width="843" height="573" alt="image" src="https://github.com/user-attachments/assets/0a85b9a6-4b94-4d81-9c1a-3da102bcb1af" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
