### PR TITLE
[Benchmark] Remove re-exports from bench_serving.py

### DIFF
--- a/benchmark/hicache/bench_long_context.py
+++ b/benchmark/hicache/bench_long_context.py
@@ -12,7 +12,7 @@ from bench_multiturn import (
 )
 from tqdm.asyncio import tqdm
 
-from sglang.bench_serving import get_tokenizer
+from sglang.benchmark.utils import get_tokenizer
 
 
 class ContextWorkloadGenerator(WorkloadGenerator):

--- a/benchmark/hicache/bench_mix.py
+++ b/benchmark/hicache/bench_mix.py
@@ -12,12 +12,9 @@ from functools import wraps
 
 import aiohttp
 
-from sglang.bench_serving import (
-    RequestFuncOutput,
-    get_tokenizer,
-    remove_prefix,
-    sample_random_requests,
-)
+from sglang.bench_serving import RequestFuncOutput
+from sglang.benchmark.datasets import sample_random_requests
+from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
 # Set up logger
 logger = logging.getLogger(__name__)

--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -11,7 +11,8 @@ import numpy as np
 import requests
 from tqdm.asyncio import tqdm
 
-from sglang.bench_serving import get_tokenizer, sample_random_requests
+from sglang.benchmark.datasets import sample_random_requests
+from sglang.benchmark.utils import get_tokenizer
 from sglang.test.kits.cache_hit_kit import async_request_sglang_generate, gen_payload
 
 

--- a/benchmark/hicache/bench_serving.py
+++ b/benchmark/hicache/bench_serving.py
@@ -32,7 +32,7 @@ from data_processing import MsgContent, SampleOutput, get_dataset
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
 
-from sglang.bench_serving import get_tokenizer, remove_prefix, set_ulimit
+from sglang.benchmark.utils import get_tokenizer, remove_prefix, set_ulimit
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
 

--- a/benchmark/hicache/data_processing.py
+++ b/benchmark/hicache/data_processing.py
@@ -11,13 +11,13 @@ from nextqa import NExTQALoader
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
 
-from sglang.bench_serving import (
+from sglang.benchmark.datasets import (
     SHAREGPT_FILENAME,
     SHAREGPT_REPO_ID,
-    download_and_cache_hf_file,
     gen_prompt,
     get_gen_prefix_cache_path,
 )
+from sglang.benchmark.utils import download_and_cache_hf_file
 from sglang.lang.chat_template import get_chat_template, get_chat_template_by_model_path
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionMessageContentPart
 from sglang.utils import encode_video_base64

--- a/benchmark/lora/lora_bench.py
+++ b/benchmark/lora/lora_bench.py
@@ -35,10 +35,9 @@ from sglang.bench_serving import (
     _create_bench_client_session,
     calculate_metrics,
     get_request,
-    get_tokenizer,
-    remove_prefix,
-    sample_random_requests,
 )
+from sglang.benchmark.datasets import sample_random_requests
+from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
 global args
 

--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -23,13 +23,8 @@ from typing import Dict, List, Optional
 
 import numpy as np
 
-from sglang.bench_serving import (
-    DatasetRow,
-    get_dataset,
-    get_tokenizer,
-    sample_random_requests,
-    set_ulimit,
-)
+from sglang.benchmark.datasets import DatasetRow, get_dataset, sample_random_requests
+from sglang.benchmark.utils import get_tokenizer, set_ulimit
 from sglang.lang.backend.runtime_endpoint import Runtime
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.server_args import ServerArgs

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -36,39 +36,15 @@ import requests
 from tqdm.asyncio import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
-from sglang.benchmark.datasets import (  # noqa: F401
-    ASSISTANT_SUFFIX,
-    MOONCAKE_DATASET_URL,
-    SHAREGPT_FILENAME,
-    SHAREGPT_REPO_ID,
+from sglang.benchmark.datasets import (
     DatasetRow,
-    compute_random_lens,
-    create_mm_data_row,
-    gen_mm_prompt,
-    gen_prompt,
-    get_available_tokens,
     get_dataset,
-    get_gen_prefix_cache_path,
     get_mooncake_request_over_time,
-    parse_image_resolution,
-    sample_custom_requests,
-    sample_generated_shared_prefix_requests,
-    sample_image_requests,
-    sample_mmmu_requests,
-    sample_openai_requests,
-    sample_random_requests,
-    sample_sharegpt_requests,
 )
-from sglang.benchmark.utils import (  # noqa: F401
-    download_and_cache_file,
-    download_and_cache_hf_file,
-    get_model,
-    get_processor,
+from sglang.benchmark.utils import (
     get_tokenizer,
-    is_file_valid_json,
     parse_custom_headers,
     remove_prefix,
-    remove_suffix,
     set_ulimit,
 )
 

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -16,11 +16,8 @@ from pydantic import BaseModel
 from tabulate import tabulate
 from transformers import AutoProcessor, PreTrainedTokenizer
 
-from sglang.bench_serving import (
-    get_dataset,
-    get_processor,
-    get_tokenizer,
-)
+from sglang.benchmark.datasets import get_dataset
+from sglang.benchmark.utils import get_processor, get_tokenizer
 from sglang.profiler import run_profile
 from sglang.srt.entrypoints.http_server import launch_server
 from sglang.srt.server_args import ServerArgs

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -5,12 +5,9 @@ import time
 import aiohttp
 import requests
 
-from sglang.bench_serving import (
-    RequestFuncOutput,
-    get_tokenizer,
-    remove_prefix,
-    sample_random_requests,
-)
+from sglang.bench_serving import RequestFuncOutput
+from sglang.benchmark.datasets import sample_random_requests
+from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
 

--- a/scripts/playground/bench_speculative.py
+++ b/scripts/playground/bench_speculative.py
@@ -19,12 +19,8 @@ import numpy as np
 import requests
 from transformers import AutoTokenizer
 
-from sglang.bench_serving import (
-    DatasetRow,
-    benchmark,
-    sample_mmmu_requests,
-    set_global_args,
-)
+from sglang.bench_serving import benchmark, set_global_args
+from sglang.benchmark.datasets import DatasetRow, sample_mmmu_requests
 from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,

--- a/scripts/playground/replay_request_dump.py
+++ b/scripts/playground/replay_request_dump.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 import requests
 
-from sglang.bench_serving import set_ulimit
+from sglang.benchmark.utils import set_ulimit
 from sglang.utils import get_exception_traceback
 
 

--- a/test/manual/hicache/test_disaggregation_hicache.py
+++ b/test/manual/hicache/test_disaggregation_hicache.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import requests
 
-from sglang.bench_serving import get_tokenizer
+from sglang.benchmark.utils import get_tokenizer
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
 )

--- a/test/registered/bench_fn/test_bench_serving_functionality.py
+++ b/test/registered/bench_fn/test_bench_serving_functionality.py
@@ -6,7 +6,8 @@ import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
-from sglang.bench_serving import parse_custom_headers, run_benchmark
+from sglang.bench_serving import run_benchmark
+from sglang.benchmark.utils import parse_custom_headers
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (

--- a/test/registered/hicache/test_hicache_storage_file_backend.py
+++ b/test/registered/hicache/test_hicache_storage_file_backend.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 
 import requests
 
-from sglang.bench_serving import get_tokenizer
+from sglang.benchmark.utils import get_tokenizer
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k

--- a/test/registered/hicache/test_hicache_variants.py
+++ b/test/registered/hicache/test_hicache_variants.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.bench_serving import get_tokenizer
+from sglang.benchmark.utils import get_tokenizer
 from sglang.srt.utils import is_hip, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (


### PR DESCRIPTION
Remove re-exports from bench_serving.py — it's not a utils module and shouldn't be used as an import hub. All consumers now import directly from sglang.benchmark.datasets and sglang.benchmark.utils.

A part of #10177