### PR TITLE
[PD-Disagg] Improve type hints across all `conn.py`

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -261,7 +261,7 @@ class CommonKVManager(BaseKVManager):
 class CommonKVSender(BaseKVSender):
     def __init__(
         self,
-        mgr: BaseKVManager,
+        mgr: CommonKVManager,
         bootstrap_addr: str,
         bootstrap_room: int,
         dest_tp_ranks: List[int],
@@ -322,7 +322,7 @@ class CommonKVReceiver(BaseKVReceiver):
 
     def __init__(
         self,
-        mgr: BaseKVManager,
+        mgr: CommonKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
         prefill_dp_rank: Optional[int] = None,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -5,7 +5,7 @@ import random
 from collections import deque
 from contextlib import nullcontext
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Literal, Optional, Type, overload
 
 import numpy as np
 import torch
@@ -15,6 +15,13 @@ from sglang.srt.environ import envs
 from sglang.srt.utils import is_npu
 
 if TYPE_CHECKING:
+    from sglang.srt.disaggregation.base.conn import KVArgs
+    from sglang.srt.disaggregation.common.conn import (
+        CommonKVBootstrapServer,
+        CommonKVManager,
+        CommonKVReceiver,
+        CommonKVSender,
+    )
     from sglang.srt.managers.schedule_batch import Req
 
 #########################
@@ -258,6 +265,28 @@ class KVClassType(Enum):
     SENDER = "sender"
     RECEIVER = "receiver"
     BOOTSTRAP_SERVER = "bootstrap_server"
+
+
+@overload
+def get_kv_class(
+    transfer_backend: TransferBackend, class_type: Literal[KVClassType.KVARGS]
+) -> Type[KVArgs]: ...
+@overload
+def get_kv_class(
+    transfer_backend: TransferBackend, class_type: Literal[KVClassType.MANAGER]
+) -> Type[CommonKVManager]: ...
+@overload
+def get_kv_class(
+    transfer_backend: TransferBackend, class_type: Literal[KVClassType.SENDER]
+) -> Type[CommonKVSender]: ...
+@overload
+def get_kv_class(
+    transfer_backend: TransferBackend, class_type: Literal[KVClassType.RECEIVER]
+) -> Type[CommonKVReceiver]: ...
+@overload
+def get_kv_class(
+    transfer_backend: TransferBackend, class_type: Literal[KVClassType.BOOTSTRAP_SERVER]
+) -> Type[CommonKVBootstrapServer]: ...
 
 
 def get_kv_class(

--- a/python/sglang/srt/managers/disagg_service.py
+++ b/python/sglang/srt/managers/disagg_service.py
@@ -1,9 +1,7 @@
 """Start bootstrap/kv-store-related server"""
 
 import os
-from typing import Type
 
-from sglang.srt.disaggregation.base import BaseKVBootstrapServer
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     KVClassType,
@@ -22,10 +20,10 @@ def start_disagg_service(
 
     if disagg_mode == DisaggregationMode.PREFILL:
         # only start bootstrap server on prefill tm
-        kv_bootstrap_server_class: Type[BaseKVBootstrapServer] = get_kv_class(
+        kv_bootstrap_server_class = get_kv_class(
             transfer_backend, KVClassType.BOOTSTRAP_SERVER
         )
-        bootstrap_server: BaseKVBootstrapServer = kv_bootstrap_server_class(
+        bootstrap_server = kv_bootstrap_server_class(
             host=server_args.host,
             port=server_args.disaggregation_bootstrap_port,
             dp_size=server_args.dp_size,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2551,6 +2551,9 @@ class ServerArgs:
             logger.warning("KV cache is forced as chunk cache for decode server")
 
         elif self.disaggregation_mode == "prefill":
+            assert (
+                self.disaggregation_transfer_backend != "fake"
+            ), "Prefill server does not support 'fake' as the transfer backend"
             if self.disaggregation_decode_tp is None:
                 self.disaggregation_decode_tp = self.tp_size
             if self.disaggregation_decode_dp is None:


### PR DESCRIPTION
## Motivation

The factory function `get_kv_class` returns `Optional[Type]`, which forces callers to manually annotate variable types (e.g. `kv_manager_class: Type[BaseKVManager]`) to get proper type inference. This PR improves type hints so that the type checker and IDE can infer concrete types automatically.

## Changes

- Add `@overload` signatures to `get_kv_class` with `Literal[KVClassType.*]`, so the return type is precisely inferred per `class_type` argument
- Upgrade type hints from `Base*` to `Common*` (e.g. `BaseKVManager` → `CommonKVManager`) in `common/conn.py`, `decode.py`, and `prefill.py`
- Remove redundant manual type annotations at call sites (now inferred by `@overload`)
- Extract `_is_fake_transfer()` helper in `decode.py` to deduplicate repeated fake-transfer checks
- Simplify fake-backend selection logic in `decode.py` and `prefill.py` (if-else → ternary)
- Add assert in `server_args.py` to reject `--disaggregation-transfer-backend fake` for prefill servers