### PR TITLE
[Observability] Add KV cache eviction and load-back tracing

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1987,7 +1987,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):
         num_tokens = self.new_tokens_required_next_decode(selected_indices)
-        evict_from_tree_cache(self.tree_cache, num_tokens)
+        evict_from_tree_cache(self.tree_cache, num_tokens, reqs=self.reqs)
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
     def retract_all(self, server_args: ServerArgs):
@@ -2083,7 +2083,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         release_kv_cache(req, self.tree_cache, is_insert=False)
         # NOTE(lsyin): we should use the newly evictable memory instantly.
         num_tokens = remaing_req_count * envs.SGLANG_RETRACT_DECODE_STEPS.get()
-        evict_from_tree_cache(self.tree_cache, num_tokens)
+        evict_from_tree_cache(self.tree_cache, num_tokens, reqs=self.reqs)
 
         req.reset_for_retract()
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 import os
 import random
+import time
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
@@ -773,12 +774,16 @@ class PrefillAdder:
                 return AddReqResult.NO_TOKEN
 
             if req.host_hit_length > 0:
+                load_back_start = time.perf_counter()
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(
                         last_host_node=req.last_host_node,
                         host_hit_length=req.host_hit_length,
                         req=req,
                     )
+                )
+                req.time_stats.trace_kv_cache_load_back(
+                    req.host_hit_length, start_ts=load_back_start
                 )
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import time
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 import triton
@@ -202,9 +203,10 @@ def alloc_token_slots(
     tree_cache: BasePrefixCache,
     num_tokens: int,
     backup_state: bool = False,
+    reqs: Optional[List[Req]] = None,
 ):
     allocator = tree_cache.token_to_kv_pool_allocator
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(tree_cache, num_tokens, reqs=reqs)
 
     state = None
     if backup_state:
@@ -226,7 +228,11 @@ def alloc_token_slots(
     return (out_cache_loc, state) if backup_state else out_cache_loc
 
 
-def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
+def evict_from_tree_cache(
+    tree_cache: BasePrefixCache | None,
+    num_tokens: int,
+    reqs: Optional[List[Req]] = None,
+):
     if tree_cache is None:
         return
 
@@ -234,6 +240,8 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
         return
 
     allocator = tree_cache.token_to_kv_pool_allocator
+    start_time = time.perf_counter()
+    evict_result = None
 
     if isinstance(allocator, SWATokenToKVPoolAllocator):
         # Hybrid allocator
@@ -243,13 +251,20 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
         if full_available_size < num_tokens or swa_available_size < num_tokens:
             full_num_tokens = max(0, num_tokens - full_available_size)
             swa_num_tokens = max(0, num_tokens - swa_available_size)
-            tree_cache.evict(
+            evict_result = tree_cache.evict(
                 EvictParams(num_tokens=full_num_tokens, swa_num_tokens=swa_num_tokens)
             )
     else:
         # Standard allocator
         if allocator.available_size() < num_tokens:
-            tree_cache.evict(EvictParams(num_tokens=num_tokens))
+            evict_result = tree_cache.evict(EvictParams(num_tokens=num_tokens))
+
+    if evict_result is not None:
+        from sglang.srt.observability.req_time_stats import (
+            trace_kv_cache_eviction_batch,
+        )
+
+        trace_kv_cache_eviction_batch(reqs, evict_result, start_ts=start_time)
 
 
 def alloc_paged_token_slots_extend(
@@ -261,11 +276,12 @@ def alloc_paged_token_slots_extend(
     last_loc: torch.Tensor,
     extend_num_tokens: int,
     backup_state: bool = False,
+    reqs: Optional[List[Req]] = None,
 ):
     # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
     num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(tree_cache, num_tokens, reqs=reqs)
 
     state = None
     if backup_state:
@@ -356,7 +372,9 @@ def alloc_for_extend(
 
     # Allocate KV cache (throws exception on failure)
     if batch.tree_cache.page_size == 1:
-        out_cache_loc = alloc_token_slots(batch.tree_cache, batch.extend_num_tokens)
+        out_cache_loc = alloc_token_slots(
+            batch.tree_cache, batch.extend_num_tokens, reqs=batch.reqs
+        )
     else:
         # Paged allocation - build last_loc
         last_loc = [
@@ -371,6 +389,7 @@ def alloc_for_extend(
             seq_lens_cpu=batch.seq_lens_cpu,
             last_loc=torch.cat(last_loc),
             extend_num_tokens=batch.extend_num_tokens,
+            reqs=batch.reqs,
         )
 
     # Write to req_to_token_pool
@@ -397,12 +416,13 @@ def alloc_paged_token_slots_decode(
     seq_lens_cpu: torch.Tensor,
     last_loc: torch.Tensor,
     token_per_req: int = 1,
+    reqs: Optional[List[Req]] = None,
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
     # Over estimate the number of tokens: assume each request needs a new page.
     num_tokens = len(seq_lens) * allocator.page_size
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(tree_cache, num_tokens, reqs=reqs)
 
     out_cache_loc = allocator.alloc_decode(seq_lens, seq_lens_cpu, last_loc)
 
@@ -434,7 +454,9 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
 
     if batch.tree_cache.page_size == 1:
         # Non-paged allocation
-        out_cache_loc = alloc_token_slots(batch.tree_cache, bs * token_per_req)
+        out_cache_loc = alloc_token_slots(
+            batch.tree_cache, bs * token_per_req, reqs=batch.reqs
+        )
     else:
         # Paged allocation
         last_loc = batch.req_to_token_pool.req_to_token[
@@ -447,6 +469,7 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
             seq_lens_cpu=batch.seq_lens_cpu + token_per_req,
             last_loc=last_loc,
             token_per_req=token_per_req,
+            reqs=batch.reqs,
         )
 
     # Write to req_to_token_pool

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -577,6 +577,18 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         ts = ts or time.perf_counter()
         self.scheduler_recv_time = ts
 
+    def trace_kv_cache_load_back(self, host_hit_length: int, start_ts: float):
+        if self.trace_ctx.tracing_enable:
+            duration_ms = round((time.perf_counter() - start_ts) * 1000, 2)
+            self.trace_ctx.trace_event(
+                "kv_cache_load_back",
+                level=1,
+                attrs={
+                    "host_hit_length": host_hit_length,
+                    "duration_ms": duration_ms,
+                },
+            )
+
     def set_retract_time(self, ts=None):
         ts = ts or time.perf_counter()
         # retract
@@ -1057,3 +1069,35 @@ def set_time_batch(reqs: List[Any], set_func: str):
     for req in reqs:
         method = getattr(req.time_stats, set_func)
         method(ts)
+
+
+def trace_kv_cache_eviction_batch(
+    reqs: Optional[List[Any]],
+    evict_result: Any,
+    start_ts: float,
+):
+    """Trace KV cache eviction event for a batch of requests."""
+    if reqs is None or len(reqs) == 0:
+        return
+    if not get_global_tracing_enabled():
+        return
+
+    total_evicted = (
+        evict_result.num_tokens_evicted + evict_result.swa_num_tokens_evicted
+    )
+    if total_evicted <= 0:
+        return
+
+    duration_ms = round((time.perf_counter() - start_ts) * 1000, 2)
+    attrs = {
+        "num_tokens_evicted": total_evicted,
+        "duration_ms": duration_ms,
+    }
+
+    for req in reqs:
+        if req.time_stats.trace_ctx.tracing_enable:
+            req.time_stats.trace_ctx.trace_event(
+                "kv_cache_eviction",
+                level=1,
+                attrs=attrs,
+            )


### PR DESCRIPTION
## Motivation

Related to #13511 ([Roadmap] roadmap of request tracing) - "Tracing for uncovered engine components"

KV cache eviction (GPU→CPU) and load-back (CPU→GPU) are critical memory management operations in SGLang that directly impact request latency, especially under memory pressure. Currently, these operations are invisible in the existing OpenTelemetry tracing infrastructure, making it difficult to diagnose latency spikes caused by cache thrashing.

This PR adds trace events for both eviction and load-back operations, leveraging the existing `TraceReqContext.trace_event()` API with zero overhead when tracing is disabled.

## Modifications

### KV Cache Eviction Tracing (`common.py`)
- Added optional `trace_contexts` parameter to `evict_from_tree_cache()` and propagated it through `alloc_token_slots()`, `alloc_paged_token_slots_extend()`, and `alloc_paged_token_slots_decode()`
- When eviction actually occurs and tracing is enabled, records a `kv_cache_eviction` event with:
  - `num_tokens_requested`: tokens requested for allocation
  - `num_tokens_evicted`: tokens actually evicted
  - `duration_ms`: eviction duration in milliseconds

### Trace Context Collection (`common.py`)
- `alloc_for_extend()` and `alloc_for_decode()` now collect `TraceReqContext` from `batch.reqs` and pass them down to allocation functions

### Schedule Batch Integration (`schedule_batch.py`)
- `check_decode_mem()` and `release_req()` now collect trace contexts from `self.reqs` and pass them to `evict_from_tree_cache()`

### KV Cache Load-back Tracing (`schedule_policy.py`)
- Added `kv_cache_load_back` trace event around `init_load_back()` call in `_prefill_one_req_sliding_window()` with:
  - `host_hit_length`: number of tokens loaded back from host
  - `duration_ms`: load-back duration in milliseconds
