### PR TITLE
[CI] fix the teardown output of disaggregation test

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -556,7 +556,9 @@ def popen_with_error_check(command: list[str]):
             return
 
         if process.returncode != 0:
-            raise Exception(f"{shlex.join(command)} exited with code {process.returncode}")
+            raise Exception(
+                f"{shlex.join(command)} exited with code {process.returncode}"
+            )
 
     t = threading.Thread(target=_run_and_check, daemon=True)
     t.start()

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -547,20 +547,20 @@ def try_cached_model(model_repo: str):
 
 
 def popen_with_error_check(command: list[str], allow_exit: bool = False):
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, stdout=None, stderr=None)
 
     def _run_and_check():
-        stdout, stderr = process.communicate()
+        process.wait()
 
-        while process.poll() is None:
-            time.sleep(5)
+        print(f"{command} exited with code {process.returncode}")
+
+        if process.returncode == -9:
+            return
 
         if not allow_exit or process.returncode != 0:
-            raise Exception(
-                f"{command} exited with code {process.returncode}\n{stdout=}\n{stderr=}"
-            )
+            raise Exception(f"{command} exited with code {process.returncode}")
 
-    t = threading.Thread(target=_run_and_check)
+    t = threading.Thread(target=_run_and_check, daemon=True)
     t.start()
     return process
 

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -546,18 +546,16 @@ def try_cached_model(model_repo: str):
     return model_dir if model_dir else model_repo
 
 
-def popen_with_error_check(command: list[str], allow_exit: bool = False):
+def popen_with_error_check(command: list[str]):
     process = subprocess.Popen(command, stdout=None, stderr=None)
 
     def _run_and_check():
         process.wait()
 
-        print(f"{command} exited with code {process.returncode}")
-
         if process.returncode == -9:
             return
 
-        if not allow_exit or process.returncode != 0:
+        if process.returncode != 0:
             raise Exception(f"{command} exited with code {process.returncode}")
 
     t = threading.Thread(target=_run_and_check, daemon=True)

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -556,7 +556,7 @@ def popen_with_error_check(command: list[str]):
             return
 
         if process.returncode != 0:
-            raise Exception(f"{command} exited with code {process.returncode}")
+            raise Exception(f"{shlex.join(command)} exited with code {process.returncode}")
 
     t = threading.Thread(target=_run_and_check, daemon=True)
     t.start()


### PR DESCRIPTION
- Fix `popen_with_error_check` to output LB logs directly to the terminal instead of piping and dumping on kill. 
- Suppress SIGKILL (-9) during teardown while still reporting real crashes.
- Remove argument `allow_exit`

Before this PR:
<img width="1535" height="321" alt="image" src="https://github.com/user-attachments/assets/4b9d993c-7452-40e5-8aee-3742c57ddcc5" />

After this PR:
<img width="1514" height="254" alt="image" src="https://github.com/user-attachments/assets/f1fcb32b-aabe-4890-bd3b-78e69969f4bb" />

