### PR TITLE
[AMD][DO NOT MERGE] Fix MI35x DeepSeek-V3.2 nightly timeout failures

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1,6 +1,9 @@
 name: Nightly Test (AMD ROCm 7.2)
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 2 * * *'
   push:
@@ -716,6 +719,30 @@ jobs:
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
+
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2)
         timeout-minutes: 120
         run: |
@@ -749,6 +776,30 @@ jobs:
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
+
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 TP+MTP)
         timeout-minutes: 120
         run: |
@@ -781,6 +832,30 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build --skip-test-time-deps
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
 
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 Basic)
         timeout-minutes: 150
@@ -847,6 +922,30 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build --skip-test-time-deps
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
 
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 MTP)
         timeout-minutes: 180

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -1,6 +1,9 @@
 name: Nightly Test (AMD)
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * *'
   push:
@@ -718,6 +721,30 @@ jobs:
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
+
       - name: Accuracy Test MI35x (8-GPU DeepSeek-V3.2)
         timeout-minutes: 120
         run: |
@@ -751,6 +778,30 @@ jobs:
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
+
       - name: Accuracy Test MI35x (8-GPU DeepSeek-V3.2 TP+MTP)
         timeout-minutes: 120
         run: |
@@ -783,6 +834,30 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
 
       - name: Performance Test MI35x (8-GPU DeepSeek-V3.2 Basic)
         timeout-minutes: 150
@@ -849,6 +924,30 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Pre-cache DeepSeek-V3.2 model
+        timeout-minutes: 240
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh python3 -c "
+          import os, time
+          from huggingface_hub import snapshot_download, scan_cache_dir
+          repo = 'deepseek-ai/DeepSeek-V3.2'
+          cache_dir = os.environ.get('HF_HOME', None)
+          try:
+              info = scan_cache_dir(cache_dir)
+              cached = [r for r in info.repos if r.repo_id == repo]
+              if cached and cached[0].size_on_disk > 400e9:
+                  print(f'Model already cached ({cached[0].size_on_disk/1e9:.1f} GB), skipping download')
+              else:
+                  print(f'Downloading {repo} to {cache_dir}...')
+                  t0 = time.time()
+                  snapshot_download(repo)
+                  print(f'Download completed in {time.time()-t0:.0f}s')
+          except Exception as e:
+              print(f'Cache check failed ({e}), downloading from scratch...')
+              snapshot_download(repo)
+          print('Model ready')
+          "
 
       - name: Performance Test MI35x (8-GPU DeepSeek-V3.2 MTP)
         timeout-minutes: 180

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_v32_dp_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_v32_dp_eval_mi35x.py
@@ -6,12 +6,6 @@ completion benchmark on MI35x.
 Registry: nightly-amd-accuracy-8-gpu-mi35x-deepseek-v32-dp suite
 """
 
-import os
-
-# Set HF cache for MI35x
-os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
-os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
-
 import unittest
 from types import SimpleNamespace
 

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_v32_eval_mi35x.py
@@ -8,11 +8,6 @@ Registry: nightly-amd-accuracy-8-gpu-mi35x-deepseek-v32 suite
 
 import ast
 import os
-
-# Set HF cache for MI35x
-os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
-os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
-
 import re
 import time
 import unittest

--- a/test/registered/amd/accuracy/mi35x/test_deepseek_v32_mtp_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_deepseek_v32_mtp_eval_mi35x.py
@@ -6,12 +6,6 @@ completion benchmark on MI35x.
 Registry: nightly-amd-accuracy-8-gpu-mi35x-deepseek-v32-mtp suite
 """
 
-import os
-
-# Set HF cache for MI35x
-os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
-os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
-
 import unittest
 from types import SimpleNamespace
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->


## Motivation

The nightly MI35x DeepSeek-V3.2 tests (`nightly-perf-8-gpu-mi35x-deepseek-v32-basic`, `nightly-accuracy-8-gpu-mi35x-deepseek-v32`, etc.) started failing with exit code 255 (timeout) since Feb 21. Feb 20 and earlier were green.

### Root Cause

MI35x Kubernetes pod was recycled, causing:

1. **No persistent volume mount** → `CACHE_VOLUME=""` in `amd_ci_start_container.sh` → all caches (HF models, MIOpen kernels, Triton kernels) go to ephemeral container storage
2. **Every CI run** must re-download models and recompile all JIT kernels from scratch, adding ~20-30 min overhead to every MI35x job
3. **DeepSeek-V3.2 tests** exceed their timeout because 400GB+ model download + kernel compilation + benchmarks > 90 min test timeout limit
4. **Self-perpetuating failure**: container is destroyed on timeout, partial downloads are lost, next run starts over

Evidence:
- ALL MI35x jobs got 2-3x slower starting Feb 21 (grok1: 21m→1h10m, kimi: 19m→48m, mxfp4: 18m→45m) - kernel cache recompilation overhead
- Only DSv32 jobs cross the timeout threshold due to the ~400GB model download on top of kernel recompilation
- MI30x jobs are unaffected (different runner, caches intact)
- PR #17953 code regression was reverted (PR #19161, Feb 22) but MI35x failures persist → confirms infrastructure root cause

Additionally, DSv32 accuracy tests hardcoded `HF_HOME` to `/data2/models/huggingface` (ephemeral pod-local storage), overriding the CI container's persistent volume path even when available.

## Modifications

1. **Remove hardcoded `/data2` paths** from 3 DSv32 MI35x accuracy test files so they inherit `HF_HOME=/sgl-data/hf-cache` from the CI container
2. **Add model pre-cache step** (`snapshot_download` with 240-min timeout) before each of the 8 MI35x DSv32 test jobs across both ROCm 7.0 and 7.2 workflows
   - Pre-cache checks if model is already cached (>400GB) before downloading
   - Logs cache status and download timing for debugging

### Files changed

| File | Change |
|------|--------|
| `nightly-test-amd.yml` | Add pre-cache step to 4 MI35x DSv32 jobs + temp PR trigger |
| `nightly-test-amd-rocm720.yml` | Add pre-cache step to 4 MI35x DSv32 jobs + temp PR trigger |
| `test_deepseek_v32_eval_mi35x.py` | Remove `/data2` HF_HOME override |
| `test_deepseek_v32_mtp_eval_mi35x.py` | Remove `/data2` HF_HOME override |
| `test_deepseek_v32_dp_eval_mi35x.py` | Remove `/data2` HF_HOME override |

> **Note:** `pull_request` triggers are temporary for CI testing and will be removed before merge.

Please help review. @yctseng0211, @bingxche.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
