### PR TITLE
Fix missing StandardCombineInput import in BF16 flashinfer_trtllm MoE

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -501,6 +501,8 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
     # lazy import
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
     try:
         from flashinfer.fused_moe import trtllm_bf16_moe
     except ImportError as e:


### PR DESCRIPTION
## Summary
- Add missing runtime import of `StandardCombineInput` in `fused_experts_none_to_flashinfer_trtllm_bf16()`, matching the pattern already used by the FP8 and FP4 variants in the same file
- Fixes `NameError: name 'StandardCombineInput' is not defined` that crashes both `test_flashinfer_trtllm_gen_attn_backend.py` and `test_flashinfer_trtllm_gen_moe_backend.py` in the nightly B200 CI
- may be related to #19266

## Error link
https://github.com/sgl-project/sglang/actions/runs/22422538348/job/64923364867

## Test plan
- [ ] Nightly B200 4-GPU tests pass (`test_flashinfer_trtllm_gen_attn_backend.py`, `test_flashinfer_trtllm_gen_moe_backend.py`)