### PR TITLE
Update rocm7.2 Dockerfile to install amdsmi for QuickReduce Initialization

### DIFF
--- a/docker/rocm720.Dockerfile
+++ b/docker/rocm720.Dockerfile
@@ -106,7 +106,7 @@ RUN python -m pip install --upgrade pip && pip install setuptools_scm
 RUN apt-get purge -y sccache; python -m pip uninstall -y sccache; rm -f "$(which sccache)"
 
 # Install AMD SMI Python package from ROCm distribution
-RUN cd /opt/rocm/share/amd_smi && python3 -m pip install .
+RUN cd /opt/rocm/share/amd_smi && python3 -m pip install --no-cache-dir .
 
 WORKDIR /sgl-workspace
 

--- a/docker/rocm720.Dockerfile
+++ b/docker/rocm720.Dockerfile
@@ -105,6 +105,9 @@ USER root
 RUN python -m pip install --upgrade pip && pip install setuptools_scm
 RUN apt-get purge -y sccache; python -m pip uninstall -y sccache; rm -f "$(which sccache)"
 
+# Install AMD SMI Python package from ROCm distribution
+RUN cd /opt/rocm/share/amd_smi && python3 -m pip install .
+
 WORKDIR /sgl-workspace
 
 # -----------------------
@@ -260,7 +263,7 @@ RUN /bin/bash -lc 'set -euo pipefail; \
       libgtest-dev libgmock-dev \
       libprotobuf-dev protobuf-compiler libgflags-dev libsqlite3-dev \
       python3 python3-dev python3-setuptools python3-pip python3-apt \
-      gcc libtinfo-dev zlib1g-dev libedit-dev libxml2-dev \
+      gcc libtinfo-dev zlib1g-dev libedit-dev libxml2-dev vim \
       cmake ninja-build pkg-config libstdc++6 software-properties-common \
   && rm -rf /var/lib/apt/lists/*; \
   \


### PR DESCRIPTION
## Description:
This update modifies the `rocm720.Dockerfile` to include the AMD SMI Python package from the installed ROCm distribution. This enables QuickReduce to initialize properly when using the `rocm7.2` Docker images.

## Motivation:
The `rocm7.2` `rocm/sgl-dev` images currently lack the **AMD SMI** package, preventing users from utilizing features like **quantized allreduce** (e.g., QuickReduce). This results in no improvements in latency or throughput for related tasks.

### Current Issue:
The issue stems from using the base image `rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1`, which is missing the `amdsmi` package. Without this package, QuickReduce cannot be initialized as intended.

#### Example Screenshot:
![Missing amdsmi package](https://github.com/user-attachments/assets/bc57ad43-c3b8-4689-8ac5-238c1d07d0f3)
<img width="760" height="59" alt="{89DF8C6F-EE1C-4834-BA22-9ED8E79CBF18}" src="https://github.com/user-attachments/assets/6340a3ca-2435-4a28-a67e-9c1432c0a087" />


## Change Summary:
- **rocm720.Dockerfile**: Added the installation of the **AMD SMI** Python package from the ROCm distribution.
- This change does **not** impact kernels or other core functionality, so **accuracy and performance testing** are not applicable.

### Before:
- Users couldn’t initialize QuickReduce due to missing package.

### After:
- QuickReduce initialization is now supported, allowing for proper use of quantized allreduce operations.

## Notes:
- No changes to kernel code or algorithms, so performance tests and accuracy measurements are **not applicable**.
- This fix only ensures that the `amdsmi` package is present and accessible for users working with AMD hardware.

## Why This is Important:
This update ensures that users relying on **QuickReduce** for efficient allreduce will now have the necessary packages available, improving the usability of the ROCm 7.2 images in production and testing environments.