### PR TITLE
[AMD] Remove Redundant tvm-ffi Installation in amd_ci_install_dependency.sh

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -167,9 +167,9 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache huggingface_hub[hf_xet]
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache pytest
 
-  # Install tvm-ffi for JIT kernel support (QK-norm, etc.)
+  # Install tvm-ffi@a8f0540556794d39a7e260977948c6719a7648e2 for JIT kernel support (QK-norm, etc.)
   echo "Installing tvm-ffi for JIT kernel support..."
-  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache git+https://github.com/apache/tvm-ffi.git || echo "tvm-ffi installation failed, JIT kernels will use fallback"
+  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache git+https://github.com/apache/tvm-ffi.git@a8f0540556794d39a7e260977948c6719a7648e2 || echo "tvm-ffi installation failed, JIT kernels will use fallback"
 
   # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204)
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache cache-dit || echo "cache-dit installation failed"

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -167,10 +167,6 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache huggingface_hub[hf_xet]
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache pytest
 
-  # Install tvm-ffi@a8f0540556794d39a7e260977948c6719a7648e2 for JIT kernel support (QK-norm, etc.)
-  echo "Installing tvm-ffi for JIT kernel support..."
-  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache git+https://github.com/apache/tvm-ffi.git@a8f0540556794d39a7e260977948c6719a7648e2 || echo "tvm-ffi installation failed, JIT kernels will use fallback"
-
   # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204)
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache cache-dit || echo "cache-dit installation failed"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
`registered/amd/test_deepseek_v32_basic.py` test failed on 20260228, the reason is because the CI install dependency script was running `pip install git+https://github.com/apache/tvm-ffi.git` without pinning a version, which pulled the latest code from main. 

The new `tvm-ffi` API broke `tilelang's is_var()` function, causing `AttributeError: 'Var' object has no attribute 'scope'` during tilelang JIT compilation of the `act_quant_kernel` used by the NSA indexer in DeepSeek V3.2.

On 20260228, in the failed CI run, `tvm-ffi` commit is `ac80ea39735f0284451141837de23dff99b95129`:
<img width="2309" height="1840" alt="image" src="https://github.com/user-attachments/assets/b7510269-27b1-45ea-911e-ecc8e8a5de8a" />
<img width="1991" height="1686" alt="image" src="https://github.com/user-attachments/assets/aacf5950-88be-4321-9e92-e72731c4a1ce" />
https://github.com/sgl-project/sglang/actions/runs/22513119574/job/65226247000#step:7:10036

On 20260227, in the passed CI run, `tvm-ffi` commit is `a8f0540556794d39a7e260977948c6719a7648e2`  
<img width="2181" height="1507" alt="image" src="https://github.com/user-attachments/assets/e88d831b-1c83-418a-a0e1-a68e930dafde" />
https://github.com/sgl-project/sglang/actions/runs/22483542788/job/65127451554#step:5:1053

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
The Docker image already has `apache-tvm-ffi` pinned to a compatible commit (37d0485) via PR #19359. So we can remove the redundant `tvm-ffi` installation.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
