### PR TITLE
[Ascend] fix: accuracy problem of pd disaggregation in pipeline parallelism mode

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -829,6 +829,7 @@ class MooncakeKVManager(CommonKVManager):
                         if self.is_mla_backend or (
                             self.attn_tp_size
                             == target_rank_registration_info.dst_attn_tp_size
+                            and self.pp_size == 1
                         ):
                             ret = self.send_kvcache(
                                 req.mooncake_session_id,


### PR DESCRIPTION
## Motivation
Fix the accuracy anomaly in Pipeline Parallelism (PP) mode under the PD (Parameter-Data) disaggregation deployment scenario.
Detailed problem scenario:
- Hardware Environment: Ascend 910C
- Model: Qwen3-32B
- Deployment Architecture: PD disaggregation, P node (TP=1, PP=4), D node (TP=2, PP=1)
- Problem Manifestation: Incorrect inference results; when testing with the gsm8k dataset, the model inference accuracy in this scenario was only 0.02 (compared with 0.87 in the colocated deployment under the same environment), resulting in severely unsatisfactory accuracy.

## Modifications
Only one key line of modification was made to the conditional judgment logic in the `transfer_worker` function of the file `python/sglang/srt/disaggregation/mooncake/conn.py`:
### Modification Details
Added `and self.pp_size == 1` to the original condition `if self.is_mla_backend or (self.attn_tp_size == target_rank_registration_info.dst_attn_tp_size):`, the complete condition is as follows:
```python
if self.is_mla_backend or (
    self.attn_tp_size == target_rank_registration_info.dst_attn_tp_size
    and self.pp_size == 1  # New line: Restrict original logic to scenarios where PP dimension is 1
):
    ret = self.send_kvcache(...)  # Original logic: Complete KV Cache transmission
else:
    ret = self.send_kvcache_slice(...)  # Branch logic: Sharded KV Cache transmission
```

## Accuracy Tests
### Test Environment (Identical to the problem reproduction environment)
- Hardware: Ascend 910C
- Model: Qwen3-32B
- Deployment Architecture: PD disaggregation, P node (TP=1, PP=4), D node (TP=2, PP=1)
- Test Dataset: gsm8k
### Test Results
After modification, the inference test was re-executed with the following outcomes:
- The inference accuracy on the gsm8k dataset recovered to the normal level (consistent with the baseline accuracy of 0.87 in colocated deployment);
- No new errors were reported, the deployment process of PD disaggregation + Pipeline Parallelism worked normally, and the KV Cache transmission logic matched the PP/TP dimension configuration.