### PR TITLE
redact api_key and admin_api_key from logs and API responses

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -543,8 +543,12 @@ class Engine(EngineBase):
         internal_states = self.loop.run_until_complete(
             self.tokenizer_manager.get_internal_state()
         )
+        server_args_dict = dataclasses.asdict(self.tokenizer_manager.server_args)
+        server_args_dict.pop("api_key", None)
+        server_args_dict.pop("admin_api_key", None)
+
         return {
-            **dataclasses.asdict(self.tokenizer_manager.server_args),
+            **server_args_dict,
             **self.scheduler_info,
             "internal_states": internal_states,
             "version": __version__,

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -445,6 +445,8 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         logger.debug("Receive server info request")
 
         server_args_dict = dataclasses.asdict(self.server_args)
+        server_args_dict.pop("api_key", None)
+        server_args_dict.pop("admin_api_key", None)
         server_args_struct = Struct()
 
         def make_serializable(obj):

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -621,8 +621,12 @@ async def server_info():
     if hasattr(_global_state.tokenizer_manager.server_args, "model_config"):
         del _global_state.tokenizer_manager.server_args.model_config
 
+    server_args_dict = dataclasses.asdict(_global_state.tokenizer_manager.server_args)
+    server_args_dict.pop("api_key", None)
+    server_args_dict.pop("admin_api_key", None)
+
     return {
-        **dataclasses.asdict(_global_state.tokenizer_manager.server_args),
+        **server_args_dict,
         **_global_state.scheduler_info,
         "internal_states": internal_states,
         "version": __version__,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -702,6 +702,17 @@ class ServerArgs:
     # For forward hooks
     forward_hooks: Optional[List[dict[str, Any]]] = None
 
+    _REDACTED_FIELDS = ("api_key", "admin_api_key")
+
+    def __repr__(self):
+        fields = []
+        for f in dataclasses.fields(self):
+            value = getattr(self, f.name)
+            if f.name in self._REDACTED_FIELDS and value is not None:
+                value = "[REDACTED]"
+            fields.append(f"{f.name}={value!r}")
+        return f"{type(self).__name__}({', '.join(fields)})"
+
     def __post_init__(self):
         """
         Orchestrates the handling of various server arguments, ensuring proper configuration and validation.


### PR DESCRIPTION
## Summary

Closes #18256

`api_key` and `admin_api_key` values were exposed in server logs (via `ServerArgs` repr) and in `/get_server_info`, `Engine.get_server_info()`, and gRPC `GetServerInfo` API responses (via `dataclasses.asdict`).

- Added `__repr__` to `ServerArgs` that replaces key values with `[REDACTED]`, fixing all log sites that use `f"{server_args=}"`
- Excluded `api_key` and `admin_api_key` from the dict returned by each `get_server_info` endpoint (HTTP, Engine, gRPC)