### PR TITLE
feat(observability): add OpenTelemetry tracing for speculative decoding

### DIFF
--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -190,6 +190,21 @@ class RequestStage:
         metrics_is_observed=True,
     )
 
+    # speculative decode
+    SPEC_DRAFT = RequestStageConfig(
+        "spec_draft",
+        level=2,
+    )
+
+    SPEC_VERIFY = RequestStageConfig(
+        "spec_verify",
+        level=2,
+    )
+
+    SPEC_DRAFT_EXTEND = RequestStageConfig(
+        "spec_draft_extend",
+        level=3,
+    )
     # other
     ANONYMOUS = RequestStageConfig("")
 
@@ -551,6 +566,11 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     last_forward_entry_time: float = 0.0
     last_prefill_finished_time: float = 0.0
 
+    # speculative decoding
+    spec_draft_start_time: float = 0.0
+    spec_verify_start_time: float = 0.0
+    spec_draft_extend_start_time: float = 0.0
+
     # other
     transfer_speed_gb_s: float = 0.0
     transfer_total_mb: float = 0.0
@@ -576,6 +596,42 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         calibrate_time_diff()
         ts = ts or time.perf_counter()
         self.scheduler_recv_time = ts
+
+    def set_spec_draft_start_time(self, ts=None):
+        if ts is None:
+            ts = time.perf_counter()
+        self.spec_draft_start_time = ts
+
+    def set_spec_draft_end_time(self, ts=None):
+        if ts is None:
+            ts = time.perf_counter()
+
+        stage = RequestStage.SPEC_DRAFT
+        self.trace_slice(stage, self.spec_draft_start_time, ts)
+
+    def set_spec_verify_start_time(self, ts=None):
+        if ts is None:
+            ts = time.perf_counter()
+        self.spec_verify_start_time = ts
+
+    def set_spec_verify_end_time(self, ts=None, accepted_tokens: int = 0):
+        if ts is None:
+            ts = time.perf_counter()
+        stage = RequestStage.SPEC_VERIFY
+        self.trace_slice(
+            stage, self.spec_verify_start_time, ts, {"accepted_tokens": accepted_tokens}
+        )
+
+    def set_spec_draft_extend_start_time(self, ts=None):
+        if ts is None:
+            ts = time.perf_counter()
+        self.spec_draft_extend_start_time = ts
+
+    def set_spec_draft_extend_end_time(self, ts=None):
+        if ts is None:
+            ts = time.perf_counter()
+        stage = RequestStage.SPEC_DRAFT_EXTEND
+        self.trace_slice(stage, self.spec_draft_extend_start_time, ts)
 
     def set_retract_time(self, ts=None):
         ts = ts or time.perf_counter()
@@ -1049,8 +1105,10 @@ def set_schedule_time_batch(batch: ScheduleBatch):
         req.time_stats.set_last_scheduled_time(batch.forward_mode, ts, _attrs)
 
 
-def set_time_batch(reqs: List[Any], set_func: str):
+def set_time_batch(reqs: List[Any], set_func: str, trace_only: bool = False):
     if reqs is None or len(reqs) == 0:
+        return
+    if trace_only and not get_global_tracing_enabled():
         return
 
     ts = time.perf_counter()

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -4,6 +4,9 @@ from typing import List, Optional, Tuple
 
 import torch
 
+from sglang.srt.observability.req_time_stats import convert_time_to_realtime_ns
+from sglang.srt.observability.trace import get_global_tracing_enabled
+
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner import (
     EAGLEDraftNpuGraphRunner,
@@ -312,13 +315,60 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
         else:
+            tracing_enabled = get_global_tracing_enabled()
+
+            if tracing_enabled:
+                draft_start_ts = convert_time_to_realtime_ns(time.perf_counter())
+                for req in batch.reqs:
+                    req.time_stats.trace_ctx.trace_slice_start(
+                        "spec_draft", 2, draft_start_ts
+                    )
+
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 spec_info = self.draft(batch)
+
+            if tracing_enabled:
+                draft_end_ts = convert_time_to_realtime_ns(time.perf_counter())
+                for req in batch.reqs:
+                    req.time_stats.trace_ctx.trace_slice_end(
+                        "spec_draft", 2, draft_end_ts
+                    )
+
+            if tracing_enabled:
+                verify_start_ts = convert_time_to_realtime_ns(time.perf_counter())
+                for req in batch.reqs:
+                    req.time_stats.trace_ctx.trace_slice_start(
+                        "spec_verify", 2, verify_start_ts
+                    )
+
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
                 self.verify(batch, spec_info)
             )
+
+            if tracing_enabled:
+                verify_end_ts = convert_time_to_realtime_ns(time.perf_counter())
+                for idx, req in enumerate(batch.reqs):
+                    accepted = verify_output.accept_length_per_req_cpu[idx]
+                    req.time_stats.trace_ctx.trace_slice_end(
+                        "spec_verify", 2, verify_end_ts
+                    )
+                    req.time_stats.trace_ctx.trace_event(
+                        "spec_accept",
+                        2,
+                        verify_end_ts,
+                        {"accepted_tokens": accepted},
+                    )
+
+            if tracing_enabled:
+                draft_extend_start_ts = convert_time_to_realtime_ns(
+                    time.perf_counter()
+                )
+                for req in batch.reqs:
+                    req.time_stats.trace_ctx.trace_slice_start(
+                        "spec_draft_extend", 3, draft_extend_start_ts
+                    )
 
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
@@ -331,6 +381,15 @@ class EAGLEWorker(TpModelWorker):
                 ):
                     # decode is not finished
                     self.forward_draft_extend_after_decode(batch)
+
+            if tracing_enabled:
+                draft_extend_end_ts = convert_time_to_realtime_ns(
+                    time.perf_counter()
+                )
+                for req in batch.reqs:
+                    req.time_stats.trace_ctx.trace_slice_end(
+                        "spec_draft_extend", 3, draft_extend_end_ts
+                    )
 
             return GenerationBatchResult(
                 logits_output=logits_output,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -4,9 +4,6 @@ from typing import List, Optional, Tuple
 
 import torch
 
-from sglang.srt.observability.req_time_stats import convert_time_to_realtime_ns
-from sglang.srt.observability.trace import get_global_tracing_enabled
-
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner import (
     EAGLEDraftNpuGraphRunner,
@@ -32,6 +29,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
@@ -315,60 +314,28 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
         else:
-            tracing_enabled = get_global_tracing_enabled()
-
-            if tracing_enabled:
-                draft_start_ts = convert_time_to_realtime_ns(time.perf_counter())
-                for req in batch.reqs:
-                    req.time_stats.trace_ctx.trace_slice_start(
-                        "spec_draft", 2, draft_start_ts
-                    )
+            set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
 
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 spec_info = self.draft(batch)
 
-            if tracing_enabled:
-                draft_end_ts = convert_time_to_realtime_ns(time.perf_counter())
-                for req in batch.reqs:
-                    req.time_stats.trace_ctx.trace_slice_end(
-                        "spec_draft", 2, draft_end_ts
-                    )
-
-            if tracing_enabled:
-                verify_start_ts = convert_time_to_realtime_ns(time.perf_counter())
-                for req in batch.reqs:
-                    req.time_stats.trace_ctx.trace_slice_start(
-                        "spec_verify", 2, verify_start_ts
-                    )
+            set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+            set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
 
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
                 self.verify(batch, spec_info)
             )
 
-            if tracing_enabled:
-                verify_end_ts = convert_time_to_realtime_ns(time.perf_counter())
+            if get_global_tracing_enabled():
                 for idx, req in enumerate(batch.reqs):
                     accepted = verify_output.accept_length_per_req_cpu[idx]
-                    req.time_stats.trace_ctx.trace_slice_end(
-                        "spec_verify", 2, verify_end_ts
-                    )
-                    req.time_stats.trace_ctx.trace_event(
-                        "spec_accept",
-                        2,
-                        verify_end_ts,
-                        {"accepted_tokens": accepted},
-                    )
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
 
-            if tracing_enabled:
-                draft_extend_start_ts = convert_time_to_realtime_ns(
-                    time.perf_counter()
-                )
-                for req in batch.reqs:
-                    req.time_stats.trace_ctx.trace_slice_start(
-                        "spec_draft_extend", 3, draft_extend_start_ts
-                    )
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_start_time", trace_only=True
+            )
 
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
@@ -382,14 +349,9 @@ class EAGLEWorker(TpModelWorker):
                     # decode is not finished
                     self.forward_draft_extend_after_decode(batch)
 
-            if tracing_enabled:
-                draft_extend_end_ts = convert_time_to_realtime_ns(
-                    time.perf_counter()
-                )
-                for req in batch.reqs:
-                    req.time_stats.trace_ctx.trace_slice_end(
-                        "spec_draft_extend", 3, draft_extend_end_ts
-                    )
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
+            )
 
             return GenerationBatchResult(
                 logits_output=logits_output,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -1,9 +1,13 @@
 import logging
+import time
 from typing import List, Optional
 
 import numpy as np
 import torch
 from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
+
+from sglang.srt.observability.req_time_stats import convert_time_to_realtime_ns
+from sglang.srt.observability.trace import get_global_tracing_enabled
 
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
 from sglang.srt.managers.schedule_batch import ScheduleBatch
@@ -250,7 +254,24 @@ class NGRAMWorker:
         self.ngram_corpus.batch_put(batch_tokens)
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        tracing_enabled = get_global_tracing_enabled()
+
+        if tracing_enabled:
+            draft_start_ts = convert_time_to_realtime_ns(time.perf_counter())
+            for req in batch.reqs:
+                req.time_stats.trace_ctx.trace_slice_start(
+                    "spec_draft", 2, draft_start_ts
+                )
+
         self._prepare_for_speculative_decoding(batch)
+
+        if tracing_enabled:
+            draft_end_ts = convert_time_to_realtime_ns(time.perf_counter())
+            for req in batch.reqs:
+                req.time_stats.trace_ctx.trace_slice_end(
+                    "spec_draft", 2, draft_end_ts
+                )
+
         model_worker_batch = batch.get_model_worker_batch()
         spec_info = model_worker_batch.spec_info
         num_accepted_tokens = 0
@@ -264,6 +285,13 @@ class NGRAMWorker:
                 draft_tokens_cpu = spec_info.draft_token.view(
                     spec_info.retrive_next_token.shape
                 ).cpu()
+
+            if tracing_enabled:
+                verify_start_ts = convert_time_to_realtime_ns(time.perf_counter())
+                for req in batch.reqs:
+                    req.time_stats.trace_ctx.trace_slice_start(
+                        "spec_verify", 2, verify_start_ts
+                    )
 
             batch_result = self.target_worker.forward_batch_generation(
                 model_worker_batch, is_verify=True
@@ -298,6 +326,24 @@ class NGRAMWorker:
                 batch, logits_output, self.page_size, vocab_mask
             )
             accept_length_per_req_cpu = verify_input.accept_length.cpu().tolist()
+
+            if tracing_enabled:
+                verify_end_ts = convert_time_to_realtime_ns(time.perf_counter())
+                for idx, req in enumerate(batch.reqs):
+                    accepted = (
+                        verify_input.accept_length[idx].item()
+                        if verify_input.accept_length is not None
+                        else 0
+                    )
+                    req.time_stats.trace_ctx.trace_slice_end(
+                        "spec_verify", 2, verify_end_ts
+                    )
+                    req.time_stats.trace_ctx.trace_event(
+                        "spec_accept",
+                        2,
+                        verify_end_ts,
+                        {"accepted_tokens": accepted},
+                    )
             # Store accept_lens for per-request metrics
             accept_lens = verify_input.accept_length
             if batch.return_logprob:

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -1,19 +1,17 @@
 import logging
-import time
 from typing import List, Optional
 
 import numpy as np
 import torch
 from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
-from sglang.srt.observability.req_time_stats import convert_time_to_realtime_ns
-from sglang.srt.observability.trace import get_global_tracing_enabled
-
 from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
@@ -254,23 +252,11 @@ class NGRAMWorker:
         self.ngram_corpus.batch_put(batch_tokens)
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
-        tracing_enabled = get_global_tracing_enabled()
-
-        if tracing_enabled:
-            draft_start_ts = convert_time_to_realtime_ns(time.perf_counter())
-            for req in batch.reqs:
-                req.time_stats.trace_ctx.trace_slice_start(
-                    "spec_draft", 2, draft_start_ts
-                )
+        set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
 
         self._prepare_for_speculative_decoding(batch)
 
-        if tracing_enabled:
-            draft_end_ts = convert_time_to_realtime_ns(time.perf_counter())
-            for req in batch.reqs:
-                req.time_stats.trace_ctx.trace_slice_end(
-                    "spec_draft", 2, draft_end_ts
-                )
+        set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
 
         model_worker_batch = batch.get_model_worker_batch()
         spec_info = model_worker_batch.spec_info
@@ -286,12 +272,7 @@ class NGRAMWorker:
                     spec_info.retrive_next_token.shape
                 ).cpu()
 
-            if tracing_enabled:
-                verify_start_ts = convert_time_to_realtime_ns(time.perf_counter())
-                for req in batch.reqs:
-                    req.time_stats.trace_ctx.trace_slice_start(
-                        "spec_verify", 2, verify_start_ts
-                    )
+            set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
 
             batch_result = self.target_worker.forward_batch_generation(
                 model_worker_batch, is_verify=True
@@ -327,23 +308,15 @@ class NGRAMWorker:
             )
             accept_length_per_req_cpu = verify_input.accept_length.cpu().tolist()
 
-            if tracing_enabled:
-                verify_end_ts = convert_time_to_realtime_ns(time.perf_counter())
+            if get_global_tracing_enabled():
                 for idx, req in enumerate(batch.reqs):
                     accepted = (
                         verify_input.accept_length[idx].item()
                         if verify_input.accept_length is not None
                         else 0
                     )
-                    req.time_stats.trace_ctx.trace_slice_end(
-                        "spec_verify", 2, verify_end_ts
-                    )
-                    req.time_stats.trace_ctx.trace_event(
-                        "spec_accept",
-                        2,
-                        verify_end_ts,
-                        {"accepted_tokens": accepted},
-                    )
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
             # Store accept_lens for per-request metrics
             accept_lens = verify_input.accept_length
             if batch.return_logprob:


### PR DESCRIPTION
## Motivation

This PR adds OpenTelemetry tracing support for the speculative decoding pipeline, as part of the tracing roadmap (#13511).

Currently, the speculative decoding phases (draft, verify, accept) are not instrumented, making it difficult to diagnose performance bottlenecks in the speculative decoding pipeline. This PR fills that gap.

## Changes

### EAGLE Worker (`eagle_worker.py`)
- **`spec_draft`** (level 2): trace span wrapping the `draft()` call
- **`spec_verify`** (level 2): trace span wrapping the `verify()` call  
- **`spec_accept`** (level 2 event): records `accepted_tokens` per request after verification
- **`spec_draft_extend`** (level 3): trace span wrapping `forward_draft_extend_after_decode()`

### NGRAM Worker (`ngram_worker.py`)
- **`spec_draft`** (level 2): trace span wrapping `_prepare_for_speculative_decoding()`
- **`spec_verify`** (level 2): trace span wrapping the target verify forward + `verify()`
- **`spec_accept`** (level 2 event): records `accepted_tokens` per request after verification

### Design Decisions
- All tracing is gated behind `get_global_tracing_enabled()` to avoid any overhead when tracing is disabled
- Uses the existing `TraceReqContext` / `TraceNullContext` pattern from `req_time_stats.py`
- Per-request tracing: iterates over `batch.reqs` to emit spans for each request individually
- Timestamps use `convert_time_to_realtime_ns(time.perf_counter())` consistent with existing tracing code