### PR TITLE
fix(docker): migrate ROCm Dockerfiles from setuptools-rust to maturin

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -214,10 +214,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
 ENV CARGO_BUILD_JOBS=4
 
 # Build and install sgl-model-gateway
-RUN python3 -m pip install --no-cache-dir setuptools-rust \
+RUN python3 -m pip install --no-cache-dir maturin \
     && cd /sgl-workspace/sglang/sgl-model-gateway/bindings/python \
-    && /bin/bash -lc 'ulimit -n 8192 && cargo build --release' \
-    && python3 -m pip install --no-cache-dir . \
+    && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
+    && python3 -m pip install --force-reinstall dist/*.whl \
     && rm -rf /root/.cache
 
 # -----------------------

--- a/docker/rocm720.Dockerfile
+++ b/docker/rocm720.Dockerfile
@@ -243,10 +243,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
 ENV CARGO_BUILD_JOBS=4
 
 # Build and install sgl-model-gateway
-RUN python3 -m pip install --no-cache-dir setuptools-rust \
+RUN python3 -m pip install --no-cache-dir maturin \
     && cd /sgl-workspace/sglang/sgl-model-gateway/bindings/python \
-    && /bin/bash -lc 'ulimit -n 8192 && cargo build --release' \
-    && python3 -m pip install --no-cache-dir . \
+    && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
+    && python3 -m pip install --force-reinstall dist/*.whl \
     && rm -rf /root/.cache
 
 # -----------------------


### PR DESCRIPTION
## Summary

The ROCm Docker image builds are failing because `rocm.Dockerfile` and `rocm720.Dockerfile` still use the old `setuptools-rust` + `cargo build --release` build path for `sgl-model-gateway`, but the project has already migrated to **maturin** as the build backend.

The CUDA `Dockerfile` and `gateway.Dockerfile` were updated in the migration, but the two ROCm Dockerfiles were missed.

Refs: https://github.com/sgl-project/sglang/actions/runs/22321937224/job/64582217549

## What changed

- **`docker/rocm.Dockerfile`** (line 217): Replace `setuptools-rust` build with maturin
- **`docker/rocm720.Dockerfile`** (line 246): Replace `setuptools-rust` build with maturin

In both files:
| Before | After |
|---|---|
| `pip install setuptools-rust` | `pip install maturin` |
| `cargo build --release` | `maturin build --release --features vendored-openssl --out dist` |
| `pip install .` | `pip install --force-reinstall dist/*.whl` |
| `ulimit -n 8192` | `ulimit -n 65536` |

## Why

The `sgl-model-gateway` Python bindings migrated from `setuptools-rust` to `maturin` (via `pyproject.toml`). The old build path fails because:

1. It runs `cargo build --release` without the `vendored-openssl` feature flag
2. It then runs `pip install .` which attempts the legacy setuptools-rust flow
3. This results in Rust compilation errors during the ROCm Docker image build

The fix aligns the ROCm Dockerfiles with the approach already used in `Dockerfile` and `gateway.Dockerfile`.

## Test plan

- [ ] ROCm Docker image build succeeds with `rocm.Dockerfile`
- [ ] ROCm 7.2 Docker image build succeeds with `rocm720.Dockerfile`
- [ ] `sglang_router` package is importable in the resulting images