### PR TITLE
[Draft][NVIDIA] Triton GDN to support pretranspose state

### DIFF
--- a/python/sglang/srt/layers/attention/fla/chunk.py
+++ b/python/sglang/srt/layers/attention/fla/chunk.py
@@ -33,6 +33,7 @@ def chunk_gated_delta_rule_fwd(
     initial_state: torch.Tensor,
     initial_state_indices: torch.Tensor,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    is_ssm_pretransposed: bool = False,
 ):
     g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
     # obtain WY representation. u is actually the new v.
@@ -56,6 +57,7 @@ def chunk_gated_delta_rule_fwd(
         initial_state=initial_state,
         initial_state_indices=initial_state_indices,
         cu_seqlens=cu_seqlens,
+        is_ssm_pretransposed=is_ssm_pretransposed,
     )
     o = chunk_fwd_o(
         q=q,
@@ -124,6 +126,7 @@ def chunk_gated_delta_rule(
     cu_seqlens: Optional[torch.LongTensor] = None,
     head_first: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
+    is_ssm_pretransposed: bool = False,
 ):
     r"""
     Args:
@@ -227,18 +230,43 @@ def chunk_gated_delta_rule(
             )
     if scale is None:
         scale = k.shape[-1] ** -0.5
-    o, h = ChunkGatedDeltaRuleFunction.apply(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        scale,
-        initial_state,
-        initial_state_indices,
-        cu_seqlens,
-        use_qk_l2norm_in_kernel,
-    )
+    if is_ssm_pretransposed:
+        # Bypass ChunkGatedDeltaRuleFunction (@input_guard would call .contiguous() on
+        # initial_state, creating a disconnected copy and breaking the in-place pool update).
+        # We are inference-only, so autograd is not needed. Make all inputs except
+        # initial_state contiguous manually; initial_state stays K-contiguous so the
+        # Triton kernel can update the pool directly via IS_PRETRANSPOSED strides.
+        q_c = q.contiguous()
+        k_c = k.contiguous()
+        if use_qk_l2norm_in_kernel:
+            q_c = l2norm_fwd(q_c)
+            k_c = l2norm_fwd(k_c)
+        _, o, _, _, h, _ = chunk_gated_delta_rule_fwd(
+            q=q_c,
+            k=k_c,
+            v=v.contiguous(),
+            g=g.contiguous(),
+            beta=beta.contiguous(),
+            scale=scale,
+            initial_state=initial_state,
+            initial_state_indices=initial_state_indices,
+            cu_seqlens=cu_seqlens,
+            is_ssm_pretransposed=True,
+        )
+        o = o.to(q.dtype)
+    else:
+        o, h = ChunkGatedDeltaRuleFunction.apply(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            initial_state,
+            initial_state_indices,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+        )
     if head_first:
         o = rearrange(o, "b t h ... -> b h t ...")
     return o, None, h

--- a/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
@@ -55,6 +55,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     INPLACE_UPDATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    IS_PRETRANSPOSED: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -100,24 +101,49 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         ht = ht + i_h * K * V
 
     # load initial state
+    # IS_PRETRANSPOSED: pool is physically [V, K] in memory (K-last, stride_K=1, stride_V=K).
+    # The order tuple must be a compile-time literal for tl.make_block_ptr, so we branch.
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
-        if K > 64:
-            p_h0_2 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+        if IS_PRETRANSPOSED:
+            p_h0_1 = tl.make_block_ptr(
+                h0, (K, V), (1, K), (0, i_v * BV), (64, BV), (0, 1)
             )
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
-        if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+            b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+            if K > 64:
+                p_h0_2 = tl.make_block_ptr(
+                    h0, (K, V), (1, K), (64, i_v * BV), (64, BV), (0, 1)
+                )
+                b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            if K > 128:
+                p_h0_3 = tl.make_block_ptr(
+                    h0, (K, V), (1, K), (128, i_v * BV), (64, BV), (0, 1)
+                )
+                b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            if K > 192:
+                p_h0_4 = tl.make_block_ptr(
+                    h0, (K, V), (1, K), (192, i_v * BV), (64, BV), (0, 1)
+                )
+                b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+        else:
+            p_h0_1 = tl.make_block_ptr(
+                h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
             )
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
-        if K > 192:
-            p_h0_4 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+            if K > 64:
+                p_h0_2 = tl.make_block_ptr(
+                    h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                )
+                b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            if K > 128:
+                p_h0_3 = tl.make_block_ptr(
+                    h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+                )
+                b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            if K > 192:
+                p_h0_4 = tl.make_block_ptr(
+                    h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                )
+                b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
@@ -252,23 +278,46 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # epilogue
     if INPLACE_UPDATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 64:
+        if IS_PRETRANSPOSED:
             p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                ht, (K, V), (1, K), (0, i_v * BV), (64, BV), (0, 1)
             )
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 128:
+            tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if K > 64:
+                p_ht = tl.make_block_ptr(
+                    ht, (K, V), (1, K), (64, i_v * BV), (64, BV), (0, 1)
+                )
+                tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if K > 128:
+                p_ht = tl.make_block_ptr(
+                    ht, (K, V), (1, K), (128, i_v * BV), (64, BV), (0, 1)
+                )
+                tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if K > 192:
+                p_ht = tl.make_block_ptr(
+                    ht, (K, V), (1, K), (192, i_v * BV), (64, BV), (0, 1)
+                )
+                tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        else:
             p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+                ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
             )
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
-        if K > 192:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if K > 64:
+                p_ht = tl.make_block_ptr(
+                    ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                )
+                tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if K > 128:
+                p_ht = tl.make_block_ptr(
+                    ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+                )
+                tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            if K > 192:
+                p_ht = tl.make_block_ptr(
+                    ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                )
+                tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
 
 
 def chunk_gated_delta_rule_fwd_h(
@@ -281,6 +330,7 @@ def chunk_gated_delta_rule_fwd_h(
     initial_state_indices: Optional[torch.Tensor] = None,
     save_new_value: bool = True,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    is_ssm_pretransposed: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     B, T, Hg, K, V = *k.shape, u.shape[-1]
     H = u.shape[-2]
@@ -334,6 +384,7 @@ def chunk_gated_delta_rule_fwd_h(
         INPLACE_UPDATE=True,
         SAVE_NEW_VALUE=v_new is not None,
         IS_VARLEN=cu_seqlens is not None,
+        IS_PRETRANSPOSED=is_ssm_pretransposed,
         num_warps=4,
         num_stages=2,
     )

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -394,16 +394,11 @@ class GDNAttnBackend(MambaAttnBackendBase):
             )
         else:
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
-            if self._use_flashinfer_pool:
-                extend_states = ssm_states[cache_indices].transpose(-1, -2).contiguous()
-                extend_indices = torch.arange(
-                    cache_indices.shape[0],
-                    dtype=torch.int32,
-                    device=cache_indices.device,
-                )
-            else:
-                extend_states = ssm_states
-                extend_indices = cache_indices
+            # K-contiguous pool (flashinfer decode): pass the pool directly using
+            # IS_PRETRANSPOSED strides in the Triton kernel — no gather/scatter needed.
+            use_pretransposed = self._use_flashinfer_pool and not (
+                is_npu() or is_cpu()
+            )
 
             core_attn_out, last_recurrent_state, h = self.kernel_dispatcher.extend(
                 q=query,
@@ -411,14 +406,13 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 v=value,
                 g=g,
                 beta=beta,
-                ssm_states=extend_states,
-                cache_indices=extend_indices,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
                 query_start_loc=query_start_loc,
+                is_ssm_pretransposed=use_pretransposed,
             )
 
-            if self._use_flashinfer_pool:
-                ssm_states[cache_indices] = extend_states.transpose(-1, -2)
-            elif (is_npu() or is_cpu()) and last_recurrent_state is not None:
+            if is_npu() or is_cpu():
                 last_recurrent_state = last_recurrent_state.to(
                     ssm_states.dtype, copy=False
                 )

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -70,7 +70,7 @@ class GDNKernelDispatcher:
             self.decode_kernel = CuteDSLGDNKernel()
         elif decode_backend.is_flashinfer():
             if not is_cuda():
-                raise ValueError("FlashInfer backend requires CUDA")
+                raise ValueError("FlashInfer GDN backend requires CUDA")
             from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
                 FlashInferGDNKernel,
             )
@@ -89,7 +89,7 @@ class GDNKernelDispatcher:
             )
         elif prefill_backend.is_flashinfer():
             if not is_cuda():
-                raise ValueError("FlashInfer backend requires CUDA")
+                raise ValueError("FlashInfer GDN backend requires CUDA")
             # Reuse the FlashInfer kernel if already created for decode
             if decode_backend.is_flashinfer():
                 self.extend_kernel = flashinfer_kernel
@@ -215,6 +215,13 @@ class GDNAttnBackend(MambaAttnBackendBase):
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = GDNKernelDispatcher(decode_backend, prefill_backend)
+        # Pool layout is [pool, HV, V, K] (K-last) for all FlashInfer paths.
+        # SM100+ uses the pool API (initial_state_indices) to avoid gather/scatter;
+        # SM90 still gathers/scatters explicitly in decode.
+        self._use_flashinfer_pool = (
+            decode_backend.is_flashinfer()
+            and self.kernel_dispatcher.decode_kernel.use_state_pool
+        )
 
     def forward_decode(
         self,
@@ -387,17 +394,31 @@ class GDNAttnBackend(MambaAttnBackendBase):
             )
         else:
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)
+            if self._use_flashinfer_pool:
+                extend_states = ssm_states[cache_indices].transpose(-1, -2).contiguous()
+                extend_indices = torch.arange(
+                    cache_indices.shape[0],
+                    dtype=torch.int32,
+                    device=cache_indices.device,
+                )
+            else:
+                extend_states = ssm_states
+                extend_indices = cache_indices
+
             core_attn_out, last_recurrent_state, h = self.kernel_dispatcher.extend(
                 q=query,
                 k=key,
                 v=value,
                 g=g,
                 beta=beta,
-                ssm_states=ssm_states,
-                cache_indices=cache_indices,
+                ssm_states=extend_states,
+                cache_indices=extend_indices,
                 query_start_loc=query_start_loc,
             )
-            if (is_npu() or is_cpu()) and last_recurrent_state is not None:
+
+            if self._use_flashinfer_pool:
+                ssm_states[cache_indices] = extend_states.transpose(-1, -2)
+            elif (is_npu() or is_cpu()) and last_recurrent_state is not None:
                 last_recurrent_state = last_recurrent_state.to(
                     ssm_states.dtype, copy=False
                 )

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -1,16 +1,11 @@
 """FlashInfer-based kernels for GDN (Gated Delta Network) linear attention.
 
-Provides K-last SSM layout support using FlashInfer CUTLASS kernels (SM90+).
-The K-last layout stores SSM states as [pool, HV, V, K] instead of V-last
-[pool, HV, K, V], enabling more efficient memory access patterns for decode.
+Both SM90 and SM100+ use the same pool layout: [pool, HV, V, K] (K-last).
 
-Requires ``flashinfer`` with GDN kernel support to be installed, e.g.
-``pip install -e ".[cutlass]"`` from the FlashInfer repo.
+SM90 (Hopper): full support — decode, prefill, MTP.  State dtype: fp32.
+SM100+ (Blackwell+): decode-only with bf16 state.  More support on the way.
 
-NOTE: FlashInfer >= 0.6.4 includes a fix (PR#2509) that caches
-cudaGetDeviceProperties in the GDN prefill JIT launcher, eliminating ~80ms
-of CPU overhead per prefill. Upgrading from 0.6.3 to 0.6.4 recovers ~50%
-prefill throughput regression observed with stock FlashInfer.
+Requires flashinfer >= 0.6.4 (SM90) or >= 0.6.5 (SM100+).
 """
 
 import logging
@@ -52,17 +47,12 @@ def _get_flashinfer_gdn_kernels():
 
             _flashinfer_chunk_gated_delta_rule = chunk_gated_delta_rule
             _flashinfer_gated_delta_rule_mtp = gated_delta_rule_mtp
-            # Use pretranspose (K-last / V-major) decode kernel to match
-            # the K-last pool layout [pool, HV, V, K]
             _flashinfer_gated_delta_rule_decode = gated_delta_rule_decode_pretranspose
-            # SM90+ required for FlashInfer GDN CUTLASS kernels
             _flashinfer_gdn_available = (
                 torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
             )
             if _flashinfer_gdn_available:
-                logger.info(
-                    "FlashInfer GDN kernels (prefill + decode + MTP) loaded successfully"
-                )
+                logger.info("FlashInfer GDN kernels loaded successfully")
         except (ImportError, RuntimeError) as e:
             logger.warning(f"FlashInfer GDN kernels not available: {e}")
             _flashinfer_gdn_available = False
@@ -81,10 +71,13 @@ def _get_flashinfer_gdn_kernels():
 
 
 class FlashInferGDNKernel(LinearAttnKernelBase):
-    """FlashInfer CUTLASS kernel for GDN with K-last SSM state layout.
+    """FlashInfer kernel for GDN with K-last SSM state layout.
 
-    Supports decode (pooled pretranspose), extend (chunked prefill) and
-    target_verify (MTP).  Requires SM90+ and FlashInfer with GDN support.
+    SM90 (Hopper): decode uses gather/scatter; prefill and MTP verify supported.
+    SM100+ (Blackwell+): decode uses pool API (initial_state_indices); prefill
+    and MTP verify are not supported (use Triton backend for those).
+
+    Requires flashinfer >= 0.6.4 (SM90) or >= 0.6.5 (SM100+).
     """
 
     def __init__(self):
@@ -100,16 +93,19 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 "FlashInfer GDN kernels are not available. "
                 "Requires SM90+ and FlashInfer with GDN kernel support."
             )
-        if self._prefill_fn is None:
-            raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
-        if self._mtp_fn is None:
-            raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
         if self._decode_fn is None:
             raise RuntimeError("FlashInfer GDN decode kernel is unavailable.")
 
-        logger.info(
-            "K-last mode: Using FlashInfer GDN prefill, decode and MTP (verify) kernels"
-        )
+        sm_major = torch.cuda.get_device_capability()[0]
+        self.use_state_pool = sm_major != 9
+
+        if sm_major == 9:
+            if self._prefill_fn is None:
+                raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
+            if self._mtp_fn is None:
+                raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
+
+        logger.info("Using FlashInfer GDN kernels")
 
     # ---- decode ----
 
@@ -128,13 +124,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         query_start_loc: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """K-last decode using FlashInfer pretranspose kernel (stock, no pool indexing).
-
-        TODO: Once FlashInfer PR#2521 is merged and released, switch back
-        to pool-indexed decode (passing state_indices directly) to avoid
-        the gather/scatter overhead (~7-9% decode regression).
-        https://github.com/flashinfer-ai/flashinfer/pull/2521
-        """
         batch_size = cache_indices.shape[0]
         num_heads = q.shape[2]
         head_k_dim = q.shape[3]
@@ -147,27 +136,39 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
 
-        # Gather states from pool
-        state_batch = ssm_states[cache_indices]
+        if self.use_state_pool:
+            output_fi, _ = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=None,
+                A_log=A_log.detach().float(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                use_qk_l2norm=True,
+                initial_state=ssm_states,
+                initial_state_indices=cache_indices,
+            )
+        else:
+            # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
+            # will no longer be needed here.
+            state_batch = ssm_states[cache_indices]
+            output_fi, new_state = self._decode_fn(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=state_batch,
+                A_log=A_log.detach(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                scale=None,
+                output=None,
+                use_qk_l2norm=True,
+            )
+            ssm_states[cache_indices] = new_state
 
-        output_fi, new_state = self._decode_fn(
-            q=query_fi,
-            k=key_fi,
-            v=value_fi,
-            state=state_batch,
-            A_log=A_log.detach(),
-            a=a_fi,
-            dt_bias=dt_bias.detach(),
-            b=b_fi,
-            scale=None,
-            output=None,
-            use_qk_l2norm=True,
-        )
-
-        # Scatter updated states back to pool
-        ssm_states[cache_indices] = new_state
-
-        # [bs, 1, HV, V] -> [1, bs, HV, V]
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 
     # ---- extend (prefill) ----
@@ -185,16 +186,15 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         query_start_loc: torch.Tensor,
         **kwargs,
     ) -> tuple:
-        """K-last chunked prefill using FlashInfer GDN prefill kernel.
+        if self.use_state_pool:
+            raise NotImplementedError(
+                "FlashInfer GDN prefill is not supported on SM100+. "
+                "Use --linear-attn-prefill-backend triton."
+            )
 
-        The FlashInfer kernel natively supports K-last state layout [N, H, V, K].
-        q and k are L2-normalized before calling the kernel (the kernel is called
-        with ``use_qk_l2norm_in_kernel=False``).
-        """
+        # SM90: chunked prefill using FlashInfer GDN prefill kernel.
         from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
 
-        # q, k: [1, seq, H, K] -> [seq, H, K]
-        # v:    [1, seq, HV, V] -> [seq, HV, V]
         total_seq_len = q.shape[1]
         num_v_heads = v.shape[2]
         head_v_dim = v.shape[3]
@@ -243,8 +243,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         core_attn_out = output_fi.view(1, total_seq_len, num_v_heads, head_v_dim)
 
         # Return (output, last_recurrent_state, h) to match Triton kernel interface.
-        # h=None since FlashInfer doesn't provide intermediate states
-        # (prefix caching for K-last prefill is not supported).
+        # h=None since FlashInfer doesn't provide intermediate states.
         return core_attn_out, None, None
 
     # ---- target_verify (MTP) ----
@@ -268,18 +267,18 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         retrieve_parent_token: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        """K-last MTP verify using FlashInfer GDN MTP kernel.
+        if self.use_state_pool:
+            raise NotImplementedError(
+                "FlashInfer GDN MTP verify is not yet supported on SM100+."
+            )
 
-        Only supports topk=1 (retrieve_parent_token must be None).
-        """
+        # SM90: MTP verify using FlashInfer gated_delta_rule_mtp kernel.
         if retrieve_parent_token is not None:
             raise RuntimeError(
                 "FlashInfer GDN verify kernel only supports topk=1 "
                 "(retrieve_parent_token must be None)."
             )
 
-        # Recover batch_size and draft_token_num from g shape
-        # g: [1, seq_len, HV] where seq_len = batch_size * draft_token_num
         seq_len = q.shape[1]
         batch_size = query_start_loc.shape[0] - 1
         draft_token_num = seq_len // batch_size
@@ -289,16 +288,13 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         num_v_heads = v.shape[2]
         head_v_dim = v.shape[3]
 
-        # Reshape [1, seq, H, D] -> [B, T, H, D] for FlashInfer MTP
         query_mtp = q.view(batch_size, draft_token_num, num_heads, head_k_dim)
         key_mtp = k.view(batch_size, draft_token_num, num_heads, head_k_dim)
         value_mtp = v.view(batch_size, draft_token_num, num_v_heads, head_v_dim)
 
-        # a, b from g/beta: [1, seq, HV] -> [B, T, HV]
         if a is None or b is None or A_log is None or dt_bias is None:
             raise RuntimeError(
-                "FlashInfer GDN MTP kernel requires a_raw, b_raw, A_log, "
-                "dt_bias to be passed via kwargs."
+                "FlashInfer GDN MTP kernel requires a, b, A_log, dt_bias."
             )
 
         a_mtp = a.view(batch_size, draft_token_num, num_v_heads)
@@ -321,5 +317,4 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             use_qk_l2norm=True,
         )
 
-        # [B, T, HV, V] -> [1, seq_len, HV, V]
         return output_fi.view(1, seq_len, num_v_heads, head_v_dim)

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_triton.py
@@ -73,6 +73,7 @@ class TritonGDNKernel(LinearAttnKernelBase):
         ssm_states: torch.Tensor,
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
+        is_ssm_pretransposed: bool = False,
         **kwargs,
     ) -> tuple:
         recurrent_state = ssm_states
@@ -80,6 +81,7 @@ class TritonGDNKernel(LinearAttnKernelBase):
         if is_npu() or is_cpu():
             recurrent_state = ssm_states[cache_indices]
             recurrent_state_indices_args = {}
+            is_ssm_pretransposed = False
         return chunk_gated_delta_rule(
             q=q,
             k=k,
@@ -90,6 +92,7 @@ class TritonGDNKernel(LinearAttnKernelBase):
             cu_seqlens=query_start_loc,
             head_first=False,
             use_qk_l2norm_in_kernel=True,
+            is_ssm_pretransposed=is_ssm_pretransposed,
             **recurrent_state_indices_args,
         )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -764,6 +764,7 @@ class ServerArgs:
         self._handle_sampling_backend()
         self._handle_attention_backend_compatibility()
         self._handle_mamba_backend()
+        self._handle_linear_attn_backend()
         self._handle_kv4_compatibility()
         self._handle_page_size()
         self._handle_amd_specifics()
@@ -2384,6 +2385,23 @@ class ServerArgs:
                 raise ValueError(
                     "FlashInfer mamba module not available, please check flashinfer installation."
                 )
+
+    def _handle_linear_attn_backend(self):
+        # SM100+ FlashInfer GDN decode requires bf16 state; SM90 uses float32.
+        import torch
+
+        decode = self.linear_attn_decode_backend or self.linear_attn_backend
+        if (
+            decode == "flashinfer"
+            and self.mamba_ssm_dtype != "bfloat16"
+            and torch.cuda.is_available()
+            and torch.cuda.get_device_capability()[0] >= 10
+        ):
+            raise ValueError(
+                "--linear-attn-decode-backend flashinfer on SM100+ requires "
+                "--mamba-ssm-dtype bfloat16, "
+                f"got {self.mamba_ssm_dtype!r}"
+            )
 
     def _handle_context_parallelism(self):
         if self.attn_cp_size > 1:


### PR DESCRIPTION
WIP. Below is prelim results. Should be done after https://github.com/sgl-project/sglang/pull/19150

Triton new VK kernel perf: 
```
Config: B=4, T=256, H=16, K=128, V=128, pool_size=32
cache_indices: [20, 1, 31, 17]

Output match:     True
Pool state match: True

pool_new strides (last 2 dims): K-stride=1, V-stride=128
pool_new is K-contiguous as expected.

PASS: IS_PRETRANSPOSED Triton kernel produces identical results.

Benchmark (B=4, T=256, H=16, K=128, V=128):
  reference  (V-contig + gather/scatter): 0.049 ms
  pretransposed (K-contig, no gather/scatter): 0.037 ms
  speedup: 1.32x
root@umb-b200-235:/scratch/repo/sglang/lab/qwen3-next-mtp# python 21.triton_pretranspose.py 
Config: B=4, T=256, H=16, K=128, V=128, pool_size=32
cache_indices: [20, 1, 31, 17]

Output match:     True
Pool state match: True

pool_new strides (last 2 dims): K-stride=1, V-stride=128
pool_new is K-contiguous as expected.

PASS: IS_PRETRANSPOSED Triton kernel produces identical results.

     B    H      T |   ref (ms)   new (ms)  speedup
------------------------------------------------------
     4   16   1024 |      0.066      0.054     1.22x
    32   16   8192 |      0.334      0.302     1.10x
   128   16  32768 |      1.217      1.132     1.08x
     4   32   1024 |      0.112      0.094     1.18x
    32   32   8192 |      0.639      0.585     1.09x
   128   32  32768 |      2.416      2.246     1.08x
```

e2e Perf:
```
Three configurations compared:                                                                                                                                     
                                         
  ┌───────────────────────────┬────────────┬──────────────────────────┬──────────────────────────┐                                                                   
  │          Metric           │ Triton (1) │ FI-decode+KV-prefill (2) │ FI-decode+VK-prefill (3) │
  ├───────────────────────────┼────────────┼──────────────────────────┼──────────────────────────┤                                                                   
  │ Output throughput (tok/s) │ 5464       │ 5546                     │ 5725                     │
  ├───────────────────────────┼────────────┼──────────────────────────┼──────────────────────────┤
  │ TPOT median (ms)          │ 21.95      │ 21.58                    │ 21.10                    │
  ├───────────────────────────┼────────────┼──────────────────────────┼──────────────────────────┤
  │ TTFT mean (ms)            │ 19404      │ 19287                    │ 18531                    │
  ├───────────────────────────┼────────────┼──────────────────────────┼──────────────────────────┤
  │ E2E latency mean (ms)     │ 42060      │ 41481                    │ 40119                    │
  ├───────────────────────────┼────────────┼──────────────────────────┼──────────────────────────┤
  │ Duration (s)              │ 95.95      │ 94.54                    │ 91.59                    │
  └───────────────────────────┴────────────┴──────────────────────────┴──────────────────────────┘

  1→2 (FlashInfer decode only): Primarily a decode-side win. TPOT improves 21.95→21.58 (-2.0%), but TTFT barely moves (19404→19287, -0.6%). Expected — FlashInfer
  decode kernel is faster than Triton, but the prefill path is unchanged.

  2→3 (adding VK prefill / IS_PRETRANSPOSED): This is where the interesting gains come from:
  - TTFT drops significantly: 19287→18531 (-3.9%). This directly reflects the removal of gather/scatter during prefill — no more temporary allocation, no data copy,
  state updated in-place.
  - TPOT improves further: 21.58→21.10 (-2.2%). The decode kernel now reads from a pool that was already correctly laid out after prefill, with no extra format
  conversion in between.
  - Output throughput: 5546→5725 (+3.2%).

  1→3 overall: +4.8% output throughput, -3.9% TPOT, -4.5% TTFT, -4.6% E2E latency.
```
cc. @hlu1