### PR TITLE
[Benchmark] Fix generated_shared_prefix attribute naming and remove args dependency

### DIFF
--- a/benchmark/hicache/data_processing.py
+++ b/benchmark/hicache/data_processing.py
@@ -442,7 +442,15 @@ def sample_generated_shared_prefix_requests(
     disable_shuffle: bool = False,
 ) -> SampleOutput:
     """Generate benchmark requests with shared system prompts using random tokens and caching."""
-    cache_path = get_gen_prefix_cache_path(args, tokenizer)
+    cache_path = get_gen_prefix_cache_path(
+        args.seed,
+        num_groups,
+        prompts_per_group,
+        system_prompt_len,
+        question_len,
+        output_len,
+        tokenizer,
+    )
 
     # Try to load from cache first
     if cache_path.exists():

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -1,4 +1,3 @@
-import argparse
 import pickle
 import random
 import uuid
@@ -29,10 +28,10 @@ class GeneratedSharedPrefixDataset(BaseDataset):
     output_len: int
     range_ratio: float
     seed: int
-    gsp_fast_prepare: bool
-    gsp_send_routing_key: bool
-    gsp_num_turns: int
-    gsp_ordered: bool
+    fast_prepare: bool
+    send_routing_key: bool
+    num_turns: int
+    ordered: bool
 
     @classmethod
     def from_args(cls, args: Namespace) -> "GeneratedSharedPrefixDataset":
@@ -45,10 +44,10 @@ class GeneratedSharedPrefixDataset(BaseDataset):
             output_len=args.gsp_output_len,
             range_ratio=getattr(args, "gsp_range_ratio", 1.0),
             seed=args.seed,
-            gsp_fast_prepare=getattr(args, "gsp_fast_prepare", False),
-            gsp_send_routing_key=getattr(args, "gsp_send_routing_key", False),
-            gsp_num_turns=getattr(args, "gsp_num_turns", 1),
-            gsp_ordered=getattr(args, "gsp_ordered", False),
+            fast_prepare=getattr(args, "gsp_fast_prepare", False),
+            send_routing_key=getattr(args, "gsp_send_routing_key", False),
+            num_turns=getattr(args, "gsp_num_turns", 1),
+            ordered=getattr(args, "gsp_ordered", False),
         )
 
     def load(
@@ -62,30 +61,29 @@ class GeneratedSharedPrefixDataset(BaseDataset):
             output_len=self.output_len,
             range_ratio=self.range_ratio,
             tokenizer=tokenizer,
-            args=self,
+            seed=self.seed,
+            send_routing_key=self.send_routing_key,
+            num_turns=self.num_turns,
+            fast_prepare=self.fast_prepare,
+            ordered=self.ordered,
         )
 
 
-def get_gen_prefix_cache_path(args, tokenizer):
+def get_gen_prefix_cache_path(
+    seed: int,
+    num_groups: int,
+    prompts_per_group: int,
+    system_prompt_len: int,
+    question_len: int,
+    output_len: int,
+    tokenizer,
+):
     """Create cache directory under ~/.cache/sglang/benchmark"""
     cache_dir = Path.home() / ".cache" / "sglang" / "benchmark"
 
-    # Support both GeneratedSharedPrefixDataset (unprefixed fields)
-    # and argparse.Namespace (gsp_-prefixed fields).
-    def _get(name):
-        val = getattr(args, name, None)
-        if val is not None:
-            return val
-        return getattr(args, f"gsp_{name}")
-
-    ng = _get("num_groups")
-    ppg = _get("prompts_per_group")
-    spl = _get("system_prompt_len")
-    ql = _get("question_len")
-    ol = _get("output_len")
     cache_key = (
-        f"gen_shared_prefix_{args.seed}_{ng}_{ppg}_"
-        f"{spl}_{ql}_{ol}_"
+        f"gen_shared_prefix_{seed}_{num_groups}_{prompts_per_group}_"
+        f"{system_prompt_len}_{question_len}_{output_len}_"
         f"{tokenizer.__class__.__name__}.pkl"
     )
     return cache_dir / cache_key
@@ -99,13 +97,22 @@ def sample_generated_shared_prefix_requests(
     output_len: int,
     range_ratio: float,
     tokenizer: PreTrainedTokenizerBase,
-    args: argparse.Namespace,
+    seed: int,
+    send_routing_key: bool = False,
+    num_turns: int = 1,
+    fast_prepare: bool = False,
+    ordered: bool = False,
 ) -> List[DatasetRow]:
     """Generate benchmark requests with shared system prompts using random tokens and caching."""
-    send_routing_key = getattr(args, "gsp_send_routing_key", False)
-    num_turns = getattr(args, "gsp_num_turns", 1)
-
-    cache_path = get_gen_prefix_cache_path(args, tokenizer)
+    cache_path = get_gen_prefix_cache_path(
+        seed,
+        num_groups,
+        prompts_per_group,
+        system_prompt_len,
+        question_len,
+        output_len,
+        tokenizer,
+    )
     should_cache = (range_ratio == 1) and not send_routing_key and num_turns == 1
 
     # Try to load from cache first
@@ -180,11 +187,7 @@ def sample_generated_shared_prefix_requests(
                 1:
             ]
             full_prompt = turn_prompts[0] if num_turns == 1 else turn_prompts
-            prompt_len = (
-                1
-                if getattr(args, "gsp_fast_prepare", False)
-                else len(tokenizer.encode(turn_prompts[0]))
-            )
+            prompt_len = 1 if fast_prepare else len(tokenizer.encode(turn_prompts[0]))
             output_len_val = int(output_lens[group_idx, prompt_idx])
 
             input_requests.append(
@@ -198,7 +201,7 @@ def sample_generated_shared_prefix_requests(
             total_input_tokens += prompt_len
             total_output_tokens += output_len_val
 
-    if not getattr(args, "gsp_ordered", False):
+    if not ordered:
         random.shuffle(input_requests)
 
     # Print statistics
@@ -207,7 +210,7 @@ def sample_generated_shared_prefix_requests(
     print(f"Prompts per group: {prompts_per_group}")
     print(f"Number of turns: {num_turns}")
     print(f"Total prompts: {len(input_requests)}")
-    if not getattr(args, "gsp_fast_prepare", False):
+    if not fast_prepare:
         print(f"Total input tokens: {total_input_tokens}")
         print(f"Total output tokens: {total_output_tokens}")
         print(

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -70,10 +70,22 @@ def get_gen_prefix_cache_path(args, tokenizer):
     """Create cache directory under ~/.cache/sglang/benchmark"""
     cache_dir = Path.home() / ".cache" / "sglang" / "benchmark"
 
-    # Create a unique cache filename based on the generation parameters
+    # Support both GeneratedSharedPrefixDataset (unprefixed fields)
+    # and argparse.Namespace (gsp_-prefixed fields).
+    def _get(name):
+        val = getattr(args, name, None)
+        if val is not None:
+            return val
+        return getattr(args, f"gsp_{name}")
+
+    ng = _get("num_groups")
+    ppg = _get("prompts_per_group")
+    spl = _get("system_prompt_len")
+    ql = _get("question_len")
+    ol = _get("output_len")
     cache_key = (
-        f"gen_shared_prefix_{args.seed}_{args.gsp_num_groups}_{args.gsp_prompts_per_group}_"
-        f"{args.gsp_system_prompt_len}_{args.gsp_question_len}_{args.gsp_output_len}_"
+        f"gen_shared_prefix_{args.seed}_{ng}_{ppg}_"
+        f"{spl}_{ql}_{ol}_"
         f"{tokenizer.__class__.__name__}.pkl"
     )
     return cache_dir / cache_key

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -294,15 +294,16 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertIn("tools", rows[1].extra_request_body)
 
     def test_generated_shared_prefix_sampler(self):
+        args = make_args(gsp_num_groups=2, gsp_prompts_per_group=2)
         rows = sample_generated_shared_prefix_requests(
-            num_groups=2,
-            prompts_per_group=2,
-            system_prompt_len=8,
-            question_len=4,
-            output_len=4,
-            range_ratio=0.0,
+            num_groups=args.gsp_num_groups,
+            prompts_per_group=args.gsp_prompts_per_group,
+            system_prompt_len=args.gsp_system_prompt_len,
+            question_len=args.gsp_question_len,
+            output_len=args.gsp_output_len,
+            range_ratio=args.gsp_range_ratio,
             tokenizer=self.tokenizer,
-            seed=1,
+            seed=args.seed,
         )
         self.assertEqual(len(rows), 4)
         self.assertTrue(all(isinstance(row, DatasetRow) for row in rows))

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -294,16 +294,15 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertIn("tools", rows[1].extra_request_body)
 
     def test_generated_shared_prefix_sampler(self):
-        args = make_args(gsp_range_ratio=0.0, gsp_num_groups=2, gsp_prompts_per_group=2)
         rows = sample_generated_shared_prefix_requests(
-            num_groups=args.gsp_num_groups,
-            prompts_per_group=args.gsp_prompts_per_group,
-            system_prompt_len=args.gsp_system_prompt_len,
-            question_len=args.gsp_question_len,
-            output_len=args.gsp_output_len,
-            range_ratio=args.gsp_range_ratio,
+            num_groups=2,
+            prompts_per_group=2,
+            system_prompt_len=8,
+            question_len=4,
+            output_len=4,
+            range_ratio=0.0,
             tokenizer=self.tokenizer,
-            args=args,
+            seed=1,
         )
         self.assertEqual(len(rows), 4)
         self.assertTrue(all(isinstance(row, DatasetRow) for row in rows))
@@ -415,6 +414,15 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
             mmmu_args = make_args(dataset_name="mmmu", num_prompts=1)
             mmmu_rows = get_dataset(mmmu_args, self.tokenizer, model_id="dummy-model")
         self.assertEqual(len(mmmu_rows), 1)
+
+        gsp_args = make_args(
+            dataset_name="generated-shared-prefix",
+            gsp_num_groups=2,
+            gsp_prompts_per_group=2,
+        )
+        gsp_rows = get_dataset(gsp_args, self.tokenizer, model_id="dummy-model")
+        self.assertEqual(len(gsp_rows), 4)
+        self.assertTrue(all(isinstance(row, DatasetRow) for row in gsp_rows))
 
     def test_get_dataset_unknown_dataset(self):
         args = make_args(dataset_name="not-a-dataset")


### PR DESCRIPTION
## Motivation

#19147 introduced `GeneratedSharedPrefixDataset` dataclass where `from_args()` strips the `gsp_` prefix (e.g. `args.gsp_num_groups` → `self.num_groups`), but `get_gen_prefix_cache_path` still accessed `args.gsp_num_groups` — causing `AttributeError` when called via `get_dataset("generated-shared-prefix")` in `bench_serving.py`.

## Modifications

Instead of adding a `_get()` fallback to paper over the naming mismatch, this PR fixes the root cause:

- **Dataclass fields**: remove `gsp_` prefix from all behavioral flags (`gsp_fast_prepare` → `fast_prepare`, `gsp_send_routing_key` → `send_routing_key`, `gsp_num_turns` → `num_turns`, `gsp_ordered` → `ordered`) so naming is consistent
- **`get_gen_prefix_cache_path`**: change signature to accept explicit values (`seed, num_groups, ...`) instead of reaching into an opaque `args` object
- **`sample_generated_shared_prefix_requests`**: replace `args: argparse.Namespace` with explicit keyword arguments for all behavioral flags; the function no longer depends on `args` at all
- **hicache `data_processing.py`**: update `get_gen_prefix_cache_path` call to pass explicit params
- **Test**: add missing e2e test for `get_dataset("generated-shared-prefix")` that exercises the full `from_args()` → `load()` path (this would have caught the original regression)

## Checklist

- [x] Format your code according to the Format code with pre-commit.