### PR TITLE
Fix bootstrap_room uint64 overflow in MetadataBuffers.set_buf

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -240,9 +240,13 @@ class MetadataBuffers:
             self.output_hidden_states[req.metadata_buffer_index].copy_(
                 req.hidden_states_tensor
             )
-        # Store bootstrap_room for validation on decode side
-        self.bootstrap_room[req.metadata_buffer_index, 0] = (
-            req.bootstrap_room if req.bootstrap_room is not None else 0
+        # Store bootstrap_room for validation on decode side.
+        # Use numpy + copy_ to bypass PyTorch's scalar assignment path which
+        # converts through C long long and overflows for uint64 values > 2^63-1.
+        # See: https://github.com/pytorch/pytorch/issues/159168
+        _br = req.bootstrap_room if req.bootstrap_room is not None else 0
+        self.bootstrap_room[req.metadata_buffer_index, 0:1].copy_(
+            torch.from_numpy(np.array([_br], dtype=np.uint64))
         )
 
 


### PR DESCRIPTION
## Motivation

The `bootstrap_room` buffer in `MetadataBuffers` was recently changed to `torch.uint64` dtype (#17430), but the scalar assignment in `set_buf` still overflows for values exceeding `2^63-1`:

```python
# This overflows when req.bootstrap_room > 2^63-1
self.bootstrap_room[req.metadata_buffer_index, 0] = req.bootstrap_room
```

PyTorch's `Tensor.__setitem__` converts Python int scalars through C `long long` (`THPUtils_unpackLong`) **regardless of tensor dtype**, causing `ValueError: Overflow when unpacking long long`. This is a known PyTorch limitation: [pytorch/pytorch#159168](https://github.com/pytorch/pytorch/issues/159168).

This affects PD disaggregation when external orchestrators (e.g. [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo)) generate `bootstrap_room` as random `u64` values — roughly 50% of values exceed signed int64 max.

```
ValueError: Overflow when unpacking long long
  File "sglang/srt/disaggregation/utils.py", line 244, in set_buf
    self.bootstrap_room[req.metadata_buffer_index, 0] = (
```

## Modifications

Use `numpy` + `torch.from_numpy` + `copy_` to write the uint64 value as a tensor-to-tensor copy, bypassing PyTorch's broken scalar unpacking path entirely:

```python
_br = req.bootstrap_room if req.bootstrap_room is not None else 0
self.bootstrap_room[req.metadata_buffer_index, 0:1].copy_(
    torch.from_numpy(np.array([_br], dtype=np.uint64))
)
```

No changes needed on the decode side — `output_bootstrap_room[0].item()` on a `uint64` tensor already returns the correct unsigned Python int.

## Environment

- **Hardware**: GB200 multi-node
- **Model**: Qwen3.5-397B-A17B (BF16)
- **Transfer backend**: NIXL (but affects all backends
- **Orchestrator**: NVIDIA Dynamo (`ai-dynamo/dynamo`), which generates `bootstrap_room` via `rand::rng().random::<u64>()` in Rust ([source](https://github.com/ai-dynamo/dynamo/blob/main/lib/llm/src/kv_router/prefill_router.rs#L311))

Relates to #19045