### PR TITLE
[PD-Disagg] Fix bootstrap server race condition when prefill workers not yet registered

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -135,13 +135,26 @@ class CommonKVManager(BaseKVManager):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
 
-    def ensure_parallel_info(self, bootstrap_addr: str) -> bool:
+    def ensure_parallel_info(
+        self, bootstrap_addr: str, max_retries: int = 20, retry_interval: float = 1.0
+    ) -> bool:
         """Fetch and cache prefill parallel info if not yet available.
         Returns True if info is available (cached or freshly fetched).
+        Retries with backoff if the prefill server hasn't registered yet.
         """
         if bootstrap_addr in self.prefill_info_table:
             return True
-        info = self._fetch_prefill_server_info(bootstrap_addr)
+        info = None
+        for attempt in range(max_retries):
+            info = self._fetch_prefill_server_info(bootstrap_addr)
+            if info is not None:
+                break
+            if attempt < max_retries - 1:
+                logger.info(
+                    f"Prefill server info not available from {bootstrap_addr}, "
+                    f"retrying ({attempt + 1}/{max_retries})..."
+                )
+                time.sleep(retry_interval)
         if info is None:
             return False
 
@@ -573,6 +586,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             int, Dict[int, Dict[int, Dict[str, Union[str, int]]]]
         ] = {}
         self.room_to_dp_rank: Dict[int, Dict[str, Union[int, float]]] = {}
+        self._registered_count = 0
         self.entry_cleanup_interval = (
             envs.SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL.get()
         )
@@ -583,6 +597,12 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
 
     def run(self):
         self.thread.start()
+
+    def _is_ready(self) -> bool:
+        if self.attn_tp_size is None or self.pp_size is None:
+            return False
+        expected = self.dp_size * self.attn_tp_size * self.pp_size
+        return self._registered_count >= expected
 
     def _setup_routes(self):
         self.app.router.add_route("*", "/route", self._handle_route)
@@ -654,8 +674,10 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 "rank_ip": rank_ip,
                 "rank_port": rank_port,
             }
+            self._registered_count += 1
             logger.debug(
                 f"Register prefill bootstrap: DP{dp_group} TP{attn_tp_rank} PP{pp_rank} with rank_ip: {rank_ip} and rank_port: {rank_port}"
+                f" ({self._registered_count}/{self.dp_size * self.attn_tp_size * self.pp_size} registered)"
             )
 
         return web.Response(text="OK", status=200)
@@ -672,6 +694,12 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             and int(prefill_dp_rank) == -1
             and int(target_pp_rank) == -1
         ):
+            if not self._is_ready():
+                return web.Response(
+                    text=f"Prefill server not fully registered yet"
+                    f" ({self._registered_count} workers registered).",
+                    status=503,
+                )
             info = PrefillServerInfo(
                 attn_tp_size=self.attn_tp_size,
                 dp_size=self.dp_size,

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -601,6 +601,8 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
     def _is_ready(self) -> bool:
         if self.attn_tp_size is None or self.pp_size is None:
             return False
+        # TODO: verify this expected count is correct for all parallelism
+        # combinations (CP / DP attention / system DP / TP / PP).
         expected = self.dp_size * self.attn_tp_size * self.pp_size
         return self._registered_count >= expected
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -599,7 +599,10 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.thread.start()
 
     def _is_ready(self) -> bool:
-        return self._registered_count > 0
+        if self.attn_tp_size is None or self.pp_size is None:
+            return False
+        expected = self.dp_size * self.attn_tp_size * self.pp_size
+        return self._registered_count >= expected
 
     def _setup_routes(self):
         self.app.router.add_route("*", "/route", self._handle_route)
@@ -672,9 +675,10 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 "rank_port": rank_port,
             }
             self._registered_count += 1
+            expected = self.dp_size * self.attn_tp_size * self.pp_size
             logger.debug(
                 f"Register prefill bootstrap: DP{dp_group} TP{attn_tp_rank} PP{pp_rank} with rank_ip: {rank_ip} and rank_port: {rank_port}"
-                f" ({self._registered_count} registered)"
+                f" ({self._registered_count}/{expected} registered)"
             )
 
         return web.Response(text="OK", status=200)
@@ -710,11 +714,25 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             )
             return web.json_response(dataclasses.asdict(info), status=200)
 
+        if not self._is_ready():
+            return web.Response(
+                text=f"Prefill server not fully registered yet"
+                f" ({self._registered_count} workers registered).",
+                status=503,
+            )
+
         # Find corresponding prefill info
-        async with self.lock:
-            bootstrap_info = self.prefill_port_table[int(prefill_dp_rank)][
-                int(engine_rank)
-            ][int(target_pp_rank)]
+        try:
+            async with self.lock:
+                bootstrap_info = self.prefill_port_table[int(prefill_dp_rank)][
+                    int(engine_rank)
+                ][int(target_pp_rank)]
+        except KeyError:
+            return web.Response(
+                text=f"Bootstrap info not found for dp_rank={prefill_dp_rank} "
+                f"engine_rank={engine_rank} pp_rank={target_pp_rank}",
+                status=404,
+            )
 
         if bootstrap_info is not None:
             return web.json_response(bootstrap_info, status=200)

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -736,10 +736,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 status=404,
             )
 
-        if bootstrap_info is not None:
-            return web.json_response(bootstrap_info, status=200)
-        else:
-            return web.Response(text="Bootstrap info not Found", status=404)
+        return web.json_response(bootstrap_info, status=200)
 
     async def _handle_register_dp_rank(self, request: web.Request):
         data = await request.json()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -599,10 +599,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.thread.start()
 
     def _is_ready(self) -> bool:
-        if self.attn_tp_size is None or self.pp_size is None:
-            return False
-        expected = self.dp_size * self.attn_tp_size * self.pp_size
-        return self._registered_count >= expected
+        return self._registered_count > 0
 
     def _setup_routes(self):
         self.app.router.add_route("*", "/route", self._handle_route)
@@ -677,7 +674,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             self._registered_count += 1
             logger.debug(
                 f"Register prefill bootstrap: DP{dp_group} TP{attn_tp_rank} PP{pp_rank} with rank_ip: {rank_ip} and rank_port: {rank_port}"
-                f" ({self._registered_count}/{self.dp_size * self.attn_tp_size * self.pp_size} registered)"
+                f" ({self._registered_count} registered)"
             )
 
         return web.Response(text="OK", status=200)


### PR DESCRIPTION
## Summary

**Bootstrap server**
- Add `_is_ready()` check: track registered worker count, return 503 until all `dp_size * tp_size * pp_size` workers have registered
- Guard both metadata query (`-1,-1,-1`) and specific worker query with `_is_ready()`
- Catch `KeyError` on `prefill_port_table` lookup instead of crashing the server
- Remove unreachable `None` check after dict lookup (dead code)

**Decode client**
- Add retry logic in `ensure_parallel_info` (20 retries, 1s interval) so decode waits for prefill registration instead of failing immediately

## Error Log

From [CI failure](https://github.com/sgl-project/sglang/actions/runs/22377079442/job/64770066939?pr=19268):

```
File ".../sglang/srt/disaggregation/common/conn.py", line 675, in _handle_route_get
    info = PrefillServerInfo(
File ".../sglang/srt/disaggregation/common/conn.py", line 56, in __post_init__
    self.attn_tp_size = int(self.attn_tp_size)
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

## Root Cause

`CommonKVBootstrapServer` starts its HTTP server before any prefill worker has registered. Fields like `attn_tp_size` are `None` until a PUT arrives. A decode GET during this window crashes with `TypeError` in `PrefillServerInfo.__post_init__`.

This race always existed but was silently masked: previously `_handle_route_get` returned a plain dict (serializing `None` as JSON `null`), and the decode-side `int(None)` was swallowed by `except Exception`. After #19195 introduced `PrefillServerInfo` with `__post_init__`, the crash moved server-side and became visible.

## Repro Patch

Delay `register_to_bootstrap()` to widen the race window:

```python
def register_to_bootstrap(self):
    timer = threading.Timer(10, self._do_register_to_bootstrap)
    timer.daemon = True
    timer.start()
    return

def _do_register_to_bootstrap(self):
    # ... original body ...
```

## Test plan

- [ ] `test_disaggregation_basic.py` passes
- [ ] `test_disaggregation_dp_attention.py` passes