### PR TITLE
fix(diffusion): handle None model_size in component load logging

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -127,6 +127,7 @@ class ComponentLoader(ABC):
             current_gpu_mem = current_platform.get_available_gpu_memory()
             model_size = get_memory_usage_of_component(component)
             consumed = gpu_mem_before_loading - current_gpu_mem
+            model_size_str = f"{model_size:.2f}" if model_size is not None else "N/A"
 
             # detect component device
             try:
@@ -138,19 +139,19 @@ class ComponentLoader(ABC):
 
             if is_on_gpu:
                 logger.info(
-                    f"Loaded %s: %s ({source} version). model size: %.2f GB, consumed GPU: %.2f GB, avail GPU mem: %.2f GB",
+                    f"Loaded %s: %s ({source} version). model size: %s GB, consumed GPU: %.2f GB, avail GPU mem: %.2f GB",
                     component_name,
                     component.__class__.__name__,
-                    model_size,
+                    model_size_str,
                     consumed,
                     current_gpu_mem,
                 )
             else:
                 logger.info(
-                    f"Loaded %s: %s ({source} version). model size: %.2f GB, device: %s, avail GPU mem: %.2f GB",
+                    f"Loaded %s: %s ({source} version). model size: %s GB, device: %s, avail GPU mem: %.2f GB",
                     component_name,
                     component.__class__.__name__,
-                    model_size,
+                    model_size_str,
                     component_device,
                     current_gpu_mem,
                 )


### PR DESCRIPTION
## Motivation                                                                                 
                  
  `get_memory_usage_of_component()` returns `None` for non-`nn.Module` components (tokenizers, schedulers, image processors) since they have no weight parameters. Calling `logger.info("...%.2f ...", None, ...)` raises a `TypeError` during formatting — Python logging emits a formatting error to stderr and skips the log record entirely. Every tokenizer and scheduler load during diffusion server startup produces no log output.

  ## Modifications
  In `python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py`:
  - Pre-format `model_size` into a string before the logger call: `f"{model_size:.2f}"` for `nn.Module` components, `"N/A"` for non-`nn.Module`
  - Change `%.2f` → `%s` for the model size slot in both `logger.info` branches

  ## Reproduction
  Tested against `QwenImagePipeline` on a live diffusion server:

  ```bash
  /venv/main/bin/python3 -m sglang.multimodal_gen.runtime.launch_server --model-path /workspace/Qwen-Image

  Before: tokenizer load emits a formatting error to stderr, log line is dropped entirely: [05:36:31] Loading tokenizer from /workspace/Qwen-Image/tokenizer. avail mem: 12.12 GB
  --- Logging error ---
  TypeError: must be real number, not NoneType
  Message: 'Loaded %s: %s (sgl-diffusion version). model size: %.2f GB, device: %s, avail GPU
  mem: %.2f GB'
  Arguments: ('tokenizer', 'Qwen2TokenizerFast', None, 'unknown', 12.12)
  # "Loaded tokenizer: ..." line never appears

  After: all components log cleanly:
  [05:41:27] Loaded text_encoder: FSDPQwen2_5_VLForConditionalGeneration (sgl-diffusion version). model size: 14.19 GB, device: cpu, avail GPU mem: 17.84 GB
[05:41:28] Loaded tokenizer: Qwen2TokenizerFast (sgl-diffusion version). model size: N/A GB, device: unknown, avail GPU mem: 17.84 GB
 [05:41:28] Loaded vae: AutoencoderKLQwenImage (sgl-diffusion version). model size: 0.47 GB, device: cpu, avail GPU mem: 17.84 GB
```

## Accuracy Tests

N/A - logging only.

## Benchmarking and Profiling

N/A - logging only.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
