### PR TITLE
[AMD] Fix DeepSeekV32 Nightly on MI30x

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -180,9 +180,6 @@ if _use_aiter_gfx95:
         get_dsv3_gemm_output_zero_allocator_size,
     )
 
-if _use_aiter:
-    from sglang.srt.layers.rocm_linear_utils import fused_qk_rope_cat_and_cache_mla
-
 if _is_cuda:
     from sgl_kernel import bmm_fp8, dsv3_fused_a_gemm, dsv3_router_gemm
 elif _is_cpu and _is_cpu_amx_available:
@@ -1738,7 +1735,7 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
         if (
             self.rotary_emb is not None
             and (not self._fuse_rope_for_trtllm_mla(forward_batch))
-            and (not _use_aiter or not _is_hip or self.use_nsa)
+            and (not _use_aiter or not _is_gfx95_supported or self.use_nsa)
         ):
             q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
 
@@ -1794,7 +1791,7 @@ class DeepseekV2AttentionMLA(nn.Module, DeepseekMHAForwardMixin):
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
         else:
-            if _use_aiter:
+            if _use_aiter_gfx95:
                 cos = self.rotary_emb.cos_cache
                 sin = self.rotary_emb.sin_cache
 

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -316,7 +316,8 @@ def get_config(
                 model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
             )
         except ValueError as e:
-            if not "deepseek_v32" in str(e):
+            err_str = str(e)
+            if "deepseek_v32" not in err_str and "DeepSeek-V3.2" not in err_str:
                 raise e
             config = _load_deepseek_v32_model(
                 model, trust_remote_code=trust_remote_code, revision=revision, **kwargs


### PR DESCRIPTION
Nightly DSv32 mi325 fail: https://github.com/sgl-project/sglang/actions/runs/22425852119/job/64933672550#step:5:4887

## Summary
- **Fix 1 (`deepseek_v2.py`):** Reverts the three changes from #18242 that broadened `fused_qk_rope_cat_and_cache_mla` from MI350x-only (`_use_aiter_gfx95` / `_is_gfx95_supported`) to all HIP platforms (`_use_aiter` / `_is_hip`). The fused RoPE+cache kernel corrupts attention on MI300x (gfx942), dropping DeepSeek-V3.2 GSM8K accuracy to ~15%.
- **Fix 2 (`hf_transformers_utils.py`):** Fixes the DeepSeek-V3.2 config fallback to also match `"DeepSeek-V3.2"` (the model path) in the error string, not just `"deepseek_v32"` (the model_type). After a HuggingFace config update changed `model_type` to `"deepseek_v32"`, the workaround failed to trigger because the `ValueError` message contains the model path but not the unregistered type.

## Motivation

**RoPE regression (Fix 1):** Both AMD nightly pipelines fail on MI300x DeepSeek-V3.2 tests since #18242:
- [Nightly (AMD) #558](https://github.com/sgl-project/sglang/actions/runs/22421861210): `nightly-8-gpu-deepseek-v32` accuracy=0.170, MTP accuracy=0.060
- [Nightly (ROCm 7.2) #126](https://github.com/sgl-project/sglang/actions/runs/22425852119): `nightly-8-gpu-deepseek-v32-rocm720` accuracy=0.155, MTP accuracy=0.070

MI350x tests pass in both runs, confirming the fused kernel is gfx950-specific. The previous nightly (Feb 24, before #18242) had no DeepSeek-V3.2 failures.

**Config fallback (Fix 2):** After Fix 1 was deployed, the MI350x DeepSeek-V3.2 test failed with:
```
ValueError: Unrecognized model in deepseek-ai/DeepSeek-V3.2
```
The HuggingFace model's `config.json` was updated to `model_type: "deepseek_v32"` (unregistered in transformers), and the existing error check (`"deepseek_v32" in str(e)`) doesn't match since the error text only contains `"DeepSeek-V3.2"` (the model path), not the model_type.

## Modifications

**`python/sglang/srt/models/deepseek_v2.py`:**
- Remove duplicate `_use_aiter` import of `fused_qk_rope_cat_and_cache_mla` (already imported under `_use_aiter_gfx95`)
- Restore RoPE skip condition: `not _is_hip` → `not _is_gfx95_supported`
- Restore fused kernel dispatch: `_use_aiter` → `_use_aiter_gfx95`

**`python/sglang/srt/utils/hf_transformers_utils.py`:**
- Match both `"deepseek_v32"` and `"DeepSeek-V3.2"` in the `ValueError` string

## Accuracy Tests

- [x] MI300x `nightly-8-gpu-deepseek-v32-rocm720` passes (verified)
- [x] MI300x `nightly-8-gpu-deepseek-v32-mtp-rocm720` passes (verified)
- [x] MI350x `nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720` passes with config fallback fix
- [x] MI350x DeepSeek-V3.2 MTP passes with config fallback fix

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer/contribution_guide.html#format-code).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer/contribution_guide.html#benchmark-the-speed).

@yctseng0211, @bingxche, @HaiShaw
