### PR TITLE
Fix: Cuda Graph + HiCache + Speculative Decoding Working Together were giving Cuda Illegal memory access error.  

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -96,6 +96,13 @@ class LayerDoneCounter:
         self.producer_index = -1
         self.consumer_index = -1
 
+    def is_loading_in_progress(self) -> bool:
+        """Check if any loading operation is currently in progress."""
+        if self.producer_index < 0:
+            return False
+        # Check if the last producer's finish event has NOT completed
+        return not self.events[self.producer_index].finish_event.query()
+
 
 class CacheOperation:
 
@@ -300,6 +307,10 @@ class HiCacheController:
         self.layer_num = self.mem_pool_device.layer_num
         self.layer_done_counter = LayerDoneCounter(self.layer_num)
         self.mem_pool_device.register_layer_transfer_counter(self.layer_done_counter)
+
+        # Track memory relocations for CUDA graph invalidation
+        # Incremented each time load() allocates new device memory
+        self.memory_relocation_version: int = 0
 
         if write_policy not in [
             "write_through",
@@ -715,6 +726,13 @@ class HiCacheController:
         device_indices = self.mem_pool_device_allocator.alloc(len(host_indices))
         if device_indices is None:
             return None
+
+        # Memory relocated from host to device - increment relocation version
+        self.memory_relocation_version += 1
+        logger.info(
+            f"[HiCache] Load: memory_relocation_version={self.memory_relocation_version}"
+        )
+
         self.load_queue.append(
             CacheOperation(host_indices, device_indices, node_id, priority)
         )
@@ -782,8 +800,25 @@ class HiCacheController:
         )
         return producer_id
 
+    def is_loading_in_progress(self) -> bool:
+        """Check if any hicache loading is currently in progress."""
+        return self.layer_done_counter.is_loading_in_progress()
+
+    def get_memory_relocation_version(self) -> int:
+        """Get current memory relocation version for CUDA graph invalidation.
+
+        Only incremented on actual HiCache memory relocations (load/evict),
+        NOT on every normal free/alloc cycle.
+        """
+        return self.memory_relocation_version
+
     def evict_device(self, device_indices: torch.Tensor) -> int:
         self.mem_pool_device_allocator.free(device_indices)
+        # Memory relocated from device to host - increment relocation version
+        self.memory_relocation_version += 1
+        logger.info(
+            f"[HiCache] Device eviction: memory_relocation_version={self.memory_relocation_version}"
+        )
         return len(device_indices)
 
     def evict_host(self, host_indices: torch.Tensor, backup_only: bool = True) -> int:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -729,9 +729,6 @@ class HiCacheController:
 
         # Memory relocated from host to device - increment relocation version
         self.memory_relocation_version += 1
-        logger.info(
-            f"[HiCache] Load: memory_relocation_version={self.memory_relocation_version}"
-        )
 
         self.load_queue.append(
             CacheOperation(host_indices, device_indices, node_id, priority)
@@ -816,9 +813,6 @@ class HiCacheController:
         self.mem_pool_device_allocator.free(device_indices)
         # Memory relocated from device to host - increment relocation version
         self.memory_relocation_version += 1
-        logger.info(
-            f"[HiCache] Device eviction: memory_relocation_version={self.memory_relocation_version}"
-        )
         return len(device_indices)
 
     def evict_host(self, host_indices: torch.Tensor, backup_only: bool = True) -> int:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1435,6 +1435,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # hicache pointer for synchronizing data loading from CPU to GPU
     hicache_consumer_index: int = -1
+    # Memory relocation version - for invalidating CUDA graphs after HiCache relocates memory
+    hicache_memory_version: int = 0
 
     # Diffusion LLM
     dllm_config: Optional[DllmConfig] = None
@@ -2367,6 +2369,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if self.spec_info:
             self.spec_info.merge_batch(other.spec_info)
 
+        # Propagate HiCache fields - use max version (most conservative for CUDA graph invalidation)
+        self.hicache_memory_version = max(
+            self.hicache_memory_version, other.hicache_memory_version
+        )
+        if other.hicache_consumer_index >= 0:
+            self.hicache_consumer_index = max(
+                self.hicache_consumer_index, other.hicache_consumer_index
+            )
+
     def get_model_worker_batch(
         self, seq_lens_cpu_cache: Optional[torch.Tensor] = None
     ) -> ModelWorkerBatch:
@@ -2425,6 +2436,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             spec_algorithm=self.spec_algorithm,
             spec_info=self.spec_info,
             hicache_consumer_index=self.hicache_consumer_index,
+            hicache_memory_version=self.hicache_memory_version,
             capture_hidden_mode=(
                 CaptureHiddenMode.FULL
                 if self.return_hidden_states
@@ -2618,6 +2630,7 @@ class ModelWorkerBatch:
     # If set, the output of the batch contains the hidden states of the run.
     capture_hidden_mode: CaptureHiddenMode = None
     hicache_consumer_index: int = -1
+    hicache_memory_version: int = 0
 
     # For matryoshka embeddings
     dimensions: Optional[list[int]] = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2578,11 +2578,21 @@ class Scheduler(
             self.spec_algorithm,
             chunked_req=self.chunked_req,
         )
+        # Always set memory relocation version for CUDA graph invalidation
+        # This tracks all KV cache free operations (request completions, evictions)
+        new_batch.hicache_memory_version = (
+            self.tree_cache.get_memory_relocation_version()
+        )
+
         self.max_prefill_bs = max(self.max_prefill_bs, len(can_run_list))
         if self.enable_hierarchical_cache:
-            # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
+            # Check both: start new loading AND check if any loading is in progress
+            # hicache_consumer_index >= 0 disables CUDA graphs in can_run() methods
+            new_idx = self.tree_cache.ready_to_load_host_cache()
+            is_loading = self.tree_cache.is_hicache_loading_in_progress()
+            # Set >= 0 if EITHER new loading started OR loading in progress
             new_batch.hicache_consumer_index = (
-                self.tree_cache.ready_to_load_host_cache()
+                new_idx if new_idx >= 0 else (0 if is_loading else -1)
             )
 
         new_batch.prepare_for_extend()
@@ -2699,6 +2709,23 @@ class Scheduler(
 
         # Update batch tensors
         batch.prepare_for_decode()
+
+        # Always set memory relocation version for CUDA graph invalidation
+        # This tracks all KV cache free operations (request completions, evictions)
+        batch.hicache_memory_version = (
+            self.tree_cache.get_memory_relocation_version()
+        )
+
+        # Set hicache_consumer_index for decode batches to disable CUDA graphs during loading
+        if self.enable_hierarchical_cache:
+            # Check both: start new loading AND check if any loading is in progress
+            new_idx = self.tree_cache.ready_to_load_host_cache()
+            is_loading = self.tree_cache.is_hicache_loading_in_progress()
+            # Set >= 0 if EITHER new loading started OR loading in progress
+            batch.hicache_consumer_index = (
+                new_idx if new_idx >= 0 else (0 if is_loading else -1)
+            )
+
         return batch
 
     def record_batch_in_overlap(self, model_worker_batch: ModelWorkerBatch):

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -20,6 +20,7 @@ Page-aligned memory pool.
 """
 
 import abc
+import logging
 from typing import TYPE_CHECKING
 
 import torch
@@ -27,6 +28,8 @@ import triton
 import triton.language as tl
 
 from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_2
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
@@ -55,6 +58,10 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         self.is_not_in_free_group = True
         self.free_group = []
 
+        # Version counter for CUDA graph invalidation
+        # Incremented when KV cache slots are freed
+        self.kv_free_version: int = 0
+
     def debug_print(self) -> str:
         return ""
 
@@ -77,6 +84,8 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
     def free_group_end(self):
         self.is_not_in_free_group = True
         if self.free_group:
+            # Increment version once for batched free - memory layout changing
+            self.kv_free_version += 1
             self.free(torch.cat(self.free_group))
 
     def merge_and_sort_free(self):
@@ -146,6 +155,9 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.merge_and_sort_free()
 
         if need_size > len(self.free_pages):
+            logger.warning(
+                f"[KVAlloc] alloc FAILED: need={need_size}, available={len(self.free_pages)}"
+            )
             return None
 
         select_index = self.free_pages[:need_size]
@@ -157,6 +169,8 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return
 
         if self.is_not_in_free_group:
+            # Increment version - memory layout changed, CUDA graphs need invalidation
+            self.kv_free_version += 1
             if self.need_sort:
                 self.release_pages = torch.cat((self.release_pages, free_index))
             else:
@@ -492,6 +506,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return
 
         if self.is_not_in_free_group:
+            # Increment version - memory layout changed, CUDA graphs need invalidation
+            self.kv_free_version += 1
             free_page_indices = torch.unique(free_index // self.page_size)
             if self.need_sort:
                 self.release_pages = torch.cat((free_page_indices, self.release_pages))

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -212,6 +212,13 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def protected_size(self):
         return 0
 
+    def get_memory_relocation_version(self) -> int:
+        """Get memory version for CUDA graph invalidation.
+
+        Override in subclasses that have a token_to_kv_pool_allocator.
+        """
+        return 0
+
     def full_protected_size(self):
         return 0
 

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -992,6 +992,14 @@ class HiRadixCache(RadixCache):
     def flush_write_through_acks(self) -> None:
         self.writing_check()
 
+    def is_hicache_loading_in_progress(self) -> bool:
+        """Check if hierarchical cache loading is currently in progress."""
+        return self.cache_controller.is_loading_in_progress()
+
+    def get_memory_relocation_version(self) -> int:
+        """Get memory relocation version from cache controller."""
+        return self.cache_controller.get_memory_relocation_version()
+
     def check_hicache_events(self):
         self.writing_check()
         self.loading_check()

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -651,6 +651,13 @@ class RadixCache(BasePrefixCache):
         # protected size refers to the size of the cache that is locked
         return self.protected_size_
 
+    def get_memory_relocation_version(self) -> int:
+        """Get memory relocation version for CUDA graph invalidation.
+
+        Non-hierarchical RadixCache never relocates memory, so always returns 0.
+        """
+        return 0
+
     def all_values_flatten(self):
         values = []
 

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -555,8 +555,6 @@ class CudaGraphRunner:
         self.capture_forward_mode = ForwardMode.DECODE
         self.capture_hidden_mode = CaptureHiddenMode.NULL
         self.num_tokens_per_bs = 1
-        # Track memory relocation version for HiCache - graphs captured at version 0
-        self.captured_memory_version: int = 0
         if model_runner.spec_algorithm.is_speculative():
             if self.model_runner.is_draft_worker:
                 # DFLASH draft workers reuse this runner for TARGET_VERIFY mode.
@@ -750,11 +748,6 @@ class CudaGraphRunner:
         # Check if hierarchical cache loading is inactive
         is_hicache_loading_inactive = forward_batch.hicache_consumer_index < 0
 
-        # Check if HiCache has relocated memory since graphs were captured
-        is_memory_version_ok = (
-            forward_batch.hicache_memory_version == self.captured_memory_version
-        )
-
         # Compute final result
         can_run = (
             is_bs_supported
@@ -763,7 +756,6 @@ class CudaGraphRunner:
             and capture_hidden_mode_matches
             and is_ngram_supported
             and is_hicache_loading_inactive
-            and is_memory_version_ok
         )
 
         return can_run

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -555,6 +555,8 @@ class CudaGraphRunner:
         self.capture_forward_mode = ForwardMode.DECODE
         self.capture_hidden_mode = CaptureHiddenMode.NULL
         self.num_tokens_per_bs = 1
+        # Track memory relocation version for HiCache - graphs captured at version 0
+        self.captured_memory_version: int = 0
         if model_runner.spec_algorithm.is_speculative():
             if self.model_runner.is_draft_worker:
                 # DFLASH draft workers reuse this runner for TARGET_VERIFY mode.
@@ -745,13 +747,26 @@ class CudaGraphRunner:
             else True
         )
 
-        return (
+        # Check if hierarchical cache loading is inactive
+        is_hicache_loading_inactive = forward_batch.hicache_consumer_index < 0
+
+        # Check if HiCache has relocated memory since graphs were captured
+        is_memory_version_ok = (
+            forward_batch.hicache_memory_version == self.captured_memory_version
+        )
+
+        # Compute final result
+        can_run = (
             is_bs_supported
             and is_encoder_lens_supported
             and is_tbo_supported
             and capture_hidden_mode_matches
             and is_ngram_supported
+            and is_hicache_loading_inactive
+            and is_memory_version_ok
         )
+
+        return can_run
 
     def _init_profile_context_and_memory_record(self):
         profile_context = profile(
@@ -1237,6 +1252,7 @@ class CudaGraphRunner:
             graph_key = f"{get_current_stream_idx()}_{self.bs}"
         else:
             graph_key = self.bs
+
         self.graphs[graph_key].replay()
         output = self.output_buffers[graph_key]
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -29,6 +29,7 @@ ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import total_ordering
@@ -37,6 +38,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import torch
 import triton
 import triton.language as tl
+
+logger = logging.getLogger(__name__)
 
 from sglang.srt.distributed.parallel_state import (
     get_moe_expert_parallel_world_size,
@@ -433,6 +436,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For ngram embedding
     ngram_embedding_info: Optional[NgramEmbeddingInfo] = None
 
+    # For hierarchical cache - disable CUDA graphs when loading is active
+    hicache_consumer_index: int = -1
+    # Memory relocation version - for invalidating CUDA graphs after HiCache relocates memory
+    hicache_memory_version: int = 0
+
     # For dumper: request IDs for cross-step sequence tracking
     rids: Optional[List[str]] = None
 
@@ -483,8 +491,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             tbo_split_seq_index=batch.tbo_split_seq_index,
             dimensions=batch.dimensions,
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
+            hicache_consumer_index=batch.hicache_consumer_index,
+            hicache_memory_version=batch.hicache_memory_version,
             rids=[req.rid for req in batch.reqs],
         )
+
         device = model_runner.device
 
         if batch.extend_input_logprob_token_ids is not None:

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -194,6 +194,8 @@ class PiecewiseCudaGraphRunner:
         )
         self.capture_forward_mode = ForwardMode.EXTEND
         self.capture_hidden_mode = CaptureHiddenMode.NULL
+        # Track memory relocation version for HiCache - graphs captured at version 0
+        self.captured_memory_version: int = 0
 
         # If returning hidden states is enabled, set initial capture hidden mode to full to avoid double-capture on startup
         if model_runner.server_args.enable_return_hidden_states:
@@ -420,6 +422,12 @@ class PiecewiseCudaGraphRunner:
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
             return False
+        # Disable CUDA graph when hierarchical cache loading is active
+        if forward_batch.hicache_consumer_index >= 0:
+            return False
+        # Disable when HiCache has relocated memory since graphs were captured
+        if forward_batch.hicache_memory_version != self.captured_memory_version:
+            return False
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
             for start_len, seq_len in zip(
@@ -428,9 +436,8 @@ class PiecewiseCudaGraphRunner:
             ):
                 if start_len is not None and start_len < seq_len:
                     return False
-        if num_tokens <= self.max_num_tokens:
-            return True
-        return False
+
+        return num_tokens <= self.max_num_tokens
 
     def capture(self) -> None:
         # Trigger CUDA graph capture for specific shapes.

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -194,8 +194,6 @@ class PiecewiseCudaGraphRunner:
         )
         self.capture_forward_mode = ForwardMode.EXTEND
         self.capture_hidden_mode = CaptureHiddenMode.NULL
-        # Track memory relocation version for HiCache - graphs captured at version 0
-        self.captured_memory_version: int = 0
 
         # If returning hidden states is enabled, set initial capture hidden mode to full to avoid double-capture on startup
         if model_runner.server_args.enable_return_hidden_states:
@@ -425,9 +423,7 @@ class PiecewiseCudaGraphRunner:
         # Disable CUDA graph when hierarchical cache loading is active
         if forward_batch.hicache_consumer_index >= 0:
             return False
-        # Disable when HiCache has relocated memory since graphs were captured
-        if forward_batch.hicache_memory_version != self.captured_memory_version:
-            return False
+
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
             for start_len, seq_len in zip(

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import bisect
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 from sglang.srt.layers.dp_attention import DpPaddingMode, set_dp_buffer_len
 from sglang.srt.model_executor.cuda_graph_runner import (
@@ -99,6 +102,9 @@ class EAGLEDraftCudaGraphRunner:
         )
         self.extend_seq_lens_cpu = [self.seq_len_fill_value] * self.max_bs
 
+        # Track memory relocation version for HiCache - graphs captured at version 0
+        self.captured_memory_version: int = 0
+
         if self.enable_torch_compile:
             set_torch_compile_config()
 
@@ -171,6 +177,14 @@ class EAGLEDraftCudaGraphRunner:
         return torch.int64
 
     def can_run(self, forward_batch: ForwardBatch):
+        # Disable CUDA graph when hierarchical cache loading is active
+        is_loading_inactive = forward_batch.hicache_consumer_index < 0
+
+        # Disable when HiCache has relocated memory since graphs were captured
+        is_memory_version_ok = (
+            forward_batch.hicache_memory_version == self.captured_memory_version
+        )
+
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -190,7 +204,9 @@ class EAGLEDraftCudaGraphRunner:
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
 
-        return is_bs_supported
+        can_run = is_bs_supported and is_loading_inactive and is_memory_version_ok
+
+        return can_run
 
     def _create_graph(self):
         return torch.cuda.CUDAGraph()

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -102,9 +102,6 @@ class EAGLEDraftCudaGraphRunner:
         )
         self.extend_seq_lens_cpu = [self.seq_len_fill_value] * self.max_bs
 
-        # Track memory relocation version for HiCache - graphs captured at version 0
-        self.captured_memory_version: int = 0
-
         if self.enable_torch_compile:
             set_torch_compile_config()
 
@@ -180,11 +177,6 @@ class EAGLEDraftCudaGraphRunner:
         # Disable CUDA graph when hierarchical cache loading is active
         is_loading_inactive = forward_batch.hicache_consumer_index < 0
 
-        # Disable when HiCache has relocated memory since graphs were captured
-        is_memory_version_ok = (
-            forward_batch.hicache_memory_version == self.captured_memory_version
-        )
-
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -204,7 +196,7 @@ class EAGLEDraftCudaGraphRunner:
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
 
-        can_run = is_bs_supported and is_loading_inactive and is_memory_version_ok
+        can_run = is_bs_supported and is_loading_inactive
 
         return can_run
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -107,9 +107,6 @@ class EAGLEDraftExtendCudaGraphRunner:
         )
         self.extend_seq_lens_cpu = [self.num_tokens_per_bs] * self.max_bs
 
-        # Track memory relocation version for HiCache - graphs captured at version 0
-        self.captured_memory_version: int = 0
-
         if self.enable_torch_compile:
             set_torch_compile_config()
 
@@ -231,11 +228,6 @@ class EAGLEDraftExtendCudaGraphRunner:
         # Disable CUDA graph when hierarchical cache loading is active
         is_loading_inactive = forward_batch.hicache_consumer_index < 0
 
-        # Disable when HiCache has relocated memory since graphs were captured
-        is_memory_version_ok = (
-            forward_batch.hicache_memory_version == self.captured_memory_version
-        )
-
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -255,7 +247,7 @@ class EAGLEDraftExtendCudaGraphRunner:
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
 
-        can_run = is_bs_supported and is_loading_inactive and is_memory_version_ok
+        can_run = is_bs_supported and is_loading_inactive
 
         return can_run
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import bisect
 from dataclasses import dataclass
+import logging
 from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 from sglang.srt.layers.dp_attention import DpPaddingMode, set_dp_buffer_len
 from sglang.srt.model_executor.cuda_graph_runner import (
@@ -103,6 +106,9 @@ class EAGLEDraftExtendCudaGraphRunner:
             (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
         )
         self.extend_seq_lens_cpu = [self.num_tokens_per_bs] * self.max_bs
+
+        # Track memory relocation version for HiCache - graphs captured at version 0
+        self.captured_memory_version: int = 0
 
         if self.enable_torch_compile:
             set_torch_compile_config()
@@ -222,6 +228,14 @@ class EAGLEDraftExtendCudaGraphRunner:
             )
 
     def can_run(self, forward_batch: ForwardBatch):
+        # Disable CUDA graph when hierarchical cache loading is active
+        is_loading_inactive = forward_batch.hicache_consumer_index < 0
+
+        # Disable when HiCache has relocated memory since graphs were captured
+        is_memory_version_ok = (
+            forward_batch.hicache_memory_version == self.captured_memory_version
+        )
+
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -241,7 +255,9 @@ class EAGLEDraftExtendCudaGraphRunner:
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
 
-        return is_bs_supported
+        can_run = is_bs_supported and is_loading_inactive and is_memory_version_ok
+
+        return can_run
 
     def _create_graph(self):
         return torch.cuda.CUDAGraph()

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -124,11 +124,20 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             prefix_lens_cpu = batch.seq_lens_cpu
             end_offset = prefix_lens + self.draft_token_num
             end_offset_cpu = prefix_lens_cpu + self.draft_token_num
+
+            # Store version BEFORE getting last_loc
+            version_before = batch.tree_cache.get_memory_relocation_version()
+
             last_loc = get_last_loc(
                 batch.req_to_token_pool.req_to_token,
                 batch.req_pool_indices,
                 prefix_lens,
             )
+
+            # Clamp last_loc to valid KV cache range (no GPU sync)
+            total_slots = batch.token_to_kv_pool_allocator.size
+            last_loc = last_loc.clamp(0, total_slots)
+
             batch.out_cache_loc = alloc_paged_token_slots_extend(
                 batch.tree_cache,
                 prefix_lens,
@@ -138,6 +147,18 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 last_loc,
                 len(batch.input_ids),
             )
+
+            # Check if HiCache relocated memory during allocation
+            version_after = batch.tree_cache.get_memory_relocation_version()
+
+            if version_after != version_before:
+                # Memory was relocated - recompute last_loc with new indices
+                last_loc = get_last_loc(
+                    batch.req_to_token_pool.req_to_token,
+                    batch.req_pool_indices,
+                    prefix_lens,
+                )
+
             self.last_loc = last_loc
 
         bs = batch.batch_size()
@@ -257,6 +278,16 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     device=batch.device,
                 ),
             )
+
+        # Log verify entry with state
+        last_loc_min = self.last_loc.min().item() if hasattr(self, 'last_loc') and self.last_loc is not None and self.last_loc.numel() > 0 else 'N/A'
+        last_loc_max = self.last_loc.max().item() if hasattr(self, 'last_loc') and self.last_loc is not None and self.last_loc.numel() > 0 else 'N/A'
+        logger.info(
+            f"[EAGLE verify] entry: bs={batch.batch_size()}, "
+            f"out_cache_loc_range=[{batch.out_cache_loc.min().item()}, {batch.out_cache_loc.max().item()}], "
+            f"last_loc_range=[{last_loc_min}, {last_loc_max}], "
+            f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
+        )
 
         bs = self.retrive_index.shape[0]
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
@@ -470,7 +501,15 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
 
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.
-            token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
+            to_free = batch.out_cache_loc[evict_mask]
+            logger.info(
+                f"[EAGLE verify] freeing slots (page_size=1): "
+                f"count={to_free.numel()}, "
+                f"range=[{to_free.min().item() if to_free.numel() > 0 else 'N/A'}, "
+                f"{to_free.max().item() if to_free.numel() > 0 else 'N/A'}], "
+                f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
+            )
+            token_to_kv_pool_allocator.free(to_free)
         else:
             if self.topk == 1:
                 # Only evict full empty page. Do not evict partial empty page
@@ -481,7 +520,15 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     self.draft_token_num,
                     next_power_of_2(self.draft_token_num),
                 )
-                token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
+                to_free = batch.out_cache_loc[evict_mask]
+                logger.info(
+                    f"[EAGLE verify] freeing slots (topk=1): "
+                    f"count={to_free.numel()}, "
+                    f"range=[{to_free.min().item() if to_free.numel() > 0 else 'N/A'}, "
+                    f"{to_free.max().item() if to_free.numel() > 0 else 'N/A'}], "
+                    f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
+                )
+                token_to_kv_pool_allocator.free(to_free)
             else:
                 # Shift the accepted tokens to the beginning.
                 # Only evict the last part
@@ -520,6 +567,13 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
 
                 # Free the kv cache
+                logger.info(
+                    f"[EAGLE verify] freeing slots (paged): "
+                    f"count={to_free_slots.numel()}, "
+                    f"range=[{to_free_slots.min().item() if to_free_slots.numel() > 0 else 'N/A'}, "
+                    f"{to_free_slots.max().item() if to_free_slots.numel() > 0 else 'N/A'}], "
+                    f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
+                )
                 token_to_kv_pool_allocator.free(to_free_slots)
 
                 # Copy the kv cache

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -279,16 +279,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 ),
             )
 
-        # Log verify entry with state
-        last_loc_min = self.last_loc.min().item() if hasattr(self, 'last_loc') and self.last_loc is not None and self.last_loc.numel() > 0 else 'N/A'
-        last_loc_max = self.last_loc.max().item() if hasattr(self, 'last_loc') and self.last_loc is not None and self.last_loc.numel() > 0 else 'N/A'
-        logger.info(
-            f"[EAGLE verify] entry: bs={batch.batch_size()}, "
-            f"out_cache_loc_range=[{batch.out_cache_loc.min().item()}, {batch.out_cache_loc.max().item()}], "
-            f"last_loc_range=[{last_loc_min}, {last_loc_max}], "
-            f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
-        )
-
         bs = self.retrive_index.shape[0]
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
         sampling_info = batch.sampling_info
@@ -501,15 +491,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
 
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.
-            to_free = batch.out_cache_loc[evict_mask]
-            logger.info(
-                f"[EAGLE verify] freeing slots (page_size=1): "
-                f"count={to_free.numel()}, "
-                f"range=[{to_free.min().item() if to_free.numel() > 0 else 'N/A'}, "
-                f"{to_free.max().item() if to_free.numel() > 0 else 'N/A'}], "
-                f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
-            )
-            token_to_kv_pool_allocator.free(to_free)
+            token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
         else:
             if self.topk == 1:
                 # Only evict full empty page. Do not evict partial empty page
@@ -520,15 +502,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     self.draft_token_num,
                     next_power_of_2(self.draft_token_num),
                 )
-                to_free = batch.out_cache_loc[evict_mask]
-                logger.info(
-                    f"[EAGLE verify] freeing slots (topk=1): "
-                    f"count={to_free.numel()}, "
-                    f"range=[{to_free.min().item() if to_free.numel() > 0 else 'N/A'}, "
-                    f"{to_free.max().item() if to_free.numel() > 0 else 'N/A'}], "
-                    f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
-                )
-                token_to_kv_pool_allocator.free(to_free)
+                token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
             else:
                 # Shift the accepted tokens to the beginning.
                 # Only evict the last part
@@ -567,13 +541,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
 
                 # Free the kv cache
-                logger.info(
-                    f"[EAGLE verify] freeing slots (paged): "
-                    f"count={to_free_slots.numel()}, "
-                    f"range=[{to_free_slots.min().item() if to_free_slots.numel() > 0 else 'N/A'}, "
-                    f"{to_free_slots.max().item() if to_free_slots.numel() > 0 else 'N/A'}], "
-                    f"hicache_ver={batch.tree_cache.get_memory_relocation_version()}"
-                )
                 token_to_kv_pool_allocator.free(to_free_slots)
 
                 # Copy the kv cache

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -136,6 +136,9 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
         seq_lens_cpu = cuda_graph_buffers["seq_lens_cpu"]
         self.extend_seq_lens_cpu = [self.num_tokens_per_bs] * self.max_bs
 
+        # Track memory relocation version for HiCache - graphs captured at version 0
+        self.captured_memory_version: int = 0
+
         if self.enable_torch_compile:
             set_torch_compile_config()
 
@@ -249,6 +252,13 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
             )
 
     def can_run(self, forward_batch: ForwardBatch):
+        # Disable CUDA graph when hierarchical cache loading is active
+        if forward_batch.hicache_consumer_index >= 0:
+            return False
+        # Disable if memory relocation version changed
+        if forward_batch.hicache_memory_version != self.captured_memory_version:
+            return False
+
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -136,9 +136,6 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
         seq_lens_cpu = cuda_graph_buffers["seq_lens_cpu"]
         self.extend_seq_lens_cpu = [self.num_tokens_per_bs] * self.max_bs
 
-        # Track memory relocation version for HiCache - graphs captured at version 0
-        self.captured_memory_version: int = 0
-
         if self.enable_torch_compile:
             set_torch_compile_config()
 
@@ -254,9 +251,6 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
     def can_run(self, forward_batch: ForwardBatch):
         # Disable CUDA graph when hierarchical cache loading is active
         if forward_batch.hicache_consumer_index >= 0:
-            return False
-        # Disable if memory relocation version changed
-        if forward_batch.hicache_memory_version != self.captured_memory_version:
             return False
 
         if self.require_mlp_tp_gather:


### PR DESCRIPTION
Change 1: HiCache Loading Guard for CUDA Graphs

  Files: scheduler.py, schedule_batch.py, forward_batch_info.py, cache_controller.py, hiradix_cache.py

  What: Propagated hicache_consumer_index through the full batch pipeline (ScheduleBatch → ModelWorkerBatch → ForwardBatch) and added checks in all CUDA graph runners to disable graphs when consumer_index >= 0.
  Also added is_loading_in_progress() to catch async loads still running from a previous batch.

  Why: When HiCache loads KV cache from host memory, it allocates new device pages and copies data asynchronously on a separate CUDA stream. During this window, page indices in req_to_token are being updated. If a
  CUDA graph replays and reads half-updated page tables → illegal memory access.

  Why wasn't it done already: The upstream code literally had a TODO comment: # todo (zhiqiang): disable cuda graph execution if hicache loading triggered. The original hicache_consumer_index field existed but was only set during prefill batches, not decode batches. We extended it to decode batches AND added the is_loading_in_progress() check.

  Why other models don't need this: Models without --enable-hierarchical-cache always have consumer_index = -1, so this check is a no-op.

  ---
  Change 2: Memory Relocation Version Tracking

  Files: cache_controller.py, base_prefix_cache.py, radix_cache.py, hiradix_cache.py, allocator.py

  What: Added memory_relocation_version counter to HiCacheController. Incremented only when HiCache actually relocates memory (host→device load, or device eviction). Separate from kv_free_version which increments on every normal free.

  Why: We needed to distinguish "normal KV cache free/alloc" (happens every decode step, safe for CUDA graphs) from "HiCache memory relocation" (changes logical page index mapping). This distinction is what allows
  the last_loc recomputation in eagle_info.py to know when to refresh stale indices.

  Why wasn't it done already: sglang had no version tracking for HiCache relocations at all. The EAGLE code path assumed page indices are stable between operations — which is true without HiCache. HiCache + EAGLE is a very new combination.

  Why other models don't need this: RadixCache (non-hierarchical) returns get_memory_relocation_version() = 0 always. Only HiRadixCache has a real counter.


  ---
  Change 3: last_loc Bounds Clamping + Version-Aware Recomputation

  File: eagle_info.py

  What: In prepare_for_verify():
  1. last_loc.clamp(0, total_slots) — prevents out-of-bounds access, no GPU sync
  2. Check memory_relocation_version before and after alloc_paged_token_slots_extend(). If version changed (HiCache relocated during allocation), recompute last_loc from fresh req_to_token data.

  Why: last_loc reads req_to_token[req_pool_indices, prefix_lens-1] — the last KV cache slot per request. If HiCache evicts/relocates pages between computing last_loc and using it, the value could point to a freed slot. The allocation itself can trigger eviction (need more device pages → evict old ones).

  Why wasn't it done already: Without HiCache, page indices in req_to_token are stable between operations. HiCache introduces asynchronous memory relocation that can invalidate indices mid-operation. This race condition is specific to the alloc → use gap in EAGLE's verify path.

  ---
  Change 4: Draft Attention Backend → FlashInfer

  File: glm5.sh (config only: --speculative-draft-attention-backend flashinfer)

  What: Use FlashInfer instead of NSA for the EAGLE draft model's attention. Target model still uses NSA.

  Why: GLM-5's NSA backend creates NativeSparseAttnMultiStepBackend (2 NSA sub-backends for 3-step draft). The CUDA graph replay path for this multi-step NSA configuration has a latent bug causing illegal memory access. This bug was always present but masked because CUDA graphs were always disabled — the original code used a kv_free_version check that incremented on every free(), so can_run() always returned False. When
  we fixed CUDA graphs to actually run, we exposed this bug.

  Rather than debugging the NSA CUDA graph kernel (deep in the NSA attention implementation), we switch the draft model to FlashInferMLAMultiStepDraftBackend which:
  - Is automatically created for MLA models (GLM-5 uses MLA architecture)
  - Supports page_size=64 and topk=1 (both used by GLM-5)
  - Has a battle-tested CUDA graph implementation
  - Shares the same MLA KV cache format, so draft and target are compatible

  Why wasn't it done already: The --speculative-draft-attention-backend flag exists but is rarely used. Most deployments use the same backend for draft and target. The NSA + EAGLE CUDA graph path was effectively
  dead code — it existed in the codebase but was never reached because can_run() always returned False.