### PR TITLE
fix(grpc): handle embedding requests in _handle_batch_output

### DIFF
--- a/python/sglang/srt/grpc/grpc_request_manager.py
+++ b/python/sglang/srt/grpc/grpc_request_manager.py
@@ -659,12 +659,14 @@ class GrpcRequestManager:
             }
 
             # Accumulate logprobs (following tokenizer_manager pattern)
-            if state.obj.return_logprob:
+            # Use getattr for safe access - not all request types have return_logprob
+            # (e.g., TokenizedEmbeddingReqInput)
+            if getattr(state.obj, "return_logprob", False):
                 self._convert_logprob_style(state, batch_out, i)
 
             # Send input logprobs based if available
             if (
-                state.obj.return_logprob
+                getattr(state.obj, "return_logprob", False)
                 and state.obj.logprob_start_len >= 0
                 and state.input_token_logprobs_val
             ):
@@ -688,7 +690,7 @@ class GrpcRequestManager:
 
             # Send output logprobs if available
             if (
-                state.obj.return_logprob
+                getattr(state.obj, "return_logprob", False)
                 and batch_out.output_token_logprobs_val
                 and i < len(batch_out.output_token_logprobs_val)
             ):


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'TokenizedEmbeddingReqInput' object has no attribute 'return_logprob'` crash when serving embedding models via gRPC without `--is-embedding`.

## What changed

- **`python/sglang/srt/grpc/grpc_request_manager.py`**: Replace 3 direct `state.obj.return_logprob` accesses with `getattr(state.obj, "return_logprob", False)`, matching the safe pattern already used in `tokenizer_manager.py`.

## Why

When an embedding model is launched without `--is-embedding`, the scheduler sends `BatchTokenIDOutput` (instead of `BatchEmbeddingOutput`), routing to `_handle_batch_output`. The state object is a `TokenizedEmbeddingReqInput` which lacks `return_logprob`, causing a crash.

## Test plan

- [ ] Serve embedding model via gRPC without `--is-embedding`, send `/v1/embeddings` request — no crash
- [ ] Serve embedding model via gRPC with `--is-embedding` — still works as before
- [ ] Generation models via gRPC with logprobs — still works as before