### PR TITLE
[AMD] Use fused GEMM with FP8 cast for FP8 prefill

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -10,6 +10,9 @@ from sglang.srt.utils import is_hip
 
 _is_hip = is_hip()
 if _is_hip:
+    from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
+        fused_gemm_afp4wfp4_split_cat,
+    )
     from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4
     from aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic import gemm_afp4wfp4_pre_quant
     from aiter.ops.triton.quant import dynamic_mxfp4_quant
@@ -87,20 +90,29 @@ class QuarkW4A4MXFP4(QuarkLinearScheme):
         assert bias is None, "bias is not supported"
 
         three_d = False
+        fused_gemm_split_cat = False
         x_s = None
         y = None
+
         if isinstance(x, tuple):
             assert len(x) in [
                 2,
                 3,
-            ], "For tuple input, only (x, x_s) or (x, x_s, y) formats are accepted"
+                5,
+            ], "For tuple input, only (x, x_s), (x, x_s, y), or (x, y_kpe, S1, S2, out_dtype) formats are accepted"
             if len(x) == 2:
                 x, x_s = x
             elif len(x) == 3:
                 x, x_s, y = x
+            elif len(x) == 5:
+                x, y, S1, S2, out_dtype = x
+                fused_gemm_split_cat = True
 
         use_fused_quant_gemm = (
-            x_s is None and y is not None and layer.weight.shape[0] == y.shape[1]
+            not fused_gemm_split_cat
+            and x_s is None
+            and y is not None
+            and layer.weight.shape[0] == y.shape[1]
         )
 
         if x.dim() == 3:
@@ -126,10 +138,23 @@ class QuarkW4A4MXFP4(QuarkLinearScheme):
         if use_fused_quant_gemm:
             gemm_afp4wfp4_pre_quant(x_q, layer.weight, layer.weight_scale, y.dtype, y)
             y = y.to(x.dtype)
+        elif fused_gemm_split_cat:
+            k, v = fused_gemm_afp4wfp4_split_cat(
+                x=x_q,
+                w=layer.weight,
+                y=y,
+                x_scale=x_s,
+                w_scale=layer.weight_scale,
+                S1=S1,
+                S2=S2,
+                dtype=out_dtype,
+            )
         else:
             gemm_afp4wfp4(x_q, layer.weight, x_s, layer.weight_scale, self.out_dtype, y)
 
-        if three_d:
+        if fused_gemm_split_cat:
+            return k, v
+        elif three_d:
             return y.view(*output_shape)
-
-        return y
+        else:
+            return y

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -99,7 +99,7 @@ class QuarkW4A4MXFP4(QuarkLinearScheme):
                 2,
                 3,
                 5,
-            ], "For tuple input, only (x, x_s), (x, x_s, y), or (x, y_kpe, S1, S2, out_dtype) formats are accepted"
+            ], "For tuple input, only (x, x_s), (x, x_s, y), or (x, y, S1, S2, out_dtype) formats are accepted"
             if len(x) == 2:
                 x, x_s = x
             elif len(x) == 3:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

cc @HaiShaw, @kkHuang-amd 

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When using FP8 prefill, q, k, v tensors require a separate element-wise BF16 to FP8 cast before the prefill attention kernel, adding overhead.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Use the aiter Triton kernel `fused_gemm_afp4wfp4_split_cat()` to fuse the GEMM, split, and k_pe concatenation into a single kernel that outputs k and v directly in FP8, eliminating the standalone cast.
- Move `kv_indices` (torch.arange) creation from per-layer forward to `init_forward_metadata`, computed once per batch.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

gsm8k cmd: ```python benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --port 9000```
GPQA cmd: ```python -m sglang.test.run_eval --eval-name gpqa--port 9000 --num-examples 198 --max-tokens 65535 --repeat 8```

| Prefill Type       | GSM8K | GPQA (mean) | GPQA (max)  
|--------------------|-------|------|-----|
| fp8 Prefill       |  0.946 |    0.669  |     0.697  |            

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

TTFT improved by ~2–3% on input length 70k, output length 200, batch size 1–16.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
