### PR TITLE
[Perf][Moe]improve cutlass_moe_fp4 performance by using apply_router_weight_on_i…

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -491,10 +491,12 @@ def cutlass_moe_fp4(
         params.to_gemm2_args(),
     )
     del int_fp4, int_blockscale
-    c2 = shuffle_rows(c2, c_map, (m_a * num_topk, params.hidden_size))
-    c2 = c2.view(m_a, num_topk, params.hidden_size)
+
     if no_combine:
+        c2 = shuffle_rows(c2, c_map, (m_a * num_topk, params.hidden_size))
+        c2 = c2.view(m_a, num_topk, params.hidden_size)
         return c2.to(out_dtype)
-    if not apply_router_weight_on_input:
-        c2 = c2 * topk_weights.view(m_a, num_topk, 1).to(out_dtype)
-    return c2.sum(dim=1).to(out_dtype)
+    output = torch.empty((m_a, k_a), device=device, dtype=out_dtype)
+    weights = topk_weights.to(out_dtype) if not apply_router_weight_on_input else None
+    apply_shuffle_mul_sum(c2, output, c_map, weights)
+    return output


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
when i running with this cmd
```bash
model_path=/pfs/pfs-OqLB2M/models/DeepSeek-R1-0528-NVFP4-v2
TP_SIZE=8
DP_SIZE=8
EP_SIZE=1
NNODES=1
NODE_RANK=0
export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
export NCCL_MNNVL_ENABLE=1
export NCCL_CUMEM_ENABLE=1
export PYTHONUNBUFFERED=1
export SGLANG_USE_MESSAGE_QUEUE_BROADCASTER=0
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
python3 -m sglang.launch_server \
    --nnodes $NNODES --node-rank $NODE_RANK \
    --model-path ${model_path} \
    --host 0.0.0.0 \
    --port 8000 \
    --decode-log-interval 1 \
    --max-running-requests 2048 \
    --disable-radix-cache \
    --disable-shared-experts-fusion \
    --watchdog-timeout 1000000 \
    --tp-size ${TP_SIZE} \
    --enable-dp-lm-head \
    --decode-log-interval 1 \
    --chunked-prefill-size 8192 \
    --max-prefill-tokens 1048576 \
    --trust-remote-code \
    --disable-cuda-graph \
    --enable-layerwise-nvtx-marker \
    --moe-runner-backend deep_gemm --tokenizer-worker-num 8 \
    --quantization modelopt_fp4 \
    --show-time-cost --enable-request-time-stats-logging --enable-metrics \
    --mem-fraction-static 0.8
```
I found that the last shuffle_rows and reduce sum operations  in the calculation of cutlass_moe_fp4 are extremely time-consuming, and their proportion increases with the increase of sequence length.
To improve the performance of moe computation,  this commen to use a fused kernel to implement these functions.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Use the kernel apply_router_weight_on_input to replace the multiple elementwise operations shuffle_rows+view+mul+reduce sum

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
### Before
test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_mmlu Score: 0.750
<img width="960" height="107" alt="image" src="https://github.com/user-attachments/assets/1f79c5d8-c393-4a82-ab6c-c18fd9c4fa05" />
test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_mgsm_en Score: 0.768
<img width="960" height="56" alt="image (1)" src="https://github.com/user-attachments/assets/33d6aee8-b056-4ec5-8b83-60b58595e153" />
test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_human_eval Score: 0.491
<img width="960" height="72" alt="image (2)" src="https://github.com/user-attachments/assets/bf3d30b9-44c9-4661-9531-ff5a37cbfa08" />

### After
test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_mmlu Score: 0.757
<img width="2327" height="137" alt="截屏2026-02-27 20 33 51" src="https://github.com/user-attachments/assets/52a63ea2-a00c-4036-b680-917f41a23242" />
test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_mgsm_en Score: 
test twice: first time is 0.752, second time is 0.792, so i think the accuracy is good
<img width="2311" height="153" alt="截屏2026-02-27 21 08 12" src="https://github.com/user-attachments/assets/0100339d-d7eb-4308-b6ed-407bb4abd6c1" />
<img width="2311" height="137" alt="截屏2026-02-27 20 39 39" src="https://github.com/user-attachments/assets/c8a9add3-05a4-4257-bd4d-7e76c38e8013" />
test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_human_eval Score: 0.463
<img width="2311" height="139" alt="截屏2026-02-27 21 14 40" src="https://github.com/user-attachments/assets/da2527a8-d99d-4fb1-af49-907d3c0bc8a4" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
use bench_serving for testing, set --random-input-len in 8k,16k,32k,64k,128k
```bash
python -m sglang.bench_serving --backend sglang-oai-chat --dataset-name random --host 0.0.0.0 --port 8000 --model /pfs/pfs-OqLB2M/models/DeepSeek-R1-0528-NVFP4-v2 --random-input-len 8192 --random-output
-len 16 --num-prompts 64 --max-concurrency 8
```

### Benchmarking Before
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/997697aa-4aaf-4dfa-8290-cbb9f4af8fb5" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/547367dc-a9a9-430f-9684-11bf268a9d74" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/53fa86d6-c480-4291-b752-c1e28182b0f0" width="100%"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/ce6f93e5-9d42-40a5-85fc-f4b6cae7625f" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/0f96caf0-4c47-4830-8f5e-06d293463b95" width="100%"></td>
    <td></td>
  </tr>
</table>
### Benchmarking After
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/55487d2e-d438-4b21-bfd2-f8d486b780f7" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/748c6e87-c722-412b-a99b-3cfa09d76510" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/852d6dfd-510b-467c-aec5-61ccb5355bb9" width="100%"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3bf08eb9-023d-4988-a1f8-1122a0f83aec" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/63f506eb-8826-4b7a-9684-a4bc51ed267d" width="100%"></td>
    <td></td>
  </tr>
</table>
Performence gain for  8k,16k,32k,64k,128k is 12.55% 19.31%, 20.35%, 18.51%, 15.36% about Mean E2E Latency;

### Profiling 
top show Before: duration of shuffle , view and reduce sum operations in one moe layer
 bottom show After: duration of fused kernel 'apply_router_weight_on_input' in one moe layer
<img width="1993" height="477" alt="截屏2026-02-27 20 35 47" src="https://github.com/user-attachments/assets/e10b7a78-1b8e-4c23-892e-35954476de94" />
Reduce the time spent of this part from 1.578ms to 214.238us.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.


























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26392922852](https://github.com/sgl-project/sglang/actions/runs/26392922852)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26392922701](https://github.com/sgl-project/sglang/actions/runs/26392922701)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->