### PR TITLE
[Logging] Fix prefill side logging in pd disagg

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -535,6 +535,14 @@ class SchedulerDisaggregationPrefillMixin:
 
         self.maybe_send_health_check_signal()
 
+        if self.current_scheduler_metrics_enabled:
+            can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+            self.log_prefill_stats(
+                prefill_stats=batch.prefill_stats,
+                can_run_cuda_graph=can_run_cuda_graph,
+                dp_cooperation_info=batch.dp_cooperation_info,
+            )
+
     def process_disagg_prefill_inflight_queue(
         self: Scheduler, rids_to_check: Optional[List[str]] = None
     ) -> List[Req]:


### PR DESCRIPTION
## Motivation

The disaggregation prefill path is missing scheduler metrics logging (prefill stats), which makes it inconsistent with the normal prefill path and harder to monitor prefill bugs and performance in disaggregated setups.

## Modifications

Add `log_prefill_stats` call in `process_batch_result_disagg_prefill` when `current_scheduler_metrics_enabled` is true, aligning the disaggregation prefill path with the standard prefill logging behavior.

Before:
<img width="1651" height="474" alt="image" src="https://github.com/user-attachments/assets/fac4d1a2-210b-487b-b3f3-3181fb90a6bf" />

After:
<img width="1492" height="880" alt="image" src="https://github.com/user-attachments/assets/f33e6329-5d34-4d44-9e73-192dc36c7d08" />


## Accuracy Tests

N/A - This change only adds optional metrics logging and does not affect model outputs.

## Benchmarking and Profiling

N/A - Logging is gated behind `current_scheduler_metrics_enabled` and has negligible overhead.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).