### PR TITLE
[EPD][Perf]: support async_send_embedding_port

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -144,7 +144,7 @@ class WaitingImageRequest:
         self.error_code = None
         self.start_time = time.time()
 
-    def send_encode_request(self):
+    async def _send_embedding_port(self):
         async def _send_single_request(session, url, payload):
             try:
                 async with session.post(url, json=payload) as response:
@@ -154,48 +154,41 @@ class WaitingImageRequest:
                 logger.error(f"Failed to send request to {url}: {e}")
                 raise
 
-        async def send_embedding_port(req_id, receive_count, host_name, embedding_port):
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=1800)
-            ) as session:
-                tasks = []
-                logger.info(f"{self.num_items_assigned = } ")
-                for idx, assigned_num in enumerate(self.num_items_assigned):
-                    if assigned_num == 0:
-                        continue
-                    encoder_url = self.encoder_urls[idx]
-                    target_url = f"{encoder_url}/scheduler_receive_url"
-                    payload = {
-                        "req_id": req_id,
-                        "receive_count": receive_count,
-                        "receive_url": f"{host_name}:{embedding_port}",
-                    }
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=1800)
+        ) as session:
+            tasks = []
+            logger.info(f"{self.num_items_assigned = } ")
+            for idx, assigned_num in enumerate(self.num_items_assigned):
+                if assigned_num == 0:
+                    continue
+                encoder_url = self.encoder_urls[idx]
+                target_url = f"{encoder_url}/scheduler_receive_url"
+                payload = {
+                    "req_id": self.recv_req.rid,
+                    "receive_count": self.receive_count,
+                    "receive_url": f"{self.host_name}:{self.embedding_port}",
+                }
+                logger.info(f"Preparing to send  to {target_url}")
+                task = _send_single_request(session, target_url, payload)
+                tasks.append(task)
 
-                    logger.info(f"Preparing to send  to {target_url}")
+            if not tasks:
+                logger.info("No tasks to send.")
+                return
+            logger.info(f"Concurrently sending {len(tasks)} requests...")
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    logger.error(f"Request {i} failed: {result}")
+                else:
+                    logger.debug(f"Request {i} succeeded.")
 
-                    task = _send_single_request(session, target_url, payload)
-                    tasks.append(task)
+    def send_encode_request(self):
+        def _run():
+            asyncio.run(self._send_embedding_port())
 
-                if not tasks:
-                    logger.info("No tasks to send.")
-                    return
-                logger.info(f"Concurrently sending {len(tasks)} requests...")
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-
-                for i, result in enumerate(results):
-                    if isinstance(result, Exception):
-                        logger.error(f"Request {i} failed: {result}")
-                    else:
-                        logger.debug(f"Request {i} succeeded.")
-
-        asyncio.run(
-            send_embedding_port(
-                self.recv_req.rid,
-                self.receive_count,
-                self.host_name,
-                self.embedding_port,
-            )
-        )
+        threading.Thread(target=_run).start()
 
     def _try_recv_mm_data(self):
         if self.status != WaitingImageRequestStatus.PENDING:

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -186,9 +186,16 @@ class WaitingImageRequest:
 
     def send_encode_request(self):
         def _run():
-            asyncio.run(self._send_embedding_port())
+            try:
+                asyncio.run(self._send_embedding_port())
+            except Exception:
+                logger.error(
+                    f"Error in _send_embedding_port thread for request {self.rid}",
+                    exc_info=True,
+                )
 
-        threading.Thread(target=_run).start()
+        self.thread = threading.Thread(target=_run, daemon=True)
+        self.thread.start()
 
     def _try_recv_mm_data(self):
         if self.status != WaitingImageRequestStatus.PENDING:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In disaggregated encoding (e.g. `zmq_to_scheduler`), when the scheduler notifies encoder nodes of the embedding receive URL/port, it previously did so synchronously: `send_encode_request()` called `asyncio.run(send_embedding_port(...))`, blocking the calling thread until all HTTP requests to encoder nodes completed. This could add latency and block other work on the scheduler. 

## Modifications

Renamed and refactored the embedding-port send logic into an async method `_send_embedding_port()` . And `send_encode_request()` now starts a background thread that runs `asyncio.run(self._send_embedding_port())`, so sending the embedding port to encoder nodes is non-blocking.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
Tested on: Qwen3-VL-235B-A22B-FP8.
Reduce TTFT ~20% under similar request-rate (scheduler no longer blocks on embedding-port HTTP notifications).
Model launch scripts:
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -m sglang.launch_server --model-path ${MODEL_PATH} --encoder-transfer-backend $TRANSFER_BACKEND \
         --host $HOST_IP --port ${PORT} --trust-remote-code --tp-size 4 --mem-fraction-static 0.65 \
         --enable-cache-report --log-level info --max-running-requests 32 --disable-radix-cache \
         --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics --max-prefill-tokens 128000 \
         --encoder-urls $ENCODE_URLS \
         --mm-attention-backend fa3 --language-only &> logs/run_prefill_${HOST_IP}_0.log &

CUDA_VISIBLE_DEVICES=4 python3 -m sglang.launch_server --model-path ${MODEL_PATH} --encoder-transfer-backend $TRANSFER_BACKEND \
         --host $HOST_IP --port 8091 --trust-remote-code --tp-size 1 --mem-fraction-static 0.7  \
         --enable-cache-report --log-level info --max-running-requests 128 --disable-radix-cache \
         --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics \
         --mm-attention-backend fa3 --encoder-only &> logs/run_encoder_1.log &



CUDA_VISIBLE_DEVICES=5 python3 -m sglang.launch_server --model-path ${MODEL_PATH} --encoder-transfer-backend $TRANSFER_BACKEND \
        --host $HOST_IP --port 8092 --trust-remote-code --tp-size 1 --mem-fraction-static 0.7  \
          --enable-cache-report --log-level info --max-running-requests 128 --disable-radix-cache \
          --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics \
          --mm-attention-backend fa3 --encoder-only &> logs/run_encoder_2.log &


CUDA_VISIBLE_DEVICES=6 python3 -m sglang.launch_server --model-path ${MODEL_PATH} --encoder-transfer-backend $TRANSFER_BACKEND \
           --host $HOST_IP --port 8093 --trust-remote-code --tp-size 1 --mem-fraction-static 0.7  \
           --enable-cache-report --log-level info --max-running-requests 64 --disable-radix-cache \
           --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics \
           --mm-attention-backend fa3 --encoder-only &> logs/run_encoder_3.log &

CUDA_VISIBLE_DEVICES=7 python3 -m sglang.launch_server --model-path ${MODEL_PATH} --encoder-transfer-backend $TRANSFER_BACKEND \
           --host $HOST_IP --port 8094 --trust-remote-code --tp-size 1 --mem-fraction-static 0.7  \
           --enable-cache-report --log-level info --max-running-requests 64 --disable-radix-cache \
           --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics \
           --mm-attention-backend fa3 --encoder-only &> logs/run_encoder_4.log &
```
bench script:
```bash
        input_len=1024
        num_prompt=64
        image_count=4
        output_len=128
        image_size=1080p
        qps=1
        python3 -m sglang.bench_serving \
                    --random-image-count \
                    --image-count $image_count \
                    --host ${HOST_IP} \
                    --port ${PORT} \
                    --model $MODEL_PATH \
                    --backend sglang-oai-chat \
                    --dataset-name "image" \
                    --random-input-len $input_len \
                    --random-output-len $output_len \
                    --random-range-ratio 1 \
                    --seed  $test_idx \
                    --num-prompt $num_prompt \
                    --warmup-requests 0 \
                    --flush-cache \
                    --image-resolution $image_size \
                    --image-format "jpeg" \
                    --image-content "random" \
                    --request-rate $qps \
                    --output-file $result_file \
                    --max-concurrency 16
```

Before:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    1.0
Max request concurrency:                 16
Successful requests:                     128
Benchmark duration (s):                  152.87
Total input tokens:                      1184549
Total input text tokens:                 139045
Total input vision tokens:               1045504
Total generated tokens:                  16384
Total generated tokens (retokenized):    2048
Request throughput (req/s):              0.84
Input token throughput (tok/s):          7748.82
Output token throughput (tok/s):         107.18
Peak output token throughput (tok/s):    704.00
Peak concurrent requests:                23
Total token throughput (tok/s):          7856.00
Concurrency:                             9.80
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11699.99
Median E2E Latency (ms):                 11862.11
P90 E2E Latency (ms):                    17457.81
P99 E2E Latency (ms):                    21349.52
---------------Time to First Token----------------
Mean TTFT (ms):                          5000.17
Median TTFT (ms):                        4541.54
P99 TTFT (ms):                           12312.73
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          52.75
Median TPOT (ms):                        56.79
P99 TPOT (ms):                           82.31
---------------Inter-Token Latency----------------
Mean ITL (ms):                           53.39
Median ITL (ms):                         15.53
P95 ITL (ms):                            33.19
P99 ITL (ms):                            772.77
Max ITL (ms):                            6551.82
==================================================
```
After:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    1.0       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  149.20    
Total input tokens:                      1184652   
Total input text tokens:                 139148    
Total input vision tokens:               1045504   
Total generated tokens:                  16384     
Total generated tokens (retokenized):    2048      
Request throughput (req/s):              0.86      
Input token throughput (tok/s):          7939.79   
Output token throughput (tok/s):         109.81    
Peak output token throughput (tok/s):    693.00    
Peak concurrent requests:                21        
Total token throughput (tok/s):          8049.59   
Concurrency:                             9.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   10496.22  
Median E2E Latency (ms):                 10921.64  
P90 E2E Latency (ms):                    15637.45  
P99 E2E Latency (ms):                    18369.40  
---------------Time to First Token----------------
Mean TTFT (ms):                          3931.03   
Median TTFT (ms):                        3194.59   
P99 TTFT (ms):                           9161.51   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.69     
Median TPOT (ms):                        55.53     
P99 TPOT (ms):                           82.22     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           52.25     
Median ITL (ms):                         15.52     
P95 ITL (ms):                            43.85     
P99 ITL (ms):                            516.35    
Max ITL (ms):                            6291.85   
==================================================
```
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
