### PR TITLE
[Minor] Rename misleading `chunked` to `reusing` in `ReqToTokenPool.alloc()`

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -129,15 +129,17 @@ class DecodeReqToTokenPool:
         return len(self.free_slots)
 
     def alloc(self, reqs: List["Req"]) -> Optional[List[int]]:
-        chunked = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
+        # Reqs that already have a req_pool_idx (e.g. from chunked prefill
+        # reusing the slot across chunks) skip allocation.
+        preallocated = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
         assert (
-            len(chunked) <= 1
+            len(preallocated) <= 1
         ), "only one chunked request may reuse req_pool_idx in a batch"
         assert all(
-            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in chunked
-        ), "request has req_pool_idx but is not chunked"
+            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in preallocated
+        ), "preallocated request must be chunked or have committed KV"
 
-        need_size = len(reqs) - len(chunked)
+        need_size = len(reqs) - len(preallocated)
         if need_size > len(self.free_slots):
             return None
         select_index = self.free_slots[:need_size]

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -129,17 +129,17 @@ class DecodeReqToTokenPool:
         return len(self.free_slots)
 
     def alloc(self, reqs: List["Req"]) -> Optional[List[int]]:
-        # Reqs that already have a req_pool_idx (e.g. from chunked prefill
-        # reusing the slot across chunks) skip allocation.
-        preallocated = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
+        # Indices of reqs that already have a req_pool_idx and will reuse
+        # their existing slot (e.g. chunked prefill continuing across chunks).
+        reusing = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
         assert (
-            len(preallocated) <= 1
+            len(reusing) <= 1
         ), "only one chunked request may reuse req_pool_idx in a batch"
         assert all(
-            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in preallocated
-        ), "preallocated request must be chunked or have committed KV"
+            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in reusing
+        ), "reusing request must be chunked or have committed KV"
 
-        need_size = len(reqs) - len(preallocated)
+        need_size = len(reqs) - len(reusing)
         if need_size > len(self.free_slots):
             return None
         select_index = self.free_slots[:need_size]

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -153,18 +153,18 @@ class ReqToTokenPool:
         return len(self.free_slots)
 
     def alloc(self, reqs: list[Req]) -> Optional[List[int]]:
-        # Reqs that already have a req_pool_idx (e.g. from chunked prefill
-        # reusing the slot across chunks) skip allocation.
-        preallocated = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
+        # Indices of reqs that already have a req_pool_idx and will reuse
+        # their existing slot (e.g. chunked prefill continuing across chunks).
+        reusing = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
         if not any(r.is_dllm() for r in reqs):
             assert (
-                len(preallocated) <= 1
+                len(reusing) <= 1
             ), "only one chunked request may reuse req_pool_idx in a batch"
         assert all(
-            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in preallocated
-        ), "preallocated request must be chunked or have committed KV"
+            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in reusing
+        ), "reusing request must be chunked or have committed KV"
 
-        need_size = len(reqs) - len(preallocated)
+        need_size = len(reqs) - len(reusing)
         if need_size > len(self.free_slots):
             return None
         select_index = self.free_slots[:need_size]

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -153,16 +153,18 @@ class ReqToTokenPool:
         return len(self.free_slots)
 
     def alloc(self, reqs: list[Req]) -> Optional[List[int]]:
-        chunked = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
+        # Reqs that already have a req_pool_idx (e.g. from chunked prefill
+        # reusing the slot across chunks) skip allocation.
+        preallocated = [i for i, r in enumerate(reqs) if r.req_pool_idx is not None]
         if not any(r.is_dllm() for r in reqs):
             assert (
-                len(chunked) <= 1
+                len(preallocated) <= 1
             ), "only one chunked request may reuse req_pool_idx in a batch"
         assert all(
-            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in chunked
-        ), "request has req_pool_idx but is not chunked"
+            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in preallocated
+        ), "preallocated request must be chunked or have committed KV"
 
-        need_size = len(reqs) - len(chunked)
+        need_size = len(reqs) - len(preallocated)
         if need_size > len(self.free_slots):
             return None
         select_index = self.free_slots[:need_size]


### PR DESCRIPTION
- Rename `chunked` → `preallocated` in `ReqToTokenPool.alloc()` to reflect its actual meaning: indices of reqs that already have a `req_pool_idx` and skip allocation
- Add comment explaining the variable's purpose
- Fix assert message from "not chunked" to "must be chunked or have committed KV" to match the actual condition
- Apply same rename in `disaggregation/decode.py` copy


Made with [Cursor](https://cursor.com)