### PR TITLE
[AMD] [MiniMax-M2.5 Day 0] Add MiniMax-M2.5 nightly accuracy test

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -34,6 +34,7 @@ on:
           - 'nightly-8-gpu-kimi-k25-rocm720'
           - 'nightly-8-gpu-qwen3-235b-rocm720'
           - 'nightly-8-gpu-glm5-rocm720'
+          - 'nightly-8-gpu-minimax-m25-rocm720'
           # MI35x ROCm 7.2 jobs
           - 'nightly-test-1-gpu-mi35x-rocm720'
           - 'nightly-8-gpu-mi35x-qwen3-235b-mxfp4-rocm720'
@@ -47,6 +48,7 @@ on:
           - 'nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720'
           - 'nightly-8-gpu-mi35x-kimi-k25-rocm720'
           - 'nightly-8-gpu-mi35x-glm5-rocm720'
+          - 'nightly-8-gpu-mi35x-minimax-m25-rocm720'
   workflow_call:
     inputs:
       ref:
@@ -561,6 +563,37 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # 8-GPU MiniMax-M2.5 (Accuracy) ROCm 7.2
+  nightly-8-gpu-minimax-m25-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-minimax-m25-rocm720')
+    runs-on: linux-mi325-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build --skip-test-time-deps
+
+      - name: Accuracy Test ROCm 7.2 (8-GPU MiniMax-M2.5)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-minimax-m25 --nightly --timeout-per-file 3600 --continue-on-error || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # ============================================== MI35x ROCm 7.2 Tests ==============================================
   # MI35x 1-GPU ROCm 7.2 tests
   nightly-test-1-gpu-mi35x-rocm720:
@@ -959,6 +992,39 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # MI35x 8-GPU MiniMax-M2.5 (Accuracy) ROCm 7.2
+  nightly-8-gpu-mi35x-minimax-m25-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-mi35x-minimax-m25-rocm720')
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build --skip-test-time-deps
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Accuracy Test MI35x ROCm 7.2 (8-GPU MiniMax-M2.5)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-minimax-m25 --nightly --timeout-per-file 3600 --continue-on-error || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # MI35x 8-GPU DeepSeek-V3.2 Performance Test (MTP) ROCm 7.2
   nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720')
@@ -1013,6 +1079,7 @@ jobs:
       - nightly-8-gpu-kimi-k25-rocm720
       - nightly-8-gpu-qwen3-235b-rocm720
       - nightly-8-gpu-glm5-rocm720
+      - nightly-8-gpu-minimax-m25-rocm720
       # MI35x ROCm 7.2 jobs
       - nightly-test-1-gpu-mi35x-rocm720
       - nightly-accuracy-8-gpu-mi35x-rocm720
@@ -1026,6 +1093,7 @@ jobs:
       - nightly-8-gpu-mi35x-kimi-k25-rocm720
       - nightly-8-gpu-mi35x-qwen3-235b-mxfp4-rocm720
       - nightly-8-gpu-mi35x-glm5-rocm720
+      - nightly-8-gpu-mi35x-minimax-m25-rocm720
     runs-on: ubuntu-latest
     steps:
       - name: Check if any job failed

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -34,11 +34,13 @@ on:
           - 'nightly-8-gpu-kimi-k25'
           - 'nightly-8-gpu-qwen3-235b'
           - 'nightly-8-gpu-glm5'
+          - 'nightly-8-gpu-minimax-m25'
           # MI35x jobs
           - 'nightly-test-1-gpu-mi35x'
           - 'nightly-8-gpu-mi35x-qwen3-235b-mxfp4'
           - 'nightly-8-gpu-mi35x-kimi-k25'
           - 'nightly-8-gpu-mi35x-glm5'
+          - 'nightly-8-gpu-mi35x-minimax-m25'
           - 'nightly-accuracy-8-gpu-mi35x'
           - 'nightly-8-gpu-mi35x-grok1-int4'
           - 'nightly-8-gpu-mi35x-grok2'
@@ -559,6 +561,37 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # 8-GPU MiniMax-M2.5 (Accuracy)
+  nightly-8-gpu-minimax-m25:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-minimax-m25')
+    runs-on: linux-mi325-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Accuracy Test (8-GPU MiniMax-M2.5)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-minimax-m25 --nightly --timeout-per-file 3600 || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # ============================================== MI35x Tests ==============================================
   # MI35x 1-GPU tests - platform-agnostic tests that may work on CDNA4 (gfx950)
   nightly-test-1-gpu-mi35x:
@@ -959,6 +992,39 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+  # MI35x 8-GPU MiniMax-M2.5 (Accuracy)
+  nightly-8-gpu-mi35x-minimax-m25:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-8-gpu-mi35x-minimax-m25')
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Accuracy Test MI35x (8-GPU MiniMax-M2.5)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-minimax-m25 --nightly --timeout-per-file 3600 || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # MI35x 8-GPU DeepSeek-V3.2 Performance Test (MTP)
   nightly-perf-8-gpu-mi35x-deepseek-v32-mtp:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-perf-8-gpu-mi35x-deepseek-v32-mtp')
@@ -1013,6 +1079,7 @@ jobs:
       - nightly-8-gpu-kimi-k25
       - nightly-8-gpu-qwen3-235b
       - nightly-8-gpu-glm5
+      - nightly-8-gpu-minimax-m25
       # MI35x jobs
       - nightly-test-1-gpu-mi35x
       - nightly-accuracy-8-gpu-mi35x
@@ -1024,6 +1091,7 @@ jobs:
       - nightly-8-gpu-mi35x-kimi-k25
       - nightly-8-gpu-mi35x-qwen3-235b-mxfp4
       - nightly-8-gpu-mi35x-glm5
+      - nightly-8-gpu-mi35x-minimax-m25
       # MI35x perf jobs excluded from check - perf failures don't block CI
       # - nightly-perf-8-gpu-mi35x-deepseek-v32-basic
       # - nightly-perf-8-gpu-mi35x-deepseek-v32-mtp

--- a/docs/basic_usage/minimax_m2.md
+++ b/docs/basic_usage/minimax_m2.md
@@ -1,13 +1,14 @@
-# MiniMax M2.1/M2 Usage
+# MiniMax M2.5/M2.1/M2 Usage
 
-[MiniMax-M2.1](https://huggingface.co/MiniMaxAI/MiniMax-M2.1) and [MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) are advanced large language models created by [MiniMax](https://www.minimax.io/).
+[MiniMax-M2.5](https://huggingface.co/MiniMaxAI/MiniMax-M2.5), [MiniMax-M2.1](https://huggingface.co/MiniMaxAI/MiniMax-M2.1), and [MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) are advanced large language models created by [MiniMax](https://www.minimax.io/).
 
-MiniMax-M2 series redefines efficiency for agents. It's a compact, fast, and cost-effective MoE model (230 billion total parameters with 10 billion active parameters) built for elite performance in coding and agentic tasks, all while maintaining powerful general intelligence. With just 10 billion activated parameters, MiniMax-M2 provides the sophisticated, end-to-end tool use performance expected from today's leading models, but in a streamlined form factor that makes deployment and scaling easier than ever.
+The MiniMax-M2 series redefines efficiency for agents. These compact, fast, and cost-effective MoE models (230 billion total parameters with 10 billion active parameters) are built for elite performance in coding and agentic tasks, all while maintaining powerful general intelligence. With just 10 billion activated parameters, the MiniMax-M2 series provides sophisticated, end-to-end tool use performance expected from today's leading models, but in a streamlined form factor that makes deployment and scaling easier than ever.
 
 ## Supported Models
 
 This guide applies to the following models. You only need to update the model name during deployment. The following examples use **MiniMax-M2**:
 
+- [MiniMaxAI/MiniMax-M2.5](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)
 - [MiniMaxAI/MiniMax-M2.1](https://huggingface.co/MiniMaxAI/MiniMax-M2.1)
 - [MiniMaxAI/MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2)
 
@@ -41,6 +42,24 @@ python -m sglang.launch_server \
     --model-path MiniMaxAI/MiniMax-M2 \
     --tp-size 8 \
     --ep-size 8 \
+    --tool-call-parser minimax-m2 \
+    --reasoning-parser minimax-append-think \
+    --host 0.0.0.0 \
+    --trust-remote-code \
+    --port 8000 \
+    --mem-fraction-static 0.85
+```
+
+### AMD GPUs (MI300X/MI325X/MI355X)
+
+8-GPU deployment command:
+
+```bash
+SGLANG_USE_AITER=1 python -m sglang.launch_server \
+    --model-path MiniMaxAI/MiniMax-M2.5 \
+    --tp-size 8 \
+    --ep-size 8 \
+    --attention-backend aiter \
     --tool-call-parser minimax-m2 \
     --reasoning-parser minimax-append-think \
     --host 0.0.0.0 \

--- a/docs/supported_models/text_generation/generative_models.md
+++ b/docs/supported_models/text_generation/generative_models.md
@@ -37,7 +37,7 @@ in the GitHub search bar.
 | **MiniCPM** (v3, 4B)               | `openbmb/MiniCPM3-4B`                            | OpenBMB’s series of compact LLMs for edge devices; MiniCPM 3 (4B) achieves GPT-3.5-level results in text tasks. |
 | **OLMo** (2, 3) | `allenai/OLMo-3-1125-32B`, `allenai/OLMo-3-32B-Think`, `allenai/OLMo-2-1124-7B-Instruct` | Allen AI’s series of Open Language Models designed to enable the science of language models. |
 | **OLMoE** (Open MoE)               | `allenai/OLMoE-1B-7B-0924`                       | Allen AI’s open Mixture-of-Experts model (7B total, 1B active parameters) delivering state-of-the-art results with sparse expert activation. |
-| **MiniMax-M2** (M2, M2.1)                     | `minimax/MiniMax-M2`, `minimax/MiniMax-M2.1`           | MiniMax’s SOTA LLM for coding & agentic workflows. |
+| **MiniMax-M2** (M2, M2.1, M2.5)               | `MiniMaxAI/MiniMax-M2.5`, `MiniMaxAI/MiniMax-M2.1`, `MiniMaxAI/MiniMax-M2` | MiniMax's SOTA LLM for coding & agentic workflows. |
 | **StableLM** (3B, 7B)               | `stabilityai/stablelm-tuned-alpha-7b`            | StabilityAI’s early open-source LLM (3B & 7B) for general text generation; a demonstration model with basic instruction-following ability. |
 | **Command-(R,A)** (Cohere)              | `CohereLabs/c4ai-command-r-v01`, `CohereLabs/c4ai-command-r7b-12-2024`, `CohereLabs/c4ai-command-a-03-2025`                 | Cohere’s open conversational LLM (Command series) optimized for long context, retrieval-augmented generation, and tool use. |
 | **DBRX** (Databricks)              | `databricks/dbrx-instruct`                       | Databricks’ 132B-parameter MoE model (36B active) trained on 12T tokens; competes with GPT-3.5 quality as a fully open foundation model. |

--- a/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
@@ -1,0 +1,245 @@
+"""AMD MiniMax-M2.5 GSM8K Completion Evaluation Test (8-GPU)
+
+Tests MiniMax-M2.5 with TP=8 + EP=8 configuration using few-shot completion
+benchmark on MI325/MI300X.
+
+Registry: nightly-amd-accuracy-8-gpu-minimax-m25 suite
+"""
+
+import ast
+import os
+import re
+import time
+import unittest
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+from sglang.utils import download_and_cache_file, read_jsonl
+
+register_amd_ci(
+    est_time=3600,
+    suite="nightly-amd-accuracy-8-gpu-minimax-m25",
+    nightly=True,
+)
+
+INVALID = -9999999
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a model to test."""
+
+    model_path: str
+    tp_size: int = 8
+    accuracy_threshold: float = 0.50
+    other_args: Optional[List[str]] = None
+    env_vars: Optional[dict] = None
+    timeout: Optional[int] = None
+    variant: Optional[str] = None
+
+    def __post_init__(self):
+        if self.other_args is None:
+            self.other_args = []
+        if self.env_vars is None:
+            self.env_vars = {}
+
+    def get_display_name(self) -> str:
+        if self.variant:
+            return f"{self.model_path} ({self.variant})"
+        return self.model_path
+
+
+MINIMAX_M25_MODELS = [
+    ModelConfig(
+        model_path="MiniMaxAI/MiniMax-M2.5",
+        tp_size=8,
+        accuracy_threshold=0.80,
+        timeout=3600,
+        variant="TP8+EP8",
+        other_args=[
+            "--ep-size",
+            "8",
+            "--trust-remote-code",
+            "--attention-backend",
+            "aiter",
+            "--mem-fraction-static",
+            "0.85",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
+            "--watchdog-timeout",
+            "1200",
+        ],
+        env_vars={"SGLANG_USE_AITER": "1"},
+    ),
+]
+
+
+def get_one_example(lines, i, include_answer):
+    """Format a single GSM8K example."""
+    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
+    if include_answer:
+        ret += " " + lines[i]["answer"]
+    return ret
+
+
+def get_few_shot_examples(lines, k):
+    """Get k few-shot examples for prompting."""
+    ret = ""
+    for i in range(k):
+        ret += get_one_example(lines, i, True) + "\n\n"
+    return ret
+
+
+def get_answer_value(answer_str):
+    """Extract numerical answer from response."""
+    answer_str = answer_str.replace(",", "")
+    numbers = re.findall(r"\d+", answer_str)
+    if len(numbers) < 1:
+        return INVALID
+    try:
+        return ast.literal_eval(numbers[-1])
+    except SyntaxError:
+        return INVALID
+
+
+def run_gsm8k_benchmark(
+    base_url: str,
+    num_questions: int = 200,
+    num_shots: int = 5,
+    parallel: int = 64,
+) -> Tuple[float, float, float]:
+    """Run GSM8K few-shot completion benchmark."""
+    import sglang as sgl
+    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+
+    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+    data_path = download_and_cache_file(url)
+    lines = list(read_jsonl(data_path))
+
+    few_shot_examples = get_few_shot_examples(lines, num_shots)
+
+    questions = []
+    labels = []
+    for i in range(len(lines[:num_questions])):
+        questions.append(get_one_example(lines, i, False))
+        labels.append(get_answer_value(lines[i]["answer"]))
+    assert all(l != INVALID for l in labels)
+    arguments = [{"question": q} for q in questions]
+
+    @sgl.function
+    def few_shot_gsm8k(s, question):
+        s += few_shot_examples + question
+        s += sgl.gen(
+            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
+        )
+
+    backend = RuntimeEndpoint(base_url)
+    sgl.set_default_backend(backend)
+
+    tic = time.perf_counter()
+    states = few_shot_gsm8k.run_batch(
+        arguments, temperature=0, num_threads=parallel, progress_bar=True
+    )
+    latency = time.perf_counter() - tic
+
+    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
+    acc = np.mean(np.array(preds) == np.array(labels))
+    invalid = np.mean(np.array(preds) == INVALID)
+
+    return float(acc), float(invalid), float(latency)
+
+
+class TestMiniMaxM25EvalAMD(unittest.TestCase):
+    """MiniMax-M2.5 GSM8K Completion Evaluation Test for AMD MI325/MI300X."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = MINIMAX_M25_MODELS
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "200"))
+
+    def test_minimax_m25_accuracy(self):
+        """Test MiniMax-M2.5 with GSM8K completion benchmark."""
+        all_results = []
+        summary = "### MiniMax-M2.5 Models (MI325)\n\n"
+        summary += "| Model | Variant | TP | Accuracy | Threshold | Status |\n"
+        summary += "| ----- | ------- | -- | -------- | --------- | ------ |\n"
+
+        for config in self.models:
+            display_name = config.get_display_name()
+            with self.subTest(model=display_name):
+                print(f"\n{'='*60}")
+                print(f"Testing: {display_name}")
+                print(f"{'='*60}")
+
+                env = os.environ.copy()
+                for key, value in config.env_vars.items():
+                    env[key] = value
+
+                other_args = list(config.other_args)
+                other_args.extend(["--tp", str(config.tp_size)])
+                timeout = config.timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+                try:
+                    process = popen_launch_server(
+                        model=config.model_path,
+                        base_url=self.base_url,
+                        timeout=timeout,
+                        other_args=other_args,
+                        env=env,
+                    )
+
+                    try:
+                        acc, invalid, latency = run_gsm8k_benchmark(
+                            self.base_url, num_questions=self.num_questions
+                        )
+                        passed = acc >= config.accuracy_threshold
+                        status = "PASS" if passed else "FAIL"
+                        print(
+                            f"  accuracy={acc:.3f} threshold={config.accuracy_threshold} {status}"
+                        )
+
+                        all_results.append(
+                            {
+                                "model": display_name,
+                                "accuracy": acc,
+                                "passed": passed,
+                            }
+                        )
+                        summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | {acc:.3f} | {config.accuracy_threshold} | {status} |\n"
+
+                    finally:
+                        kill_process_tree(process.pid)
+
+                except Exception as e:
+                    summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | N/A | {config.accuracy_threshold} | ERROR |\n"
+                    all_results.append(
+                        {
+                            "model": display_name,
+                            "accuracy": None,
+                            "passed": False,
+                            "error": str(e),
+                        }
+                    )
+
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        failed = [r for r in all_results if not r["passed"]]
+        if failed:
+            raise AssertionError(f"Failed models: {[r['model'] for r in failed]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py
@@ -64,7 +64,7 @@ MINIMAX_M25_MODELS = [
     ModelConfig(
         model_path="MiniMaxAI/MiniMax-M2.5",
         tp_size=8,
-        accuracy_threshold=0.80,
+        accuracy_threshold=0.93,
         timeout=3600,
         variant="TP8+EP8",
         other_args=[

--- a/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
@@ -68,7 +68,7 @@ MI35X_MINIMAX_M25_MODELS = [
     ModelConfig(
         model_path="MiniMaxAI/MiniMax-M2.5",
         tp_size=8,
-        accuracy_threshold=0.80,
+        accuracy_threshold=0.93,
         timeout=5400,
         variant="TP8+EP8",
         other_args=[

--- a/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py
@@ -1,0 +1,249 @@
+"""MI35x MiniMax-M2.5 GSM8K Completion Evaluation Test (8-GPU)
+
+Tests MiniMax-M2.5 with TP=8 + EP=8 configuration using few-shot completion
+benchmark on MI35x.
+
+Registry: nightly-amd-8-gpu-mi35x-minimax-m25 suite
+"""
+
+import ast
+import os
+
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
+
+import re
+import time
+import unittest
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+from sglang.utils import download_and_cache_file, read_jsonl
+
+register_amd_ci(
+    est_time=5400,
+    suite="nightly-amd-8-gpu-mi35x-minimax-m25",
+    nightly=True,
+)
+
+INVALID = -9999999
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a model to test."""
+
+    model_path: str
+    tp_size: int = 8
+    accuracy_threshold: float = 0.50
+    other_args: Optional[List[str]] = None
+    env_vars: Optional[dict] = None
+    timeout: Optional[int] = None
+    variant: Optional[str] = None
+
+    def __post_init__(self):
+        if self.other_args is None:
+            self.other_args = []
+        if self.env_vars is None:
+            self.env_vars = {}
+
+    def get_display_name(self) -> str:
+        if self.variant:
+            return f"{self.model_path} ({self.variant})"
+        return self.model_path
+
+
+MI35X_MINIMAX_M25_MODELS = [
+    ModelConfig(
+        model_path="MiniMaxAI/MiniMax-M2.5",
+        tp_size=8,
+        accuracy_threshold=0.80,
+        timeout=5400,
+        variant="TP8+EP8",
+        other_args=[
+            "--ep-size",
+            "8",
+            "--trust-remote-code",
+            "--attention-backend",
+            "aiter",
+            "--mem-fraction-static",
+            "0.85",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
+            "--watchdog-timeout",
+            "1200",
+        ],
+        env_vars={"SGLANG_USE_AITER": "1"},
+    ),
+]
+
+
+def get_one_example(lines, i, include_answer):
+    """Format a single GSM8K example."""
+    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
+    if include_answer:
+        ret += " " + lines[i]["answer"]
+    return ret
+
+
+def get_few_shot_examples(lines, k):
+    """Get k few-shot examples for prompting."""
+    ret = ""
+    for i in range(k):
+        ret += get_one_example(lines, i, True) + "\n\n"
+    return ret
+
+
+def get_answer_value(answer_str):
+    """Extract numerical answer from response."""
+    answer_str = answer_str.replace(",", "")
+    numbers = re.findall(r"\d+", answer_str)
+    if len(numbers) < 1:
+        return INVALID
+    try:
+        return ast.literal_eval(numbers[-1])
+    except SyntaxError:
+        return INVALID
+
+
+def run_gsm8k_benchmark(
+    base_url: str,
+    num_questions: int = 200,
+    num_shots: int = 5,
+    parallel: int = 64,
+) -> Tuple[float, float, float]:
+    """Run GSM8K few-shot completion benchmark."""
+    import sglang as sgl
+    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+
+    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+    data_path = download_and_cache_file(url)
+    lines = list(read_jsonl(data_path))
+
+    few_shot_examples = get_few_shot_examples(lines, num_shots)
+
+    questions = []
+    labels = []
+    for i in range(len(lines[:num_questions])):
+        questions.append(get_one_example(lines, i, False))
+        labels.append(get_answer_value(lines[i]["answer"]))
+    assert all(l != INVALID for l in labels)
+    arguments = [{"question": q} for q in questions]
+
+    @sgl.function
+    def few_shot_gsm8k(s, question):
+        s += few_shot_examples + question
+        s += sgl.gen(
+            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
+        )
+
+    backend = RuntimeEndpoint(base_url)
+    sgl.set_default_backend(backend)
+
+    tic = time.perf_counter()
+    states = few_shot_gsm8k.run_batch(
+        arguments, temperature=0, num_threads=parallel, progress_bar=True
+    )
+    latency = time.perf_counter() - tic
+
+    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
+    acc = np.mean(np.array(preds) == np.array(labels))
+    invalid = np.mean(np.array(preds) == INVALID)
+
+    return float(acc), float(invalid), float(latency)
+
+
+class TestMiniMaxM25EvalMI35x(unittest.TestCase):
+    """MiniMax-M2.5 GSM8K Completion Evaluation Test for AMD MI35x."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = MI35X_MINIMAX_M25_MODELS
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "200"))
+
+    def test_minimax_m25_accuracy(self):
+        """Test MiniMax-M2.5 with GSM8K completion benchmark."""
+        all_results = []
+        summary = "### MiniMax-M2.5 Models (MI35x)\n\n"
+        summary += "| Model | Variant | TP | Accuracy | Threshold | Status |\n"
+        summary += "| ----- | ------- | -- | -------- | --------- | ------ |\n"
+
+        for config in self.models:
+            display_name = config.get_display_name()
+            with self.subTest(model=display_name):
+                print(f"\n{'='*60}")
+                print(f"Testing: {display_name}")
+                print(f"{'='*60}")
+
+                env = os.environ.copy()
+                for key, value in config.env_vars.items():
+                    env[key] = value
+
+                other_args = list(config.other_args)
+                other_args.extend(["--tp", str(config.tp_size)])
+                timeout = config.timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+                try:
+                    process = popen_launch_server(
+                        model=config.model_path,
+                        base_url=self.base_url,
+                        timeout=timeout,
+                        other_args=other_args,
+                        env=env,
+                    )
+
+                    try:
+                        acc, invalid, latency = run_gsm8k_benchmark(
+                            self.base_url, num_questions=self.num_questions
+                        )
+                        passed = acc >= config.accuracy_threshold
+                        status = "PASS" if passed else "FAIL"
+                        print(
+                            f"  accuracy={acc:.3f} threshold={config.accuracy_threshold} {status}"
+                        )
+
+                        all_results.append(
+                            {
+                                "model": display_name,
+                                "accuracy": acc,
+                                "passed": passed,
+                            }
+                        )
+                        summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | {acc:.3f} | {config.accuracy_threshold} | {status} |\n"
+
+                    finally:
+                        kill_process_tree(process.pid)
+
+                except Exception as e:
+                    summary += f"| {config.model_path} | {config.variant or 'N/A'} | {config.tp_size} | N/A | {config.accuracy_threshold} | ERROR |\n"
+                    all_results.append(
+                        {
+                            "model": display_name,
+                            "accuracy": None,
+                            "passed": False,
+                            "error": str(e),
+                        }
+                    )
+
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        failed = [r for r in all_results if not r["passed"]]
+        if failed:
+            raise AssertionError(f"Failed models: {[r['model'] for r in failed]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add MiniMax-M2.5 (`MiniMaxAI/MiniMax-M2.5`) GSM8K few-shot accuracy tests for AMD GPUs (8-GPU, TP=8 + EP=8)
  - **MI30x** (MI325/MI300X): `nightly-8-gpu-minimax-m25` with aiter backend
  - **MI35x**: `nightly-8-gpu-mi35x-minimax-m25` with aiter backend
- Register both tests in the AMD nightly workflow
- No model code changes required -- MiniMax-M2.5 is a pure softmax-attention MoE model whose components all already support AMD

## Motivation

MiniMax-M2.5 is a 256-expert MoE model (8 active, ~230B total / ~10B active params) with FP8 quantization. The [official SGLang deployment guide](https://github.com/MiniMax-AI/MiniMax-M2.5/blob/main/docs/sglang_deploy_guide.md) targets NVIDIA GPUs. This PR adds AMD coverage to the nightly CI to validate correctness on both MI30x and MI35x.

### Architecture compatibility

MiniMax-M2.5 uses standard MHA (not MLA or DSA), so NSA backends do not apply. The aiter backend is the correct choice for AMD.

| Component | AMD Support |
|---|---|
| Attention (RadixAttention, standard MHA) | aiter backend auto-selected for MHA on HIP |
| MoE (FusedMoE, 256 experts, sigmoid routing) | Triton-based + aiter.fused_moe |
| FP8 quantization (float8_e4m3fn, block [128,128]) | HIP FP8 code paths in fp8.py |
| RMSNormTP (Triton JIT kernels) | ROCm Triton compatible |
| QK normalization, partial RoPE | Standard PyTorch ops |

The model does NOT use linear/lightning attention (all 62 layers are standard softmax attention), so the `torch.cuda.get_device_capability()` check in `lightning_attn.py` is never triggered.

## Changes

- **New**: `test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py` -- MI30x GSM8K accuracy test (threshold 0.93, aiter backend, `SGLANG_USE_AITER=1`)
- **New**: `test/registered/amd/accuracy/mi35x/test_minimax_m25_eval_mi35x.py` -- MI35x GSM8K accuracy test (threshold 0.93, aiter backend, `SGLANG_USE_AITER=1`)
- **Modified**: `.github/workflows/nightly-test-amd.yml` and `.github/workflows/nightly-test-amd-rocm720.yml` -- added both MI30x and MI35x job definitions, filter options, and needs entries

## Test plan

- [x] Verify MI30x test passes on `linux-mi325-gpu-8` runner via `workflow_dispatch` with `job_filter: nightly-8-gpu-minimax-m25` (Success: [Run link](https://github.com/sgl-project/sglang/actions/runs/22463604179/job/65064039190))
- [x] Verify MI35x test passes on `linux-mi35x-gpu-8` runner via `workflow_dispatch` with `job_filter: nightly-8-gpu-mi35x-minimax-m25` (Success: [Run link](https://github.com/sgl-project/sglang/actions/runs/22459902605/job/65051072954))
- [x] Confirm GSM8K accuracy meets the 0.93 threshold on both platforms

Please help review. Thanks! @sogalin, @HaiShaw, @yctseng0211, @bingxche    