### PR TITLE
[JIT Kernel] Migrate custom_all_reduce to JIT kernel

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_custom_all_reduce.py
+++ b/python/sglang/jit_kernel/benchmark/bench_custom_all_reduce.py
@@ -1,0 +1,448 @@
+"""
+Benchmark latency comparison for custom all-reduce implementations.
+
+Compares:
+- JIT custom allreduce (sglang.jit_kernel.custom_all_reduce)
+- NCCL allreduce (torch.distributed.all_reduce)
+- AOT custom allreduce (sgl_kernel.allreduce), if available
+
+Requires multiple GPUs.
+
+Usage:
+    # Default: benchmark with 2 GPUs
+    python bench_custom_all_reduce.py
+
+    # Specify world size
+    python bench_custom_all_reduce.py --world-size 4
+
+    # Specify dtypes and sizes
+    python bench_custom_all_reduce.py --world-size 2 --dtype float16
+"""
+
+import argparse
+import ctypes
+import multiprocessing as mp
+import socket
+import statistics
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+
+
+def get_open_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+    except OSError:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return s.getsockname()[1]
+
+
+def create_shared_buffer(
+    size_in_bytes: int, group: Optional[ProcessGroup] = None
+) -> List[int]:
+    lib = CudaRTLibrary()
+    pointer = lib.cudaMalloc(size_in_bytes)
+    handle = lib.cudaIpcGetMemHandle(pointer)
+    if group is None:
+        group = dist.group.WORLD
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+
+    handle_bytes = ctypes.string_at(ctypes.addressof(handle), ctypes.sizeof(handle))
+    input_tensor = torch.ByteTensor(list(handle_bytes)).to(f"cuda:{rank}")
+    gathered_tensors = [torch.empty_like(input_tensor) for _ in range(world_size)]
+    dist.all_gather(gathered_tensors, input_tensor, group=group)
+
+    handles = []
+    handle_type = type(handle)
+    for tensor in gathered_tensors:
+        bytes_list = tensor.cpu().tolist()
+        bytes_data = bytes(bytes_list)
+        handle_obj = handle_type()
+        ctypes.memmove(ctypes.addressof(handle_obj), bytes_data, len(bytes_data))
+        handles.append(handle_obj)
+
+    pointers: List[int] = []
+    for i, h in enumerate(handles):
+        if i == rank:
+            pointers.append(pointer.value)
+        else:
+            opened_ptr = lib.cudaIpcOpenMemHandle(h)
+            pointers.append(opened_ptr.value)
+
+    dist.barrier(group=group)
+    return pointers
+
+
+def free_shared_buffer(
+    pointers: List[int], group: Optional[ProcessGroup] = None
+) -> None:
+    if group is None:
+        group = dist.group.WORLD
+    rank = dist.get_rank(group=group)
+    lib = CudaRTLibrary()
+    if pointers and len(pointers) > rank and pointers[rank] is not None:
+        lib.cudaFree(ctypes.c_void_p(pointers[rank]))
+    dist.barrier(group=group)
+
+
+def _bench_worker(
+    world_size: int,
+    rank: int,
+    distributed_init_port: int,
+    test_sizes: List[int],
+    dtypes: List[torch.dtype],
+    warmup: int,
+    repeat: int,
+    results_queue,
+):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    distributed_init_method = f"tcp://localhost:{distributed_init_port}"
+    dist.init_process_group(
+        backend="nccl",
+        init_method=distributed_init_method,
+        rank=rank,
+        world_size=world_size,
+        device_id=device,
+    )
+    group = dist.group.WORLD
+
+    # Try to import JIT custom allreduce
+    try:
+        from sglang.jit_kernel.custom_all_reduce import all_reduce as jit_all_reduce
+        from sglang.jit_kernel.custom_all_reduce import (
+            dispose,
+            init_custom_ar,
+            meta_size,
+            register_buffer,
+        )
+
+        jit_available = True
+    except Exception as e:
+        if rank == 0:
+            print(f"  JIT custom_all_reduce not available: {e}")
+        jit_available = False
+
+    # Try to import AOT custom allreduce
+    try:
+        import sgl_kernel.allreduce as _aot_ar
+
+        aot_available = True
+    except ImportError:
+        aot_available = False
+
+    custom_ptr = None
+    buffer_ptrs = None
+    meta_ptrs = None
+
+    results = {}
+
+    try:
+        max_size = 8192 * 1024  # 8 MiB buffer
+
+        if jit_available:
+            meta_ptrs = create_shared_buffer(meta_size() + max_size, group=group)
+            rank_data = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=device)
+            buffer_ptrs = create_shared_buffer(max_size, group=group)
+            custom_ptr = init_custom_ar(meta_ptrs, rank_data, rank, True)
+            register_buffer(custom_ptr, buffer_ptrs)
+
+        for dtype in dtypes:
+            dtype_results = {}
+            for sz in test_sizes:
+                inp = torch.ones(sz, dtype=dtype, device=device)
+                out_jit = torch.empty_like(inp)
+                out_nccl = torch.empty_like(inp)
+
+                sz_bytes = inp.nbytes
+
+                # ---- NCCL benchmark ----
+                # Warmup
+                for _ in range(warmup):
+                    inp_ref = inp.clone()
+                    dist.all_reduce(inp_ref, group=group)
+                dist.barrier()
+                torch.cuda.synchronize()
+
+                # Timed runs using CUDA events
+                nccl_times = []
+                for _ in range(repeat):
+                    inp_ref = inp.clone()
+                    start_ev = torch.cuda.Event(enable_timing=True)
+                    end_ev = torch.cuda.Event(enable_timing=True)
+                    start_ev.record()
+                    dist.all_reduce(inp_ref, group=group)
+                    end_ev.record()
+                    torch.cuda.synchronize()
+                    nccl_times.append(start_ev.elapsed_time(end_ev) * 1000)  # us
+                out_nccl.copy_(inp_ref)
+
+                # ---- JIT custom allreduce benchmark ----
+                jit_times = []
+                if jit_available and sz_bytes <= max_size:
+                    # Warmup
+                    for _ in range(warmup):
+                        jit_all_reduce(
+                            custom_ptr, inp, out_jit, buffer_ptrs[rank], max_size
+                        )
+                    dist.barrier()
+                    torch.cuda.synchronize()
+
+                    for _ in range(repeat):
+                        start_ev = torch.cuda.Event(enable_timing=True)
+                        end_ev = torch.cuda.Event(enable_timing=True)
+                        start_ev.record()
+                        jit_all_reduce(
+                            custom_ptr, inp, out_jit, buffer_ptrs[rank], max_size
+                        )
+                        end_ev.record()
+                        torch.cuda.synchronize()
+                        jit_times.append(start_ev.elapsed_time(end_ev) * 1000)  # us
+
+                # ---- AOT allreduce benchmark (rank 0 only checks availability) ----
+                aot_times = []
+                if aot_available and sz_bytes <= max_size:
+                    # Reuse same buffers if possible (AOT has same interface)
+                    try:
+                        # Warmup
+                        for _ in range(warmup):
+                            _aot_ar.all_reduce(
+                                custom_ptr, inp, out_jit, buffer_ptrs[rank], max_size
+                            )
+                        dist.barrier()
+                        torch.cuda.synchronize()
+
+                        for _ in range(repeat):
+                            start_ev = torch.cuda.Event(enable_timing=True)
+                            end_ev = torch.cuda.Event(enable_timing=True)
+                            start_ev.record()
+                            _aot_ar.all_reduce(
+                                custom_ptr, inp, out_jit, buffer_ptrs[rank], max_size
+                            )
+                            end_ev.record()
+                            torch.cuda.synchronize()
+                            aot_times.append(start_ev.elapsed_time(end_ev) * 1000)
+                    except Exception:
+                        aot_times = []
+
+                dist.barrier()
+
+                if rank == 0:
+                    dtype_results[sz] = {
+                        "nccl": nccl_times,
+                        "jit": jit_times,
+                        "aot": aot_times,
+                        "skipped": sz_bytes > max_size,
+                    }
+
+            if rank == 0:
+                results[dtype] = dtype_results
+
+    finally:
+        dist.barrier(group=group)
+        if custom_ptr is not None:
+            dispose(custom_ptr)
+        if buffer_ptrs:
+            free_shared_buffer(buffer_ptrs, group)
+        if meta_ptrs:
+            free_shared_buffer(meta_ptrs, group)
+        dist.destroy_process_group(group=group)
+
+    if rank == 0:
+        results_queue.put(
+            {
+                "results": results,
+                "jit_available": jit_available,
+                "aot_available": aot_available,
+            }
+        )
+
+
+def _dtype_str(dtype: torch.dtype) -> str:
+    return {
+        torch.float32: "float32",
+        torch.float16: "float16",
+        torch.bfloat16: "bfloat16",
+    }.get(dtype, str(dtype))
+
+
+def _print_results(
+    results: dict,
+    test_sizes: List[int],
+    dtypes: List[torch.dtype],
+    world_size: int,
+    jit_available: bool,
+    aot_available: bool,
+):
+    col_nccl = "NCCL (us)"
+    col_jit = "JIT (us)"
+    col_aot = "AOT (us)"
+    col_speedup_nccl = "Speedup (JIT/NCCL)"
+    col_speedup_aot = "Speedup (AOT/JIT)"
+
+    for dtype in dtypes:
+        print(f"\n--- dtype={_dtype_str(dtype)}, world_size={world_size} ---")
+        header = f"{'Elements':>12}  {'Bytes':>10}  {col_nccl:>12}"
+        if jit_available:
+            header += f"  {col_jit:>12}  {col_speedup_nccl:>20}"
+        if aot_available:
+            header += f"  {col_aot:>12}"
+        if jit_available and aot_available:
+            header += f"  {col_speedup_aot:>18}"
+        print(header)
+        print("-" * len(header))
+
+        dtype_results = results.get(dtype, {})
+        for sz in test_sizes:
+            r = dtype_results.get(sz)
+            if r is None:
+                continue
+
+            elem_bytes = torch.empty(1, dtype=dtype).element_size()
+            nbytes = sz * elem_bytes
+
+            nccl_med = statistics.median(r["nccl"]) if r["nccl"] else float("nan")
+            line = f"{sz:>12,}  {nbytes:>10,}  {nccl_med:>12.2f}"
+
+            jit_med = None
+            if jit_available:
+                if r["skipped"]:
+                    line += f"  {'SKIP':>12}  {'N/A':>20}"
+                elif r["jit"]:
+                    jit_med = statistics.median(r["jit"])
+                    speedup = nccl_med / jit_med if jit_med > 0 else float("nan")
+                    line += f"  {jit_med:>12.2f}  {speedup:>20.2f}x"
+                else:
+                    line += f"  {'N/A':>12}  {'N/A':>20}"
+
+            aot_med = None
+            if aot_available:
+                if r["aot"]:
+                    aot_med = statistics.median(r["aot"])
+                    line += f"  {aot_med:>12.2f}"
+                else:
+                    line += f"  {'N/A':>12}"
+
+            if jit_available and aot_available:
+                if jit_med is not None and aot_med is not None and jit_med > 0:
+                    speedup_aot = aot_med / jit_med
+                    line += f"  {speedup_aot:>18.2f}x"
+                else:
+                    line += f"  {'N/A':>18}"
+
+            print(line)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark custom allreduce JIT kernel"
+    )
+    parser.add_argument(
+        "--world-size",
+        type=int,
+        default=None,
+        help="Number of GPUs to use (default: all available, up to 8)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16", "float32", "all"],
+        default="all",
+        help="Dtype to benchmark (default: all)",
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=20, help="Warmup iterations (default: 20)"
+    )
+    parser.add_argument(
+        "--repeat", type=int, default=100, help="Measurement iterations (default: 100)"
+    )
+    args = parser.parse_args()
+
+    dtype_map = {
+        "float16": [torch.float16],
+        "bfloat16": [torch.bfloat16],
+        "float32": [torch.float32],
+        "all": [torch.float16, torch.bfloat16, torch.float32],
+    }
+    dtypes = dtype_map[args.dtype]
+
+    # Element counts to benchmark
+    test_sizes = [512, 2048, 8192, 32768, 131072, 524288, 1048576, 2097152]
+
+    available_gpus = torch.cuda.device_count()
+    if args.world_size is not None:
+        world_size = args.world_size
+    else:
+        world_size = min(available_gpus, 2)
+
+    print("=" * 70)
+    print("Custom All-Reduce JIT Kernel Benchmark")
+    print("=" * 70)
+    print(f"GPUs available:  {available_gpus}")
+    print(f"World size:      {world_size}")
+    print(f"Dtypes:          {[_dtype_str(d) for d in dtypes]}")
+    print(f"Element counts:  {test_sizes}")
+    print(f"Warmup:          {args.warmup}")
+    print(f"Repeat:          {args.repeat}")
+    print("=" * 70)
+
+    if world_size < 2:
+        print("ERROR: Need at least 2 GPUs for this benchmark.")
+        return
+    if world_size > available_gpus:
+        print(
+            f"ERROR: Requested {world_size} GPUs but only {available_gpus} available."
+        )
+        return
+
+    mp.set_start_method("spawn", force=True)
+    port = get_open_port()
+    results_queue = mp.Queue()
+
+    procs = []
+    for rank in range(world_size):
+        p = mp.Process(
+            target=_bench_worker,
+            args=(
+                world_size,
+                rank,
+                port,
+                test_sizes,
+                dtypes,
+                args.warmup,
+                args.repeat,
+                results_queue,
+            ),
+            name=f"Worker-{rank}",
+        )
+        p.start()
+        procs.append(p)
+
+    for p in procs:
+        p.join()
+        if p.exitcode != 0:
+            print(f"Process {p.name} exited with code {p.exitcode}")
+
+    if not results_queue.empty():
+        data = results_queue.get()
+        _print_results(
+            data["results"],
+            test_sizes,
+            dtypes,
+            world_size,
+            data["jit_available"],
+            data["aot_available"],
+        )
+    else:
+        print("No results collected (benchmark may have failed).")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/jit_kernel/csrc/allreduce/custom_all_reduce.cuh
+++ b/python/sglang/jit_kernel/csrc/allreduce/custom_all_reduce.cuh
@@ -1,0 +1,630 @@
+// Adapted from: https://github.com/vllm-project/vllm/blob/v0.8.2/csrc/custom_all_reduce.cu
+// And: https://github.com/vllm-project/vllm/blob/v0.8.2/csrc/custom_all_reduce.cuh
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/stl.h>
+
+#include <array>
+#include <cstdint>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#define CHECK_CUDA_SUCCESS(cmd) ::host::RuntimeDeviceCheck(cmd)
+
+namespace sglang {
+
+constexpr int kMaxBlocks = 36;
+// Counter may overflow, but it's fine since unsigned int overflow is
+// well-defined behavior.
+using FlagType = uint32_t;
+struct Signal {
+  alignas(128) FlagType self_counter[kMaxBlocks][8];
+  // Two sets of peer counters are needed for two syncs. The reason is that
+  // it's possible for peer GPU block to arrive at the second sync point while
+  // the current GPU block haven't passed the first sync point. Thus, peer GPU
+  // may write counter+1 while current GPU is busy waiting for counter. We use
+  // alternating counter array to avoid this possibility.
+  alignas(128) FlagType peer_counter[2][kMaxBlocks][8];
+};
+
+struct __align__(16) RankData {
+  const void* __restrict__ ptrs[8];
+};
+
+struct __align__(16) RankSignals {
+  Signal* signals[8];
+};
+
+// like std::array, but aligned
+template <typename T, int sz>
+struct __align__(alignof(T) * sz) array_t {
+  T data[sz];
+  using type = T;
+  static constexpr int size = sz;
+};
+
+// use packed type to maximize memory efficiency
+// goal: generate ld.128 and st.128 instructions
+template <typename T>
+struct packed_t {
+  // the (P)acked type for load/store
+  using P = array_t<T, 16 / sizeof(T)>;
+  // the (A)ccumulator type for reduction
+  using A = array_t<float, 16 / sizeof(T)>;
+};
+
+#define DINLINE __device__ __forceinline__
+
+// scalar cast functions
+DINLINE float upcast_s(half val) {
+  return __half2float(val);
+}
+
+template <typename T>
+DINLINE T downcast_s(float val);
+template <>
+DINLINE half downcast_s(float val) {
+  return __float2half(val);
+}
+
+// scalar add functions
+// for some reason when compiling with Pytorch, the + operator for half and
+// bfloat is disabled so we call the intrinsics directly
+DINLINE half& assign_add(half& a, half b) {
+  a = __hadd(a, b);
+  return a;
+}
+DINLINE float& assign_add(float& a, float b) {
+  return a += b;
+}
+
+#if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
+DINLINE float upcast_s(nv_bfloat16 val) {
+  return __bfloat162float(val);
+}
+template <>
+DINLINE nv_bfloat16 downcast_s(float val) {
+  return __float2bfloat16(val);
+}
+DINLINE nv_bfloat16& assign_add(nv_bfloat16& a, nv_bfloat16 b) {
+  a = __hadd(a, b);
+  return a;
+}
+#endif
+
+template <typename T, int N>
+DINLINE array_t<T, N>& packed_assign_add(array_t<T, N>& a, array_t<T, N> b) {
+#pragma unroll
+  for (int i = 0; i < N; i++) {
+    assign_add(a.data[i], b.data[i]);
+  }
+  return a;
+}
+
+template <typename T, int N>
+DINLINE array_t<float, N> upcast(array_t<T, N> val) {
+  if constexpr (std::is_same<T, float>::value) {
+    return val;
+  } else {
+    array_t<float, N> out;
+#pragma unroll
+    for (int i = 0; i < N; i++) {
+      out.data[i] = upcast_s(val.data[i]);
+    }
+    return out;
+  }
+}
+
+template <typename O>
+DINLINE O downcast(array_t<float, O::size> val) {
+  if constexpr (std::is_same<typename O::type, float>::value) {
+    return val;
+  } else {
+    O out;
+#pragma unroll
+    for (int i = 0; i < O::size; i++) {
+      out.data[i] = downcast_s<typename O::type>(val.data[i]);
+    }
+    return out;
+  }
+}
+
+static DINLINE void st_flag_release(FlagType* flag_addr, FlagType flag) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+  asm volatile("st.release.sys.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
+#else
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
+#endif
+}
+
+static DINLINE FlagType ld_flag_acquire(FlagType* flag_addr) {
+  FlagType flag;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+  asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
+#else
+  asm volatile("ld.volatile.global.u32 %0, [%1]; membar.gl;" : "=r"(flag) : "l"(flag_addr));
+#endif
+  return flag;
+}
+
+static DINLINE void st_flag_volatile(FlagType* flag_addr, FlagType flag) {
+  asm volatile("st.volatile.global.u32 [%1], %0;" ::"r"(flag), "l"(flag_addr));
+}
+
+static DINLINE FlagType ld_flag_volatile(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.volatile.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
+  return flag;
+}
+
+// is_start: whether this is the very first synchronization barrier.
+// need_fence: whether a memory fence is needed. If true, a release-acquire
+// semantic is used to enforce memory access order before and after this
+// barrier.
+template <int ngpus, bool is_start, bool need_fence = false>
+DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+  if constexpr (!is_start) __syncthreads();
+  static_assert(!(is_start && need_fence));  // Start barrier shouldn't need fence.
+  if (threadIdx.x < ngpus) {
+    // Increment the counter. Technically we only need one counter, but we use
+    // multiple per block to eliminate the need to share the counter via smem.
+    auto val = self_sg->self_counter[blockIdx.x][threadIdx.x] += 1;
+    // Write the expected counter value to peer and wait for correct value from
+    // peer.
+    auto peer_counter_ptr = &sg.signals[threadIdx.x]->peer_counter[val % 2][blockIdx.x][rank];
+    auto self_counter_ptr = &self_sg->peer_counter[val % 2][blockIdx.x][threadIdx.x];
+    if constexpr (need_fence) {
+      st_flag_release(peer_counter_ptr, val);
+      while (ld_flag_acquire(self_counter_ptr) != val)
+        ;
+    } else {
+      st_flag_volatile(peer_counter_ptr, val);
+      while (ld_flag_volatile(self_counter_ptr) != val)
+        ;
+    }
+  }
+  if constexpr (is_start || need_fence) __syncthreads();
+}
+
+template <typename P, int ngpus, typename A>
+DINLINE P packed_reduce(const P* ptrs[], int idx) {
+  A tmp = upcast(ptrs[0][idx]);
+#pragma unroll
+  for (int i = 1; i < ngpus; i++) {
+    packed_assign_add(tmp, upcast(ptrs[i][idx]));
+  }
+  return downcast<P>(tmp);
+}
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) cross_device_reduce_1stage(
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  // note: we don't reorder the address so the accumulation order is the same
+  // for all ranks, ensuring bitwise identical results
+  auto dp = *_dp;
+  multi_gpu_barrier<ngpus, true>(sg, self_sg, rank);
+  // do the actual reduction
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+    ((P*)result)[idx] = packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0], idx);
+  }
+  multi_gpu_barrier<ngpus, false>(sg, self_sg, rank);
+}
+
+template <typename P>
+DINLINE P* get_tmp_buf(Signal* sg) {
+  return (P*)(((Signal*)sg) + 1);
+}
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) cross_device_reduce_2stage(
+    RankData* _dp, RankSignals sg, Signal* self_sg, T* __restrict__ result, int rank, int size) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int stride = gridDim.x * blockDim.x;
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  int part = size / ngpus;
+  int start = rank * part;
+  int end = rank == ngpus - 1 ? size : start + part;
+  int largest_part = part + size % ngpus;
+  const P* ptrs[ngpus];
+  P* tmps[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    int target = (rank + i) % ngpus;
+    ptrs[i] = (const P*)_dp->ptrs[target];
+    tmps[i] = get_tmp_buf<P>(sg.signals[target]);
+  }
+  auto tmp_out = tmps[0];
+  multi_gpu_barrier<ngpus, true>(sg, self_sg, rank);
+  // stage 1: reduce scatter
+  for (int idx = start + tid; idx < end; idx += stride) {
+    tmp_out[idx - start] = packed_reduce<P, ngpus, A>(ptrs, idx);
+  }
+  multi_gpu_barrier<ngpus, false, true>(sg, self_sg, rank);
+
+  // stage 2: allgather. Note: it's important to match the tid between
+  // the two stages, because visibility across devices is only guaranteed
+  // between threads that have the same tid. If thread i computes the sum of
+  // start + i in the first stage, then thread i also gathers start + i from all
+  // ranks.
+  for (int idx = tid; idx < largest_part; idx += stride) {
+#pragma unroll
+    for (int i = 0; i < ngpus; i++) {
+      int gather_from_rank = ((rank + i) % ngpus);
+      if (gather_from_rank == ngpus - 1 || idx < part) {
+        int dst_idx = gather_from_rank * part + idx;
+        ((P*)result)[dst_idx] = tmps[i][idx];
+      }
+    }
+  }
+}
+
+using IPC_KEY = std::array<uint8_t, sizeof(cudaIpcMemHandle_t)>;
+static_assert(sizeof(IPC_KEY) == sizeof(cudaIpcMemHandle_t));
+static_assert(alignof(IPC_KEY) == alignof(cudaIpcMemHandle_t));
+
+class CustomAllreduce {
+ public:
+  int rank_;
+  int world_size_;
+  bool full_nvlink_;
+
+  RankSignals sg_;
+  // Stores an map from a pointer to its peer pointters from all ranks.
+  std::unordered_map<void*, RankData*> buffers_;
+  Signal* self_sg_;
+
+  // Stores rank data from all ranks. This is mainly for cuda graph purposes.
+  // For cuda graph to work, all kernel arguments must be fixed during graph
+  // capture time. However, the peer pointers are not known during graph capture
+  // time. Therefore, during capture, we increment the rank data pointer and use
+  // that as the argument to the kernel. The kernel arguments are stored in
+  // graph_unreg_buffers_. The actual peer pointers will be filled in at the
+  // memory pointed to by the pointers in graph_unreg_buffers_ when
+  // the IPC handles are exchanged between ranks.
+  //
+  // The overall process looks like this:
+  // 1. Graph capture.
+  // 2. Each rank obtains the IPC handles for each addresses used during cuda
+  // graph capture using get_graph_buffer_ipc_meta.
+  // 3. (In Python) all gather the IPC handles.
+  // 4. Obtain the peer pointers by opening the IPC handles, and store them in
+  // the rank data array at corresponding positions.
+  RankData *d_rank_data_base_, *d_rank_data_end_;
+  std::vector<void*> graph_unreg_buffers_;
+  // a map from IPC handles to opened IPC pointers
+  std::map<IPC_KEY, char*> ipc_handles_;
+
+  /**
+   * Signals are an array of ipc-enabled buffers from all ranks.
+   * For each of the buffer, the layout is as follows:
+   * | -- sizeof(Signal) -- | ------ a few MB ----- |
+   * The first section is for allreduce synchronization, and the second section
+   * is for storing the intermediate results required by some allreduce algos.
+   *
+   * Note: this class does not own any device memory. Any required buffers
+   * are passed in from the constructor.
+   */
+  CustomAllreduce(
+      Signal** signals, void* rank_data, size_t rank_data_sz, int rank, int world_size, bool full_nvlink = true)
+      : rank_(rank),
+        world_size_(world_size),
+        full_nvlink_(full_nvlink),
+        self_sg_(signals[rank]),
+        d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)) {
+    for (int i = 0; i < world_size_; i++) {
+      sg_.signals[i] = signals[i];
+    }
+  }
+
+  char* open_ipc_handle(const void* ipc_handle) {
+    auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
+    if (new_handle) {
+      char* ipc_ptr;
+      CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
+          (void**)&ipc_ptr, *((const cudaIpcMemHandle_t*)ipc_handle), cudaIpcMemLazyEnablePeerAccess));
+      it->second = ipc_ptr;
+    }
+    return it->second;
+  }
+
+  std::pair<std::string, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
+    auto num_buffers = graph_unreg_buffers_.size();
+    auto handle_sz = sizeof(cudaIpcMemHandle_t);
+    std::string handles(handle_sz * num_buffers, static_cast<char>(0));
+    std::vector<int64_t> offsets(num_buffers);
+    for (int i = 0; i < num_buffers; i++) {
+      auto ptr = graph_unreg_buffers_[i];
+      void* base_ptr;
+      // note: must share the base address of each allocation, or we get wrong
+      // address
+      if (cuPointerGetAttribute(&base_ptr, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR, (CUdeviceptr)ptr) != CUDA_SUCCESS)
+        throw std::runtime_error("failed to get pointer attr");
+      CHECK_CUDA_SUCCESS(cudaIpcGetMemHandle((cudaIpcMemHandle_t*)&handles[i * handle_sz], base_ptr));
+      offsets[i] = ((char*)ptr) - ((char*)base_ptr);
+    }
+    return std::make_pair(handles, offsets);
+  }
+
+  void check_rank_data_capacity(size_t num = 1) {
+    if (d_rank_data_base_ + num > d_rank_data_end_)
+      throw std::runtime_error(
+          "Rank data buffer is overflowed by " + std::to_string(d_rank_data_base_ + num - d_rank_data_end_));
+  }
+
+  /**
+   * Register already-shared IPC pointers.
+   */
+  void register_buffer(void** ptrs) {
+    check_rank_data_capacity();
+    RankData data;
+    for (int i = 0; i < world_size_; i++) {
+      data.ptrs[i] = ptrs[i];
+    }
+    auto d_data = d_rank_data_base_++;
+    CHECK_CUDA_SUCCESS(cudaMemcpy(d_data, &data, sizeof(RankData), cudaMemcpyHostToDevice));
+    buffers_[ptrs[rank_]] = d_data;
+  }
+
+  // Note: when registering graph buffers, we intentionally choose to not
+  // deduplicate the addresses. That means if the allocator reuses some
+  // addresses, they will be registered again. This is to account for the remote
+  // possibility of different allocation patterns between ranks. For example,
+  // rank 1 may get the same input address for the second allreduce, but rank 2
+  // got a different address. IPC handles have internal reference counting
+  // mechanism so overhead should be small.
+  void
+  register_graph_buffers(const std::vector<std::string>& handles, const std::vector<std::vector<int64_t>>& offsets) {
+    auto num_buffers = graph_unreg_buffers_.size();
+    check_rank_data_capacity(num_buffers);
+    std::vector<RankData> rank_data(num_buffers);
+    for (int i = 0; i < num_buffers; i++) {
+      auto self_ptr = graph_unreg_buffers_[i];
+      auto& rd = rank_data[i];
+      for (int j = 0; j < world_size_; j++) {
+        if (j != rank_) {
+          char* handle = open_ipc_handle(&handles[j][i * sizeof(cudaIpcMemHandle_t)]);
+          handle += offsets[j][i];
+          rd.ptrs[j] = handle;
+        } else {
+          rd.ptrs[j] = self_ptr;
+        }
+      }
+    }
+    CHECK_CUDA_SUCCESS(
+        cudaMemcpy(d_rank_data_base_, rank_data.data(), sizeof(RankData) * num_buffers, cudaMemcpyHostToDevice));
+    d_rank_data_base_ += num_buffers;
+    graph_unreg_buffers_.clear();
+  }
+
+  /**
+   * Performs allreduce, assuming input has already been registered.
+   *
+   * Block and grid default configs are results after careful grid search. Using
+   * 36 blocks give the best or close to the best runtime on the devices I
+   * tried: A100, A10, A30, T4, V100. You'll notice that NCCL kernels also only
+   * take a small amount of SMs. Not quite sure the underlying reason, but my
+   * guess is that too many SMs will cause contention on NVLink bus.
+   */
+  template <typename T>
+  void allreduce(cudaStream_t stream, T* input, T* output, int size, int threads = 512, int block_limit = 36) {
+    auto d = packed_t<T>::P::size;
+    if (size % d != 0)
+      throw std::runtime_error(
+          "custom allreduce currently requires input length to be multiple "
+          "of " +
+          std::to_string(d));
+    if (block_limit > kMaxBlocks)
+      throw std::runtime_error(
+          "max supported block limit is " + std::to_string(kMaxBlocks) + ". Got " + std::to_string(block_limit));
+
+    RankData* ptrs;
+    cudaStreamCaptureStatus status;
+    CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+    if (status == cudaStreamCaptureStatusActive) {
+      ptrs = d_rank_data_base_ + graph_unreg_buffers_.size();
+      graph_unreg_buffers_.push_back(input);
+    } else {
+      auto it = buffers_.find(input);
+      if (it == buffers_.end())
+        throw std::runtime_error(
+            "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+      ptrs = it->second;
+    }
+
+    size /= d;
+    auto bytes = size * sizeof(typename packed_t<T>::P);
+    int blocks = std::min(block_limit, (size + threads - 1) / threads);
+
+    // Check environment variable once
+    const char* env_algo = std::getenv("SGLANG_CUSTOM_ALLREDUCE_ALGO");
+    bool force_1stage = false;
+    bool force_2stage = false;
+    if (env_algo != nullptr) {
+      if (std::strcmp(env_algo, "1stage") == 0 || std::strcmp(env_algo, "oneshot") == 0) {
+        force_1stage = true;
+      } else if (std::strcmp(env_algo, "2stage") == 0 || std::strcmp(env_algo, "twoshot") == 0) {
+        force_2stage = true;
+      } else {
+        throw std::runtime_error(
+            "Invalid SGLANG_CUSTOM_ALLREDUCE_ALGO: " + std::string(env_algo) +
+            ". Valid values: 1stage, oneshot, 2stage, twoshot");
+      }
+    }
+
+#define KL(ngpus, name) name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+    // TODO(hanzhi713): Threshold is different for A100 and H100.
+    // Add per device threshold.
+#define REDUCE_CASE(ngpus)                                                                          \
+  case ngpus: {                                                                                     \
+    if (force_1stage) {                                                                             \
+      KL(ngpus, cross_device_reduce_1stage);                                                        \
+    } else if (force_2stage) {                                                                      \
+      KL(ngpus, cross_device_reduce_2stage);                                                        \
+    } else {                                                                                        \
+      if (world_size_ == 2) {                                                                       \
+        KL(ngpus, cross_device_reduce_1stage);                                                      \
+      } else if (full_nvlink_) {                                                                    \
+        if ((world_size_ <= 4 && bytes < 512 * 1024) || (world_size_ <= 8 && bytes < 256 * 1024)) { \
+          KL(ngpus, cross_device_reduce_1stage);                                                    \
+        } else {                                                                                    \
+          KL(ngpus, cross_device_reduce_2stage);                                                    \
+        }                                                                                           \
+      }                                                                                             \
+    }                                                                                               \
+    break;                                                                                          \
+  }
+
+    switch (world_size_) {
+      REDUCE_CASE(2)
+      REDUCE_CASE(4)
+      REDUCE_CASE(6)
+      REDUCE_CASE(8)
+      default:
+        throw std::runtime_error(
+            "custom allreduce only supports num gpus in (2,4,6,8). Actual num "
+            "gpus = " +
+            std::to_string(world_size_));
+    }
+#undef REDUCE_CASE
+#undef KL
+  }
+
+  ~CustomAllreduce() {
+    for (auto [_, ptr] : ipc_handles_) {
+      CHECK_CUDA_SUCCESS(cudaIpcCloseMemHandle(ptr));
+    }
+  }
+};
+
+}  // namespace sglang
+
+// ---------------------------------------------------------------------------
+// TVM FFI wrapper functions
+// ---------------------------------------------------------------------------
+
+// Fake pointer type: int64_t used as opaque handle to CustomAllreduce*.
+using fptr_t = int64_t;
+static_assert(sizeof(void*) == sizeof(fptr_t));
+
+namespace {
+
+int64_t
+init_custom_ar(std::vector<int64_t> fake_ipc_ptrs, tvm::ffi::TensorView rank_data, int64_t rank, bool full_nvlink) {
+  int world_size = static_cast<int>(fake_ipc_ptrs.size());
+  if (world_size > 8) throw std::invalid_argument("world size > 8 is not supported");
+  if (world_size % 2 != 0) throw std::invalid_argument("Odd num gpus is not supported for now");
+  if (rank < 0 || rank >= world_size) throw std::invalid_argument("invalid rank passed in");
+
+  sglang::Signal* ipc_ptrs[8];
+  for (int i = 0; i < world_size; i++) {
+    ipc_ptrs[i] = reinterpret_cast<sglang::Signal*>(fake_ipc_ptrs[i]);
+  }
+  return (fptr_t) new sglang::CustomAllreduce(
+      ipc_ptrs, rank_data.data_ptr(), rank_data.numel(), static_cast<int>(rank), world_size, full_nvlink);
+}
+
+/**
+ * Performs an out-of-place allreduce and stores result in out.
+ *
+ * If _reg_buffer is null, assumes inp.data_ptr() is already IPC-registered.
+ * Otherwise, _reg_buffer is assumed to be IPC-registered and inp is first
+ * copied into _reg_buffer.
+ */
+void all_reduce(
+    int64_t _fa, tvm::ffi::TensorView inp, tvm::ffi::TensorView out, int64_t _reg_buffer, int64_t reg_buffer_sz_bytes) {
+  using namespace host;
+
+  auto fa = reinterpret_cast<sglang::CustomAllreduce*>(_fa);
+  auto stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(inp.device().device_type, inp.device().device_id));
+
+  RuntimeCheck(inp.dtype() == out.dtype(), "inp and out must have the same dtype");
+  RuntimeCheck(inp.numel() == out.numel(), "inp and out must have the same numel");
+  RuntimeCheck(out.is_contiguous(), "out must be contiguous");
+  RuntimeCheck(inp.is_contiguous(), "inp must be contiguous");
+
+  int64_t element_size = inp.dtype().bits / 8;
+  int64_t input_size = inp.numel() * element_size;
+  auto reg_buffer = reinterpret_cast<void*>(_reg_buffer);
+
+  if (reg_buffer) {
+    RuntimeCheck(input_size <= reg_buffer_sz_bytes, "input exceeds reg_buffer size");
+    RuntimeDeviceCheck(
+        cudaMemcpyAsync(reg_buffer, inp.data_ptr(), static_cast<size_t>(input_size), cudaMemcpyDeviceToDevice, stream));
+  } else {
+    reg_buffer = inp.data_ptr();
+  }
+
+  auto dtype = out.dtype();
+  int out_numel = static_cast<int>(out.numel());
+  if (host::is_type<fp32_t>(dtype)) {
+    fa->allreduce<float>(
+        stream, reinterpret_cast<float*>(reg_buffer), reinterpret_cast<float*>(out.data_ptr()), out_numel);
+  } else if (host::is_type<fp16_t>(dtype)) {
+    fa->allreduce<half>(
+        stream, reinterpret_cast<half*>(reg_buffer), reinterpret_cast<half*>(out.data_ptr()), out_numel);
+  } else if (host::is_type<bf16_t>(dtype)) {
+    fa->allreduce<nv_bfloat16>(
+        stream, reinterpret_cast<nv_bfloat16*>(reg_buffer), reinterpret_cast<nv_bfloat16*>(out.data_ptr()), out_numel);
+  } else {
+    throw std::runtime_error("custom allreduce only supports float32, float16 and bfloat16");
+  }
+}
+
+void dispose(int64_t _fa) {
+  delete reinterpret_cast<sglang::CustomAllreduce*>(_fa);
+}
+
+int64_t meta_size() {
+  return static_cast<int64_t>(sizeof(sglang::Signal));
+}
+
+void register_buffer(int64_t _fa, std::vector<int64_t> fake_ipc_ptrs) {
+  auto fa = reinterpret_cast<sglang::CustomAllreduce*>(_fa);
+  if (static_cast<int>(fake_ipc_ptrs.size()) != fa->world_size_)
+    throw std::invalid_argument("fake_ipc_ptrs size must match world_size");
+  void* ipc_ptrs[8];
+  for (int i = 0; i < static_cast<int>(fake_ipc_ptrs.size()); i++) {
+    ipc_ptrs[i] = reinterpret_cast<void*>(fake_ipc_ptrs[i]);
+  }
+  fa->register_buffer(ipc_ptrs);
+}
+
+// Returns (handles_as_int64_bytes, offsets).
+std::tuple<std::vector<int64_t>, std::vector<int64_t>> get_graph_buffer_ipc_meta(int64_t _fa) {
+  auto fa = reinterpret_cast<sglang::CustomAllreduce*>(_fa);
+  auto [handle, offsets] = fa->get_graph_buffer_ipc_meta();
+  std::vector<int64_t> bytes(handle.begin(), handle.end());
+  return std::make_tuple(bytes, offsets);
+}
+
+// handles and offsets use int64 instead of uint8/char for Python binding compatibility.
+void register_graph_buffers(
+    int64_t _fa, std::vector<std::vector<int64_t>> handles, std::vector<std::vector<int64_t>> offsets) {
+  auto fa = reinterpret_cast<sglang::CustomAllreduce*>(_fa);
+  std::vector<std::string> bytes;
+  bytes.reserve(handles.size());
+  for (size_t i = 0; i < handles.size(); i++) {
+    bytes.emplace_back(handles[i].begin(), handles[i].end());
+  }
+  fa->register_graph_buffers(bytes, offsets);
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/custom_all_reduce.py
+++ b/python/sglang/jit_kernel/custom_all_reduce.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_custom_ar_module() -> Module:
+    return load_jit(
+        "custom_all_reduce",
+        cuda_files=["allreduce/custom_all_reduce.cuh"],
+        cuda_wrappers=[
+            ("init_custom_ar", "init_custom_ar"),
+            ("all_reduce", "all_reduce"),
+            ("dispose", "dispose"),
+            ("meta_size", "meta_size"),
+            ("register_buffer", "register_buffer"),
+            ("get_graph_buffer_ipc_meta", "get_graph_buffer_ipc_meta"),
+            ("register_graph_buffers", "register_graph_buffers"),
+        ],
+    )
+
+
+def init_custom_ar(
+    ipc_tensors: List[int],
+    rank_data: torch.Tensor,
+    rank: int,
+    full_nvlink: bool,
+) -> int:
+    module = _jit_custom_ar_module()
+    return module.init_custom_ar(ipc_tensors, rank_data, rank, full_nvlink)
+
+
+def all_reduce(
+    fa: int,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    reg_buffer: int,
+    reg_buffer_sz_bytes: int,
+) -> None:
+    module = _jit_custom_ar_module()
+    module.all_reduce(fa, inp, out, reg_buffer, reg_buffer_sz_bytes)
+
+
+def dispose(fa: int) -> None:
+    module = _jit_custom_ar_module()
+    module.dispose(fa)
+
+
+def meta_size() -> int:
+    module = _jit_custom_ar_module()
+    return module.meta_size()
+
+
+def register_buffer(fa: int, fake_ipc_ptrs: List[int]) -> None:
+    module = _jit_custom_ar_module()
+    module.register_buffer(fa, fake_ipc_ptrs)
+
+
+def get_graph_buffer_ipc_meta(fa: int) -> Tuple[List[int], List[int]]:
+    module = _jit_custom_ar_module()
+    return module.get_graph_buffer_ipc_meta(fa)
+
+
+def register_graph_buffers(
+    fa: int,
+    handles: List[List[int]],
+    offsets: List[List[int]],
+) -> None:
+    module = _jit_custom_ar_module()
+    module.register_graph_buffers(fa, handles, offsets)

--- a/python/sglang/jit_kernel/tests/test_custom_all_reduce.py
+++ b/python/sglang/jit_kernel/tests/test_custom_all_reduce.py
@@ -1,0 +1,179 @@
+"""
+Correctness tests for the custom_all_reduce JIT kernel.
+
+Tests the JIT-compiled custom allreduce against torch.distributed allreduce.
+Requires multiple GPUs. Single-GPU tests cover meta_size and module loading.
+"""
+
+import ctypes
+import multiprocessing as mp
+import socket
+import unittest
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.jit_kernel.custom_all_reduce import (
+    all_reduce,
+    dispose,
+    init_custom_ar,
+    meta_size,
+    register_buffer,
+)
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+
+
+def get_open_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+    except OSError:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return s.getsockname()[1]
+
+
+def create_shared_buffer(
+    size_in_bytes: int, group: Optional[ProcessGroup] = None
+) -> List[int]:
+    lib = CudaRTLibrary()
+    pointer = lib.cudaMalloc(size_in_bytes)
+    handle = lib.cudaIpcGetMemHandle(pointer)
+    if group is None:
+        group = dist.group.WORLD
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+
+    handle_bytes = ctypes.string_at(ctypes.addressof(handle), ctypes.sizeof(handle))
+    input_tensor = torch.ByteTensor(list(handle_bytes)).to(f"cuda:{rank}")
+    gathered_tensors = [torch.empty_like(input_tensor) for _ in range(world_size)]
+    dist.all_gather(gathered_tensors, input_tensor, group=group)
+
+    handles = []
+    handle_type = type(handle)
+    for tensor in gathered_tensors:
+        bytes_list = tensor.cpu().tolist()
+        bytes_data = bytes(bytes_list)
+        handle_obj = handle_type()
+        ctypes.memmove(ctypes.addressof(handle_obj), bytes_data, len(bytes_data))
+        handles.append(handle_obj)
+
+    pointers: List[int] = []
+    for i, h in enumerate(handles):
+        if i == rank:
+            pointers.append(pointer.value)
+        else:
+            opened_ptr = lib.cudaIpcOpenMemHandle(h)
+            pointers.append(opened_ptr.value)
+
+    dist.barrier(group=group)
+    return pointers
+
+
+def free_shared_buffer(
+    pointers: List[int], group: Optional[ProcessGroup] = None
+) -> None:
+    if group is None:
+        group = dist.group.WORLD
+    rank = dist.get_rank(group=group)
+    lib = CudaRTLibrary()
+    if pointers and len(pointers) > rank and pointers[rank] is not None:
+        lib.cudaFree(ctypes.c_void_p(pointers[rank]))
+    dist.barrier(group=group)
+
+
+def _run_correctness_worker(world_size, rank, distributed_init_port, test_sizes):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    distributed_init_method = f"tcp://localhost:{distributed_init_port}"
+    dist.init_process_group(
+        backend="nccl",
+        init_method=distributed_init_method,
+        rank=rank,
+        world_size=world_size,
+    )
+    group = dist.group.WORLD
+
+    custom_ptr = None
+    buffer_ptrs = None
+    meta_ptrs = None
+    try:
+        max_size = 8192 * 1024
+        meta_ptrs = create_shared_buffer(meta_size() + max_size, group=group)
+        rank_data = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=device)
+        buffer_ptrs = create_shared_buffer(max_size, group=group)
+
+        custom_ptr = init_custom_ar(meta_ptrs, rank_data, rank, True)
+        register_buffer(custom_ptr, buffer_ptrs)
+
+        for sz in test_sizes:
+            for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+                inp = torch.randint(1, 16, (sz,), dtype=dtype, device=device)
+                inp_ref = inp.clone()
+                out = torch.empty_like(inp)
+
+                all_reduce(custom_ptr, inp, out, buffer_ptrs[rank], max_size)
+                dist.all_reduce(inp_ref, group=group)
+
+                torch.testing.assert_close(out, inp_ref)
+
+    finally:
+        dist.barrier(group=group)
+        if custom_ptr is not None:
+            dispose(custom_ptr)
+        if buffer_ptrs:
+            free_shared_buffer(buffer_ptrs, group)
+        if meta_ptrs:
+            free_shared_buffer(meta_ptrs, group)
+        dist.destroy_process_group(group=group)
+
+
+def multi_process_parallel(
+    world_size: int, test_target, target_args: tuple = ()
+) -> None:
+    mp.set_start_method("spawn", force=True)
+    procs = []
+    distributed_init_port = get_open_port()
+    for i in range(world_size):
+        proc_args = (world_size, i, distributed_init_port) + target_args
+        proc = mp.Process(target=test_target, args=proc_args, name=f"Worker-{i}")
+        proc.start()
+        procs.append(proc)
+
+    for i in range(world_size):
+        procs[i].join()
+        assert (
+            procs[i].exitcode == 0
+        ), f"Process {i} failed with exit code {procs[i].exitcode}"
+
+
+class TestCustomAllReduceJIT(unittest.TestCase):
+    test_sizes = [512, 2560, 4096, 32768, 262144, 524288, 1048576]
+    world_sizes = [2, 4, 8]
+
+    def test_meta_size(self):
+        """meta_size() should return a positive integer."""
+        size = meta_size()
+        assert isinstance(size, int) and size > 0, f"Expected positive int, got {size}"
+
+    def test_correctness(self):
+        for world_size in self.world_sizes:
+            available_gpus = torch.cuda.device_count()
+            if world_size > available_gpus:
+                print(
+                    f"Skipping world_size={world_size}, requires {world_size} GPUs, "
+                    f"found {available_gpus}"
+                )
+                continue
+
+            multi_process_parallel(
+                world_size, _run_correctness_worker, target_args=(self.test_sizes,)
+            )
+            print(f"custom allreduce JIT tp={world_size}: OK")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py
@@ -17,14 +17,22 @@ IS_QUICK_AR_AVAILABLE = _is_hip
 # TODO(zyksir): mscclpp is untested on AMD and therefore disabled.
 IS_MSCCLPP_AR_AVAILABLE = _is_cuda
 
-try:
-    import sgl_kernel.allreduce as _custom_ar
-except ImportError as e:
-    if _is_cuda or _is_hip:
-        logger.warning("Failed to import from custom_ar with %r", e)
-    IS_CUSTOM_AR_AVAILABLE = False
-    IS_QUICK_AR_AVAILABLE = False
-    IS_MSCCLPP_AR_AVAILABLE = False
+_custom_ar = None
+if _is_cuda or _is_musa:
+    try:
+        import sglang.jit_kernel.custom_all_reduce as _custom_ar
+    except Exception as e:
+        logger.warning("Failed to import JIT custom_all_reduce with %r", e)
+
+if _custom_ar is None:
+    try:
+        import sgl_kernel.allreduce as _custom_ar
+    except ImportError as e:
+        if _is_cuda or _is_hip:
+            logger.warning("Failed to import from custom_ar with %r", e)
+        IS_CUSTOM_AR_AVAILABLE = False
+        IS_QUICK_AR_AVAILABLE = False
+        IS_MSCCLPP_AR_AVAILABLE = False
 
 # region IS_CUSTOM_AR_AVAILABLE
 
@@ -35,7 +43,7 @@ elif _is_cuda or _is_musa:
     # CUDA custom allreduce
 
     def init_custom_ar(
-        ipc_tensors: List[torch.Tensor],
+        ipc_tensors: List[int],
         rank_data: torch.Tensor,
         rank: int,
         full_nvlink: bool,


### PR DESCRIPTION
## Motivation                                                                            
 https://github.com/sgl-project/sglang/issues/17865
                                                           
  Custom allreduce is currently implemented as an AOT (ahead-of-time) compiled kernel in   
  `sgl_kernel`. This PR migrates it to the JIT kernel system, consistent with the ongoing  
  effort to slim down `sgl_kernel` and move kernels to JIT compilation. The JIT approach   
  allows the kernel to be compiled at runtime for the exact target architecture, reducing  
  package size and improving maintainability.

## Modifications

  Adds JIT-compiled custom allreduce as the primary implementation on CUDA/MUSA, with
  fallback to the AOT `sgl_kernel.allreduce`.

  - `csrc/allreduce/custom_all_reduce.cuh`: combined kernel + TVM FFI wrappers adapted from
   `sgl-kernel/csrc/allreduce/custom_all_reduce.cu`
  - `jit_kernel/custom_all_reduce.py`: Python JIT loader wrapping all 7 ops
  (`init_custom_ar`, `all_reduce`, `dispose`, `meta_size`, `register_buffer`,
  `get_graph_buffer_ipc_meta`, `register_graph_buffers`)
  - `tests/test_custom_all_reduce.py`: correctness tests (`meta_size` + multi-GPU)
  - `benchmark/bench_custom_all_reduce.py`: latency benchmark comparing JIT vs NCCL and AOT
   across dtypes and tensor sizes
  - `custom_all_reduce_ops.py`: try JIT first, fall back to `sgl_kernel.allreduce`

## Accuracy Tests
  Correctness is verified in `python/sglang/jit_kernel/tests/test_custom_all_reduce.py`:

  - **`test_meta_size`**: verifies `meta_size()` returns a positive integer (single-GPU).
  - **`test_correctness`**: runs multi-GPU allreduce (world sizes 2, 4, 8) across
  `float32`, `float16`, and `bfloat16`, comparing JIT custom allreduce output against
  `torch.distributed.all_reduce` using `torch.testing.assert_close`.

  bash
`  python python/sglang/jit_kernel/tests/test_custom_all_reduce.py`

## Benchmarking and Profiling
`python python/sglang/jit_kernel/benchmark/bench_custom_all_reduce.py --world-size 2 --dtype float16`
<img width="813" height="310" alt="image" src="https://github.com/user-attachments/assets/6b99f30f-e988-45e6-aa4b-1fafaf296305" />

`python python/sglang/jit_kernel/benchmark/bench_custom_all_reduce.py --world-size 8 --dtype float16`

<img width="813" height="307" alt="image" src="https://github.com/user-attachments/assets/d9a68e2b-8133-489a-af95-d15e1b44364b" />

Benchmark results on H200, float16, vs NCCL and AOT sgl_kernel:

  JIT vs NCCL: JIT is consistently 1.4–2.5x faster than NCCL across all sizes and world sizes. The 
  speedup is highest at small tensors (≤32K elements, ~2x) and tapers slightly at large tensors (2M
   elements, ~1.4–1.6x).                                                                           
                                                            
  JIT vs AOT: JIT is consistently ~1.04–1.11x faster than AOT across all sizes — a modest but
  consistent improvement, likely from architecture-specific JIT compilation targeting the H200
  exactly.

  Scaling (2→8 GPUs): Both JIT and NCCL latency increase moderately with more GPUs (e.g. at 2M
  elements: JIT 29.8 → 46.8 µs), but JIT maintains its advantage. NCCL scales similarly (48.2 →
  66.2 µs).

<img width="470" height="109" alt="image" src="https://github.com/user-attachments/assets/fe688874-4336-4ac7-899e-8a6f3912d9c0" />



<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
