### PR TITLE
fix: add missing blank line after docstring in serving_transcription.py

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -14,6 +14,7 @@
 """
 OpenAI-compatible transcription endpoint handler for Whisper models.
 """
+
 from __future__ import annotations
 
 import io


### PR DESCRIPTION
## Summary
- Fix black formatting lint failure on main by adding a missing blank line between the module docstring and the first import in `serving_transcription.py`

## Test plan
- [x] `pre-commit run --all-files` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)