### PR TITLE
[diffusion] support hybrid parallelism for diffusers backend

### DIFF
--- a/docs/diffusion/api/cli.md
+++ b/docs/diffusion/api/cli.md
@@ -296,3 +296,7 @@ For pipeline-specific parameters not exposed via CLI, use `diffusers_kwargs` in 
 ```bash
 sglang generate --config config.json
 ```
+
+### Cache-DiT Acceleration
+
+Users who use the diffusers backend can also leverage Cache-DiT acceleration and load custom cache configs from a YAML file to boost performance of diffusers pipelines. See the [Cache-DiT Acceleration](https://docs.sglang.io/diffusion/performance/cache/cache_dit.html) documentation for details.

--- a/docs/diffusion/performance/cache/cache_dit.md
+++ b/docs/diffusion/performance/cache/cache_dit.md
@@ -130,7 +130,17 @@ parallelism_config:
     attention_backend: native
     extra_parallel_modules: ["text_encoder", "vae"]
 ```
+
 Then, apply the hybrid cache and parallel acceleration config from yaml.
+
+```bash
+sglang generate \
+  --backend diffusers \
+  --num-gpus 4 \
+  --model-path Qwen/Qwen-Image \
+  --cache-dit-config hybrid.yaml \
+  --prompt "A beautiful sunset over the mountains"
+```
 
 ## Advanced Configuration
 
@@ -251,14 +261,6 @@ SGLang Diffusion x Cache-DiT supports almost all models originally supported in 
 - **Model support**: Only models registered in Cache-DiT's BlockAdapterRegister are supported
 
 ## Troubleshooting
-
-### Distributed environment warning
-
-```
-WARNING: cache-dit is disabled in distributed environment (world_size=N)
-```
-
-This is expected behavior. Cache-DiT currently only supports single-GPU inference.
 
 ### SCM disabled for low step count
 

--- a/docs/diffusion/performance/cache/cache_dit.md
+++ b/docs/diffusion/performance/cache/cache_dit.md
@@ -20,15 +20,15 @@ sglang generate --model-path Qwen/Qwen-Image \
     --prompt "A beautiful sunset over the mountains"
 ```
 
-## Diffusers Backend Configuration
+## Diffusers Backend
 
 Cache-DiT supports loading acceleration configs from a custom YAML file. For
-diffusers pipelines, pass the YAML/JSON path via `--cache-dit-config`. This
+diffusers pipelines (`diffusers` backend), pass the YAML/JSON path via `--cache-dit-config`. This
 flow requires cache-dit >= 1.2.0 (`cache_dit.load_configs`).
 
 ### Single GPU inference
 
-Define a `config.yaml` file that contains:
+Define a `cache.yaml` file that contains:
 
 ```yaml
 cache_config:
@@ -46,15 +46,72 @@ cache_config:
 Then apply the config with:
 
 ```bash
-sglang generate --backend diffusers \
+sglang generate \
+  --backend diffusers \
   --model-path Qwen/Qwen-Image \
-  --cache-dit-config config.yaml \
+  --cache-dit-config cache.yaml \
   --prompt "A beautiful sunset over the mountains"
 ```
 
 ### Distributed inference
 
-Define a `parallel_config.yaml` file that contains:
+- 1D Parallelism
+
+Define a parallelism only config yaml `parallel.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: auto
+  parallel_kwargs:
+    attention_backend: native
+    extra_parallel_modules: ["text_encoder", "vae"]
+```
+
+Then, apply the distributed inference acceleration config from yaml. `ulysses_size: auto` means that cache-dit will auto detect the `world_size` as the ulysses_size. Otherwise, you should manually set it as specific int number, e.g, 4.
+
+Then apply the distributed config with: (Note: please add `--num-gpus N` to specify the number of gpus for distributed inference)
+
+```bash
+sglang generate \
+  --backend diffusers \
+  --num-gpus 4 \
+  --model-path Qwen/Qwen-Image \
+  --cache-dit-config parallel.yaml \
+  --prompt "A futuristic cityscape at sunset"
+```
+
+- 2D Parallelism
+
+You can also define a 2D parallelism config yaml `parallel_2d.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: auto
+  tp_size: 2
+  parallel_kwargs:
+    attention_backend: native
+    extra_parallel_modules: ["text_encoder", "vae"]
+```
+Then, apply the 2D parallelism config from yaml. Here `tp_size: 2` means using tensor parallelism with size 2. The `ulysses_size: auto` means that cache-dit will auto detect the `world_size // tp_size` as the ulysses_size.
+
+- 3D Parallelism
+
+You can also define a 3D parallelism config yaml `parallel_3d.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: 2
+  ring_size: 2
+  tp_size: 2
+  parallel_kwargs:
+    attention_backend: native
+    extra_parallel_modules: ["text_encoder", "vae"]
+```
+Then, apply the 3D parallelism config from yaml. Here `ulysses_size: 2`, `ring_size: 2`, `tp_size: 2` means using ulysses parallelism with size 2, ring parallelism with size 2 and tensor parallelism with size 2.
+
+### Hybrid Cache and Parallelism
+
+Define a hybrid cache and parallel acceleration config yaml `hybrid.yaml` file that contains:
 
 ```yaml
 cache_config:
@@ -73,18 +130,7 @@ parallelism_config:
     attention_backend: native
     extra_parallel_modules: ["text_encoder", "vae"]
 ```
-
-`ulysses_size: auto` means cache-dit will auto-detect the world_size. Otherwise,
-set it to a specific integer (e.g., `4`).
-
-Then apply the distributed config with:
-
-```bash
-sglang generate --backend diffusers \
-  --model-path Qwen/Qwen-Image \
-  --cache-dit-config parallel_config.yaml \
-  --prompt "A futuristic cityscape at sunset"
-```
+Then, apply the hybrid cache and parallel acceleration config from yaml.
 
 ## Advanced Configuration
 
@@ -221,5 +267,5 @@ acceleration still works.
 
 ## References
 
-- [Cache-Dit](https://github.com/vipshop/cache-dit)
+- [Cache-DiT](https://github.com/vipshop/cache-dit)
 - [SGLang Diffusion](../index.md)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -111,7 +111,7 @@ diffusion = [
   "st_attn==0.0.7 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "vsa==0.0.4 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "runai_model_streamer>=0.15.5",
-  "cache-dit==1.2.0",
+  "cache-dit==1.2.3",
   "addict==2.4.0",
   "av==16.1.0",
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Optimize the inference performance of `diffusers` backend.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

- Bump cache-dit version to v1.2.3: support USP and hybrid 2D/3D/... parallelism (USP + TP + ...) for `diffusers` backend
- Add many cache-dit config examples and update related docs for diffusers backend.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Device: NVIDIA L20 x 8 node, FLUX.1-dev, 28 steps, 1024 x 1024, enabled TE-P, VAE-P by default.

|sgld backend|diffusers backend|diffusers be + cache-dit scm | diffusers be + cache-dit ulysses-2|
|:---:|:---:|:---:|:---:|
|20.20s|23.59s|14.65s|13.92s|
|<img width="1024" height="1024" alt="flux_sgld" src="https://github.com/user-attachments/assets/ddd990a9-18fa-4c99-afdf-d8856bc85bdc" />|<img width="1024" height="1024" alt="flux_diffusers" src="https://github.com/user-attachments/assets/68f28f6a-2422-4df0-be3a-2b3420184727" />|<img width="1024" height="1024" alt="flux_cache_diffusers" src="https://github.com/user-attachments/assets/fe764b89-cbff-498c-8182-13682ad22106" />|<img width="1024" height="1024" alt="flux_ulysses2_diffusers" src="https://github.com/user-attachments/assets/159a510c-f204-4515-b83a-de7810f5a96f" />|
|diffusers be + cache-dit ulysses-4|diffusers be + cache-dit ulysses-2 + tp-2|diffusers be + cache-dit ulysses-2 + ring-2|diffusers be + cache-dit ulysses-2 + ring-2 + tp-2|
|8.46s|9.81s|8.66s|10.87s|
|<img width="1024" height="1024" alt="flux_ulysses4_diffusers" src="https://github.com/user-attachments/assets/dc80bfb8-ff42-4b18-b112-157472da6923" />|<img width="1024" height="1024" alt="flux_parallel_ulysses2_tp2_diffusers" src="https://github.com/user-attachments/assets/b86433da-817b-4cd0-802b-66849e7ba034" />|<img width="1024" height="1024" alt="flux_parallel_ulysses2_ring2_diffusers" src="https://github.com/user-attachments/assets/4d90637f-fb8a-4e6f-aeff-8743a97bf909" />|<img width="1024" height="1024" alt="flux_parallel_ulysses2_ring2_tp2_diffusers" src="https://github.com/user-attachments/assets/32b033d4-81a9-46c8-b4b6-bc5b38dc794d" />|

### Reproduce

config files: https://github.com/vipshop/cache-dit/tree/main/examples/configs

```bash
git clone https://github.com/vipshop/cache-dit.git && cd cache-dit/examples/configs
```

command lines: 

```bash
# --- Test different parallelism configurations with diffusers backend ---
# FLUX + SGLD backend, baseline
sglang generate \
  --model-path=$FLUX_DIR \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --save-output --output-path outputs --output-file-name flux_sgld.png

# FLUX + diffusers backend, baseline
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --save-output --output-path outputs --output-file-name flux_diffusers.png

# FLUX + diffusers backend, cache + SCM
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./cache.yaml \
  --save-output --output-path outputs --output-file-name flux_cache_diffusers.png

# FLUX + diffusers backend, 1d parallelism (ulysses)
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 2 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel.yaml \
  --save-output --output-path outputs --output-file-name flux_ulysses2_diffusers.png

sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 4 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel.yaml \
  --save-output --output-path outputs --output-file-name flux_ulysses4_diffusers.png

# FLUX + diffusers backend, 2d parallelism: ulysses + tp
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 4 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel_2d.yaml \
  --save-output --output-path outputs --output-file-name flux_parallel_ulysses2_tp2_diffusers.png

# FLUX + diffusers backend, USP parallelism: ulysses + ring
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 4 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel_usp.yaml \
  --save-output --output-path outputs --output-file-name flux_parallel_ulysses2_ring2_diffusers.png

# FLUX + diffusers backend, 3d parallelism: usp + tp
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 8 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel_3d.yaml \
  --save-output --output-path outputs --output-file-name flux_parallel_ulysses2_ring2_tp2_diffusers.png
```
For examples: 

```bash

# FLUX + diffusers backend, USP parallelism: ulysses + ring
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 4 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel_usp.yaml \
  --save-output --output-path outputs --output-file-name flux_parallel_ulysses2_ring2_diffusers.png

# Output logs:
[2026-02-26 08:10:58] INFO utils.py:131: Diffusion model detected
[2026-02-26 08:10:58] INFO registry.py:361: Using diffusers backend for model '/workspace/dev/vipdev/hf_models/FLUX.1-dev' (explicitly requested)
[02-26 08:10:58] Disabling some offloading (except dit, text_encoder) for image generation model
[02-26 08:10:58] Warmup enabled, the launch time is expected to be longer than usual
[02-26 08:10:58] Automatically set ulysses_degree=sp_degree=4 for best performance
[02-26 08:10:58] server_args: {"model_path": "/workspace/dev/vipdev/hf_models/FLUX.1-dev", "backend": "diffusers", "attention_backend": null, "attention_backend_config": {}, "cache_dit_config": "./parallel_usp.yaml", "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 4, "tp_size": 1, "sp_degree": 4, "ulysses_degree": 4, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 4, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": false, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": false, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "comfyui_mode": false, "enable_torch_compile": false, "warmup": true, "warmup_resolutions": null, "disable_autocast": false, "master_port": 30088, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5638, "output_path": "outputs", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "log_level": "info"}
[02-26 08:10:58] Local mode: True
[02-26 08:10:58] Starting server...
[02-26 08:11:08] Scheduler bind at endpoint: tcp://127.0.0.1:5638
[02-26 08:11:08] Initializing distributed environment with world_size=4, device=cuda:0, timeout=3600
[02-26 08:11:08] Setting distributed timeout to 3600 seconds
[02-26 08:11:09] Found nccl from library libnccl.so.2
[02-26 08:11:09] sglang-diffusion is using nccl==2.27.5
[02-26 08:11:10] Found nccl from library libnccl.so.2
[02-26 08:11:10] sglang-diffusion is using nccl==2.27.5
[02-26 08:11:10] No pipeline_class_name specified, using model_index.json
[02-26 08:11:10] Using diffusers backend for model '/workspace/dev/vipdev/hf_models/FLUX.1-dev' (explicitly requested)
[02-26 08:11:10] Using pipeline from model_index.json: DiffusersPipeline
[02-26 08:11:10] Loading diffusers pipeline from /workspace/dev/vipdev/hf_models/FLUX.1-dev
[02-26 08:11:10] Model already exists locally and is complete
[02-26 08:11:10] Loading diffusers pipeline with dtype=torch.bfloat16
Keyword arguments {'trust_remote_code': False} are not expected by FluxPipeline and will be ignored.
Keyword arguments {'trust_remote_code': False} are not expected by FluxPipeline and will be ignored.
Loading pipeline components...:   0%|                                                                                                                                                                                               | 0/7 [00:00<?, ?it/s]Keyword arguments {'trust_remote_code': False} are not expected by FluxPipeline and will be ignored.
Loading pipeline components...:   0%|                                                                                                                                                                                               | 0/7 [00:00<?, ?it/s]Keyword arguments {'trust_remote_code': False} are not expected by FluxPipeline and will be ignored.
Loading pipeline components...:   0%|                                                                                                                                                                                               | 0/7 [00:00<?, ?it/s]`torch_dtype` is deprecated! Use `dtype` instead!
`torch_dtype` is deprecated! Use `dtype` instead!
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 96.77it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 37.18it/s]
Loading pipeline components...:  29%|████████████████████████████████████████████████████▎                                                                                                                                  | 2/7 [00:00<00:01,  3.96it/s]`torch_dtype` is deprecated! Use `dtype` instead!
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 38.93it/s]
Loading pipeline components...:  71%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                                                    | 5/7 [00:00<00:00,  9.09it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 38.50it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 97.40it/s]
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers                                                                                                                                            | 0/2 [00:00<?, ?it/s]
`torch_dtype` is deprecated! Use `dtype` instead!
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 95.13it/s]
Loading pipeline components...:  57%|████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                                                              | 4/7 [00:00<00:00,  5.91it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 39.30it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 98.91it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  7.37it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  7.11it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  7.18it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:01<00:00,  6.31it/s]
[02-26 08:11:22] [Cache-DiT] Auto selected parallel size for ulysses_size to 2.
[02-26 08:11:22] [Cache-DiT] Auto selected parallelism backend for transformer: Native_Diffuser
[02-26 08:11:22] [Cache-DiT] Parallelism is enabled and cache_config is None. Please manually set cache_config to avoid potential compatibility issues. Otherwise, cache will not be enabled.
[02-26 08:11:22] [Cache-DiT] cache_config is None, skip enabling cache for FluxPipeline.
[02-26 08:11:22] [Cache-DiT] Registered custom attn backends: native, _sdpa_cudnn, sage, _flash_3, _native_npu, _npu_fia.
[02-26 08:11:22] [Cache-DiT] Parallelize Transformer: FluxTransformer2DModel, id:140237797993712, ParallelismConfig(backend=Native_Diffuser, ulysses_size=2, ring_size=2)
Attention backends are an experimental feature and the API may be subject to change.
Attention backends are an experimental feature and the API may be subject to change.
Attention backends are an experimental feature and the API may be subject to change.
Attention backends are an experimental feature and the API may be subject to change.
[02-26 08:11:22] [Cache-DiT] Found attention_backend from config, set attention backend of FluxTransformer2DModel to: native.
[02-26 08:11:25] Enabled cache-dit for diffusers pipeline
[02-26 08:11:25] Loaded diffusers pipeline: FluxPipeline
[02-26 08:11:25] Pipeline instantiated
[02-26 08:11:25] Worker 0: Initialized device, model, and distributed environment.
[02-26 08:11:25] Worker 0: Scheduler loop started.
[02-26 08:11:25] Processing prompt 1/1: A fantasy landscape with mountains and a river, detailed, vibrant colors
[02-26 08:11:25] Processing warmup req... (1/1)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.16it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.17it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.16it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.18it/s]
[02-26 08:11:27] Warmup req (1/1) processed in 1.90 seconds
[02-26 08:11:27] [DiffusersExecutionStage] started...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:08<00:00,  3.45it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:08<00:00,  3.45it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:08<00:00,  3.45it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:08<00:00,  3.45it/s]
[02-26 08:11:36] [DiffusersExecutionStage] finished in 8.6837 seconds
[02-26 08:11:36] Peak GPU memory: 36.12 GB, Peak allocated: 33.83 GB, Memory pool overhead: 2.29 GB (6.3%), Remaining GPU memory at peak: 8.87 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[02-26 08:11:36] Output saved to outputs/flux_parallel_ulysses2_ring2_diffusers.png
[02-26 08:11:36] Pixel data generated successfully in 11.06 seconds
[02-26 08:11:36] Completed batch processing. Generated 1 outputs in 11.06 seconds
[02-26 08:11:36] Warmed-up request processed in 8.69 seconds (with warmup excluded)
[02-26 08:11:36] Memory usage - Max peak: 36988.00 MB, Avg peak: 36988.00 MB
[02-26 08:11:36] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
[02-26 08:11:42] Worker 0: Shutdown complete.

# FLUX + diffusers backend, 1d parallelism (ulysses)
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --num-gpus 2 \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./parallel.yaml \
  --save-output --output-path outputs --output-file-name flux_ulysses2_diffusers.png

# Output logs:
[2026-02-26 08:41:43] INFO utils.py:131: Diffusion model detected
[2026-02-26 08:41:43] INFO registry.py:361: Using diffusers backend for model '/workspace/dev/vipdev/hf_models/FLUX.1-dev' (explicitly requested)
[02-26 08:41:43] Disabling some offloading (except dit, text_encoder) for image generation model
[02-26 08:41:43] Warmup enabled, the launch time is expected to be longer than usual
[02-26 08:41:43] Automatically set ulysses_degree=sp_degree=2 for best performance
[02-26 08:41:43] server_args: {"model_path": "/workspace/dev/vipdev/hf_models/FLUX.1-dev", "backend": "diffusers", "attention_backend": null, "attention_backend_config": {}, "cache_dit_config": "./parallel.yaml", "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 2, "tp_size": 1, "sp_degree": 2, "ulysses_degree": 2, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 2, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": false, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": false, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "comfyui_mode": false, "enable_torch_compile": false, "warmup": true, "warmup_resolutions": null, "disable_autocast": false, "master_port": 30047, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5555, "output_path": "outputs", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "log_level": "info"}
[02-26 08:41:43] Local mode: True
[02-26 08:41:43] Starting server...
[02-26 08:41:53] Scheduler bind at endpoint: tcp://127.0.0.1:5555
[02-26 08:41:53] Initializing distributed environment with world_size=2, device=cuda:0, timeout=3600
[02-26 08:41:53] Setting distributed timeout to 3600 seconds
[02-26 08:41:54] Found nccl from library libnccl.so.2
[02-26 08:41:54] sglang-diffusion is using nccl==2.27.5
[02-26 08:41:54] Found nccl from library libnccl.so.2
[02-26 08:41:54] sglang-diffusion is using nccl==2.27.5
[02-26 08:41:54] No pipeline_class_name specified, using model_index.json
[02-26 08:41:54] Using diffusers backend for model '/workspace/dev/vipdev/hf_models/FLUX.1-dev' (explicitly requested)
[02-26 08:41:54] Using pipeline from model_index.json: DiffusersPipeline
[02-26 08:41:54] Loading diffusers pipeline from /workspace/dev/vipdev/hf_models/FLUX.1-dev
[02-26 08:41:54] Model already exists locally and is complete
[02-26 08:41:54] Loading diffusers pipeline with dtype=torch.bfloat16
Keyword arguments {'trust_remote_code': False} are not expected by FluxPipeline and will be ignored.
Keyword arguments {'trust_remote_code': False} are not expected by FluxPipeline and will be ignored.
Loading pipeline components...:   0%|                                                                                                                                                                                               | 0/7 [00:00<?, ?it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading pipeline components...:  14%|██████████████████████████▏                                                                                                                                                            | 1/7 [00:00<00:03,  1.81it/s]`torch_dtype` is deprecated! Use `dtype` instead!
`torch_dtype` is deprecated! Use `dtype` instead!
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 99.03it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 39.38it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 39.72it/s]
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 100.22it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  8.00it/s]
Loading pipeline components...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  8.00it/s]
[02-26 08:42:04] [Cache-DiT] Auto selected parallel size for ulysses_size to 2.
[02-26 08:42:04] [Cache-DiT] Auto selected parallelism backend for transformer: Native_Diffuser
[02-26 08:42:04] [Cache-DiT] Parallelism is enabled and cache_config is None. Please manually set cache_config to avoid potential compatibility issues. Otherwise, cache will not be enabled.
[02-26 08:42:04] [Cache-DiT] cache_config is None, skip enabling cache for FluxPipeline.
[02-26 08:42:04] [Cache-DiT] Registered custom attn backends: native, _sdpa_cudnn, sage, _flash_3, _native_npu, _npu_fia.
[02-26 08:42:04] [Cache-DiT] Parallelize Transformer: FluxTransformer2DModel, id:139961148053248, ParallelismConfig(backend=Native_Diffuser, ulysses_size=2)
Attention backends are an experimental feature and the API may be subject to change.
Attention backends are an experimental feature and the API may be subject to change.
[02-26 08:42:04] [Cache-DiT] Found attention_backend from config, set attention backend of FluxTransformer2DModel to: native.
[02-26 08:42:04] [Cache-DiT] Parallelize Text Encoder: T5EncoderModel, id:139960973257152, ParallelismConfig(backend=Native_PyTorch, tp_size=2)
[02-26 08:42:04] [Cache-DiT] Parallelize Auto Encoder: AutoencoderKL, id:139960844764224, ParallelismConfig(backend=Native_PyTorch, dp_size=2)
[02-26 08:42:07] Enabled cache-dit for diffusers pipeline
[02-26 08:42:07] Loaded diffusers pipeline: FluxPipeline
[02-26 08:42:07] Pipeline instantiated
[02-26 08:42:07] Worker 0: Initialized device, model, and distributed environment.
[02-26 08:42:07] Worker 0: Scheduler loop started.
[02-26 08:42:07] Processing prompt 1/1: A fantasy landscape with mountains and a river, detailed, vibrant colors
[02-26 08:42:07] Processing warmup req... (1/1)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.74it/s]

[02-26 08:42:08] Warmup req (1/1) processed in 1.38 seconds
[02-26 08:42:08] [DiffusersExecutionStage] started...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:13<00:00,  2.08it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:13<00:00,  2.08it/s]
[02-26 08:42:22] [DiffusersExecutionStage] finished in 13.9375 seconds
[02-26 08:42:22] Peak GPU memory: 31.58 GB, Peak allocated: 29.52 GB, Memory pool overhead: 2.07 GB (6.5%), Remaining GPU memory at peak: 13.40 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[02-26 08:42:23] Output saved to outputs/flux_ulysses2_diffusers.png
[02-26 08:42:23] Pixel data generated successfully in 15.77 seconds
[02-26 08:42:23] Completed batch processing. Generated 1 outputs in 15.77 seconds
[02-26 08:42:23] Warmed-up request processed in 13.94 seconds (with warmup excluded)
[02-26 08:42:23] Memory usage - Max peak: 32342.00 MB, Avg peak: 32342.00 MB
[02-26 08:42:23] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
[02-26 08:42:28] Worker 0: Shutdown complete.
```


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

cc @mickqian 