### PR TITLE
[NVIDIA] Integrate FlashInfer decode kernel (Blackwell) for Qwen3.5

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -72,7 +72,7 @@ class GDNKernelDispatcher:
             self.decode_kernel = CuteDSLGDNKernel()
         elif decode_backend.is_flashinfer():
             if not is_cuda():
-                raise ValueError("FlashInfer backend requires CUDA")
+                raise ValueError("FlashInfer GDN backend requires CUDA")
             from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
                 FlashInferGDNKernel,
             )
@@ -91,7 +91,7 @@ class GDNKernelDispatcher:
             )
         elif prefill_backend.is_flashinfer():
             if not is_cuda():
-                raise ValueError("FlashInfer backend requires CUDA")
+                raise ValueError("FlashInfer GDN backend requires CUDA")
             # Reuse the FlashInfer kernel if already created for decode
             if decode_backend.is_flashinfer():
                 self.extend_kernel = flashinfer_kernel
@@ -217,6 +217,13 @@ class GDNAttnBackend(MambaAttnBackendBase):
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = GDNKernelDispatcher(decode_backend, prefill_backend)
+        # Pool layout is [pool, HV, V, K] (K-last) for all FlashInfer paths.
+        # SM100+ uses the pool API (initial_state_indices) to avoid gather/scatter;
+        # SM90 still gathers/scatters explicitly in decode.
+        self._use_flashinfer_pool = (
+            decode_backend.is_flashinfer()
+            and self.kernel_dispatcher.decode_kernel.use_state_pool
+        )
 
     def forward_decode(
         self,
@@ -389,17 +396,31 @@ class GDNAttnBackend(MambaAttnBackendBase):
             )
         else:
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
+            if self._use_flashinfer_pool:
+                extend_states = ssm_states[cache_indices].transpose(-1, -2).contiguous()
+                extend_indices = torch.arange(
+                    cache_indices.shape[0],
+                    dtype=torch.int32,
+                    device=cache_indices.device,
+                )
+            else:
+                extend_states = ssm_states
+                extend_indices = cache_indices
+
             core_attn_out, last_recurrent_state, h = self.kernel_dispatcher.extend(
                 q=query,
                 k=key,
                 v=value,
                 g=g,
                 beta=beta,
-                ssm_states=ssm_states,
-                cache_indices=cache_indices,
+                ssm_states=extend_states,
+                cache_indices=extend_indices,
                 query_start_loc=query_start_loc,
             )
-            if (is_npu() or is_cpu()) and last_recurrent_state is not None:
+
+            if self._use_flashinfer_pool:
+                ssm_states[cache_indices] = extend_states.transpose(-1, -2)
+            elif (is_npu() or is_cpu()) and last_recurrent_state is not None:
                 last_recurrent_state = last_recurrent_state.to(
                     ssm_states.dtype, copy=False
                 )

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -217,13 +217,6 @@ class GDNAttnBackend(MambaAttnBackendBase):
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = GDNKernelDispatcher(decode_backend, prefill_backend)
-        # Pool layout is [pool, HV, V, K] (K-last) for all FlashInfer paths.
-        # SM100+ uses the pool API (initial_state_indices) to avoid gather/scatter;
-        # SM90 still gathers/scatters explicitly in decode.
-        self._use_flashinfer_pool = (
-            decode_backend.is_flashinfer()
-            and self.kernel_dispatcher.decode_kernel.use_state_pool
-        )
 
     def forward_decode(
         self,
@@ -396,31 +389,18 @@ class GDNAttnBackend(MambaAttnBackendBase):
             )
         else:
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
-            if self._use_flashinfer_pool:
-                extend_states = ssm_states[cache_indices].transpose(-1, -2).contiguous()
-                extend_indices = torch.arange(
-                    cache_indices.shape[0],
-                    dtype=torch.int32,
-                    device=cache_indices.device,
-                )
-            else:
-                extend_states = ssm_states
-                extend_indices = cache_indices
-
             core_attn_out, last_recurrent_state, h = self.kernel_dispatcher.extend(
                 q=query,
                 k=key,
                 v=value,
                 g=g,
                 beta=beta,
-                ssm_states=extend_states,
-                cache_indices=extend_indices,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
                 query_start_loc=query_start_loc,
             )
 
-            if self._use_flashinfer_pool:
-                ssm_states[cache_indices] = extend_states.transpose(-1, -2)
-            elif (is_npu() or is_cpu()) and last_recurrent_state is not None:
+            if (is_npu() or is_cpu()) and last_recurrent_state is not None:
                 last_recurrent_state = last_recurrent_state.to(
                     ssm_states.dtype, copy=False
                 )

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -1,16 +1,11 @@
 """FlashInfer-based kernels for GDN (Gated Delta Network) linear attention.
 
-Provides K-last SSM layout support using FlashInfer CUTLASS kernels (SM90+).
-The K-last layout stores SSM states as [pool, HV, V, K] instead of V-last
-[pool, HV, K, V], enabling more efficient memory access patterns for decode.
+Both SM90 and SM100+ use the same pool layout: [pool, HV, V, K] (K-last).
 
-Requires ``flashinfer`` with GDN kernel support to be installed, e.g.
-``pip install -e ".[cutlass]"`` from the FlashInfer repo.
+SM90 (Hopper): full support — decode, prefill, MTP.  State dtype: fp32.
+SM100+ (Blackwell+): decode-only with bf16 state.  More support on the way.
 
-NOTE: FlashInfer >= 0.6.4 includes a fix (PR#2509) that caches
-cudaGetDeviceProperties in the GDN prefill JIT launcher, eliminating ~80ms
-of CPU overhead per prefill. Upgrading from 0.6.3 to 0.6.4 recovers ~50%
-prefill throughput regression observed with stock FlashInfer.
+Requires flashinfer >= 0.6.4 (SM90) or >= 0.6.5 (SM100+).
 """
 
 import logging
@@ -52,17 +47,12 @@ def _get_flashinfer_gdn_kernels():
 
             _flashinfer_chunk_gated_delta_rule = chunk_gated_delta_rule
             _flashinfer_gated_delta_rule_mtp = gated_delta_rule_mtp
-            # Use pretranspose (K-last / V-major) decode kernel to match
-            # the K-last pool layout [pool, HV, V, K]
             _flashinfer_gated_delta_rule_decode = gated_delta_rule_decode_pretranspose
-            # SM90+ required for FlashInfer GDN CUTLASS kernels
             _flashinfer_gdn_available = (
                 torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
             )
             if _flashinfer_gdn_available:
-                logger.info(
-                    "FlashInfer GDN kernels (prefill + decode + MTP) loaded successfully"
-                )
+                logger.info("FlashInfer GDN kernels loaded successfully")
         except (ImportError, RuntimeError) as e:
             logger.warning(f"FlashInfer GDN kernels not available: {e}")
             _flashinfer_gdn_available = False
@@ -81,10 +71,13 @@ def _get_flashinfer_gdn_kernels():
 
 
 class FlashInferGDNKernel(LinearAttnKernelBase):
-    """FlashInfer CUTLASS kernel for GDN with K-last SSM state layout.
+    """FlashInfer kernel for GDN with K-last SSM state layout.
 
-    Supports decode (pooled pretranspose), extend (chunked prefill) and
-    target_verify (MTP).  Requires SM90+ and FlashInfer with GDN support.
+    SM90 (Hopper): decode uses gather/scatter; prefill and MTP verify supported.
+    SM100+ (Blackwell+): decode uses pool API (initial_state_indices); prefill
+    and MTP verify are not supported (use Triton backend for those).
+
+    Requires flashinfer >= 0.6.4 (SM90) or >= 0.6.5 (SM100+).
     """
 
     def __init__(self):
@@ -100,16 +93,19 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 "FlashInfer GDN kernels are not available. "
                 "Requires SM90+ and FlashInfer with GDN kernel support."
             )
-        if self._prefill_fn is None:
-            raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
-        if self._mtp_fn is None:
-            raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
         if self._decode_fn is None:
             raise RuntimeError("FlashInfer GDN decode kernel is unavailable.")
 
-        logger.info(
-            "K-last mode: Using FlashInfer GDN prefill, decode and MTP (verify) kernels"
-        )
+        sm_major = torch.cuda.get_device_capability()[0]
+        self.use_state_pool = sm_major != 9
+
+        if sm_major == 9:
+            if self._prefill_fn is None:
+                raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
+            if self._mtp_fn is None:
+                raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
+
+        logger.info("Using FlashInfer GDN kernels")
 
     # ---- decode ----
 
@@ -128,13 +124,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         query_start_loc: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """K-last decode using FlashInfer pretranspose kernel (stock, no pool indexing).
-
-        TODO: Once FlashInfer PR#2521 is merged and released, switch back
-        to pool-indexed decode (passing state_indices directly) to avoid
-        the gather/scatter overhead (~7-9% decode regression).
-        https://github.com/flashinfer-ai/flashinfer/pull/2521
-        """
         batch_size = cache_indices.shape[0]
         num_heads = q.shape[2]
         head_k_dim = q.shape[3]
@@ -147,27 +136,39 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
 
-        # Gather states from pool
-        state_batch = ssm_states[cache_indices]
+        if self.use_state_pool:
+            output_fi, _ = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=None,
+                A_log=A_log.detach().float(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                use_qk_l2norm=True,
+                initial_state=ssm_states,
+                initial_state_indices=cache_indices,
+            )
+        else:
+            # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
+            # will no longer be needed here.
+            state_batch = ssm_states[cache_indices]
+            output_fi, new_state = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=state_batch,
+                A_log=A_log.detach(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                scale=None,
+                output=None,
+                use_qk_l2norm=True,
+            )
+            ssm_states[cache_indices] = new_state
 
-        output_fi, new_state = self._decode_fn(
-            q=query_fi,
-            k=key_fi,
-            v=value_fi,
-            state=state_batch,
-            A_log=A_log.detach(),
-            a=a_fi,
-            dt_bias=dt_bias.detach(),
-            b=b_fi,
-            scale=None,
-            output=None,
-            use_qk_l2norm=True,
-        )
-
-        # Scatter updated states back to pool
-        ssm_states[cache_indices] = new_state
-
-        # [bs, 1, HV, V] -> [1, bs, HV, V]
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 
     # ---- extend (prefill) ----
@@ -185,16 +186,15 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         query_start_loc: torch.Tensor,
         **kwargs,
     ) -> tuple:
-        """K-last chunked prefill using FlashInfer GDN prefill kernel.
+        if self.use_state_pool:
+            raise NotImplementedError(
+                "FlashInfer GDN prefill is not supported on SM100+. "
+                "Use --linear-attn-prefill-backend triton."
+            )
 
-        The FlashInfer kernel natively supports K-last state layout [N, H, V, K].
-        q and k are L2-normalized before calling the kernel (the kernel is called
-        with ``use_qk_l2norm_in_kernel=False``).
-        """
+        # SM90: chunked prefill using FlashInfer GDN prefill kernel.
         from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
 
-        # q, k: [1, seq, H, K] -> [seq, H, K]
-        # v:    [1, seq, HV, V] -> [seq, HV, V]
         total_seq_len = q.shape[1]
         num_v_heads = v.shape[2]
         head_v_dim = v.shape[3]
@@ -243,8 +243,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         core_attn_out = output_fi.view(1, total_seq_len, num_v_heads, head_v_dim)
 
         # Return (output, last_recurrent_state, h) to match Triton kernel interface.
-        # h=None since FlashInfer doesn't provide intermediate states
-        # (prefix caching for K-last prefill is not supported).
+        # h=None since FlashInfer doesn't provide intermediate states.
         return core_attn_out, None, None
 
     # ---- target_verify (MTP) ----
@@ -268,18 +267,18 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         retrieve_parent_token: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """K-last MTP verify using FlashInfer GDN MTP kernel.
+        if self.use_state_pool:
+            raise NotImplementedError(
+                "FlashInfer GDN MTP verify is not yet supported on SM100+."
+            )
 
-        Only supports topk=1 (retrieve_parent_token must be None).
-        """
+        # SM90: MTP verify using FlashInfer gated_delta_rule_mtp kernel.
         if retrieve_parent_token is not None:
             raise RuntimeError(
                 "FlashInfer GDN verify kernel only supports topk=1 "
                 "(retrieve_parent_token must be None)."
             )
 
-        # Recover batch_size and draft_token_num from g shape
-        # g: [1, seq_len, HV] where seq_len = batch_size * draft_token_num
         seq_len = q.shape[1]
         batch_size = query_start_loc.shape[0] - 1
         draft_token_num = seq_len // batch_size
@@ -289,16 +288,13 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         num_v_heads = v.shape[2]
         head_v_dim = v.shape[3]
 
-        # Reshape [1, seq, H, D] -> [B, T, H, D] for FlashInfer MTP
         query_mtp = q.view(batch_size, draft_token_num, num_heads, head_k_dim)
         key_mtp = k.view(batch_size, draft_token_num, num_heads, head_k_dim)
         value_mtp = v.view(batch_size, draft_token_num, num_v_heads, head_v_dim)
 
-        # a, b from g/beta: [1, seq, HV] -> [B, T, HV]
         if a is None or b is None or A_log is None or dt_bias is None:
             raise RuntimeError(
-                "FlashInfer GDN MTP kernel requires a_raw, b_raw, A_log, "
-                "dt_bias to be passed via kwargs."
+                "FlashInfer GDN MTP kernel requires a, b, A_log, dt_bias."
             )
 
         a_mtp = a.view(batch_size, draft_token_num, num_v_heads)
@@ -321,5 +317,4 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             use_qk_l2norm=True,
         )
 
-        # [B, T, HV, V] -> [1, seq_len, HV, V]
         return output_fi.view(1, seq_len, num_v_heads, head_v_dim)

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -137,25 +137,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         b_fi = b.view(batch_size, 1, num_v_heads)
 
         if self.use_state_pool:
-            # # DEBUG: use Triton decode to isolate SM100+ decode accuracy gap
-            # from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
-            #     fused_sigmoid_gating_delta_rule_update,
-            # )
-            # return fused_sigmoid_gating_delta_rule_update(
-            #     A_log=A_log,
-            #     dt_bias=dt_bias,
-            #     q=q,
-            #     k=k,
-            #     v=v,
-            #     a=a,
-            #     b=b,
-            #     initial_state_source=ssm_states,
-            #     initial_state_indices=cache_indices,
-            #     cu_seqlens=query_start_loc,
-            #     use_qk_l2norm_in_kernel=True,
-            #     softplus_beta=1.0,
-            #     softplus_threshold=20.0,
-            # )
             output_fi, _ = self._decode_fn(
                 q=query_fi,
                 k=key_fi,
@@ -163,7 +144,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 state=None,
                 A_log=A_log.detach().float(),
                 a=a_fi,
-                dt_bias=dt_bias.detach().float(),
+                dt_bias=dt_bias.detach(),
                 b=b_fi,
                 use_qk_l2norm=True,
                 initial_state=ssm_states,

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -137,19 +137,38 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         b_fi = b.view(batch_size, 1, num_v_heads)
 
         if self.use_state_pool:
-            output_fi, _ = self._decode_fn(
-                q=query_fi,
-                k=key_fi,
-                v=value_fi,
-                state=None,
-                A_log=A_log.detach().float(),
-                a=a_fi,
-                dt_bias=dt_bias.detach(),
-                b=b_fi,
-                use_qk_l2norm=True,
-                initial_state=ssm_states,
-                initial_state_indices=cache_indices,
+            # DEBUG: use Triton decode to isolate SM100+ decode accuracy gap
+            from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+                fused_sigmoid_gating_delta_rule_update,
             )
+            return fused_sigmoid_gating_delta_rule_update(
+                A_log=A_log,
+                dt_bias=dt_bias,
+                q=q,
+                k=k,
+                v=v,
+                a=a,
+                b=b,
+                initial_state_source=ssm_states,
+                initial_state_indices=cache_indices,
+                cu_seqlens=query_start_loc,
+                use_qk_l2norm_in_kernel=True,
+                softplus_beta=1.0,
+                softplus_threshold=20.0,
+            )
+            # output_fi, _ = self._decode_fn(
+            #     q=query_fi,
+            #     k=key_fi,
+            #     v=value_fi,
+            #     state=None,
+            #     A_log=A_log.detach().float(),
+            #     a=a_fi,
+            #     dt_bias=dt_bias.detach(),
+            #     b=b_fi,
+            #     use_qk_l2norm=True,
+            #     initial_state=ssm_states,
+            #     initial_state_indices=cache_indices,
+            # )
         else:
             # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
             # will no longer be needed here.

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -137,38 +137,38 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         b_fi = b.view(batch_size, 1, num_v_heads)
 
         if self.use_state_pool:
-            # DEBUG: use Triton decode to isolate SM100+ decode accuracy gap
-            from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
-                fused_sigmoid_gating_delta_rule_update,
-            )
-            return fused_sigmoid_gating_delta_rule_update(
-                A_log=A_log,
-                dt_bias=dt_bias,
-                q=q,
-                k=k,
-                v=v,
-                a=a,
-                b=b,
-                initial_state_source=ssm_states,
-                initial_state_indices=cache_indices,
-                cu_seqlens=query_start_loc,
-                use_qk_l2norm_in_kernel=True,
-                softplus_beta=1.0,
-                softplus_threshold=20.0,
-            )
-            # output_fi, _ = self._decode_fn(
-            #     q=query_fi,
-            #     k=key_fi,
-            #     v=value_fi,
-            #     state=None,
-            #     A_log=A_log.detach().float(),
-            #     a=a_fi,
-            #     dt_bias=dt_bias.detach(),
-            #     b=b_fi,
-            #     use_qk_l2norm=True,
-            #     initial_state=ssm_states,
-            #     initial_state_indices=cache_indices,
+            # # DEBUG: use Triton decode to isolate SM100+ decode accuracy gap
+            # from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+            #     fused_sigmoid_gating_delta_rule_update,
             # )
+            # return fused_sigmoid_gating_delta_rule_update(
+            #     A_log=A_log,
+            #     dt_bias=dt_bias,
+            #     q=q,
+            #     k=k,
+            #     v=v,
+            #     a=a,
+            #     b=b,
+            #     initial_state_source=ssm_states,
+            #     initial_state_indices=cache_indices,
+            #     cu_seqlens=query_start_loc,
+            #     use_qk_l2norm_in_kernel=True,
+            #     softplus_beta=1.0,
+            #     softplus_threshold=20.0,
+            # )
+            output_fi, _ = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=None,
+                A_log=A_log.detach().float(),
+                a=a_fi,
+                dt_bias=dt_bias.detach().float(),
+                b=b_fi,
+                use_qk_l2norm=True,
+                initial_state=ssm_states,
+                initial_state_indices=cache_indices,
+            )
         else:
             # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
             # will no longer be needed here.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2057,6 +2057,19 @@ class ServerArgs:
                     % min(FLA_CHUNK_SIZE, self.page_size)
                     == 0
                 ), f"For SSM models with extra buffer, either FLA_CHUNK_SIZE or page_size must be divisible by the other, got {FLA_CHUNK_SIZE=}, {self.page_size=}"
+        # FlashInfer GDN decode is incompatible with no_buffer scheduling.
+        # See https://github.com/sgl-project/sglang/issues/20791
+        if (
+            self.linear_attn_decode_backend == "flashinfer"
+            and self.mamba_scheduler_strategy == "no_buffer"
+        ):
+            raise ValueError(
+                "FlashInfer GDN decode (--linear-attn-decode-backend flashinfer) is not "
+                "compatible with --mamba-scheduler-strategy no_buffer. "
+                "Please use --mamba-scheduler-strategy extra_buffer instead. "
+                "See https://github.com/sgl-project/sglang/issues/20791"
+            )
+
         elif not self.disable_radix_cache:  # no_buffer
             if self.speculative_algorithm is None:
                 logger.warning(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2032,6 +2032,19 @@ class ServerArgs:
                 not self.enable_mamba_extra_buffer()
             ), f"mamba extra_buffer is not supported for {model_arch} model"
 
+        # FlashInfer GDN decode is incompatible with no_buffer scheduling.
+        # See https://github.com/sgl-project/sglang/issues/20791
+        if (
+            self.linear_attn_decode_backend == "flashinfer"
+            and self.mamba_scheduler_strategy == "no_buffer"
+        ):
+            raise ValueError(
+                "FlashInfer GDN decode (--linear-attn-decode-backend flashinfer) is not "
+                "compatible with --mamba-scheduler-strategy no_buffer. "
+                "Please use --mamba-scheduler-strategy extra_buffer instead. "
+                "See https://github.com/sgl-project/sglang/issues/20791"
+            )
+
         if self.enable_mamba_extra_buffer():  # extra_buffer
             if self.disable_radix_cache:
                 raise ValueError(
@@ -2057,19 +2070,6 @@ class ServerArgs:
                     % min(FLA_CHUNK_SIZE, self.page_size)
                     == 0
                 ), f"For SSM models with extra buffer, either FLA_CHUNK_SIZE or page_size must be divisible by the other, got {FLA_CHUNK_SIZE=}, {self.page_size=}"
-        # FlashInfer GDN decode is incompatible with no_buffer scheduling.
-        # See https://github.com/sgl-project/sglang/issues/20791
-        if (
-            self.linear_attn_decode_backend == "flashinfer"
-            and self.mamba_scheduler_strategy == "no_buffer"
-        ):
-            raise ValueError(
-                "FlashInfer GDN decode (--linear-attn-decode-backend flashinfer) is not "
-                "compatible with --mamba-scheduler-strategy no_buffer. "
-                "Please use --mamba-scheduler-strategy extra_buffer instead. "
-                "See https://github.com/sgl-project/sglang/issues/20791"
-            )
-
         elif not self.disable_radix_cache:  # no_buffer
             if self.speculative_algorithm is None:
                 logger.warning(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -767,6 +767,7 @@ class ServerArgs:
         self._handle_sampling_backend()
         self._handle_attention_backend_compatibility()
         self._handle_mamba_backend()
+        self._handle_linear_attn_backend()
         self._handle_kv4_compatibility()
         self._handle_page_size()
         self._handle_amd_specifics()
@@ -2429,6 +2430,23 @@ class ServerArgs:
                 raise ValueError(
                     "FlashInfer mamba module not available, please check flashinfer installation."
                 )
+
+    def _handle_linear_attn_backend(self):
+        # SM100+ FlashInfer GDN decode requires bf16 state; SM90 uses float32.
+        import torch
+
+        decode = self.linear_attn_decode_backend or self.linear_attn_backend
+        if (
+            decode == "flashinfer"
+            and self.mamba_ssm_dtype != "bfloat16"
+            and torch.cuda.is_available()
+            and torch.cuda.get_device_capability()[0] >= 10
+        ):
+            raise ValueError(
+                "--linear-attn-decode-backend flashinfer on SM100+ requires "
+                "--mamba-ssm-dtype bfloat16, "
+                f"got {self.mamba_ssm_dtype!r}"
+            )
 
     def _handle_context_parallelism(self):
         if self.attn_cp_size > 1:

--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -27,6 +27,7 @@ class AccuracyTestParams:
     thinking_mode: Optional[str] = None  # e.g., "deepseek-v3"
     temperature: Optional[float] = None
     top_p: Optional[float] = None
+    top_k: Optional[int] = None
     repeat: Optional[int] = None
 
 
@@ -83,6 +84,7 @@ def _run_simple_eval(
     thinking_mode: Optional[str] = None,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
+    top_k: Optional[int] = None,
     repeat: Optional[int] = None,
 ) -> Tuple[bool, Optional[str], Optional[dict]]:
     """Run evaluation using simple_eval backend (run_eval.py).
@@ -122,6 +124,9 @@ def _run_simple_eval(
 
         if top_p is not None:
             args.top_p = top_p
+
+        if top_k is not None:
+            args.top_k = top_k
 
         if repeat is not None:
             args.repeat = repeat
@@ -223,7 +228,7 @@ def run_accuracy_test(
     # Use simple_eval when any extended params are set that few_shot_eval doesn't support.
     has_extended_params = any(
         getattr(params, field) is not None
-        for field in ("thinking_mode", "temperature", "top_p", "repeat")
+        for field in ("thinking_mode", "temperature", "top_p", "top_k", "repeat")
     )
     if params.dataset == "gsm8k" and not has_extended_params:
         success, error, metrics = _run_few_shot_eval(
@@ -244,6 +249,7 @@ def run_accuracy_test(
             thinking_mode=params.thinking_mode,
             temperature=params.temperature,
             top_p=params.top_p,
+            top_k=params.top_k,
             repeat=params.repeat,
         )
 

--- a/test/registered/4-gpu-models/test_qwen35_models.py
+++ b/test/registered/4-gpu-models/test_qwen35_models.py
@@ -309,5 +309,65 @@ class TestQwen35WithHiCache(CustomTestCase):
         self.assertGreaterEqual(metrics["score"], ACC_THRESHOLDS[self.model]["gsm8k"])
 
 
+class TestQwen35FP4Flashinfer(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN35_FP4_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--chunked-prefill-size",
+                "2048",
+                "--mamba-scheduler-strategy",
+                "extra_buffer",
+                "--mamba-track-interval",
+                "128",
+                "--mamba-ssm-dtype",
+                "bfloat16",
+                "--max-running-requests",
+                "128",
+                "--reasoning-parser",
+                "qwen3",
+                "--attention-backend",
+                "trtllm_mha",
+                "--quantization",
+                "modelopt_fp4",
+                "--linear-attn-decode-backend",
+                "flashinfer",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true,"num_threads": 64}',
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            model=self.model,
+            eval_name="gsm8k",
+            num_shots=5,
+            num_examples=200,
+            max_tokens=16000,
+            num_threads=128,
+            repeat=1,
+            temperature=0.6,
+            top_p=0.95,
+            top_k=20,
+            base_url=self.base_url,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreaterEqual(metrics["score"], 0.95)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/4-gpu-models/test_qwen35_models.py
+++ b/test/registered/4-gpu-models/test_qwen35_models.py
@@ -7,15 +7,18 @@ import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
+from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_cuda_ci
 
 # This eval harness applies the chat_template, which is critical for qwen3.5
 # to get good accuracy on gsm8k
+from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    ModelLaunchSettings,
     popen_launch_server,
 )
 
@@ -26,62 +29,59 @@ QWEN35_27B_MODEL = "Qwen/Qwen3.5-27B"
 ACC_THRESHOLDS = {QWEN35_FP4_MODEL: {"gsm8k": 0.95}, QWEN35_27B_MODEL: {"gsm8k": 0.8}}
 
 
-class TestQwen35FP4(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = QWEN35_FP4_MODEL
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--tp-size",
-                "4",
-                "--chunked-prefill-size",
-                "2048",
-                "--mamba-scheduler-strategy",
-                "extra_buffer",
-                "--mamba-track-interval",
-                "128",
-                "--mamba-ssm-dtype",
-                "bfloat16",
-                "--max-running-requests",
-                "128",
-                "--reasoning-parser",
-                "qwen3",
-                "--attention-backend",
-                "trtllm_mha",
-                "--quantization",
-                "modelopt_fp4",
-                "--model-loader-extra-config",
-                '{"enable_multithread_load": true,"num_threads": 64}',
-            ],
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
+class TestQwen35FP4(unittest.TestCase):
     def test_gsm8k(self):
-        args = SimpleNamespace(
-            model=self.model,
-            eval_name="gsm8k",
-            num_shots=5,
-            num_examples=200,
-            max_tokens=16000,
-            num_threads=128,
-            repeat=1,
-            temperature=0.6,
-            top_p=0.95,
-            top_k=20,
-            base_url=self.base_url,
-            host="http://127.0.0.1",
-            port=int(self.base_url.split(":")[-1]),
+        base_args = [
+            "--tp-size",
+            "4",
+            "--chunked-prefill-size",
+            "2048",
+            "--mamba-scheduler-strategy",
+            "extra_buffer",
+            "--mamba-track-interval",
+            "128",
+            "--mamba-ssm-dtype",
+            "bfloat16",
+            "--max-running-requests",
+            "128",
+            "--reasoning-parser",
+            "qwen3",
+            "--attention-backend",
+            "trtllm_mha",
+            "--quantization",
+            "modelopt_fp4",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true,"num_threads": 64}',
+        ]
+
+        variants = [
+            ModelLaunchSettings(
+                QWEN35_FP4_MODEL,
+                extra_args=base_args,
+                variant="Triton",
+            ),
+            ModelLaunchSettings(
+                QWEN35_FP4_MODEL,
+                extra_args=base_args + ["--linear-attn-decode-backend", "flashinfer"],
+                variant="FlashInfer",
+            ),
+        ]
+
+        run_combined_tests(
+            models=variants,
+            test_name="Qwen3.5-397B-A17B-NVFP4",
+            accuracy_params=AccuracyTestParams(
+                dataset="gsm8k",
+                baseline_accuracy=ACC_THRESHOLDS[QWEN35_FP4_MODEL]["gsm8k"],
+                num_examples=200,
+                num_threads=128,
+                max_tokens=16000,
+                thinking_mode="qwen3",
+                temperature=0.6,
+                top_p=0.95,
+                top_k=20,
+            ),
         )
-        metrics = run_eval(args)
-        print(f"{metrics=}")
-        self.assertGreaterEqual(metrics["score"], ACC_THRESHOLDS[self.model]["gsm8k"])
 
 
 class TestQwen35FP4MTP(CustomTestCase):
@@ -307,66 +307,6 @@ class TestQwen35WithHiCache(CustomTestCase):
         metrics = run_eval(args)
         print(f"{metrics=}")
         self.assertGreaterEqual(metrics["score"], ACC_THRESHOLDS[self.model]["gsm8k"])
-
-
-class TestQwen35FP4Flashinfer(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = QWEN35_FP4_MODEL
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--tp-size",
-                "4",
-                "--chunked-prefill-size",
-                "2048",
-                "--mamba-scheduler-strategy",
-                "extra_buffer",
-                "--mamba-track-interval",
-                "128",
-                "--mamba-ssm-dtype",
-                "bfloat16",
-                "--max-running-requests",
-                "128",
-                "--reasoning-parser",
-                "qwen3",
-                "--attention-backend",
-                "trtllm_mha",
-                "--quantization",
-                "modelopt_fp4",
-                "--linear-attn-decode-backend",
-                "flashinfer",
-                "--model-loader-extra-config",
-                '{"enable_multithread_load": true,"num_threads": 64}',
-            ],
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def test_gsm8k(self):
-        args = SimpleNamespace(
-            model=self.model,
-            eval_name="gsm8k",
-            num_shots=5,
-            num_examples=200,
-            max_tokens=16000,
-            num_threads=128,
-            repeat=1,
-            temperature=0.6,
-            top_p=0.95,
-            top_k=20,
-            base_url=self.base_url,
-            host="http://127.0.0.1",
-            port=int(self.base_url.split(":")[-1]),
-        )
-        metrics = run_eval(args)
-        print(f"{metrics=}")
-        self.assertGreaterEqual(metrics["score"], 0.95)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Integrate [FlashInfer](https://github.com/flashinfer-ai/flashinfer)'s `gated_delta_rule_decode_pretranspose` kernel as an optional backend (`--gdn-backend flashinfer`) for GDN (Gated Delta Network) layers in Qwen3.5 hybrid linear attention models.

### What changed

- Added `--gdn-backend {triton,cutedsl,flashinfer}` server argument (default: `triton`)
- **FlashInfer decode path**: uses the bf16 pretranspose kernel (`gated_delta_rule_decode_pretranspose`) which operates directly on the K-last state pool via `initial_state`/`initial_state_indices`, eliminating explicit gather/scatter calls on every decode step (https://github.com/flashinfer-ai/flashinfer/pull/2619)
- **FlashInfer prefill path**: uses `chunk_kda` with `initial_state_indices` for gather/scatter into the pool
- Requires FlashInfer ≥ 0.6.4 (Need update!)

### Performance (Qwen3.5-FP8, decode-focused, 256 concurrency, 8xB200)

| Metric | Before | After | Δ |
|---|---|---|---|
| Output throughput (tok/s) | 5638 | 5741 | **+1.8%** |
| TPOT (ms) | 21.51 | 20.96 | **-2.6%** |
| Mean ITL (ms) | 21.58 | 21.04 | **-2.5%** |
| Total throughput (tok/s) | 7047 | 7176 | **+1.8%** |

Per-step profiling: overall decode step 353 µs → 316 µs (−10%), GDN kernel 30 µs → 16 µs (−47%).

The end-to-end gains are modest (~2%) because GDN accounts for a relatively small fraction of the total decode step. The kernel-level improvement is more significant: GDN alone drops by ~47%, contributing ~38% of the overall per-step savings. The remaining improvement comes from other FlashInfer kernel optimizations.

Note: the prefill path still uses KV layout with explicit gather/scatter (the pool->batch trick), which limits the overall e2e gains. A dedicated prefill kernel with native pool support is left for a follow-up PR.

### Kernel microbenchmark — T=1 decode latency (µs)

At batch sizes ≥ 32, the FlashInfer bf16 kernel (this PR) achieves **~2.4–2.8x** speedup over the triton KV reference and **~1.4–1.6x** over the CuteDSL VK kernel from [#17981](https://github.com/sgl-project/sglang/pull/17981). Note, both #17981 and this PR use VK layout.

| B | TRI-KV-BF16 (triton, ref) | SG-VK-BF16 ([#17981](https://github.com/sgl-project/sglang/pull/17981)) | FI-VK-BF16 (this PR) |
|--:|--:|--:|--:|
| 1 | 4.3 | 3.0 | **2.8** |
| 32 | 59.1 | 34.4 | **20.9** |
| 64 | 118.4 | 69.5 | **49.0** |
| 128 | 235.7 | 139.0 | **95.8** |
| 256 | 466.1 | 283.7 | **187.8** |
| 512 | 931.4 | 565.9 | **365.6** |

### Accuracy

| Benchmark | Backend | Accuracy |
|---|---|---|
| GSM8K | flashinfer (this PR) | 0.945 |
| GPQA | flashinfer (this PR) | 0.848, 0.874, 0.884, 0.879, 0.889, 0.838, 0.889, 0.869 (mean: **0.871**) |