### PR TITLE
[diffusion][llm] macOS support

### DIFF
--- a/docs/diffusion/environment_variables.md
+++ b/docs/diffusion/environment_variables.md
@@ -1,3 +1,9 @@
+## Apple MPS
+
+| Environment Variable | Default | Description                                                  |
+|----------------------|---------|--------------------------------------------------------------|
+| `SGLANG_USE_MLX`     | not set | Set to `1` to enable MLX fused Metal kernels for norm ops on MPS |
+
 ## Caching Acceleration
 
 These variables configure caching acceleration for Diffusion Transformer (DiT) models.

--- a/docs/diffusion/index.md
+++ b/docs/diffusion/index.md
@@ -7,7 +7,11 @@ SGLang Diffusion is an inference framework for accelerated image and video gener
 - **Broad Model Support**: Wan series, FastWan series, Hunyuan, Qwen-Image, Qwen-Image-Edit, Flux, Z-Image, GLM-Image, and more
 - **Fast Inference**: Optimized kernels, efficient scheduler loop, and Cache-DiT acceleration
 - **Ease of Use**: OpenAI-compatible API, CLI, and Python SDK
-- **Multi-Platform**: NVIDIA GPUs (H100, H200, A100, B200, 4090), AMD GPUs (MI300X, MI325X) and Ascend NPU (A2, A3)
+- **Multi-Platform**:
+  - NVIDIA GPUs (H100, H200, A100, B200, 4090)
+  - AMD GPUs (MI300X, MI325X)
+  - Ascend NPU (A2, A3)
+  - Apple Silicon (M-series via MPS)
 
 ---
 

--- a/docs/diffusion/installation.md
+++ b/docs/diffusion/installation.md
@@ -102,19 +102,19 @@ For Apple MPS, please follow the instructions below to install from source:
 # Install ffmpeg
 brew install ffmpeg
 
-# Install miniconda (optional, for an isolated environment; uv is also a good alternative)
-brew install --cask miniconda
+# Install uv
+brew brew install uv
 
 # Clone the repository
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 
-# Create and activate a conda environment (optional, for an isolated environment)
-conda create -n sglang-diffusion python=3.11 -y
-conda activate sglang-diffusion
+# Create and activate a virtual environment
+uv venv -p 3.11 sglang-diffusion
+source sglang-diffusion/bin/activate
 
 # Install the Python packages
-pip install --upgrade pip
+uv pip install --upgrade pip
 rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
-pip install -e "python[all_mps]"
+uv pip install -e "python[all_mps]"
 ```

--- a/docs/diffusion/installation.md
+++ b/docs/diffusion/installation.md
@@ -103,7 +103,7 @@ For Apple MPS, please follow the instructions below to install from source:
 brew install ffmpeg
 
 # Install uv
-brew brew install uv
+brew install uv
 
 # Clone the repository
 git clone https://github.com/sgl-project/sglang.git

--- a/docs/diffusion/installation.md
+++ b/docs/diffusion/installation.md
@@ -69,7 +69,7 @@ For detailed ROCm system configuration and installation from source, see [AMD GP
 
 ## Platform-Specific: MUSA (Moore Threads GPUs)
 
-For Moore Threads GPUs (MTGPU) with the MUSA software stack:
+For Moore Threads GPUs (MTGPU) with the MUSA software stack, please follow the instructions below to install from source:
 
 ```bash
 # Clone the repository
@@ -92,4 +92,29 @@ Quick test:
 sglang generate --model-path black-forest-labs/FLUX.1-dev \
     --prompt "A logo With Bold Large text: SGL Diffusion" \
     --save-output
+```
+
+## Platform-Specific: Apple MPS
+
+For Apple MPS, please follow the instructions below to install from source:
+
+```bash
+# Install ffmpeg
+brew install ffmpeg
+
+# Install miniconda (optional, for an isolated environment; uv is also a good alternative)
+brew install --cask miniconda
+
+# Clone the repository
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+
+# Create and activate a conda environment (optional, for an isolated environment)
+conda create -n sglang-diffusion python=3.11 -y
+conda activate sglang-diffusion
+
+# Install the Python packages
+pip install --upgrade pip
+rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
+pip install -e "python[all_mps]"
 ```

--- a/docs/platforms/apple_metal.md
+++ b/docs/platforms/apple_metal.md
@@ -1,0 +1,20 @@
+# Apple Silicon with Metal
+
+This document describes how run SGLang on Apple Silicon using [Metal](https://developer.apple.com/metal/). If you encounter issues or have questions, please [open an issue](https://github.com/sgl-project/sglang/issues).
+
+## Install SGLang
+
+You can install SGLang using one of the methods below.
+
+### Install from Source
+
+```bash
+# Use the default branch
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+
+# Install sglang python package
+pip install --upgrade pip
+rm -f python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
+uv pip install -e "python[all_mps]"
+```

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -137,6 +137,29 @@ diffusion_musa = [
   "xatlas",
 ]
 
+# https://docs.sglang.io/platforms/mps.md
+srt_mps = [
+    "sglang[runtime_common]",
+    "torch==2.9.1",
+    "torchao==0.9.0",
+    "torchaudio==2.9.1",
+    "torchvision",
+]
+
+diffusion_mps = [
+  "PyYAML==6.0.1",
+  "cloudpickle==3.1.2",
+  "diffusers==0.36.0",
+  "imageio==2.36.0",
+  "imageio-ffmpeg==0.5.1",
+  "moviepy>=2.0.0",
+  "opencv-python-headless==4.10.0.84",
+  "remote-pdb==2.1.0",
+  "cache-dit==1.2.3",
+  "addict==2.4.0",
+  "av==16.1.0",
+]
+
 test = [
   "accelerate",
   "expecttest",
@@ -153,10 +176,12 @@ test = [
 all_hip = ["sglang[srt_hip]", "sglang[diffusion_hip]"]
 all_hpu = ["sglang[srt_hpu]"]
 all_musa = ["sglang[srt_musa]", "sglang[diffusion_musa]"]
+all_mps = ["sglang[srt_mps]", "sglang[diffusion_mps]"]
 
 dev_hip = ["sglang[all_hip]", "sglang[test]"]
 dev_hpu = ["sglang[all_hpu]", "sglang[test]"]
 dev_musa = ["sglang[all_musa]", "sglang[test]"]
+dev_mps = ["sglang[all_mps]", "sglang[test]"]
 
 [project.urls]
 "Homepage" = "https://github.com/sgl-project/sglang"

--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -1,5 +1,29 @@
 # SGLang public APIs
 
+# Install stubs early for platforms where certain dependencies are unavailable
+# (e.g. macOS/MPS has no triton, and torch.mps lacks Stream / set_device /
+# get_device_properties).  This must run before any downstream imports.
+import sys as _sys
+
+if _sys.platform == "darwin":
+    try:
+        import torch as _torch
+
+        if _torch.backends.mps.is_available():
+            from sglang._triton_stub import install as _install_triton_stub
+
+            _install_triton_stub()
+            del _install_triton_stub
+
+            from sglang._mps_stub import install as _install_mps_stub
+
+            _install_mps_stub()
+            del _install_mps_stub
+        del _torch
+    except ImportError:
+        pass
+del _sys
+
 # Frontend Language APIs
 from sglang.global_config import global_config
 from sglang.lang.api import (

--- a/python/sglang/_mps_stub.py
+++ b/python/sglang/_mps_stub.py
@@ -1,0 +1,136 @@
+"""Stub implementations for APIs missing from ``torch.mps``.
+
+``torch.mps`` lacks several APIs that ``torch.cuda`` provides (``Stream``,
+``set_device``, ``get_device_properties``, …).  Rather than scattering
+``hasattr`` / ``getattr`` guards throughout the codebase, we monkey-patch
+``torch.mps`` once at startup so that generic device-agnostic code paths
+just work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Stream – a no-op placeholder (MPS serialises everything on one stream)
+# ---------------------------------------------------------------------------
+class Stream:
+    """Minimal stand-in for ``torch.cuda.Stream``.
+
+    MPS does not expose user-visible streams.  Every method is a no-op so
+    that code written for CUDA's multi-stream model still runs.
+    """
+
+    def __init__(self, device: Any = None, priority: int = 0) -> None:
+        pass
+
+    # -- public API expected by the codebase ---------------------------------
+    def synchronize(self) -> None:
+        pass
+
+    def wait_stream(self, stream: Any) -> None:
+        pass
+
+    def wait_event(self, event: Any) -> None:
+        pass
+
+    def record_event(self, event: Any = None) -> Any:
+        return None
+
+    def query(self) -> bool:
+        return True
+
+    # context-manager protocol (``with stream:``)
+    def __enter__(self) -> "Stream":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# set_device – MPS has exactly one device; this is a no-op.
+# ---------------------------------------------------------------------------
+def set_device(device: Any) -> None:  # noqa: ARG001
+    pass
+
+
+# ---------------------------------------------------------------------------
+# current_device / device_count – trivial for single-device MPS
+# ---------------------------------------------------------------------------
+def current_device() -> int:
+    return 0
+
+
+def device_count() -> int:
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# get_device_properties – returns a lightweight dataclass
+# ---------------------------------------------------------------------------
+@dataclass
+class _MPSDeviceProperties:
+    """Mimics the object returned by ``torch.cuda.get_device_properties``."""
+
+    name: str = "Apple MPS"
+    total_memory: int = 0  # populated at install time
+    multi_processor_count: int = 0
+    warp_size: int = 32
+    is_integrated: bool = True
+    major: int = 0
+    minor: int = 0
+    # Extra attrs some callers inspect
+    _extra: dict = field(default_factory=dict)
+
+    def __getattr__(self, name: str) -> Any:
+        # Return a safe default for any attribute we didn't anticipate
+        try:
+            return self._extra[name]
+        except KeyError:
+            return None
+
+
+_cached_props: _MPSDeviceProperties | None = None
+
+
+def get_device_properties(device: Any = 0) -> _MPSDeviceProperties:  # noqa: ARG001
+    global _cached_props
+    if _cached_props is None:
+        import psutil
+
+        _cached_props = _MPSDeviceProperties(
+            total_memory=psutil.virtual_memory().total,
+        )
+    return _cached_props
+
+
+# ---------------------------------------------------------------------------
+# install – monkey-patch torch.mps
+# ---------------------------------------------------------------------------
+_installed = False
+
+
+def install() -> None:
+    """Patch ``torch.mps`` with the stubs above.  Safe to call multiple times."""
+    global _installed
+    if _installed:
+        return
+
+    import torch
+
+    mps = torch.mps
+    # Only patch attributes that are actually missing
+    for name, obj in [
+        ("Stream", Stream),
+        ("set_device", set_device),
+        ("current_device", current_device),
+        ("device_count", device_count),
+        ("get_device_properties", get_device_properties),
+    ]:
+        if not hasattr(mps, name):
+            setattr(mps, name, obj)
+
+    _installed = True

--- a/python/sglang/_mps_stub.py
+++ b/python/sglang/_mps_stub.py
@@ -14,9 +14,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
-# ---------------------------------------------------------------------------
-# Stream – a no-op placeholder (MPS serialises everything on one stream)
-# ---------------------------------------------------------------------------
 class Stream:
     """Minimal stand-in for ``torch.cuda.Stream``.
 
@@ -27,7 +24,6 @@ class Stream:
     def __init__(self, device: Any = None, priority: int = 0) -> None:
         pass
 
-    # -- public API expected by the codebase ---------------------------------
     def synchronize(self) -> None:
         pass
 
@@ -51,9 +47,6 @@ class Stream:
         pass
 
 
-# ---------------------------------------------------------------------------
-# Event – a no-op placeholder (MPS has no user-visible events)
-# ---------------------------------------------------------------------------
 class Event:
     """Minimal stand-in for ``torch.cuda.Event``."""
 
@@ -90,27 +83,21 @@ def stream(s: Any) -> Stream:
     return s if s is not None else _default_stream
 
 
-# ---------------------------------------------------------------------------
-# set_device – MPS has exactly one device; this is a no-op.
-# ---------------------------------------------------------------------------
 def set_device(device: Any) -> None:  # noqa: ARG001
+    """Set the current device. This is a no-op for MPS as it has exactly one device."""
     pass
 
 
-# ---------------------------------------------------------------------------
-# current_device / device_count – trivial for single-device MPS
-# ---------------------------------------------------------------------------
 def current_device() -> int:
+    """Return the index of the current MPS device (always 0)."""
     return 0
 
 
 def device_count() -> int:
+    """Return the number of available MPS devices (always 1)."""
     return 1
 
 
-# ---------------------------------------------------------------------------
-# get_device_properties – returns a lightweight dataclass
-# ---------------------------------------------------------------------------
 @dataclass
 class _MPSDeviceProperties:
     """Mimics the object returned by ``torch.cuda.get_device_properties``."""
@@ -147,11 +134,6 @@ def get_device_properties(device: Any = 0) -> _MPSDeviceProperties:  # noqa: ARG
     return _cached_props
 
 
-# ---------------------------------------------------------------------------
-# Memory tracking – MPS only provides *current* values; CUDA code expects
-# peak-tracking APIs like ``max_memory_allocated`` / ``max_memory_reserved``.
-# We maintain the peaks ourselves.
-# ---------------------------------------------------------------------------
 class _MPSMemoryTracker:
     """Tracks peak memory values on top of ``torch.mps`` current-value APIs.
 
@@ -164,7 +146,6 @@ class _MPSMemoryTracker:
         self._peak_allocated: int = 0
         self._peak_reserved: int = 0
 
-    # -- current values (CUDA-compatible names) ----------------------------
     def memory_allocated(self, device: Any = None) -> int:  # noqa: ARG002
         import torch
 
@@ -181,7 +162,6 @@ class _MPSMemoryTracker:
             self._peak_reserved = val
         return val
 
-    # -- peak values -------------------------------------------------------
     def max_memory_allocated(self, device: Any = None) -> int:  # noqa: ARG002
         # Refresh peak before returning
         self.memory_allocated()
@@ -201,9 +181,6 @@ class _MPSMemoryTracker:
 _memory_tracker = _MPSMemoryTracker()
 
 
-# ---------------------------------------------------------------------------
-# non_blocking patch – MPS does not properly synchronise async H2D copies
-# ---------------------------------------------------------------------------
 def _patch_non_blocking() -> None:
     """Force ``non_blocking=False`` for copies targeting the MPS device.
 
@@ -244,9 +221,6 @@ def _patch_non_blocking() -> None:
     torch.Tensor.copy_ = _patched_copy_
 
 
-# ---------------------------------------------------------------------------
-# install – monkey-patch torch.mps
-# ---------------------------------------------------------------------------
 _installed = False
 
 

--- a/python/sglang/_mps_stub.py
+++ b/python/sglang/_mps_stub.py
@@ -69,7 +69,6 @@ class Event:
         return 0.0
 
 
-# Singleton stream instance for current_stream()
 _default_stream = Stream()
 
 
@@ -124,6 +123,7 @@ _cached_props: _MPSDeviceProperties | None = None
 
 
 def get_device_properties(device: Any = 0) -> _MPSDeviceProperties:  # noqa: ARG001
+    """Return the properties of the MPS device. Results are cached after first call."""
     global _cached_props
     if _cached_props is None:
         import psutil
@@ -163,7 +163,6 @@ class _MPSMemoryTracker:
         return val
 
     def max_memory_allocated(self, device: Any = None) -> int:  # noqa: ARG002
-        # Refresh peak before returning
         self.memory_allocated()
         return self._peak_allocated
 
@@ -252,7 +251,6 @@ def install() -> None:
         if not hasattr(mps, name):
             setattr(mps, name, obj)
 
-    # Patch non_blocking for MPS device transfers
     _patch_non_blocking()
 
     _installed = True

--- a/python/sglang/_mps_stub.py
+++ b/python/sglang/_mps_stub.py
@@ -9,6 +9,7 @@ just work.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -48,6 +49,45 @@ class Stream:
 
     def __exit__(self, *args: Any) -> None:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Event – a no-op placeholder (MPS has no user-visible events)
+# ---------------------------------------------------------------------------
+class Event:
+    """Minimal stand-in for ``torch.cuda.Event``."""
+
+    def __init__(self, enable_timing: bool = False) -> None:
+        pass
+
+    def record(self, stream: Any = None) -> None:
+        pass
+
+    def wait(self, stream: Any = None) -> None:
+        pass
+
+    def query(self) -> bool:
+        return True
+
+    def synchronize(self) -> None:
+        pass
+
+    def elapsed_time(self, end_event: Any) -> float:
+        return 0.0
+
+
+# Singleton stream instance for current_stream()
+_default_stream = Stream()
+
+
+def current_stream(device: Any = None) -> Stream:
+    """Return the default (and only) MPS stream."""
+    return _default_stream
+
+
+def stream(s: Any) -> Stream:
+    """Return a context manager that is a no-op on MPS."""
+    return s if s is not None else _default_stream
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +202,49 @@ _memory_tracker = _MPSMemoryTracker()
 
 
 # ---------------------------------------------------------------------------
+# non_blocking patch – MPS does not properly synchronise async H2D copies
+# ---------------------------------------------------------------------------
+def _patch_non_blocking() -> None:
+    """Force ``non_blocking=False`` for copies targeting the MPS device.
+
+    Unlike CUDA, MPS does not guarantee that a subsequent kernel on the same
+    "stream" will wait for an async host-to-device transfer to finish.  Reading
+    the tensor before the transfer completes yields uninitialised (garbage)
+    data.  Patching ``Tensor.to`` and ``Tensor.copy_`` centrally avoids having
+    to sprinkle ``non_blocking=not is_mps()`` at every call-site.
+    """
+    import torch
+
+    _original_to = torch.Tensor.to
+
+    @functools.wraps(_original_to)
+    def _patched_to(self, *args, **kwargs):
+        if kwargs.get("non_blocking"):
+            # Detect target device from positional or keyword args
+            device = None
+            if args and isinstance(args[0], (str, torch.device)):
+                device = torch.device(args[0]) if isinstance(args[0], str) else args[0]
+            elif "device" in kwargs:
+                d = kwargs["device"]
+                device = torch.device(d) if isinstance(d, str) else d
+            if device is not None and device.type == "mps":
+                kwargs = {**kwargs, "non_blocking": False}
+        return _original_to(self, *args, **kwargs)
+
+    torch.Tensor.to = _patched_to
+
+    _original_copy_ = torch.Tensor.copy_
+
+    @functools.wraps(_original_copy_)
+    def _patched_copy_(self, src, non_blocking=False):
+        if non_blocking and self.device.type == "mps":
+            non_blocking = False
+        return _original_copy_(self, src, non_blocking=non_blocking)
+
+    torch.Tensor.copy_ = _patched_copy_
+
+
+# ---------------------------------------------------------------------------
 # install – monkey-patch torch.mps
 # ---------------------------------------------------------------------------
 _installed = False
@@ -179,6 +262,9 @@ def install() -> None:
     # Only patch attributes that are actually missing
     for name, obj in [
         ("Stream", Stream),
+        ("Event", Event),
+        ("current_stream", current_stream),
+        ("stream", stream),
         ("set_device", set_device),
         ("current_device", current_device),
         ("device_count", device_count),
@@ -191,5 +277,8 @@ def install() -> None:
     ]:
         if not hasattr(mps, name):
             setattr(mps, name, obj)
+
+    # Patch non_blocking for MPS device transfers
+    _patch_non_blocking()
 
     _installed = True

--- a/python/sglang/_mps_stub.py
+++ b/python/sglang/_mps_stub.py
@@ -108,6 +108,60 @@ def get_device_properties(device: Any = 0) -> _MPSDeviceProperties:  # noqa: ARG
 
 
 # ---------------------------------------------------------------------------
+# Memory tracking – MPS only provides *current* values; CUDA code expects
+# peak-tracking APIs like ``max_memory_allocated`` / ``max_memory_reserved``.
+# We maintain the peaks ourselves.
+# ---------------------------------------------------------------------------
+class _MPSMemoryTracker:
+    """Tracks peak memory values on top of ``torch.mps`` current-value APIs.
+
+    * ``memory_allocated`` → ``torch.mps.current_allocated_memory()``
+    * ``memory_reserved``  → ``torch.mps.driver_allocated_memory()``
+    * ``max_memory_*``     → high-water marks of the above
+    """
+
+    def __init__(self) -> None:
+        self._peak_allocated: int = 0
+        self._peak_reserved: int = 0
+
+    # -- current values (CUDA-compatible names) ----------------------------
+    def memory_allocated(self, device: Any = None) -> int:  # noqa: ARG002
+        import torch
+
+        val = torch.mps.current_allocated_memory()
+        if val > self._peak_allocated:
+            self._peak_allocated = val
+        return val
+
+    def memory_reserved(self, device: Any = None) -> int:  # noqa: ARG002
+        import torch
+
+        val = torch.mps.driver_allocated_memory()
+        if val > self._peak_reserved:
+            self._peak_reserved = val
+        return val
+
+    # -- peak values -------------------------------------------------------
+    def max_memory_allocated(self, device: Any = None) -> int:  # noqa: ARG002
+        # Refresh peak before returning
+        self.memory_allocated()
+        return self._peak_allocated
+
+    def max_memory_reserved(self, device: Any = None) -> int:  # noqa: ARG002
+        self.memory_reserved()
+        return self._peak_reserved
+
+    def reset_peak_memory_stats(self, device: Any = None) -> None:  # noqa: ARG002
+        import torch
+
+        self._peak_allocated = torch.mps.current_allocated_memory()
+        self._peak_reserved = torch.mps.driver_allocated_memory()
+
+
+_memory_tracker = _MPSMemoryTracker()
+
+
+# ---------------------------------------------------------------------------
 # install – monkey-patch torch.mps
 # ---------------------------------------------------------------------------
 _installed = False
@@ -129,6 +183,11 @@ def install() -> None:
         ("current_device", current_device),
         ("device_count", device_count),
         ("get_device_properties", get_device_properties),
+        ("reset_peak_memory_stats", _memory_tracker.reset_peak_memory_stats),
+        ("memory_allocated", _memory_tracker.memory_allocated),
+        ("memory_reserved", _memory_tracker.memory_reserved),
+        ("max_memory_allocated", _memory_tracker.max_memory_allocated),
+        ("max_memory_reserved", _memory_tracker.max_memory_reserved),
     ]:
         if not hasattr(mps, name):
             setattr(mps, name, obj)

--- a/python/sglang/_triton_stub.py
+++ b/python/sglang/_triton_stub.py
@@ -45,8 +45,6 @@ class _MockModule(types.ModuleType):
 
         self.__spec__ = importlib.machinery.ModuleSpec(name, None, is_package=True)
 
-    # --- attribute access ---------------------------------------------------
-
     def __getattr__(self, name: str):
         # Avoid infinite recursion on dunder lookups
         if name.startswith("__") and name.endswith("__"):
@@ -65,8 +63,6 @@ class _MockModule(types.ModuleType):
         self._children[name] = child
         return child
 
-    # --- decorator / callable behaviour -------------------------------------
-
     def __call__(self, *args, **kwargs):
         # Direct decorator usage:  @triton.jit  (receives the function)
         if len(args) == 1 and callable(args[0]) and not kwargs:
@@ -78,12 +74,8 @@ class _MockModule(types.ModuleType):
 
         return _decorator
 
-    # --- make it behave as a type for isinstance / annotations ---------------
-
     def __instancecheck__(self, instance):
         return False
-
-    # --- container protocol (for ``"x" in triton.backends.backends``) --------
 
     def __contains__(self, item):
         return False
@@ -96,8 +88,6 @@ class _MockModule(types.ModuleType):
 
     def __bool__(self):
         return False
-
-    # --- repr for debugging --------------------------------------------------
 
     def __repr__(self):
         return f"<triton-stub {self.__name__!r}>"
@@ -177,7 +167,6 @@ def install() -> None:
     # during the rest of install() (or later) is handled.
     sys.meta_path.insert(0, _TritonFinder())
 
-    # -- build the mock tree --------------------------------------------------
     triton = _make_mock("triton")
     triton.__version__ = "3.0.0"
     triton.cdiv = _cdiv

--- a/python/sglang/_triton_stub.py
+++ b/python/sglang/_triton_stub.py
@@ -46,7 +46,7 @@ class _MockModule(types.ModuleType):
         self.__spec__ = importlib.machinery.ModuleSpec(name, None, is_package=True)
 
     def __getattr__(self, name: str):
-        # Avoid infinite recursion on dunder lookups
+        """Handle attribute access by creating and returning a child _MockModule."""
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
         full = f"{self.__name__}.{name}"
@@ -75,9 +75,11 @@ class _MockModule(types.ModuleType):
         return _decorator
 
     def __instancecheck__(self, instance):
+        """Return False for all instance checks against the mock."""
         return False
 
     def __contains__(self, item):
+        """Return False for all membership checks."""
         return False
 
     def __iter__(self):

--- a/python/sglang/_triton_stub.py
+++ b/python/sglang/_triton_stub.py
@@ -1,0 +1,239 @@
+"""
+Mock triton module for platforms where triton is not available (e.g., macOS/MPS).
+
+This module provides stub implementations of triton APIs so that modules which
+import triton at the top level can be loaded without error.  The actual triton
+kernels are never executed on these platforms – alternative backends (e.g. SDPA
+for MPS) are used instead.
+
+Usage – call ``install()`` **before** any ``import triton`` in the process:
+
+    from sglang._triton_stub import install
+    install()
+"""
+
+import sys
+import types
+
+
+class _StubBase:
+    """A base class that any mock attribute can safely be subclassed from.
+
+    Used when external code does ``class Foo(triton.runtime.KernelInterface):``.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+
+class _MockModule(types.ModuleType):
+    """A module whose every attribute is itself a ``_MockModule``.
+
+    When called (e.g. ``@triton.jit``), it acts as a pass-through decorator so
+    that kernel *definitions* are syntactically valid even though they will never
+    be compiled.
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.__path__: list[str] = []  # make it look like a package
+        self.__package__ = name
+        self.__file__ = __file__
+        self._children: dict[str, object] = {}
+        # Set __spec__ so that importlib.util.find_spec() works on cached modules
+        import importlib
+
+        self.__spec__ = importlib.machinery.ModuleSpec(name, None, is_package=True)
+
+    # --- attribute access ---------------------------------------------------
+
+    def __getattr__(self, name: str):
+        # Avoid infinite recursion on dunder lookups
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        full = f"{self.__name__}.{name}"
+        if full in sys.modules:
+            return sys.modules[full]
+        # If the name looks like a class (CamelCase / uppercase), return a
+        # stub class that can be used as a base class for inheritance.
+        if name[0:1].isupper():
+            stub_cls = type(name, (_StubBase,), {"__module__": self.__name__})
+            self._children[name] = stub_cls
+            return stub_cls
+        child = _MockModule(full)
+        sys.modules[full] = child
+        self._children[name] = child
+        return child
+
+    # --- decorator / callable behaviour -------------------------------------
+
+    def __call__(self, *args, **kwargs):
+        # Direct decorator usage:  @triton.jit  (receives the function)
+        if len(args) == 1 and callable(args[0]) and not kwargs:
+            return args[0]
+
+        # Parameterised decorator: @triton.jit(...)  → returns a decorator
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+    # --- make it behave as a type for isinstance / annotations ---------------
+
+    def __instancecheck__(self, instance):
+        return False
+
+    # --- container protocol (for ``"x" in triton.backends.backends``) --------
+
+    def __contains__(self, item):
+        return False
+
+    def __iter__(self):
+        return iter([])
+
+    def __len__(self):
+        return 0
+
+    def __bool__(self):
+        return False
+
+    # --- repr for debugging --------------------------------------------------
+
+    def __repr__(self):
+        return f"<triton-stub {self.__name__!r}>"
+
+
+def _cdiv(a: int, b: int) -> int:
+    """Ceiling division – mirrors ``triton.cdiv``."""
+    return -(a // -b)
+
+
+def _next_power_of_2(n: int) -> int:
+    """Mirrors ``triton.next_power_of_2``."""
+    return 1 << (n - 1).bit_length() if n > 0 else 1
+
+
+class _Config:
+    """Minimal stand-in for ``triton.Config`` used in ``@triton.autotune``."""
+
+    def __init__(self, kwargs=None, num_warps=4, num_stages=2, **extra):
+        self.kwargs = kwargs or {}
+        self.num_warps = num_warps
+        self.num_stages = num_stages
+
+
+class _TritonFinder:
+    """A meta-path finder that intercepts all ``import triton.*`` statements.
+
+    When Python encounters ``import triton.backends.compiler``, it walks the
+    dotted path and tries to import each component.  Our mock module's
+    ``__getattr__`` handles *attribute* access, but the import machinery uses
+    ``importlib`` finders, not attribute access, for sub-module resolution.
+    This finder bridges that gap by creating ``_MockModule`` instances for any
+    ``triton.*`` sub-module that isn't already in ``sys.modules``.
+    """
+
+    def find_module(self, fullname, path=None):
+        if fullname == "triton" or fullname.startswith("triton."):
+            return self
+        return None
+
+    def load_module(self, fullname):
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+        mod = _MockModule(fullname)
+        sys.modules[fullname] = mod
+        # Wire up the parent relationship
+        parts = fullname.rsplit(".", 1)
+        if len(parts) == 2:
+            parent_name, child_name = parts
+            parent = sys.modules.get(parent_name)
+            if parent is not None:
+                setattr(parent, child_name, mod)
+        return mod
+
+
+def _make_mock(name: str) -> _MockModule:
+    """Create a ``_MockModule`` and register it in ``sys.modules``."""
+    mod = _MockModule(name)
+    sys.modules[name] = mod
+    return mod
+
+
+def install() -> None:
+    """Register a mock ``triton`` package in *sys.modules*.
+
+    This is a no-op if a real ``triton`` is already importable.
+    """
+    if "triton" in sys.modules:
+        return
+    # Check whether a real triton exists before installing the stub.
+    import importlib.util
+
+    if importlib.util.find_spec("triton") is not None:
+        return
+
+    # Register the meta-path finder FIRST so that any ``import triton.X``
+    # during the rest of install() (or later) is handled.
+    sys.meta_path.insert(0, _TritonFinder())
+
+    # -- build the mock tree --------------------------------------------------
+    triton = _make_mock("triton")
+    triton.__version__ = "3.0.0"
+    triton.cdiv = _cdiv
+    triton.next_power_of_2 = _next_power_of_2
+    triton.Config = _Config
+
+    # triton.language  (commonly imported as ``tl``)
+    tl = _make_mock("triton.language")
+
+    class _constexpr:
+        """Stand-in for ``tl.constexpr`` – works as both annotation and value wrapper."""
+
+        def __init__(self, value=None):
+            self.value = value
+
+        def __repr__(self):
+            return f"constexpr({self.value!r})"
+
+    tl.constexpr = _constexpr
+    triton.language = tl
+
+    # triton.language.extra.libdevice
+    extra = _make_mock("triton.language.extra")
+    tl.extra = extra
+    libdevice = _make_mock("triton.language.extra.libdevice")
+    extra.libdevice = libdevice
+
+    # triton.runtime.jit  (JITFunction used in isinstance checks)
+    runtime = _make_mock("triton.runtime")
+    triton.runtime = runtime
+    jit_mod = _make_mock("triton.runtime.jit")
+
+    class _JITFunction:
+        """Dummy so ``isinstance(fn, triton.runtime.jit.JITFunction)`` works."""
+
+        pass
+
+    jit_mod.JITFunction = _JITFunction
+    runtime.jit = jit_mod
+
+    # triton.runtime.driver  (used by fla/utils.py)
+    driver = _make_mock("triton.runtime.driver")
+    runtime.driver = driver
+
+    # triton.testing
+    testing = _make_mock("triton.testing")
+    triton.testing = testing
+
+    # triton.tools / triton.tools.tensor_descriptor
+    tools = _make_mock("triton.tools")
+    triton.tools = tools
+    td = _make_mock("triton.tools.tensor_descriptor")
+    tools.tensor_descriptor = td
+
+    # triton.backends / triton.backends.compiler  (used by torch._inductor)
+    backends = _make_mock("triton.backends")
+    triton.backends = backends
+    compiler = _make_mock("triton.backends.compiler")
+    backends.compiler = compiler

--- a/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
+++ b/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
@@ -1,0 +1,318 @@
+"""MPS (Apple Silicon) fallbacks for Triton diffusion kernels.
+
+Triton is not available on macOS / Metal, so these pure-PyTorch (and
+optionally MLX-accelerated) implementations replace the Triton kernels
+at import time when ``current_platform.is_mps()`` is True.
+
+MLX acceleration (opt-in via ``SGLANG_USE_MLX=1``):
+    Norm ops use ``mx.fast.rms_norm`` / ``mx.fast.layer_norm`` — single fused
+    Metal kernels that are 1.4x–2.9x faster than the multi-step PyTorch MPS
+    decomposition for medium-to-large tensors.
+"""
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from sglang.srt.environ import envs
+
+# ---------------------------------------------------------------------------
+# MLX acceleration – opt-in via SGLANG_USE_MLX=1
+# ---------------------------------------------------------------------------
+_MLX_AVAILABLE = False
+try:
+    import mlx.core as mx
+
+    _MLX_AVAILABLE = True
+except ImportError:
+    pass
+
+_USE_MLX = envs.SGLANG_USE_MLX.get() and _MLX_AVAILABLE
+
+# Dtype mapping for torch <-> MLX tensor bridge
+_TORCH_TO_MLX_DTYPE = (
+    {
+        torch.float32: mx.float32,
+        torch.float16: mx.float16,
+        torch.bfloat16: mx.bfloat16,
+    }
+    if _MLX_AVAILABLE
+    else {}
+)
+
+_MLX_TO_TORCH_DTYPE = {v: k for k, v in _TORCH_TO_MLX_DTYPE.items()}
+
+
+def _torch_to_mlx(tensor: torch.Tensor) -> "mx.array":
+    """Convert a PyTorch tensor to an MLX array (via numpy on CPU)."""
+    t = tensor.cpu().detach()
+    if t.dtype == torch.bfloat16:
+        return mx.array(t.float().numpy(), dtype=mx.bfloat16)
+    return mx.array(t.numpy())
+
+
+def _mlx_to_torch(array: "mx.array", device: torch.device) -> torch.Tensor:
+    """Convert an MLX array to a PyTorch tensor (zero-copy via memoryview)."""
+    torch_dtype = _MLX_TO_TORCH_DTYPE.get(array.dtype, torch.float32)
+    array = mx.contiguous(array)
+    mx.eval(array)
+    tensor = torch.frombuffer(memoryview(array), dtype=torch_dtype).reshape(array.shape)
+    if device.type == "mps":
+        tensor = tensor.to(device)
+    return tensor
+
+
+# ---------------------------------------------------------------------------
+# Scale-shift fallbacks (pure PyTorch – simple arithmetic, no MLX benefit)
+# ---------------------------------------------------------------------------
+
+
+def fuse_scale_shift_kernel_native(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    scale_constant: float = 1.0,
+    block_l: int = 128,
+    block_c: int = 128,
+):
+    """Native fallback for fuse_scale_shift_kernel with scale_constant support."""
+    if scale.dim() == 4:
+        B, L, C = x.shape
+        num_frames = scale.shape[1]
+        frame_seqlen = L // num_frames
+        scale = (
+            scale.squeeze(2)
+            .unsqueeze(2)
+            .expand(-1, -1, frame_seqlen, -1)
+            .reshape(B, L, C)
+        )
+    return x * (scale_constant + scale) + shift
+
+
+def fuse_scale_shift_gate_select01_kernel_native(
+    x: torch.Tensor,
+    scale0: torch.Tensor,
+    shift0: torch.Tensor,
+    gate0: torch.Tensor,
+    scale1: torch.Tensor,
+    shift1: torch.Tensor,
+    gate1: torch.Tensor,
+    index: torch.Tensor,
+    block_l: int = 128,
+    block_c: int = 128,
+):
+    """Native fallback for fuse_scale_shift_gate_select01_kernel."""
+    idx = index.unsqueeze(-1).bool()
+    scale = torch.where(idx, scale1.unsqueeze(1), scale0.unsqueeze(1))
+    shift = torch.where(idx, shift1.unsqueeze(1), shift0.unsqueeze(1))
+    gate = torch.where(idx, gate1.unsqueeze(1), gate0.unsqueeze(1))
+    y = x * (1 + scale) + shift
+    return y, gate
+
+
+# ---------------------------------------------------------------------------
+# Rotary embedding fallback (shared with NPU – same implementation)
+# ---------------------------------------------------------------------------
+
+
+def apply_rotary_embedding_native(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, interleaved: bool = False
+) -> torch.Tensor:
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    x1 = x[..., ::2]
+    x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+# ---------------------------------------------------------------------------
+# Norm fallbacks (torch native, overridden by MLX below when enabled)
+# ---------------------------------------------------------------------------
+
+
+def norm_infer_native(
+    x: Tensor,
+    weight: Optional[Tensor],
+    bias: Optional[Tensor],
+    eps: float,
+    is_rms_norm: bool = False,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    """Native fallback for norm_infer (layer norm / rms norm inference)."""
+    orig_dtype = x.dtype
+    x = x.contiguous().float()
+    if is_rms_norm:
+        variance = x.pow(2).mean(dim=-1, keepdim=True)
+        x_hat = x * torch.rsqrt(variance + eps)
+    else:
+        mean = x.mean(dim=-1, keepdim=True)
+        variance = (x - mean).pow(2).mean(dim=-1, keepdim=True)
+        x_hat = (x - mean) * torch.rsqrt(variance + eps)
+    if weight is not None:
+        x_hat = x_hat * weight.float()
+    if bias is not None:
+        x_hat = x_hat + bias.float()
+    result = x_hat.to(orig_dtype)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def triton_one_pass_rms_norm_native(
+    x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
+) -> torch.Tensor:
+    """Native fallback for triton_one_pass_rms_norm."""
+    shape = x.shape
+    orig_dtype = x.dtype
+    x = x.contiguous().float()
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x_hat = x * torch.rsqrt(variance + eps)
+    return (x_hat * w.float()).to(orig_dtype).view(shape)
+
+
+def rms_norm_fn_native(
+    x,
+    weight,
+    bias,
+    residual=None,
+    x1=None,
+    weight1=None,
+    bias1=None,
+    eps=1e-6,
+    dropout_p=0.0,
+    rowscale=None,
+    prenorm=False,
+    residual_in_fp32=False,
+    zero_centered_weight=False,
+    return_dropout_mask=False,
+    out_dtype=None,
+    out=None,
+    residual_out=None,
+):
+    """Native fallback for rms_norm_fn (inference only, no dropout/x1 support)."""
+    x_shape_og = x.shape
+    orig_dtype = x.dtype
+    x = x.reshape(-1, x.shape[-1]).float()
+    if residual is not None:
+        residual = residual.reshape(-1, residual.shape[-1]).float()
+        x = x + residual
+        residual_out_val = x.to(torch.float32 if residual_in_fp32 else orig_dtype)
+    else:
+        residual_out_val = None
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x_hat = x * torch.rsqrt(variance + eps)
+    if weight is not None:
+        w = weight.float()
+        if zero_centered_weight:
+            w = w + 1.0
+        x_hat = x_hat * w
+    if bias is not None:
+        x_hat = x_hat + bias.float()
+    final_dtype = out_dtype if out_dtype is not None else orig_dtype
+    y = x_hat.to(final_dtype).reshape(x_shape_og)
+    if residual is not None and residual_out_val is not None:
+        return y, residual_out_val.reshape(x_shape_og)
+    return y
+
+
+# ---------------------------------------------------------------------------
+# MLX-accelerated norm ops (1.4x–2.9x faster than torch native on MPS)
+# Uses mx.fast.rms_norm / mx.fast.layer_norm — single fused Metal kernels
+# instead of 7+ separate PyTorch MPS kernel launches.
+# ---------------------------------------------------------------------------
+
+if _USE_MLX:
+
+    def norm_infer_native(  # noqa: F811
+        x: Tensor,
+        weight: Optional[Tensor],
+        bias: Optional[Tensor],
+        eps: float,
+        is_rms_norm: bool = False,
+        out: Optional[Tensor] = None,
+    ) -> Tensor:
+        """MLX-accelerated norm_infer (layer norm / rms norm inference)."""
+        device = x.device
+        orig_dtype = x.dtype
+        x_mx = _torch_to_mlx(x)
+        if is_rms_norm:
+            w_mx = (
+                _torch_to_mlx(weight) if weight is not None else mx.ones(x_mx.shape[-1])
+            )
+            result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)
+        else:
+            w_mx = _torch_to_mlx(weight) if weight is not None else None
+            b_mx = _torch_to_mlx(bias) if bias is not None else None
+            result_mx = mx.fast.layer_norm(x_mx, w_mx, b_mx, eps)
+        result = _mlx_to_torch(result_mx, device).to(orig_dtype)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    def triton_one_pass_rms_norm_native(  # noqa: F811
+        x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
+    ) -> torch.Tensor:
+        """MLX-accelerated triton_one_pass_rms_norm."""
+        shape = x.shape
+        device = x.device
+        orig_dtype = x.dtype
+        x_mx = _torch_to_mlx(x.reshape(-1, x.shape[-1]))
+        w_mx = _torch_to_mlx(w)
+        result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)
+        return _mlx_to_torch(result_mx, device).to(orig_dtype).view(shape)
+
+    def rms_norm_fn_native(  # noqa: F811
+        x,
+        weight,
+        bias,
+        residual=None,
+        x1=None,
+        weight1=None,
+        bias1=None,
+        eps=1e-6,
+        dropout_p=0.0,
+        rowscale=None,
+        prenorm=False,
+        residual_in_fp32=False,
+        zero_centered_weight=False,
+        return_dropout_mask=False,
+        out_dtype=None,
+        out=None,
+        residual_out=None,
+    ):
+        """MLX-accelerated rms_norm_fn (inference only, no dropout/x1 support)."""
+        x_shape_og = x.shape
+        device = x.device
+        orig_dtype = x.dtype
+        x_flat = x.reshape(-1, x.shape[-1])
+        # Handle residual addition on torch side (stays on MPS)
+        if residual is not None:
+            residual = residual.reshape(-1, residual.shape[-1]).float()
+            x_flat = x_flat.float() + residual
+            residual_out_val = x_flat.to(
+                torch.float32 if residual_in_fp32 else orig_dtype
+            )
+        else:
+            residual_out_val = None
+        # Prepare weight
+        if weight is not None and zero_centered_weight:
+            w = weight.float() + 1.0
+        else:
+            w = weight
+        # MLX fast RMS norm
+        x_mx = _torch_to_mlx(x_flat)
+        w_mx = _torch_to_mlx(w) if w is not None else mx.ones(x_mx.shape[-1])
+        result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)
+        x_hat = _mlx_to_torch(result_mx, device)
+        if bias is not None:
+            x_hat = x_hat + bias.to(x_hat.device, x_hat.dtype)
+        final_dtype = out_dtype if out_dtype is not None else orig_dtype
+        y = x_hat.to(final_dtype).reshape(x_shape_og)
+        if residual is not None and residual_out_val is not None:
+            return y, residual_out_val.reshape(x_shape_og)
+        return y

--- a/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
+++ b/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
@@ -17,9 +17,7 @@ from torch import Tensor
 
 from sglang.srt.environ import envs
 
-# ---------------------------------------------------------------------------
 # MLX acceleration – opt-in via SGLANG_USE_MLX=1
-# ---------------------------------------------------------------------------
 _MLX_AVAILABLE = False
 try:
     import mlx.core as mx
@@ -61,11 +59,6 @@ def _mlx_to_torch(array: "mx.array", device: torch.device) -> torch.Tensor:
     if device.type == "mps":
         tensor = tensor.to(device)
     return tensor
-
-
-# ---------------------------------------------------------------------------
-# Scale-shift fallbacks (pure PyTorch – simple arithmetic, no MLX benefit)
-# ---------------------------------------------------------------------------
 
 
 def fuse_scale_shift_kernel_native(
@@ -111,14 +104,10 @@ def fuse_scale_shift_gate_select01_kernel_native(
     return y, gate
 
 
-# ---------------------------------------------------------------------------
-# Rotary embedding fallback (shared with NPU – same implementation)
-# ---------------------------------------------------------------------------
-
-
 def apply_rotary_embedding_native(
     x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, interleaved: bool = False
 ) -> torch.Tensor:
+    """Native fallback for rotary embedding (shared with NPU implementation)."""
     cos = cos.unsqueeze(-2).to(x.dtype)
     sin = sin.unsqueeze(-2).to(x.dtype)
     x1 = x[..., ::2]
@@ -126,11 +115,6 @@ def apply_rotary_embedding_native(
     o1 = x1 * cos - x2 * sin
     o2 = x2 * cos + x1 * sin
     return torch.stack((o1, o2), dim=-1).flatten(-2)
-
-
-# ---------------------------------------------------------------------------
-# Norm fallbacks (torch native, overridden by MLX below when enabled)
-# ---------------------------------------------------------------------------
 
 
 def norm_infer_native(
@@ -219,11 +203,9 @@ def rms_norm_fn_native(
     return y
 
 
-# ---------------------------------------------------------------------------
 # MLX-accelerated norm ops (1.4x–2.9x faster than torch native on MPS)
 # Uses mx.fast.rms_norm / mx.fast.layer_norm — single fused Metal kernels
 # instead of 7+ separate PyTorch MPS kernel launches.
-# ---------------------------------------------------------------------------
 
 if _USE_MLX:
 
@@ -290,7 +272,6 @@ if _USE_MLX:
         device = x.device
         orig_dtype = x.dtype
         x_flat = x.reshape(-1, x.shape[-1])
-        # Handle residual addition on torch side (stays on MPS)
         if residual is not None:
             residual = residual.reshape(-1, residual.shape[-1]).float()
             x_flat = x_flat.float() + residual
@@ -299,12 +280,10 @@ if _USE_MLX:
             )
         else:
             residual_out_val = None
-        # Prepare weight
         if weight is not None and zero_centered_weight:
             w = weight.float() + 1.0
         else:
             w = weight
-        # MLX fast RMS norm
         x_mx = _torch_to_mlx(x_flat)
         w_mx = _torch_to_mlx(w) if w is not None else mx.ones(x_mx.shape[-1])
         result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)

--- a/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
+++ b/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
@@ -70,16 +70,27 @@ def fuse_scale_shift_kernel_native(
     block_c: int = 128,
 ):
     """Native fallback for fuse_scale_shift_kernel with scale_constant support."""
-    if scale.dim() == 4:
-        B, L, C = x.shape
-        num_frames = scale.shape[1]
-        frame_seqlen = L // num_frames
-        scale = (
-            scale.squeeze(2)
-            .unsqueeze(2)
-            .expand(-1, -1, frame_seqlen, -1)
-            .reshape(B, L, C)
-        )
+    B, L, C = x.shape
+
+    def _expand(t: torch.Tensor) -> torch.Tensor:
+        if t.dim() == 4:
+            # [B, F, 1, C] -> [B, L, C]
+            num_frames = t.shape[1]
+            frame_seqlen = L // num_frames
+            return (
+                t.squeeze(2)
+                .unsqueeze(2)
+                .expand(-1, -1, frame_seqlen, -1)
+                .reshape(B, L, C)
+            )
+        elif t.dim() == 2:
+            # [B, C] -> [B, 1, C]
+            return t.unsqueeze(1)
+        return t
+
+    scale = _expand(scale)
+    shift = _expand(shift)
+
     return x * (scale_constant + scale) + shift
 
 

--- a/python/sglang/jit_kernel/diffusion/triton/norm.py
+++ b/python/sglang/jit_kernel/diffusion/triton/norm.py
@@ -618,3 +618,12 @@ def rms_norm_fn(
         out,
         residual_out,
     )
+
+
+from sglang.multimodal_gen.runtime.platforms import current_platform
+
+if current_platform.is_mps():
+    from .mps_fallback import norm_infer_native, rms_norm_fn_native
+
+    norm_infer = norm_infer_native
+    rms_norm_fn = rms_norm_fn_native

--- a/python/sglang/jit_kernel/diffusion/triton/rmsnorm_onepass.py
+++ b/python/sglang/jit_kernel/diffusion/triton/rmsnorm_onepass.py
@@ -56,3 +56,11 @@ def triton_one_pass_rms_norm(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-6
             BLOCK_SIZE_SEQ=BLOCK_SIZE_SEQ,
         )
     return y
+
+
+from sglang.multimodal_gen.runtime.platforms import current_platform
+
+if current_platform.is_mps():
+    from .mps_fallback import triton_one_pass_rms_norm_native
+
+    triton_one_pass_rms_norm = triton_one_pass_rms_norm_native

--- a/python/sglang/jit_kernel/diffusion/triton/rotary.py
+++ b/python/sglang/jit_kernel/diffusion/triton/rotary.py
@@ -111,3 +111,8 @@ if current_platform.is_npu():
     from .npu_fallback import apply_rotary_embedding_native
 
     apply_rotary_embedding = apply_rotary_embedding_native
+
+if current_platform.is_mps():
+    from .mps_fallback import apply_rotary_embedding_native
+
+    apply_rotary_embedding = apply_rotary_embedding_native

--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -411,3 +411,12 @@ if current_platform.is_npu():
     from .npu_fallback import fuse_scale_shift_native
 
     fuse_scale_shift_kernel = fuse_scale_shift_native
+
+if current_platform.is_mps():
+    from .mps_fallback import (
+        fuse_scale_shift_gate_select01_kernel_native,
+        fuse_scale_shift_kernel_native,
+    )
+
+    fuse_scale_shift_kernel = fuse_scale_shift_kernel_native
+    fuse_scale_shift_gate_select01_kernel = fuse_scale_shift_gate_select01_kernel_native

--- a/python/sglang/multimodal_gen/README.md
+++ b/python/sglang/multimodal_gen/README.md
@@ -12,7 +12,11 @@ SGLang Diffusion has the following features:
   - Broad model support: Wan series, FastWan series, Hunyuan, Qwen-Image, Qwen-Image-Edit, Flux, Z-Image, GLM-Image
   - Fast inference speed: enpowered by highly optimized kernel from sgl-kernel and efficient scheduler loop
   - Ease of use: OpenAI-compatible api, CLI, and python sdk support
-  - Multi-platform support: NVIDIA GPUs (H100, H200, A100, B200, 4090) and AMD GPUs (MI300X, MI325X)
+  - Multi-platform support:
+    - NVIDIA GPUs (H100, H200, A100, B200, 4090)
+    - AMD GPUs (MI300X, MI325X)
+    - Ascend NPU (A2, A3)
+    - Apple Silicon (M-series via MPS)
 
 ### AMD/ROCm Support
 
@@ -21,6 +25,10 @@ SGLang Diffusion supports AMD Instinct GPUs through ROCm. On AMD platforms, we u
 ### Moore Threads/MUSA Support
 
 SGLang Diffusion supports Moore Threads GPUs (MTGPU) through the MUSA software stack. On MUSA platforms, we use the Torch SDPA backend for attention. See the [installation guide](https://github.com/sgl-project/sglang/tree/main/docs/diffusion/installation.md) for setup instructions.
+
+### Apple MPS Support
+
+SGLang Diffusion supports Apple Silicon (M-series) via the MPS backend. Since Triton is Linux-only, all Triton kernels are replaced with PyTorch-native fallbacks on MPS. Norm operations can be optionally accelerated with MLX fused Metal kernels (`SGLANG_USE_MLX=1`). See the [installation guide](https://github.com/sgl-project/sglang/tree/main/docs/diffusion/installation.md) for setup instructions.
 
 ## Getting Started
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -756,6 +756,9 @@ class DenoisingStage(PipelineStage):
         ):
             self.save_sta_search_results(batch)
 
+        # Capture references before potential deletion on MPS
+        dits = list(filter(None, [self.transformer, self.transformer_2]))
+
         # deallocate transformer if on mps
         pipeline = self.pipeline() if self.pipeline else None
         if torch.backends.mps.is_available() and not is_warmup:
@@ -773,7 +776,7 @@ class DenoisingStage(PipelineStage):
             )
 
         # reset offload managers with prefetching first layer for next forward
-        for dit in filter(None, [self.transformer, self.transformer_2]):
+        for dit in dits:
             if isinstance(dit, OffloadableDiTMixin):
                 # release all DiT weights to avoid peak VRAM usage, which may increasing the latency for next req
                 # TODO: should be make this an option?

--- a/python/sglang/srt/configs/device_config.py
+++ b/python/sglang/srt/configs/device_config.py
@@ -5,13 +5,15 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+SUPPORTED_DEVICES = ["cuda", "xpu", "hpu", "cpu", "npu", "musa", "mps"]
+
 
 class DeviceConfig:
     device: Optional[torch.device]
     gpu_id: Optional[int]
 
     def __init__(self, device: str = "cuda", gpu_id: int = -1) -> None:
-        if device in ["cuda", "xpu", "hpu", "cpu", "npu", "musa", "mps"]:
+        if device in SUPPORTED_DEVICES:
             self.device_type = device
         else:
             raise RuntimeError(f"Not supported device type: {device}")

--- a/python/sglang/srt/configs/device_config.py
+++ b/python/sglang/srt/configs/device_config.py
@@ -11,7 +11,7 @@ class DeviceConfig:
     gpu_id: Optional[int]
 
     def __init__(self, device: str = "cuda", gpu_id: int = -1) -> None:
-        if device in ["cuda", "xpu", "hpu", "cpu", "npu", "musa"]:
+        if device in ["cuda", "xpu", "hpu", "cpu", "npu", "musa", "mps"]:
             self.device_type = device
         else:
             raise RuntimeError(f"Not supported device type: {device}")

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -305,6 +305,9 @@ class Envs:
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
 
+    # MPS (Apple Silicon)
+    SGLANG_USE_MLX = EnvBool(False)
+
     # NPU
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -15,6 +15,7 @@ from sglang.srt.utils import (
     is_cpu,
     is_cuda,
     is_hip,
+    is_mps,
     is_musa,
     is_npu,
     is_xpu,
@@ -31,6 +32,7 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_xpu = is_xpu()
 _is_musa = is_musa()
+_is_mps = is_mps()
 
 if _is_cuda:
     from sglang.jit_kernel.rope import apply_rope_with_cos_sin_cache_inplace
@@ -70,6 +72,7 @@ class RotaryEmbedding(MultiPlatformOp):
             and not (_is_xpu)
             and not (_is_npu)
             and not (_is_musa)
+            and not (_is_mps)
         ):
             # rotary_embedding from sglang.jit_kernel.pos_enc and vllm._custom_ops has the same implementation.
             # TODO: Test on different devices and remove this conditional.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -31,7 +31,6 @@ import torch
 import torch.distributed
 import zmq
 from torch.cuda import Stream as CudaStream
-from torch.cuda import StreamContext as CudaStreamContext
 from torch.distributed import barrier
 
 from sglang.srt.configs.model_config import ModelConfig
@@ -201,6 +200,7 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_int_env_var,
     get_zmq_socket,
+    is_mps,
     kill_itself_when_parent_died,
     numa_bind_to_node,
     point_to_point_pyobj,
@@ -216,6 +216,11 @@ from sglang.srt.utils.hf_transformers_utils import (
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
+
+if is_mps():
+    CudaStreamContext = nullcontext
+else:
+    from torch.cuda import StreamContext as CudaStreamContext
 
 logger = logging.getLogger(__name__)
 
@@ -3204,8 +3209,6 @@ def run_scheduler_process(
         scheduler.schedule_stream = scheduler.device_module.Stream(priority=0)
         if scheduler.device == "cpu":
             scheduler.schedule_stream.synchronize = lambda: None  # No-op for CPU
-        elif scheduler.device == "mps":
-            CudaStreamContext = nullcontext  # MPS has no stream context
         with CudaStreamContext(scheduler.schedule_stream):
             dispatch_event_loop(scheduler)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -20,6 +20,7 @@ import signal
 import sys
 import time
 from collections import deque
+from contextlib import nullcontext
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, Deque, List, Optional, Tuple, Union
@@ -3203,6 +3204,8 @@ def run_scheduler_process(
         scheduler.schedule_stream = scheduler.device_module.Stream(priority=0)
         if scheduler.device == "cpu":
             scheduler.schedule_stream.synchronize = lambda: None  # No-op for CPU
+        elif scheduler.device == "mps":
+            CudaStreamContext = nullcontext  # MPS has no stream context
         with CudaStreamContext(scheduler.schedule_stream):
             dispatch_event_loop(scheduler)
 

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -23,12 +23,13 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     NSATokenToKVPool,
 )
-from sglang.srt.utils import is_cuda, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
-if not (_is_npu or _is_xpu):
+_is_mps = is_mps()
+if not (_is_npu or _is_xpu or _is_mps):
     from sgl_kernel.kvcacheio import (
         transfer_kv_all_layer,
         transfer_kv_all_layer_direct_lf_pf,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -929,8 +929,8 @@ class ServerArgs:
         # 5. Pipeline parallelism
         if self.pp_size > 1:
             self.disable_piecewise_cuda_graph = True
-        # 6. Non-CUDA hardware (AMD, NPU, CPU, etc.)
-        if is_hip() or is_npu() or is_cpu():
+        # 6. Non-CUDA hardware (AMD, NPU, CPU, MPS, etc.)
+        if is_hip() or is_npu() or is_cpu() or is_mps():
             self.disable_piecewise_cuda_graph = True
         # 7. MoE A2A backend
         if self.moe_a2a_backend != "none":

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -52,6 +52,7 @@ from sglang.srt.utils.common import (
     is_hip,
     is_hopper_with_cuda_12_3,
     is_mps,
+    is_musa,
     is_no_spec_infer_or_topk_one,
     is_npu,
     is_remote_url,
@@ -929,8 +930,8 @@ class ServerArgs:
         # 5. Pipeline parallelism
         if self.pp_size > 1:
             self.disable_piecewise_cuda_graph = True
-        # 6. Non-CUDA hardware (AMD, NPU, CPU, MPS, etc.)
-        if is_hip() or is_npu() or is_cpu() or is_mps():
+        # 6. Non-CUDA hardware (AMD, NPU, CPU, MPS, MUSA, etc.)
+        if is_hip() or is_npu() or is_cpu() or is_mps() or is_musa():
             self.disable_piecewise_cuda_graph = True
         # 7. MoE A2A backend
         if self.moe_a2a_backend != "none":

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1955,10 +1955,10 @@ class ServerArgs:
                 # TODO current aiter only support head number 16 or 128 head number
                 if head_num == 128 or head_num == 16:
                     return "aiter"
-                elif is_mps():
-                    return "torch_native"
                 else:
                     return "triton"
+            elif is_mps():
+                return "torch_native"
             else:
                 return "triton"
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -51,6 +51,7 @@ from sglang.srt.utils.common import (
     is_flashinfer_available,
     is_hip,
     is_hopper_with_cuda_12_3,
+    is_mps,
     is_no_spec_infer_or_topk_one,
     is_npu,
     is_remote_url,
@@ -1939,6 +1940,8 @@ class ServerArgs:
                 return "trtllm_mha"
             elif is_hip():
                 return "aiter"
+            elif is_mps():
+                return "torch_native"
             else:
                 return "flashinfer" if is_flashinfer_available() else "triton"
         else:
@@ -1952,6 +1955,8 @@ class ServerArgs:
                 # TODO current aiter only support head number 16 or 128 head number
                 if head_num == 128 or head_num == 16:
                     return "aiter"
+                elif is_mps():
+                    return "torch_native"
                 else:
                     return "triton"
             else:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -196,6 +196,11 @@ def is_musa() -> bool:
     return hasattr(torch.version, "musa") and torch.version.musa is not None
 
 
+@lru_cache(maxsize=1)
+def is_mps() -> bool:
+    return torch.backends.mps.is_available()
+
+
 def is_float4_e2m1fn_x2(dtype) -> bool:
     """Check if dtype is float4_e2m1fn_x2 and CUDA is available."""
     target_dtype = getattr(torch, "float4_e2m1fn_x2", None)
@@ -598,6 +603,8 @@ def get_available_gpu_memory(
             # memory metric instead.
             free_gpu_memory = psutil.virtual_memory().available
         free_gpu_memory, total_gpu_memory = torch.musa.mem_get_info()
+    elif device == "mps":
+        free_gpu_memory = psutil.virtual_memory().available
 
     if distributed:
         tensor = torch.tensor(free_gpu_memory, dtype=torch.float32)
@@ -2056,7 +2063,10 @@ def get_device(device_id: Optional[int] = None) -> str:
             return "musa"
         return "musa:{}".format(device_id)
 
-    raise RuntimeError("No accelerator (CUDA, XPU, HPU, NPU, MUSA) is available.")
+    if is_mps():
+        return "mps"
+
+    raise RuntimeError("No accelerator (CUDA, XPU, HPU, NPU, MUSA, MPS) is available.")
 
 
 @lru_cache(maxsize=1)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2064,7 +2064,9 @@ def get_device(device_id: Optional[int] = None) -> str:
         return "musa:{}".format(device_id)
 
     if is_mps():
-        return "mps"
+        if device_id is None:
+            return "mps"
+        return "mps:{}".format(device_id)
 
     raise RuntimeError("No accelerator (CUDA, XPU, HPU, NPU, MUSA, MPS) is available.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Make SGLang run natively on macOS: https://github.com/sgl-project/sglang/issues/19185

## Modifications

<!-- Detail the changes made in this pull request. -->
Since Triton is not available on macOS, Triton kernels cannot be used at all — not even as a fallback. There are 200+ places in the codebase that import Triton, so a Triton stub (`_triton_stub.py`) is introduced to keep those import paths working without errors.

For the actual kernel implementations, the NPU backend already handles similar cases where Triton is not working by providing pure-PyTorch native fallbacks. I followed the same pattern for MPS, with platform-specific fallback modules (`npu_fallback.py` for NPU, `mps_fallback.py` for MPS) that replace the Triton kernels at import time.

On the MPS side, norm ops can optionally be accelerated using MLX (`mx.fast.rms_norm` / `mx.fast.layer_norm`), which are single fused Metal kernels that avoid the multi-step decomposition PyTorch MPS performs. This is gated behind `SGLANG_USE_MLX=1` and yields ~13% faster denoising steps in end-to-end benchmarks.

Additionally, `torch.mps` exposes a more limited API surface compared to `torch.cuda`, `torch.npu`, or `torch.musa`. Some APIs (e.g., `Stream`, `set_device`, `get_device_properties`, and memory tracking) need to be stubbed via `_mps_stub.py` to ensure the code runs correctly on macOS.

### MLX Related Issues

https://github.com/sgl-project/sglang/issues/17846 https://github.com/sgl-project/sglang/issues/17846 https://github.com/sgl-project/sglang/issues/19137

### References

* [Triton only supports Linux](https://github.com/triton-lang/triton?tab=readme-ov-file#compatibility)
* [torch.mps.* API](https://docs.pytorch.org/docs/stable/mps.html)
* [mlx.core.fast.*](https://ml-explore.github.io/mlx/build/html/python/fast.html)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified `black-forest-labs/FLUX.1-dev` on macOS (with and without `SGLANG_USE_MLX=1`), the image generation works correctly. Appreciate @weiqiangt's help!

<img width="1280" height="720" alt="gen" src="https://github.com/user-attachments/assets/dcb194ba-f755-4e39-864a-446e332763c2" />

```bash
> sglang generate --model-path black-forest-labs/FLUX.1-dev \
    --prompt "A logo With Bold Large text: SGL Diffusion" \
    --save-output
/Users/weiqiangt/sglang/python/sglang/srt/layers/attention/fla/utils.py:212: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
W0303 21:40:35.983000 66330 torch/distributed/elastic/multiprocessing/redirects.py:29] NOTE: Redirects are currently not supported in Windows or MacOs.
/Users/weiqiangt/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")
/Users/weiqiangt/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")
/Users/weiqiangt/sglang/.venv/lib/python3.11/site-packages/torch/amp/autocast_mode.py:270: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
[03-03 21:40:43] Disabling some offloading (except dit, text_encoder) for image generation model
[03-03 21:40:43] server_args: {"model_path": "black-forest-labs/FLUX.1-dev", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": false, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "disable_autocast": true, "master_port": 30008, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5631, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "log_level": "info"}
[03-03 21:40:43] Local mode: True
[03-03 21:40:43] Starting server...
/Users/weiqiangt/sglang/python/sglang/srt/layers/attention/fla/utils.py:212: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
W0303 21:40:46.232000 66352 torch/distributed/elastic/multiprocessing/redirects.py:29] NOTE: Redirects are currently not supported in Windows or MacOs.
/Users/weiqiangt/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")
/Users/weiqiangt/sglang/python/sglang/srt/layers/quantization/gguf.py:47: UserWarning: Only CUDA support GGUF quantization currently.
  warnings.warn(f"Only CUDA support GGUF quantization currently.")
/Users/weiqiangt/sglang/.venv/lib/python3.11/site-packages/torch/amp/autocast_mode.py:270: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
[03-03 21:40:47] Scheduler bind at endpoint: tcp://127.0.0.1:5631
[03-03 21:40:47] Initializing distributed environment with world_size=1, device=mps, timeout=3600
[03-03 21:40:47] Setting distributed timeout to 3600 seconds
[03-03 21:40:47] No pipeline_class_name specified, using model_index.json
'(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: d768f3d5-f7d6-4573-8120-f257d2934bc4)')' thrown while requesting HEAD https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/main/model_index.json
[03-03 21:40:57] '(ReadTimeoutError("HTTPSConnectionPool(host='huggingface.co', port=443): Read timed out. (read timeout=10)"), '(Request ID: d768f3d5-f7d6-4573-8120-f257d2934bc4)')' thrown while requesting HEAD https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/main/model_index.json
Retrying in 1s [Retry 1/5].
[03-03 21:40:57] Retrying in 1s [Retry 1/5].
[03-03 21:41:03] Using pipeline from model_index.json: FluxPipeline
[03-03 21:41:03] Loading pipeline modules...
[03-03 21:41:03] Checking for cached model in HF Hub cache for black-forest-labs/FLUX.1-dev...
[03-03 21:41:03] Found complete model in cache at /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21
[03-03 21:41:03] Model path: /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21
[03-03 21:41:03] Diffusers version: 0.30.0.dev0
[03-03 21:41:03] Loading pipeline modules from config: {'_class_name': 'FluxPipeline', '_diffusers_version': '0.30.0.dev0', 'scheduler': ['diffusers', 'FlowMatchEulerDiscreteScheduler'], 'text_encoder': ['transformers', 'CLIPTextModel'], 'text_encoder_2': ['transformers', 'T5EncoderModel'], 'tokenizer': ['transformers', 'CLIPTokenizer'], 'tokenizer_2': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'FluxTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderKL']}
[03-03 21:41:03] Loading required components: ['text_encoder', 'text_encoder_2', 'tokenizer', 'tokenizer_2', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                                                                                                         | 0/7 [00:00<?, ?it/s][03-03 21:41:03] Loading text_encoder from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/text_encoder. avail mem: 94.66 GB
[03-03 21:41:03] Using Torch SDPA backend for MPS.

Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  6.21it/s]

[03-03 21:41:04] Disabling FSDP sharding for MPS platform as it's not compatible
[03-03 21:41:04] Loaded text_encoder: CLIPTextModel (sgl-diffusion version). model size: 0.23 GB, consumed GPU mem: 1.44 GB, avail GPU mem: 93.22 GB
Loading required modules:  14%|█████████████████████████▎                                                                                                                                                       | 1/7 [00:00<00:01,  4.98it/s][03-03 21:41:04] Loading text_encoder_2 from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/text_encoder_2. avail mem: 93.22 GB

Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:02<00:02,  2.12s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:04<00:00,  2.04s/it]

[03-03 21:41:08] Disabling FSDP sharding for MPS platform as it's not compatible
[03-03 21:41:08] Loaded text_encoder_2: T5EncoderModel (sgl-diffusion version). model size: 8.87 GB, consumed GPU mem: 12.71 GB, avail GPU mem: 80.51 GB
Loading required modules:  29%|██████████████████████████████████████████████████▌                                                                                                                              | 2/7 [00:04<00:12,  2.49s/it][03-03 21:41:08] Loading tokenizer from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/tokenizer. avail mem: 80.51 GB
[03-03 21:41:08] Loaded tokenizer: CLIPTokenizerFast (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.02 GB, avail GPU mem: 80.49 GB
[03-03 21:41:08] Loading tokenizer_2 from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/tokenizer_2. avail mem: 80.49 GB
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
[03-03 21:41:08] Loaded tokenizer_2: T5TokenizerFast (sgl-diffusion version). model size: NA GB, consumed GPU mem: -3.95 GB, avail GPU mem: 84.44 GB
Loading required modules:  57%|█████████████████████████████████████████████████████████████████████████████████████████████████████▏                                                                           | 4/7 [00:04<00:03,  1.09s/it][03-03 21:41:08] Loading vae from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/vae. avail mem: 84.44 GB
[03-03 21:41:08] Loaded vae: AutoencoderKL (sgl-diffusion version). model size: 0.31 GB, consumed GPU mem: 0.73 GB, avail GPU mem: 83.72 GB
Loading required modules:  71%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▍                                                  | 5/7 [00:04<00:01,  1.26it/s][03-03 21:41:08] Loading transformer from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/transformer. avail mem: 83.72 GB
[03-03 21:41:08] Loading FluxTransformer2DModel from 3 safetensors file(s) , param_dtype: torch.bfloat16
[03-03 21:41:08] Using Torch SDPA backend for MPS.
[03-03 21:41:09] Disabling FSDP for MPS platform as it's not compatible

Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:00<00:00, 33.80it/s]

[03-03 21:41:20] Loaded model with 11.90B parameters
[03-03 21:41:20] Loaded transformer: FluxTransformer2DModel (sgl-diffusion version). model size: 22.17 GB, consumed GPU mem: 7.89 GB, avail GPU mem: 75.83 GB
Loading required modules:  86%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋                         | 6/7 [00:16<00:04,  4.22s/it][03-03 21:41:20] Loading scheduler from /Users/weiqiangt/.cache/huggingface/hub/models--black-forest-labs--FLUX.1-dev/snapshots/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/scheduler. avail mem: 75.83 GB
[03-03 21:41:20] Loaded scheduler: FlowMatchEulerDiscreteScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: -0.00 GB, avail GPU mem: 75.83 GB
Loading required modules: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:16<00:00,  2.42s/it]
[03-03 21:41:20] Creating pipeline stages...
[03-03 21:41:20] Using Torch SDPA backend for MPS.
[03-03 21:41:20] Pipeline instantiated
[03-03 21:41:20] Worker 0: Initialized device, model, and distributed environment.
[03-03 21:41:20] Worker 0: Scheduler loop started.
[03-03 21:41:21] Processing prompt 1/1: A logo With Bold Large text: SGL Diffusion
[03-03 21:41:21] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage_primary', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[03-03 21:41:21] [InputValidationStage] started...
[03-03 21:41:21] [InputValidationStage] finished in 0.0000 seconds
[03-03 21:41:21] [TextEncodingStage] started...
[03-03 21:41:21] [TextEncodingStage] finished in 0.1337 seconds
[03-03 21:41:21] [TimestepPreparationStage] started...
[03-03 21:41:21] [TimestepPreparationStage] finished in 0.0027 seconds
[03-03 21:41:21] [LatentPreparationStage] started...
[03-03 21:41:21] [LatentPreparationStage] finished in 0.0020 seconds
[03-03 21:41:21] [DenoisingStage] started...
  0%|                                                                                                                                                                                                                  | 0/50 [00:00<?, ?it/s]/Users/weiqiangt/sglang/python/sglang/multimodal_gen/runtime/models/dits/flux.py:393: UserWarning: FlashInfer not available, using Triton fallback for RoPE
  query, key = apply_flashinfer_rope_qk_inplace(
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [06:25<00:00,  7.71s/it]
[03-03 21:47:47] [DenoisingStage] average time per step: 7.7094 seconds
[03-03 21:47:47] Memory before deallocating transformer: 33963322624
[03-03 21:47:47] Memory after deallocating transformer: 33963322624
[03-03 21:47:47] [DenoisingStage] finished in 385.4929 seconds
[03-03 21:47:47] [DecodingStage] started...
/Users/weiqiangt/sglang/.venv/lib/python3.11/site-packages/torch/amp/autocast_mode.py:350: UserWarning: In MPS autocast, but the target dtype is not supported. Disabling autocast.
MPS Autocast only supports dtype of torch.bfloat16 and torch.float16 currently.
  warnings.warn(error_message)
[03-03 21:47:49] [DecodingStage] finished in 2.0959 seconds
[03-03 21:47:49] Peak GPU memory: 43.13 GB, Peak allocated: 31.65 GB, Memory pool overhead: 11.49 GB (26.6%), Remaining GPU memory at peak: 84.87 GB. Components that could stay resident (based on the last request workload): ['text_encoder', 'text_encoder_2', 'transformer']. Related offload server args to disable: --dit-cpu-offload, --text-encoder-cpu-offload
[03-03 21:47:51] Output saved to outputs/A_logo_With_Bold_Large_text_SGL_Diffusion_20260303-214121_84e56531.png
[03-03 21:47:51] Pixel data generated successfully in 390.42 seconds
[03-03 21:47:51] Completed batch processing. Generated 1 outputs in 390.42 seconds
[03-03 21:47:51] Memory usage - Max peak: 44167.20 MB, Avg peak: 44167.20 MB
[03-03 21:47:51] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
[03-03 21:47:51] Worker 0: Shutdown complete.
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
