### PR TITLE
[Fix][Qwen3.5] Fix KV cache slice transfer for GQA models with replicated KV heads

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -32,6 +32,7 @@ class KVArgs:
     # for different tp
     decode_tp_size: int
     kv_head_num: int
+    total_kv_head_num: int
     page_size: int
     # for pp prefill
     prefill_pp_size: int

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -441,9 +441,7 @@ class MooncakeKVManager(CommonKVManager):
             src_head_start_offset = 0
             num_heads_to_send = src_heads_per_rank
             unique_head_idx = local_tp_rank_in_group // src_replication
-            dst_head_start_offset = (
-                unique_head_idx * src_heads_per_rank
-            ) % dst_heads_per_rank
+            dst_head_start_offset = unique_head_idx * src_heads_per_rank
         else:
             # Send KVCache from 1 prefill instance to multiple decode instances
             src_head_start_offset = (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -442,6 +442,8 @@ class MooncakeKVManager(CommonKVManager):
             num_heads_to_send = src_heads_per_rank
             unique_head_idx = local_tp_rank_in_group // src_replication
             dst_head_start_offset = unique_head_idx * src_heads_per_rank
+            # Ensure the head slice fits within the decode buffer
+            assert dst_head_start_offset + num_heads_to_send <= dst_heads_per_rank
         else:
             # Send KVCache from 1 prefill instance to multiple decode instances
             src_head_start_offset = (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -441,7 +441,9 @@ class MooncakeKVManager(CommonKVManager):
             src_head_start_offset = 0
             num_heads_to_send = src_heads_per_rank
             unique_head_idx = local_tp_rank_in_group // src_replication
-            dst_head_start_offset = (unique_head_idx * src_heads_per_rank) % dst_heads_per_rank
+            dst_head_start_offset = (
+                unique_head_idx * src_heads_per_rank
+            ) % dst_heads_per_rank
         else:
             # Send KVCache from 1 prefill instance to multiple decode instances
             src_head_start_offset = (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -441,7 +441,7 @@ class MooncakeKVManager(CommonKVManager):
             src_head_start_offset = 0
             num_heads_to_send = src_heads_per_rank
             unique_head_idx = local_tp_rank_in_group // src_replication
-            dst_head_start_offset = unique_head_idx * src_heads_per_rank
+            dst_head_start_offset = (unique_head_idx * src_heads_per_rank) % dst_heads_per_rank
         else:
             # Send KVCache from 1 prefill instance to multiple decode instances
             src_head_start_offset = (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -418,22 +418,34 @@ class MooncakeKVManager(CommonKVManager):
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         src_kv_item_len = self.kv_args.kv_item_lens[0]
         dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
-        num_kv_heads = self.kv_args.kv_head_num
         page_size = self.kv_args.page_size
 
-        # Calculate head distribution
-        src_heads_per_rank = num_kv_heads
-        dst_heads_per_rank = num_kv_heads * self.attn_tp_size // dst_attn_tp_size
+        # Use total (un-sharded) KV head count for correct head distribution.
+        # With GQA replication (num_kv_heads < tp_size), per-rank kv_head_num
+        # is max(1, total//tp) and multiple ranks share the same head.
+        # Back-computing total as kv_head_num * tp_size overestimates in this case.
+        total_kv_heads = getattr(self.kv_args, "total_kv_head_num", 0)
+        if total_kv_heads <= 0:
+            total_kv_heads = self.kv_args.kv_head_num * self.attn_tp_size
+
+        src_heads_per_rank = max(1, total_kv_heads // self.attn_tp_size)
+        dst_heads_per_rank = max(1, total_kv_heads // dst_attn_tp_size)
         bytes_per_head_slice_to_send = (
             dst_kv_item_len // page_size // dst_heads_per_rank
         )
 
+        # Replication factor: how many prefill ranks share the same KV head
+        src_replication = max(1, self.attn_tp_size // total_kv_heads)
+
         # Determine slicing parameters based on TP configuration
         if self.attn_tp_size > dst_attn_tp_size:
-            # Send KVCache from multiple prefill instances to 1 decode instance
+            # Send KVCache from multiple prefill instances to 1 decode instance.
+            # With replication, multiple prefill ranks hold the same head.
+            # Use (rank // replication) to map to the correct unique head index.
             src_head_start_offset = 0
             num_heads_to_send = src_heads_per_rank
-            dst_head_start_offset = local_tp_rank_in_group * src_heads_per_rank
+            unique_head_idx = local_tp_rank_in_group // src_replication
+            dst_head_start_offset = unique_head_idx * src_heads_per_rank
         else:
             # Send KVCache from 1 prefill instance to multiple decode instances
             src_head_start_offset = (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -441,9 +441,9 @@ class MooncakeKVManager(CommonKVManager):
             src_head_start_offset = 0
             num_heads_to_send = src_heads_per_rank
             unique_head_idx = local_tp_rank_in_group // src_replication
-            dst_head_start_offset = unique_head_idx * src_heads_per_rank
-            # Ensure the head slice fits within the decode buffer
-            assert dst_head_start_offset + num_heads_to_send <= dst_heads_per_rank
+            dst_head_start_offset = (
+                unique_head_idx * src_heads_per_rank
+            ) % dst_heads_per_rank
         else:
             # Send KVCache from 1 prefill instance to multiple decode instances
             src_head_start_offset = (

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -162,7 +162,9 @@ class PrefillBootstrapQueue:
         kv_args.kv_item_lens = kv_item_lens
         if not self.is_mla_backend:
             kv_args.kv_head_num = self.token_to_kv_pool.head_num
-            kv_args.total_kv_head_num = self.scheduler.model_config.get_total_num_kv_heads()
+            kv_args.total_kv_head_num = (
+                self.scheduler.model_config.get_total_num_kv_heads()
+            )
         kv_args.page_size = self.token_to_kv_pool.page_size
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -162,6 +162,7 @@ class PrefillBootstrapQueue:
         kv_args.kv_item_lens = kv_item_lens
         if not self.is_mla_backend:
             kv_args.kv_head_num = self.token_to_kv_pool.head_num
+            kv_args.total_kv_head_num = self.scheduler.model_config.get_total_num_kv_heads()
         kv_args.page_size = self.token_to_kv_pool.page_size
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (


### PR DESCRIPTION
## Motivation

Merge with https://github.com/sgl-project/sglang/pull/19076

PD disaggregation with heterogeneous `attn_tp_size` (e.g., prefill TP4 with decode TP4/DP4/dp_attention where decode `attn_tp=1`) produces completely wrong outputs for non-MLA GQA models. This affects models like Qwen3.5-397B-A17B-FP8 which has only 2 KV heads — fewer than `tp_size`.

With GQA replication (`num_kv_heads < tp_size`), per-rank `kv_head_num = max(1, total // tp)`. The existing code back-computes total heads as `kv_head_num * attn_tp_size`, which overestimates when heads are replicated:

```
Qwen3.5: total_kv_heads=2, prefill attn_tp=4
  kv_head_num = max(1, 2//4) = 1 (replicated)
  computed total = 1 * 4 = 4  (wrong, actual = 2)
  dst_heads_per_rank = 4 // 1 = 4  (wrong, should be 2)
```

This causes each prefill rank to write KV data to incorrect offsets in the decode buffer, corrupting the transferred KV cache.

## Modifications

**`base/conn.py`**: Add `total_kv_head_num` field to `KVArgs` to carry the un-sharded total KV head count.

**`prefill.py`**: Set `total_kv_head_num` from `model_config.get_total_num_kv_heads()` during KV manager initialization.

**`mooncake/conn.py`**:
`send_kvcache_slice`: Use `total_kv_head_num` for correct head distribution. Introduce `src_replication` factor to map replicated ranks to unique head indices via `rank // replication`.

## Accuracy Tests

Model: Qwen3.5-397B-A17B-FP8, Benchmark: GSM8K (1319 examples, 5-shot), Hardware: GB200 (4 GPUs/node)

| Config | Prefill | Decode | Before Fix | After Fix |
|--------|---------|--------|------------|-----------|
| AGG + TP4/DP4/dp_attn (baseline, no disagg) | — | TP4/DP4/dp_attn, 1 node | 0.970 (GSM8k Full)| — |
| 1P1D homogeneous TP (no dp_attn) | TP4, 1 node | TP4, 1 node | 0.875 (GPQA) | — |
| 1P1D + TP4/DP4/dp_attn | TP4, 1 node | TP4/DP4/dp_attn, 1 node | **0.010** | **0.976** |
| 1P1D + TP8/DP8/dp_attn | TP4, 1 node | TP8/DP8/dp_attn, 2 nodes | **0.010** | **0.976** |

Config for 1P1D + TP4/DP4/dp_attn:
```
prefill:
  tensor-parallel-size: 4
  disaggregation-mode: "prefill"
  disaggregation-decode-tp: 4
  disaggregation-decode-dp: 4

decode:
  tp-size: 4
  dp-size: 4
  ep-size: 1
  enable-dp-attention: true
  disaggregation-mode: "decode"
```

Config for 1P1D + TP8/DP8/dp_attn:
```
prefill:
  tensor-parallel-size: 4
  disaggregation-mode: "prefill"
  disaggregation-decode-tp: 8
  disaggregation-decode-dp: 8

decode:
  tp-size: 8
  dp-size: 8
  ep-size: 1
  enable-dp-attention: true
  disaggregation-mode: "decode"
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).