### PR TITLE
[AMD] Fix ROCm Docker builds, update apache-tvm-ffi

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -280,7 +280,7 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   \
   # TVM Python bits need Cython + z3 before configure.
   # Pin z3-solver==4.15.4.0: 4.15.4.0 has a manylinux wheel; 4.15.5.0 has no wheel and builds from source (fails: C++20 <format> needs GCC 14+, image has GCC 11).
-  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@v0.1.9-rc1" "z3-solver==4.15.4.0"; \
+  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@37d0485b2058885bf4e7a486f7d7b2174a8ac1ce" "z3-solver==4.15.4.0"; \
   \
   # Clone + pin TileLang (bundled TVM), then build
   git clone --recursive "${TILELANG_REPO}" /opt/tilelang && \

--- a/docker/rocm720.Dockerfile
+++ b/docker/rocm720.Dockerfile
@@ -309,7 +309,7 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   \
   # TVM Python bits need Cython + z3 before configure.
   # Pin z3-solver==4.15.4.0: 4.15.4.0 has a manylinux wheel; 4.15.5.0 has no wheel and builds from source (fails: C++20 <format> needs GCC 14+, image has GCC 11).
-  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@v0.1.9-rc1" "z3-solver==4.15.4.0"; \
+  "$VENV_PIP" install --no-cache-dir "cython>=0.29.36,<3.0" "apache-tvm-ffi @ git+https://github.com/apache/tvm-ffi.git@37d0485b2058885bf4e7a486f7d7b2174a8ac1ce" "z3-solver==4.15.4.0"; \
   \
   # Clone + pin TileLang (bundled TVM), then build
   git clone --recursive "${TILELANG_REPO}" /opt/tilelang && \


### PR DESCRIPTION
## Motivation

The nightly AMD Docker image build ([#402](https://github.com/sgl-project/sglang/actions/runs/22396653938/job/64831945003)) is failing because the `apache-tvm-ffi` git tag `v0.1.9-rc1` was deleted from the [apache/tvm-ffi](https://github.com/apache/tvm-ffi) repository.

## Modifications

- Pinned `apache-tvm-ffi` to commit [`37d0485`](https://github.com/apache/tvm-ffi/commit/37d0485b2058885bf4e7a486f7d7b2174a8ac1ce) in both `docker/rocm.Dockerfile` and `docker/rocm720.Dockerfile`. @hubertlu-tw confirmed.
- This commit includes the ROCm DLPack `current_work_stream` fix ([apache/tvm-ffi#466](https://github.com/apache/tvm-ffi/pull/466)) needed by SGLang.
- Pinning to a full commit hash avoids breakage from deleted tags (which caused this failure).

@HaiShaw, @bingxche, @yctseng0211, @hubertlu-tw please help review.

## Test plan

- [ ] Re-run [Release Docker Images Nightly (AMD)](https://github.com/sgl-project/sglang/actions/workflows/release-docker-amd-nightly.yml) on branch `fix/rocm-dockerfile-tvm-ffi-tag`
- [ ] Re-run [Release Docker Images ROCm 7.2.0 Nightly Preview (AMD)](https://github.com/sgl-project/sglang/actions/workflows/release-docker-amd-rocm720-nightly.yml) on branch `fix/rocm-dockerfile-tvm-ffi-tag`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
