### PR TITLE
[PD-Disagg] Support `FAKE` transfer backend for more cases

### DIFF
--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -28,6 +28,9 @@ class FakeKVManager(BaseKVManager):
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
 
+    def register_to_bootstrap(self):
+        pass
+
 
 class FakeKVSender(BaseKVSender):
     def __init__(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1532,7 +1532,10 @@ class Scheduler(
 
             if self.disaggregation_mode != DisaggregationMode.NULL:
                 # Invalid request for disaggregated mode
-                if recv_req.bootstrap_room is None:
+                if (
+                    recv_req.bootstrap_room is None
+                    and self.transfer_backend != TransferBackend.FAKE
+                ):
                     error_msg = (
                         f"Invalid request: Disaggregated request received without "
                         f"bootstrap room id. {req.rid=}"


### PR DESCRIPTION
Prev #18345 refactor the `--disaggregation-decode-enable-fake-auto` into `FAKE` transfer backend. But the former implementation only works when dp attention and `follow_bootstrap_room` are enabled.

This PR enables more cases.