### PR TITLE
[Bugfix] Fix /server_info and load metrics hanging when TokenizerManager handle_loop is not started

### DIFF
--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -855,6 +855,7 @@ class TokenizerCommunicatorMixin:
         await self.slow_down_communicator(obj)
 
     async def get_internal_state(self: TokenizerManager) -> List[Dict[Any, Any]]:
+        self.auto_create_handle_loop()
         req = GetInternalStateReq()
         responses: List[GetInternalStateReqOutput] = (
             await self.get_internal_state_communicator(req)
@@ -865,6 +866,7 @@ class TokenizerCommunicatorMixin:
     async def set_internal_state(
         self: TokenizerManager, obj: SetInternalStateReq
     ) -> List[bool]:
+        self.auto_create_handle_loop()
         responses: List[SetInternalStateReqOutput] = (
             await self.set_internal_state_communicator(obj)
         )
@@ -873,9 +875,11 @@ class TokenizerCommunicatorMixin:
     async def dumper_control(
         self: TokenizerManager, obj: DumperControlReqInput
     ) -> List[DumperControlReqOutput]:
+        self.auto_create_handle_loop()
         return await self.dumper_control_communicator(obj)
 
     async def get_load(self: TokenizerManager) -> List[GetLoadReqOutput]:
+        self.auto_create_handle_loop()
         req = GetLoadReqInput()
         return await self.get_load_communicator(req)
 
@@ -894,6 +898,7 @@ class TokenizerCommunicatorMixin:
         Returns:
             List of GetLoadsReqOutput, one per scheduler (filtered by dp_rank if specified)
         """
+        self.auto_create_handle_loop()
         req = GetLoadsReqInput(
             include=include if include else ["all"],
             dp_rank=dp_rank,


### PR DESCRIPTION
## Motivation

Fixes a class of hangs where management endpoints such as `/server_info` and `/v1/loads`
can block indefinitely when the `TokenizerManager` handle loop has not been started yet.

In practice this is easy to hit in PD-disaggregated deployments where
the router / gateway probes `/server_info` early, before any generation request has
been processed.

### Root Cause

The `TokenizerManager` uses a `_Communicator` abstraction to implement request/response
patterns with the scheduler (e.g. `GetInternalStateReq`, `GetLoadsReqInput`, etc.).
These communicators wait on an internal `asyncio.Event` that is only fulfilled when
the `TokenizerManager.handle_loop` is running and consuming ZMQ messages from the
scheduler.

Most communicator-based methods already call `auto_create_handle_loop()` to lazily
start `handle_loop` on first use. However, a few methods were missing this call:

- `get_internal_state()`
- `set_internal_state(...)`
- `dumper_control(...)`
- `get_load()`
- `get_loads(...)`

When any of these were invoked before `generate_request()` (or other APIs that
*do* call `auto_create_handle_loop()`), the request would be sent to the scheduler,
but the response would never be consumed and the coroutine would hang indefinitely.

This shows up as:

- `/server_info` hanging (it calls `tokenizer_manager.get_internal_state()`),
  especially in PD disaggregated setups where the router inspects workers early.
- `/get_load` / `/v1/loads` hanging when called before any traffic.
- `dumper` HTTP control endpoints hanging in similar conditions.

## Modifications

Extend the same lazy-loop-starting pattern to all communicator-based helpers:

In `python/sglang/srt/managers/tokenizer_communicator_mixin.py`:

- `get_internal_state(...)` now calls `self.auto_create_handle_loop()` before
  sending `GetInternalStateReq`.
- `set_internal_state(...)` now calls `self.auto_create_handle_loop()` before
  sending `SetInternalStateReq`.
- `dumper_control(...)` now calls `self.auto_create_handle_loop()` before
  sending `DumperControlReqInput`.
- `get_load(...)` now calls `self.auto_create_handle_loop()` before
  sending `GetLoadReqInput`.
- `get_loads(...)` now calls `self.auto_create_handle_loop()` before
  sending `GetLoadsReqInput`.

`auto_create_handle_loop()` is idempotent, so this change is safe even when the
loop has already been started by other code paths.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
