### PR TITLE
Fix NSA CP positions mismatch in eagle NextN model

### DIFF
--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -29,6 +29,7 @@ from sglang.srt.layers.attention.nsa.utils import (
     can_cp_split,
     cp_all_gather_rerange_output,
     cp_split_and_rebuild_data,
+    cp_split_and_rebuild_position,
     is_nsa_enable_prefill_cp,
     nsa_use_prefill_cp,
     prepare_input_dp_with_cp_dsa,
@@ -160,6 +161,7 @@ class DeepseekModelNextN(nn.Module):
 
         if nsa_use_prefill_cp(forward_batch, self.nsa_enable_prefill_cp):
             hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+            positions = cp_split_and_rebuild_position(forward_batch, positions)
         residual = None
         with get_global_expert_distribution_recorder().disable_this_region():
             hidden_states, residual = self.decoder(


### PR DESCRIPTION
## Summary
- When context parallelism (CP) is enabled, the eagle NextN model (`deepseek_nextn.py`) splits `hidden_states` across CP ranks but does **not** split `positions`, causing a shape mismatch in the NSA indexer's rotary embedding
- The rotary embedding uses `positions.size(0)` as batch size to reshape `k_rope`, but `k_rope` has fewer elements because `hidden_states` was already CP-split
- Adds the missing `cp_split_and_rebuild_position` call, matching what the main model (`deepseek_v2.py:2707`) already does

## Error
```
RuntimeError: shape '[8, -1, 64]' is invalid for input of size 64
```
at `rotary_embedding/base.py:292` during eagle speculative decoding with `ATTN_CP4 TP4`.

Full trace: https://github.com/sgl-project/sglang/actions/runs/22376709996/job/64768484941

## Test plan
- [ ] Run eagle speculative decoding with NSA + CP enabled (ATTN_CP4 TP4)