### PR TITLE
[jit_kernel] Add JIT segment_packbits kernel (port of sgl-kernel packbit.cu) 

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_packbit.py
+++ b/python/sglang/jit_kernel/benchmark/bench_packbit.py
@@ -1,0 +1,134 @@
+"""
+Benchmark: segment_packbits JIT vs AOT (sgl_kernel)
+
+Measures throughput (µs) across typical batch sizes and segment lengths.
+
+Run:
+    python python/sglang/jit_kernel/benchmark/bench_packbit.py
+"""
+
+import itertools
+import random
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
+from sglang.jit_kernel.packbit import segment_packbits as segment_packbits_jit
+
+try:
+    from sgl_kernel import segment_packbits as segment_packbits_aot
+
+    AOT_AVAILABLE = True
+except ImportError:
+    segment_packbits_aot = None
+    AOT_AVAILABLE = False
+
+DEVICE = "cuda"
+
+LINE_VALS = ["jit", "aot"] if AOT_AVAILABLE else ["jit"]
+LINE_NAMES = ["JIT (new)", "AOT sgl_kernel"] if AOT_AVAILABLE else ["JIT (new)"]
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+BATCH_SIZE_RANGE = get_benchmark_range(
+    full_range=[1, 4, 16, 64],
+    ci_range=[4],
+)
+
+SEG_LEN_RANGE = get_benchmark_range(
+    full_range=[64, 256, 1024, 4096],
+    ci_range=[256],
+)
+
+
+# ---------------------------------------------------------------------------
+# Input helpers
+# ---------------------------------------------------------------------------
+
+
+def make_inputs(bs, seg_len):
+    random.seed(42)
+    input_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
+    output_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
+    for i in range(bs):
+        input_indptr[i + 1] = input_indptr[i] + seg_len
+        output_indptr[i + 1] = output_indptr[i] + (seg_len + 7) // 8
+
+    total_in = input_indptr[-1].item()
+    total_out = output_indptr[-1].item()
+    x = torch.randint(0, 2, (total_in,), dtype=torch.bool, device=DEVICE)
+    y = torch.zeros(total_out, dtype=torch.uint8, device=DEVICE)
+
+    return x, input_indptr, output_indptr, y
+
+
+# ---------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["bs", "seg_len"],
+        x_vals=list(itertools.product(BATCH_SIZE_RANGE, SEG_LEN_RANGE)),
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=[("blue", "--"), ("orange", "-")][: len(LINE_VALS)],
+        ylabel="us",
+        plot_name="segment-packbits-performance",
+        args={},
+    )
+)
+def bench_segment_packbits(bs: int, seg_len: int, provider: str):
+    x, input_indptr, output_indptr, y = make_inputs(bs, seg_len)
+    backup = y.clone()
+
+    if provider == "jit":
+
+        def fn():
+            y.copy_(backup)
+            segment_packbits_jit(x, input_indptr, output_indptr, y, batch_size=bs)
+
+    elif provider == "aot":
+
+        def fn():
+            y.copy_(backup)
+            segment_packbits_aot(x, input_indptr, output_indptr, y, batch_size=bs)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run_benchmark(fn)
+
+
+# ---------------------------------------------------------------------------
+# Quick correctness diff
+# ---------------------------------------------------------------------------
+
+
+def calculate_diff():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel not available — skipping AOT diff check")
+        return
+
+    print("Correctness diff — segment_packbits (JIT vs AOT):")
+    for bs, seg_len in [(1, 64), (4, 256), (8, 1024)]:
+        x, input_indptr, output_indptr, y_jit = make_inputs(bs, seg_len)
+        y_aot = y_jit.clone()
+
+        segment_packbits_jit(x, input_indptr, output_indptr, y_jit, batch_size=bs)
+        segment_packbits_aot(x, input_indptr, output_indptr, y_aot, batch_size=bs)
+
+        status = "OK" if torch.equal(y_jit, y_aot) else "MISMATCH"
+        print(f"  bs={bs:2d} seg_len={seg_len:5d}  [{status}]")
+
+
+if __name__ == "__main__":
+    calculate_diff()
+    print()
+    bench_segment_packbits.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_packbit.py
+++ b/python/sglang/jit_kernel/benchmark/bench_packbit.py
@@ -8,7 +8,6 @@ Run:
 """
 
 import itertools
-import random
 
 import torch
 import triton
@@ -51,7 +50,7 @@ SEG_LEN_RANGE = get_benchmark_range(
 
 
 def make_inputs(bs, seg_len):
-    random.seed(42)
+    torch.manual_seed(42)
     input_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
     output_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
     for i in range(bs):

--- a/python/sglang/jit_kernel/csrc/speculative/packbit.cuh
+++ b/python/sglang/jit_kernel/csrc/speculative/packbit.cuh
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 by SGLang team.
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Adapted from
+// https://github.com/sgl-project/sglang/blob/main/sgl-kernel/csrc/speculative/packbit.cu
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <flashinfer/quantization.cuh>
+#include <tvm/ffi/container/tensor.h>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// tvm-ffi entry point
+// ---------------------------------------------------------------------------
+
+// x:             [sum(input_indptr)] bool — input bits (little-endian)
+// input_indptr:  [batch_size + 1] int32 — segment start offsets for input
+// output_indptr: [batch_size + 1] int32 — segment start offsets for output
+// y:             [sum(output_indptr)] uint8 — packed output
+// batch_size:    number of segments
+void segment_packbits(
+    tvm::ffi::TensorView x,
+    tvm::ffi::TensorView input_indptr,
+    tvm::ffi::TensorView output_indptr,
+    tvm::ffi::TensorView y,
+    int64_t batch_size) {
+  using namespace host;
+
+  RuntimeCheck(x.device().device_type == kDLCUDA, "x must be a CUDA tensor");
+  RuntimeCheck(x.ndim() == 1, "x must be 1D");
+  RuntimeCheck(x.is_contiguous(), "x must be contiguous");
+  RuntimeCheck(host::dtype_bytes(x.dtype()) == 1, "x element size must be 1 byte (bool or uint8)");
+
+  RuntimeCheck(input_indptr.ndim() == 1, "input_indptr must be 1D");
+  RuntimeCheck(input_indptr.is_contiguous(), "input_indptr must be contiguous");
+  RuntimeCheck(
+      input_indptr.dtype().code == kDLInt && input_indptr.dtype().bits == 32,
+      "input_indptr must be int32");
+  RuntimeCheck(input_indptr.size(0) >= batch_size + 1, "input_indptr size must be >= batch_size + 1");
+
+  RuntimeCheck(output_indptr.ndim() == 1, "output_indptr must be 1D");
+  RuntimeCheck(output_indptr.is_contiguous(), "output_indptr must be contiguous");
+  RuntimeCheck(
+      output_indptr.dtype().code == kDLInt && output_indptr.dtype().bits == 32,
+      "output_indptr must be int32");
+  RuntimeCheck(output_indptr.size(0) >= batch_size + 1, "output_indptr size must be >= batch_size + 1");
+
+  RuntimeCheck(y.ndim() == 1, "y must be 1D");
+  RuntimeCheck(y.is_contiguous(), "y must be contiguous");
+  RuntimeCheck(
+      y.dtype().code == kDLUInt && y.dtype().bits == 8, "y must be uint8");
+
+  cudaStream_t stream = LaunchKernel::resolve_device(x.device());
+  cudaError_t status = flashinfer::quantization::SegmentPackBits(
+      static_cast<bool*>(x.data_ptr()),
+      static_cast<uint8_t*>(y.data_ptr()),
+      static_cast<int32_t*>(input_indptr.data_ptr()),
+      static_cast<int32_t*>(output_indptr.data_ptr()),
+      static_cast<uint32_t>(batch_size),
+      flashinfer::quantization::BitOrder::kLittle,
+      stream);
+
+  RuntimeCheck(status == cudaSuccess, "segment_packbits failed: ", cudaGetErrorString(status));
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/speculative/packbit.cuh
+++ b/python/sglang/jit_kernel/csrc/speculative/packbit.cuh
@@ -51,22 +51,17 @@ void segment_packbits(
 
   RuntimeCheck(input_indptr.ndim() == 1, "input_indptr must be 1D");
   RuntimeCheck(input_indptr.is_contiguous(), "input_indptr must be contiguous");
-  RuntimeCheck(
-      input_indptr.dtype().code == kDLInt && input_indptr.dtype().bits == 32,
-      "input_indptr must be int32");
+  RuntimeCheck(input_indptr.dtype().code == kDLInt && input_indptr.dtype().bits == 32, "input_indptr must be int32");
   RuntimeCheck(input_indptr.size(0) >= batch_size + 1, "input_indptr size must be >= batch_size + 1");
 
   RuntimeCheck(output_indptr.ndim() == 1, "output_indptr must be 1D");
   RuntimeCheck(output_indptr.is_contiguous(), "output_indptr must be contiguous");
-  RuntimeCheck(
-      output_indptr.dtype().code == kDLInt && output_indptr.dtype().bits == 32,
-      "output_indptr must be int32");
+  RuntimeCheck(output_indptr.dtype().code == kDLInt && output_indptr.dtype().bits == 32, "output_indptr must be int32");
   RuntimeCheck(output_indptr.size(0) >= batch_size + 1, "output_indptr size must be >= batch_size + 1");
 
   RuntimeCheck(y.ndim() == 1, "y must be 1D");
   RuntimeCheck(y.is_contiguous(), "y must be contiguous");
-  RuntimeCheck(
-      y.dtype().code == kDLUInt && y.dtype().bits == 8, "y must be uint8");
+  RuntimeCheck(y.dtype().code == kDLUInt && y.dtype().bits == 8, "y must be uint8");
 
   cudaStream_t stream = LaunchKernel::resolve_device(x.device());
   cudaError_t status = flashinfer::quantization::SegmentPackBits(

--- a/python/sglang/jit_kernel/packbit.py
+++ b/python/sglang/jit_kernel/packbit.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING
+
+import flashinfer
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_packbit_module() -> Module:
+    flashinfer_include_path = str(
+        (pathlib.Path(flashinfer.__file__).parent / "data" / "include").resolve()
+    )
+    return load_jit(
+        "packbit",
+        cuda_files=["speculative/packbit.cuh"],
+        cuda_wrappers=[
+            ("segment_packbits", "segment_packbits"),
+        ],
+        extra_include_paths=[flashinfer_include_path],
+    )
+
+
+@register_custom_op(
+    op_name="segment_packbits_out",
+    mutates_args=["y"],
+)
+def segment_packbits(
+    x: torch.Tensor,
+    input_indptr: torch.Tensor,
+    output_indptr: torch.Tensor,
+    y: torch.Tensor,
+    batch_size: int,
+) -> None:
+    """
+    Pack boolean bits into bytes, segment by segment (little-endian bit order).
+
+    Args:
+        x:             [sum(input_indptr)] bool — input bits
+        input_indptr:  [batch_size + 1] int32 — segment start offsets for input
+        output_indptr: [batch_size + 1] int32 — segment start offsets for output
+        y:             [sum(output_indptr)] uint8 — packed output (mutated in-place)
+        batch_size:    number of segments
+    """
+    module = _jit_packbit_module()
+    module.segment_packbits(x, input_indptr, output_indptr, y, batch_size)

--- a/python/sglang/jit_kernel/tests/test_packbit.py
+++ b/python/sglang/jit_kernel/tests/test_packbit.py
@@ -1,0 +1,176 @@
+"""
+Tests for the JIT segment_packbits kernel.
+
+Correctness is validated by:
+1. Known-answer tests against numpy/CPU reference for little-endian packing.
+2. Single-segment and multi-segment cases.
+3. JIT vs AOT cross-validation (when sgl_kernel is available).
+"""
+
+import pytest
+import torch
+
+DEVICE = "cuda"
+
+
+# ---------------------------------------------------------------------------
+# CPU reference
+# ---------------------------------------------------------------------------
+
+
+def cpu_segment_packbits(bits: torch.Tensor, input_indptr: torch.Tensor, output_indptr: torch.Tensor) -> torch.Tensor:
+    """
+    Reference implementation: pack bool bits into uint8 with little-endian bit order.
+    Bit i within a byte is placed at position i % 8 (LSB first).
+    """
+    batch_size = input_indptr.numel() - 1
+    total_out = output_indptr[-1].item()
+    out = torch.zeros(total_out, dtype=torch.uint8)
+    bits_cpu = bits.cpu().bool()
+    for b in range(batch_size):
+        seg_bits = bits_cpu[input_indptr[b].item() : input_indptr[b + 1].item()]
+        out_start = output_indptr[b].item()
+        for i, bit in enumerate(seg_bits):
+            if bit:
+                byte_idx = i // 8
+                bit_idx = i % 8  # little-endian
+                out[out_start + byte_idx] |= 1 << bit_idx
+    return out
+
+
+def make_inputs(segments, device=DEVICE):
+    """
+    Build tensors for segment_packbits from a list of bool lists (one per segment).
+
+    Returns x, input_indptr, output_indptr, y (zeroed output).
+    """
+    input_lengths = [len(s) for s in segments]
+    output_lengths = [(l + 7) // 8 for l in input_lengths]
+    batch_size = len(segments)
+
+    input_indptr = torch.zeros(batch_size + 1, dtype=torch.int32)
+    output_indptr = torch.zeros(batch_size + 1, dtype=torch.int32)
+    for i, (il, ol) in enumerate(zip(input_lengths, output_lengths)):
+        input_indptr[i + 1] = input_indptr[i] + il
+        output_indptr[i + 1] = output_indptr[i] + ol
+
+    x = torch.zeros(input_indptr[-1].item(), dtype=torch.bool)
+    offset = 0
+    for seg in segments:
+        for b in seg:
+            x[offset] = b
+            offset += 1
+
+    y = torch.zeros(output_indptr[-1].item(), dtype=torch.uint8)
+
+    return (
+        x.to(device),
+        input_indptr.to(device),
+        output_indptr.to(device),
+        y.to(device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Known-answer tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_byte_all_ones():
+    """8 True bits → 0xFF in little-endian."""
+    from sglang.jit_kernel.packbit import segment_packbits
+
+    segments = [[True] * 8]
+    x, input_indptr, output_indptr, y = make_inputs(segments)
+    segment_packbits(x, input_indptr, output_indptr, y, batch_size=1)
+    assert y[0].item() == 0xFF
+
+
+def test_single_byte_all_zeros():
+    """8 False bits → 0x00."""
+    from sglang.jit_kernel.packbit import segment_packbits
+
+    segments = [[False] * 8]
+    x, input_indptr, output_indptr, y = make_inputs(segments)
+    segment_packbits(x, input_indptr, output_indptr, y, batch_size=1)
+    assert y[0].item() == 0x00
+
+
+def test_little_endian_order():
+    """[True, False, False, False, False, False, False, False] → 0x01 (LSB first)."""
+    from sglang.jit_kernel.packbit import segment_packbits
+
+    segments = [[True, False, False, False, False, False, False, False]]
+    x, input_indptr, output_indptr, y = make_inputs(segments)
+    segment_packbits(x, input_indptr, output_indptr, y, batch_size=1)
+    assert y[0].item() == 0x01
+
+
+def test_known_pattern():
+    """[1,0,1,0,1,0,1,0] → 0x55 in little-endian."""
+    from sglang.jit_kernel.packbit import segment_packbits
+
+    bits = [True, False, True, False, True, False, True, False]
+    segments = [bits]
+    x, input_indptr, output_indptr, y = make_inputs(segments)
+    segment_packbits(x, input_indptr, output_indptr, y, batch_size=1)
+    assert y[0].item() == 0x55
+
+
+def test_partial_byte():
+    """5 bits → 1 output byte; unused bits should be 0."""
+    from sglang.jit_kernel.packbit import segment_packbits
+
+    segments = [[True, False, True, True, False]]
+    x, input_indptr, output_indptr, y = make_inputs(segments)
+    segment_packbits(x, input_indptr, output_indptr, y, batch_size=1)
+    # little-endian: bit0=1, bit1=0, bit2=1, bit3=1, bit4=0 → 0b00001101 = 0x0D
+    assert y[0].item() == 0x0D
+
+
+@pytest.mark.parametrize("bs,seg_len", [(1, 64), (4, 32), (8, 128), (2, 7)])
+def test_vs_cpu_reference(bs, seg_len):
+    """JIT output matches CPU reference for random inputs."""
+    import random
+
+    from sglang.jit_kernel.packbit import segment_packbits
+
+    random.seed(42)
+    segments = [[random.random() > 0.5 for _ in range(seg_len)] for _ in range(bs)]
+    x, input_indptr, output_indptr, y = make_inputs(segments)
+
+    segment_packbits(x, input_indptr, output_indptr, y, batch_size=bs)
+
+    expected = cpu_segment_packbits(x.cpu(), input_indptr.cpu(), output_indptr.cpu())
+    assert torch.equal(y.cpu(), expected), f"mismatch for bs={bs} seg_len={seg_len}"
+
+
+# ---------------------------------------------------------------------------
+# JIT vs AOT cross-validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bs,seg_len", [(1, 32), (4, 64), (2, 7)])
+def test_vs_aot(bs, seg_len):
+    try:
+        from sgl_kernel import segment_packbits as segment_packbits_aot
+    except ImportError:
+        pytest.skip("sgl_kernel not available")
+
+    import random
+
+    from sglang.jit_kernel.packbit import segment_packbits as segment_packbits_jit
+
+    random.seed(0)
+    segments = [[random.random() > 0.5 for _ in range(seg_len)] for _ in range(bs)]
+    x, input_indptr, output_indptr, y_jit = make_inputs(segments)
+    y_aot = y_jit.clone()
+
+    segment_packbits_jit(x, input_indptr, output_indptr, y_jit, batch_size=bs)
+    segment_packbits_aot(x, input_indptr, output_indptr, y_aot, batch_size=bs)
+
+    assert torch.equal(y_jit, y_aot), f"JIT vs AOT mismatch for bs={bs} seg_len={seg_len}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
https://github.com/sgl-project/sglang/issues/17865

`sgl-kernel` ships an AOT CUDA kernel for `segment_packbits`. This PR ports
 it to the JIT kernel framework so it can be used without the pre-built    
`sgl-kernel` wheel, following the same pattern as the `eagle_utils` and    
`ngram_utils` JIT ports. 
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
  - **`python/sglang/jit_kernel/csrc/speculative/packbit.cuh`**: TVM FFI
  entry point wrapping `flashinfer::quantization::SegmentPackBits`; uses
  `RuntimeCheck` for input validation and `LaunchKernel::resolve_device` for
  stream handling.
  - **`python/sglang/jit_kernel/packbit.py`**: Python wrapper with
  `@register_custom_op` (`mutates_args=["y"]`) and `@cache_once`; loads with
  the flashinfer include path for `quantization.cuh`.
  - **`python/sglang/jit_kernel/tests/test_packbit.py`**: 13 tests —
  known-answer (0xFF, 0x00, little-endian, partial byte), CPU reference
  validation for fixed-length and variable-length segments, and JIT vs AOT
  cross-validation.
  - **`python/sglang/jit_kernel/benchmark/bench_packbit.py`**: Throughput
  benchmark across batch sizes and segment lengths with a correctness diff
  between JIT and AOT.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
python -m pytest python/sglang/jit_kernel/tests/test_packbit.py 
<img width="1247" height="153" alt="image" src="https://github.com/user-attachments/assets/9e70ffd4-9a4d-4cf6-a8d4-339892f18dcc" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
`python python/sglang/jit_kernel/benchmark/bench_packbit.py `

<img width="801" height="357" alt="image" src="https://github.com/user-attachments/assets/3348ff7b-0f10-4b23-b869-2d6d8ee4f63c" />


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
