### PR TITLE
[Diffusion] [Wan]: Fuse the element-wise operations cross transformer blocks

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -328,7 +328,7 @@ class WanTransformerBlock(nn.Module):
         super().__init__()
 
         # 1. Self-attention
-        self.norm1 = LayerNormScaleShift(
+        self.norm1 = ScaleResidualLayerNormScaleShift(
             dim,
             eps=eps,
             elementwise_affine=False,
@@ -433,41 +433,62 @@ class WanTransformerBlock(nn.Module):
         self.mlp_residual = MulAdd()
 
         self.scale_shift_table = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
+        self.register_buffer("null_gate", None, persistent=False)
+        self.register_buffer("null_shift", None, persistent=False)
+        self.register_buffer("null_scale", None, persistent=False)
 
     def forward(
         self,
+        residual: torch.Tensor,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
+        c_gate_msa: torch.Tensor,
         temb: torch.Tensor,
         freqs_cis: tuple[torch.Tensor, torch.Tensor],
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if hidden_states.dim() == 4:
             hidden_states = hidden_states.squeeze(1)
         bs, seq_length, _ = hidden_states.shape
         orig_dtype = hidden_states.dtype
         if temb.dim() == 4:
             # temb: batch_size, seq_len, 6, inner_dim (wan2.2 ti2v)
-            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
-                self.scale_shift_table.unsqueeze(0) + temb.float()
-            ).chunk(6, dim=2)
+            (
+                shift_msa,
+                scale_msa,
+                gate_msa,
+                c_shift_msa,
+                c_scale_msa,
+                next_c_gate_msa,
+            ) = (self.scale_shift_table.unsqueeze(0) + temb.float()).chunk(6, dim=2)
             # batch_size, seq_len, 1, inner_dim
             shift_msa = shift_msa.squeeze(2)
             scale_msa = scale_msa.squeeze(2)
             gate_msa = gate_msa.squeeze(2)
             c_shift_msa = c_shift_msa.squeeze(2)
             c_scale_msa = c_scale_msa.squeeze(2)
-            c_gate_msa = c_gate_msa.squeeze(2)
+            next_c_gate_msa = next_c_gate_msa.squeeze(2)
         else:
             # temb: batch_size, 6, inner_dim (wan2.1/wan2.2 14B)
             e = self.scale_shift_table + temb.float()
-            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
-                e.chunk(6, dim=1)
-            )
+            (
+                shift_msa,
+                scale_msa,
+                gate_msa,
+                c_shift_msa,
+                c_scale_msa,
+                next_c_gate_msa,
+            ) = e.chunk(6, dim=1)
 
         assert shift_msa.dtype == torch.float32
 
         # 1. Self-attention
-        norm_hidden_states = self.norm1(hidden_states, shift_msa, scale_msa)
+        norm_hidden_states, hidden_states = self.norm1(
+            residual,
+            hidden_states,
+            c_gate_msa,
+            shift_msa,
+            scale_msa,
+        )
         query, _ = self.to_q(norm_hidden_states)
         key, _ = self.to_k(norm_hidden_states)
         value, _ = self.to_v(norm_hidden_states)
@@ -508,11 +529,17 @@ class WanTransformerBlock(nn.Module):
         attn_output, _ = self.to_out(attn_output)
         attn_output = attn_output.squeeze(1)
 
-        null_shift = null_scale = torch.zeros(
-            (1,), device=hidden_states.device, dtype=hidden_states.dtype
-        )
+        if self.null_shift is None or self.null_scale is None or self.null_gate is None:
+            # Initialize null_shift, null_scale, and null_gate as attributes, so they are created only once, avoiding repeated cudaMalloc and cudaMemset operations.
+            self.null_shift = self.null_scale = torch.zeros(
+                1, dtype=torch.float32, device=hidden_states.device
+            )
+            self.null_gate = torch.ones(
+                1, dtype=torch.float32, device=hidden_states.device
+            )
+
         norm_hidden_states, hidden_states = self.self_attn_residual_norm(
-            hidden_states, attn_output, gate_msa, null_shift, null_scale
+            hidden_states, attn_output, gate_msa, self.null_shift, self.null_scale
         )
         norm_hidden_states, hidden_states = norm_hidden_states.to(
             orig_dtype
@@ -523,7 +550,7 @@ class WanTransformerBlock(nn.Module):
             norm_hidden_states, context=encoder_hidden_states, context_lens=None
         )
         norm_hidden_states, hidden_states = self.cross_attn_residual_norm(
-            hidden_states, attn_output, 1, c_shift_msa, c_scale_msa
+            hidden_states, attn_output, self.null_gate, c_shift_msa, c_scale_msa
         )
         norm_hidden_states, hidden_states = norm_hidden_states.to(
             orig_dtype
@@ -531,10 +558,7 @@ class WanTransformerBlock(nn.Module):
 
         # 3. Feed-forward
         ff_output = self.ffn(norm_hidden_states)
-        hidden_states = self.mlp_residual(ff_output, c_gate_msa, hidden_states)
-        hidden_states = hidden_states.to(orig_dtype)
-
-        return hidden_states
+        return hidden_states, ff_output, next_c_gate_msa
 
 
 class WanTransformerBlock_VSA(nn.Module):
@@ -555,7 +579,7 @@ class WanTransformerBlock_VSA(nn.Module):
         super().__init__()
 
         # 1. Self-attention
-        self.norm1 = LayerNormScaleShift(
+        self.norm1 = ScaleResidualLayerNormScaleShift(
             dim,
             eps=eps,
             elementwise_affine=False,
@@ -643,27 +667,34 @@ class WanTransformerBlock_VSA(nn.Module):
         self.mlp_residual = MulAdd()
 
         self.scale_shift_table = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
+        self.register_buffer("null_gate", None, persistent=False)
+        self.register_buffer("null_shift", None, persistent=False)
+        self.register_buffer("null_scale", None, persistent=False)
 
     def forward(
         self,
+        residual: torch.Tensor,
         hidden_states: torch.Tensor,
+        c_gate_msa: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         temb: torch.Tensor,
         freqs_cis: tuple[torch.Tensor, torch.Tensor],
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if hidden_states.dim() == 4:
             hidden_states = hidden_states.squeeze(1)
         bs, seq_length, _ = hidden_states.shape
         orig_dtype = hidden_states.dtype
         # assert orig_dtype != torch.float32
         e = self.scale_shift_table + temb.float()
-        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = e.chunk(
-            6, dim=1
+        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, next_c_gate_msa = (
+            e.chunk(6, dim=1)
         )
         assert shift_msa.dtype == torch.float32
 
         # 1. Self-attention
-        norm_hidden_states = self.norm1(hidden_states, shift_msa, scale_msa)
+        norm_hidden_states = self.norm1(
+            residual, hidden_states, c_gate_msa, shift_msa, scale_msa
+        )
         query, _ = self.to_q(norm_hidden_states)
         key, _ = self.to_k(norm_hidden_states)
         value, _ = self.to_v(norm_hidden_states)
@@ -704,9 +735,17 @@ class WanTransformerBlock_VSA(nn.Module):
         attn_output, _ = self.to_out(attn_output)
         attn_output = attn_output.squeeze(1)
 
-        null_shift = null_scale = torch.zeros((1,), device=hidden_states.device)
+        if self.null_shift is None or self.null_scale is None or self.null_gate is None:
+            # Initialize null_shift, null_scale, and null_gate as attributes, so they are created only once, avoiding repeated cudaMalloc and cudaMemset operations.
+            self.null_shift = self.null_scale = torch.zeros(
+                1, dtype=torch.float32, device=hidden_states.device
+            )
+            self.null_gate = torch.ones(
+                1, dtype=torch.float32, device=hidden_states.device
+            )
+
         norm_hidden_states, hidden_states = self.self_attn_residual_norm(
-            hidden_states, attn_output, gate_msa, null_shift, null_scale
+            hidden_states, attn_output, gate_msa, self.null_shift, self.null_scale
         )
         norm_hidden_states, hidden_states = norm_hidden_states.to(
             orig_dtype
@@ -717,7 +756,7 @@ class WanTransformerBlock_VSA(nn.Module):
             norm_hidden_states, context=encoder_hidden_states, context_lens=None
         )
         norm_hidden_states, hidden_states = self.cross_attn_residual_norm(
-            hidden_states, attn_output, 1, c_shift_msa, c_scale_msa
+            hidden_states, attn_output, self.null_gate, c_shift_msa, c_scale_msa
         )
         norm_hidden_states, hidden_states = norm_hidden_states.to(
             orig_dtype
@@ -725,10 +764,7 @@ class WanTransformerBlock_VSA(nn.Module):
 
         # 3. Feed-forward
         ff_output = self.ffn(norm_hidden_states)
-        hidden_states = self.mlp_residual(ff_output, c_gate_msa, hidden_states)
-        hidden_states = hidden_states.to(orig_dtype)
-
-        return hidden_states
+        return hidden_states, ff_output, next_c_gate_msa
 
 
 class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
@@ -841,6 +877,7 @@ class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
         )
 
         self.layer_names = ["blocks"]
+        self.mlp_residual = MulAdd()
 
     @lru_cache(maxsize=1)
     def _compute_rope_for_sequence_shard(
@@ -1025,11 +1062,21 @@ class WanTransformer3DModel(CachableDiT, OffloadableDiTMixin):
             # if teacache is enabled, we need to cache the original hidden states
             if self.enable_teacache:
                 original_hidden_states = hidden_states.clone()
-
+            dtype = hidden_states.dtype
+            residual = torch.zeros_like(hidden_states)
+            c_gate_msa = torch.ones(1, dtype=torch.float32, device=hidden_states.device)
             for block in self.blocks:
-                hidden_states = block(
-                    hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
+                residual, hidden_states, c_gate_msa = block(
+                    residual,
+                    hidden_states,
+                    encoder_hidden_states,
+                    c_gate_msa,
+                    timestep_proj,
+                    freqs_cis,
                 )
+            hidden_states = self.mlp_residual(hidden_states, c_gate_msa, residual)
+            hidden_states = hidden_states.to(dtype=dtype)
+
             # if teacache is enabled, we need to cache the original hidden states
             if self.enable_teacache:
                 self.maybe_cache_states(hidden_states, original_hidden_states)

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -675,8 +675,8 @@ class WanTransformerBlock_VSA(nn.Module):
         self,
         residual: torch.Tensor,
         hidden_states: torch.Tensor,
-        c_gate_msa: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
+        c_gate_msa: torch.Tensor,
         temb: torch.Tensor,
         freqs_cis: tuple[torch.Tensor, torch.Tensor],
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -692,7 +692,7 @@ class WanTransformerBlock_VSA(nn.Module):
         assert shift_msa.dtype == torch.float32
 
         # 1. Self-attention
-        norm_hidden_states = self.norm1(
+        norm_hidden_states, hidden_states = self.norm1(
             residual, hidden_states, c_gate_msa, shift_msa, scale_msa
         )
         query, _ = self.to_q(norm_hidden_states)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

1. Fuse the element-wise operations at the end of block i (`MulAdd`) and the beginning of block i+1 (`LayerNormScaleShift`) into a single `ScaleResidualLayerNormScaleShift` kernel to reduce kernel launches and improve efficiency.
2. Store null_gate, null_shift, and null_scale as attributes instead of recreating them in each block during the forward pass, reducing repeated tensor allocations and runtime overhead.
3. Modified block inputs and outputs to propagate residual, ff_output, and c_gate_msa between blocks, improving data flow.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Wan2.2 benchmark:

Test input image:

![ikun](https://github.com/user-attachments/assets/5ea81548-b369-404a-81da-a149cde3a67c)

### command

```bash
CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" sglang generate \
    --model-path "Wan-AI/Wan2.2-I2V-A14B-Diffusers" \
    --attention-backend fa \
    --trust-remote-code \
    --num-gpus 8 \
    --ulysses-degree 8 \
    --use-fsdp-inference false \
    --dit-cpu-offload false \
    --dit-layerwise-offload false \
    --text-encoder-cpu-offload false \
    --image-encoder-cpu-offload false \
    --vae-cpu-offload false \
    --pin-cpu-memory false \
    --backend sglang \
    --num-frames 81 \
    --fps 16 \
    --height 720 \
    --width 1280 \
    --num-inference-steps 40 \
    --prompt "一位名叫蔡徐坤的中国男明星站在室外篮球场中央，夕阳的金色光线洒在球场上。他手持篮球，深情而自信地凝望镜头。镜头缓慢推进，他开始运球，在球场上做出流畅的篮球动作。随着节奏感强烈的音乐，他一边打篮球一边跳舞，将篮球动作与舞蹈动作自然结合。他的身材修长而结实，动作充满节奏感和魅力，舞步干净利落，充满舞台表现力。篮球在地面弹跳，他转身、运球、投篮，同时加入优雅又富有力量感的舞蹈动作。整体氛围充满运动活力与男性魅力，画面具有电影质感，慢动作镜头、动态跟拍、光影细节丰富，4K，high detail，cinematic lighting。" \
    --image-path "ikun.jpeg" \
    --warmup \
    --save-output
```

### log:

- main:

```text

[02-27 07:26:49] Running pipeline stages: ['input_validation_stage', 'text_encoding_stage', 'image_v_a_e_encoding_stage', 'latent_preparation_stage', 'timestep_preparation_stage', 'denoising_stage', 'decoding_stage']
[02-27 07:26:49] [InputValidationStage] started...
[02-27 07:26:49] [InputValidationStage] finished in 0.1189 seconds
[02-27 07:26:49] [TextEncodingStage] started...
[02-27 07:26:49] [TextEncodingStage] finished in 0.0938 seconds
[02-27 07:26:49] [ImageVAEEncodingStage] started...
[02-27 07:26:49] [ImageVAEEncodingStage] finished in 0.6635 seconds
[02-27 07:26:49] [LatentPreparationStage] started...
[02-27 07:26:49] [LatentPreparationStage] finished in 0.0002 seconds
[02-27 07:26:49] [TimestepPreparationStage] started...
[02-27 07:26:49] [TimestepPreparationStage] finished in 0.0003 seconds
[02-27 07:26:49] [DenoisingStage] started...

  0%|          | 0/40 [00:00<?, ?it/s]
  2%|▎         | 1/40 [00:00<00:24,  1.60it/s]
  5%|▌         | 2/40 [00:01<00:29,  1.31it/s]
  8%|▊         | 3/40 [00:02<00:29,  1.25it/s]
 10%|█         | 4/40 [00:03<00:29,  1.22it/s]
 12%|█▎        | 5/40 [00:04<00:28,  1.21it/s]
 15%|█▌        | 6/40 [00:04<00:28,  1.20it/s]
 18%|█▊        | 7/40 [00:05<00:27,  1.20it/s]
 20%|██        | 8/40 [00:06<00:26,  1.19it/s]
 22%|██▎       | 9/40 [00:07<00:26,  1.19it/s]
 25%|██▌       | 10/40 [00:08<00:25,  1.19it/s]
 28%|██▊       | 11/40 [00:09<00:24,  1.19it/s]
 30%|███       | 12/40 [00:09<00:23,  1.19it/s]
 32%|███▎      | 13/40 [00:10<00:22,  1.19it/s]
 35%|███▌      | 14/40 [00:11<00:21,  1.19it/s]
 38%|███▊      | 15/40 [00:12<00:21,  1.19it/s]
 40%|████      | 16/40 [00:13<00:20,  1.19it/s]
 42%|████▎     | 17/40 [00:14<00:19,  1.19it/s]
 45%|████▌     | 18/40 [00:14<00:18,  1.19it/s]
 48%|████▊     | 19/40 [00:15<00:17,  1.19it/s]
 50%|█████     | 20/40 [00:16<00:16,  1.19it/s]
 52%|█████▎    | 21/40 [00:17<00:16,  1.19it/s]
 55%|█████▌    | 22/40 [00:18<00:15,  1.19it/s]
 57%|█████▊    | 23/40 [00:19<00:14,  1.19it/s]
 60%|██████    | 24/40 [00:20<00:13,  1.19it/s]
 62%|██████▎   | 25/40 [00:20<00:12,  1.19it/s]
 65%|██████▌   | 26/40 [00:21<00:11,  1.19it/s]
 68%|██████▊   | 27/40 [00:22<00:10,  1.19it/s]
 70%|███████   | 28/40 [00:23<00:10,  1.19it/s]
 72%|███████▎  | 29/40 [00:24<00:09,  1.19it/s]
 75%|███████▌  | 30/40 [00:25<00:08,  1.19it/s]
 78%|███████▊  | 31/40 [00:25<00:07,  1.19it/s]
 80%|████████  | 32/40 [00:26<00:06,  1.19it/s]
 82%|████████▎ | 33/40 [00:27<00:05,  1.19it/s]
 85%|████████▌ | 34/40 [00:28<00:05,  1.19it/s]
 88%|████████▊ | 35/40 [00:29<00:04,  1.19it/s]
 90%|█████████ | 36/40 [00:30<00:03,  1.19it/s]
 92%|█████████▎| 37/40 [00:30<00:02,  1.19it/s]
 95%|█████████▌| 38/40 [00:31<00:01,  1.19it/s]
 98%|█████████▊| 39/40 [00:32<00:00,  1.19it/s]
100%|██████████| 40/40 [00:33<00:00,  1.19it/s]
100%|██████████| 40/40 [00:33<00:00,  1.19it/s]
[02-27 07:27:23] [DenoisingStage] average time per step: 0.8370 seconds
[02-27 07:27:23] [DenoisingStage] finished in 33.4850 seconds
[02-27 07:27:23] [DecodingStage] started...
[02-27 07:27:24] [DecodingStage] finished in 0.7335 seconds
[02-27 07:27:24] Peak GPU memory: 80.99 GB, Peak allocated: 77.24 GB, Memory pool overhead: 3.76 GB (4.6%), Remaining GPU memory at peak: 59.41 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[02-27 07:27:24] Output saved to [1;36moutputs/20260227-072557_56903893.mp4[0;0m
[02-27 07:27:24] Pixel data generated successfully in [92m87.04[0;0m seconds
[02-27 07:27:24] Completed batch processing. Generated 1 outputs in [92m87.04[0;0m seconds
[02-27 07:27:24] Warmed-up request processed in [92m35.11[0;0m seconds (with warmup excluded)
[02-27 07:27:24] Memory usage - Max peak: 82934.00 MB, Avg peak: 82934.00 MB
[93m[02-27 07:27:24] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[93m[02-27 07:27:34] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m
```

- pr:

```text
[02-27 07:23:07] Running pipeline stages: ['input_validation_stage', 'text_encoding_stage', 'image_v_a_e_encoding_stage', 'latent_preparation_stage', 'timestep_preparation_stage', 'denoising_stage', 'decoding_stage']
[02-27 07:23:07] [InputValidationStage] started...
[02-27 07:23:07] [InputValidationStage] finished in 0.1245 seconds
[02-27 07:23:07] [TextEncodingStage] started...
[02-27 07:23:07] [TextEncodingStage] finished in 0.1235 seconds
[02-27 07:23:07] [ImageVAEEncodingStage] started...
[02-27 07:23:08] [ImageVAEEncodingStage] finished in 0.6451 seconds
[02-27 07:23:08] [LatentPreparationStage] started...
[02-27 07:23:08] [LatentPreparationStage] finished in 0.0001 seconds
[02-27 07:23:08] [TimestepPreparationStage] started...
[02-27 07:23:08] [TimestepPreparationStage] finished in 0.0002 seconds
[02-27 07:23:08] [DenoisingStage] started...

  0%|          | 0/40 [00:00<?, ?it/s]
  2%|▎         | 1/40 [00:00<00:23,  1.65it/s]
  5%|▌         | 2/40 [00:01<00:28,  1.33it/s]
  8%|▊         | 3/40 [00:02<00:29,  1.26it/s]
 10%|█         | 4/40 [00:03<00:29,  1.23it/s]
 12%|█▎        | 5/40 [00:03<00:28,  1.22it/s]
 15%|█▌        | 6/40 [00:04<00:28,  1.21it/s]
 18%|█▊        | 7/40 [00:05<00:27,  1.20it/s]
 20%|██        | 8/40 [00:06<00:26,  1.20it/s]
 22%|██▎       | 9/40 [00:07<00:25,  1.19it/s]
 25%|██▌       | 10/40 [00:08<00:25,  1.19it/s]
 28%|██▊       | 11/40 [00:09<00:24,  1.19it/s]
 30%|███       | 12/40 [00:09<00:23,  1.19it/s]
 32%|███▎      | 13/40 [00:10<00:22,  1.19it/s]
 35%|███▌      | 14/40 [00:11<00:21,  1.19it/s]
 38%|███▊      | 15/40 [00:12<00:21,  1.19it/s]
 40%|████      | 16/40 [00:13<00:20,  1.19it/s]
 42%|████▎     | 17/40 [00:14<00:19,  1.19it/s]
 45%|████▌     | 18/40 [00:14<00:18,  1.19it/s]
 48%|████▊     | 19/40 [00:15<00:17,  1.19it/s]
 50%|█████     | 20/40 [00:16<00:16,  1.19it/s]
 52%|█████▎    | 21/40 [00:17<00:15,  1.19it/s]
 55%|█████▌    | 22/40 [00:18<00:15,  1.19it/s]
 57%|█████▊    | 23/40 [00:19<00:14,  1.19it/s]
 60%|██████    | 24/40 [00:19<00:13,  1.19it/s]
 62%|██████▎   | 25/40 [00:20<00:12,  1.19it/s]
 65%|██████▌   | 26/40 [00:21<00:11,  1.19it/s]
 68%|██████▊   | 27/40 [00:22<00:10,  1.19it/s]
 70%|███████   | 28/40 [00:23<00:10,  1.19it/s]
 72%|███████▎  | 29/40 [00:24<00:09,  1.19it/s]
 75%|███████▌  | 30/40 [00:25<00:08,  1.19it/s]
 78%|███████▊  | 31/40 [00:25<00:07,  1.19it/s]
 80%|████████  | 32/40 [00:26<00:06,  1.19it/s]
 82%|████████▎ | 33/40 [00:27<00:05,  1.19it/s]
 85%|████████▌ | 34/40 [00:28<00:05,  1.19it/s]
 88%|████████▊ | 35/40 [00:29<00:04,  1.19it/s]
 90%|█████████ | 36/40 [00:30<00:03,  1.19it/s]
 92%|█████████▎| 37/40 [00:30<00:02,  1.19it/s]
 95%|█████████▌| 38/40 [00:31<00:01,  1.19it/s]
 98%|█████████▊| 39/40 [00:32<00:00,  1.19it/s]
100%|██████████| 40/40 [00:33<00:00,  1.19it/s]
100%|██████████| 40/40 [00:33<00:00,  1.20it/s]
[02-27 07:23:41] [DenoisingStage] average time per step: 0.8346 seconds
[02-27 07:23:41] [DenoisingStage] finished in 33.3878 seconds
[02-27 07:23:41] [DecodingStage] started...
[02-27 07:23:42] [DecodingStage] finished in 0.7505 seconds
[02-27 07:23:42] Peak GPU memory: 80.73 GB, Peak allocated: 77.23 GB, Memory pool overhead: 3.50 GB (4.3%), Remaining GPU memory at peak: 59.67 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[02-27 07:23:43] Output saved to [1;36moutputs/20260227-072204_d85152b3.mp4[0;0m
[02-27 07:23:43] Pixel data generated successfully in [92m98.27[0;0m seconds
[02-27 07:23:43] Completed batch processing. Generated 1 outputs in [92m98.27[0;0m seconds
[02-27 07:23:43] Warmed-up request processed in [92m35.05[0;0m seconds (with warmup excluded)
[02-27 07:23:43] Memory usage - Max peak: 82664.00 MB, Avg peak: 82664.00 MB
[93m[02-27 07:23:43] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[93m[02-27 07:23:53] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m
```

### result

33.4850s(main) -> 33.3878s(pr)
About **0.29%** end-to-end performance improvement.

- main:

https://github.com/user-attachments/assets/79426660-2378-49f6-9585-703d2c5943b2


- pr:

https://github.com/user-attachments/assets/c4207b74-ab24-465a-99f0-2a498ad511da


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
6. After green CI and required approvals, ask Merge Oncalls to merge.
