### PR TITLE
[Fix] Fix cuda vit encoder graph has conflict with rotary emb compiled

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/utils.py
+++ b/python/sglang/srt/layers/rotary_embedding/utils.py
@@ -18,7 +18,9 @@ if _is_npu:
     NPU_ROTARY_MUL_MAX_NUM_HEADS = 1000
     NPU_ROTARY_MUL_MAX_HEAD_SIZE = 896
 
-
+# Disable torch.compile for apply_rotary_pos_emb_native when ViT CUDA graph is enabled
+# to avoid `torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: Cannot call
+# CUDAGeneratorImpl::current_seed during CUDA graph capture.`
 _disable_rotary_pos_emb_compile = envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get()
 
 

--- a/python/sglang/srt/layers/rotary_embedding/utils.py
+++ b/python/sglang/srt/layers/rotary_embedding/utils.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.utils import get_compiler_backend, is_npu
 
 _is_npu = is_npu()
@@ -16,6 +17,9 @@ if _is_npu:
 
     NPU_ROTARY_MUL_MAX_NUM_HEADS = 1000
     NPU_ROTARY_MUL_MAX_HEAD_SIZE = 896
+
+
+_disable_rotary_pos_emb_compile = envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get()
 
 
 def rotate_neox(x: torch.Tensor) -> torch.Tensor:
@@ -68,7 +72,11 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@torch.compile(
+    dynamic=True,
+    backend=get_compiler_backend(),
+    disable=_disable_rotary_pos_emb_compile,
+)
 def apply_rotary_pos_emb_native(
     q: torch.Tensor,
     k: torch.Tensor,


### PR DESCRIPTION
## Motivation

When running Qwen3-VL-30B-A3B, setting `export SGLANG_VIT_ENABLE_CUDA_GRAPH=1` triggered an error; there is a conflict between the graph capture feature and dynamic operator compilation.

```shell
unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32
export SGLANG_VIT_ENABLE_CUDA_GRAPH=1

python -m sglang.launch_server \
    --model-path /home/weight/Qwen3-VL-30B-A3B-Instruct \
    --host 127.0.0.1 --port 23388 \
    --tp 2 \
    --max-prefill-tokens 40960 \
    --chunked-prefill-size 40960 \
    --mem-fraction-static 0.8 \
    --max-running-requests 512 \
    --disable-radix-cache \
    --cuda-graph-bs 10 20 30 50 60 70 100 \
    --base-gpu-id 0 \
    --trust-remote-code \
    --enable-multimodal \
    --mm-attention-backend fa3 \
    --sampling-backend flashinfer \
    --attention-backend fa3 \
    --mm-enable-dp-encoder --enable-dp-attention --dp-size 2 \
    --enable-dp-lm-head 
```

```shell
[2026-02-27 07:49:14 DP0 TP0] Scheduler hit an exception: Traceback (most recent call last):
...
  File "/home/xjw/code/sglang/python/sglang/srt/multimodal/vit_cuda_graph_runner.py", line 186, in _create_graph
    y = blk(
        ^^^^
...
  File "/home/xjw/code/sglang/python/sglang/srt/layers/attention/vision.py", line 1042, in forward
    q, k = apply_rotary_pos_emb(q, k, cos, sin)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/random.py", line 43, in get_rng_state
    return default_generator.get_state()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch._dynamo.exc.InternalTorchDynamoError: RuntimeError: Cannot call CUDAGeneratorImpl::current_seed during CUDA graph capture. If you need this call to be captured, please file an issue. Current cudaStreamCaptureStatus: cudaStreamCaptureStatusActive
```

## Modifications

Add a toggle to skip `apply_rotary_pos_emb` compilation when ViT Graph is enabled.

## Accuracy Tests

TODO

## Benchmarking and Profiling

TODO

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
