### PR TITLE
[DeepSeek-V3.2][JIT-kernel] Support nsa fuse store indexer k cache

### DIFF
--- a/python/sglang/jit_kernel/csrc/nsa/fused_store_index_cache.cuh
+++ b/python/sglang/jit_kernel/csrc/nsa/fused_store_index_cache.cuh
@@ -1,0 +1,131 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+#include <cuda_fp8.h>
+
+namespace {
+
+struct FusedStoreCacheParam {
+  const void* __restrict__ input;
+  void* __restrict__ cache;
+  const void* __restrict__ indices;
+  uint32_t num_tokens;
+};
+
+[[maybe_unused]]
+SGL_DEVICE int32_t cast_to_ue8m0(float x) {
+  uint32_t u = __float_as_uint(x);
+  int32_t exp = int32_t((u >> 23) & 0xFF);
+  uint32_t mant = u & 0x7FFFFF;
+  return exp + (mant != 0);
+}
+
+[[maybe_unused]]
+SGL_DEVICE float inv_scale_ue8m0(int32_t exp) {
+  return __uint_as_float((127 + 127 - exp) << 23);
+}
+
+[[maybe_unused]]
+SGL_DEVICE float fp8_e4m3_clip(float val) {
+  namespace math = device::math;
+  return math::max(math::min(val, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
+}
+
+[[maybe_unused]]
+SGL_DEVICE fp8x2_e4m3_t pack_fp8(float x, float y) {
+  return fp8x2_e4m3_t{fp32x2_t{fp8_e4m3_clip(x), fp8_e4m3_clip(y)}};
+}
+
+template <typename Float, typename IndicesT, uint32_t kPageBits>
+__global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCacheParam param) {
+  using namespace device;
+
+  /// NOTE: 132 = 128 + 4
+  constexpr int64_t kPageBytes = 132 << kPageBits;
+
+  // each warp handles 128 elements, 1 warp, each block handles multiple rows
+  const auto& [input, cache, indices, num_tokens] = param;
+  const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto global_wid = global_tid / 32;
+  const auto lane_id = threadIdx.x % 32;
+
+  if (global_wid >= num_tokens) return;
+  // prefetch the index
+  const auto index = static_cast<const IndicesT*>(indices)[global_wid];
+  // always load the value from input (don't store if invalid)
+  using Float2 = packed_t<Float>;
+  using InStorage = AlignedVector<Float2, 2>;
+  using OutStorage = AlignedVector<fp8x2_e4m3_t, 2>;
+  const auto elems = static_cast<const InStorage*>(input)[global_tid];
+  const auto [x0, x1] = cast<fp32x2_t>(elems[0]);
+  const auto [y0, y1] = cast<fp32x2_t>(elems[1]);
+  const auto local_max = fmaxf(fmaxf(fabs(x0), fabs(x1)), fmaxf(fabs(y0), fabs(y1)));
+  const auto abs_max = warp::reduce_max(local_max);
+  // use normal fp32 scale
+  const auto scale = fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX;
+  const auto inv_scale = 1.0f / scale;
+  const int32_t page = index >> kPageBits;
+  const int32_t offset = index & ((1 << kPageBits) - 1);
+  const auto page_ptr = pointer::offset(cache, page * kPageBytes);
+  const auto value_ptr = pointer::offset(page_ptr, offset * 128);
+  const auto scale_ptr = pointer::offset(page_ptr, 128 << kPageBits, offset * 4);
+  OutStorage result;
+  result[0] = pack_fp8(x0 * inv_scale, x1 * inv_scale);
+  result[1] = pack_fp8(y0 * inv_scale, y1 * inv_scale);
+  static_cast<OutStorage*>(value_ptr)[lane_id] = result;
+  static_cast<float*>(scale_ptr)[0] = scale;
+}
+
+template <typename Float, typename IndicesT, uint32_t kPageSize>
+struct FusedStoreCacheIndexerKernel {
+  static constexpr int32_t kLogSize = std::countr_zero(kPageSize);
+  static constexpr int64_t kPageBytes = 132 * kPageSize;
+  static constexpr auto kernel = fused_store_indexer_cache<Float, IndicesT, kLogSize>;
+
+  static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
+  static_assert(1 << kLogSize == kPageSize);
+
+  static void run(tvm::ffi::TensorView input, tvm::ffi::TensorView cache, tvm::ffi::TensorView indices) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+    TensorMatcher({N, 128})  // input
+        .with_dtype<Float>()
+        .with_device(device_)
+        .verify(input);
+    TensorMatcher({-1, -1})  // cache
+        .with_strides({kPageBytes, 1})
+        .with_dtype<uint8_t>()
+        .with_device(device_)
+        .verify(cache);
+    TensorMatcher({N})  // indices
+        .with_dtype<IndicesT>()
+        .with_device(device_)
+        .verify(indices);
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto params = FusedStoreCacheParam{
+        .input = input.data_ptr(),
+        .cache = cache.data_ptr(),
+        .indices = indices.data_ptr(),
+        .num_tokens = num_tokens,
+    };
+    const auto kBlockSize = 128;
+    const auto num_blocks = div_ceil(num_tokens * 32, kBlockSize);
+    LaunchKernel(num_blocks, kBlockSize, device_.unwrap())(kernel, params);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/nsa/fused_store_index_cache.cuh
+++ b/python/sglang/jit_kernel/csrc/nsa/fused_store_index_cache.cuh
@@ -24,19 +24,6 @@ struct FusedStoreCacheParam {
 };
 
 [[maybe_unused]]
-SGL_DEVICE int32_t cast_to_ue8m0(float x) {
-  uint32_t u = __float_as_uint(x);
-  int32_t exp = int32_t((u >> 23) & 0xFF);
-  uint32_t mant = u & 0x7FFFFF;
-  return exp + (mant != 0);
-}
-
-[[maybe_unused]]
-SGL_DEVICE float inv_scale_ue8m0(int32_t exp) {
-  return __uint_as_float((127 + 127 - exp) << 23);
-}
-
-[[maybe_unused]]
 SGL_DEVICE float fp8_e4m3_clip(float val) {
   namespace math = device::math;
   return math::max(math::min(val, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
@@ -47,25 +34,28 @@ SGL_DEVICE fp8x2_e4m3_t pack_fp8(float x, float y) {
   return fp8x2_e4m3_t{fp32x2_t{fp8_e4m3_clip(x), fp8_e4m3_clip(y)}};
 }
 
-template <typename Float, typename IndicesT, uint32_t kPageBits>
+template <typename KeyT, typename IndicesT, uint32_t kPageBits, bool kUsePDL>
 __global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCacheParam param) {
   using namespace device;
 
   /// NOTE: 132 = 128 + 4
   constexpr int64_t kPageBytes = 132 << kPageBits;
 
-  // each warp handles 128 elements, 1 warp, each block handles multiple rows
+  // each warp handles 128 elements, each block handles multiple rows
   const auto& [input, cache, indices, num_tokens] = param;
   const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
   const auto global_wid = global_tid / 32;
   const auto lane_id = threadIdx.x % 32;
 
   if (global_wid >= num_tokens) return;
+
+  PDLWaitPrimary<kUsePDL>();  // wait for primary kernel
+
   // prefetch the index
   const auto index = static_cast<const IndicesT*>(indices)[global_wid];
   // always load the value from input (don't store if invalid)
-  using Float2 = packed_t<Float>;
-  using InStorage = AlignedVector<Float2, 2>;
+  using KeyT2 = packed_t<KeyT>;
+  using InStorage = AlignedVector<KeyT2, 2>;
   using OutStorage = AlignedVector<fp8x2_e4m3_t, 2>;
   const auto elems = static_cast<const InStorage*>(input)[global_tid];
   const auto [x0, x1] = cast<fp32x2_t>(elems[0]);
@@ -85,13 +75,16 @@ __global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCach
   result[1] = pack_fp8(y0 * inv_scale, y1 * inv_scale);
   static_cast<OutStorage*>(value_ptr)[lane_id] = result;
   static_cast<float*>(scale_ptr)[0] = scale;
+
+  PDLTriggerSecondary<kUsePDL>();  // launch secondary kernel
 }
 
-template <typename Float, typename IndicesT, uint32_t kPageSize>
+template <typename KeyT, typename IndicesT, uint32_t kPageSize, bool kUsePDL>
 struct FusedStoreCacheIndexerKernel {
   static constexpr int32_t kLogSize = std::countr_zero(kPageSize);
+  /// NOTE: 132 = 128 + 4 (128 represent K and 4 represent scale)
   static constexpr int64_t kPageBytes = 132 * kPageSize;
-  static constexpr auto kernel = fused_store_indexer_cache<Float, IndicesT, kLogSize>;
+  static constexpr auto kernel = fused_store_indexer_cache<KeyT, IndicesT, kLogSize, kUsePDL>;
 
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
   static_assert(1 << kLogSize == kPageSize);
@@ -103,7 +96,7 @@ struct FusedStoreCacheIndexerKernel {
     auto device_ = SymbolicDevice{};
     device_.set_options<kDLCUDA>();
     TensorMatcher({N, 128})  // input
-        .with_dtype<Float>()
+        .with_dtype<KeyT>()
         .with_device(device_)
         .verify(input);
     TensorMatcher({-1, -1})  // cache
@@ -124,7 +117,7 @@ struct FusedStoreCacheIndexerKernel {
     };
     const auto kBlockSize = 128;
     const auto num_blocks = div_ceil(num_tokens * 32, kBlockSize);
-    LaunchKernel(num_blocks, kBlockSize, device_.unwrap())(kernel, params);
+    LaunchKernel(num_blocks, kBlockSize, device_.unwrap()).enable_pdl(kUsePDL)(kernel, params);
   }
 };
 

--- a/python/sglang/jit_kernel/fused_store_index_cache.py
+++ b/python/sglang/jit_kernel/fused_store_index_cache.py
@@ -1,0 +1,93 @@
+"""
+This module provides JIT-compiled CUDA kernels for fusing multiple tensor
+copy operations into single kernel launches, reducing kernel launch overhead
+and improving CUDA graph replay performance.
+
+The kernels are compiled on-demand using TVM FFI and cached for subsequent use.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+logger = logging.getLogger(__name__)
+
+
+@cache_once
+def _jit_nsa_fused_store_module() -> Module:
+    """
+    Build a JIT module that exposes:
+      module.fused_store_index_k_cache(input_bf16, index_k_with_scale_u8, loc_i64)
+    """
+    return load_jit(
+        "fused_store_index_k_cache",
+        cuda_files=["nsa/fused_store_index_cache.cuh"],
+        cuda_wrappers=[
+            (
+                "fused_store_index_k_cache",
+                # - Float  = bf16_t (sgl_kernel/type.cuh)
+                # - IndicesT = int64_t (out_cache_loc is int64 in SGLang SetKAndS)
+                # - kPageSize = 64 (CUDA NSA)
+                "FusedStoreCacheIndexerKernel<bf16_t, int64_t, 64>::run",
+            )
+        ],
+    )
+
+
+@cache_once
+def can_use_nsa_fused_store() -> bool:
+    """
+    Similar spirit to can_use_store_cache(): compile once and cache result.
+    """
+    try:
+        _jit_nsa_fused_store_module()
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to load nsa fused store JIT kernel: {e}")
+        return False
+
+
+def fused_store_index_k_cache(
+    key_bf16: torch.Tensor,
+    index_k_with_scale_u8: torch.Tensor,
+    out_cache_loc_i64: torch.Tensor,
+) -> None:
+    """
+    Fused: quantize bf16 key (N,128) -> fp8 + fp32 scale and write into NSATokenToKVPool.index_k_with_scale_buffer.
+
+    key_bf16:            (num_tokens, 128) bf16 (or reshapeable to it)
+    index_k_with_scale:  (num_pages, 64*(128+4)) uint8
+    out_cache_loc:       (num_tokens,) int64 token indices in TokenToKVPool
+    """
+    assert key_bf16.is_cuda
+    assert index_k_with_scale_u8.is_cuda
+    assert out_cache_loc_i64.is_cuda
+
+    # 1) normalize shapes
+    if key_bf16.dim() != 2:
+        key_bf16 = key_bf16.view(-1, key_bf16.shape[-1])
+    assert key_bf16.shape[1] == 128, f"expected key last-dim=128, got {key_bf16.shape}"
+
+    # 2) dtypes
+    assert key_bf16.dtype == torch.bfloat16, f"{key_bf16.dtype=}"
+    assert index_k_with_scale_u8.dtype == torch.uint8, f"{index_k_with_scale_u8.dtype=}"
+    assert out_cache_loc_i64.dtype == torch.int64, f"{out_cache_loc_i64.dtype=}"
+
+    # 3) contiguity
+    if not key_bf16.is_contiguous():
+        key_bf16 = key_bf16.contiguous()
+    if not out_cache_loc_i64.is_contiguous():
+        out_cache_loc_i64 = out_cache_loc_i64.contiguous()
+    if not index_k_with_scale_u8.is_contiguous():
+        index_k_with_scale_u8 = index_k_with_scale_u8.contiguous()
+
+    module = _jit_nsa_fused_store_module()
+    module.fused_store_index_k_cache(key_bf16, index_k_with_scale_u8, out_cache_loc_i64)

--- a/python/sglang/jit_kernel/fused_store_index_cache.py
+++ b/python/sglang/jit_kernel/fused_store_index_cache.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.jit_kernel.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -22,13 +27,17 @@ logger = logging.getLogger(__name__)
 
 
 @cache_once
-def _jit_nsa_fused_store_module() -> Module:
+def _jit_nsa_fused_store_module(
+    key_dtype: torch.dtype, indices_dtype: torch.dtype, page_size: int
+) -> Module:
     """
     Build a JIT module that exposes:
       module.fused_store_index_k_cache(input_bf16, index_k_with_scale_u8, loc_i64)
     """
+    args = make_cpp_args(key_dtype, indices_dtype, page_size, is_arch_support_pdl())
     return load_jit(
         "fused_store_index_k_cache",
+        *args,
         cuda_files=["nsa/fused_store_index_cache.cuh"],
         cuda_wrappers=[
             (
@@ -36,19 +45,19 @@ def _jit_nsa_fused_store_module() -> Module:
                 # - Float  = bf16_t (sgl_kernel/type.cuh)
                 # - IndicesT = int64_t (out_cache_loc is int64 in SGLang SetKAndS)
                 # - kPageSize = 64 (CUDA NSA)
-                "FusedStoreCacheIndexerKernel<bf16_t, int64_t, 64>::run",
+                f"FusedStoreCacheIndexerKernel<{args}>::run",
             )
         ],
     )
 
 
 @cache_once
-def can_use_nsa_fused_store() -> bool:
-    """
-    Similar spirit to can_use_store_cache(): compile once and cache result.
-    """
+def can_use_nsa_fused_store(
+    key_dtype: torch.dtype, indices_dtype: torch.dtype, page_size: int
+) -> bool:
+    logger = logging.getLogger(__name__)
     try:
-        _jit_nsa_fused_store_module()
+        _jit_nsa_fused_store_module(key_dtype, indices_dtype, page_size)
         return True
     except Exception as e:
         logger.warning(f"Failed to load nsa fused store JIT kernel: {e}")
@@ -56,38 +65,39 @@ def can_use_nsa_fused_store() -> bool:
 
 
 def fused_store_index_k_cache(
-    key_bf16: torch.Tensor,
-    index_k_with_scale_u8: torch.Tensor,
-    out_cache_loc_i64: torch.Tensor,
+    key: torch.Tensor,
+    index_k_with_scale: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    page_size: int = 64,
 ) -> None:
     """
     Fused: quantize bf16 key (N,128) -> fp8 + fp32 scale and write into NSATokenToKVPool.index_k_with_scale_buffer.
 
-    key_bf16:            (num_tokens, 128) bf16 (or reshapeable to it)
+    key:            (num_tokens, 128) bf16 (or reshapeable to it)
     index_k_with_scale:  (num_pages, 64*(128+4)) uint8
     out_cache_loc:       (num_tokens,) int64 token indices in TokenToKVPool
     """
-    assert key_bf16.is_cuda
-    assert index_k_with_scale_u8.is_cuda
-    assert out_cache_loc_i64.is_cuda
+    assert key.is_cuda
+    assert index_k_with_scale.is_cuda
+    assert out_cache_loc.is_cuda
 
     # 1) normalize shapes
-    if key_bf16.dim() != 2:
-        key_bf16 = key_bf16.view(-1, key_bf16.shape[-1])
-    assert key_bf16.shape[1] == 128, f"expected key last-dim=128, got {key_bf16.shape}"
+    if key.dim() != 2:
+        key = key.view(-1, key.shape[-1])
+    assert key.shape[1] == 128, f"expected key last-dim=128, got {key.shape}"
 
     # 2) dtypes
-    assert key_bf16.dtype == torch.bfloat16, f"{key_bf16.dtype=}"
-    assert index_k_with_scale_u8.dtype == torch.uint8, f"{index_k_with_scale_u8.dtype=}"
-    assert out_cache_loc_i64.dtype == torch.int64, f"{out_cache_loc_i64.dtype=}"
+    assert key.dtype == torch.bfloat16, f"{key.dtype=}"
+    assert index_k_with_scale.dtype == torch.uint8, f"{index_k_with_scale.dtype=}"
+    assert out_cache_loc.dtype == torch.int64, f"{out_cache_loc.dtype=}"
 
     # 3) contiguity
-    if not key_bf16.is_contiguous():
-        key_bf16 = key_bf16.contiguous()
-    if not out_cache_loc_i64.is_contiguous():
-        out_cache_loc_i64 = out_cache_loc_i64.contiguous()
-    if not index_k_with_scale_u8.is_contiguous():
-        index_k_with_scale_u8 = index_k_with_scale_u8.contiguous()
+    if not key.is_contiguous():
+        key = key.contiguous()
+    if not out_cache_loc.is_contiguous():
+        out_cache_loc = out_cache_loc.contiguous()
+    if not index_k_with_scale.is_contiguous():
+        index_k_with_scale = index_k_with_scale.contiguous()
 
-    module = _jit_nsa_fused_store_module()
-    module.fused_store_index_k_cache(key_bf16, index_k_with_scale_u8, out_cache_loc_i64)
+    module = _jit_nsa_fused_store_module(key.dtype, out_cache_loc.dtype, page_size)
+    module.fused_store_index_k_cache(key, index_k_with_scale, out_cache_loc)

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -78,6 +78,7 @@ CPP_DTYPE_MAP = {
     torch.float8_e4m3fn: "fp8_e4m3_t",
     torch.bfloat16: "bf16_t",
     torch.int8: "int8_t",
+    torch.int64: "int64_t",
 }
 
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -678,20 +678,12 @@ class Indexer(MultiPlatformOp):
         if not forward_batch.out_cache_loc.is_contiguous():
             forward_batch.out_cache_loc = forward_batch.out_cache_loc.contiguous()
 
-        if can_use_nsa_fused_store():
-            buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
-                layer_id=layer_id
-            )
-            fused_store_index_k_cache(key, buf, forward_batch.out_cache_loc)
-        else:
-            # Fallback
-            k_fp8, k_scale = act_quant(key, self.block_size, self.scale_fmt)
-            forward_batch.token_to_kv_pool.set_index_k_scale_buffer(
-                layer_id=layer_id,
-                loc=forward_batch.out_cache_loc,
-                index_k=k_fp8,
-                index_k_scale=k_scale,
-            )
+        self._store_index_k_cache(
+            forward_batch=forward_batch,
+            layer_id=layer_id,
+            key=key,
+            act_quant=act_quant,
+        )
 
         # MHA doesn't need topk_indices
         if not return_indices:
@@ -944,32 +936,42 @@ class Indexer(MultiPlatformOp):
         self,
         forward_batch: ForwardBatch,
         layer_id: int,
-        key_bf16: torch.Tensor,
+        key: torch.Tensor,
         *,
         act_quant=None,  # fallback only
     ) -> None:
         """
         Store NSA indexer K cache for current step.
 
-        Preferred: fused_store_index_k_cache(key_bf16, cache_u8, out_cache_loc_i64)
-        Fallback : act_quant(key_bf16) + token_to_kv_pool.set_index_k_scale_buffer(...)
+        Preferred: fused_store_index_k_cache(key, cache, out_cache_loc, page_size)
+        Fallback : act_quant(key) + token_to_kv_pool.set_index_k_scale_buffer(...)
         """
 
         # Fast path: JIT fused store (CUDA, page_size=64, non-fnuz)
-        if can_use_nsa_fused_store() and _is_cuda and (not _is_fp8_fnuz):
-            if forward_batch.token_to_kv_pool.page_size == 64:
-                # NOTE: wrapper already normalizes shape/contiguity and asserts dtypes.
-                cache_u8 = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
-                    layer_id=layer_id
-                )
-                fused_store_index_k_cache(
-                    key_bf16, cache_u8, forward_batch.out_cache_loc
-                )
-                return
+        if (
+            _is_cuda
+            and (not _is_fp8_fnuz)
+            and can_use_nsa_fused_store(
+                key.dtype,
+                forward_batch.out_cache_loc.dtype,
+                forward_batch.token_to_kv_pool.page_size,
+            )
+        ):
+            # NOTE: wrapper already normalizes shape/contiguity and asserts dtypes.
+            buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
+                layer_id=layer_id
+            )
+            fused_store_index_k_cache(
+                key,
+                buf,
+                forward_batch.out_cache_loc,
+                forward_batch.token_to_kv_pool.page_size,
+            )
+            return
 
         # Fallback: original path
         assert act_quant is not None
-        k_fp8, k_scale = act_quant(key_bf16, self.block_size, self.scale_fmt)
+        k_fp8, k_scale = act_quant(key, self.block_size, self.scale_fmt)
 
         out_loc = forward_batch.out_cache_loc
         if not out_loc.is_contiguous():
@@ -1039,9 +1041,6 @@ class Indexer(MultiPlatformOp):
                 return_indices,
             )
 
-        buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
-            layer_id=layer_id
-        )
         if enable_dual_stream and forward_batch.forward_mode.is_decode_or_idle():
             current_stream = torch.cuda.current_stream()
             self.alt_stream.wait_stream(current_stream)
@@ -1054,7 +1053,7 @@ class Indexer(MultiPlatformOp):
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
                     layer_id=layer_id,
-                    key_bf16=key,
+                    key=key,
                     act_quant=act_quant,
                 )
             current_stream.wait_stream(self.alt_stream)
@@ -1073,7 +1072,7 @@ class Indexer(MultiPlatformOp):
                     self._store_index_k_cache(
                         forward_batch=forward_batch,
                         layer_id=layer_id,
-                        key_bf16=key,
+                        key=key,
                         act_quant=act_quant,
                     )
                 current_stream.wait_stream(self.alt_stream)
@@ -1082,7 +1081,7 @@ class Indexer(MultiPlatformOp):
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
                     layer_id=layer_id,
-                    key_bf16=key,
+                    key=key,
                     act_quant=act_quant,
                 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In DeepSeek v3.2, after the Indexer produces key in bf16 (roughly (N, 128)), it needs to populate NSA’s index_k_with_scale_buffer. The previous implementation used two steps:

1. Quantization: act_quant(key, ...) converts bf16 keys into k_fp8: FP8(E4M3) key bytes (128 dims) and k_scale: per-token FP32 scale (NSA uses one scale for the 128-d block)
2. Store into cache: token_to_kv_pool.set_index_k_scale_buffer(layer_id, loc, k_fp8, k_scale) writes k_fp8 and k_scale into the paged index_k_with_scale_buffer using out_cache_loc.

This path requires at least two kernel launches (quant + store). Under CUDA Graph / multi-stream execution, launch and sync overhead becomes more noticeable.

This PR is to introduce a JIT-compiled CUDA kernel that fuses quantization and store:
Inside the kernel, it will do:
1. per-token absmax reduction
2. compute FP32 scale (max(1e-4, absmax)/FP8_MAX)
3. FP8(E4M3) quantize + pack
4. compute page/offset from loc and write K(128B) + scale(4B) into the same paged buffer in one pass

**Inspired by @DarkSharpness**

Before PR:
<img width="2560" height="1434" alt="image" src="https://github.com/user-attachments/assets/a49d48f6-4a32-4551-a7c1-9e64d16f44cd" />

After PR:
<img width="2944" height="1504" alt="image" src="https://github.com/user-attachments/assets/fe6e7c5a-0c61-4951-a7ff-22b8c8003e16" />


Performance improved slightly. Will do more testing. 

gsm8k no drops.
```
Server:
➜  sglang_dev3 python3 -m sglang.launch_server \
  --model-path deepseek-ai/DeepSeek-V3.2-Exp \
  --trust-remote-code \
  --tp-size 8 --dp-size 8 --enable-dp-attention \
  --tool-call-parser deepseekv31 \
  --reasoning-parser deepseek-v3 \
  --chat-template ./examples/chat_template/tool_chat_template_deepseekv32.jinja

Client:
➜  sglang git:(main) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:19<00:00, 10.46it/s]
Accuracy: 0.975
Invalid: 0.000
Latency: 19.125 s
Output throughput: 1038.949 token/s
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
