### PR TITLE
[Diffusion] Detect Flux2 custom VAE path from component_paths

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -600,9 +600,9 @@ class PipelineConfig:
             pipeline_config_cls = model_info.pipeline_config_cls
         vae_path = kwargs.get(prefix_with_dot + "vae_path") or kwargs.get("vae_path")
         if vae_path is None:
-            component_paths = kwargs.get(prefix_with_dot + "component_paths") or kwargs.get(
-                "component_paths"
-            )
+            component_paths = kwargs.get(
+                prefix_with_dot + "component_paths"
+            ) or kwargs.get("component_paths")
             if isinstance(component_paths, dict):
                 vae_path = component_paths.get("vae")
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -599,6 +599,12 @@ class PipelineConfig:
             # 1.5. Adjust pipeline config for fine-tuned VAE if needed
             pipeline_config_cls = model_info.pipeline_config_cls
         vae_path = kwargs.get(prefix_with_dot + "vae_path") or kwargs.get("vae_path")
+        if vae_path is None:
+            component_paths = kwargs.get(prefix_with_dot + "component_paths") or kwargs.get(
+                "component_paths"
+            )
+            if isinstance(component_paths, dict):
+                vae_path = component_paths.get("vae")
 
         # Check if this is a Flux2 model with fal/FLUX.2-Tiny-AutoEncoder
         if (


### PR DESCRIPTION
## Motivation
`--vae-path` is parsed as a dynamic component override and stored in `component_paths["vae"]`.

For `flux_2_t2i_customized_vae_path`, pipeline selection in `PipelineConfig.from_kwargs()` only checked `vae_path`, so it missed the custom VAE case and did not switch to `Flux2FinetunedPipelineConfig`. This led to incorrect decode scaling for `fal/FLUX.2-Tiny-AutoEncoder` and visibly washed-out outputs.

## Modification
- In `PipelineConfig.from_kwargs()`, when `vae_path` is not provided, also read `component_paths["vae"]` (including prefixed kwargs).
- Keep existing Flux2 finetuned/tiny VAE detection logic unchanged, but feed it the resolved VAE path from either source.

This makes `--vae-path` and explicit `vae_path` behave consistently during pipeline config selection.