### PR TITLE
[fix] use ORJSONResponse for non-stream /generate

### DIFF
--- a/test/registered/sampling/test_http_server_generate_response.py
+++ b/test/registered/sampling/test_http_server_generate_response.py
@@ -1,0 +1,39 @@
+import types
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.entrypoints import http_server
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=1, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=1, suite="stage-b-test-small-1-gpu-amd")
+
+
+class _FakeTokenizerManager:
+    def generate_request(self, _obj, _request):
+        async def _gen():
+            yield {
+                "text": "ok",
+                "meta_info": {
+                    "top_logprobs": [[float("-inf"), -1, None]],
+                },
+            }
+
+        return _gen()
+
+
+class TestGenerateRequestResponseSerialization(unittest.IsolatedAsyncioTestCase):
+    async def test_non_stream_generate_serializes_non_finite_logprobs(self):
+        fake_state = types.SimpleNamespace(tokenizer_manager=_FakeTokenizerManager())
+        fake_obj = types.SimpleNamespace(stream=False)
+
+        with patch.object(http_server, "_global_state", fake_state):
+            resp = await http_server.generate_request(fake_obj, request=None)
+
+        self.assertEqual(resp.media_type, "application/json")
+        self.assertIn(b"null", resp.body)
+        self.assertNotIn(b"-Infinity", resp.body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The non-stream `/generate` endpoint can return payloads containing non-finite values
(e.g. `-inf` in `meta_info.top_logprobs`). Returning the raw dict on this path may
lead to serialization inconsistencies.

## Modifications

- Set `response_class=ORJSONResponse` for `/generate`
- Return `ORJSONResponse(content=ret)` on the non-stream path
- Add a regression unit test for non-stream generate response serialization

## Accuracy Tests

N/A (HTTP response serialization fix only)

## Benchmarking and Profiling

N/A (no kernel/model/inference speed changes)

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style guidance.

Additional tests run:
- `PYTHONPATH=python python -m unittest discover -s python/sglang/test -p test_http_server_generate_response.py -v`
- `PYTHONPATH=python python -m pytest -q python/sglang/test/test_http_server_generate_response.py`

Note:
Related to #4097

Related PR: #6600 (closed)
This PR adds a regression test for the non-stream `/generate` response serialization path.

