### PR TITLE
fix: add --cuda-graph-max-bs to DSV3 FA3 FP8 KV cache test

### DIFF
--- a/test/registered/mla/test_mla_deepseek_v3.py
+++ b/test/registered/mla/test_mla_deepseek_v3.py
@@ -110,7 +110,9 @@ class TestMLADeepseekV3Fa3Fp8Kvcache(CustomTestCase):
             "fp8_e4m3",
         ]
         if is_cuda():
-            other_args.extend(["--attention-backend", "fa3"])
+            other_args.extend(
+                ["--attention-backend", "fa3", "--cuda-graph-max-bs", "2"]
+            )
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,


### PR DESCRIPTION
## Summary
- Add `--cuda-graph-max-bs 2` to `TestMLADeepseekV3Fa3Fp8Kvcache`, matching all other DSV3 test classes in the file
- Without this flag, on H200 GPUs (143GB VRAM), the server attempts to capture 36 CUDA graph batch sizes (up to bs=256), consuming all available memory and causing OOM during graph capture
- On H100 (80GB), only 2 batch sizes are captured naturally due to less available memory, so the test passes
- Failure example: https://github.com/sgl-project/sglang/actions/runs/22383690598/job/64790089972

## Test plan
- [ ] Verify `TestMLADeepseekV3Fa3Fp8Kvcache` passes on both H100 and H200 1-GPU runners
- [ ] Verify no regression on other DSV3 test classes in the same file