### PR TITLE
Add configurable src_rank to weight sync broadcast

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -604,6 +604,7 @@ class Engine(EngineBase):
         group_name: str = "weight_update_group",
         flush_cache: bool = True,
         load_format: Optional[str] = None,
+        src_rank: int = 0,
     ):
         """Update weights from distributed source."""
         obj = UpdateWeightsFromDistributedReqInput(
@@ -611,6 +612,7 @@ class Engine(EngineBase):
             dtypes=dtypes,
             shapes=shapes,
             group_name=group_name,
+            src_rank=src_rank,
             flush_cache=flush_cache,
             load_format=load_format,
         )

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1319,6 +1319,8 @@ class UpdateWeightsFromDistributedReqInput(BaseReq):
     shapes: List[List[int]]
     # The group name
     group_name: str = "weight_update_group"
+    # The source rank for broadcast (default 0 for backward compatibility)
+    src_rank: int = 0
     # Whether to flush the cache after updating weights
     flush_cache: bool = True
     # Whether to abort all requests before updating weights

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -150,6 +150,7 @@ class BaseTpWorker(ABC):
             recv_req.shapes,
             recv_req.group_name,
             recv_req.load_format,
+            recv_req.src_rank,
         )
         return success, message
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1358,6 +1358,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         shapes,
         group_name,
         load_format: Optional[str] = None,
+        src_rank: int = 0,
     ):
         """
         Update specific parameter in the model weights online
@@ -1376,7 +1377,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if load_format == "flattened_bucket":
             return self._update_bucketed_weights_from_distributed(
-                names, dtypes, shapes, group_name
+                names, dtypes, shapes, group_name, src_rank=src_rank
             )
         try:
             weights = []
@@ -1389,7 +1390,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 handles.append(
                     torch.distributed.broadcast(
                         weight,
-                        src=0,
+                        src=src_rank,
                         group=self._model_update_group[group_name],
                         async_op=True,
                     )
@@ -1411,7 +1412,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return False, error_msg
 
     def _update_bucketed_weights_from_distributed(
-        self, names, dtypes, shapes, group_name
+        self, names, dtypes, shapes, group_name, src_rank: int = 0
     ):
         try:
             named_tensors = []
@@ -1426,7 +1427,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             flattened_tensor = bucket.get_flattened_tensor()
             torch.distributed.broadcast(
                 flattened_tensor,
-                src=0,
+                src=src_rank,
                 group=self._model_update_group[group_name],
             )
             reconstructed_tensors = bucket.reconstruct_tensors()


### PR DESCRIPTION
## Summary

- Adds a `src_rank` parameter (default `0`) to `update_weights_from_distributed` to make the broadcast source rank configurable
- Fixes deadlock when multi-GPU training processes (via `torchrun`) sync weights with SGLang, since NCCL doesn't allow a process to be rank 0 in multiple independent process groups
- Fully backward compatible — existing callers are unaffected since `src_rank` defaults to `0`

## Changes

- `io_struct.py`: Added `src_rank: int = 0` field to `UpdateWeightsFromDistributedReqInput`
- `model_runner.py`: Changed hardcoded `src=0` → `src=src_rank` in both `update_weights_from_distributed` and `_update_bucketed_weights_from_distributed`
- `tp_worker.py`: Forwards `recv_req.src_rank` to model runner
- `engine.py`: Accepts and passes through `src_rank` parameter

No changes needed to `http_server.py` (FastAPI auto-deserializes from the dataclass), `tokenizer_communicator_mixin.py`, `scheduler_update_weights_mixin.py`, or `scheduler.py`.

Closes #19251

## Test plan

- [ ] Existing tests pass unchanged (backward compatible, default `src_rank=0`)
- [ ] `python -m pytest test/registered/rl/test_update_weights_from_distributed.py` (requires 2+ GPUs)
- [ ] Verified with `torchrun` multi-GPU training setup syncing weights as non-zero rank

🤖 Generated with [Claude Code](https://claude.com/claude-code)