### PR TITLE
[PD-Disagg][Fix] Remove 'test_external_dp_routing' from Rust Router constructor parameters.

### DIFF
--- a/sgl-model-gateway/bindings/python/src/sglang_router/router.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router.py
@@ -285,6 +285,7 @@ class Router:
         # Remove fields that shouldn't be passed to Rust Router constructor
         fields_to_remove = [
             "mini_lb",
+            "test_external_dp_routing",
             "oracle_wallet_path",
             "oracle_tns_alias",
             "oracle_connect_descriptor",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
cc @hnyls2002 

## Motivation

`test_external_dp_routing` param has been introduced in #19268 for `minilb` test and was not filtered out when transmitted to the Rust implementation. The error occured.

```
python -m sglang_router.launch_router --pd-disaggregation --port 30000 --policy random --prefill-policy random --decode-policy random --prefill http://10.235.192.132:8000 --decode http://10.235.192.132:8000
Both --prefill-policy and --decode-policy are specified. The main --policy flag will be ignored for PD mode.
Error starting router: Router.__new__() got an unexpected keyword argument 'test_external_dp_routing'
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/venv/lib/python3.10/site-packages/sglang_router/launch_router.py", line 109, in <module>
    main()
  File "/opt/venv/lib/python3.10/site-packages/sglang_router/launch_router.py", line 105, in main
    launch_router(router_args)
  File "/opt/venv/lib/python3.10/site-packages/sglang_router/launch_router.py", line 52, in launch_router
    raise e
  File "/opt/venv/lib/python3.10/site-packages/sglang_router/launch_router.py", line 47, in launch_router
    router = Router.from_args(router_args)
  File "/opt/venv/lib/python3.10/site-packages/sglang_router/router.py", line 312, in from_args
    return Router(_Router(**args_dict))
TypeError: Router.__new__() got an unexpected keyword argument 'test_external_dp_routing'
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Add it to filter list.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
GSM8K test with 1P/1D of DeepSeek R1 TP8
```
/sgl-workspace/sglang/benchmark/gsm8k# python bench_sglang.py --num-questions 200 --port 8000
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 20.4MB/s]                                                           
100%|████████████████████████████████████████████████████████████| 200/200 [00:16<00:00, 12.48it/s]
Accuracy: 0.970
Invalid: 0.000
Latency: 16.031 s
Output throughput: 1129.922 token/s
```
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
