### PR TITLE
[DLLM] [BUG] Fix topk kernel bug for lower arch

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -53,6 +53,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
     get_compiler_backend,
+    get_device_capability,
     is_cpu,
     is_cuda,
     is_hip,
@@ -728,6 +729,9 @@ def biased_grouped_topk_gpu(
 
     if (
         _is_cuda
+        # fused_topk_deepseek only supports the following architectures: 89, 90, 100, 103, 120, 121
+        and get_device_capability()
+        in [(8, 9), (9, 0), (10, 0), (10, 3), (12, 0), (12, 1)]
         and fused_topk_deepseek is not None
         and num_fused_shared_experts == 0
         and is_power_of_two(num_experts)

--- a/test/registered/dllm/test_llada2_mini.py
+++ b/test/registered/dllm/test_llada2_mini.py
@@ -56,7 +56,7 @@ class TestLLaDA2Mini(CustomTestCase):
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
 
-    def test_gsm8k(self):
+    def test_gsm8k(self, mocking_lower_arch: bool = False):
         args = SimpleNamespace(
             num_shots=5,
             data_path=None,
@@ -72,10 +72,12 @@ class TestLLaDA2Mini(CustomTestCase):
         self.assertGreater(metrics["accuracy"], 0.88)
         if is_in_amd_ci():
             self.assertGreater(metrics["output_throughput"], 80)
+        elif mocking_lower_arch:
+            self.assertGreater(metrics["output_throughput"], 100)
         else:
             self.assertGreater(metrics["output_throughput"], 250)
 
-    def test_bs_1_speed(self):
+    def test_bs_1_speed(self, mocking_lower_arch: bool = False):
         args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=2048)
         acc_length, speed = send_one_prompt(args)
 
@@ -88,8 +90,20 @@ class TestLLaDA2Mini(CustomTestCase):
             )
             if is_in_amd_ci():
                 self.assertGreater(speed, 10)
+            elif mocking_lower_arch:
+                self.assertGreater(speed, 100)
             else:
                 self.assertGreater(speed, 250)
+
+    def test_for_lower_arch(self):
+        """Simulate sm_86 to verify fallback path works (fused_topk_deepseek unsupported)."""
+        if not is_in_amd_ci():
+            with unittest.mock.patch(
+                "sglang.srt.layers.moe.topk.get_device_capability",
+                return_value=(8, 6),
+            ):
+                self.test_gsm8k(mocking_lower_arch=True)
+                self.test_bs_1_speed(mocking_lower_arch=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation
FlashInfer's `fused_topk_deepseek` only supports compute capability 89, 90, 100, 103, 120, 121, and does not support lower archs like sm_86. Running MoE models (LLaDA2.0) on sm_86 GPUs raises `BackendSupportedError`. This PR adds a capability check and falls back to `moe_fused_gate` or `biased_grouped_topk_impl` on unsupported architectures.

## Modifications
- **topk.py**: Add `get_device_capability()` check before using `fused_topk_deepseek`; when capability is not in `[89, 90, 100, 103, 120, 121]`, use the existing fallback path instead.

## Testing
- **test_llada2_mini**: Add `test_for_lower_arch`, mocking sm_86 to verify the fallback path.
- Manually verified on RTX 3090 with TP 8: LLaDA2.0 server starts and runs without `BackendSupportedError`.

## Checklist
- [x] Format code
- [x] Add unit tests
- [ ] Update documentation (N/A)
- [ ] Benchmark (N/A – correctness-only fix)
- [x] Follow SGLang code style