### PR TITLE
Add kv_cache_dtype consistency check between prefill and decode

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -918,9 +918,21 @@ class MooncakeKVManager(CommonKVManager):
                 room = waiting_req_bytes[0].decode("ascii")
                 mooncake_session_id = waiting_req_bytes[3].decode("ascii")
                 if room == "None":
-                    self.decode_kv_args_table[mooncake_session_id] = (
-                        KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
-                    )
+                    reg_info = KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
+
+                    local_item_len = self.kv_args.kv_item_lens[0]
+                    remote_item_len = reg_info.dst_kv_item_len
+                    if local_item_len != remote_item_len:
+                        logger.error(
+                            f"KV cache item_len mismatch between prefill ({local_item_len}) and "
+                            f"decode ({remote_item_len}). This means prefill and decode use different "
+                            f"kv_cache_dtype, which is NOT supported in PD disaggregation. "
+                            f"Please set the same --kv-cache-dtype on both prefill and decode. "
+                            f"Refusing to register decode peer {mooncake_session_id}."
+                        )
+                        continue
+
+                    self.decode_kv_args_table[mooncake_session_id] = reg_info
                     with self.session_lock:
                         if mooncake_session_id in self.failed_sessions:
                             self.failed_sessions.remove(mooncake_session_id)

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -325,6 +325,19 @@ class NixlKVManager(CommonKVManager):
         if agent_name in self.decode_kv_args_table:
             logger.info(f"Peer {agent_name} was already registered, ignoring.")
             return
+
+        local_item_len = self.kv_args.kv_item_lens[0]
+        remote_item_len = decode_kv_args.dst_kv_item_len
+        if local_item_len != remote_item_len:
+            logger.error(
+                f"KV cache item_len mismatch between prefill ({local_item_len}) and "
+                f"decode ({remote_item_len}). This means prefill and decode use different "
+                f"kv_cache_dtype, which is NOT supported in PD disaggregation. "
+                f"Please set the same --kv-cache-dtype on both prefill and decode. "
+                f"Refusing to register decode peer {agent_name}."
+            )
+            return
+
         self.decode_kv_args_table[agent_name] = decode_kv_args
         self.agent.add_remote_agent(decode_kv_args.agent_metadata)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When prefill and decode use different kv_cache_dtype (e.g. prefill bf16, decode fp8_e4m3), the per-page item_len differs (32768 vs 16384). Since the transfer layer uses prefill's item_len to compute both src and dst addresses, this causes dst address overflow into unregistered memory at high concurrency, crashing with "Requested address not found" (Mooncake) or "NIXL_ERR_NOT_FOUND" (NIXL).

There is no dtype conversion in the transfer path, so mismatched dtype silently produces corrupted data at low concurrency and crashes at high concurrency. Add an item_len check when prefill receives decode's KV registration; on mismatch, log an error and refuse the peer instead of crashing the prefill process.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
