### PR TITLE
[Qwen3.5] Raise Exception when radix_cache and extra_buffer are enabled at the same time

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -360,7 +360,7 @@ class ModelRunnerKVCacheMixin:
                 else:
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
             if self.server_args.disable_radix_cache:
-                ratio = 1 + additional_ratio
+                ratio = 1
             else:
                 ratio = MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO + additional_ratio
             max_num_reqs = min(

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -360,7 +360,7 @@ class ModelRunnerKVCacheMixin:
                 else:
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
             if self.server_args.disable_radix_cache:
-                ratio = 1
+                ratio = 1 + additional_ratio
             else:
                 ratio = MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO + additional_ratio
             max_num_reqs = min(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1726,6 +1726,15 @@ class ServerArgs:
             ), f"mamba extra_buffer is not supported for {model_arch} model"
 
         if self.enable_mamba_extra_buffer():  # extra_buffer
+            if self.disable_radix_cache:
+                logger.warning(
+                    "mamba extra_buffer is not needed when radix cache is disabled. "
+                    "Overlap scheduling is already supported with no_buffer + disable_radix_cache. "
+                    "Falling back to mamba_scheduler_strategy='no_buffer'."
+                )
+                self.mamba_scheduler_strategy = "no_buffer"
+                return
+
             assert (
                 is_cuda()
             ), "Mamba extra_buffer is only supported on CUDA devices with FLA backend"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1726,10 +1726,9 @@ class ServerArgs:
             ), f"mamba extra_buffer is not supported for {model_arch} model"
 
         if self.enable_mamba_extra_buffer():  # extra_buffer
-            if self.disable_radix_cache and self.speculative_algorithm is None:
+            if self.disable_radix_cache:
                 raise ValueError(
                     "mamba extra_buffer is not compatible with --disable-radix-cache "
-                    "when speculative decoding is not in use. "
                     "Overlap scheduling is already supported with no_buffer + disable_radix_cache. "
                     "Please use --mamba-scheduler-strategy no_buffer instead."
                 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1726,14 +1726,13 @@ class ServerArgs:
             ), f"mamba extra_buffer is not supported for {model_arch} model"
 
         if self.enable_mamba_extra_buffer():  # extra_buffer
-            if self.disable_radix_cache:
-                logger.warning(
-                    "mamba extra_buffer is not needed when radix cache is disabled. "
+            if self.disable_radix_cache and self.speculative_algorithm is None:
+                raise ValueError(
+                    "mamba extra_buffer is not compatible with --disable-radix-cache "
+                    "when speculative decoding is not in use. "
                     "Overlap scheduling is already supported with no_buffer + disable_radix_cache. "
-                    "Falling back to mamba_scheduler_strategy='no_buffer'."
+                    "Please use --mamba-scheduler-strategy no_buffer instead."
                 )
-                self.mamba_scheduler_strategy = "no_buffer"
-                return
 
             assert (
                 is_cuda()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Two issues with mamba cache handling when `disable_radix_cache=True`:

1. **Invalid extra_buffer usage**: `extra_buffer` (ping-pong track buffer for radix cache overlap scheduling) serves no purpose when radix cache is disabled and speculative decoding is not in use — `no_buffer` already supports overlap scheduling in this case. Allowing this wastes 2 mamba slots per request and will cause OOM at high concurrency.

2. **Ratio calculation bug**: When `extra_buffer` is used with `disable_radix_cache=True` (possible with speculative decoding), each request allocates track buffer slot(s) from the mamba pool. But the ratio was hardcoded to `1`, not accounting for the extra track buffer slots (`additional_ratio`), which could lead to mamba pool overflow.

## Modifications

- `server_args.py`: Raise `ValueError` when `extra_buffer` + `disable_radix_cache` + no speculative decoding, guiding users to use `--mamba-scheduler-strategy no_buffer` instead.
- `model_runner_kv_cache_mixin.py`: Fix ratio from `1` to `1 + additional_ratio` in the `disable_radix_cache` branch, consistent with the `else` branch. This correctly accounts for the track buffer slots allocated by `extra_buffer`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

Verified with Qwen3.5 on PD disagg (tp4/tep4/dep4) with concurrency 8x32x128x256x512x1024.
Before the fix (crash after concurrency>=128)
```
Maximum request concurrency: 128
[Sending] All 384 requests sent. Waiting for completions...
slurmstepd: error: *** STEP 998582.10 ON lyris0127 CANCELLED AT 2026-02-22T04:10:02 DUE TO TIME LIMIT ***


  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 515, in alloc
    mid is not None
AssertionError: Not enough space for mamba cache, try to increase --mamba-full-memory-ratio or --max-mamba-cache-size. mid=None, self.mamba_pool.size=60, self.mamba_pool.available_size()=0, len(reqs)=1
```
After the fix (remains stable across different concurrencies)
```
+ set +x
2026-02-22 15:10:21
Completed benchmark with concurrency: 1024
-----------------------------------------
SA-Bench complete. Results in /logs/sa-bench_isl_1024_osl_1024
```


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
