### PR TITLE
[Diffusion] [Wan] Skip USP for Cross-Attention with Replicated KV in Wan

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -366,7 +366,7 @@ class USPAttention(nn.Module):
         ), "USPAttention does not support replicated_qkv."
         forward_context: ForwardContext = get_forward_context()
         ctx_attn_metadata = forward_context.attn_metadata
-        if get_sequence_parallel_world_size() == 1 or skip_sp: #skip_sp or
+        if skip_sp or get_sequence_parallel_world_size() == 1:
             out = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
             return out
 

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -347,11 +347,17 @@ class USPAttention(nn.Module):
         replicated_q: torch.Tensor | None = None,
         replicated_k: torch.Tensor | None = None,
         replicated_v: torch.Tensor | None = None,
+        skip_sp: bool = False,
     ) -> torch.Tensor:
         """
         Forward pass for USPAttention.
 
             q, k, v: [B, S_local, H, D]
+
+        Args:
+            skip_sp: If True, skip all sequence parallelism (both Ulysses
+                and Ring) and compute local attention directly. Use this for
+                cross-attention where KV is replicated across all ranks.
 
         Note: Replicated tensors are not supported in this implementation.
         """
@@ -360,8 +366,7 @@ class USPAttention(nn.Module):
         ), "USPAttention does not support replicated_qkv."
         forward_context: ForwardContext = get_forward_context()
         ctx_attn_metadata = forward_context.attn_metadata
-        if get_sequence_parallel_world_size() == 1:
-            # No sequence parallelism, just run local attention.
+        if get_sequence_parallel_world_size() == 1 or skip_sp: #skip_sp or
             out = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
             return out
 

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -304,9 +304,17 @@ class USPAttention(nn.Module):
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         prefix: str = "",
         dropout_rate: float = 0.0,
-        is_cross_attention: bool = False,
+        skip_sequence_parallel: bool = False,
         **extra_impl_args,
     ) -> None:
+        """
+        Args:
+            skip_sequence_parallel:
+              when KV is replicated across all SP ranks (e.g. cross-attention to
+              text/image encoder outputs), the full USP pipeline is redundant:
+              each rank's local Q shard can attend directly to the locally-held
+              full KV without any collective communication.
+        """
         super().__init__()
         if softmax_scale is None:
             self.softmax_scale = head_size**-0.5
@@ -339,6 +347,8 @@ class USPAttention(nn.Module):
         self.dropout_p = dropout_rate
         self.is_cross_attention = is_cross_attention
 
+        self.skip_sequence_parallel = skip_sequence_parallel
+
     def forward(
         self,
         q: torch.Tensor,
@@ -347,26 +357,23 @@ class USPAttention(nn.Module):
         replicated_q: torch.Tensor | None = None,
         replicated_k: torch.Tensor | None = None,
         replicated_v: torch.Tensor | None = None,
-        skip_sp: bool = False,
     ) -> torch.Tensor:
         """
         Forward pass for USPAttention.
 
             q, k, v: [B, S_local, H, D]
 
-        Args:
-            skip_sp: If True, skip all sequence parallelism (both Ulysses
-                and Ring) and compute local attention directly. Use this for
-                cross-attention where KV is replicated across all ranks.
-
         Note: Replicated tensors are not supported in this implementation.
+        When skip_sequence_parallel=True (set at construction time), all SP
+        communication is bypassed — use this for cross-attention where KV
+        content is replicated across ranks (distinct from replicated_k/v args).
         """
         assert (
             replicated_q is None and replicated_k is None and replicated_v is None
         ), "USPAttention does not support replicated_qkv."
         forward_context: ForwardContext = get_forward_context()
         ctx_attn_metadata = forward_context.attn_metadata
-        if skip_sp or get_sequence_parallel_world_size() == 1:
+        if self.skip_sequence_parallel or get_sequence_parallel_world_size() == 1:
             out = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
             return out
 

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -374,6 +374,7 @@ class USPAttention(nn.Module):
         forward_context: ForwardContext = get_forward_context()
         ctx_attn_metadata = forward_context.attn_metadata
         if self.skip_sequence_parallel or get_sequence_parallel_world_size() == 1:
+            # No sequence parallelism, just run local attention.
             out = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
             return out
 

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -22,7 +22,6 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
 )
 from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
 from sglang.multimodal_gen.runtime.layers.usp import (
-    _ulysses_input_split,
     _usp_input_all_to_all,
     _usp_output_all_to_all,
     ring_attn,
@@ -345,7 +344,6 @@ class USPAttention(nn.Module):
         self.dtype = dtype
         self.causal = causal
         self.dropout_p = dropout_rate
-        self.is_cross_attention = is_cross_attention
 
         self.skip_sequence_parallel = skip_sequence_parallel
 
@@ -382,15 +380,11 @@ class USPAttention(nn.Module):
         if get_ulysses_parallel_world_size() > 1:
             # -> [B, S, H_local, D]
             q = _usp_input_all_to_all(q, head_dim=2)
-            if self.is_cross_attention:
-                k = _ulysses_input_split(k, dim=2)
-                v = _ulysses_input_split(v, dim=2)
-            else:
-                k = _usp_input_all_to_all(k, head_dim=2)
-                v = _usp_input_all_to_all(v, head_dim=2)
+            k = _usp_input_all_to_all(k, head_dim=2)
+            v = _usp_input_all_to_all(v, head_dim=2)
 
         # Ring Attention within subgroups or local attention
-        if get_ring_parallel_world_size() > 1 and not self.is_cross_attention:
+        if get_ring_parallel_world_size() > 1:
             out = ring_attn(
                 q,
                 k,

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -181,9 +181,6 @@ class WanSelfAttention(nn.Module):
         r"""
         Args:
             x(Tensor): Shape [B, L, num_heads, C / num_heads]
-            seq_lens(Tensor): Shape [B]
-            grid_sizes(Tensor): Shape [B, 3], the second dimension contains (F, H, W)
-            freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]
         """
         pass
 
@@ -223,6 +220,7 @@ class WanT2VCrossAttention(WanSelfAttention):
         v, _ = self.to_v(context)
         v = v.unflatten(2, (self.local_num_heads, self.head_dim))
 
+        # compute attention
         x = self.attn(q, k, v)
 
         # output

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -187,13 +187,6 @@ class WanSelfAttention(nn.Module):
 
 class WanT2VCrossAttention(WanSelfAttention):
     def __init__(self, *args, **kwargs):
-        super().__init__(
-            *args,
-            **kwargs,
-            is_cross_attention=True,
-        )
-
-    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs, is_cross_attention=True)
 
     def forward(self, x, context, context_lens):

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -136,6 +136,7 @@ class WanSelfAttention(nn.Module):
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         is_cross_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
+        is_cross_attention: bool = False,
     ) -> None:
         assert dim % num_heads == 0
         super().__init__()
@@ -174,7 +175,7 @@ class WanSelfAttention(nn.Module):
             softmax_scale=None,
             causal=False,
             supported_attention_backends=supported_attention_backends,
-            is_cross_attention=is_cross_attention,
+            skip_sequence_parallel=is_cross_attention,
         )
 
     def forward(self, x: torch.Tensor, context: torch.Tensor, context_lens: int):
@@ -195,6 +196,9 @@ class WanT2VCrossAttention(WanSelfAttention):
             **kwargs,
             is_cross_attention=True,
         )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, is_cross_attention=True)
 
     def forward(self, x, context, context_lens):
         r"""
@@ -220,7 +224,7 @@ class WanT2VCrossAttention(WanSelfAttention):
         v, _ = self.to_v(context)
         v = v.unflatten(2, (self.local_num_heads, self.head_dim))
 
-        x = self.attn(q, k, v, skip_sp=True)
+        x = self.attn(q, k, v)
 
         # output
         x = x.flatten(2)
@@ -249,6 +253,7 @@ class WanI2VCrossAttention(WanSelfAttention):
             supported_attention_backends=supported_attention_backends,
             is_cross_attention=True,
             quant_config=quant_config,
+            is_cross_attention=True,
         )
 
         self.add_k_proj = ColumnParallelLinear(
@@ -296,8 +301,8 @@ class WanI2VCrossAttention(WanSelfAttention):
         v_img, _ = self.add_v_proj(context_img)
         v_img = v_img.unflatten(2, (self.local_num_heads, self.head_dim))
 
-        img_x = self.attn(q, k_img, v_img, skip_sp=True)
-        x = self.attn(q, k, v, skip_sp=True)
+        img_x = self.attn(q, k_img, v_img)
+        x = self.attn(q, k, v)
 
         # output
         x = x.flatten(2)

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -220,8 +220,7 @@ class WanT2VCrossAttention(WanSelfAttention):
         v, _ = self.to_v(context)
         v = v.unflatten(2, (self.local_num_heads, self.head_dim))
 
-        # compute attention
-        x = self.attn(q, k, v)
+        x = self.attn(q, k, v, skip_sp=True)
 
         # output
         x = x.flatten(2)
@@ -267,6 +266,13 @@ class WanI2VCrossAttention(WanSelfAttention):
             context(Tensor): Shape [B, L2, C]
             context_lens(Tensor): Shape [B]
         """
+        if not WanTransformerBlock._attn_shape_logged:
+            logger.info(
+                f"[I2V CrossAttn] raw input: x(video)={list(x.shape)}, "
+                f"context(full)={list(context.shape)}, "
+                f"context_img=context[:, :257]={list(context[:, :257].shape)}, "
+                f"context_txt=context[:, 257:]={list(context[:, 257:].shape)}"
+            )
         context_img = context[:, :257]
         context = context[:, 257:]
 
@@ -297,8 +303,18 @@ class WanI2VCrossAttention(WanSelfAttention):
         v_img, _ = self.add_v_proj(context_img)
         v_img = v_img.unflatten(2, (self.local_num_heads, self.head_dim))
 
-        img_x = self.attn(q, k_img, v_img)
-        x = self.attn(q, k, v)
+        if not WanTransformerBlock._attn_shape_logged:
+            logger.info(
+                f"[I2V CrossAttn] image path: Q={list(q.shape)}, K_img={list(k_img.shape)}, V_img={list(v_img.shape)}"
+            )
+        img_x = self.attn(q, k_img, v_img, skip_sp=True)
+
+        if not WanTransformerBlock._attn_shape_logged:
+            logger.info(
+                f"[I2V CrossAttn] text path:  Q={list(q.shape)}, K_txt={list(k.shape)}, V_txt={list(v.shape)}"
+            )
+            WanTransformerBlock._attn_shape_logged = True
+        x = self.attn(q, k, v, skip_sp=True)
 
         # output
         x = x.flatten(2)
@@ -309,6 +325,8 @@ class WanI2VCrossAttention(WanSelfAttention):
 
 
 class WanTransformerBlock(nn.Module):
+
+    _attn_shape_logged = False
 
     def __init__(
         self,
@@ -503,6 +521,10 @@ class WanTransformerBlock(nn.Module):
             query, key = _apply_rotary_emb(
                 query, cos, sin, is_neox_style=False
             ), _apply_rotary_emb(key, cos, sin, is_neox_style=False)
+        if not WanTransformerBlock._attn_shape_logged:
+            logger.info(
+                f"[Self-Attn] Q={list(query.shape)}, K={list(key.shape)}, V={list(value.shape)}"
+            )
         attn_output = self.attn1(query, key, value)
         attn_output = attn_output.flatten(2)
         attn_output, _ = self.to_out(attn_output)
@@ -519,6 +541,11 @@ class WanTransformerBlock(nn.Module):
         ), hidden_states.to(orig_dtype)
 
         # 2. Cross-attention
+        if not WanTransformerBlock._attn_shape_logged:
+            logger.info(
+                f"[Block CrossAttn call] video_hidden={list(norm_hidden_states.shape)}, "
+                f"encoder_hidden_states={list(encoder_hidden_states.shape)}"
+            )
         attn_output = self.attn2(
             norm_hidden_states, context=encoder_hidden_states, context_lens=None
         )

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -266,13 +266,6 @@ class WanI2VCrossAttention(WanSelfAttention):
             context(Tensor): Shape [B, L2, C]
             context_lens(Tensor): Shape [B]
         """
-        if not WanTransformerBlock._attn_shape_logged:
-            logger.info(
-                f"[I2V CrossAttn] raw input: x(video)={list(x.shape)}, "
-                f"context(full)={list(context.shape)}, "
-                f"context_img=context[:, :257]={list(context[:, :257].shape)}, "
-                f"context_txt=context[:, 257:]={list(context[:, 257:].shape)}"
-            )
         context_img = context[:, :257]
         context = context[:, 257:]
 
@@ -303,17 +296,7 @@ class WanI2VCrossAttention(WanSelfAttention):
         v_img, _ = self.add_v_proj(context_img)
         v_img = v_img.unflatten(2, (self.local_num_heads, self.head_dim))
 
-        if not WanTransformerBlock._attn_shape_logged:
-            logger.info(
-                f"[I2V CrossAttn] image path: Q={list(q.shape)}, K_img={list(k_img.shape)}, V_img={list(v_img.shape)}"
-            )
         img_x = self.attn(q, k_img, v_img, skip_sp=True)
-
-        if not WanTransformerBlock._attn_shape_logged:
-            logger.info(
-                f"[I2V CrossAttn] text path:  Q={list(q.shape)}, K_txt={list(k.shape)}, V_txt={list(v.shape)}"
-            )
-            WanTransformerBlock._attn_shape_logged = True
         x = self.attn(q, k, v, skip_sp=True)
 
         # output
@@ -325,8 +308,6 @@ class WanI2VCrossAttention(WanSelfAttention):
 
 
 class WanTransformerBlock(nn.Module):
-
-    _attn_shape_logged = False
 
     def __init__(
         self,
@@ -521,10 +502,6 @@ class WanTransformerBlock(nn.Module):
             query, key = _apply_rotary_emb(
                 query, cos, sin, is_neox_style=False
             ), _apply_rotary_emb(key, cos, sin, is_neox_style=False)
-        if not WanTransformerBlock._attn_shape_logged:
-            logger.info(
-                f"[Self-Attn] Q={list(query.shape)}, K={list(key.shape)}, V={list(value.shape)}"
-            )
         attn_output = self.attn1(query, key, value)
         attn_output = attn_output.flatten(2)
         attn_output, _ = self.to_out(attn_output)
@@ -541,11 +518,6 @@ class WanTransformerBlock(nn.Module):
         ), hidden_states.to(orig_dtype)
 
         # 2. Cross-attention
-        if not WanTransformerBlock._attn_shape_logged:
-            logger.info(
-                f"[Block CrossAttn call] video_hidden={list(norm_hidden_states.shape)}, "
-                f"encoder_hidden_states={list(encoder_hidden_states.shape)}"
-            )
         attn_output = self.attn2(
             norm_hidden_states, context=encoder_hidden_states, context_lens=None
         )

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -136,7 +136,6 @@ class WanSelfAttention(nn.Module):
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         is_cross_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
-        is_cross_attention: bool = False,
     ) -> None:
         assert dim % num_heads == 0
         super().__init__()
@@ -253,7 +252,6 @@ class WanI2VCrossAttention(WanSelfAttention):
             supported_attention_backends=supported_attention_backends,
             is_cross_attention=True,
             quant_config=quant_config,
-            is_cross_attention=True,
         )
 
         self.add_k_proj = ColumnParallelLinear(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In Wan Video's cross-attention layers, the KV tensors are derived from text encoder (512 tokens) or image encoder (257 tokens) outputs, which are identical (replicated) across all sequence-parallel ranks. The existing code unnecessarily applies the full USP pipeline to these replicated tensors:
* Ulysses all-to-all on replicated KV inflates the sequence dimension by ulysses_world_sizex (e.g., 512 tokens become 2048 on 4 GPUs), producing duplicated data and wasting both communication bandwidth and FLOPs on the subsequent attention computation.
* Ring Attention rotates identical KV blocks across ranks, gaining nothing since every rank already holds the full KV.

Since each rank's local Q shard only needs to attend to the full (and already locally available) KV, we can skip sequence parallelism entirely for cross-attention and compute local attention directly — producing mathematically identical results with less communication and less computation.

## Modifications

python/sglang/multimodal_gen/runtime/layers/attention/layer.py
Added skip_sp: bool = False parameter to USPAttention.forward().
When skip_sp=True, the method returns immediately after computing local attention, bypassing Ulysses all-to-all and Ring Attention.
python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
WanT2VCrossAttention.forward(): passes skip_sp=True to self.attn().
WanI2VCrossAttention.forward(): passes skip_sp=True to both self.attn() calls (image path and text path).

## Accuracy Tests

ring degree 4:
https://github.com/user-attachments/assets/4aa05019-fd08-44a0-85d4-652483647517

ring degree 4 skip cross attn:
https://github.com/user-attachments/assets/219484f3-b65f-4abf-a93a-c488ad4f75e6


## Benchmarking and Profiling
time per step/s on B200, achieves 7–15% speed up.
|  | baseline| cross attn skip sp |
| --- | --- | --- | 
| ring 4| 4.72 | 3.99  |
| ring2 uly 2 | 4.57 | 3.94 |
| uly 4|  4.01 | 3.68 |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
