### PR TITLE
fix(gateway): pin internal crate dependencies to exact versions

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -75,16 +75,16 @@ url = "2.5.4"
 validator = { version = "0.20.0", features = ["derive"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 anyhow = "1.0"
-reasoning-parser = "~1.0.0"
-openai-protocol = { version = "~1.0.0", features = ["axum"] }
-tool-parser = "~1.0.0"
-llm-tokenizer = "~1.0.0"
-smg-auth = "~1.0.0"
-wfaas = "~1.0.0"
-data-connector = "~1.0.0"
-smg-mcp = "~1.0.0"
-smg-wasm = "~1.0.0"
-smg-mesh = "~1.0.0"
+reasoning-parser = "=1.0.0"
+openai-protocol = { version = "=1.0.0", features = ["axum"] }
+tool-parser = "=1.0.0"
+llm-tokenizer = "=1.0.0"
+smg-auth = "=1.0.0"
+wfaas = "=1.0.0"
+data-connector = "=1.0.0"
+smg-mcp = "=1.0.0"
+smg-wasm = "=1.0.0"
+smg-mesh = "=1.0.0"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2.2"
 openssl = "0.10.73"
@@ -107,7 +107,7 @@ openmetrics-parser = "0.4.4"
 arc-swap = "1.7.1"
 
 # gRPC and Protobuf dependencies
-smg-grpc-client = "~1.0.0"
+smg-grpc-client = "=1.0.0"
 tonic = { version = "0.14.2", features = ["gzip", "transport"] }
 prost = "0.14.1"
 prost-types = "0.14.1"


### PR DESCRIPTION
## Summary

Fix CI Docker build failures caused by unpinned internal crate dependencies resolving to newer versions with breaking API changes.

## What changed

- **`sgl-model-gateway/Cargo.toml`**: Pin 11 internal crates from `~1.0.0` to `=1.0.0`

## Why

The `~1.0.0` version specifier allows patch bumps (1.0.1, 1.0.2, etc.). Since `Cargo.lock` is gitignored, CI resolves fresh dependencies and picks up newer versions of `smg-wasm`, `wfaas`, etc. that have breaking API changes (`WasmModuleManager::new()` return type, `Arc<Vec<u8>>` field type), causing Rust compilation failures.

Pinning to `=1.0.0` ensures CI builds use the same versions that work locally.

Refs: https://github.com/sgl-project/sglang/actions/runs/22335011921/job/64625492351

## Test plan

- [x] Removed `Cargo.lock` and ran `maturin build --release --features vendored-openssl` — builds successfully
- [ ] CI Docker build passes with pinned versions