### PR TITLE
Allow PR authors to use /rerun-failed-ci on their own PRs

### DIFF
--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -73,9 +73,9 @@ Then your PR can be merged.
 We have a lot of open PRs but limited CI machines, so only top and trusted contributors have permission to trigger CI tests.
 Users with permission are listed in the [CI_PERMISSIONS.json](https://github.com/sgl-project/sglang/blob/main/.github/CI_PERMISSIONS.json)
 
-**PR authors** can always use `/rerun-failed-ci`, `/tag-run-ci-label`, and `/tag-and-rerun-ci` on their own PRs, even if they are not listed in `CI_PERMISSIONS.json`.
+**PR authors** can always use `/rerun-failed-ci` on their own PRs, even if they are not listed in `CI_PERMISSIONS.json`.
 
-For CI to run on a pull request, it must have the "run-ci" label. Authorized users (and PR authors on their own PRs) can add the label or rerun failed tests by commenting on the PR with one of these commands:
+For CI to run on a pull request, it must have the "run-ci" label. Authorized users can add the label or rerun failed tests by commenting on the PR with one of these commands:
 
 - `/tag-run-ci-label`: Adds the "run-ci" label. Every future commit will trigger CI.
 - `/rerun-failed-ci`: Reruns the failed or flaky tests from the most recent commit.

--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -73,7 +73,9 @@ Then your PR can be merged.
 We have a lot of open PRs but limited CI machines, so only top and trusted contributors have permission to trigger CI tests.
 Users with permission are listed in the [CI_PERMISSIONS.json](https://github.com/sgl-project/sglang/blob/main/.github/CI_PERMISSIONS.json)
 
-For CI to run on a pull request, it must have the "run-ci" label. Authorized users can add the label or rerun failed tests by commenting on the PR with one of these commands:
+**PR authors** can always use `/rerun-failed-ci`, `/tag-run-ci-label`, and `/tag-and-rerun-ci` on their own PRs, even if they are not listed in `CI_PERMISSIONS.json`.
+
+For CI to run on a pull request, it must have the "run-ci" label. Authorized users (and PR authors on their own PRs) can add the label or rerun failed tests by commenting on the PR with one of these commands:
 
 - `/tag-run-ci-label`: Adds the "run-ci" label. Every future commit will trigger CI.
 - `/rerun-failed-ci`: Reruns the failed or flaky tests from the most recent commit.
@@ -86,7 +88,7 @@ To avoid spamming a PR with too many `/rerun-failed-ci` comments, you can also t
 
 Example of rerunning a single test stage: `/rerun-stage unit-test-backend-4-gpu`.
 
-If you don’t have permission, please ask maintainers to trigger CI for you.
+If you don’t have permission and you’re not the PR author, please ask maintainers to trigger CI for you.
 
 ### CI rate limits
 

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -415,12 +415,8 @@ def main():
     comment_body = get_env_var("COMMENT_BODY").strip()
     user_login = get_env_var("USER_LOGIN")
 
-    # 2. Load Permissions (Local Check)
+    # 2. Load Permissions (local file check first to avoid unnecessary API calls)
     user_perms = load_permissions(user_login)
-
-    if not user_perms:
-        print(f"User {user_login} does not have any configured permissions. Exiting.")
-        return
 
     # 3. Initialize GitHub API with Auth
     auth = Auth.Token(token)
@@ -429,6 +425,25 @@ def main():
     repo = g.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     comment = repo.get_issue(pr_number).get_comment(comment_id)
+
+    # PR authors can always rerun CI and tag their own PRs,
+    # even if they are not listed in CI_PERMISSIONS.json.
+    # Note: /rerun-stage still requires CI_PERMISSIONS.json membership.
+    if pr.user.login == user_login:
+        if user_perms is None:
+            print(
+                f"User {user_login} is the PR author (not in CI_PERMISSIONS.json). "
+                "Granting CI rerun permissions."
+            )
+            user_perms = {}
+        else:
+            print(f"User {user_login} is the PR author and has existing CI permissions.")
+        user_perms["can_tag_run_ci_label"] = True
+        user_perms["can_rerun_failed_ci"] = True
+
+    if not user_perms:
+        print(f"User {user_login} does not have any configured permissions. Exiting.")
+        return
 
     # 4. Parse Command and Execute
     first_line = comment_body.split("\n")[0].strip()

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -437,7 +437,9 @@ def main():
             )
             user_perms = {}
         else:
-            print(f"User {user_login} is the PR author and has existing CI permissions.")
+            print(
+                f"User {user_login} is the PR author and has existing CI permissions."
+            )
         user_perms["can_rerun_failed_ci"] = True
 
     if not user_perms:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -426,9 +426,9 @@ def main():
     pr = repo.get_pull(pr_number)
     comment = repo.get_issue(pr_number).get_comment(comment_id)
 
-    # PR authors can always rerun CI and tag their own PRs,
+    # PR authors can always rerun failed CI on their own PRs,
     # even if they are not listed in CI_PERMISSIONS.json.
-    # Note: /rerun-stage still requires CI_PERMISSIONS.json membership.
+    # Note: /tag-run-ci-label and /rerun-stage still require CI_PERMISSIONS.json.
     if pr.user.login == user_login:
         if user_perms is None:
             print(
@@ -438,7 +438,6 @@ def main():
             user_perms = {}
         else:
             print(f"User {user_login} is the PR author and has existing CI permissions.")
-        user_perms["can_tag_run_ci_label"] = True
         user_perms["can_rerun_failed_ci"] = True
 
     if not user_perms:


### PR DESCRIPTION
## Motivation

PR authors not in `CI_PERMISSIONS.json` currently have to ask maintainers to rerun failed CI. This adds friction for new contributors.

## Modifications

- **`scripts/ci/utils/slash_command_handler.py`**: Check if commenter is the PR author; if so, auto-grant `can_rerun_failed_ci`. Other commands (`/tag-run-ci-label`, `/rerun-stage`) still require `CI_PERMISSIONS.json`.
- **`docs/developer_guide/contribution_guide.md`**: Updated docs accordingly.