### PR TITLE
Fix HiCacheNixl TypeError: mem_pool_host passed as file_path

### DIFF
--- a/python/sglang/srt/mem_cache/storage/backend_factory.py
+++ b/python/sglang/srt/mem_cache/storage/backend_factory.py
@@ -161,7 +161,7 @@ class StorageBackendFactory:
         if backend_name == "file":
             return backend_class(storage_config)
         elif backend_name == "nixl":
-            return backend_class(storage_config, mem_pool_host)
+            return backend_class(storage_config)
         elif backend_name == "mooncake":
             backend = backend_class(storage_config, mem_pool_host)
             return backend


### PR DESCRIPTION
## Summary

`StorageBackendFactory._create_builtin_backend()` passes `mem_pool_host` (a `MHATokenToKVPoolHost` object) as the second argument to `HiCacheNixl.__init__()`, which expects `file_path: str`. This causes a `TypeError` in `os.makedirs()` when `--hicache-storage-backend nixl` is used.

`register_mem_pool_host()` is already called separately by the cache controller after backend creation, so the factory should not pass `mem_pool_host` to the nixl constructor.

## Fix

Stop passing `mem_pool_host` to `HiCacheNixl.__init__()` in the backend factory's nixl branch, matching the pattern used by the `file` backend.

## Test

Launched SGLang with `--enable-hierarchical-cache --hicache-ratio 2 --hicache-write-policy write_through --hicache-storage-backend nixl` on 2x L40S. Scheduler init succeeds and end-to-end inference works.