### PR TITLE
[CI] Disable test_lora_update: Nutanix LoRA adapter removed from HuggingFace

### DIFF
--- a/test/registered/lora/test_lora_update.py
+++ b/test/registered/lora/test_lora_update.py
@@ -34,7 +34,11 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=487, suite="stage-b-test-large-1-gpu")
+register_cuda_ci(
+    est_time=487,
+    suite="stage-b-test-large-1-gpu",
+    disabled="Nutanix/Meta-Llama-3.1-8B-Instruct_lora_4_alpha_16 removed from HuggingFace",
+)
 
 PROMPTS = [
     "SGL is a",


### PR DESCRIPTION
## Summary
- Disable `test/registered/lora/test_lora_update.py` via `register_cuda_ci(disabled=...)` flag
- `Nutanix/Meta-Llama-3.1-8B-Instruct_lora_4_alpha_16` has been removed from HuggingFace (returns 404), causing all `TestLoRADynamicUpdate` tests to fail

failure example: https://github.com/sgl-project/sglang/actions/runs/22503179074/job/65207037049

## Test plan
- [ ] CI should skip this test and not fail on missing adapter
- [ ] Follow-up: replace the Nutanix adapter with an available alternative and re-enable