### PR TITLE
[Quantization] Fix per-tensor FP8 MoE parameter identity for EPLB hot-reload

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1147,25 +1147,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w13_weight = torch.empty_like(layer.w13_weight.data, dtype=fp8_dtype)
             w2_weight = torch.empty_like(layer.w2_weight.data, dtype=fp8_dtype)
 
-            # Re-initialize w13_scale because we directly quantize
-            # merged w13 weights and generate a single scaling factor.
-            layer.w13_weight_scale = torch.nn.Parameter(
-                torch.ones(
-                    layer.num_local_experts,
-                    dtype=torch.float32,
-                    device=w13_weight.device,
-                ),
-                requires_grad=False,
-            )
+            # Quantize merged w13 weights and generate a single scaling factor
+            # per expert.  We fill both columns of the original [E, 2] scale
+            # Parameter in-place (same value) to preserve its object identity
+            # and custom attributes (weight_loader, quant_method) for EPLB
+            # hot-reload, following the same principle as _copy_or_rebind in
+            # process_weights_after_loading_block_quant.
             for expert in range(layer.num_local_experts):
-                w13_weight[expert, :, :], layer.w13_weight_scale[expert] = (
-                    scaled_fp8_quant(layer.w13_weight.data[expert, :, :])
+                w13_weight[expert, :, :], scale = scaled_fp8_quant(
+                    layer.w13_weight.data[expert, :, :]
                 )
-                w2_weight[expert, :, :], layer.w2_weight_scale[expert] = (
+                layer.w13_weight_scale.data[expert].fill_(scale)
+                w2_weight[expert, :, :], layer.w2_weight_scale.data[expert] = (
                     scaled_fp8_quant(layer.w2_weight.data[expert, :, :])
                 )
-            layer.w13_weight = torch.nn.Parameter(w13_weight, requires_grad=False)
-            layer.w2_weight = torch.nn.Parameter(w2_weight, requires_grad=False)
+            # Rebind underlying tensor data while preserving Parameter objects.
+            layer.w13_weight.data = w13_weight
+            layer.w2_weight.data = w2_weight
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
@@ -1191,12 +1189,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         "fp8 MoE layer. Using the maximum across experts "
                         "for each layer. "
                     )
-                layer.w13_input_scale = torch.nn.Parameter(
-                    layer.w13_input_scale.max(), requires_grad=False
-                )
-                layer.w2_input_scale = torch.nn.Parameter(
-                    layer.w2_input_scale.max(), requires_grad=False
-                )
+                # Fill in-place to preserve the Parameter object and its
+                # custom attributes (weight_loader, quant_method, etc.)
+                # needed for EPLB hot-reload, following the same principle
+                # as _copy_or_rebind in process_weights_after_loading_block_quant.
+                layer.w13_input_scale.data.fill_(layer.w13_input_scale.data.max())
+                layer.w2_input_scale.data.fill_(layer.w2_input_scale.data.max())
 
             # If ROCm, normalize the weights and scales to e4m3fnuz
             if _is_fp8_fnuz:
@@ -1246,9 +1244,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     ) = scaled_fp8_quant(dq_weight, max_w13_scales[expert_id])
                     start += shard_size
 
-            layer.w13_weight_scale = torch.nn.Parameter(
-                max_w13_scales, requires_grad=False
-            )
+            # Fill in-place to preserve the Parameter object and its
+            # custom attributes (weight_loader, quant_method, etc.)
+            # needed for EPLB hot-reload.  Both columns of the [E, 2]
+            # tensor are set to the same per-expert max so that the
+            # weight_loader can reuse the original shape on reload.
+            # The runtime extracts a 1-D [E] view via [:, 0] in apply().
+            for expert_id in range(layer.num_local_experts):
+                layer.w13_weight_scale.data[expert_id].fill_(max_w13_scales[expert_id])
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
@@ -1459,8 +1462,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 block_shape = [scale_block_size, scale_block_size]
                 w13_scale_n = (w13_weight.shape[1] - 1) // scale_block_size + 1
                 w13_scale_k = (w13_weight.shape[2] - 1) // scale_block_size + 1
+                # w13_weight_scale is kept as [E, 2] for EPLB hot-reload
+                # compatibility; both columns hold the same per-expert max.
+                # Collapse to [E] before expanding to block shape.
+                _w13_ws = layer.w13_weight_scale
+                if _w13_ws.ndim == 2:
+                    _w13_ws = _w13_ws[:, 0]
                 w13_scale = (
-                    layer.w13_weight_scale.unsqueeze(1)
+                    _w13_ws.unsqueeze(1)
                     .repeat_interleave(w13_scale_n, dim=1)
                     .unsqueeze(2)
                     .repeat_interleave(w13_scale_k, dim=2)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -136,7 +136,11 @@ from sglang.srt.model_executor.model_runner_kv_cache_mixin import (
 from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
     PiecewiseCudaGraphRunner,
 )
-from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
+from sglang.srt.model_loader.loader import (
+    DefaultModelLoader,
+    device_loading_context,
+    get_model_loader,
+)
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
     register_memory_region,
@@ -1158,7 +1162,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return iter
 
         def model_load_weights(model, iter):
-            loader.load_weights_and_postprocess(model, iter, target_device)
+            if weight_name_filter is not None:
+                # Partial reload (e.g. EPLB expert rebalancing): only load the
+                # filtered weights and run process_weights_after_loading on MoE
+                # modules whose weights were actually updated.  Running it on
+                # ALL modules would double-process unrelated layers (e.g. the
+                # FP8 linear transpose in attention) and corrupt their weights.
+                model.load_weights(iter)
+                for name, module in model.named_modules():
+                    quant_method = getattr(module, "quant_method", None)
+                    if quant_method is not None and weight_name_filter(name):
+                        with device_loading_context(module, target_device):
+                            quant_method.process_weights_after_loading(module)
+            else:
+                loader.load_weights_and_postprocess(model, iter, target_device)
             return model
 
         with set_default_torch_dtype(self.model_config.dtype):


### PR DESCRIPTION
## Motivation

When using per-tensor FP8 quantized MoE models (e.g., `RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8`) with Elastic EP Load Balancing (EPLB), the failover weight hot-reload crashes with:
```
AttributeError: 'Parameter' object has no attribute 'weight_loader'
```
followed by (after working around the above):

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x2048 and 1536x2048)
```
This was also mentioned in https://github.com/sgl-project/sglang/issues/18191. 

**Issue 1 — Parameter identity loss in per-tensor FP8 MoE**

`Fp8MoEMethod.process_weights_after_loading()` creates new `Parameter` objects via `torch.nn.Parameter(...)` for `w13_input_scale`, `w2_input_scale`, and `w13_weight_scale`.  This destroys custom attributes (`weight_loader`, `quant_method`) that `deepseek_weight_loader.py` relies on during EPLB hot-reload.

The block-quant path was already fixed in #17449 via `_copy_or_rebind()`, but the per-tensor path was never updated.

**Issue 2 — Double `process_weights_after_loading` on partial reload**

`update_weights_from_disk()` calls `load_weights_and_postprocess()`, which runs `process_weights_after_loading()` on **all** quantized modules unconditionally — even when only expert weights were reloaded.  For FP8 linear attention layers (e.g., `q_proj`), this means the weight gets transposed twice (once during initial load, once during reload), corrupting the shape from `[K, N]` back to `[N, K]`.

## Modifications

### `python/sglang/srt/layers/quantization/fp8.py`

**Dynamic-quant path** (non-checkpoint FP8):
- Use `.data =` for weight rebinding and `.data[expert].fill_()` for scale updates instead of `Parameter` replacement.

**Checkpoint-FP8 path — `input_scale` merging:**
- Replace `torch.nn.Parameter(max_val)` with `layer.w13_input_scale.data.fill_(max_val)` to preserve the original `Parameter` object in-place.

**Checkpoint-FP8 path — `w13_weight_scale` merging:**
- Instead of replacing the `[E, 2]` Parameter with a new `[E]` one, fill both columns with the same per-expert max in-place.  The `[E, 2]` shape is preserved so `weight_loader` can still index `param.data[expert_id][shard_idx]` during reload.

**`apply()` — DeepGEMM path:**
- Add `ndim == 2` guard to collapse `w13_weight_scale` from `[E, 2]` to `[E]` via `[:, 0]` before expanding to block shape.

### `python/sglang/srt/model_executor/model_runner.py`

**Partial reload isolation:**
- When `weight_name_filter` is set (EPLB expert rebalancing), split `load_weights` and `process_weights_after_loading` into two steps, only calling the latter on modules whose names match the filter.  This prevents double-processing of attention layers and other non-expert modules.

## Accuracy Tests

Validated with `test_mooncake_ep_small.py` (use DeepSeek-Coder-V2-Lite-Instruct-FP8): 7/7 tests passed.

![image](https://github.com/user-attachments/assets/7ed0ab46-5794-4cd1-a930-32e93a7ef841)

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
