### PR TITLE
feat: add flaky test reporting to CI failure monitor

### DIFF
--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -102,12 +102,17 @@ class SGLangFailuresAnalyzer:
         print(f"Collected {len(all_runs)} total runs")
         return all_runs
 
-    def get_jobs_for_run(self, run_id: int) -> List[Dict]:
-        """Get all jobs for a specific workflow run, handling pagination."""
+    def get_jobs_for_run(self, run_id: int, filter: str = "latest") -> List[Dict]:
+        """Get all jobs for a specific workflow run, handling pagination.
+
+        Args:
+            run_id: The workflow run ID
+            filter: Job filter - "latest" (default) or "all" (all attempts)
+        """
         try:
             all_jobs = []
             url = f"{self.base_url}/repos/{self.repo}/actions/runs/{run_id}/jobs"
-            params = {"per_page": 100}  # Max per page
+            params = {"per_page": 100, "filter": filter}
 
             while url:
                 response = self.session.get(url, params=params, timeout=30)
@@ -1014,7 +1019,9 @@ class SGLangFailuresAnalyzer:
                 run_info["pr_number"] = pull_requests[0].get("number")
 
             # Get jobs for this run
-            jobs = self.get_jobs_for_run(run.get("id"))
+            run_id = run.get("id")
+            jobs = self.get_jobs_for_run(run_id)
+            potential_flaky_jobs = []
 
             for job in jobs:
                 job_name = job.get("name", "")
@@ -1073,11 +1080,11 @@ class SGLangFailuresAnalyzer:
                 # Track recent runs (last 5 for each job)
                 run_attempt = job.get("run_attempt", 1)
 
-                # Track flaky: passed on rerun (run_attempt > 1 means it failed earlier)
+                # Collect potential flaky candidates (verified below)
                 if run_attempt > 1 and conclusion == "success":
-                    job_flaky_count[job_name] += 1
-                    job_flaky_runs[job_name].append(
+                    potential_flaky_jobs.append(
                         {
+                            "job_name": job_name,
                             "run_number": run_info["run_number"],
                             "run_attempt": run_attempt,
                             "job_url": job.get("html_url", run_info["url"]),
@@ -1117,6 +1124,29 @@ class SGLangFailuresAnalyzer:
                         "run_attempt": run_attempt,
                     }
                 )
+
+            # Verify potential flaky jobs by checking if they actually failed
+            # on a previous attempt (avoids false positives from "rerun all jobs")
+            if potential_flaky_jobs:
+                all_attempt_jobs = self.get_jobs_for_run(run_id, filter="all")
+                # Build set of job names that failed on an earlier attempt
+                failed_on_earlier_attempt = set()
+                for aj in all_attempt_jobs:
+                    aj_name = aj.get("name", "")
+                    aj_attempt = aj.get("run_attempt", 1)
+                    aj_conclusion = aj.get("conclusion")
+                    # If this job failed on an earlier attempt, mark it
+                    if (
+                        aj_attempt < run.get("run_attempt", 1)
+                        and aj_conclusion == "failure"
+                    ):
+                        failed_on_earlier_attempt.add(aj_name)
+
+                # Only count truly flaky jobs (ones that actually failed before)
+                for pf in potential_flaky_jobs:
+                    if pf["job_name"] in failed_on_earlier_attempt:
+                        job_flaky_count[pf["job_name"]] += 1
+                        job_flaky_runs[pf["job_name"]].append(pf)
 
             time.sleep(0.05)
 
@@ -1424,19 +1454,38 @@ class SGLangFailuresAnalyzer:
             (nightly_intel_scheduled_data, "Intel", "Nightly"),
             (nightly_npu_scheduled_data, "NPU", "Nightly"),
         ]
+        # Only include flaky runs from the past 24 hours
+        from datetime import timedelta, timezone
+
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=24)
+
         flaky_jobs = {}
         for workflow_data, hardware, test_type in scheduled_workflow_map:
             for job_name, job_data in workflow_data.items():
-                flaky_count = job_data.get("flaky_count", 0)
-                if flaky_count >= 1:
+                all_flaky_runs = job_data.get("flaky_runs", [])
+                # Filter to only flaky runs within the past 24 hours
+                recent_flaky_runs = []
+                for fr in all_flaky_runs:
+                    created_at = fr.get("created_at", "")
+                    if created_at:
+                        try:
+                            run_time = datetime.fromisoformat(
+                                created_at.replace("Z", "+00:00")
+                            )
+                            if run_time >= cutoff_time:
+                                recent_flaky_runs.append(fr)
+                        except (ValueError, TypeError):
+                            pass
+
+                if recent_flaky_runs:
                     flaky_jobs[f"{hardware}/{test_type}/{job_name}"] = {
                         "job_name": job_name,
                         "hardware": hardware,
                         "test_type": test_type,
-                        "flaky_count": flaky_count,
+                        "flaky_count": len(recent_flaky_runs),
                         "total_runs": job_data.get("total_runs", 0),
                         "flaky_rate": job_data.get("flaky_rate", 0),
-                        "recent_flaky_runs": job_data.get("flaky_runs", []),
+                        "recent_flaky_runs": recent_flaky_runs,
                     }
 
         report_data = {

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -984,6 +984,9 @@ class SGLangFailuresAnalyzer:
         job_max_streak: Dict[str, int] = defaultdict(int)
         job_total_failures: Dict[str, int] = defaultdict(int)
         job_total_runs: Dict[str, int] = defaultdict(int)
+        # Track flaky jobs (failed on first attempt, passed on rerun)
+        job_flaky_count: Dict[str, int] = defaultdict(int)
+        job_flaky_runs: Dict[str, List[Dict]] = defaultdict(list)
         job_first_failure_in_streak: Dict[str, Optional[Dict]] = {}
         job_last_failure_in_streak: Dict[str, Optional[Dict]] = {}
         job_recovery_info: Dict[str, Optional[Dict]] = {}
@@ -1070,6 +1073,18 @@ class SGLangFailuresAnalyzer:
                 # Track recent runs (last 5 for each job)
                 run_attempt = job.get("run_attempt", 1)
 
+                # Track flaky: passed on rerun (run_attempt > 1 means it failed earlier)
+                if run_attempt > 1 and conclusion == "success":
+                    job_flaky_count[job_name] += 1
+                    job_flaky_runs[job_name].append(
+                        {
+                            "run_number": run_info["run_number"],
+                            "run_attempt": run_attempt,
+                            "job_url": job.get("html_url", run_info["url"]),
+                            "created_at": run_info["created_at"],
+                        }
+                    )
+
                 # Create status emoji with superscript if retry attempt > 1
                 if conclusion == "success":
                     status = "✅"
@@ -1111,20 +1126,25 @@ class SGLangFailuresAnalyzer:
             # Get last 10 runs (oldest to latest, chronological order)
             recent_runs = job_recent_runs.get(job_name, [])[-10:]
 
+            flaky_count = job_flaky_count.get(job_name, 0)
+            total_runs = job_total_runs[job_name]
             job_streak_data[job_name] = {
                 "current_streak": job_current_streak[job_name],
                 "max_streak": job_max_streak[job_name],
                 "total_failures": job_total_failures[job_name],
-                "total_runs": job_total_runs[job_name],
+                "total_runs": total_runs,
                 "failure_rate": (
-                    job_total_failures[job_name] / job_total_runs[job_name] * 100
-                    if job_total_runs[job_name] > 0
+                    job_total_failures[job_name] / total_runs * 100
+                    if total_runs > 0
                     else 0
                 ),
                 "first_failure_in_streak": job_first_failure_in_streak.get(job_name),
                 "last_failure_in_streak": job_last_failure_in_streak.get(job_name),
                 "recovery_info": job_recovery_info.get(job_name),
                 "recent_runs": recent_runs,  # Last 10 runs with status emoji
+                "flaky_count": flaky_count,
+                "flaky_rate": (flaky_count / total_runs * 100 if total_runs > 0 else 0),
+                "flaky_runs": job_flaky_runs.get(job_name, [])[-5:],  # Last 5
             }
 
         return job_streak_data, job_current_streak
@@ -1391,6 +1411,34 @@ class SGLangFailuresAnalyzer:
             1 for d in nightly_scheduled_combined.values() if d["current_streak"] >= 2
         )
 
+        # Aggregate flaky jobs from scheduled data
+        # Map workflow data variable names to (hardware, test_type)
+        scheduled_workflow_map = [
+            (pr_test_nvidia_scheduled_data, "Nvidia", "PR Test"),
+            (pr_test_amd_scheduled_data, "AMD", "PR Test"),
+            (pr_test_xeon_scheduled_data, "Intel", "PR Test"),
+            (pr_test_xpu_scheduled_data, "XPU", "PR Test"),
+            (pr_test_npu_scheduled_data, "NPU", "PR Test"),
+            (nightly_nvidia_scheduled_data, "Nvidia", "Nightly"),
+            (nightly_amd_scheduled_data, "AMD", "Nightly"),
+            (nightly_intel_scheduled_data, "Intel", "Nightly"),
+            (nightly_npu_scheduled_data, "NPU", "Nightly"),
+        ]
+        flaky_jobs = {}
+        for workflow_data, hardware, test_type in scheduled_workflow_map:
+            for job_name, job_data in workflow_data.items():
+                flaky_count = job_data.get("flaky_count", 0)
+                if flaky_count >= 1:
+                    flaky_jobs[f"{hardware}/{test_type}/{job_name}"] = {
+                        "job_name": job_name,
+                        "hardware": hardware,
+                        "test_type": test_type,
+                        "flaky_count": flaky_count,
+                        "total_runs": job_data.get("total_runs", 0),
+                        "flaky_rate": job_data.get("flaky_rate", 0),
+                        "recent_flaky_runs": job_data.get("flaky_runs", []),
+                    }
+
         report_data = {
             "summary": {
                 "total_jobs": len(sorted_jobs),
@@ -1445,6 +1493,7 @@ class SGLangFailuresAnalyzer:
                 runner_test_failures if runner_test_failures else {}
             ),
             "online_runners": online_runners if online_runners else {},
+            "flaky_jobs": flaky_jobs,
         }
 
         # Save to JSON only if output file is specified
@@ -2376,6 +2425,65 @@ class SGLangFailuresAnalyzer:
                 show_test_failures=True,
                 test_failures_dict=job_test_failures_general,
             )
+
+            # Flaky Jobs Section
+            flaky_jobs = report_data.get("flaky_jobs", {})
+            if flaky_jobs:
+                summary_lines.append("## Flaky Jobs (Passed After Rerun)")
+                summary_lines.append("")
+                summary_lines.append(
+                    "_These jobs failed on their first attempt but passed after rerun. "
+                    "Gate/admin jobs are excluded._"
+                )
+                summary_lines.append("")
+                summary_lines.append(
+                    "| Job | Hardware | Test Type | Flaky Count | Total Runs | Flaky Rate | Recent Flaky Runs |"
+                )
+                summary_lines.append(
+                    "|-----|----------|-----------|-------------|------------|------------|-------------------|"
+                )
+
+                # Sort by flaky_count descending
+                sorted_flaky = sorted(
+                    flaky_jobs.values(),
+                    key=lambda x: (x["flaky_count"], x.get("flaky_rate", 0)),
+                    reverse=True,
+                )
+
+                for fj in sorted_flaky:
+                    job_name = fj["job_name"]
+                    hardware = fj["hardware"]
+                    test_type = fj["test_type"]
+                    flaky_count = fj["flaky_count"]
+                    total_runs = fj["total_runs"]
+                    flaky_rate = fj["flaky_rate"]
+
+                    # Build links to recent flaky runs
+                    recent_links = []
+                    for fr in fj.get("recent_flaky_runs", [])[-3:]:
+                        run_num = fr.get("run_number", "?")
+                        attempt = fr.get("run_attempt", 2)
+                        url = fr.get("job_url", "")
+                        if url:
+                            recent_links.append(
+                                f"[#{run_num} (attempt {attempt})]({url})"
+                            )
+                        else:
+                            recent_links.append(f"#{run_num} (attempt {attempt})")
+
+                    recent_str = ", ".join(recent_links) if recent_links else "N/A"
+
+                    summary_lines.append(
+                        f"| `{job_name}` | {hardware} | {test_type} | "
+                        f"{flaky_count} | {total_runs} | {flaky_rate:.0f}% | {recent_str} |"
+                    )
+
+                summary_lines.append("")
+            else:
+                summary_lines.append("## Flaky Jobs (Passed After Rerun)")
+                summary_lines.append("")
+                summary_lines.append("No flaky jobs detected in scheduled runs.")
+                summary_lines.append("")
 
             # Write summary
             with open(github_step_summary, "a", encoding="utf-8") as f:

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -1129,22 +1129,25 @@ class SGLangFailuresAnalyzer:
             # on a previous attempt (avoids false positives from "rerun all jobs")
             if potential_flaky_jobs:
                 all_attempt_jobs = self.get_jobs_for_run(run_id, filter="all")
-                # Build set of job names that failed on an earlier attempt
-                failed_on_earlier_attempt = set()
+                # Build map: job_name -> set of (attempt, conclusion) pairs
+                job_attempt_results: Dict[str, List[Tuple[int, str]]] = defaultdict(
+                    list
+                )
                 for aj in all_attempt_jobs:
-                    aj_name = aj.get("name", "")
-                    aj_attempt = aj.get("run_attempt", 1)
-                    aj_conclusion = aj.get("conclusion")
-                    # If this job failed on an earlier attempt, mark it
-                    if (
-                        aj_attempt < run.get("run_attempt", 1)
-                        and aj_conclusion == "failure"
-                    ):
-                        failed_on_earlier_attempt.add(aj_name)
+                    job_attempt_results[aj.get("name", "")].append(
+                        (aj.get("run_attempt", 1), aj.get("conclusion", ""))
+                    )
 
                 # Only count truly flaky jobs (ones that actually failed before)
                 for pf in potential_flaky_jobs:
-                    if pf["job_name"] in failed_on_earlier_attempt:
+                    pf_attempt = pf["run_attempt"]
+                    attempts = job_attempt_results.get(pf["job_name"], [])
+                    # Check if any earlier attempt for this job was a failure
+                    had_earlier_failure = any(
+                        attempt < pf_attempt and conclusion == "failure"
+                        for attempt, conclusion in attempts
+                    )
+                    if had_earlier_failure:
                         job_flaky_count[pf["job_name"]] += 1
                         job_flaky_runs[pf["job_name"]].append(pf)
 
@@ -1441,9 +1444,10 @@ class SGLangFailuresAnalyzer:
             1 for d in nightly_scheduled_combined.values() if d["current_streak"] >= 2
         )
 
-        # Aggregate flaky jobs from scheduled data
-        # Map workflow data variable names to (hardware, test_type)
-        scheduled_workflow_map = [
+        # Aggregate flaky jobs from scheduled + general Nvidia data
+        # General Nvidia runs have higher volume, good for flaky detection
+        flaky_workflow_map = [
+            # Scheduled runs (all hardware)
             (pr_test_nvidia_scheduled_data, "Nvidia", "PR Test"),
             (pr_test_amd_scheduled_data, "AMD", "PR Test"),
             (pr_test_xeon_scheduled_data, "Intel", "PR Test"),
@@ -1453,6 +1457,9 @@ class SGLangFailuresAnalyzer:
             (nightly_amd_scheduled_data, "AMD", "Nightly"),
             (nightly_intel_scheduled_data, "Intel", "Nightly"),
             (nightly_npu_scheduled_data, "NPU", "Nightly"),
+            # General Nvidia runs
+            (pr_test_nvidia_general_data, "Nvidia", "PR Test"),
+            (nightly_nvidia_general_data, "Nvidia", "Nightly"),
         ]
         # Only include flaky runs from the past 24 hours
         from datetime import timedelta, timezone
@@ -1460,7 +1467,7 @@ class SGLangFailuresAnalyzer:
         cutoff_time = datetime.now(timezone.utc) - timedelta(hours=24)
 
         flaky_jobs = {}
-        for workflow_data, hardware, test_type in scheduled_workflow_map:
+        for workflow_data, hardware, test_type in flaky_workflow_map:
             for job_name, job_data in workflow_data.items():
                 all_flaky_runs = job_data.get("flaky_runs", [])
                 # Filter to only flaky runs within the past 24 hours
@@ -1478,15 +1485,31 @@ class SGLangFailuresAnalyzer:
                             pass
 
                 if recent_flaky_runs:
-                    flaky_jobs[f"{hardware}/{test_type}/{job_name}"] = {
-                        "job_name": job_name,
-                        "hardware": hardware,
-                        "test_type": test_type,
-                        "flaky_count": len(recent_flaky_runs),
-                        "total_runs": job_data.get("total_runs", 0),
-                        "flaky_rate": job_data.get("flaky_rate", 0),
-                        "recent_flaky_runs": recent_flaky_runs,
-                    }
+                    key = f"{hardware}/{test_type}/{job_name}"
+                    if key in flaky_jobs:
+                        # Merge runs from general data into scheduled data
+                        # Deduplicate by run_number to avoid double-counting
+                        existing_run_nums = {
+                            r.get("run_number")
+                            for r in flaky_jobs[key]["recent_flaky_runs"]
+                        }
+                        for fr in recent_flaky_runs:
+                            if fr.get("run_number") not in existing_run_nums:
+                                flaky_jobs[key]["recent_flaky_runs"].append(fr)
+                        flaky_jobs[key]["flaky_count"] = len(
+                            flaky_jobs[key]["recent_flaky_runs"]
+                        )
+                        flaky_jobs[key]["total_runs"] += job_data.get("total_runs", 0)
+                    else:
+                        flaky_jobs[key] = {
+                            "job_name": job_name,
+                            "hardware": hardware,
+                            "test_type": test_type,
+                            "flaky_count": len(recent_flaky_runs),
+                            "total_runs": job_data.get("total_runs", 0),
+                            "flaky_rate": job_data.get("flaky_rate", 0),
+                            "recent_flaky_runs": recent_flaky_runs,
+                        }
 
         report_data = {
             "summary": {

--- a/scripts/ci_monitor/post_ci_failures_to_slack.py
+++ b/scripts/ci_monitor/post_ci_failures_to_slack.py
@@ -153,33 +153,57 @@ def post_ci_failures_to_slack(report_file: str) -> bool:
                 f"https://github.com/sgl-project/sglang/actions/runs/{run_id}"
             )
 
-        if not hardware_jobs:
-            summary = "✅ No critical failures detected in scheduled runs"
+        # Collect flaky jobs from report data
+        flaky_jobs = report_data.get("flaky_jobs", {})
+        flaky_list = sorted(
+            flaky_jobs.values(),
+            key=lambda x: (x.get("flaky_count", 0), x.get("flaky_rate", 0)),
+            reverse=True,
+        )
+
+        if not hardware_jobs and not flaky_list:
+            summary = "✅ No critical failures or flaky jobs detected in scheduled runs"
             if workflow_url:
                 summary += f"\n<{workflow_url}|View CI Monitor Run>"
             color = "good"
         else:
             # Ping relevant people when there are failures
             mentions = "<@U09R55D8EAY> <@U09ABMCKQPM>"
-            summary_lines = [f"{mentions} 🚨 *CI Critical Failures (Scheduled Runs)*"]
+            summary_lines = []
 
-            # Iterate in hardware priority order, with PR Test before Nightly
-            test_type_order = ["PR Test", "Nightly"]
-            for hardware in hardware_order:
-                if hardware not in hardware_jobs:
-                    continue
-                summary_lines.append(f"\n*{hardware}:*")
-                for test_type in test_type_order:
-                    if test_type not in hardware_jobs[hardware]:
+            if hardware_jobs:
+                summary_lines.append(
+                    f"{mentions} 🚨 *CI Critical Failures (Scheduled Runs)*"
+                )
+
+                # Iterate in hardware priority order, with PR Test before Nightly
+                test_type_order = ["PR Test", "Nightly"]
+                for hardware in hardware_order:
+                    if hardware not in hardware_jobs:
                         continue
-                    jobs = hardware_jobs[hardware][test_type]
-                    job_list = ", ".join(jobs)
-                    summary_lines.append(f"  • {test_type}: {job_list}")
+                    summary_lines.append(f"\n*{hardware}:*")
+                    for test_type in test_type_order:
+                        if test_type not in hardware_jobs[hardware]:
+                            continue
+                        jobs = hardware_jobs[hardware][test_type]
+                        job_list = ", ".join(jobs)
+                        summary_lines.append(f"  • {test_type}: {job_list}")
+
+            if flaky_list:
+                if not hardware_jobs:
+                    summary_lines.append(mentions)
+                flaky_job_names = [fj["job_name"] for fj in flaky_list[:5]]
+                summary_lines.append(
+                    f"\n⚠️ *Flaky Jobs ({len(flaky_list)} jobs passed after rerun):* "
+                    + ", ".join(flaky_job_names)
+                )
+                if len(flaky_list) > 5:
+                    summary_lines.append(f"  ...and {len(flaky_list) - 5} more")
 
             if workflow_url:
                 summary_lines.append(f"\n<{workflow_url}|View Full CI Monitor Report>")
             summary = "\n".join(summary_lines)
-            color = "danger"
+            color = "danger" if hardware_jobs else "warning"
 
         # Post parent message
         response = client.chat_postMessage(
@@ -197,43 +221,77 @@ def post_ci_failures_to_slack(report_file: str) -> bool:
 
         thread_ts = response["ts"]
 
-        # If there are failures, post detailed breakdown in thread
-        if hardware_jobs:
-            details_lines = ["*Detailed Failure Breakdown*\n"]
+        # Post detailed breakdown in thread (failures + flaky together)
+        if hardware_jobs or flaky_list:
+            details_lines = []
 
-            # Sort critical_failures by hardware order, then test_order
-            hardware_order_map = {hw: i for i, hw in enumerate(hardware_order)}
-            sorted_failures = sorted(
-                critical_failures,
-                key=lambda x: (
-                    hardware_order_map.get(x.get("hardware", ""), 99),
-                    x.get("test_order", 99),
-                    x.get("job_name", ""),
-                ),
-            )
+            if hardware_jobs:
+                details_lines.append("*Detailed Failure Breakdown*\n")
 
-            current_hardware = None
-            for job in sorted_failures:
-                hardware = job.get("hardware", "Unknown")
-                test_type = job.get("test_type", "Unknown")
-                job_name = job.get("job_name", "unknown")
-                consecutive = job.get("consecutive_failures", 0)
-                first_url = job.get("first_failed_url", "")
-                first_at = job.get("first_failed_at", "unknown")
-                last_url = job.get("last_failed_url", "")
-                last_at = job.get("last_failed_at", "unknown")
-
-                # Add hardware section header
-                if hardware != current_hardware:
-                    details_lines.append(f"\n*━━━ {hardware} ━━━*")
-                    current_hardware = hardware
-
-                details_lines.append(
-                    f"• *{test_type}* → `{job_name}`\n"
-                    f"  Consecutive failures: {consecutive}\n"
-                    f"  First failed: <{first_url}|{first_at}>\n"
-                    f"  Last failed: <{last_url}|{last_at}>\n"
+                # Sort critical_failures by hardware order, then test_order
+                hardware_order_map = {hw: i for i, hw in enumerate(hardware_order)}
+                sorted_failures = sorted(
+                    critical_failures,
+                    key=lambda x: (
+                        hardware_order_map.get(x.get("hardware", ""), 99),
+                        x.get("test_order", 99),
+                        x.get("job_name", ""),
+                    ),
                 )
+
+                current_hardware = None
+                for job in sorted_failures:
+                    hardware = job.get("hardware", "Unknown")
+                    test_type = job.get("test_type", "Unknown")
+                    job_name = job.get("job_name", "unknown")
+                    consecutive = job.get("consecutive_failures", 0)
+                    first_url = job.get("first_failed_url", "")
+                    first_at = job.get("first_failed_at", "unknown")
+                    last_url = job.get("last_failed_url", "")
+                    last_at = job.get("last_failed_at", "unknown")
+
+                    # Add hardware section header
+                    if hardware != current_hardware:
+                        details_lines.append(f"\n*━━━ {hardware} ━━━*")
+                        current_hardware = hardware
+
+                    details_lines.append(
+                        f"• *{test_type}* → `{job_name}`\n"
+                        f"  Consecutive failures: {consecutive}\n"
+                        f"  First failed: <{first_url}|{first_at}>\n"
+                        f"  Last failed: <{last_url}|{last_at}>\n"
+                    )
+
+            if flaky_list:
+                details_lines.append("\n*━━━ Flaky Jobs (Passed After Rerun) ━━━*\n")
+                for fj in flaky_list:
+                    job_name = fj.get("job_name", "unknown")
+                    hardware = fj.get("hardware", "Unknown")
+                    test_type = fj.get("test_type", "Unknown")
+                    flaky_count = fj.get("flaky_count", 0)
+                    total_runs = fj.get("total_runs", 0)
+                    flaky_rate = fj.get("flaky_rate", 0)
+
+                    # Build links to recent flaky runs
+                    recent_links = []
+                    for fr in fj.get("recent_flaky_runs", [])[-3:]:
+                        run_num = fr.get("run_number", "?")
+                        attempt = fr.get("run_attempt", 2)
+                        url = fr.get("job_url", "")
+                        if url:
+                            recent_links.append(
+                                f"<{url}|#{run_num} (attempt {attempt})>"
+                            )
+                        else:
+                            recent_links.append(f"#{run_num} (attempt {attempt})")
+
+                    recent_str = ", ".join(recent_links) if recent_links else "N/A"
+
+                    details_lines.append(
+                        f"• *{hardware} {test_type}* → `{job_name}`\n"
+                        f"  Flaky: {flaky_count}/{total_runs} runs ({flaky_rate:.0f}%)\n"
+                        f"  Recent: {recent_str}\n"
+                    )
 
             details_text = "\n".join(details_lines)
 


### PR DESCRIPTION
## Summary
- Detect **flaky jobs** — jobs that failed on their first attempt but passed after rerun (`run_attempt > 1` AND `conclusion == "success"`)
- Report flaky jobs in the JSON report (`flaky_jobs` key), GitHub Actions step summary (new "Flaky Jobs" table), and Slack notification (in parent summary + detail thread)
- Gate/admin jobs (`call-gate`, `pr-gate`, `check-all-jobs`, etc.) are already excluded from analysis, so their automatic reruns are not counted as flaky

## Changes
- `scripts/ci_monitor/ci_failures_analysis.py`: Track `flaky_count` and `flaky_runs` per job in `analyze_consecutive_failures()`, aggregate into `flaky_jobs` in report data, add flaky section to GitHub summary
- `scripts/ci_monitor/post_ci_failures_to_slack.py`: Include flaky jobs in parent summary and detail thread (alongside failure breakdown)

## Test plan
- [ ] Verify script parses correctly: `python scripts/ci_monitor/ci_failures_analysis.py --help`
- [ ] Trigger CI failure monitor workflow manually and verify flaky section appears in GitHub summary
- [ ] Check Slack notification includes flaky section when flaky jobs exist