### PR TITLE
fix(connector): make device optional in create_remote_connector

### DIFF
--- a/python/sglang/srt/connector/__init__.py
+++ b/python/sglang/srt/connector/__init__.py
@@ -22,7 +22,7 @@ class ConnectorType(str, enum.Enum):
     INSTANCE = "instance"
 
 
-def create_remote_connector(url, device, **kwargs) -> BaseConnector:
+def create_remote_connector(url, device: str = "cpu", **kwargs) -> BaseConnector:
     connector_type = parse_connector_type(url)
     if connector_type == "redis":
         return RedisConnector(url)

--- a/test/registered/utils/test_create_remote_connector.py
+++ b/test/registered/utils/test_create_remote_connector.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="default")
+
+
+class TestCreateRemoteConnector(unittest.TestCase):
+    """Verify that create_remote_connector works without an explicit device arg."""
+
+    @patch("sglang.srt.connector.S3Connector")
+    def test_s3_without_device(self, mock_s3):
+        from sglang.srt.connector import create_remote_connector
+
+        mock_s3.return_value = MagicMock()
+        client = create_remote_connector("s3://bucket/model")
+        mock_s3.assert_called_once_with("s3://bucket/model")
+        self.assertIsNotNone(client)
+
+    @patch("sglang.srt.connector.RedisConnector")
+    def test_redis_without_device(self, mock_redis):
+        from sglang.srt.connector import create_remote_connector
+
+        mock_redis.return_value = MagicMock()
+        client = create_remote_connector("redis://localhost:6379")
+        mock_redis.assert_called_once_with("redis://localhost:6379")
+        self.assertIsNotNone(client)
+
+    @patch("sglang.srt.connector.RemoteInstanceConnector")
+    def test_instance_with_device(self, mock_instance):
+        from sglang.srt.connector import create_remote_connector
+
+        mock_instance.return_value = MagicMock()
+        client = create_remote_connector("instance://host:1234", "cuda:0")
+        mock_instance.assert_called_once_with("instance://host:1234", "cuda:0")
+        self.assertIsNotNone(client)
+
+    @patch("sglang.srt.connector.RemoteInstanceConnector")
+    def test_instance_default_device(self, mock_instance):
+        from sglang.srt.connector import create_remote_connector
+
+        mock_instance.return_value = MagicMock()
+        client = create_remote_connector("instance://host:1234")
+        mock_instance.assert_called_once_with("instance://host:1234", "cpu")
+        self.assertIsNotNone(client)
+
+    def test_invalid_url(self):
+        from sglang.srt.connector import create_remote_connector
+
+        with self.assertRaises(ValueError):
+            create_remote_connector("unknown://foo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`create_remote_connector(url, device)` requires a positional `device` argument, but `device` is only used by `RemoteInstanceConnector` (for `instance://` URLs). S3 and Redis connectors ignore it entirely.

Three call-sites invoke `create_remote_connector` without `device`, causing `TypeError` at startup for any S3/Redis remote path:
- `ModelConfig._maybe_pull_model_tokenizer_from_remote` (model_config.py:1101)
- `get_config` (hf_transformers_utils.py:304)
- `get_tokenizer` (hf_transformers_utils.py:515)

## Modifications

### `python/sglang/srt/connector/__init__.py` (1 line)
- Add `device: str = "cpu"` default parameter.

### `test/registered/utils/test_create_remote_connector.py` (new)
- Unit tests verifying that `create_remote_connector` works:
  - `s3://` without device
  - `redis://` without device
  - `instance://` with explicit device
  - `instance://` with default device
  - Invalid URL raises `ValueError`

## Accuracy Tests

No model code changes.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [x] Follow SGLang code style guidance