### PR TITLE
[Bugfix] Fix KeyError: 'prompt_tokens' when streaming requests are aborted

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -632,8 +632,10 @@ class OpenAIServingChat(OpenAIServingBase):
             ):
                 index = content.get("index", 0)
 
-                prompt_tokens[index] = content["meta_info"]["prompt_tokens"]
-                completion_tokens[index] = content["meta_info"]["completion_tokens"]
+                prompt_tokens[index] = content["meta_info"].get("prompt_tokens", 0)
+                completion_tokens[index] = content["meta_info"].get(
+                    "completion_tokens", 0
+                )
                 cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -209,8 +209,10 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 index = content.get("index", 0)
 
                 text = content["text"]
-                prompt_tokens[index] = content["meta_info"]["prompt_tokens"]
-                completion_tokens[index] = content["meta_info"]["completion_tokens"]
+                prompt_tokens[index] = content["meta_info"].get("prompt_tokens", 0)
+                completion_tokens[index] = content["meta_info"].get(
+                    "completion_tokens", 0
+                )
                 cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)

--- a/python/sglang/srt/entrypoints/openai/usage_processor.py
+++ b/python/sglang/srt/entrypoints/openai/usage_processor.py
@@ -20,10 +20,12 @@ class UsageProcessor:
         n_choices: int = 1,
         enable_cache_report: bool = False,
     ) -> UsageInfo:
-        completion_tokens = sum(r["meta_info"]["completion_tokens"] for r in responses)
+        completion_tokens = sum(
+            r["meta_info"].get("completion_tokens", 0) for r in responses
+        )
 
         prompt_tokens = sum(
-            responses[i]["meta_info"]["prompt_tokens"]
+            responses[i]["meta_info"].get("prompt_tokens", 0)
             for i in range(0, len(responses), n_choices)
         )
 


### PR DESCRIPTION
## Motivation

Fix `KeyError: 'prompt_tokens'` crash when streaming requests are aborted by scheduler (e.g., due to `--max-queued-requests` limit being reached).

When scheduler aborts a streaming request, `_handle_abort_req` in `tokenizer_manager.py` generates `meta_info` without `prompt_tokens` field. The streaming handlers access it directly with `["prompt_tokens"]`, causing `KeyError` and breaking the SSE connection.

**Error traceback:**

```
[2026-02-21 17:48:27] ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
    | Traceback (most recent call last):
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     prompt_tokens[index] = content["meta_info"]["prompt_tokens"]
    | KeyError: 'prompt_tokens'
```

## Modifications

- `serving_chat.py`: Use `.get("prompt_tokens", 0)` and `.get("completion_tokens", 0)` for safe dictionary access
- `serving_completions.py`: Same change
- `usage_processor.py`: Same change (defensive fix)

This pattern is already used elsewhere in the codebase (e.g., `serving_chat.py` lines 1282, 1332).

## Accuracy Tests

N/A - This change only affects error handling path, no impact on model outputs.

## Benchmarking and Profiling

N/A - No impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).