### PR TITLE
[Perf] Optimize NSA backend metadata under MTP

### DIFF
--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -1,5 +1,4 @@
 import torch
-
 import triton
 import triton.language as tl
 

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -1,4 +1,5 @@
 import torch
+
 import triton
 import triton.language as tl
 
@@ -284,6 +285,67 @@ def pad_sequence_with_mask(
     )
 
     return B, output, attn_mask
+
+
+@triton.jit
+def seqlens_expand_kernel(
+    extend_seq_lens_ptr,  # [N]
+    seq_lens_ptr,  # [N]
+    offsets_ptr,  # [N+1]
+    output_ptr,  # [sum(extend_seq_lens)]
+    N,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    if pid >= N:
+        return
+
+    qo_len = tl.load(extend_seq_lens_ptr + pid)
+    kv_len = tl.load(seq_lens_ptr + pid)
+
+    start = kv_len - qo_len + 1
+    out_offset = tl.load(offsets_ptr + pid)
+
+    offs = tl.arange(0, BLOCK)
+    mask = offs < qo_len
+
+    values = start + offs
+    tl.store(output_ptr + out_offset + offs, values, mask=mask)
+
+
+def seqlens_expand_triton(
+    extend_seq_lens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    total_len: int,
+    max_q_len: int,
+):
+    """
+    extend_seq_lens: [N], int32, CUDA
+    seq_lens:        [N], int32, CUDA
+    """
+    assert extend_seq_lens.is_cuda
+    assert seq_lens.is_cuda
+
+    N = extend_seq_lens.numel()
+
+    offsets = torch.zeros(N + 1, device=extend_seq_lens.device, dtype=torch.int32)
+    offsets[1:] = torch.cumsum(extend_seq_lens, dim=0)
+    output = torch.empty(total_len, device=extend_seq_lens.device, dtype=torch.int32)
+
+    BLOCK = triton.next_power_of_2(max_q_len)
+    grid = (N,)
+
+    seqlens_expand_kernel[grid](
+        extend_seq_lens,
+        seq_lens,
+        offsets,
+        output,
+        N,
+        BLOCK=BLOCK,
+    )
+
+    return output
 
 
 # When num_kv_heads=1, we have tensors with degenerate strides,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR is authored by @Baidu-AIAK in https://github.com/sgl-project/sglang/pull/17647. I just tested the code, since the author hasn't replied in a while.

<!-- Describe the purpose and goals of this pull request. -->

## Accuracy Tests

Run with FlashMLA on SM100. It should be the same for `trtllm`
```
python3 -m sglang.launch_server \
  --model-path nvidia/DeepSeek-V3.2-NVFP4 \
  --trust-remote-code \
  --tp 8 \
  --quantization modelopt_fp4 \
  --kv-cache-dtype fp8_e4m3 \
  --attention-backend nsa \
  --tool-call-parser deepseekv32 \
  --reasoning-parser deepseek-v3 \
  --speculative-algorithm EAGLE
```

Before
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 200
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:19<00:00,  9.49it/s]
Accuracy: 0.942
Invalid: 0.000
Latency: 139.013 s
Output throughput: 908.118 token/s
```

After
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 200
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:33<00:00,  8.60it/s]
Accuracy: 0.949
Invalid: 0.000
Latency: 153.288 s
Output throughput: 829.051 token/s
```

After (Spec V2) (You can ignore the throughput number of GSM8K. I was running some other benchmark at the same time)
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 200
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [03:37<00:00,  6.07it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 217.130 s
Output throughput: 594.478 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

Mainly testing for accept length (no change). This should only affects spec decode. Will share profile later

Before
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    7.775    |  1024  |   2.768    |     131.70      |
+-------------+--------+------------+-----------------+
```

After
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    7.270    |  1024  |   2.768    |     140.86      |
+-------------+--------+------------+-----------------+
```

After (Spec V2)
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    5.980    |  1024  |   2.768    |     171.22      |
+-------------+--------+------------+-----------------+
```

For long-context. I didn't run into any issues.
```
python3 -m sglang.bench_serving --backend sglang --flush-cache \
  --dataset-name random \
  --random-input-len 128000 \
  --random-output-len 8000 \
  --random-range-ratio 1.0 \
  --num-prompts 64 \
  --max-concurrency 4
```

```
[WARNING] batch_size=16384 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=16384 exceeds shared mem limit, falling back to low-smem kernel
[2026-02-28 17:52:19 TP0] Prefill batch, #new-seq: 1, #new-token: 16384, #cached-token: 0, token usage: 0.22, #running-req: 3, #queue-req: 0, input throughput (token/s): 1174.83, cuda graph: False
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[WARNING] batch_size=14256 exceeds shared mem limit, falling back to low-smem kernel
[2026-02-28 17:52:32 TP0] Prefill batch, #new-seq: 1, #new-token: 16384, #cached-token: 0, token usage: 0.22, #running-req: 3, #queue-req: 0, input throughput (token/s): 1236.78, cuda graph: False
[2026-02-28 17:52:33 TP0] Prefill batch, #new-seq: 1, #new-token: 14272, #cached-token: 0, token usage: 0.22, #running-req: 3, #queue-req: 0, input throughput (token/s): 226517.25, cuda graph: False
[2026-02-28 17:52:34 TP0] Decode batch, #running-req: 4, #token: 513536, token usage: 0.22, accept len: 3.11, accept rate: 0.78, cuda graph: True, gen throughput (token/s): 0.65, #queue-req: 0
[2026-02-28 17:52:37 TP0] Decode batch, #running-req: 4, #token: 514112, token usage: 0.22, accept len: 3.06, accept rate: 0.77, cuda graph: True, gen throughput (token/s): 239.83, #queue-req: 0
[2026-02-28 17:52:39 TP0] Decode batch, #running-req: 4, #token: 514560, token usage: 0.22, accept len: 3.09, accept rate: 0.77, cuda graph: True, gen throughput (token/s): 236.36, #queue-req: 0
[2026-02-28 17:52:41 TP0] Decode batch, #running-req: 4, #token: 515072, token usage: 0.22, accept len: 3.03, accept rate: 0.76, cuda graph: True, gen throughput (token/s): 217.03, #queue-req: 0
[2026-02-28 17:52:43 TP0] Decode batch, #running-req: 4, #token: 515584, token usage: 0.22, accept len: 3.10, accept rate: 0.78, cuda graph: True, gen throughput (token/s): 222.06, #queue-req: 0
[2026-02-28 17:52:45 TP0] Decode batch, #running-req: 4, #token: 516096, token usage: 0.22, accept len: 3.09, accept rate: 0.77, cuda graph: True, gen throughput (token/s): 219.47, #queue-req: 0
```