### PR TITLE
[diffusion] model: Fix a performance bug in the Wan model about usp

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/bridges/mova_dual_tower.py
+++ b/python/sglang/multimodal_gen/runtime/models/bridges/mova_dual_tower.py
@@ -220,6 +220,7 @@ class ConditionalCrossAttention(nn.Module):
             head_size=self.head_dim,
             causal=False,
             softmax_scale=None,
+            is_cross_attention=True,
         )
 
     def forward(

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -134,6 +134,7 @@ class WanSelfAttention(nn.Module):
         eps=1e-6,
         parallel_attention=False,
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
+        is_cross_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
     ) -> None:
         assert dim % num_heads == 0
@@ -173,6 +174,7 @@ class WanSelfAttention(nn.Module):
             softmax_scale=None,
             causal=False,
             supported_attention_backends=supported_attention_backends,
+            is_cross_attention=is_cross_attention,
         )
 
     def forward(self, x: torch.Tensor, context: torch.Tensor, context_lens: int):
@@ -187,6 +189,12 @@ class WanSelfAttention(nn.Module):
 
 
 class WanT2VCrossAttention(WanSelfAttention):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            **kwargs,
+            is_cross_attention=True,
+        )
 
     def forward(self, x, context, context_lens):
         r"""
@@ -240,6 +248,7 @@ class WanI2VCrossAttention(WanSelfAttention):
             qk_norm,
             eps,
             supported_attention_backends=supported_attention_backends,
+            is_cross_attention=True,
             quant_config=quant_config,
         )
 
@@ -359,6 +368,7 @@ class WanTransformerBlock(nn.Module):
                 head_size=dim // num_heads,
                 causal=False,
                 supported_attention_backends=self_attn_backends,
+                is_cross_attention=False,
                 prefix=f"{prefix}.attn1",
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

For non-cross-attention (self-attention), applying Ulysses all-to-all on q/k/v is correct and required.
Wan cross-attention is different: k/v come from conditioning branches (text/image), their sequence is relatively short, and they are not sequence-sharded before attention. In practice, cross-attention k/v are already full-sequence tensors on each rank. Applying _usp_input_all_to_all to them is therefore semantically wrong and causes runtime issues.

For the Wan model, there is currently an issue with the text and image inputs in cross-attention when sp > 1.
The sequence length produced by the text encoder is 257, while the sequence length produced by the image encoder is 512. I printed the tensor shape changes inside the cross-attention module under USP (sequence parallelism), as shown in the screenshot.

<img width="1279" height="110" alt="image" src="https://github.com/user-attachments/assets/b2cb72f2-6f51-490a-abaa-454bea5b2913" />

From the logs, we can see that after the all_to_all communication, the sequence lengths of k/v and k_img/v_img become sp times larger, which is incorrect.

This indicates that the cross-attention inputs for text and image are being improperly handled under sequence parallelism.

## Modifications

<!-- Detail the changes made in this pull request. -->
Explicitly separate self-attention and cross-attention paths:

1. Keep self-attention USP behavior unchanged
- Under Ulysses, q/k/v still use all-to-all.
- Under ring parallelism, still use ring_attn.
2. Add a dedicated cross-attention path
- q still goes through _usp_input_all_to_all (query-side parallel behavior preserved).
- k/v no longer use all-to-all; instead, select only the local head shard for the current rank via _ulysses_input_split.
3. Disable ring_attn for cross-attention to avoid entering an incompatible ring path.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
