### PR TITLE
Fix GLM4 MoE Lite CompressedTensors serving and transformers version checks

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1009,7 +1009,20 @@ class ModelConfig:
             # The vision config model type for GLM-4.5v is 'glm4v_moe',
             # while for GLM-4.6v, it is 'glm4v_moe_vision'.
         )
-        needs_tf_v5 = is_glm_46vmoe
+        model_type = getattr(self.hf_config, "model_type", None)
+        architectures = set(getattr(self.hf_config, "architectures", []) or [])
+        is_glm4_moe_lite = model_type in {"glm4_moe_lite", "glm4_moe_lite_mtp"} or (
+            len(
+                architectures
+                & {
+                    "Glm4MoeLiteForCausalLM",
+                    "Glm4MoeLiteMTP",
+                    "Glm4MoeLiteMTPModel",
+                }
+            )
+            > 0
+        )
+        needs_tf_v5 = is_glm_46vmoe or is_glm4_moe_lite
 
         tf_version = version.parse(tf_version_str)
         required_version = version.parse("5.0.0dev0")

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -29,7 +29,12 @@ def _dispatch_mla_subtype(attn, forward_batch):
         else:
             return AttnForwardMethod.MLA
     else:
-        if hasattr(attn, "fused_qkv_a_proj_with_mqa") and use_intel_amx_backend(attn):
+        fused_qkv_a_proj = getattr(attn, "fused_qkv_a_proj_with_mqa", None)
+        if (
+            fused_qkv_a_proj is not None
+            and getattr(fused_qkv_a_proj, "weight", None) is not None
+            and use_intel_amx_backend(attn)
+        ):
             return AttnForwardMethod.MLA_FUSED_ROPE_CPU
         else:
             return AttnForwardMethod.MLA

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -35,10 +35,10 @@ from sglang.srt.layers.quantization.fp8_utils import (
     normalize_e4m3fn_to_e4m3fnuz,
     quant_weight_ue8m0,
 )
+from sglang.srt.layers.quantization.gptq import unpack_from_int32
 from sglang.srt.layers.quantization.int8_utils import (
     block_dequant as int8_block_dequant,
 )
-from sglang.srt.layers.quantization.gptq import unpack_from_int32
 from sglang.srt.layers.utils import get_layer_id
 from sglang.srt.model_loader.utils import (
     maybe_executor_submit,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1308,10 +1308,11 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
             else None
         )
 
-        is_packed_weight = (
-            has_fused_proj
-            and fused_proj_quant_name in {"awq", "awq_marlin", "moe_wna16"}
-        )
+        is_packed_weight = has_fused_proj and fused_proj_quant_name in {
+            "awq",
+            "awq_marlin",
+            "moe_wna16",
+        }
         self.use_min_latency_fused_a_gemm = (
             has_fused_proj
             and not is_packed_weight

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1275,27 +1275,50 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
             "SGLANG_ROCM_FUSED_DECODE_MLA", "false"
         )
 
-        # If we have self.fused_qkv_a_proj_with_mqa and we're running on CPU, we will choose the torch.ops.sgl_kernel.qkv_proj_with_rope_fused_weight kernel
-        # which requires self.w_kc and self.w_vc to be packed.
-        # If not, we will use torch.bmm and weight shouldn't be packed in this case
-        has_fused_proj = hasattr(self, "fused_qkv_a_proj_with_mqa")
+        # If we have self.fused_qkv_a_proj_with_mqa and we're running on CPU,
+        # we will choose the torch.ops.sgl_kernel.qkv_proj_with_rope_fused_weight
+        # kernel which requires self.w_kc and self.w_vc to be packed.
+        # If not, we will use torch.bmm and weight shouldn't be packed in this case.
+        fused_qkv_a_proj_with_mqa = getattr(self, "fused_qkv_a_proj_with_mqa", None)
+        has_fused_proj = fused_qkv_a_proj_with_mqa is not None
         if has_fused_proj and _is_cpu and _is_cpu_amx_available:
             self.quant_method = PackWeightMethod(
                 weight_names=["w_kc", "w_vc"], transpose_dims=[[1, 2], [1, 2]]
             )
 
+        # Some quantization paths (e.g. compressed-tensors wNa16) do not expose a
+        # dense `.weight` tensor on ReplicatedLinear; guard all fast-path checks.
+        fused_proj_quant_method = (
+            getattr(fused_qkv_a_proj_with_mqa, "quant_method", None)
+            if has_fused_proj
+            else None
+        )
+        fused_proj_quant_config = getattr(fused_proj_quant_method, "quant_config", None)
+        fused_proj_quant_name = (
+            fused_proj_quant_config.get_name()
+            if (
+                fused_proj_quant_config is not None
+                and hasattr(fused_proj_quant_config, "get_name")
+            )
+            else None
+        )
+        fused_proj_weight = (
+            getattr(fused_qkv_a_proj_with_mqa, "weight", None)
+            if has_fused_proj
+            else None
+        )
+
         is_packed_weight = (
             has_fused_proj
-            and hasattr(self.fused_qkv_a_proj_with_mqa.quant_method, "quant_config")
-            and self.fused_qkv_a_proj_with_mqa.quant_method.quant_config.get_name()
-            in {"awq", "awq_marlin", "moe_wna16"}
+            and fused_proj_quant_name in {"awq", "awq_marlin", "moe_wna16"}
         )
         self.use_min_latency_fused_a_gemm = (
             has_fused_proj
             and not is_packed_weight
-            and self.fused_qkv_a_proj_with_mqa.weight.dtype == torch.bfloat16
-            and self.fused_qkv_a_proj_with_mqa.weight.shape[0] == 2112
-            and self.fused_qkv_a_proj_with_mqa.weight.shape[1] == 7168
+            and fused_proj_weight is not None
+            and fused_proj_weight.dtype == torch.bfloat16
+            and fused_proj_weight.shape[0] == 2112
+            and fused_proj_weight.shape[1] == 7168
             and _is_cuda
             and 90 <= _device_sm < 120
         )
@@ -1303,12 +1326,14 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
         self.qkv_proj_with_rope_is_int8 = (
             has_fused_proj
             and not is_packed_weight
-            and self.fused_qkv_a_proj_with_mqa.weight.dtype == torch.int8
+            and fused_proj_weight is not None
+            and fused_proj_weight.dtype == torch.int8
         )
         self.qkv_proj_with_rope_is_fp8 = (
             has_fused_proj
             and not is_packed_weight
-            and self.fused_qkv_a_proj_with_mqa.weight.dtype == torch.float8_e4m3fn
+            and fused_proj_weight is not None
+            and fused_proj_weight.dtype == torch.float8_e4m3fn
         )
 
         self.weight_block_size = None
@@ -2791,8 +2816,18 @@ class DeepseekV2Model(nn.Module):
 
 
 class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
-    # for quark model load
-    packed_modules_mapping = {}
+    # Map fused modules to their unfused checkpoint names so quantization
+    # ignore rules and scheme matching work for packed projections.
+    packed_modules_mapping = {
+        "fused_qkv_a_proj_with_mqa": [
+            "q_a_proj",
+            "kv_a_proj_with_mqa",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
 
     def __init__(
         self,
@@ -2801,17 +2836,6 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         prefix: str = "",
     ) -> None:
         super().__init__()
-
-        # for quark model load
-        # Fuse q_a_proj and kv_a_proj_with_mqa along output dimension when q_lora_rank is not None
-        self.fuse_qkv_a_proj = (
-            hasattr(config, "q_lora_rank") and config.q_lora_rank is not None
-        )
-        if self.fuse_qkv_a_proj:
-            self.packed_modules_mapping["fused_qkv_a_proj_with_mqa"] = [
-                "q_a_proj",
-                "kv_a_proj_with_mqa",
-            ]
 
         self.pp_group = get_pp_group()
         self.config = config

--- a/test/registered/core/test_deepseek_attention_backend_handler.py
+++ b/test/registered/core/test_deepseek_attention_backend_handler.py
@@ -23,9 +23,7 @@ def test_dispatch_mla_subtype_requires_weight_for_cpu_fused_path(monkeypatch):
 
     attn = SimpleNamespace(fused_qkv_a_proj_with_mqa=SimpleNamespace())
 
-    assert (
-        _dispatch_mla_subtype(attn, _dummy_forward_batch()) == AttnForwardMethod.MLA
-    )
+    assert _dispatch_mla_subtype(attn, _dummy_forward_batch()) == AttnForwardMethod.MLA
 
 
 def test_dispatch_mla_subtype_uses_cpu_fused_path_when_weight_exists(monkeypatch):

--- a/test/registered/core/test_deepseek_attention_backend_handler.py
+++ b/test/registered/core/test_deepseek_attention_backend_handler.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from sglang.srt.models.deepseek_common.attention_backend_handler import (
+    _dispatch_mla_subtype,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
+    AttnForwardMethod,
+)
+
+
+def _dummy_forward_batch():
+    return SimpleNamespace(forward_mode=SimpleNamespace(is_decode=lambda: False))
+
+
+def test_dispatch_mla_subtype_requires_weight_for_cpu_fused_path(monkeypatch):
+    monkeypatch.setattr(
+        "sglang.srt.models.deepseek_common.attention_backend_handler._is_hip", False
+    )
+    monkeypatch.setattr(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.use_intel_amx_backend",
+        lambda _: True,
+    )
+
+    attn = SimpleNamespace(fused_qkv_a_proj_with_mqa=SimpleNamespace())
+
+    assert (
+        _dispatch_mla_subtype(attn, _dummy_forward_batch()) == AttnForwardMethod.MLA
+    )
+
+
+def test_dispatch_mla_subtype_uses_cpu_fused_path_when_weight_exists(monkeypatch):
+    monkeypatch.setattr(
+        "sglang.srt.models.deepseek_common.attention_backend_handler._is_hip", False
+    )
+    monkeypatch.setattr(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.use_intel_amx_backend",
+        lambda _: True,
+    )
+
+    attn = SimpleNamespace(fused_qkv_a_proj_with_mqa=SimpleNamespace(weight=object()))
+
+    assert (
+        _dispatch_mla_subtype(attn, _dummy_forward_batch())
+        == AttnForwardMethod.MLA_FUSED_ROPE_CPU
+    )

--- a/test/registered/core/test_deepseek_packed_modules_mapping.py
+++ b/test/registered/core/test_deepseek_packed_modules_mapping.py
@@ -1,0 +1,37 @@
+from sglang.srt.layers.quantization.compressed_tensors.utils import should_ignore_layer
+from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
+from sglang.srt.models.glm4_moe import Glm4MoeForCausalLM
+from sglang.srt.models.glm4_moe_lite import Glm4MoeLiteForCausalLM
+
+
+def test_deepseek_v2_gate_up_proj_ignore_via_fused_mapping():
+    assert should_ignore_layer(
+        "model.layers.0.mlp.gate_up_proj",
+        ignore=[
+            "model.layers.0.mlp.gate_proj",
+            "model.layers.0.mlp.up_proj",
+        ],
+        fused_mapping=DeepseekV2ForCausalLM.packed_modules_mapping,
+    )
+
+
+def test_glm4_moe_lite_fused_qkv_ignore_via_fused_mapping():
+    assert should_ignore_layer(
+        "model.layers.0.self_attn.fused_qkv_a_proj_with_mqa",
+        ignore=[
+            "model.layers.0.self_attn.q_a_proj",
+            "model.layers.0.self_attn.kv_a_proj_with_mqa",
+        ],
+        fused_mapping=Glm4MoeLiteForCausalLM.packed_modules_mapping,
+    )
+
+
+def test_glm4_moe_gate_up_proj_ignore_via_fused_mapping():
+    assert should_ignore_layer(
+        "model.layers.0.mlp.gate_up_proj",
+        ignore=[
+            "model.layers.0.mlp.gate_proj",
+            "model.layers.0.mlp.up_proj",
+        ],
+        fused_mapping=Glm4MoeForCausalLM.packed_modules_mapping,
+    )

--- a/test/registered/core/test_deepseek_weight_loader.py
+++ b/test/registered/core/test_deepseek_weight_loader.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
+    DeepseekV2WeightLoaderMixin,
+)
+
+
+def _pack_int4_row(values: list[int]) -> int:
+    packed = 0
+    for i, value in enumerate(values):
+        packed |= ((value + 8) & 0xF) << (4 * i)
+    # Convert to signed int32 range.
+    if packed >= 2**31:
+        packed -= 2**32
+    return packed
+
+
+def test_dequantize_ct_wna16_weight():
+    row0 = [-8, -7, -6, -5, -4, -3, -2, -1]
+    row1 = [0, 1, 2, 3, 4, 5, 6, 7]
+    weight_packed = torch.tensor(
+        [[_pack_int4_row(row0)], [_pack_int4_row(row1)]], dtype=torch.int32
+    )
+    weight_scale = torch.tensor([[0.5], [2.0]], dtype=torch.bfloat16)
+    weight_shape = torch.tensor([2, 8], dtype=torch.int64)
+
+    layer = SimpleNamespace(
+        weight_packed=weight_packed,
+        weight_scale=weight_scale,
+        weight_shape=weight_shape,
+    )
+
+    dequant = DeepseekV2WeightLoaderMixin._dequantize_ct_wna16_weight(layer)
+    expected = torch.tensor(
+        [
+            [v * 0.5 for v in row0],
+            [v * 2.0 for v in row1],
+        ],
+        dtype=torch.bfloat16,
+    )
+    assert dequant.dtype == torch.bfloat16
+    assert tuple(dequant.shape) == (2, 8)
+    assert torch.equal(dequant, expected)
+
+
+def test_post_load_weights_dequantizes_ct_kv_b_proj():
+    class _DummyLoader(DeepseekV2WeightLoaderMixin):
+        pass
+
+    kv_b_proj = SimpleNamespace(
+        weight_packed=torch.tensor(
+            [
+                [_pack_int4_row([-8, -7, -6, -5, -4, -3, -2, -1])],
+                [_pack_int4_row([0, 1, 2, 3, 4, 5, 6, 7])],
+            ],
+            dtype=torch.int32,
+        ),
+        weight_scale=torch.tensor([[1.0], [1.0]], dtype=torch.bfloat16),
+        weight_shape=torch.tensor([2, 8], dtype=torch.int64),
+    )
+    self_attn = SimpleNamespace(
+        kv_b_proj=kv_b_proj,
+        qk_nope_head_dim=1,
+        v_head_dim=1,
+        w_kc=None,
+        w_vc=None,
+        w_scale=None,
+    )
+
+    loader = _DummyLoader()
+    loader.config = SimpleNamespace(num_hidden_layers=1)
+    loader.model = SimpleNamespace(
+        start_layer=0,
+        end_layer=1,
+        layers=[SimpleNamespace(self_attn=self_attn)],
+    )
+    loader.quant_config = None
+
+    loader.post_load_weights()
+
+    assert self_attn.w_kc is not None
+    assert self_attn.w_vc is not None
+    assert tuple(self_attn.w_kc.shape) == (1, 1, 8)
+    assert tuple(self_attn.w_vc.shape) == (1, 8, 1)

--- a/test/registered/core/test_glm4_moe_lite_shared_experts_fusion.py
+++ b/test/registered/core/test_glm4_moe_lite_shared_experts_fusion.py
@@ -13,7 +13,9 @@ def test_disable_shared_experts_fusion_for_ignored_shared_experts(monkeypatch):
     )
 
     server_args = SimpleNamespace(disable_shared_experts_fusion=False)
-    monkeypatch.setattr(glm4_moe_lite_mod, "get_global_server_args", lambda: server_args)
+    monkeypatch.setattr(
+        glm4_moe_lite_mod, "get_global_server_args", lambda: server_args
+    )
 
     model = object.__new__(glm4_moe_lite_mod.Glm4MoeLiteForCausalLM)
     model.config = SimpleNamespace(

--- a/test/registered/core/test_glm4_moe_lite_shared_experts_fusion.py
+++ b/test/registered/core/test_glm4_moe_lite_shared_experts_fusion.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+import sglang.srt.models.glm4_moe_lite as glm4_moe_lite_mod
+
+
+def test_disable_shared_experts_fusion_for_ignored_shared_experts(monkeypatch):
+    monkeypatch.setattr(glm4_moe_lite_mod, "_is_cuda", True)
+    monkeypatch.setattr(
+        glm4_moe_lite_mod.torch.cuda, "get_device_capability", lambda *_: (8, 6)
+    )
+    monkeypatch.setattr(
+        glm4_moe_lite_mod, "get_moe_expert_parallel_world_size", lambda: 1
+    )
+
+    server_args = SimpleNamespace(disable_shared_experts_fusion=False)
+    monkeypatch.setattr(glm4_moe_lite_mod, "get_global_server_args", lambda: server_args)
+
+    model = object.__new__(glm4_moe_lite_mod.Glm4MoeLiteForCausalLM)
+    model.config = SimpleNamespace(
+        architectures=["Glm4MoeLiteForCausalLM"],
+        n_shared_experts=1,
+    )
+    model.quant_config = SimpleNamespace(
+        ignore=["model.layers.1.mlp.shared_experts.gate_proj"]
+    )
+
+    model.determine_num_fused_shared_experts()
+
+    assert model.num_fused_shared_experts == 0
+    assert server_args.disable_shared_experts_fusion is True

--- a/test/registered/core/test_glm4_moe_shared_experts_fusion.py
+++ b/test/registered/core/test_glm4_moe_shared_experts_fusion.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+import sglang.srt.models.glm4_moe as glm4_moe_mod
+
+
+def test_disable_shared_experts_fusion_for_ignored_shared_experts(monkeypatch):
+    monkeypatch.setattr(glm4_moe_mod, "_is_cuda", True)
+    monkeypatch.setattr(glm4_moe_mod, "_device_sm", 90)
+    monkeypatch.setattr(glm4_moe_mod, "get_moe_expert_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(
+        glm4_moe_mod,
+        "get_moe_a2a_backend",
+        lambda: SimpleNamespace(is_deepep=lambda: False),
+    )
+
+    server_args = SimpleNamespace(disable_shared_experts_fusion=False)
+    monkeypatch.setattr(glm4_moe_mod, "get_global_server_args", lambda: server_args)
+
+    model = object.__new__(glm4_moe_mod.Glm4MoeForCausalLM)
+    model.config = SimpleNamespace(n_shared_experts=1)
+    model.quant_config = SimpleNamespace(
+        ignore=["model.layers.1.mlp.shared_experts.gate_proj"]
+    )
+    model.num_fused_shared_experts = 0
+
+    model.determine_num_fused_shared_experts()
+
+    assert model.num_fused_shared_experts == 0
+    assert server_args.disable_shared_experts_fusion is True

--- a/test/registered/core/test_model_config_transformers_version.py
+++ b/test/registered/core/test_model_config_transformers_version.py
@@ -1,0 +1,84 @@
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.configs.model_config import ModelConfig
+
+
+def _build_model_config_stub(
+    *,
+    model_path: str,
+    model_type: str,
+    architectures: list[str] | None = None,
+    vision_model_type: str | None = None,
+) -> ModelConfig:
+    config = object.__new__(ModelConfig)
+    config.model_path = model_path
+
+    hf_config = SimpleNamespace(
+        model_type=model_type,
+        architectures=architectures or [],
+    )
+    if vision_model_type is not None:
+        hf_config.vision_config = SimpleNamespace(model_type=vision_model_type)
+
+    config.hf_config = hf_config
+    return config
+
+
+def _mock_transformers_version(monkeypatch, version: str) -> None:
+    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(__version__=version))
+
+
+def test_verify_transformers_version_glm4_moe_lite_no_downgrade_warning(
+    monkeypatch, caplog
+):
+    _mock_transformers_version(monkeypatch, "5.3.0.dev0")
+    model_config = _build_model_config_stub(
+        model_path="/ssd512g/models/GLM-4.7-Flash",
+        model_type="glm4_moe_lite",
+        architectures=["Glm4MoeLiteForCausalLM"],
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        model_config._verify_transformers_version()
+
+    assert not any(
+        "downgrading to transformers==4.57.1" in message
+        for message in caplog.messages
+    )
+
+
+def test_verify_transformers_version_glm4_moe_lite_requires_tf5(monkeypatch):
+    _mock_transformers_version(monkeypatch, "4.57.1")
+    model_config = _build_model_config_stub(
+        model_path="/ssd512g/models/GLM-4.7-Flash",
+        model_type="glm4_moe_lite",
+        architectures=["Glm4MoeLiteForCausalLM"],
+    )
+
+    with pytest.raises(ValueError, match="Please upgrade transformers to >= 5.0.0"):
+        model_config._verify_transformers_version()
+
+
+def test_verify_transformers_version_non_glm4_moe_lite_warns_on_tf5(
+    monkeypatch, caplog
+):
+    _mock_transformers_version(monkeypatch, "5.3.0.dev0")
+    model_config = _build_model_config_stub(
+        model_path="/tmp/llama",
+        model_type="llama",
+        architectures=["LlamaForCausalLM"],
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        model_config._verify_transformers_version()
+
+    assert any(
+        "downgrading to transformers==4.57.1" in message
+        for message in caplog.messages
+    )

--- a/test/registered/core/test_model_config_transformers_version.py
+++ b/test/registered/core/test_model_config_transformers_version.py
@@ -29,7 +29,9 @@ def _build_model_config_stub(
 
 
 def _mock_transformers_version(monkeypatch, version: str) -> None:
-    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(__version__=version))
+    monkeypatch.setitem(
+        sys.modules, "transformers", SimpleNamespace(__version__=version)
+    )
 
 
 def test_verify_transformers_version_glm4_moe_lite_no_downgrade_warning(
@@ -47,8 +49,7 @@ def test_verify_transformers_version_glm4_moe_lite_no_downgrade_warning(
         model_config._verify_transformers_version()
 
     assert not any(
-        "downgrading to transformers==4.57.1" in message
-        for message in caplog.messages
+        "downgrading to transformers==4.57.1" in message for message in caplog.messages
     )
 
 
@@ -79,6 +80,5 @@ def test_verify_transformers_version_non_glm4_moe_lite_warns_on_tf5(
         model_config._verify_transformers_version()
 
     assert any(
-        "downgrading to transformers==4.57.1" in message
-        for message in caplog.messages
+        "downgrading to transformers==4.57.1" in message for message in caplog.messages
     )


### PR DESCRIPTION
## Summary
This PR fixes `Glm4MoeLiteForCausalLM` serving failures for CompressedTensors checkpoints (e.g. `GLM-4.7-Flash-REAP-23B-A3B-AWQ-4bit`) in SGLang, while keeping regular AWQ behavior intact.

It also fixes an incorrect Transformers downgrade warning for GLM-4.7/GLM4 MoE Lite models.

## Problem
SGLang could serve `/ssd512g/models/GLM-4.7-Flash-AWQ`, but failed on `/ssd512g/models/GLM-4.7-Flash-REAP-23B-A3B-AWQ-4bit` with:

```
AttributeError: 'ReplicatedLinear' object has no attribute 'weight'
```

Additionally, SGLang printed a misleading warning suggesting `transformers==4.57.1` for `glm4_moe_lite` even though this architecture requires Transformers >=5.

## Root cause
1. MLA attention init and backend dispatch assumed `.weight` exists on fused projection modules. CompressedTensors wrappers can expose packed weights without a dense `.weight`.
2. Fused module names (`fused_qkv_a_proj_with_mqa`, `gate_up_proj`) were not fully mapped to unfused names for ignore/scheme matching in quantized checkpoints.
3. `kv_b_proj` post-load path did not dequantize CT WNA16 packed tensors for MLA `w_kc`/`w_vc` generation.
4. Shared-experts fusion could be enabled even when shared experts are explicitly marked ignored/non-quantized in checkpoint config, causing bad weight routing.
5. `glm4_moe_lite` was missing from TF>=5 model checks, causing wrong downgrade guidance.

## Changes
- Add robust `.weight` guards in MLA path selection and init:
  - `python/sglang/srt/models/deepseek_v2.py`
  - `python/sglang/srt/models/deepseek_common/attention_backend_handler.py`
- Add CT WNA16 dequant helper and use it for `kv_b_proj` post-load processing:
  - `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`
- Add packed fused-module mapping for ignore/scheme compatibility:
  - `python/sglang/srt/models/deepseek_v2.py`
  - `python/sglang/srt/models/glm4_moe_lite.py`
  - `python/sglang/srt/models/glm4_moe.py`
- Disable shared-experts fusion when checkpoint marks shared experts ignored/non-quantized:
  - `python/sglang/srt/models/glm4_moe_lite.py`
  - `python/sglang/srt/models/glm4_moe.py`
- Handle GLM q_a/kv_a fused `weight_shape` metadata correctly for CT fusion path:
  - `python/sglang/srt/models/glm4_moe_lite.py`
- Treat `glm4_moe_lite` as TF>=5-required architecture in version verification:
  - `python/sglang/srt/configs/model_config.py`

## Validation
### Unit tests
Added targeted tests and verified all pass:

```
12 passed
```

New tests:
- `test/registered/core/test_model_config_transformers_version.py`
- `test/registered/core/test_deepseek_attention_backend_handler.py`
- `test/registered/core/test_deepseek_weight_loader.py`
- `test/registered/core/test_deepseek_packed_modules_mapping.py`
- `test/registered/core/test_glm4_moe_lite_shared_experts_fusion.py`
- `test/registered/core/test_glm4_moe_shared_experts_fusion.py`

### Runtime validation (single-node, 2x3090)
- REAP model now boots successfully on SGLang (port 8088).
- Confirmed runtime log includes:
  - `Using CompressedTensorsWNA16MarlinMoEMethod`
  - shared-experts fusion auto-disabled due to ignored shared experts
- Actual inference works and returns correct answers (not blank/repeating output after fix).
- Compared against AWQ baseline server (port 8089), both produce valid outputs with expected latency/throughput range.

## Notes
- For OpenAI chat endpoint with `reasoning_parser=glm45`, responses can go to `reasoning_content` by default. Validation used `chat_template_kwargs.enable_thinking=false` when comparing final answer content.
