### PR TITLE
[diffusion] model: usp all_to_all optimize

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -141,7 +141,6 @@ def _usp_output_all_to_all(x: torch.Tensor, head_dim: int = 1) -> torch.Tensor:
     if head_dim == 1:
         x = x.permute(2, 0, 3, 1, 4).contiguous().reshape(b, h_global, s_local, d)
     else:  # head_dim == 2
-        # [p, s_local, b, h_local, d] -> [b, s_local, p, h_local, d]
         x = x.permute(2, 1, 0, 3, 4).contiguous().reshape(b, s_local, h_global, d)
 
     return x

--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -71,11 +71,14 @@ def _usp_input_all_to_all(x: torch.Tensor, head_dim: int = 1) -> torch.Tensor:
     assert x.ndim == 4, f"x must have 4 dimensions, got {x.ndim}"
     assert head_dim in (1, 2), f"head_dim must be 1 or 2, got {head_dim}"
 
+    # Move the dimension to be split (h_global) to dim 0 for all_to_all_single
     if head_dim == 1:
         b, h_global, s_local, d = x.shape
+        # Shape transition: [b, h_global, s_local, d] -> [h_global, b, s_local, d]
         permute_order = (1, 0, 2, 3)
     else:  # head_dim == 2
         b, s_local, h_global, d = x.shape
+        # Shape transition: [b, s_local, h_global, d] -> [h_global, b, s_local, d]
         permute_order = (2, 0, 1, 3)
 
     assert (
@@ -88,9 +91,12 @@ def _usp_input_all_to_all(x: torch.Tensor, head_dim: int = 1) -> torch.Tensor:
     x = _usp_all_to_all_single(x)
     x = x.reshape(world_size, h_local, b, s_local, d)
 
+    # Reorder dims to place 'world_size' adjacent to 's_local' to merge them into 's_global'
     if head_dim == 1:
+        # Shape transition: [world_size, h_local, b, s_local, d] -> [b, h_local, world_size, s_local, d]
         x = x.permute(2, 1, 0, 3, 4).contiguous().reshape(b, h_local, s_global, d)
     else:  # head_dim == 2
+        # Shape transition: [world_size, h_local, b, s_local, d] -> [b, world_size, s_local, h_local, d]
         x = x.permute(2, 0, 3, 1, 4).contiguous().reshape(b, s_global, h_local, d)
 
     return x
@@ -121,11 +127,14 @@ def _usp_output_all_to_all(x: torch.Tensor, head_dim: int = 1) -> torch.Tensor:
     assert x.ndim == 4, f"x must have 4 dimensions, got {x.ndim}"
     assert head_dim in (1, 2), f"head_dim must be 1 or 2, got {head_dim}"
 
+    # Move the dimension to be split (s_global) to dim 0 for all_to_all_single
     if head_dim == 1:
         b, h_local, s_global, d = x.shape
+        # Shape transition: [b, h_local, s_global, d] -> [s_global, b, h_local, d]
         permute_order = (2, 0, 1, 3)
     else:  # head_dim == 2
         b, s_global, h_local, d = x.shape
+        # Shape transition: [b, s_global, h_local, d] -> [s_global, b, h_local, d]
         permute_order = (1, 0, 2, 3)
 
     assert (
@@ -138,9 +147,12 @@ def _usp_output_all_to_all(x: torch.Tensor, head_dim: int = 1) -> torch.Tensor:
     x = _usp_all_to_all_single(x)
     x = x.reshape(world_size, s_local, b, h_local, d)
 
+    # Reorder dims to place 'world_size' adjacent to 'h_local' to merge them into 'h_global'
     if head_dim == 1:
+        # Shape transition: [world_size, s_local, b, h_local, d] -> [b, world_size, h_local, s_local, d]
         x = x.permute(2, 0, 3, 1, 4).contiguous().reshape(b, h_global, s_local, d)
     else:  # head_dim == 2
+        # Shape transition: [world_size, s_local, b, h_local, d] -> [b, s_local, world_size, h_local, d]
         x = x.permute(2, 1, 0, 3, 4).contiguous().reshape(b, s_local, h_global, d)
 
     return x


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The previous implementation of `_usp_input_all_to_all` and `_usp_output_all_to_all`
relied on implicit `seq_dim` inference and multiple permutation branches,
which made the tensor layout transformations difficult to follow.

## Modifications

<!-- Detail the changes made in this pull request. -->

This PR refactors the USP all-to-all tensor transform logic:

- Remove implicit `seq_dim` derivation
- Introduce explicit `h_global`, `h_local`, `s_global`, and `s_local` naming
- Simplify permutation and reshape pipeline
- Unify tensor layout handling for both `head_dim=1` and `head_dim=2`
- Remove special-case early returns
- Improve readability and symmetry between input and output transforms


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

command:

```bash
CUDA_VISIBLE_DEVICES="2,3,6,7" sglang generate \
    --model-path "Wan-AI/Wan2.1-T2V-14B-Diffusers" \
    --attention-backend fa \
    --trust-remote-code \
    --num-gpus 4 \
    --ulysses-degree 4 \
    --use-fsdp-inference false \
    --dit-cpu-offload false \
    --dit-layerwise-offload false \
    --text-encoder-cpu-offload false \
    --image-encoder-cpu-offload false \
    --vae-cpu-offload false \
    --pin-cpu-memory false \
    --backend sglang \
    --num-frames 81 \
    --fps 16 \
    --height 720 \
    --width 1280 \
    --num-inference-steps 40 \
    --prompt "A cinematic video of an adult woman (age 25+) dancing confidently on a tropical beach at golden hour. She wears a stylish, elegant bikini designed for a fashion photoshoot, paired with a sheer flowing cover-up that moves naturally in the sea breeze." \
    --warmup \
    --save-output
```

before pr:

https://github.com/user-attachments/assets/e12ede4a-01d5-4141-8a48-32072d9023ea

after pr:

https://github.com/user-attachments/assets/70277b4f-91b4-4492-9d2d-e8724b861ff5



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

before pr:
```text
  0%|          | 0/40 [00:00<?, ?it/s]
  2%|▎         | 1/40 [00:05<03:51,  5.92s/it]
  5%|▌         | 2/40 [00:13<04:20,  6.86s/it]
  8%|▊         | 3/40 [00:20<04:23,  7.11s/it]
 10%|█         | 4/40 [00:28<04:20,  7.23s/it]
 12%|█▎        | 5/40 [00:35<04:15,  7.29s/it]
 15%|█▌        | 6/40 [00:43<04:08,  7.32s/it]
 18%|█▊        | 7/40 [00:50<04:02,  7.34s/it]
 20%|██        | 8/40 [00:57<03:55,  7.35s/it]
 22%|██▎       | 9/40 [01:05<03:48,  7.36s/it]
 25%|██▌       | 10/40 [01:12<03:40,  7.36s/it]
 28%|██▊       | 11/40 [01:19<03:33,  7.37s/it]
 30%|███       | 12/40 [01:27<03:26,  7.37s/it]
 32%|███▎      | 13/40 [01:34<03:19,  7.37s/it]
 35%|███▌      | 14/40 [01:42<03:11,  7.37s/it]
 38%|███▊      | 15/40 [01:49<03:04,  7.38s/it]
 40%|████      | 16/40 [01:56<02:57,  7.38s/it]
 42%|████▎     | 17/40 [02:04<02:49,  7.38s/it]
 45%|████▌     | 18/40 [02:11<02:42,  7.38s/it]
 48%|████▊     | 19/40 [02:18<02:34,  7.38s/it]
 50%|█████     | 20/40 [02:26<02:27,  7.38s/it]
 52%|█████▎    | 21/40 [02:33<02:20,  7.38s/it]
 55%|█████▌    | 22/40 [02:41<02:12,  7.38s/it]
 57%|█████▊    | 23/40 [02:48<02:05,  7.38s/it]
 60%|██████    | 24/40 [02:55<01:58,  7.38s/it]
 62%|██████▎   | 25/40 [03:03<01:50,  7.38s/it]
 65%|██████▌   | 26/40 [03:10<01:43,  7.38s/it]
 68%|██████▊   | 27/40 [03:17<01:35,  7.38s/it]
 70%|███████   | 28/40 [03:25<01:28,  7.38s/it]
 72%|███████▎  | 29/40 [03:32<01:21,  7.38s/it]
 75%|███████▌  | 30/40 [03:40<01:13,  7.38s/it]
 78%|███████▊  | 31/40 [03:47<01:06,  7.38s/it]
 80%|████████  | 32/40 [03:54<00:59,  7.38s/it]
 82%|████████▎ | 33/40 [04:02<00:51,  7.38s/it]
 85%|████████▌ | 34/40 [04:09<00:44,  7.38s/it]
 88%|████████▊ | 35/40 [04:16<00:36,  7.38s/it]
 90%|█████████ | 36/40 [04:24<00:29,  7.38s/it]
 92%|█████████▎| 37/40 [04:31<00:22,  7.38s/it]
 95%|█████████▌| 38/40 [04:39<00:14,  7.38s/it]
 98%|█████████▊| 39/40 [04:46<00:07,  7.38s/it]
100%|██████████| 40/40 [04:53<00:00,  7.37s/it]
100%|██████████| 40/40 [04:53<00:00,  7.35s/it]
[02-22 12:58:31] [DenoisingStage] average time per step: 7.3457 seconds
[02-22 12:58:31] [DenoisingStage] finished in 293.8296 seconds
[02-22 12:58:31] [DecodingStage] started...
[02-22 12:58:35] [DecodingStage] finished in 3.7481 seconds
```

after pr:

```text
  0%|          | 0/40 [00:00<?, ?it/s]
  2%|▎         | 1/40 [00:05<03:29,  5.38s/it]
  5%|▌         | 2/40 [00:12<04:06,  6.49s/it]
  8%|▊         | 3/40 [00:19<04:12,  6.83s/it]
 10%|█         | 4/40 [00:27<04:10,  6.96s/it]
 12%|█▎        | 5/40 [00:34<04:05,  7.03s/it]
 15%|█▌        | 6/40 [00:41<04:00,  7.06s/it]
 18%|█▊        | 7/40 [00:48<03:53,  7.08s/it]
 20%|██        | 8/40 [00:55<03:47,  7.10s/it]
 22%|██▎       | 9/40 [01:02<03:40,  7.11s/it]
 25%|██▌       | 10/40 [01:09<03:33,  7.12s/it]
 28%|██▊       | 11/40 [01:16<03:26,  7.12s/it]
 30%|███       | 12/40 [01:24<03:19,  7.12s/it]
 32%|███▎      | 13/40 [01:31<03:12,  7.13s/it]
 35%|███▌      | 14/40 [01:38<03:05,  7.13s/it]
 38%|███▊      | 15/40 [01:45<02:58,  7.13s/it]
 40%|████      | 16/40 [01:52<02:51,  7.13s/it]
 42%|████▎     | 17/40 [01:59<02:43,  7.13s/it]
 45%|████▌     | 18/40 [02:06<02:36,  7.13s/it]
 48%|████▊     | 19/40 [02:14<02:29,  7.13s/it]
 50%|█████     | 20/40 [02:21<02:22,  7.13s/it]
 52%|█████▎    | 21/40 [02:28<02:15,  7.13s/it]
 55%|█████▌    | 22/40 [02:35<02:08,  7.13s/it]
 57%|█████▊    | 23/40 [02:42<02:01,  7.13s/it]
 60%|██████    | 24/40 [02:49<01:54,  7.13s/it]
 62%|██████▎   | 25/40 [02:56<01:46,  7.13s/it]
 65%|██████▌   | 26/40 [03:03<01:39,  7.13s/it]
 68%|██████▊   | 27/40 [03:11<01:32,  7.13s/it]
 70%|███████   | 28/40 [03:18<01:25,  7.13s/it]
 72%|███████▎  | 29/40 [03:25<01:18,  7.13s/it]
 75%|███████▌  | 30/40 [03:32<01:11,  7.13s/it]
 78%|███████▊  | 31/40 [03:39<01:04,  7.13s/it]
 80%|████████  | 32/40 [03:46<00:57,  7.13s/it]
 82%|████████▎ | 33/40 [03:53<00:49,  7.13s/it]
 85%|████████▌ | 34/40 [04:00<00:42,  7.13s/it]
 88%|████████▊ | 35/40 [04:08<00:35,  7.13s/it]
 90%|█████████ | 36/40 [04:15<00:28,  7.13s/it]
 92%|█████████▎| 37/40 [04:22<00:21,  7.13s/it]
 95%|█████████▌| 38/40 [04:29<00:14,  7.13s/it]
 98%|█████████▊| 39/40 [04:36<00:07,  7.13s/it]
100%|██████████| 40/40 [04:43<00:00,  7.11s/it]
100%|██████████| 40/40 [04:43<00:00,  7.09s/it]
[02-22 13:07:05] [DenoisingStage] average time per step: 7.0928 seconds
[02-22 13:07:05] [DenoisingStage] finished in 283.7157 seconds
[02-22 13:07:05] [DecodingStage] started...
[02-22 13:07:09] [DecodingStage] finished in 4.0423 seconds
```

7.3457s/step -> 7.0928s/step


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
