### PR TITLE
[diffusion] model: fix image generation without base_64 return unexpected 400 

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -159,6 +159,7 @@ async def generations(
         result,
         b64_list=b64_list,
         cloud_url=cloud_url,
+        fallback_url=f"/v1/images/{request_id}/content",
     )
 
     return ImageResponse(**response_kwargs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #19346

Fix a bug where image generation requests without explicitly specifying `response_format: "b64_json"` return an unexpected HTTP 400 error, even though the image is successfully generated and saved to disk.

The root cause is that `ImageGenerationsRequest.response_format` defaults to `"url"` (per OpenAI API spec), but the `generations` endpoint does not pass a `fallback_url` to `_build_image_response_kwargs`. When cloud storage is not configured, the `"url"` branch has no URL to return and raises a 400. The `edits` endpoint already handles this correctly by providing a local download fallback URL.

## Modifications

- Added `fallback_url=f"/v1/images/{request_id}/content"` to the `_build_image_response_kwargs` call in the `generations` endpoint (`image_api.py`), consistent with the existing `edits` endpoint behavior.
- This allows `response_format="url"` (the default) to fall back to a local image download URL when cloud storage is not configured, instead of returning 400.

## Accuracy Tests

以下是根据您提供的测试结果整理好的 PR Accuracy Tests 部分。您可以直接替换 PR 模板中对应的章节。

---

## Accuracy Tests

**Setup**
*   **Model**: `Qwen/Qwen-Image`
*   **Server Command**:
    ```bash
    sglang serve \
      --model-path Qwen/Qwen-Image \
      --port 30010 \
      --num-gpus 1
    ```

**Test Case: Default `response_format` behavior**
*   **Objective**: Verify that the endpoint returns a valid URL instead of an HTTP 400 error when `response_format` is omitted (defaults to `"url"`).
*   **Request**:
    ```bash
    curl -X POST http://127.0.0.1:30010/v1/images/generations \
      -H "Content-Type: application/json" \
      -d '{
        "prompt": "a cute cat sitting on a chair",
        "size": "1024x1024",
        "seed": 1024,
        "num_inference_steps": 2
      }'
    ```
    *(Note: `response_format` is intentionally omitted to test the default value "url".)*

**Results**
<img width="2608" height="1618" alt="image" src="https://github.com/user-attachments/assets/67a8f04f-5587-4fd5-bd65-f843087fe430" />

1.  **HTTP Status**: `200 OK` (Previously `400 Bad Request`).
2.  **Response Body**:
    The API correctly returns a local download URL path.
    ```json
    {
      "id": "182292b5-b45b-4a43-919e-784c965b81a6",
      "data": [
        {
          "url": "/v1/images/182292b5-b45b-4a43-919e-784c965b81a6/content"
        }
      ]
    }
    ```
3.  **Server Logs**:
    Image generation and saving completed successfully.
    ```text
    Output saved to outputs/182292b5-b45b-4a43-919e-784c965b81a6.jpg
    [2026-02-26 12:14:22] INFO: 127.0.0.1:58782 - "POST /v1/images/generations HTTP/1.1" 200 OK
    ```

=============

Launch server without --dit-cpu-offload and --text-encoder-cpu-offload:

```
sglang serve \
  --model-path Qwen/Qwen-Image \
  --port 30010 \
  --num-gpus 1 \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false
```

And test:

```
curl -sS "$SGL_BASE/health" && echo "Server is Ready."

# 1. check
echo "=== Before sleep (Full GPU mode) ==="
check_gpu

# 2. Sleep
do_sleep

# 3. Wake
do_wake

# 4. gen
for i in 1 2 3; do generate "S4-NoOffload-$i"; done
```

result:

<img width="1792" height="606" alt="image" src="https://github.com/user-attachments/assets/e8e2c4b2-158f-41b1-b0c3-cfc362d45e23" />

## Benchmarking and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
