### PR TITLE
Enable Building on gfx1100

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -19,6 +19,7 @@ ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+ARG BASE_IMAGE_1100="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950
@@ -31,6 +32,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
+ENV AITER_PREBUILD_KERNELS="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
 # ===============================
@@ -51,6 +53,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
+ENV AITER_PREBUILD_KERNELS="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
 # ===============================
@@ -60,9 +63,19 @@ ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
+ENV AITER_PREBUILD_KERNELS="0"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
+# Base image 1100 and args
+FROM $BASE_IMAGE_1100 AS gfx1100
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="0"
+ENV BUILD_LLVM="0"
+ENV BUILD_MOONCAKE="1"
+ENV BUILD_AITER_ALL="1"
+ENV AITER_PREBUILD_KERNELS="0"
+ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 # ===============================
 # Chosen arch and args
 FROM ${GPU_ARCH}
@@ -70,7 +83,7 @@ FROM ${GPU_ARCH}
 # This is necessary for scope purpose, again
 ARG GPU_ARCH=gfx950
 ENV GPU_ARCH_LIST=${GPU_ARCH%-*}
-ENV PYTORCH_ROCM_ARCH=gfx942;gfx950
+ENV PYTORCH_ROCM_ARCH=gfx942;gfx950;gfx1100
 
 ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
 ARG SGL_DEFAULT="main"
@@ -217,10 +230,10 @@ RUN cd aiter \
      && echo "[AITER] GPU_ARCH=${GPU_ARCH}" \
      && echo "[AITER] AITER_USE_SYSTEM_TRITON=${AITER_USE_SYSTEM_TRITON}" \
      && if [ "$BUILD_AITER_ALL" = "1" ] && [ "$BUILD_LLVM" = "1" ]; then \
-          sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
+          sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ PREBUILD_KERNELS=$AITER_PREBUILD_KERNELS GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
           && sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
         elif [ "$BUILD_AITER_ALL" = "1" ]; then \
-          sh -c "PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
+          sh -c "PREBUILD_KERNELS=$AITER_PREBUILD_KERNELS GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
           && sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
         else \
           sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -351,14 +351,10 @@ class RMSNorm(MultiPlatformOp):
             # NOTE: Remove this if aiter kernel supports discontinuous input
             x = x.contiguous()
         if residual is not None:
-            out = torch.empty_like(x)
-            residual_out = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            fused_add_rms_norm(
-                out, x, residual_out, residual, self.weight.data, self.variance_epsilon
-            )
-            return out, residual_out
+            fused_add_rms_norm(x, residual, self.weight.data, self.variance_epsilon)
+            return x, residual
         out = torch.empty_like(x)
         rms_norm(out, x, self.weight.data, self.variance_epsilon)
         return out

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -74,12 +74,14 @@ if torch.cuda.is_available():
 else:
     print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
+supported_targets = ["gfx942", "gfx950", "gfx1100"]
+if amdgpu_target not in supported_targets:
     print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
+        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected one of {supported_targets}."
     )
     sys.exit(1)
 
+enable_fp8 = amdgpu_target in ["gfx942", "gfx950"]
 fp8_macro = (
     "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
 )
@@ -88,7 +90,11 @@ fp8_macro = (
 # - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
 #   (leaves room for static shared allocations in the kernel).
 # - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+if amdgpu_target == "gfx950":
+    topk_dynamic_smem_bytes = 32 * 1024 * 4
+else:
+    # gfx942 and gfx1100 use a smaller LDS budget
+    topk_dynamic_smem_bytes = 48 * 1024
 
 hipcc_flags = [
     "-DNDEBUG",
@@ -99,10 +105,11 @@ hipcc_flags = [
     "-std=c++17",
     f"--amdgpu-target={amdgpu_target}",
     "-DENABLE_BF16",
-    "-DENABLE_FP8",
-    fp8_macro,
     f"-DSGL_TOPK_DYNAMIC_SMEM_BYTES={topk_dynamic_smem_bytes}",
 ]
+
+if enable_fp8:
+    hipcc_flags.extend(["-DENABLE_FP8", fp8_macro])
 
 ext_modules = [
     CUDAExtension(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Yet another PR attempting to add gfx1100. I do see that there is an open PR #17957 , but I see that the aforementioned PR seems to be quite messy, seems to check in a bunch of generated files, and has unnecessary changes.  I am opening this PR instead, with the aim to make the minimal possible changes needed to run an LLM using sglang on gfx1100.

The changes in this PR are written by me, without LLM assistance. The exception being the changes to `sgl-kernel/setup_rocm.py`, which was copied from #17957 

For convenience, I have pushed this image to docker hub: https://hub.docker.com/r/calandracas/sglang_gfx1100

Here is the command used to build the docker image:
```bash
$ docker build \
    --ulimit nofile=65536 \
    -t calandracas/sglang_gfx1100 \
    --build-arg GPU_ARCH=gfx1100 \
    --build-arg SGL_REPO=https://github.com/Calandracas606/sglang.git \
    --build-arg SGL_BRANCH=feature/gfx1100 \
    -f docker/rocm.Dockerfile .
```

Here's how I've been running the server:

```bash
$ docker run -it --rm \
  -e SGLANG_USE_AITER="0" \
  -e SGLANG_USE_AITER_AR="0" \
  -v $HOME/.cache/huggingface:/root/.cache/huggingface \
  --ipc=host \
  --network=host \
  --device=/dev/kfd \
  --device=/dev/dri \
  --shm-size 16G \
  --cap-add=SYS_PTRACE \
  --security-opt seccomp=unconfined \
  --ulimit nofile=65536:65536 \
  docker.io/calandracas/sglang_gfx1100 \
  python -m sglang.launch_server --model Qwen/Qwen3.5-9B --attention-backend triton --mem-fraction-static 0.8 --context-length 4096
```

Tensor Parallel seems to be working well too.

MOE models still need some work, but I want to keep this PR minimal, with just basic functionality.

## Motivation

I have some gfx1100 GPUs, they are fast and cost effective for the amount of VRAM. I would like to use sglang since it performs very well at batched inference.

Currently, sglang only allows building on a limited subset of rocm devices, and that does not include any RDNA devices, like the gfx1100.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

This pull request makes 3 changes:

1.  `sgl-kernel/setup_rocm.py` is modified to allow building on gfx1100. This includes adding it the the device whitelist, and setting the appropriate macros for disabling fp8. This code snippet was copied from: #17957
2. `docker/rocm.Dockerfile` allows building a docker image to run sglang on gfx1100. All development and testing was done using docker. Notably, there is a change to `AITER_PREBUILD_KERNELS`. Prebuilding of Aiter kernels needs to be disabled on gfx1100 since not all of the kernels build on this architecture. Some in theory some kernels could still be jit compiled at runtime, which is why Aiter has not been disabled completely.
3. `python/sglang/srt/layers/layernorm.py` since Aiter currently needs to be disabled for sglang to run on gfx1100, the fallback code paths from vllm are being used instead. The vllm function signature for `fused_add_rms_norm` is different from what is seen in the code, which was causing runtime errors. Therefore, the function was modified to use the correct signature from vllm. Since this will only be called from the HIP code path, and only when Aiter is disabled, this should be a low impact change.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```bash
$ python -m sglang.test.few_shot_gsm8k --num-questions 200
Accuracy: 0.900
Invalid: 0.000
Latency: 27.100 s
Output throughput: 1131.776 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

```bash
$ python -m sglang.bench_one_batch_server --base-url http://127.0.0.1:30000 --model-path Qwen/Qwen3-4B-Instruct-2507 --batch 32 --input-len 256 --output-len 32
#Input tokens: 8192
#Output tokens: 1024
batch size: 32
input_len: 256
output_len: 32
latency: 1.70 s
input throughput: 9119.47 tok/s
output throughput: 1273.63 tok/s
last_ttft: 0.90 s
last generation throughput: 138.21 tok/s
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
6. After green CI and required approvals, ask Merge Oncalls to merge.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26418302017](https://github.com/sgl-project/sglang/actions/runs/26418302017)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26418301929](https://github.com/sgl-project/sglang/actions/runs/26418301929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->