### PR TITLE
Revised fix for HybridAttnBackend forward for linear attn

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -111,6 +111,34 @@ class HybridAttnBackend(AttentionBackend):
     def get_cuda_graph_seq_len_fill_value(self):
         return self.decode_backend.get_cuda_graph_seq_len_fill_value()
 
+    def forward(
+        self,
+        q: Optional[torch.Tensor] = None,  # For full attention
+        k: Optional[torch.Tensor] = None,  # For full attention
+        v: Optional[torch.Tensor] = None,  # For full attention
+        layer: Optional[RadixAttention] = None,
+        forward_batch: Optional[ForwardBatch] = None,
+        save_kv_cache: bool = True,
+        *,
+        mixed_qkv: Optional[torch.Tensor] = None,  # For linear attention
+        a: Optional[torch.Tensor] = None,  # For linear attention
+        b: Optional[torch.Tensor] = None,  # For linear attention
+        **kwargs,
+    ):
+        """Forward method that supports both regular attention (q, k, v) and linear attention (mixed_qkv, a, b)."""
+        backend = self._select_backend(forward_batch.forward_mode)
+        if mixed_qkv is not None:
+            return backend.forward(
+                layer=layer,
+                forward_batch=forward_batch,
+                save_kv_cache=save_kv_cache,
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                **kwargs,
+            )
+        return backend.forward(q, k, v, layer, forward_batch, save_kv_cache, **kwargs)
+
     def forward_decode(
         self,
         q: torch.Tensor,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Corrects https://github.com/sgl-project/sglang/pull/19006 which was reverted due to a bug where unused mixed_qkv, a, b were being incorrectly passed to standard attention backend.

`HybridAttnBackend` lacked a `forward()` method, causing `TypeError` when `RadixLinearAttention` called `attn_backend.forward()` with `mixed_qkv, a, b` arguments. This occurs for hybrid attention models (e.g., Qwen3-Next) when we select different attention backends for prefill/decode.

## Modifications

Added `forward()` method that accepts both regular attention (q, k, v) and linear attention (mixed_qkv, a, b) interfaces and routes to the appropriate `HybridLinearAttnBackend`.

## Accuracy Tests

Checked qwen3-8b runs as expected. Accuracy results carried over from previous PR for Qwen3-next.
```
python -m sglang.launch_server --model $MODEL_PATH --tp 4 --chunked-prefill-size 2048 --mem-fraction-static 0.8 --disable-radix-cache --mamba-ssm-dtype float32 --prefill-attention-backend fa3 --decode-attention-backend flashinfer
```

```
python -m sglang.launch_server --model $MODEL_PATH --tp 4 --chunked-prefill-size 2048 --mem-fraction-static 0.8 --disable-radix-cache --mamba-ssm-dtype float32 --prefill-attention-backend fa3 --decode-attention-backend flashinfer

python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 120000 --repeat 8 --top-k 20

Repeat: 8, mean: 0.742
Scores: ['0.742', '0.758', '0.727', '0.732', '0.747', '0.742', '0.747', '0.737']

Baseline: (fa3 backend for prefill and decode)
Repeat: 8, mean: 0.745
Scores: ['0.737', '0.753', '0.763', '0.737', '0.747', '0.747', '0.727', '0.747']
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
