### PR TITLE
[Session] Gate streaming sessions with `--enable-streaming-session` and spec v2 guard

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2929,9 +2929,7 @@ class Scheduler(
         return ExpertDistributionReqOutput()
 
     def open_session(self, recv_req: OpenSessionReqInput):
-        # handle error
         session_id = recv_req.session_id
-        is_streaming = bool(recv_req.streaming)
         if session_id in self.sessions:
             logger.warning(f"session id {session_id} already exist, cannot open.")
             return OpenSessionReqOutput(session_id, False)
@@ -2939,19 +2937,10 @@ class Scheduler(
             logger.warning("session id is None, cannot open.")
             return OpenSessionReqOutput(session_id, False)
         else:
-            if is_streaming:
-                assert self.server_args.enable_streaming_session, (
-                    "Streaming sessions are disabled. "
-                    "Please set --enable-streaming-session to enable this feature."
-                )
-                assert self.spec_algorithm == SpeculativeAlgorithm.NONE, (
-                    "Streaming sessions are incompatible with speculative decoding "
-                    f"(speculative_algorithm={self.server_args.speculative_algorithm})."
-                )
             self.sessions[session_id] = Session(
                 recv_req.capacity_of_str_len,
                 session_id,
-                streaming=is_streaming,
+                streaming=bool(recv_req.streaming),
                 timeout=recv_req.timeout,
             )
             return OpenSessionReqOutput(session_id, True)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -172,6 +172,7 @@ from sglang.srt.managers.utils import GenerationBatchResult, validate_input_leng
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.mem_cache.session_aware_cache import SessionAwareCache
 from sglang.srt.model_executor.forward_batch_info import ForwardMode, PPProxyTensors
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin
 from sglang.srt.observability.req_time_stats import (
@@ -721,9 +722,9 @@ class Scheduler(
             else:
                 self.tree_cache = RadixCache(params)
 
-        from sglang.srt.mem_cache.session_aware_cache import SessionAwareCache
+        if server_args.enable_streaming_session:
 
-        self.tree_cache = SessionAwareCache(self.tree_cache)
+            self.tree_cache = SessionAwareCache(self.tree_cache)
 
         if (
             server_args.disaggregation_mode == "decode"
@@ -2930,6 +2931,7 @@ class Scheduler(
     def open_session(self, recv_req: OpenSessionReqInput):
         # handle error
         session_id = recv_req.session_id
+        is_streaming = bool(recv_req.streaming)
         if session_id in self.sessions:
             logger.warning(f"session id {session_id} already exist, cannot open.")
             return OpenSessionReqOutput(session_id, False)
@@ -2937,10 +2939,19 @@ class Scheduler(
             logger.warning("session id is None, cannot open.")
             return OpenSessionReqOutput(session_id, False)
         else:
+            if is_streaming:
+                assert self.server_args.enable_streaming_session, (
+                    "Streaming sessions are disabled. "
+                    "Please set --enable-streaming-session to enable this feature."
+                )
+                assert self.spec_algorithm == SpeculativeAlgorithm.NONE, (
+                    "Streaming sessions are incompatible with speculative decoding "
+                    f"(speculative_algorithm={self.server_args.speculative_algorithm})."
+                )
             self.sessions[session_id] = Session(
                 recv_req.capacity_of_str_len,
                 session_id,
-                streaming=bool(recv_req.streaming),
+                streaming=is_streaming,
                 timeout=recv_req.timeout,
             )
             return OpenSessionReqOutput(session_id, True)
@@ -2959,7 +2970,8 @@ class Scheduler(
             req = next(iter(session.req_nodes.values())).req
             if not req.finished():
                 req.session = None
-        self.tree_cache.release_session(session_id)
+        if isinstance(self.tree_cache, SessionAwareCache):
+            self.tree_cache.release_session(session_id)
         del self.sessions[session_id]
 
     def reap_timed_out_sessions(self):

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -912,11 +912,21 @@ class TokenizerCommunicatorMixin:
         request: Optional[fastapi.Request] = None,
     ):
         self.auto_create_handle_loop()
-        if obj.streaming and not self.server_args.enable_streaming_session:
-            raise ValueError(
-                "Streaming sessions are disabled. "
-                "Please relaunch with --enable-streaming-session."
-            )
+        if obj.streaming:
+            if not self.server_args.enable_streaming_session:
+                raise ValueError(
+                    "Streaming sessions are disabled. "
+                    "Please relaunch with --enable-streaming-session."
+                )
+            if (
+                self.server_args.speculative_algorithm is not None
+                and not self.server_args.disable_overlap_schedule
+            ):
+                raise ValueError(
+                    "Streaming sessions are incompatible with speculative decoding v2 "
+                    "(overlap + speculative). Use --disable-overlap-schedule or "
+                    "disable speculative decoding."
+                )
 
         if obj.session_id is None:
             obj.session_id = uuid.uuid4().hex

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -480,7 +480,7 @@ class TokenizerCommunicatorMixin:
         return _Communicator.merge_results(results)
 
     async def destroy_weights_update_group(
-        self,
+        self: TokenizerManager,
         obj: DestroyWeightsUpdateGroupReqInput,
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
@@ -523,7 +523,7 @@ class TokenizerCommunicatorMixin:
         return success, message
 
     async def init_weights_send_group_for_remote_instance(
-        self,
+        self: TokenizerManager,
         obj: InitWeightsSendGroupForRemoteInstanceReqInput,
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
@@ -538,7 +538,7 @@ class TokenizerCommunicatorMixin:
         return result.success, result.message
 
     async def send_weights_to_remote_instance(
-        self,
+        self: TokenizerManager,
         obj: SendWeightsToRemoteInstanceReqInput,
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
@@ -581,7 +581,7 @@ class TokenizerCommunicatorMixin:
         return success, message
 
     async def update_weights_from_ipc(
-        self,
+        self: TokenizerManager,
         obj: UpdateWeightsFromIPCReqInput,
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
@@ -907,9 +907,16 @@ class TokenizerCommunicatorMixin:
         return results
 
     async def open_session(
-        self, obj: OpenSessionReqInput, request: Optional[fastapi.Request] = None
+        self: TokenizerManager,
+        obj: OpenSessionReqInput,
+        request: Optional[fastapi.Request] = None,
     ):
         self.auto_create_handle_loop()
+        if obj.streaming and not self.server_args.enable_streaming_session:
+            raise ValueError(
+                "Streaming sessions are disabled. "
+                "Please relaunch with --enable-streaming-session."
+            )
 
         if obj.session_id is None:
             obj.session_id = uuid.uuid4().hex
@@ -924,11 +931,15 @@ class TokenizerCommunicatorMixin:
         return session_id
 
     async def close_session(
-        self, obj: CloseSessionReqInput, request: Optional[fastapi.Request] = None
+        self: TokenizerManager,
+        obj: CloseSessionReqInput,
+        request: Optional[fastapi.Request] = None,
     ):
         await self.send_to_scheduler.send_pyobj(obj)
 
-    def _update_weight_version_if_provided(self, weight_version: Optional[str]) -> None:
+    def _update_weight_version_if_provided(
+        self: TokenizerManager, weight_version: Optional[str]
+    ) -> None:
         """Update weight version if provided."""
         if weight_version is not None:
             self.server_args.weight_version = weight_version

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -354,6 +354,7 @@ class ServerArgs:
     pp_async_batch_depth: int = 0
     stream_interval: int = 1
     stream_output: bool = False
+    enable_streaming_session: bool = False
     random_seed: Optional[int] = None
     constrained_json_whitespace_pattern: Optional[str] = None
     constrained_json_disable_any_whitespace: bool = False
@@ -3386,6 +3387,12 @@ class ServerArgs:
             "--stream-output",
             action="store_true",
             help="Whether to output as a sequence of disjoint segments.",
+        )
+        parser.add_argument(
+            "--enable-streaming-session",
+            action="store_true",
+            default=ServerArgs.enable_streaming_session,
+            help="Enable streaming session mode and SessionAwareCache wrapper.",
         )
         parser.add_argument(
             "--random-seed",

--- a/test/registered/sessions/test_session_control.py
+++ b/test/registered/sessions/test_session_control.py
@@ -45,6 +45,7 @@ class TestSessionControl(unittest.TestCase):
             other_args=[
                 "--attention-backend",
                 "flashinfer",
+                "--enable-streaming-session",
             ],
         )
 

--- a/test/registered/sessions/test_session_latency.py
+++ b/test/registered/sessions/test_session_latency.py
@@ -309,7 +309,11 @@ class BenchSessionLatency(CustomTestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--attention-backend", "flashinfer"],
+            other_args=[
+                "--attention-backend",
+                "flashinfer",
+                "--enable-streaming-session",
+            ],
         )
         cls.tokenizer = get_tokenizer(cls.model)
 


### PR DESCRIPTION
- Add `--enable-streaming-session` server flag; wrap `tree_cache` with `SessionAwareCache` only when enabled.
- Reject `open_session(streaming=True)` with HTTP 400 when the flag is disabled or spec v2 (overlap + speculative) is active.
- Allow spec v1 (non-overlap) with streaming sessions since it has no KV over-allocation issue.
- Remove scheduler-side asserts for streaming/spec checks; all validation is now at the tokenizer/HTTP layer.
- Make runtime memory checks (`session_held_tokens`, `session_held_req_count`) safe via `isinstance(SessionAwareCache)` guards.
- Use `isinstance(SessionAwareCache)` for `release_session` in `_close_session` instead of `hasattr`.