### PR TITLE
[Qwen3-Next] Fuse Qwen3-Next GDN's qkvz_proj and ba_proj

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -531,8 +531,15 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         self,
         param: Parameter,
         loaded_weight: torch.Tensor,
-        loaded_shard_id: Optional[int] = None,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
     ):
+        if isinstance(loaded_shard_id, tuple):
+            if hasattr(param, "load_merged_column_weight"):
+                return self.weight_loader_v2(param, loaded_weight, loaded_shard_id)
+            raise NotImplementedError(
+                "Shard id with multiple indices is not supported in weight_loader, "
+                "please use weight_loader_v2 instead."
+            )
 
         # Special case for GGUF
         # initialize GGUF param after we know the quantize type
@@ -699,7 +706,10 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         param_data.copy_(loaded_weight)
 
     def _load_fused_module_from_checkpoint(
-        self, param: BasevLLMParameter, loaded_weight: torch.Tensor
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        output_sizes: list[int] | None = None,
     ):
         """
         Handle special case for models where MLP layers are already
@@ -713,7 +723,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         current_shard_offset = 0
         shard_offsets: List[Tuple[int, int, int]] = []
-        for i, output_size in enumerate(self.output_sizes):
+        output_sizes = output_sizes or self.output_sizes
+        for i, output_size in enumerate(output_sizes):
             shard_offsets.append((i, current_shard_offset, output_size))
             current_shard_offset += output_size
 
@@ -783,9 +794,9 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         self,
         param: BasevLLMParameter,
         loaded_weight: torch.Tensor,
-        loaded_shard_id: Optional[int] = None,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
     ):
-        if loaded_shard_id is None:
+        if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
             if isinstance(param, PerTensorScaleParameter):
                 param.load_merged_column_weight(
                     loaded_weight=loaded_weight,
@@ -804,8 +815,15 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     tp_size=self.tp_size,
                 )
                 return
+            output_sizes = (
+                [self.output_sizes[idx] for idx in loaded_shard_id]
+                if loaded_shard_id
+                else None
+            )
             # TODO: @dsikka - move to parameter.py
-            self._load_fused_module_from_checkpoint(param, loaded_weight)
+            self._load_fused_module_from_checkpoint(
+                param, loaded_weight, output_sizes=output_sizes
+            )
             return
 
         assert loaded_shard_id < len(self.output_sizes)

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -253,7 +253,9 @@ class Qwen3GatedDeltaNet(nn.Module):
             key_dim=self.key_dim,
             value_dim=self.value_dim,
             quant_config=quant_config,
-            prefix=prefix,
+            prefix=add_prefix("in_proj_qkvz", prefix),
+            tp_rank=self.attn_tp_rank,
+            tp_size=self.attn_tp_size,
         )
 
         self.in_proj_ba = MergedColumnParallelLinear(
@@ -264,6 +266,15 @@ class Qwen3GatedDeltaNet(nn.Module):
             prefix=add_prefix("in_proj_ba", prefix),
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,
+        )
+
+        # Override weight_loader for interleaved checkpoint format.
+        # Must capture original_loader BEFORE overwriting.
+        self.in_proj_qkvz.weight.weight_loader = self._make_interleaved_weight_loader(
+            self.in_proj_qkvz
+        )
+        self.in_proj_ba.weight.weight_loader = self._make_interleaved_weight_loader(
+            self.in_proj_ba
         )
 
         # Conv1d weight loader setup
@@ -340,6 +351,36 @@ class Qwen3GatedDeltaNet(nn.Module):
             dt_bias=self.dt_bias,
         )
 
+    @staticmethod
+    def _make_interleaved_weight_loader(module):
+        """Create a weight_loader that does contiguous TP slicing for fused
+        (interleaved-format) checkpoint weights (shard_id=None), and delegates
+        to the standard MergedColumnParallelLinear loader for split checkpoint
+        weights (shard_id=int/tuple)."""
+        original_loader = module.weight.weight_loader
+
+        def weight_loader(param, loaded_weight, loaded_shard_id=None):
+            if loaded_shard_id is None:
+                # Fused checkpoint: weight is in interleaved (per-head-group)
+                # format. Do contiguous TP slice like ColumnParallelLinear.
+                output_dim = getattr(param, "output_dim", None)
+                if output_dim is not None and module.tp_size > 1:
+                    shard_size = param.data.shape[output_dim]
+                    start_idx = module.tp_rank * shard_size
+                    loaded_weight = loaded_weight.narrow(
+                        output_dim, start_idx, shard_size
+                    )
+                assert param.data.shape == loaded_weight.shape, (
+                    f"Shape mismatch: param {param.data.shape} vs "
+                    f"loaded {loaded_weight.shape}"
+                )
+                param.data.copy_(loaded_weight)
+            else:
+                # Split checkpoint (int or tuple shard_id) → standard path
+                original_loader(param, loaded_weight, loaded_shard_id)
+
+        return weight_loader
+
     def create_qkvz_proj(
         self,
         hidden_size: int,
@@ -347,13 +388,17 @@ class Qwen3GatedDeltaNet(nn.Module):
         value_dim: int,
         quant_config: QuantizationConfig | None,
         prefix: str,
+        tp_rank: Optional[int] = None,
+        tp_size: Optional[int] = None,
     ) -> MergedColumnParallelLinear:
         return MergedColumnParallelLinear(
             input_size=hidden_size,
-            output_sizes=[sum((key_dim, key_dim, value_dim)), value_dim],
+            output_sizes=[key_dim, key_dim, value_dim, value_dim],
             bias=False,
             quant_config=quant_config,
             prefix=prefix,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
         )
 
     def fix_query_key_value_ordering(
@@ -1060,10 +1105,10 @@ class Qwen3NextForCausalLM(nn.Module):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
             # GDN
-            ("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),
-            ("in_proj_qkvz", "in_proj_z", 3),
-            ("in_proj_ba", "in_proj_b", 0),
-            ("in_proj_ba", "in_proj_a", 1),
+            ("in_proj_qkvz.", "in_proj_qkv.", (0, 1, 2)),
+            ("in_proj_qkvz.", "in_proj_z.", 3),
+            ("in_proj_ba.", "in_proj_b.", 0),
+            ("in_proj_ba.", "in_proj_a.", 1),
         ]
 
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.layernorm import GemmaRMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,
+    MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
 )
@@ -245,28 +246,27 @@ class Qwen3GatedDeltaNet(nn.Module):
             prefix=add_prefix("conv1d", prefix),
         )
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
-        projection_size_qkvz = self.key_dim * 2 + self.value_dim * 2
-        projection_size_ba = self.num_v_heads * 2
 
-        self.in_proj_qkvz = ColumnParallelLinear(
-            input_size=self.hidden_size,
-            output_size=projection_size_qkvz,
-            bias=False,
+        # projection of the input hidden states
+        self.in_proj_qkvz = self.create_qkvz_proj(
+            hidden_size=self.hidden_size,
+            key_dim=self.key_dim,
+            value_dim=self.value_dim,
             quant_config=quant_config,
-            tp_rank=self.attn_tp_rank,
-            tp_size=self.attn_tp_size,
-            prefix=add_prefix("in_proj_qkvz", prefix),
+            prefix=prefix,
         )
-        self.in_proj_ba = ColumnParallelLinear(
+
+        self.in_proj_ba = MergedColumnParallelLinear(
             input_size=self.hidden_size,
-            output_size=projection_size_ba,
+            output_sizes=[self.num_v_heads] * 2,
             bias=False,
             quant_config=quant_config,
-            tp_rank=self.attn_tp_rank,
-            tp_size=self.attn_tp_size,
             prefix=add_prefix("in_proj_ba", prefix),
+            tp_rank=self.attn_tp_rank,
+            tp_size=self.attn_tp_size,
         )
 
+        # Conv1d weight loader setup
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
 
@@ -340,7 +340,27 @@ class Qwen3GatedDeltaNet(nn.Module):
             dt_bias=self.dt_bias,
         )
 
-    def fix_query_key_value_ordering(self, mixed_qkvz, mixed_ba):
+    def create_qkvz_proj(
+        self,
+        hidden_size: int,
+        key_dim: int,
+        value_dim: int,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> MergedColumnParallelLinear:
+        return MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_sizes=[sum((key_dim, key_dim, value_dim)), value_dim],
+            bias=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    def fix_query_key_value_ordering(
+        self,
+        mixed_qkvz: torch.Tensor,
+        mixed_ba: torch.Tensor,
+    ):
         """
         Derives `query`, `key` and `value` tensors from `mixed_qkvzba`.
         """
@@ -1032,11 +1052,18 @@ class Qwen3NextForCausalLM(nn.Module):
     ) -> Set[str]:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
+            # self attention
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
+            # mlp
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
+            # GDN
+            ("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),
+            ("in_proj_qkvz", "in_proj_z", 3),
+            ("in_proj_ba", "in_proj_b", 0),
+            ("in_proj_ba", "in_proj_a", 1),
         ]
 
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -268,12 +268,12 @@ class Qwen3GatedDeltaNet(nn.Module):
             tp_size=self.attn_tp_size,
         )
 
-        # Override weight_loader for interleaved checkpoint format.
+        # Override weight_loader for packed checkpoint format.
         # Must capture original_loader BEFORE overwriting.
-        self.in_proj_qkvz.weight.weight_loader = self._make_interleaved_weight_loader(
+        self.in_proj_qkvz.weight.weight_loader = self._make_packed_weight_loader(
             self.in_proj_qkvz
         )
-        self.in_proj_ba.weight.weight_loader = self._make_interleaved_weight_loader(
+        self.in_proj_ba.weight.weight_loader = self._make_packed_weight_loader(
             self.in_proj_ba
         )
 
@@ -352,16 +352,16 @@ class Qwen3GatedDeltaNet(nn.Module):
         )
 
     @staticmethod
-    def _make_interleaved_weight_loader(module):
+    def _make_packed_weight_loader(module):
         """Create a weight_loader that does contiguous TP slicing for fused
-        (interleaved-format) checkpoint weights (shard_id=None), and delegates
+        (packed-format) checkpoint weights (shard_id=None), and delegates
         to the standard MergedColumnParallelLinear loader for split checkpoint
         weights (shard_id=int/tuple)."""
         original_loader = module.weight.weight_loader
 
         def weight_loader(param, loaded_weight, loaded_shard_id=None):
             if loaded_shard_id is None:
-                # Fused checkpoint: weight is in interleaved (per-head-group)
+                # Fused checkpoint: weight is in packed (per-head-group)
                 # format. Do contiguous TP slice like ColumnParallelLinear.
                 output_dim = getattr(param, "output_dim", None)
                 if output_dim is not None and module.tp_size > 1:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR is to fuse Qwen3-Next GDN's qkvz_proj and ba_proj with MergedColumnParallelLinear in order to improve performance.

TTFT speedup 2.6%. (Stably) E2E throughput increases 2.6%. (Stably in several testing)

We plan to fuse Qwen3.5 GDN's qkvz_proj and ba_proj in the follow up PR.

```
Server:
CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server --model Qwen/Qwen3-Next-80B-A3B-Thinking --tp 4 --dp 4 --enable-dp-attention --speculative-num-steps 3  --speculative-eagle-topk 1  --speculative-num-draft-tokens 4 --speculative-algo NEXTN --reasoning-parser deepseek-r1

Client:
python3 -m sglang.bench_serving   --backend sglang   --host 127.0.0.1 --port 30000 --dataset-name random   --random-input-len 8000 --random-output 1500 --dataset-path /data/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 200

MAIN:
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     200
Benchmark duration (s):                  61.54
Total input tokens:                      788704
Total input text tokens:                 788704
Total generated tokens:                  153723
Total generated tokens (retokenized):    153714
Request throughput (req/s):              3.25
Input token throughput (tok/s):          12816.74
Output token throughput (tok/s):         2498.06
Peak output token throughput (tok/s):    6013.00
Peak concurrent requests:                200
Total token throughput (tok/s):          15314.80
Concurrency:                             117.91
Accept length:                           3.83
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   36279.77
Median E2E Latency (ms):                 37102.72
P90 E2E Latency (ms):                    57863.55
P99 E2E Latency (ms):                    60756.83
---------------Time to First Token----------------
Mean TTFT (ms):                          23169.69
Median TTFT (ms):                        21970.22
P99 TTFT (ms):                           54750.62
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.76
Median TPOT (ms):                        17.16
P99 TPOT (ms):                           28.55
---------------Inter-Token Latency----------------
Mean ITL (ms):                           17.08
Median ITL (ms):                         5.65
P95 ITL (ms):                            86.60
P99 ITL (ms):                            113.28
Max ITL (ms):                            695.47
==================================================


PR:
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     200
Benchmark duration (s):                  59.90
Total input tokens:                      788704
Total input text tokens:                 788704
Total generated tokens:                  153723
Total generated tokens (retokenized):    153714
Request throughput (req/s):              3.34
Input token throughput (tok/s):          13167.35
Output token throughput (tok/s):         2566.39
Peak output token throughput (tok/s):    5970.00
Peak concurrent requests:                200
Total token throughput (tok/s):          15733.74
Concurrency:                             118.04
Accept length:                           3.83
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   35351.34
Median E2E Latency (ms):                 36184.38
P90 E2E Latency (ms):                    56356.19
P99 E2E Latency (ms):                    59344.63
---------------Time to First Token----------------
Mean TTFT (ms):                          22555.29
Median TTFT (ms):                        21430.94
P99 TTFT (ms):                           53358.06
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.36
Median TPOT (ms):                        16.70
P99 TPOT (ms):                           28.37
---------------Inter-Token Latency----------------
Mean ITL (ms):                           16.67
Median ITL (ms):                         5.64
P95 ITL (ms):                            84.05
P99 ITL (ms):                            114.39
Max ITL (ms):                            687.11
==================================================
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

GSM8k no drop:
```
➜  sglang_dev2 git:(fuse_gdn_proj) ✗ lm_eval --model local-completions --tasks gsm8k   --model_args base_url=http://localhost:30000/v1/completions,model=Qwen/Qwen3-Next-80B-A3B-Instruct,num_concurrent=109;
2026-02-25:08:10:54 INFO     [_cli.run:376] Selected Tasks: ['gsm8k']
2026-02-25:08:10:54 WARNING  [evaluator:181] pretrained=None appears to be an instruct or chat variant but chat template is not applied. Recommend setting `apply_chat_template`
        (optionally `fewshot_as_multiturn`).
2026-02-25:08:10:54 INFO     [evaluator:211] Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234 | Setting fewshot manual seed to 1234
2026-02-25:08:10:54 INFO     [evaluator:236] Initializing local-completions model, with arguments: {'base_url': 'http://localhost:30000/v1/completions', 'model': 'Qwen/Qwen3-Next-80B-A3B-Instruct', 'num_concurrent': 109}
2026-02-25:08:10:54 INFO     [models.openai_completions:42] Remote tokenizer not supported. Using huggingface tokenizer backend.
2026-02-25:08:10:54 INFO     [models.api_models:172] Using max length 2048 - 1
2026-02-25:08:10:54 INFO     [models.api_models:193] Using tokenizer huggingface
2026-02-25:08:10:58 INFO     [tasks:700] Selected tasks:
2026-02-25:08:10:58 INFO     [tasks:691] Task: gsm8k (gsm8k/gsm8k.yaml)
2026-02-25:08:10:58 INFO     [evaluator:314] gsm8k: Using gen_kwargs: {'until': ['Question:', '</s>', '<|im_end|>'], 'do_sample': False, 'temperature': 0.0}
2026-02-25:08:10:58 INFO     [api.task:311] Building contexts for gsm8k on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:04<00:00, 291.61it/s]
2026-02-25:08:11:02 INFO     [evaluator:584] Running generate_until requests
Requesting API: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:37<00:00,  8.39it/s]
2026-02-25:08:13:50 INFO     [loggers.evaluation_tracker:316] Output path not provided, skipping saving results aggregated
local-completions ({'base_url': 'http://localhost:30000/v1/completions', 'model': 'Qwen/Qwen3-Next-80B-A3B-Instruct', 'num_concurrent': 109}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8650|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.8491|±  |0.0099|
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
