### PR TITLE
perf(diffusion): parallelize pipeline module loading

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/adapter_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/adapter_loader.py
@@ -6,6 +6,7 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader imp
 )
 from sglang.multimodal_gen.runtime.loader.utils import (
     _list_safetensors_files,
+    _model_construction_lock,
     set_default_torch_dtype,
     skip_init_modules,
 )
@@ -52,7 +53,9 @@ class AdapterLoader(ComponentLoader):
 
         from types import SimpleNamespace
 
-        with set_default_torch_dtype(default_dtype), skip_init_modules():
+        with _model_construction_lock, set_default_torch_dtype(
+            default_dtype
+        ), skip_init_modules():
             connector_cfg = SimpleNamespace(**config)
             model = model_cls(connector_cfg).to(
                 device=target_device, dtype=default_dtype

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -17,6 +17,7 @@ from transformers import AutoImageProcessor, AutoProcessor, AutoTokenizer
 from sglang.multimodal_gen.configs.models import ModelConfig
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.loader.utils import (
+    _model_construction_lock,
     _normalize_component_type,
     component_name_to_loader_cls,
     get_memory_usage_of_component,
@@ -105,9 +106,14 @@ class ComponentLoader(ABC):
                     f"Error while loading customized {component_name}, falling back to native version"
                 )
             # fallback to native version
-            component = self.load_native(
-                component_model_path, server_args, transformers_or_diffusers
-            )
+            # Hold _model_construction_lock so that AutoModel.from_pretrained's
+            # accelerate.init_empty_weights() — which patches
+            # nn.Module.register_parameter globally — cannot race with FSDP
+            # sharding in other threads (which also modify module state).
+            with _model_construction_lock:
+                component = self.load_native(
+                    component_model_path, server_args, transformers_or_diffusers
+                )
             should_offload = self.should_offload(server_args)
             target_device = self.target_device(should_offload)
             component = component.to(device=target_device)

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -22,6 +22,7 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader imp
 )
 from sglang.multimodal_gen.runtime.loader.fsdp_load import shard_model
 from sglang.multimodal_gen.runtime.loader.utils import (
+    _model_construction_lock,
     set_default_torch_dtype,
     skip_init_modules,
 )
@@ -247,37 +248,39 @@ class TextEncoderLoader(ComponentLoader):
         else:
             model_device = local_torch_device
 
-        with set_default_torch_dtype(PRECISION_TO_TYPE[dtype]):
-            with model_device, skip_init_modules():
-                architectures = getattr(model_config, "architectures", [])
-                model_cls, _ = ModelRegistry.resolve_model_cls(architectures)
-                enable_image_understanding = (
-                    True
-                    if isinstance(
-                        server_args.pipeline_config, QwenImageEditPipelineConfig
+        with _model_construction_lock:
+            with set_default_torch_dtype(PRECISION_TO_TYPE[dtype]):
+                with model_device, skip_init_modules():
+                    architectures = getattr(model_config, "architectures", [])
+                    model_cls, _ = ModelRegistry.resolve_model_cls(architectures)
+                    enable_image_understanding = (
+                        True
+                        if isinstance(
+                            server_args.pipeline_config, QwenImageEditPipelineConfig
+                        )
+                        else False
                     )
-                    else False
+                    model_config.enable_image_understanding = enable_image_understanding
+                    model = model_cls(model_config)
+
+        weights_to_load = {name for name, _ in model.named_parameters()}
+        loaded_weights = model.load_weights(
+            self._get_all_weights(model, model_path, to_cpu=should_offload)
+        )
+
+        # Explicitly move model to target device after loading weights
+        if not should_offload:
+            model = model.to(local_torch_device)
+
+        if should_offload:
+            # Disable FSDP for MPS as it's not compatible
+            if current_platform.is_mps():
+                logger.info(
+                    "Disabling FSDP sharding for MPS platform as it's not compatible"
                 )
-                model_config.enable_image_understanding = enable_image_understanding
-                model = model_cls(model_config)
-
-            weights_to_load = {name for name, _ in model.named_parameters()}
-            loaded_weights = model.load_weights(
-                self._get_all_weights(model, model_path, to_cpu=should_offload)
-            )
-
-            # Explicitly move model to target device after loading weights
-            if not should_offload:
                 model = model.to(local_torch_device)
-
-            if should_offload:
-                # Disable FSDP for MPS as it's not compatible
-                if current_platform.is_mps():
-                    logger.info(
-                        "Disabling FSDP sharding for MPS platform as it's not compatible"
-                    )
-                    model = model.to(local_torch_device)
-                else:
+            else:
+                with _model_construction_lock:
                     mesh = init_device_mesh(
                         current_platform.device_type,
                         mesh_shape=(1, dist.get_world_size()),
@@ -292,41 +295,41 @@ class TextEncoderLoader(ComponentLoader):
                         or getattr(model, "_fsdp_shard_conditions", None),
                         pin_cpu_memory=server_args.pin_cpu_memory,
                     )
-            else:
-                model = model.to(local_torch_device)
-            # We only enable strict check for non-quantized models
-            # that have loaded weights tracking currently.
-            # if loaded_weights is not None:
-            weights_not_loaded = weights_to_load - loaded_weights
-            if weights_not_loaded:
-                # NOTE:
-                # If we silently continue with uninitialized weights, the text encoder can
-                # produce NaNs/garbage embeddings that later fail stage verification in a
-                # hard-to-debug way (e.g., `prompt_embeds` fails the NaN check).
-                #
-                # We allow a small set of known-optional parameters to be missing, but
-                # default to strict behavior for the rest.
-                allowed_missing_patterns = (
-                    getattr(model, "_allowed_missing_weights_patterns", []) or []
+        else:
+            model = model.to(local_torch_device)
+        # We only enable strict check for non-quantized models
+        # that have loaded weights tracking currently.
+        # if loaded_weights is not None:
+        weights_not_loaded = weights_to_load - loaded_weights
+        if weights_not_loaded:
+            # NOTE:
+            # If we silently continue with uninitialized weights, the text encoder can
+            # produce NaNs/garbage embeddings that later fail stage verification in a
+            # hard-to-debug way (e.g., `prompt_embeds` fails the NaN check).
+            #
+            # We allow a small set of known-optional parameters to be missing, but
+            # default to strict behavior for the rest.
+            allowed_missing_patterns = (
+                getattr(model, "_allowed_missing_weights_patterns", []) or []
+            )
+            unexpected_missing = {
+                n
+                for n in weights_not_loaded
+                if not any(pat in n for pat in allowed_missing_patterns)
+            }
+            if unexpected_missing:
+                raise ValueError(
+                    "Following text encoder weights were not initialized from checkpoint: "
+                    f"{sorted(unexpected_missing)}. "
+                    "This usually indicates a checkpoint/model-arch mismatch or a broken "
+                    "weight-name mapping. If these are truly optional, set "
+                    "`model._allowed_missing_weights_patterns` to whitelist patterns."
                 )
-                unexpected_missing = {
-                    n
-                    for n in weights_not_loaded
-                    if not any(pat in n for pat in allowed_missing_patterns)
-                }
-                if unexpected_missing:
-                    raise ValueError(
-                        "Following text encoder weights were not initialized from checkpoint: "
-                        f"{sorted(unexpected_missing)}. "
-                        "This usually indicates a checkpoint/model-arch mismatch or a broken "
-                        "weight-name mapping. If these are truly optional, set "
-                        "`model._allowed_missing_weights_patterns` to whitelist patterns."
-                    )
-                logger.warning(
-                    "Following (allowed) text encoder weights were not initialized from "
-                    "checkpoint: %s (allowed patterns: %s)",
-                    sorted(weights_not_loaded),
-                    allowed_missing_patterns,
-                )
+            logger.warning(
+                "Following (allowed) text encoder weights were not initialized from "
+                "checkpoint: %s (allowed patterns: %s)",
+                sorted(weights_not_loaded),
+                allowed_missing_patterns,
+            )
 
         return model

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -101,7 +101,10 @@ class VAELoader(ComponentLoader):
             spec.loader.exec_module(custom_module)
             vae_cls = getattr(custom_module, cls_name)
             vae_dtype = PRECISION_TO_TYPE[vae_precision]
-            with set_default_torch_dtype(vae_dtype):
+            # Hold _model_construction_lock so that from_pretrained()'s
+            # init_empty_weights() — which patches nn.Module.register_parameter
+            # globally — cannot race with model construction in other threads.
+            with _model_construction_lock, set_default_torch_dtype(vae_dtype):
                 vae = vae_cls.from_pretrained(
                     component_model_path,
                     revision=server_args.revision,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -12,6 +12,7 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader imp
 )
 from sglang.multimodal_gen.runtime.loader.utils import (
     _list_safetensors_files,
+    _model_construction_lock,
     set_default_torch_dtype,
     skip_init_modules,
 )
@@ -121,10 +122,9 @@ class VAELoader(ComponentLoader):
             return vae
 
         # Load from ModelRegistry (standard VAE classes)
-        with (
-            set_default_torch_dtype(PRECISION_TO_TYPE[vae_precision]),
-            skip_init_modules(),
-        ):
+        with _model_construction_lock, set_default_torch_dtype(
+            PRECISION_TO_TYPE[vae_precision]
+        ), skip_init_modules():
             vae_cls, _ = ModelRegistry.resolve_model_cls(class_name)
             vae = vae_cls(vae_config).to(target_device)
 

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vocoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vocoder_loader.py
@@ -6,6 +6,7 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader imp
 )
 from sglang.multimodal_gen.runtime.loader.utils import (
     _list_safetensors_files,
+    _model_construction_lock,
     set_default_torch_dtype,
     skip_init_modules,
 )
@@ -56,7 +57,9 @@ class VocoderLoader(ComponentLoader):
         should_offload = self.should_offload(server_args)
         target_device = self.target_device(should_offload)
 
-        with set_default_torch_dtype(vocoder_dtype), skip_init_modules():
+        with _model_construction_lock, set_default_torch_dtype(
+            vocoder_dtype
+        ), skip_init_modules():
             vocoder_cls, _ = ModelRegistry.resolve_model_cls(class_name)
             vocoder = vocoder_cls(vocoder_config).to(target_device)
 

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -25,6 +25,7 @@ from torch.nn.modules.module import _IncompatibleKeys
 
 from sglang.multimodal_gen.runtime.layers.linear import UnquantizedLinearMethod
 from sglang.multimodal_gen.runtime.loader.utils import (
+    _model_construction_lock,
     get_param_names_mapping,
     hf_to_custom_state_dict,
     set_default_torch_dtype,
@@ -112,16 +113,6 @@ def maybe_load_fsdp_model(
         default_torch_dtype, reduce_dtype, output_dtype, cast_forward_inputs=False
     )
 
-    set_mixed_precision_policy(
-        param_dtype=default_torch_dtype,
-        reduce_dtype=reduce_dtype,
-        output_dtype=output_dtype,
-        mp_policy=mp_policy,
-    )
-
-    with set_default_torch_dtype(default_torch_dtype), torch.device("meta"):
-        model = model_cls(**init_params)
-
     # Check if we should use FSDP
     use_fsdp = fsdp_inference
 
@@ -130,27 +121,38 @@ def maybe_load_fsdp_model(
         use_fsdp = False
         logger.info("Disabling FSDP for MPS platform as it's not compatible")
 
-    if use_fsdp:
-        world_size = hsdp_replicate_dim * hsdp_shard_dim
-        if not fsdp_inference:
-            hsdp_replicate_dim = world_size
-            hsdp_shard_dim = 1
-
-        device_mesh = init_device_mesh(
-            current_platform.device_type,
-            # (Replicate(), Shard(dim=0))
-            mesh_shape=(hsdp_replicate_dim, hsdp_shard_dim),
-            mesh_dim_names=("replicate", "shard"),
-        )
-        shard_model(
-            model,
-            cpu_offload=cpu_offload,
-            reshard_after_forward=True,
+    with _model_construction_lock:
+        set_mixed_precision_policy(
+            param_dtype=default_torch_dtype,
+            reduce_dtype=reduce_dtype,
+            output_dtype=output_dtype,
             mp_policy=mp_policy,
-            mesh=device_mesh,
-            fsdp_shard_conditions=model._fsdp_shard_conditions,
-            pin_cpu_memory=pin_cpu_memory,
         )
+
+        with set_default_torch_dtype(default_torch_dtype), torch.device("meta"):
+            model = model_cls(**init_params)
+
+        if use_fsdp:
+            world_size = hsdp_replicate_dim * hsdp_shard_dim
+            if not fsdp_inference:
+                hsdp_replicate_dim = world_size
+                hsdp_shard_dim = 1
+
+            device_mesh = init_device_mesh(
+                current_platform.device_type,
+                # (Replicate(), Shard(dim=0))
+                mesh_shape=(hsdp_replicate_dim, hsdp_shard_dim),
+                mesh_dim_names=("replicate", "shard"),
+            )
+            shard_model(
+                model,
+                cpu_offload=cpu_offload,
+                reshard_after_forward=True,
+                mp_policy=mp_policy,
+                mesh=device_mesh,
+                fsdp_shard_conditions=model._fsdp_shard_conditions,
+                pin_cpu_memory=pin_cpu_memory,
+            )
 
     weight_iterator = safetensors_weights_iterator(weight_dir_list)
     param_names_mapping_fn = get_param_names_mapping(model.param_names_mapping)

--- a/python/sglang/multimodal_gen/runtime/loader/utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/utils.py
@@ -7,6 +7,7 @@ import contextlib
 import glob
 import os
 import re
+import threading
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from typing import Any, Dict, Type
@@ -24,6 +25,11 @@ _QUANTIZED_DTYPES = {
     torch.float8_e5m2,
     torch.int8,
 }
+
+# Serializes model construction to prevent races on process-global state
+# (torch.set_default_dtype, skip_init_modules class patches). Weight loading
+# runs outside this lock so the parallel startup speedup is preserved.
+_model_construction_lock = threading.Lock()
 
 
 @contextlib.contextmanager

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -7,6 +7,7 @@ Base class for composed pipelines.
 This module defines the base class for pipelines that are composed of multiple stages.
 """
 
+import concurrent.futures
 import os
 import re
 from abc import ABC, abstractmethod
@@ -40,6 +41,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     verify_model_config_and_directory,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 logger = init_logger(__name__)
 
@@ -270,11 +272,15 @@ class ComposedPipelineBase(ABC):
         required_modules = self.required_config_modules
         logger.info("Loading required components: %s", required_modules)
 
-        loaded_components = {}
+        loaded_components: dict[str, Any] = {}
+
+        # Pre-pass: handle null/pre-loaded modules and resolve all paths sequentially.
+        # This must be sequential to safely mutate self.required_config_modules for null entries.
+        to_load: dict[str, tuple[str, str, str]] = {}
         for module_name, (
             transformers_or_diffusers,
             architecture,
-        ) in tqdm(iterable=model_index.items(), desc="Loading required modules"):
+        ) in model_index.items():
             if transformers_or_diffusers is None:
                 logger.warning(
                     "Module %s in model_index.json has null value, removing from required_config_modules",
@@ -300,18 +306,59 @@ class ComposedPipelineBase(ABC):
             component_model_path = self._resolve_component_path(
                 server_args, module_name, load_module_name
             )
+
+            to_load[module_name] = (
+                transformers_or_diffusers,
+                load_module_name,
+                component_model_path,
+            )
+
+        def _load_one(module_name: str) -> tuple[str, str, Any, float]:
+            transformers_or_diffusers, load_module_name, component_model_path = to_load[
+                module_name
+            ]
             module, memory_usage = PipelineComponentLoader.load_component(
                 component_name=load_module_name,
                 component_model_path=component_model_path,
                 transformers_or_diffusers=transformers_or_diffusers,
                 server_args=server_args,
             )
+            return module_name, load_module_name, module, memory_usage
 
-            self.memory_usages[load_module_name] = memory_usage
+        use_parallel = server_args.parallel_loading and len(to_load) > 1
 
-            if module_name in loaded_components:
-                logger.warning("Overwriting module %s", module_name)
-            loaded_components[module_name] = module
+        if use_parallel:
+            _prior_dtype = torch.get_default_dtype()
+            _target_dtype = PRECISION_TO_TYPE.get(
+                getattr(server_args.pipeline_config, "dit_precision", "bf16"),
+                torch.bfloat16,
+            )
+            torch.set_default_dtype(_target_dtype)
+            logger.info(
+                "Loading %d pipeline components in parallel: %s",
+                len(to_load),
+                list(to_load.keys()),
+            )
+            try:
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=len(to_load)
+                ) as executor:
+                    futures = [executor.submit(_load_one, name) for name in to_load]
+                    for future in concurrent.futures.as_completed(futures):
+                        mod_name, load_mod_name, module, memory_usage = future.result()
+                        self.memory_usages[load_mod_name] = memory_usage
+                        if mod_name in loaded_components:
+                            logger.warning("Overwriting module %s", mod_name)
+                        loaded_components[mod_name] = module
+            finally:
+                torch.set_default_dtype(_prior_dtype)
+        else:
+            for module_name in tqdm(to_load, desc="Loading required modules"):
+                _, load_mod_name, module, memory_usage = _load_one(module_name)
+                self.memory_usages[load_mod_name] = memory_usage
+                if module_name in loaded_components:
+                    logger.warning("Overwriting module %s", module_name)
+                loaded_components[module_name] = module
 
         # Check if all required modules were loaded
         for module_name in required_modules:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -325,7 +325,13 @@ class ComposedPipelineBase(ABC):
             )
             return module_name, load_module_name, module, memory_usage
 
-        use_parallel = server_args.parallel_loading and len(to_load) > 1
+        is_multi_rank = (
+            torch.distributed.is_initialized()
+            and torch.distributed.get_world_size() > 1
+        )
+        use_parallel = (
+            server_args.parallel_loading and len(to_load) > 1 and not is_multi_rank
+        )
 
         if use_parallel:
             _prior_dtype = torch.get_default_dtype()

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -169,6 +169,7 @@ class ServerArgs:
     vae_cpu_offload: bool | None = None
     use_fsdp_inference: bool = False
     pin_cpu_memory: bool = True
+    parallel_loading: bool = True
 
     # ComfyUI integration
     comfyui_mode: bool = False
@@ -764,6 +765,13 @@ class ServerArgs:
             action=StoreBoolean,
             help='Pin memory for CPU offload. Only added as a temp workaround if it throws "CUDA error: invalid argument". '
             "Should be enabled in almost all cases",
+        )
+        parser.add_argument(
+            "--parallel-loading",
+            action=StoreBoolean,
+            default=ServerArgs.parallel_loading,
+            help="Load pipeline components (text encoder, transformer, VAE, etc.) in parallel using threads "
+            "to reduce server startup time. Disable if components have ordering dependencies.",
         )
         parser.add_argument(
             "--disable-autocast",


### PR DESCRIPTION
Fixes #19092

   `load_modules()` loads every pipeline component sequentially. For
   Qwen-Image, the text encoder and transformer have no ordering dependency and
   are both disk-I/O bound, so they can be loaded concurrently.

   ## Modifications

   - Parallel load phase using `ThreadPoolExecutor` after a sequential pre-pass
    for path resolution and shared state mutation.
   - Adds `_model_construction_lock` to serialize model construction across
   loader threads, preventing races on process-global state
   (`torch.set_default_dtype`, `skip_init_modules` class patches). Weight
   loading runs outside the lock so the parallel speedup is preserved.
   - Pre-sets global dtype before spawning threads so concurrent
   `set_default_torch_dtype` context managers are no-ops.
   - Adds `parallel_loading: bool = True` to `ServerArgs` with
   `--parallel-loading` / `--no-parallel-loading` to opt out.

   ## Benchmarking

   Hardware: 1x NVIDIA A100-SXM4-80GB, model: Qwen/Qwen-Image (53.5 GiB), cold
   cache, no CPU offload.

   | Mode | Time |
   |------|------|
   | Sequential (main) | 113.7s |
   | Parallel (this PR) | 52.0s |
   | Speedup | 2.2x (54% faster) |"

## Follow-up                                                                      
- Validated that weights are currently loaded into **pageable** CPU memory          
  (`is_pinned() = False`). H2D transfer benchmarks on H100 80GB show `safe_open(device="cuda")` would be ~1.74x faster for non-FSDP loaders (5.39 GB/s vs 3.09 GB/s). Will address in a separate PR.


