### PR TITLE
fix: use consistent time denominator for throughput metrics in bench_one_batch_server

### DIFF
--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -581,8 +581,8 @@ def run_one_case(
 
     # Compute metrics
     latency = time.perf_counter() - tic
-    input_throughput = batch_size * input_len / last_ttft
-    output_throughput = batch_size * output_len / (latency - last_ttft)
+    input_throughput = batch_size * input_len / latency
+    output_throughput = batch_size * output_len / latency
     overall_throughput = batch_size * (input_len + output_len) / latency
 
     if backend == "vllm":


### PR DESCRIPTION
## Summary
- Fixed `input_throughput` and `output_throughput` in `bench_one_batch_server` to use the same wall-clock `latency` denominator as `overall_throughput`
- Previously they used different time windows (`last_ttft` and `latency - last_ttft`), so `input_throughput + output_throughput != overall_throughput`
- Now all three metrics are consistent, matching the approach in `bench_serving.py`

Fixes #18712