### PR TITLE
Add server CUDA graph warmup CI step for cold H200 nodes

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1327,7 +1327,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: |
           cd test && python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8
 
@@ -1472,7 +1472,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: |
           cd test && python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-deepep-8-gpu-h200 --tp 8
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1326,10 +1326,10 @@ jobs:
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
-      - name: Warmup Weights and JIT Compilation
+      - name: Warmup DeepGEMM JIT Compilation
         timeout-minutes: 20
         run: |
-          python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code
+          cd test && python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8
 
       - name: Run test
         timeout-minutes: 30
@@ -1471,10 +1471,10 @@ jobs:
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
-      - name: Warmup Weights and JIT Compilation
+      - name: Warmup DeepGEMM JIT Compilation
         timeout-minutes: 20
         run: |
-          python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code
+          cd test && python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-deepep-8-gpu-h200 --tp 8
 
       - name: Run test
         timeout-minutes: 45

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1329,7 +1329,9 @@ jobs:
       - name: Warmup DeepGEMM JIT Compilation
         timeout-minutes: 40
         run: |
-          cd test && python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8
+          python3 scripts/ci/cuda/warmup_deep_gemm.py \
+            deepseek-ai/DeepSeek-V3-0324:8 \
+            deepseek-ai/DeepSeek-V3.2-Exp:8
 
       - name: Run test
         timeout-minutes: 30
@@ -1474,7 +1476,9 @@ jobs:
       - name: Warmup DeepGEMM JIT Compilation
         timeout-minutes: 40
         run: |
-          cd test && python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-deepep-8-gpu-h200 --tp 8
+          python3 scripts/ci/cuda/warmup_deep_gemm.py \
+            deepseek-ai/DeepSeek-V3-0324:8 \
+            deepseek-ai/DeepSeek-V3.2-Exp:8
 
       - name: Run test
         timeout-minutes: 45

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1327,7 +1327,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        timeout-minutes: 40
+        timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
             deepseek-ai/DeepSeek-V3-0324:8 \
@@ -1474,7 +1474,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        timeout-minutes: 40
+        timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
             deepseek-ai/DeepSeek-V3-0324:8 \

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1326,14 +1326,13 @@ jobs:
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
-      # - name: Warmup Weights and JIT Compilation
-      #   timeout-minutes: 20
-      #   run: |
-      #     # An example command for testing the warmup. TODO: make this more general and move them to python scripts.
-      #     python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code
+      - name: Warmup Weights and JIT Compilation
+        timeout-minutes: 20
+        run: |
+          python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code
 
       - name: Run test
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           cd test
           CONTINUE_ON_ERROR_FLAG=""
@@ -1471,6 +1470,11 @@ jobs:
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
+
+      - name: Warmup Weights and JIT Compilation
+        timeout-minutes: 20
+        run: |
+          python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code
 
       - name: Run test
         timeout-minutes: 45

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1333,6 +1333,13 @@ jobs:
             deepseek-ai/DeepSeek-V3-0324:8 \
             deepseek-ai/DeepSeek-V3.2-Exp:8
 
+      - name: Warmup Server CUDA Graphs
+        timeout-minutes: 25
+        run: |
+          python3 scripts/ci/cuda/warmup_server.py \
+            deepseek-ai/DeepSeek-V3-0324:8 \
+            inclusionAI/Ring-2.5-1T:8
+
       - name: Run test
         timeout-minutes: 30
         run: |
@@ -1479,6 +1486,12 @@ jobs:
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
             deepseek-ai/DeepSeek-V3-0324:8 \
             deepseek-ai/DeepSeek-V3.2-Exp:8
+
+      - name: Warmup Server CUDA Graphs
+        timeout-minutes: 25
+        run: |
+          python3 scripts/ci/cuda/warmup_server.py \
+            deepseek-ai/DeepSeek-V3-0324:8
 
       - name: Run test
         timeout-minutes: 45

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -108,6 +108,9 @@ if [ "$IS_BLACKWELL" = "1" ]; then
 else
     # In normal cases, we use uv, which is much faster than pip.
     pip install uv
+    # Ensure user bin directory is in PATH (pip may install to ~/.local/bin on
+    # non-root runners where system site-packages is not writable)
+    export PATH="$HOME/.local/bin:$PATH"
     export UV_SYSTEM_PYTHON=true
 
     PIP_CMD="uv pip"

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -108,9 +108,6 @@ if [ "$IS_BLACKWELL" = "1" ]; then
 else
     # In normal cases, we use uv, which is much faster than pip.
     pip install uv
-    # Ensure user bin directory is in PATH (pip may install to ~/.local/bin on
-    # non-root runners where system site-packages is not writable)
-    export PATH="$HOME/.local/bin:$PATH"
     export UV_SYSTEM_PYTHON=true
 
     PIP_CMD="uv pip"

--- a/scripts/ci/cuda/warmup_deep_gemm.py
+++ b/scripts/ci/cuda/warmup_deep_gemm.py
@@ -3,10 +3,10 @@ Auto-discover models needing DeepGEMM warmup from CI test suite config.
 
 This script:
 1. Discovers test files for a given CI suite using collect_tests()
-2. Extracts model names from test files via AST parsing
+2. Extracts model names and TP sizes from test files via AST parsing
 3. Filters to MoE models present in HF cache that need DeepGEMM
-4. Deduplicates models sharing the same kernel dimensions
-5. Runs compile_deep_gemm for each unique architecture
+4. Deduplicates models sharing the same kernel dimensions + TP
+5. Runs compile_deep_gemm for each unique (architecture, tp) group
 
 Usage (from test/ directory):
     python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8
@@ -26,7 +26,6 @@ from pathlib import Path
 
 def get_test_utils_constants():
     """Pre-resolve model name constants from test_utils.py via AST parsing."""
-    # This script runs from test/ directory; test_utils is at ../python/sglang/test/test_utils.py
     test_utils_path = os.path.join(
         os.path.dirname(__file__),
         "..",
@@ -56,14 +55,72 @@ def get_test_utils_constants():
     return constants
 
 
-def extract_models_from_file(filepath, external_constants):
-    """Extract model names from a test file using AST parsing.
+def _resolve_value(node, all_constants):
+    """Resolve an AST node to a string model path, or None."""
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and "/" in node.value
+    ):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in all_constants:
+        return all_constants[node.id]
+    return None
 
-    Patterns:
-    - Module-level: NAME_WITH_MODEL = "org/model"
-    - Class attribute: model = "org/model"
-    - cls.model = "org/model" or cls.model = CONSTANT (in setUpClass)
-    - ModelLaunchSettings("org/model", ...) or ModelLaunchSettings(CONSTANT, ...)
+
+def _extract_tp_from_list(node):
+    """Extract --tp value from a List AST node (e.g. other_args = ["--tp", "8"]).
+
+    Handles both "--tp", "N" (two elements) and "--tp=N" (single element).
+    """
+    if not isinstance(node, ast.List):
+        return None
+    for i, elt in enumerate(node.elts):
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            # Pattern: "--tp=N"
+            if elt.value.startswith("--tp="):
+                try:
+                    return int(elt.value.split("=")[1])
+                except (ValueError, IndexError):
+                    pass
+            # Pattern: "--tp", "N"
+            if elt.value == "--tp" and i + 1 < len(node.elts):
+                next_elt = node.elts[i + 1]
+                if isinstance(next_elt, ast.Constant):
+                    try:
+                        return int(next_elt.value)
+                    except (ValueError, TypeError):
+                        pass
+    return None
+
+
+def _extract_tp_from_class(class_node):
+    """Extract --tp value from a class body by scanning list assignments and calls."""
+    for node in ast.walk(class_node):
+        # Pattern: other_args = ["--tp", "8", ...]
+        if isinstance(node, ast.Assign):
+            tp = _extract_tp_from_list(node.value)
+            if tp is not None:
+                return tp
+        # Pattern: popen_launch_server(..., other_args=[...])
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "other_args":
+                    tp = _extract_tp_from_list(kw.value)
+                    if tp is not None:
+                        return tp
+            # Also check positional list args
+            for arg in node.args:
+                tp = _extract_tp_from_list(arg)
+                if tp is not None:
+                    return tp
+    return None
+
+
+def extract_models_from_file(filepath, external_constants, default_tp):
+    """Extract (model_name, tp_size) pairs from a test file using AST parsing.
+
+    Returns a list of (model_name, tp_size) tuples.
     """
     with open(filepath) as f:
         source = f.read()
@@ -71,9 +128,7 @@ def extract_models_from_file(filepath, external_constants):
     try:
         tree = ast.parse(source, filepath)
     except SyntaxError:
-        return set()
-
-    models = set()
+        return []
 
     # Build local constant map from module-level assignments
     local_constants = {}
@@ -84,63 +139,89 @@ def extract_models_from_file(filepath, external_constants):
                 if isinstance(node.value.value, str) and "/" in node.value.value:
                     local_constants[target.id] = node.value.value
 
-    # Combined lookup: local constants first, then external (test_utils)
     all_constants = {**external_constants, **local_constants}
+    results = []  # list of (model, tp)
+    seen = set()
 
-    def resolve_value(node):
-        """Resolve a node to a string model path, or None."""
-        if (
-            isinstance(node, ast.Constant)
-            and isinstance(node.value, str)
-            and "/" in node.value
-        ):
-            return node.value
-        if isinstance(node, ast.Name) and node.id in all_constants:
-            return all_constants[node.id]
-        return None
+    def add_result(model, tp):
+        key = (model, tp)
+        if key not in seen:
+            seen.add(key)
+            results.append(key)
 
-    for node in ast.walk(tree):
-        # Pattern 1: Module-level constant assignment with MODEL in name
+    # Walk classes to extract (model, tp) pairs with correct per-class TP
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef):
+            class_models = set()
+
+            for child in ast.walk(node):
+                # cls.model = ... or model = ...
+                if isinstance(child, ast.Assign) and len(child.targets) == 1:
+                    target = child.targets[0]
+                    if isinstance(target, ast.Name) and target.id == "model":
+                        val = _resolve_value(child.value, all_constants)
+                        if val:
+                            class_models.add(val)
+                    elif (
+                        isinstance(target, ast.Attribute)
+                        and target.attr == "model"
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id == "cls"
+                    ):
+                        val = _resolve_value(child.value, all_constants)
+                        if val:
+                            class_models.add(val)
+
+                # ModelLaunchSettings("org/model", tp_size=N, ...)
+                if isinstance(child, ast.Call):
+                    func = child.func
+                    is_mls = (
+                        isinstance(func, ast.Name) and func.id == "ModelLaunchSettings"
+                    ) or (
+                        isinstance(func, ast.Attribute)
+                        and func.attr == "ModelLaunchSettings"
+                    )
+                    if is_mls and child.args:
+                        val = _resolve_value(child.args[0], all_constants)
+                        if val:
+                            # Get tp_size from keyword arg or second positional
+                            mls_tp = None
+                            for kw in child.keywords:
+                                if kw.arg == "tp_size" and isinstance(
+                                    kw.value, ast.Constant
+                                ):
+                                    try:
+                                        mls_tp = int(kw.value.value)
+                                    except (ValueError, TypeError):
+                                        pass
+                            if mls_tp is None and len(child.args) >= 2:
+                                if isinstance(child.args[1], ast.Constant):
+                                    try:
+                                        mls_tp = int(child.args[1].value)
+                                    except (ValueError, TypeError):
+                                        pass
+                            add_result(val, mls_tp or default_tp)
+
+            # Extract TP from the class body (other_args, popen_launch_server, etc.)
+            class_tp = _extract_tp_from_class(node) or default_tp
+
+            for model in class_models:
+                add_result(model, class_tp)
+
+    # Also check module-level constant assignments with MODEL in name
+    for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Assign) and len(node.targets) == 1:
             target = node.targets[0]
             if isinstance(target, ast.Name) and "MODEL" in target.id.upper():
-                val = resolve_value(node.value)
+                val = _resolve_value(node.value, all_constants)
                 if val:
-                    models.add(val)
+                    # These are just constant definitions; the actual TP comes
+                    # from wherever they're used (class context above).
+                    # Only add if not already found in a class context.
+                    if not any(m == val for m, _ in results):
+                        add_result(val, default_tp)
 
-        # Pattern 2: Class-level attribute: model = "org/model"
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and target.id == "model":
-                val = resolve_value(node.value)
-                if val:
-                    models.add(val)
-
-        # Pattern 3: cls.model = ... in setUpClass
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if (
-                isinstance(target, ast.Attribute)
-                and target.attr == "model"
-                and isinstance(target.value, ast.Name)
-                and target.value.id == "cls"
-            ):
-                val = resolve_value(node.value)
-                if val:
-                    models.add(val)
-
-        # Pattern 4: ModelLaunchSettings("org/model", ...) or ModelLaunchSettings(CONST, ...)
-        if isinstance(node, ast.Call):
-            func = node.func
-            if (isinstance(func, ast.Name) and func.id == "ModelLaunchSettings") or (
-                isinstance(func, ast.Attribute) and func.attr == "ModelLaunchSettings"
-            ):
-                if node.args:
-                    val = resolve_value(node.args[0])
-                    if val:
-                        models.add(val)
-
-    return models
+    return results
 
 
 def check_deepgemm_disabled(filepath):
@@ -161,12 +242,10 @@ def model_in_hf_cache(model_name):
     )
     hub_dir = os.path.join(cache_dir, "hub")
 
-    # HF cache stores models as models--org--name
     safe_name = "models--" + model_name.replace("/", "--")
     model_cache_path = os.path.join(hub_dir, safe_name)
 
     if os.path.isdir(model_cache_path):
-        # Check that there's at least one snapshot
         snapshots_dir = os.path.join(model_cache_path, "snapshots")
         if os.path.isdir(snapshots_dir) and os.listdir(snapshots_dir):
             return True
@@ -185,7 +264,6 @@ def get_config_json(model_name):
     if not os.path.isdir(snapshots_dir):
         return None
 
-    # Use the most recent snapshot
     snapshots = sorted(
         Path(snapshots_dir).iterdir(), key=lambda p: p.stat().st_mtime, reverse=True
     )
@@ -212,11 +290,12 @@ def is_moe_model(config):
     return False
 
 
-def get_architecture_key(config):
+def get_architecture_key(config, tp):
     """Get a key that identifies the kernel dimensions for deduplication.
 
-    Models with the same (num_experts, hidden_size, intermediate_size) share
-    the same DeepGEMM kernel shapes.
+    Models with the same (num_experts, hidden_size, intermediate_size, tp) share
+    the same DeepGEMM kernel shapes. TP matters because it determines
+    experts-per-GPU and weight shard sizes.
     """
     if config is None:
         return None
@@ -232,28 +311,25 @@ def get_architecture_key(config):
         "moe_intermediate_size", 0
     )
 
-    return (num_experts, hidden_size, intermediate_size)
+    return (num_experts, hidden_size, intermediate_size, tp)
 
 
 def discover_suite_files(suite):
     """Discover test files for a suite using collect_tests()."""
-    # We run from the test/ directory, same as run_suite.py
     files = glob.glob("registered/**/*.py", recursive=True)
     if not files:
         print(
-            f"No test files found in registered/. Are you running from the test/ directory?"
+            "No test files found in registered/. "
+            "Are you running from the test/ directory?"
         )
         return []
 
-    # Import collect_tests from ci_register
     sys.path.insert(
         0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "python")
     )
     from sglang.test.ci.ci_register import collect_tests
 
     all_tests = collect_tests(files, sanity_check=True)
-
-    # Filter to our suite (both per-commit and nightly)
     suite_tests = [t for t in all_tests if t.suite == suite]
 
     if not suite_tests:
@@ -269,7 +345,11 @@ def main():
     )
     parser.add_argument("--suite", type=str, required=True, help="CI test suite name")
     parser.add_argument(
-        "--tp", type=int, default=8, help="Tensor parallelism degree (default: 8)"
+        "--tp",
+        type=int,
+        default=8,
+        help="Default tensor parallelism degree (default: 8). "
+        "Overridden by per-model TP extracted from test files.",
     )
     parser.add_argument(
         "--dry-run",
@@ -292,38 +372,43 @@ def main():
         print(f"  {t.filename} ({status})")
     print()
 
-    # Step 2: Extract model names from test files
+    # Step 2: Extract (model, tp) pairs from test files
     external_constants = get_test_utils_constants()
     print(f"Loaded {len(external_constants)} model constants from test_utils.py")
 
-    all_models = set()
-    file_models = {}
+    all_model_tp_pairs = []  # list of (model, tp)
+    file_models = {}  # filepath -> set of model names (for deepgemm disable check)
+    seen_pairs = set()
     for t in suite_tests:
-        models = extract_models_from_file(t.filename, external_constants)
-        if models:
-            file_models[t.filename] = models
-            all_models.update(models)
+        pairs = extract_models_from_file(t.filename, external_constants, args.tp)
+        models_in_file = set()
+        for model, tp in pairs:
+            models_in_file.add(model)
+            key = (model, tp)
+            if key not in seen_pairs:
+                seen_pairs.add(key)
+                all_model_tp_pairs.append((model, tp))
+        if models_in_file:
+            file_models[t.filename] = models_in_file
 
-    print(f"\nDiscovered {len(all_models)} unique model(s) across all test files:")
-    for m in sorted(all_models):
-        print(f"  {m}")
+    print(f"\nDiscovered {len(all_model_tp_pairs)} unique (model, tp) pair(s):")
+    for model, tp in sorted(all_model_tp_pairs):
+        print(f"  {model} (tp={tp})")
     print()
 
     # Step 3: Filter to models that need DeepGEMM warmup
     warmup_candidates = []
-    for model in sorted(all_models):
-        # Check if model is in HF cache
+    for model, tp in sorted(all_model_tp_pairs):
         if not model_in_hf_cache(model):
-            print(f"  SKIP {model}: not in HF cache")
+            print(f"  SKIP {model} (tp={tp}): not in HF cache")
             continue
 
-        # Check config for MoE
         config = get_config_json(model)
         if not is_moe_model(config):
-            print(f"  SKIP {model}: not an MoE model")
+            print(f"  SKIP {model} (tp={tp}): not an MoE model")
             continue
 
-        # Check if any test file that uses this model explicitly disables DeepGEMM
+        # Check if any test file using this model explicitly disables DeepGEMM
         disabled = False
         for filepath, models in file_models.items():
             if model in models and check_deepgemm_disabled(filepath):
@@ -331,11 +416,11 @@ def main():
                 break
 
         if disabled:
-            print(f"  SKIP {model}: DeepGEMM explicitly disabled in test")
+            print(f"  SKIP {model} (tp={tp}): DeepGEMM explicitly disabled in test")
             continue
 
-        warmup_candidates.append((model, config))
-        print(f"  NEED {model}: MoE model in cache, DeepGEMM enabled")
+        warmup_candidates.append((model, tp, config))
+        print(f"  NEED {model} (tp={tp}): MoE model in cache, DeepGEMM enabled")
 
     print()
 
@@ -343,42 +428,46 @@ def main():
         print("No models need DeepGEMM warmup. Done.")
         return
 
-    # Step 4: Deduplicate by architecture (same kernel dimensions)
+    # Step 4: Deduplicate by architecture + TP (same kernel dimensions)
     arch_groups = {}
-    for model, config in warmup_candidates:
-        key = get_architecture_key(config)
+    for model, tp, config in warmup_candidates:
+        key = get_architecture_key(config, tp)
         if key not in arch_groups:
             arch_groups[key] = []
-        arch_groups[key].append(model)
+        arch_groups[key].append((model, tp))
 
     print(
-        f"Architecture deduplication: {len(warmup_candidates)} model(s) -> {len(arch_groups)} unique architecture(s)"
+        f"Architecture deduplication: {len(warmup_candidates)} candidate(s) "
+        f"-> {len(arch_groups)} unique architecture(s)"
     )
-    models_to_warmup = []
+    models_to_warmup = []  # list of (model, tp)
     for key, group in arch_groups.items():
         representative = group[0]
         models_to_warmup.append(representative)
         if len(group) > 1:
+            others = ", ".join(f"{m}" for m, _ in group[1:])
             print(
-                f"  Architecture {key}: using {representative} (also covers: {', '.join(group[1:])})"
+                f"  {key}: using {representative[0]} tp={representative[1]} "
+                f"(also covers: {others})"
             )
         else:
-            print(f"  Architecture {key}: {representative}")
+            print(f"  {key}: {representative[0]} tp={representative[1]}")
     print()
 
     # Step 5: Run compile_deep_gemm for each unique architecture
     if args.dry_run:
         print("DRY RUN - would compile for:")
-        for model in models_to_warmup:
+        for model, tp in models_to_warmup:
             print(
-                f"  python3 -m sglang.compile_deep_gemm --model {model} --tp {args.tp} --trust-remote-code"
+                f"  python3 -m sglang.compile_deep_gemm "
+                f"--model {model} --tp {tp} --trust-remote-code"
             )
         return
 
-    for i, model in enumerate(models_to_warmup, 1):
-        print(f"\n{'='*60}")
-        print(f"[{i}/{len(models_to_warmup)}] Warming up: {model}")
-        print(f"{'='*60}")
+    for i, (model, tp) in enumerate(models_to_warmup, 1):
+        print(f"\n{'=' * 60}")
+        print(f"[{i}/{len(models_to_warmup)}] Warming up: {model} (tp={tp})")
+        print(f"{'=' * 60}")
         cmd = [
             sys.executable,
             "-m",
@@ -386,13 +475,14 @@ def main():
             "--model",
             model,
             "--tp",
-            str(args.tp),
+            str(tp),
             "--trust-remote-code",
         ]
         result = subprocess.run(cmd)
         if result.returncode != 0:
             print(
-                f"Warning: compile_deep_gemm failed for {model} (exit code {result.returncode})"
+                f"Warning: compile_deep_gemm failed for {model} "
+                f"(exit code {result.returncode})"
             )
             print("Continuing with remaining models...")
         else:

--- a/scripts/ci/cuda/warmup_deep_gemm.py
+++ b/scripts/ci/cuda/warmup_deep_gemm.py
@@ -1,238 +1,20 @@
 """
-Auto-discover models needing DeepGEMM warmup from CI test suite config.
+Warmup DeepGEMM JIT compilation for specified models.
 
-This script:
-1. Discovers test files for a given CI suite using collect_tests()
-2. Extracts model names and TP sizes from test files via AST parsing
-3. Filters to MoE models present in HF cache that need DeepGEMM
-4. Deduplicates models sharing the same kernel dimensions + TP
-5. Runs compile_deep_gemm for each unique (architecture, tp) group
+Takes an explicit list of model:tp pairs. Skips models not in HF cache
+and deduplicates models sharing the same architecture.
 
-Usage (from test/ directory):
-    python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8
-    python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8 --dry-run
+Usage:
+    python3 scripts/ci/cuda/warmup_deep_gemm.py \
+        deepseek-ai/DeepSeek-V3-0324:8 \
+        deepseek-ai/DeepSeek-V3.2-Exp:8
 """
 
-import argparse
-import ast
-import glob
 import json
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
-
-
-def get_test_utils_constants():
-    """Pre-resolve model name constants from test_utils.py via AST parsing."""
-    test_utils_path = os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "..",
-        "..",
-        "python",
-        "sglang",
-        "test",
-        "test_utils.py",
-    )
-    test_utils_path = os.path.normpath(test_utils_path)
-
-    if not os.path.exists(test_utils_path):
-        print(f"Warning: test_utils.py not found at {test_utils_path}")
-        return {}
-
-    with open(test_utils_path) as f:
-        tree = ast.parse(f.read(), test_utils_path)
-
-    constants = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
-                if isinstance(node.value.value, str) and "/" in node.value.value:
-                    constants[target.id] = node.value.value
-    return constants
-
-
-def _resolve_value(node, all_constants):
-    """Resolve an AST node to a string model path, or None."""
-    if (
-        isinstance(node, ast.Constant)
-        and isinstance(node.value, str)
-        and "/" in node.value
-    ):
-        return node.value
-    if isinstance(node, ast.Name) and node.id in all_constants:
-        return all_constants[node.id]
-    return None
-
-
-def _extract_tp_from_list(node):
-    """Extract --tp value from a List AST node (e.g. other_args = ["--tp", "8"]).
-
-    Handles both "--tp", "N" (two elements) and "--tp=N" (single element).
-    """
-    if not isinstance(node, ast.List):
-        return None
-    for i, elt in enumerate(node.elts):
-        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-            # Pattern: "--tp=N"
-            if elt.value.startswith("--tp="):
-                try:
-                    return int(elt.value.split("=")[1])
-                except (ValueError, IndexError):
-                    pass
-            # Pattern: "--tp", "N"
-            if elt.value == "--tp" and i + 1 < len(node.elts):
-                next_elt = node.elts[i + 1]
-                if isinstance(next_elt, ast.Constant):
-                    try:
-                        return int(next_elt.value)
-                    except (ValueError, TypeError):
-                        pass
-    return None
-
-
-def _extract_tp_from_class(class_node):
-    """Extract --tp value from a class body by scanning list assignments and calls."""
-    for node in ast.walk(class_node):
-        # Pattern: other_args = ["--tp", "8", ...]
-        if isinstance(node, ast.Assign):
-            tp = _extract_tp_from_list(node.value)
-            if tp is not None:
-                return tp
-        # Pattern: popen_launch_server(..., other_args=[...])
-        if isinstance(node, ast.Call):
-            for kw in node.keywords:
-                if kw.arg == "other_args":
-                    tp = _extract_tp_from_list(kw.value)
-                    if tp is not None:
-                        return tp
-            # Also check positional list args
-            for arg in node.args:
-                tp = _extract_tp_from_list(arg)
-                if tp is not None:
-                    return tp
-    return None
-
-
-def extract_models_from_file(filepath, external_constants, default_tp):
-    """Extract (model_name, tp_size) pairs from a test file using AST parsing.
-
-    Returns a list of (model_name, tp_size) tuples.
-    """
-    with open(filepath) as f:
-        source = f.read()
-
-    try:
-        tree = ast.parse(source, filepath)
-    except SyntaxError:
-        return []
-
-    # Build local constant map from module-level assignments
-    local_constants = {}
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
-                if isinstance(node.value.value, str) and "/" in node.value.value:
-                    local_constants[target.id] = node.value.value
-
-    all_constants = {**external_constants, **local_constants}
-    results = []  # list of (model, tp)
-    seen = set()
-
-    def add_result(model, tp):
-        key = (model, tp)
-        if key not in seen:
-            seen.add(key)
-            results.append(key)
-
-    # Walk classes to extract (model, tp) pairs with correct per-class TP
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.ClassDef):
-            class_models = set()
-
-            for child in ast.walk(node):
-                # cls.model = ... or model = ...
-                if isinstance(child, ast.Assign) and len(child.targets) == 1:
-                    target = child.targets[0]
-                    if isinstance(target, ast.Name) and target.id == "model":
-                        val = _resolve_value(child.value, all_constants)
-                        if val:
-                            class_models.add(val)
-                    elif (
-                        isinstance(target, ast.Attribute)
-                        and target.attr == "model"
-                        and isinstance(target.value, ast.Name)
-                        and target.value.id == "cls"
-                    ):
-                        val = _resolve_value(child.value, all_constants)
-                        if val:
-                            class_models.add(val)
-
-                # ModelLaunchSettings("org/model", tp_size=N, ...)
-                if isinstance(child, ast.Call):
-                    func = child.func
-                    is_mls = (
-                        isinstance(func, ast.Name) and func.id == "ModelLaunchSettings"
-                    ) or (
-                        isinstance(func, ast.Attribute)
-                        and func.attr == "ModelLaunchSettings"
-                    )
-                    if is_mls and child.args:
-                        val = _resolve_value(child.args[0], all_constants)
-                        if val:
-                            # Get tp_size from keyword arg or second positional
-                            mls_tp = None
-                            for kw in child.keywords:
-                                if kw.arg == "tp_size" and isinstance(
-                                    kw.value, ast.Constant
-                                ):
-                                    try:
-                                        mls_tp = int(kw.value.value)
-                                    except (ValueError, TypeError):
-                                        pass
-                            if mls_tp is None and len(child.args) >= 2:
-                                if isinstance(child.args[1], ast.Constant):
-                                    try:
-                                        mls_tp = int(child.args[1].value)
-                                    except (ValueError, TypeError):
-                                        pass
-                            add_result(val, mls_tp or default_tp)
-
-            # Extract TP from the class body (other_args, popen_launch_server, etc.)
-            class_tp = _extract_tp_from_class(node) or default_tp
-
-            for model in class_models:
-                add_result(model, class_tp)
-
-    # Also check module-level constant assignments with MODEL in name
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and "MODEL" in target.id.upper():
-                val = _resolve_value(node.value, all_constants)
-                if val:
-                    # These are just constant definitions; the actual TP comes
-                    # from wherever they're used (class context above).
-                    # Only add if not already found in a class context.
-                    if not any(m == val for m, _ in results):
-                        add_result(val, default_tp)
-
-    return results
-
-
-def check_deepgemm_disabled(filepath):
-    """Check if a test file explicitly disables DeepGEMM."""
-    with open(filepath) as f:
-        source = f.read()
-    if "SGLANG_ENABLE_JIT_DEEPGEMM" not in source:
-        return False
-    # Match patterns like: SGLANG_ENABLE_JIT_DEEPGEMM...False/0/false
-    # Covers: .set(False), .override(False), env["..."] = "0", "...": "False"
-    return bool(re.search(r'SGLANG_ENABLE_JIT_DEEPGEMM.*(?:False|"0"|"false")', source))
 
 
 def model_in_hf_cache(model_name):
@@ -241,19 +23,13 @@ def model_in_hf_cache(model_name):
         "HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
     )
     hub_dir = os.path.join(cache_dir, "hub")
-
     safe_name = "models--" + model_name.replace("/", "--")
-    model_cache_path = os.path.join(hub_dir, safe_name)
-
-    if os.path.isdir(model_cache_path):
-        snapshots_dir = os.path.join(model_cache_path, "snapshots")
-        if os.path.isdir(snapshots_dir) and os.listdir(snapshots_dir):
-            return True
-    return False
+    snapshots_dir = os.path.join(hub_dir, safe_name, "snapshots")
+    return os.path.isdir(snapshots_dir) and bool(os.listdir(snapshots_dir))
 
 
 def get_config_json(model_name):
-    """Load config.json for a cached model, returning the parsed dict or None."""
+    """Load config.json for a cached model."""
     cache_dir = os.environ.get(
         "HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
     )
@@ -272,34 +48,13 @@ def get_config_json(model_name):
         if config_path.exists():
             with open(config_path) as f:
                 return json.load(f)
-
     return None
 
 
-def is_moe_model(config):
-    """Check if a model config indicates an MoE architecture."""
-    if config is None:
-        return False
-
-    moe_fields = ["num_local_experts", "n_routed_experts", "num_experts"]
-    for field in moe_fields:
-        val = config.get(field, 0)
-        if isinstance(val, int) and val > 0:
-            return True
-
-    return False
-
-
 def get_architecture_key(config, tp):
-    """Get a key that identifies the kernel dimensions for deduplication.
-
-    Models with the same (num_experts, hidden_size, intermediate_size, tp) share
-    the same DeepGEMM kernel shapes. TP matters because it determines
-    experts-per-GPU and weight shard sizes.
-    """
+    """Key for dedup: models with same key share DeepGEMM kernels."""
     if config is None:
         return None
-
     num_experts = (
         config.get("num_local_experts")
         or config.get("n_routed_experts")
@@ -310,163 +65,65 @@ def get_architecture_key(config, tp):
     intermediate_size = config.get("intermediate_size") or config.get(
         "moe_intermediate_size", 0
     )
-
     return (num_experts, hidden_size, intermediate_size, tp)
 
 
-def discover_suite_files(suite):
-    """Discover test files for a suite using collect_tests()."""
-    files = glob.glob("registered/**/*.py", recursive=True)
-    if not files:
-        print(
-            "No test files found in registered/. "
-            "Are you running from the test/ directory?"
-        )
-        return []
-
-    sys.path.insert(
-        0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "python")
-    )
-    from sglang.test.ci.ci_register import collect_tests
-
-    all_tests = collect_tests(files, sanity_check=True)
-    suite_tests = [t for t in all_tests if t.suite == suite]
-
-    if not suite_tests:
-        print(f"No tests found for suite '{suite}'")
-        return []
-
-    return suite_tests
-
-
 def main():
-    parser = argparse.ArgumentParser(
-        description="Warmup DeepGEMM JIT compilation for CI test suites"
-    )
-    parser.add_argument("--suite", type=str, required=True, help="CI test suite name")
-    parser.add_argument(
-        "--tp",
-        type=int,
-        default=8,
-        help="Default tensor parallelism degree (default: 8). "
-        "Overridden by per-model TP extracted from test files.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Only print what would be compiled, don't run",
-    )
-    args = parser.parse_args()
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("Usage: warmup_deep_gemm.py model1:tp1 [model2:tp2 ...]")
+        print("Example: warmup_deep_gemm.py deepseek-ai/DeepSeek-V3-0324:8")
+        sys.exit(0)
 
-    print(f"=== DeepGEMM Warmup for suite: {args.suite} ===\n")
+    # Parse model:tp pairs
+    model_tp_pairs = []
+    for arg in sys.argv[1:]:
+        if ":" not in arg:
+            print(f"Error: expected model:tp format, got '{arg}'")
+            sys.exit(1)
+        model, tp_str = arg.rsplit(":", 1)
+        model_tp_pairs.append((model, int(tp_str)))
 
-    # Step 1: Discover test files for the suite
-    suite_tests = discover_suite_files(args.suite)
-    if not suite_tests:
-        print("No test files to process. Exiting.")
+    print(f"=== DeepGEMM Warmup ({len(model_tp_pairs)} model(s) requested) ===\n")
+
+    # Filter to models in HF cache
+    cached = []
+    for model, tp in model_tp_pairs:
+        if model_in_hf_cache(model):
+            cached.append((model, tp))
+            print(f"  FOUND  {model} (tp={tp})")
+        else:
+            print(f"  SKIP   {model} (tp={tp}): not in HF cache")
+
+    if not cached:
+        print("\nNo requested models found in HF cache. Done.")
         return
 
-    print(f"Found {len(suite_tests)} test file(s) in suite '{args.suite}':")
-    for t in suite_tests:
-        status = "DISABLED" if t.disabled else "enabled"
-        print(f"  {t.filename} ({status})")
-    print()
-
-    # Step 2: Extract (model, tp) pairs from test files
-    external_constants = get_test_utils_constants()
-    print(f"Loaded {len(external_constants)} model constants from test_utils.py")
-
-    all_model_tp_pairs = []  # list of (model, tp)
-    file_models = {}  # filepath -> set of model names (for deepgemm disable check)
-    seen_pairs = set()
-    for t in suite_tests:
-        pairs = extract_models_from_file(t.filename, external_constants, args.tp)
-        models_in_file = set()
-        for model, tp in pairs:
-            models_in_file.add(model)
-            key = (model, tp)
-            if key not in seen_pairs:
-                seen_pairs.add(key)
-                all_model_tp_pairs.append((model, tp))
-        if models_in_file:
-            file_models[t.filename] = models_in_file
-
-    print(f"\nDiscovered {len(all_model_tp_pairs)} unique (model, tp) pair(s):")
-    for model, tp in sorted(all_model_tp_pairs):
-        print(f"  {model} (tp={tp})")
-    print()
-
-    # Step 3: Filter to models that need DeepGEMM warmup
-    warmup_candidates = []
-    for model, tp in sorted(all_model_tp_pairs):
-        if not model_in_hf_cache(model):
-            print(f"  SKIP {model} (tp={tp}): not in HF cache")
-            continue
-
-        config = get_config_json(model)
-        if not is_moe_model(config):
-            print(f"  SKIP {model} (tp={tp}): not an MoE model")
-            continue
-
-        # Check if any test file using this model explicitly disables DeepGEMM
-        disabled = False
-        for filepath, models in file_models.items():
-            if model in models and check_deepgemm_disabled(filepath):
-                disabled = True
-                break
-
-        if disabled:
-            print(f"  SKIP {model} (tp={tp}): DeepGEMM explicitly disabled in test")
-            continue
-
-        warmup_candidates.append((model, tp, config))
-        print(f"  NEED {model} (tp={tp}): MoE model in cache, DeepGEMM enabled")
-
-    print()
-
-    if not warmup_candidates:
-        print("No models need DeepGEMM warmup. Done.")
-        return
-
-    # Step 4: Deduplicate by architecture + TP (same kernel dimensions)
+    # Deduplicate by architecture
     arch_groups = {}
-    for model, tp, config in warmup_candidates:
+    for model, tp in cached:
+        config = get_config_json(model)
         key = get_architecture_key(config, tp)
         if key not in arch_groups:
             arch_groups[key] = []
         arch_groups[key].append((model, tp))
 
+    to_warmup = []
     print(
-        f"Architecture deduplication: {len(warmup_candidates)} candidate(s) "
-        f"-> {len(arch_groups)} unique architecture(s)"
+        f"\nDedup: {len(cached)} model(s) -> {len(arch_groups)} unique architecture(s)"
     )
-    models_to_warmup = []  # list of (model, tp)
     for key, group in arch_groups.items():
-        representative = group[0]
-        models_to_warmup.append(representative)
+        rep = group[0]
+        to_warmup.append(rep)
         if len(group) > 1:
-            others = ", ".join(f"{m}" for m, _ in group[1:])
-            print(
-                f"  {key}: using {representative[0]} tp={representative[1]} "
-                f"(also covers: {others})"
-            )
+            others = ", ".join(m for m, _ in group[1:])
+            print(f"  {rep[0]} tp={rep[1]} (also covers: {others})")
         else:
-            print(f"  {key}: {representative[0]} tp={representative[1]}")
-    print()
+            print(f"  {rep[0]} tp={rep[1]}")
 
-    # Step 5: Run compile_deep_gemm for each unique architecture
-    if args.dry_run:
-        print("DRY RUN - would compile for:")
-        for model, tp in models_to_warmup:
-            print(
-                f"  python3 -m sglang.compile_deep_gemm "
-                f"--model {model} --tp {tp} --trust-remote-code"
-            )
-        return
-
-    for i, (model, tp) in enumerate(models_to_warmup, 1):
+    # Run compile_deep_gemm for each unique architecture
+    for i, (model, tp) in enumerate(to_warmup, 1):
         print(f"\n{'=' * 60}")
-        print(f"[{i}/{len(models_to_warmup)}] Warming up: {model} (tp={tp})")
+        print(f"[{i}/{len(to_warmup)}] Warming up: {model} (tp={tp})")
         print(f"{'=' * 60}")
         cmd = [
             sys.executable,
@@ -482,15 +139,12 @@ def main():
         ]
         result = subprocess.run(cmd)
         if result.returncode != 0:
-            print(
-                f"Warning: compile_deep_gemm failed for {model} "
-                f"(exit code {result.returncode})"
-            )
+            print(f"Warning: failed for {model} (exit code {result.returncode})")
             print("Continuing with remaining models...")
         else:
             print(f"Successfully warmed up: {model}")
 
-    print(f"\nDeepGEMM warmup complete for suite '{args.suite}'.")
+    print("\nDeepGEMM warmup complete.")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/cuda/warmup_deep_gemm.py
+++ b/scripts/ci/cuda/warmup_deep_gemm.py
@@ -1,0 +1,405 @@
+"""
+Auto-discover models needing DeepGEMM warmup from CI test suite config.
+
+This script:
+1. Discovers test files for a given CI suite using collect_tests()
+2. Extracts model names from test files via AST parsing
+3. Filters to MoE models present in HF cache that need DeepGEMM
+4. Deduplicates models sharing the same kernel dimensions
+5. Runs compile_deep_gemm for each unique architecture
+
+Usage (from test/ directory):
+    python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8
+    python3 ../scripts/ci/cuda/warmup_deep_gemm.py --suite stage-c-test-8-gpu-h200 --tp 8 --dry-run
+"""
+
+import argparse
+import ast
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_test_utils_constants():
+    """Pre-resolve model name constants from test_utils.py via AST parsing."""
+    # This script runs from test/ directory; test_utils is at ../python/sglang/test/test_utils.py
+    test_utils_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "python",
+        "sglang",
+        "test",
+        "test_utils.py",
+    )
+    test_utils_path = os.path.normpath(test_utils_path)
+
+    if not os.path.exists(test_utils_path):
+        print(f"Warning: test_utils.py not found at {test_utils_path}")
+        return {}
+
+    with open(test_utils_path) as f:
+        tree = ast.parse(f.read(), test_utils_path)
+
+    constants = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
+                if isinstance(node.value.value, str) and "/" in node.value.value:
+                    constants[target.id] = node.value.value
+    return constants
+
+
+def extract_models_from_file(filepath, external_constants):
+    """Extract model names from a test file using AST parsing.
+
+    Patterns:
+    - Module-level: NAME_WITH_MODEL = "org/model"
+    - Class attribute: model = "org/model"
+    - cls.model = "org/model" or cls.model = CONSTANT (in setUpClass)
+    - ModelLaunchSettings("org/model", ...) or ModelLaunchSettings(CONSTANT, ...)
+    """
+    with open(filepath) as f:
+        source = f.read()
+
+    try:
+        tree = ast.parse(source, filepath)
+    except SyntaxError:
+        return set()
+
+    models = set()
+
+    # Build local constant map from module-level assignments
+    local_constants = {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
+                if isinstance(node.value.value, str) and "/" in node.value.value:
+                    local_constants[target.id] = node.value.value
+
+    # Combined lookup: local constants first, then external (test_utils)
+    all_constants = {**external_constants, **local_constants}
+
+    def resolve_value(node):
+        """Resolve a node to a string model path, or None."""
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and "/" in node.value
+        ):
+            return node.value
+        if isinstance(node, ast.Name) and node.id in all_constants:
+            return all_constants[node.id]
+        return None
+
+    for node in ast.walk(tree):
+        # Pattern 1: Module-level constant assignment with MODEL in name
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and "MODEL" in target.id.upper():
+                val = resolve_value(node.value)
+                if val:
+                    models.add(val)
+
+        # Pattern 2: Class-level attribute: model = "org/model"
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and target.id == "model":
+                val = resolve_value(node.value)
+                if val:
+                    models.add(val)
+
+        # Pattern 3: cls.model = ... in setUpClass
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "model"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "cls"
+            ):
+                val = resolve_value(node.value)
+                if val:
+                    models.add(val)
+
+        # Pattern 4: ModelLaunchSettings("org/model", ...) or ModelLaunchSettings(CONST, ...)
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (isinstance(func, ast.Name) and func.id == "ModelLaunchSettings") or (
+                isinstance(func, ast.Attribute) and func.attr == "ModelLaunchSettings"
+            ):
+                if node.args:
+                    val = resolve_value(node.args[0])
+                    if val:
+                        models.add(val)
+
+    return models
+
+
+def check_deepgemm_disabled(filepath):
+    """Check if a test file explicitly disables DeepGEMM."""
+    with open(filepath) as f:
+        source = f.read()
+    if "SGLANG_ENABLE_JIT_DEEPGEMM" not in source:
+        return False
+    # Match patterns like: SGLANG_ENABLE_JIT_DEEPGEMM...False/0/false
+    # Covers: .set(False), .override(False), env["..."] = "0", "...": "False"
+    return bool(re.search(r'SGLANG_ENABLE_JIT_DEEPGEMM.*(?:False|"0"|"false")', source))
+
+
+def model_in_hf_cache(model_name):
+    """Check if a model exists in the HF cache."""
+    cache_dir = os.environ.get(
+        "HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
+    )
+    hub_dir = os.path.join(cache_dir, "hub")
+
+    # HF cache stores models as models--org--name
+    safe_name = "models--" + model_name.replace("/", "--")
+    model_cache_path = os.path.join(hub_dir, safe_name)
+
+    if os.path.isdir(model_cache_path):
+        # Check that there's at least one snapshot
+        snapshots_dir = os.path.join(model_cache_path, "snapshots")
+        if os.path.isdir(snapshots_dir) and os.listdir(snapshots_dir):
+            return True
+    return False
+
+
+def get_config_json(model_name):
+    """Load config.json for a cached model, returning the parsed dict or None."""
+    cache_dir = os.environ.get(
+        "HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
+    )
+    hub_dir = os.path.join(cache_dir, "hub")
+    safe_name = "models--" + model_name.replace("/", "--")
+    snapshots_dir = os.path.join(hub_dir, safe_name, "snapshots")
+
+    if not os.path.isdir(snapshots_dir):
+        return None
+
+    # Use the most recent snapshot
+    snapshots = sorted(
+        Path(snapshots_dir).iterdir(), key=lambda p: p.stat().st_mtime, reverse=True
+    )
+    for snapshot in snapshots:
+        config_path = snapshot / "config.json"
+        if config_path.exists():
+            with open(config_path) as f:
+                return json.load(f)
+
+    return None
+
+
+def is_moe_model(config):
+    """Check if a model config indicates an MoE architecture."""
+    if config is None:
+        return False
+
+    moe_fields = ["num_local_experts", "n_routed_experts", "num_experts"]
+    for field in moe_fields:
+        val = config.get(field, 0)
+        if isinstance(val, int) and val > 0:
+            return True
+
+    return False
+
+
+def get_architecture_key(config):
+    """Get a key that identifies the kernel dimensions for deduplication.
+
+    Models with the same (num_experts, hidden_size, intermediate_size) share
+    the same DeepGEMM kernel shapes.
+    """
+    if config is None:
+        return None
+
+    num_experts = (
+        config.get("num_local_experts")
+        or config.get("n_routed_experts")
+        or config.get("num_experts")
+        or 0
+    )
+    hidden_size = config.get("hidden_size", 0)
+    intermediate_size = config.get("intermediate_size") or config.get(
+        "moe_intermediate_size", 0
+    )
+
+    return (num_experts, hidden_size, intermediate_size)
+
+
+def discover_suite_files(suite):
+    """Discover test files for a suite using collect_tests()."""
+    # We run from the test/ directory, same as run_suite.py
+    files = glob.glob("registered/**/*.py", recursive=True)
+    if not files:
+        print(
+            f"No test files found in registered/. Are you running from the test/ directory?"
+        )
+        return []
+
+    # Import collect_tests from ci_register
+    sys.path.insert(
+        0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "python")
+    )
+    from sglang.test.ci.ci_register import collect_tests
+
+    all_tests = collect_tests(files, sanity_check=True)
+
+    # Filter to our suite (both per-commit and nightly)
+    suite_tests = [t for t in all_tests if t.suite == suite]
+
+    if not suite_tests:
+        print(f"No tests found for suite '{suite}'")
+        return []
+
+    return suite_tests
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Warmup DeepGEMM JIT compilation for CI test suites"
+    )
+    parser.add_argument("--suite", type=str, required=True, help="CI test suite name")
+    parser.add_argument(
+        "--tp", type=int, default=8, help="Tensor parallelism degree (default: 8)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print what would be compiled, don't run",
+    )
+    args = parser.parse_args()
+
+    print(f"=== DeepGEMM Warmup for suite: {args.suite} ===\n")
+
+    # Step 1: Discover test files for the suite
+    suite_tests = discover_suite_files(args.suite)
+    if not suite_tests:
+        print("No test files to process. Exiting.")
+        return
+
+    print(f"Found {len(suite_tests)} test file(s) in suite '{args.suite}':")
+    for t in suite_tests:
+        status = "DISABLED" if t.disabled else "enabled"
+        print(f"  {t.filename} ({status})")
+    print()
+
+    # Step 2: Extract model names from test files
+    external_constants = get_test_utils_constants()
+    print(f"Loaded {len(external_constants)} model constants from test_utils.py")
+
+    all_models = set()
+    file_models = {}
+    for t in suite_tests:
+        models = extract_models_from_file(t.filename, external_constants)
+        if models:
+            file_models[t.filename] = models
+            all_models.update(models)
+
+    print(f"\nDiscovered {len(all_models)} unique model(s) across all test files:")
+    for m in sorted(all_models):
+        print(f"  {m}")
+    print()
+
+    # Step 3: Filter to models that need DeepGEMM warmup
+    warmup_candidates = []
+    for model in sorted(all_models):
+        # Check if model is in HF cache
+        if not model_in_hf_cache(model):
+            print(f"  SKIP {model}: not in HF cache")
+            continue
+
+        # Check config for MoE
+        config = get_config_json(model)
+        if not is_moe_model(config):
+            print(f"  SKIP {model}: not an MoE model")
+            continue
+
+        # Check if any test file that uses this model explicitly disables DeepGEMM
+        disabled = False
+        for filepath, models in file_models.items():
+            if model in models and check_deepgemm_disabled(filepath):
+                disabled = True
+                break
+
+        if disabled:
+            print(f"  SKIP {model}: DeepGEMM explicitly disabled in test")
+            continue
+
+        warmup_candidates.append((model, config))
+        print(f"  NEED {model}: MoE model in cache, DeepGEMM enabled")
+
+    print()
+
+    if not warmup_candidates:
+        print("No models need DeepGEMM warmup. Done.")
+        return
+
+    # Step 4: Deduplicate by architecture (same kernel dimensions)
+    arch_groups = {}
+    for model, config in warmup_candidates:
+        key = get_architecture_key(config)
+        if key not in arch_groups:
+            arch_groups[key] = []
+        arch_groups[key].append(model)
+
+    print(
+        f"Architecture deduplication: {len(warmup_candidates)} model(s) -> {len(arch_groups)} unique architecture(s)"
+    )
+    models_to_warmup = []
+    for key, group in arch_groups.items():
+        representative = group[0]
+        models_to_warmup.append(representative)
+        if len(group) > 1:
+            print(
+                f"  Architecture {key}: using {representative} (also covers: {', '.join(group[1:])})"
+            )
+        else:
+            print(f"  Architecture {key}: {representative}")
+    print()
+
+    # Step 5: Run compile_deep_gemm for each unique architecture
+    if args.dry_run:
+        print("DRY RUN - would compile for:")
+        for model in models_to_warmup:
+            print(
+                f"  python3 -m sglang.compile_deep_gemm --model {model} --tp {args.tp} --trust-remote-code"
+            )
+        return
+
+    for i, model in enumerate(models_to_warmup, 1):
+        print(f"\n{'='*60}")
+        print(f"[{i}/{len(models_to_warmup)}] Warming up: {model}")
+        print(f"{'='*60}")
+        cmd = [
+            sys.executable,
+            "-m",
+            "sglang.compile_deep_gemm",
+            "--model",
+            model,
+            "--tp",
+            str(args.tp),
+            "--trust-remote-code",
+        ]
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            print(
+                f"Warning: compile_deep_gemm failed for {model} (exit code {result.returncode})"
+            )
+            print("Continuing with remaining models...")
+        else:
+            print(f"Successfully warmed up: {model}")
+
+    print(f"\nDeepGEMM warmup complete for suite '{args.suite}'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/cuda/warmup_deep_gemm.py
+++ b/scripts/ci/cuda/warmup_deep_gemm.py
@@ -477,6 +477,8 @@ def main():
             "--tp",
             str(tp),
             "--trust-remote-code",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true, "num_threads": 64}',
         ]
         result = subprocess.run(cmd)
         if result.returncode != 0:

--- a/scripts/ci/cuda/warmup_deep_gemm.py
+++ b/scripts/ci/cuda/warmup_deep_gemm.py
@@ -1,8 +1,12 @@
 """
-Warmup DeepGEMM JIT compilation for specified models.
+Lightweight DeepGEMM JIT compilation warmup without loading model weights.
 
-Takes an explicit list of model:tp pairs. Skips models not in HF cache
-and deduplicates models sharing the same architecture.
+Reads model config.json from HF cache to derive kernel shapes, then compiles
+DeepGEMM kernels directly. This avoids the expensive model weight loading step
+that the full `sglang.compile_deep_gemm` requires.
+
+Supports DeepSeek V2/V3 family models. Falls back to `sglang.compile_deep_gemm`
+for unsupported architectures.
 
 Usage:
     python3 scripts/ci/cuda/warmup_deep_gemm.py \
@@ -14,22 +18,22 @@ import json
 import os
 import subprocess
 import sys
+import time
+from math import ceil
 from pathlib import Path
 
+# Configure DeepGEMM cache before importing deep_gemm
+os.environ["DG_JIT_CACHE_DIR"] = os.getenv(
+    "SGLANG_DG_CACHE_DIR",
+    os.path.join(os.path.expanduser("~"), ".cache", "deep_gemm"),
+)
+os.environ["DG_JIT_USE_NVRTC"] = os.getenv("SGL_DG_USE_NVRTC", "0")
 
-def model_in_hf_cache(model_name):
-    """Check if a model exists in the HF cache."""
-    cache_dir = os.environ.get(
-        "HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
-    )
-    hub_dir = os.path.join(cache_dir, "hub")
-    safe_name = "models--" + model_name.replace("/", "--")
-    snapshots_dir = os.path.join(hub_dir, safe_name, "snapshots")
-    return os.path.isdir(snapshots_dir) and bool(os.listdir(snapshots_dir))
+BLOCK_SIZE = 128
 
 
 def get_config_json(model_name):
-    """Load config.json for a cached model."""
+    """Load config.json for a cached model from HF cache."""
     cache_dir = os.environ.get(
         "HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
     )
@@ -51,27 +55,269 @@ def get_config_json(model_name):
     return None
 
 
+def is_deepseek_v2v3(config):
+    """Check if a model is from the DeepSeek V2/V3 family."""
+    architectures = config.get("architectures", [])
+    model_type = config.get("model_type", "")
+    return any(
+        "DeepseekV2" in a or "DeepseekV3" in a for a in architectures
+    ) or model_type in ("deepseek_v2", "deepseek_v3")
+
+
+def compute_deepseek_v2v3_shapes(config, tp):
+    """Compute all DeepGEMM (kernel_type, N, K, num_groups) for DeepSeek V2/V3.
+
+    Shape derivation based on:
+    - MoE: python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+    - MLA: python/sglang/srt/models/deepseek_v2.py
+    - FP8: python/sglang/srt/layers/quantization/fp8_kernel.py
+    """
+    shapes = []
+
+    hidden_size = config["hidden_size"]
+    num_attention_heads = config.get("num_attention_heads", 128)
+    kv_lora_rank = config.get("kv_lora_rank", 512)
+    qk_nope_head_dim = config.get("qk_nope_head_dim", 128)
+    v_head_dim = config.get("v_head_dim", 128)
+    n_routed_experts = config.get("n_routed_experts", 0)
+    n_shared_experts = config.get("n_shared_experts", 0)
+    moe_intermediate_size = config.get("moe_intermediate_size", 0)
+
+    num_local_heads = num_attention_heads // tp
+    # Shared expert fusion is enabled by default (disable_shared_experts_fusion=False)
+    # so the FusedMoE weight tensor includes shared experts
+    num_local_experts = n_routed_experts + n_shared_experts
+
+    # --- MoE expert GEMM shapes ---
+    # FusedMoE shards intermediate_size across TP ranks (column parallel for gate/up,
+    # row parallel for down). All experts are replicated on each TP rank.
+    if n_routed_experts > 0 and moe_intermediate_size > 0:
+        moe_inter_per_tp = moe_intermediate_size // tp
+
+        # Gate-Up projection: (tokens, hidden_size) @ (experts, 2*inter_per_tp, hidden_size)^T
+        # Both masked and contiguous paths are used at runtime
+        shapes.append(("MASKED", moe_inter_per_tp * 2, hidden_size, num_local_experts))
+        shapes.append(("CONTIG", moe_inter_per_tp * 2, hidden_size, num_local_experts))
+
+        # Down projection: (tokens, inter_per_tp) @ (experts, hidden_size, inter_per_tp)^T
+        shapes.append(("MASKED", hidden_size, moe_inter_per_tp, num_local_experts))
+        shapes.append(("CONTIG", hidden_size, moe_inter_per_tp, num_local_experts))
+
+    # --- MLA attention GEMM shapes (masked grouped GEMM) ---
+    if kv_lora_rank > 0 and num_local_heads > 0:
+        # Q_nope -> compressed K: (heads, m, qk_nope_head_dim) @ (heads, kv_lora_rank, qk_nope_head_dim)^T
+        shapes.append(("MASKED", kv_lora_rank, qk_nope_head_dim, num_local_heads))
+
+        # Attention output -> V: (heads, m, kv_lora_rank) @ (heads, v_head_dim, kv_lora_rank)^T
+        shapes.append(("MASKED", v_head_dim, kv_lora_rank, num_local_heads))
+
+    # --- kv_b_proj (non-grouped GEMM via FP8 kernel) ---
+    # ColumnParallelLinear(kv_lora_rank, num_heads * (qk_nope + v_head_dim))
+    # Per TP rank: N = num_local_heads * (qk_nope_head_dim + v_head_dim)
+    if kv_lora_rank > 0 and num_local_heads > 0:
+        kv_b_proj_n = num_local_heads * (qk_nope_head_dim + v_head_dim)
+        shapes.append(("NORMAL", kv_b_proj_n, kv_lora_rank, 1))
+
+    return shapes
+
+
 def get_architecture_key(config, tp):
     """Key for dedup: models with same key share DeepGEMM kernels."""
     if config is None:
         return None
-    num_experts = (
-        config.get("num_local_experts")
-        or config.get("n_routed_experts")
-        or config.get("num_experts")
-        or 0
+    fields = [
+        config.get("hidden_size", 0),
+        config.get("moe_intermediate_size", 0),
+        config.get("n_routed_experts", 0),
+        config.get("n_shared_experts", 0),
+        config.get("num_attention_heads", 0),
+        config.get("kv_lora_rank", 0),
+        config.get("qk_nope_head_dim", 0),
+        config.get("v_head_dim", 0),
+        tp,
+    ]
+    return tuple(fields)
+
+
+def compute_m_list(fast_warmup=False, chunked_prefill_size=8192):
+    """Compute the list of M values to compile (matches compile_utils.py logic)."""
+    m_list = []
+    if fast_warmup:
+        m_list += list(range(1, 1025))
+        next_m, sample_step = 1024, 2
+        max_prefill_bs = min(chunked_prefill_size, 32 * 1024)
+        while next_m < max_prefill_bs:
+            m_list += list(range(next_m, 2 * next_m, sample_step))
+            next_m *= 2
+            sample_step *= 2
+        m_list.append(max_prefill_bs)
+        m_list = sorted(set(m_list))
+    else:
+        m_max = 16 * 1024
+        if chunked_prefill_size > 8192:
+            m_max = chunked_prefill_size * 2
+        m_max = min(128 * 1024, m_max)
+        m_list = list(range(1, m_max + 1))
+    return m_list
+
+
+def _empty_token_fp8(size):
+    """Create FP8 token tensor + per-block scale tensor."""
+    import torch
+
+    *dims, k = size
+    return (
+        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
+        torch.empty((*dims, ceil(k / BLOCK_SIZE)), device="cuda", dtype=torch.float32),
     )
-    hidden_size = config.get("hidden_size", 0)
-    intermediate_size = config.get("intermediate_size") or config.get(
-        "moe_intermediate_size", 0
+
+
+def _empty_block_fp8(size):
+    """Create FP8 block tensor + per-block scale tensor."""
+    import torch
+
+    *dims, n, k = size
+    return (
+        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
+        torch.empty(
+            (*dims, ceil(n / BLOCK_SIZE), ceil(k / BLOCK_SIZE)),
+            device="cuda",
+            dtype=torch.float32,
+        ),
     )
-    return (num_experts, hidden_size, intermediate_size, tp)
+
+
+def get_memory_requirement(kernel_type, max_m, n, k, num_groups):
+    """Estimate GPU memory needed in GB for compilation buffers."""
+    _GB = 1 << 30
+    if kernel_type == "NORMAL":
+        return (max_m * k + n * k + max_m * n * 2) / _GB
+    elif kernel_type == "CONTIG":
+        return (max_m * k + num_groups * n * k + max_m * 4 + max_m * n * 2) / _GB
+    elif kernel_type == "MASKED":
+        return (
+            num_groups * max_m * k
+            + num_groups * n * k
+            + num_groups * 4
+            + num_groups * max_m * n * 2
+        ) / _GB
+    return 0
+
+
+def compile_one_shape(kernel_type, n, k, num_groups, m_list):
+    """Compile DeepGEMM kernels for one (kernel_type, N, K, num_groups) shape."""
+    import deep_gemm
+    import torch
+    from tqdm import tqdm
+
+    # Filter M list for contiguous layout alignment
+    if kernel_type == "CONTIG":
+        m_alignment = deep_gemm.get_mk_alignment_for_contiguous_layout()
+        m_list = sorted(set(m for m in m_list if m % m_alignment == 0))
+
+    if not m_list:
+        return
+
+    max_m = max(m_list)
+
+    # Reduce max_m if not enough GPU memory
+    mem_free = torch.cuda.mem_get_info()[0] / (1 << 30)
+    mem_required = get_memory_requirement(kernel_type, max_m, n, k, num_groups)
+    if mem_required > mem_free:
+        while (
+            get_memory_requirement(kernel_type, max_m, n, k, num_groups) > mem_free
+            and max_m > 4096
+        ):
+            max_m //= 2
+        print(
+            f"  Memory {mem_free:.1f}GB < required {mem_required:.1f}GB, "
+            f"reducing max_m to {max_m}"
+        )
+        m_list = [m for m in m_list if m <= max_m]
+
+    old_mode = deep_gemm.get_compile_mode()
+    deep_gemm.set_compile_mode(1)
+    try:
+        if kernel_type == "NORMAL":
+            lhs_q, lhs_s = _empty_token_fp8((max_m, k))
+            rhs_q, rhs_s = _empty_block_fp8((n, k))
+            out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+            for m in tqdm(m_list, desc=f"  NORMAL N={n} K={k}"):
+                deep_gemm.fp8_gemm_nt((lhs_q[:m], lhs_s[:m]), (rhs_q, rhs_s), out[:m])
+
+        elif kernel_type == "CONTIG":
+            lhs_q, lhs_s = _empty_token_fp8((max_m, k))
+            rhs_q, rhs_s = _empty_block_fp8((num_groups, n, k))
+            m_indices = torch.zeros((max_m,), device="cuda", dtype=torch.int32)
+            out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+            for m in tqdm(m_list, desc=f"  CONTIG N={n} K={k} G={num_groups}"):
+                deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
+                    (lhs_q[:m], lhs_s[:m]),
+                    (rhs_q, rhs_s),
+                    out[:m],
+                    m_indices=m_indices[:m],
+                )
+
+        elif kernel_type == "MASKED":
+            lhs_q, lhs_s = _empty_token_fp8((num_groups, max_m, k))
+            rhs_q, rhs_s = _empty_block_fp8((num_groups, n, k))
+            masked_m = torch.zeros((num_groups,), device="cuda", dtype=torch.int32)
+            out = torch.empty(
+                (num_groups, max_m, n), device="cuda", dtype=torch.bfloat16
+            )
+            for m in tqdm(m_list, desc=f"  MASKED N={n} K={k} G={num_groups}"):
+                deep_gemm.fp8_m_grouped_gemm_nt_masked(
+                    (lhs_q, lhs_s),
+                    (rhs_q, rhs_s),
+                    out,
+                    masked_m=masked_m,
+                    expected_m=m,
+                )
+    finally:
+        deep_gemm.set_compile_mode(old_mode)
+
+    torch.cuda.current_stream().synchronize()
+    torch.cuda.empty_cache()
+
+
+def compile_shapes_lightweight(shapes, m_list):
+    """Compile all DeepGEMM shapes directly (no model loading)."""
+    for i, (kernel_type, n, k, num_groups) in enumerate(shapes, 1):
+        print(f"\n[{i}/{len(shapes)}] {kernel_type} N={n} K={k} G={num_groups}")
+        t0 = time.time()
+        compile_one_shape(kernel_type, n, k, num_groups, m_list)
+        elapsed = time.time() - t0
+        print(f"  Done in {elapsed:.1f}s")
+
+
+def fallback_compile_deep_gemm(model, tp):
+    """Fall back to full sglang.compile_deep_gemm (loads model weights)."""
+    print(f"Falling back to full compile_deep_gemm for {model} (tp={tp})...")
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang.compile_deep_gemm",
+        "--model",
+        model,
+        "--tp",
+        str(tp),
+        "--trust-remote-code",
+        "--model-loader-extra-config",
+        '{"enable_multithread_load": true, "num_threads": 64}',
+    ]
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"Warning: fallback failed for {model} (exit code {result.returncode})")
+    return result.returncode == 0
 
 
 def main():
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
         print("Usage: warmup_deep_gemm.py model1:tp1 [model2:tp2 ...]")
-        print("Example: warmup_deep_gemm.py deepseek-ai/DeepSeek-V3-0324:8")
+        print("\nDerives DeepGEMM kernel shapes from config.json without loading model")
+        print(
+            "weights. Falls back to full compile_deep_gemm for unknown architectures."
+        )
         sys.exit(0)
 
     # Parse model:tp pairs
@@ -83,68 +329,70 @@ def main():
         model, tp_str = arg.rsplit(":", 1)
         model_tp_pairs.append((model, int(tp_str)))
 
-    print(f"=== DeepGEMM Warmup ({len(model_tp_pairs)} model(s) requested) ===\n")
+    fast_warmup = os.environ.get("SGLANG_JIT_DEEPGEMM_FAST_WARMUP", "0").lower() in (
+        "1",
+        "true",
+    )
+    print(f"=== DeepGEMM Lightweight Warmup ({len(model_tp_pairs)} model(s)) ===")
+    print(f"    Fast warmup: {fast_warmup}")
+    print(
+        f"    Cache dir: {os.environ.get('DG_JIT_CACHE_DIR', '~/.cache/deep_gemm')}\n"
+    )
 
-    # Filter to models in HF cache
-    cached = []
+    # Load configs and deduplicate by architecture
+    seen_keys = {}
+    to_process = []  # (model, tp, config_or_None, shapes_or_None)
+
     for model, tp in model_tp_pairs:
-        if model_in_hf_cache(model):
-            cached.append((model, tp))
-            print(f"  FOUND  {model} (tp={tp})")
-        else:
-            print(f"  SKIP   {model} (tp={tp}): not in HF cache")
+        config = get_config_json(model)
+        if config is None:
+            print(f"  SKIP   {model} (tp={tp}): config.json not in HF cache")
+            continue
 
-    if not cached:
-        print("\nNo requested models found in HF cache. Done.")
+        key = get_architecture_key(config, tp)
+        if key in seen_keys:
+            print(f"  DEDUP  {model} (tp={tp}): same shapes as {seen_keys[key]}")
+            continue
+
+        if is_deepseek_v2v3(config):
+            shapes = compute_deepseek_v2v3_shapes(config, tp)
+            seen_keys[key] = model
+            to_process.append((model, tp, config, shapes))
+            print(f"  FOUND  {model} (tp={tp}): {len(shapes)} DeepGEMM shape(s)")
+        else:
+            # Unknown architecture: will use fallback
+            seen_keys[key] = model
+            to_process.append((model, tp, config, None))
+            arch = config.get("architectures", ["unknown"])
+            print(f"  FOUND  {model} (tp={tp}): unknown arch {arch}, will use fallback")
+
+    if not to_process:
+        print("\nNo models to process. Done.")
         return
 
-    # Deduplicate by architecture
-    arch_groups = {}
-    for model, tp in cached:
-        config = get_config_json(model)
-        key = get_architecture_key(config, tp)
-        if key not in arch_groups:
-            arch_groups[key] = []
-        arch_groups[key].append((model, tp))
+    m_list = compute_m_list(fast_warmup=fast_warmup)
+    print(f"\nM list: {len(m_list)} values (range {min(m_list)}-{max(m_list)})")
 
-    to_warmup = []
-    print(
-        f"\nDedup: {len(cached)} model(s) -> {len(arch_groups)} unique architecture(s)"
-    )
-    for key, group in arch_groups.items():
-        rep = group[0]
-        to_warmup.append(rep)
-        if len(group) > 1:
-            others = ", ".join(m for m, _ in group[1:])
-            print(f"  {rep[0]} tp={rep[1]} (also covers: {others})")
-        else:
-            print(f"  {rep[0]} tp={rep[1]}")
-
-    # Run compile_deep_gemm for each unique architecture
-    for i, (model, tp) in enumerate(to_warmup, 1):
+    for model, tp, config, shapes in to_process:
         print(f"\n{'=' * 60}")
-        print(f"[{i}/{len(to_warmup)}] Warming up: {model} (tp={tp})")
+        print(f"Model: {model} (tp={tp})")
         print(f"{'=' * 60}")
-        cmd = [
-            sys.executable,
-            "-m",
-            "sglang.compile_deep_gemm",
-            "--model",
-            model,
-            "--tp",
-            str(tp),
-            "--trust-remote-code",
-            "--model-loader-extra-config",
-            '{"enable_multithread_load": true, "num_threads": 64}',
-        ]
-        result = subprocess.run(cmd)
-        if result.returncode != 0:
-            print(f"Warning: failed for {model} (exit code {result.returncode})")
-            print("Continuing with remaining models...")
-        else:
-            print(f"Successfully warmed up: {model}")
 
-    print("\nDeepGEMM warmup complete.")
+        if shapes is None:
+            # Unknown architecture: fall back to full compile_deep_gemm
+            fallback_compile_deep_gemm(model, tp)
+            continue
+
+        # Print shape summary
+        for kernel_type, n, k, num_groups in shapes:
+            print(f"  {kernel_type:8s} N={n:<6d} K={k:<6d} G={num_groups}")
+
+        t0 = time.time()
+        compile_shapes_lightweight(shapes, m_list)
+        elapsed = time.time() - t0
+        print(f"\nCompleted {model} in {elapsed:.1f}s")
+
+    print("\nDeepGEMM lightweight warmup complete.")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/cuda/warmup_server.py
+++ b/scripts/ci/cuda/warmup_server.py
@@ -163,8 +163,6 @@ def warmup_one_model(model, tp, port):
         "--port",
         str(port),
         "--trust-remote-code",
-        "--mem-fraction-static",
-        "0.7",
         "--model-loader-extra-config",
         '{"enable_multithread_load": true, "num_threads": 64}',
     ]

--- a/scripts/ci/cuda/warmup_server.py
+++ b/scripts/ci/cuda/warmup_server.py
@@ -1,0 +1,315 @@
+"""
+Full server warmup to pre-warm Triton autotuning and CUDA graph capture.
+
+On cold H200 nodes (new nodes or after container recreation), CUDA graph capture
+triggers Triton autotuning which takes ~330s per server launch. This script
+launches actual servers with CUDA graphs enabled to cache the autotuned kernels,
+so subsequent test launches are fast (~30-60s).
+
+Uses marker files to skip warmup on already-warm nodes. Marker files are
+invalidated when Python, Triton, or PyTorch versions change.
+
+Usage:
+    python3 scripts/ci/cuda/warmup_server.py \
+        deepseek-ai/DeepSeek-V3-0324:8 \
+        inclusionAI/Ring-2.5-1T:8
+"""
+
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Reuse helpers from warmup_deep_gemm (same directory)
+sys.path.insert(0, os.path.dirname(__file__))
+from warmup_deep_gemm import get_architecture_key, get_config_json
+
+MARKER_DIR = os.path.join(os.path.expanduser("~"), ".cache", "sglang", "warmup_markers")
+HEALTH_POLL_INTERVAL = 10  # seconds between health checks
+SERVER_STARTUP_TIMEOUT = 900  # 15 min max to wait for server ready
+DEFAULT_PORT = 39876
+
+
+def get_version_key():
+    """Hash of Python + Triton + PyTorch versions to invalidate markers on upgrades."""
+    parts = [sys.version]
+    try:
+        import triton
+
+        parts.append(f"triton={triton.__version__}")
+    except ImportError:
+        parts.append("triton=none")
+    try:
+        import torch
+
+        parts.append(f"torch={torch.__version__}")
+    except ImportError:
+        parts.append("torch=none")
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()[:12]
+
+
+def get_marker_path(model, tp):
+    """Get the marker file path for a model:tp pair."""
+    version_key = get_version_key()
+    safe_model = model.replace("/", "--")
+    return os.path.join(
+        MARKER_DIR, f"server_warmup_{safe_model}_tp{tp}_{version_key}.done"
+    )
+
+
+def check_marker(model, tp):
+    """Check if warmup marker exists (node already warm)."""
+    marker = get_marker_path(model, tp)
+    return os.path.exists(marker)
+
+
+def write_marker(model, tp):
+    """Write warmup marker after successful warmup."""
+    marker = get_marker_path(model, tp)
+    os.makedirs(os.path.dirname(marker), exist_ok=True)
+    Path(marker).write_text(
+        json.dumps(
+            {
+                "model": model,
+                "tp": tp,
+                "version_key": get_version_key(),
+                "timestamp": time.time(),
+            }
+        )
+    )
+    print(f"  Wrote marker: {marker}")
+
+
+def kill_server(proc):
+    """Kill server process tree."""
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def wait_for_server(base_url, proc, timeout):
+    """Poll /health_generate until server is ready or timeout."""
+    import requests
+
+    start = time.time()
+    while time.time() - start < timeout:
+        ret = proc.poll()
+        if ret is not None:
+            return False, f"Server exited with code {ret}"
+        try:
+            resp = requests.get(f"{base_url}/health_generate", timeout=5)
+            if resp.status_code == 200:
+                return True, None
+        except requests.RequestException:
+            pass
+        time.sleep(HEALTH_POLL_INTERVAL)
+    return False, "Timed out waiting for server"
+
+
+def send_generate_request(base_url):
+    """Send one /generate request to exercise the full inference path."""
+    import requests
+
+    payload = {
+        "input_ids": [0, 1, 2, 3],
+        "sampling_params": {
+            "max_new_tokens": 8,
+            "temperature": 0,
+        },
+    }
+    try:
+        resp = requests.post(f"{base_url}/generate", json=payload, timeout=120)
+        if resp.status_code == 200:
+            print("  Generate request succeeded")
+        else:
+            print(f"  Warning: generate request returned {resp.status_code}")
+    except requests.RequestException as e:
+        print(f"  Warning: generate request failed: {e}")
+
+
+def warmup_one_model(model, tp, port):
+    """Launch server, wait for ready, send one request, then kill."""
+    base_url = f"http://127.0.0.1:{port}"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        model,
+        "--tp",
+        str(tp),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--trust-remote-code",
+        "--mem-fraction-static",
+        "0.7",
+        "--model-loader-extra-config",
+        '{"enable_multithread_load": true, "num_threads": 64}',
+    ]
+
+    # Use a temp file for server output to avoid pipe buffer deadlock
+    # (server logs can exceed the 64KB pipe buffer during CUDA graph capture)
+    log_file = tempfile.NamedTemporaryFile(
+        mode="w", prefix="warmup_server_", suffix=".log", delete=False
+    )
+    log_path = log_file.name
+
+    print(f"  Launching server: {' '.join(cmd)}")
+    print(f"  Server log: {log_path}")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        preexec_fn=os.setsid,
+    )
+
+    try:
+        # Wait for server to be ready (includes CUDA graph capture)
+        print(
+            f"  Waiting for server (timeout={SERVER_STARTUP_TIMEOUT}s, "
+            f"polling every {HEALTH_POLL_INTERVAL}s)..."
+        )
+        ok, err = wait_for_server(base_url, proc, SERVER_STARTUP_TIMEOUT)
+        if not ok:
+            print(f"  Warning: server not ready: {err}")
+            # Dump last lines of server log for debugging
+            try:
+                log_file.flush()
+                with open(log_path) as f:
+                    lines = f.readlines()
+                for line in lines[-20:]:
+                    print(f"    | {line.rstrip()}")
+            except Exception:
+                pass
+            return False
+
+        print("  Server ready, sending generate request...")
+        send_generate_request(base_url)
+        return True
+
+    finally:
+        print("  Killing server...")
+        kill_server(proc)
+        log_file.close()
+        try:
+            os.unlink(log_path)
+        except OSError:
+            pass
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("Usage: warmup_server.py model1:tp1 [model2:tp2 ...]")
+        print(
+            "\nLaunches full servers with CUDA graphs enabled to pre-warm"
+            " Triton autotuning."
+        )
+        print("Skips instantly on warm nodes (marker file exists).")
+        sys.exit(0)
+
+    # Parse model:tp pairs
+    model_tp_pairs = []
+    for arg in sys.argv[1:]:
+        if ":" not in arg:
+            print(f"Error: expected model:tp format, got '{arg}'")
+            sys.exit(1)
+        model, tp_str = arg.rsplit(":", 1)
+        model_tp_pairs.append((model, int(tp_str)))
+
+    print(f"=== Server CUDA Graph Warmup ({len(model_tp_pairs)} model(s)) ===")
+    print(f"    Marker dir: {MARKER_DIR}")
+    print(f"    Version key: {get_version_key()}\n")
+
+    # Deduplicate by architecture and check markers
+    seen_keys = {}
+    to_warmup = []
+
+    for model, tp in model_tp_pairs:
+        # Check marker first (fast path)
+        if check_marker(model, tp):
+            print(f"  SKIP   {model} (tp={tp}): already warm (marker exists)")
+            continue
+
+        # Architecture dedup
+        config = get_config_json(model)
+        if config is not None:
+            key = get_architecture_key(config, tp)
+            if key in seen_keys:
+                print(
+                    f"  DEDUP  {model} (tp={tp}): same architecture as {seen_keys[key]}"
+                )
+                continue
+            seen_keys[key] = model
+
+        to_warmup.append((model, tp))
+        print(f"  QUEUE  {model} (tp={tp}): needs warmup")
+
+    if not to_warmup:
+        print("\nAll models already warm. Done.")
+        return
+
+    print(f"\n{len(to_warmup)} model(s) to warm up.\n")
+
+    port = DEFAULT_PORT
+    for i, (model, tp) in enumerate(to_warmup, 1):
+        print(f"\n{'=' * 60}")
+        print(f"[{i}/{len(to_warmup)}] {model} (tp={tp})")
+        print(f"{'=' * 60}")
+
+        t0 = time.time()
+        success = warmup_one_model(model, tp, port)
+        elapsed = time.time() - t0
+
+        if success:
+            print(f"  Completed in {elapsed:.0f}s")
+            write_marker(model, tp)
+            # Also write markers for dedup'd models that share this architecture
+            config = get_config_json(model)
+            if config is not None:
+                key = get_architecture_key(config, tp)
+                for other_model, other_tp in model_tp_pairs:
+                    if (other_model, other_tp) == (model, tp):
+                        continue
+                    other_config = get_config_json(other_model)
+                    if other_config is not None:
+                        other_key = get_architecture_key(other_config, other_tp)
+                        if other_key == key and not check_marker(other_model, other_tp):
+                            write_marker(other_model, other_tp)
+                            print(
+                                f"  Also marked {other_model} (tp={other_tp}) as warm (same arch)"
+                            )
+        else:
+            print(
+                f"  Warning: warmup failed after {elapsed:.0f}s (non-fatal, tests will still work)"
+            )
+
+        # Use a different port for the next model to avoid bind conflicts
+        port += 100
+
+    print("\nServer CUDA graph warmup complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/8-gpu-models/test_ring_2_5_1t.py
+++ b/test/registered/8-gpu-models/test_ring_2_5_1t.py
@@ -20,7 +20,6 @@ class TestRing2_5_1T(unittest.TestCase):
 
     def test_ring_2_5_1t(self):
         base_args = [
-            "--tp=8",
             "--trust-remote-code",
             "--model-loader-extra-config",
             '{"enable_multithread_load": true, "num_threads": 64}',


### PR DESCRIPTION
## Summary
- On cold H200 nodes (new nodes or after container recreation), CUDA graph capture triggers Triton autotuning which takes ~330s per server launch (vs ~30-60s on warm nodes). This caused `test_deepseek_v32_basic.py` to [timeout (1200s)](https://github.com/sgl-project/sglang/actions/runs/13479756506/job/37664899503) on new `gmi-h200-wk03` — server startup consumed ~450s, and the test launches 2 servers.
- New `warmup_server.py` launches actual servers with CUDA graphs enabled to pre-cache Triton autotuning results. Uses marker files to skip instantly on warm nodes, with version-key invalidation on library upgrades.
- Added warmup step to `stage-c-test-8-gpu-h200` (DeepSeek-V3-0324 + Ring-2.5-1T) and `stage-c-test-deepep-8-gpu-h200` (DeepSeek-V3-0324).

Followup to #18955

## Test plan
- [ ] On warm node: script detects marker files and skips instantly (<1s)
- [ ] On cold node (delete markers): script launches servers, captures CUDA graphs, writes markers
- [ ] After warmup: CUDA graph capture time drops from ~330s to ~30-60s on subsequent server launches
- [ ] CI: the new step appears between DeepGEMM warmup and test execution