### PR TITLE
[Qwen3.5] Qwen3.5-27B inference repeat bug fix

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -352,6 +352,7 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
             allow_reduce_scatter=True,
+            is_last_layer=(layer_id == config.num_hidden_layers - 1),
         )
 
     def forward(
@@ -542,6 +543,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
             allow_reduce_scatter=True,
+            is_last_layer=(layer_id == config.num_hidden_layers - 1),
         )
 
         self.alt_stream = alt_stream


### PR DESCRIPTION
## Motivation

fix [#19393](https://github.com/sgl-project/sglang/issues/19393)
fix [#19322](https://github.com/sgl-project/sglang/issues/19322)

When deploying the `Qwen3.5-27B` model with `tp=2`, the model produces repetitive (degenerate) outputs, while `tp=1` works correctly.

### Root Cause

`Qwen3_5LinearDecoderLayer` and `Qwen3_5AttentionDecoderLayer` do not pass `is_last_layer` to `LayerCommunicator` (defaults to `False` for all layers, including the last one).

When `tp >= 2` on sm90+ GPUs with flashinfer available, `should_fuse_mlp_allreduce_with_next_layer()` returns `True` for **every layer including the last one**, because `not self.is_last_layer` is always `True`. This causes the last layer's MLP output to skip `all-reduce` and `postprocess_layer`, but there is no subsequent layer to perform the deferred all-reduce. The final `self.norm(hidden_states, residual)` then adds **un-reduced partial MLP output** to the **already-reduced residual**, producing incorrect hidden states per TP rank, which leads to wrong logits and repetitive text generation.

With `tp=1`, `should_fuse_mlp_allreduce_with_next_layer()` always returns `False` (requires `tp_size > 1`), so the issue never triggers.

All other models using allreduce fusion (DeepSeek V2, Qwen3 MoE, GLM4 MoE, SDAR MoE, etc.) correctly set `is_last_layer`.

## Modifications

Added `is_last_layer=(layer_id == config.num_hidden_layers - 1)` to `LayerCommunicator` initialization in both:

- `Qwen3_5LinearDecoderLayer` (line 355)
- `Qwen3_5AttentionDecoderLayer` (line 546)

This is consistent with how other models handle it, e.g.:

- `qwen3_moe.py`: `is_last_layer=(self.layer_id == self.config.num_hidden_layers - 1)`

## Accuracy Tests

- `tp=1`: No change (allreduce fusion was never triggered).
- `tp=2`: Previously produced repetitive/degenerate output; after fix, should produce correct output matching `tp=1`.

deploy cmd:

```
nohup python -m sglang.launch_server \
  --model Qwen/Qwen3.5-27B \
  --tp 2 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --speculative-algo NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --host 0.0.0.0 \
  --port 8123 > sgl_server.log 2>&1 &
```

fix before:

```
curl --location --request POST 'http://localhost:8123/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data-raw '{
  "model": "qwen35-27b",
  "messages": [
    {
      "role": "system",
      "content": "you are a useful assistant."
    },
    {
      "role": "user",
      "content": "why are electric vehicle batteries more durable than mobile phone batteries?"
    }
  ],
  "max_tokens": 1000,
  "stream": false
}'
```

output:
<img width="2600" height="1092" alt="image" src="https://github.com/user-attachments/assets/09579565-96a6-4363-b93e-de7e91b3fb80" />

=================

after fixing:

<img width="2600" height="1384" alt="image" src="https://github.com/user-attachments/assets/7a98a7e3-0585-4cbc-8311-cb4f3232bac1" />



## Benchmarking and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.