### PR TITLE
[PP] Refactor Async Pipeline Parallelism

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1237,19 +1237,22 @@ class GroupCoordinator:
                 async_handle.wait()
         return tensor_dict
 
-    def send_tensor_dict(
+    def isend_tensor_dict(
         self,
         tensor_dict: Dict[str, Union[torch.Tensor, Any]],
         dst: Optional[int] = None,
         all_gather_group: Optional["GroupCoordinator"] = None,
-        async_send: bool = False,
-    ) -> Optional[List[P2PWork]]:
-        """Send the input tensor dictionary.
-        NOTE: `dst` is the local rank of the source rank.
+    ) -> List["P2PWork"]:
         """
-        # Bypass the function if we are using only 1 GPU.
-        if self.world_size == 1:
-            return tensor_dict
+        Non-blocking send of a tensor dictionary. Returns a list of P2PWork
+        handles that the caller must wait on before the send buffers can be
+        reused or freed.
+
+        This is the async building-block; send_tensor_dict() is a
+        synchronous wrapper around this method.
+        """
+        if self.world_size <= 1:
+            return []
 
         all_gather_size = 1 if all_gather_group is None else all_gather_group.world_size
         all_gather_rank = (
@@ -1263,46 +1266,89 @@ class GroupCoordinator:
             dst = (self.rank_in_group + 1) % self.world_size
         assert dst < self.world_size, f"Invalid dst rank ({dst})"
 
-        assert isinstance(
-            tensor_dict, dict
-        ), f"Expecting a dictionary, got {type(tensor_dict)}"
         metadata_list, tensor_list = _split_tensor_dict(tensor_dict)
-        # Note: While switching to Device-to-Device (D2D) would introduce an extra
-        # Device-to-Host (D2H) memory copy overhead for serialization, our benchmarks
-        # show better overall transmission performance with D2D due to:
-        # 1. Superior D2D transfer bandwidth
-        # 2. Ability to overlap send and recv operations
-        # Thus the net performance gain justifies this approach.
 
-        send_func = torch.distributed.isend if async_send else torch.distributed.send
-        p2p_works = self.send_object(metadata_list, dst=dst, async_send=async_send)
+        # Async send metadata (pickle object on CPU)
+        p2p_works = self.send_object(metadata_list, dst=dst, async_send=True)
 
         for tensor in tensor_list:
             if tensor.numel() == 0:
-                # Skip sending empty tensors.
                 continue
-
-            # send-allgather: send only a slice, then do allgather.
             if all_gather_group is not None and tensor.numel() % all_gather_size == 0:
                 tensor = tensor.reshape(all_gather_size, -1)[all_gather_rank]
 
             comm_group = metadata_group if tensor.is_cpu else group
-            work = send_func(tensor, self.ranks[dst], group=comm_group)
-            if async_send:
-                p2p_works.append(P2PWork(work, tensor))
+            work = torch.distributed.isend(tensor, self.ranks[dst], group=comm_group)
+
+            if tensor.is_cuda:
+                tensor.record_stream(torch.cuda.current_stream(tensor.device))
+
+            p2p_works.append(P2PWork(work, tensor))
+
         return p2p_works
 
-    def recv_tensor_dict(
+    def send_tensor_dict(
+        self,
+        tensor_dict: Dict[str, Union[torch.Tensor, Any]],
+        dst: Optional[int] = None,
+        all_gather_group: Optional["GroupCoordinator"] = None,
+        async_send: bool = False,
+    ) -> Optional[List[P2PWork]]:
+        """Send the input tensor dictionary.
+        NOTE: `dst` is the local rank of the destination rank.
+
+        When async_send=True, returns a list of P2PWork handles.
+        When async_send=False (default), blocks until all sends complete.
+        """
+        if self.world_size == 1:
+            return tensor_dict if not async_send else []
+
+        handles = self.isend_tensor_dict(
+            tensor_dict,
+            dst=dst,
+            all_gather_group=all_gather_group,
+        )
+
+        # Async mode
+        if async_send:
+            return handles
+
+        # Sync mode
+        for h in handles:
+            if h.work is not None:
+                h.work.wait()
+        return None
+
+    def irecv_tensor_dict(
         self,
         src: Optional[int] = None,
         all_gather_group: Optional["GroupCoordinator"] = None,
-    ) -> Optional[Dict[str, Union[torch.Tensor, Any]]]:
-        """Recv the input tensor dictionary.
-        NOTE: `src` is the local rank of the source rank.
+    ) -> Tuple[
+        Optional[Dict[str, Union[torch.Tensor, Any]]],
+        List[torch.distributed.Work],
+        List[Callable[[], None]],
+    ]:
         """
-        # Bypass the function if we are using only 1 GPU.
-        if not torch.distributed.is_initialized() or self.world_size == 1:
-            return None
+        Non-blocking receive of a tensor dictionary.
+
+        Returns:
+            tensor_dict: pre-allocated tensor dict (tensor data is not ready yet,
+                        need to wait until handles complete）
+            handles:     irecv's work object list, caller needs to wait
+            postprocess: the function list to be executed after wait completed
+                        (used by all_gather to rebuild complete tensor)
+
+        Usage:
+            tensor_dict, handles, postprocess = pp_group.irecv_tensor_dict(src=src)
+            # ... here can do overlap to perform computation ...
+            for h in handles:
+                h.wait()
+            for fn in postprocess:
+                fn()
+            # till now data in tensor_dict is ready
+        """
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            return None, [], []
 
         all_gather_size = 1 if all_gather_group is None else all_gather_group.world_size
         all_gather_rank = (
@@ -1316,40 +1362,85 @@ class GroupCoordinator:
             src = (self.rank_in_group - 1) % self.world_size
         assert src < self.world_size, f"Invalid src rank ({src})"
 
+        # recv metadata
         recv_metadata_list = self.recv_object(src=src)
+
         tensor_dict: Dict[str, Any] = {}
+        handles: List[torch.distributed.Work] = []
+        postprocess: List[Callable[[], None]] = []
+
         for key, value in recv_metadata_list:
             if isinstance(value, TensorMetadata):
-                tensor = torch.empty(value.size, dtype=value.dtype, device=value.device)
-                if tensor.numel() == 0:
-                    # Skip broadcasting empty tensors.
-                    tensor_dict[key] = tensor
+                full_tensor = torch.empty(
+                    value.size, dtype=value.dtype, device=value.device
+                )
+                if full_tensor.numel() == 0:
+                    tensor_dict[key] = full_tensor
                     continue
 
-                # send-allgather: send only a slice, then do allgather.
+                # send-allgather
                 use_all_gather = (
                     all_gather_group is not None
-                    and tensor.numel() % all_gather_size == 0
+                    and full_tensor.numel() % all_gather_size == 0
                 )
 
                 if use_all_gather:
-                    orig_shape = tensor.shape
-                    tensor = tensor.reshape(all_gather_size, -1)[all_gather_rank]
+                    orig_shape = full_tensor.shape
+                    slice_tensor = full_tensor.reshape(all_gather_size, -1)[
+                        all_gather_rank
+                    ]
+                    comm_group = metadata_group if slice_tensor.is_cpu else group
+                    handle = torch.distributed.irecv(
+                        slice_tensor, src=self.ranks[src], group=comm_group
+                    )
+                    handles.append(handle)
 
-                # We have to use irecv here to make it work for both isend and send.
-                comm_group = metadata_group if tensor.is_cpu else group
-                work = torch.distributed.irecv(
-                    tensor, src=self.ranks[src], group=comm_group
-                )
-                work.wait()
+                    def _postprocess(
+                        key=key,
+                        slice_tensor=slice_tensor,
+                        orig_shape=tuple(orig_shape),
+                        all_gather_group=all_gather_group,
+                    ):
+                        assert all_gather_group is not None
+                        tensor_dict[key] = all_gather_group.all_gather(
+                            slice_tensor, dim=0
+                        ).reshape(orig_shape)
 
-                if use_all_gather:
-                    tensor = all_gather_group.all_gather(tensor, dim=0)
-                    tensor = tensor.reshape(orig_shape)
-
-                tensor_dict[key] = tensor
+                    postprocess.append(_postprocess)
+                    tensor_dict[key] = slice_tensor
+                else:
+                    comm_group = metadata_group if full_tensor.is_cpu else group
+                    handle = torch.distributed.irecv(
+                        full_tensor, src=self.ranks[src], group=comm_group
+                    )
+                    handles.append(handle)
+                    tensor_dict[key] = full_tensor
             else:
                 tensor_dict[key] = value
+
+        return tensor_dict, handles, postprocess
+
+    def recv_tensor_dict(
+        self,
+        src: Optional[int] = None,
+        all_gather_group: Optional["GroupCoordinator"] = None,
+    ) -> Optional[Dict[str, Union[torch.Tensor, Any]]]:
+        """Recv the input tensor dictionary (synchronous wrapper).
+        NOTE: `src` is the local rank of the source rank.
+        """
+        if not torch.distributed.is_initialized() or self.world_size == 1:
+            return None
+
+        tensor_dict, handles, postprocess = self.irecv_tensor_dict(
+            src=src,
+            all_gather_group=all_gather_group,
+        )
+
+        for handle in handles:
+            handle.wait()
+        for fn in postprocess:
+            fn()
+
         return tensor_dict
 
     def barrier(self):

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -90,9 +90,13 @@ class SchedulerPPMixin:
                     self.mbs[mb_id] = self.get_next_batch_to_run()
                 self.running_mbs[mb_id] = self.running_batch
                 self.cur_batch: Optional[ScheduleBatch] = self.mbs[mb_id]
+
+                # Async pp processing
+                proxy_recv_state = None
                 if self.cur_batch:
                     server_is_idle = False
-                    pp_proxy_tensors = self._pp_recv_proxy_tensors()
+                    proxy_recv_state = self._pp_irecv_proxy_tensors()
+
                 next_pp_outputs = None
                 next_batch_result = None
                 d2h_event = None
@@ -104,13 +108,16 @@ class SchedulerPPMixin:
                         )
                     )
                 self._pp_commit_comm_work(self.send_proxy_work)
+
                 if self.cur_batch:
+                    pp_proxy_tensors = self._pp_wait_proxy_tensors(proxy_recv_state)
                     result, self.launch_event = self._pp_launch_batch(
                         mb_id,
                         pp_proxy_tensors,
                         self.mb_metadata,
                         self.last_rank_comm_queue,
                     )
+
                 if self.server_args.pp_async_batch_depth == 0:
                     next_pp_outputs, next_batch_result, d2h_event = (
                         self._pp_commit_send_output_work_and_preprocess_output_tensors(
@@ -229,10 +236,12 @@ class SchedulerPPMixin:
                 self.mbs[mb_id] = batch
                 self.running_mbs[mb_id] = self.running_batch
 
+                # Async PP processing
+                proxy_recv_state = None
                 self.cur_batch: Optional[ScheduleBatch] = self.mbs[mb_id]
                 if self.cur_batch:
                     server_is_idle = False
-                    pp_proxy_tensors = self._pp_recv_proxy_tensors()
+                    proxy_recv_state = self._pp_irecv_proxy_tensors()
 
                 if self.server_args.pp_async_batch_depth > 0:
                     next_pp_outputs, next_batch_result, d2h_event = (
@@ -242,13 +251,16 @@ class SchedulerPPMixin:
                         )
                     )
                 self._pp_commit_comm_work(self.send_proxy_work)
+
                 if self.cur_batch:
+                    pp_proxy_tensors = self._pp_wait_proxy_tensors(proxy_recv_state)
                     result, self.launch_event = self._pp_launch_batch(
                         mb_id,
                         pp_proxy_tensors,
                         self.mb_metadata,
                         self.last_rank_comm_queue,
                     )
+
                 if self.server_args.pp_async_batch_depth == 0:
                     next_pp_outputs, next_batch_result, d2h_event = (
                         self._pp_commit_send_output_work_and_preprocess_output_tensors(
@@ -378,11 +390,14 @@ class SchedulerPPMixin:
                 self.running_mbs[mb_id] = self.running_batch
 
                 self.cur_batch: Optional[ScheduleBatch] = self.mbs[mb_id]
+
+                # Async PP processing
+                proxy_recv_state = None
                 if self.cur_batch:
                     server_is_idle = False
                     pp_proxy_tensors = None
                     if not self.cur_batch.forward_mode.is_prebuilt():
-                        pp_proxy_tensors = self._pp_recv_proxy_tensors()
+                        proxy_recv_state = self._pp_irecv_proxy_tensors()
 
                 # early send output if possible
                 if self.server_args.pp_async_batch_depth > 0:
@@ -395,6 +410,9 @@ class SchedulerPPMixin:
                 self._pp_commit_comm_work(self.send_proxy_work)
 
                 if self.cur_batch:
+                    pp_proxy_tensors = None
+                    if not self.cur_batch.forward_mode.is_prebuilt():
+                        pp_proxy_tensors = self._pp_wait_proxy_tensors(proxy_recv_state)
                     result, self.launch_event = self._pp_launch_batch(
                         mb_id,
                         pp_proxy_tensors,
@@ -745,6 +763,40 @@ class SchedulerPPMixin:
             self.waiting_queue.extend(good_reqs)
             return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
         return None
+
+    def _pp_irecv_proxy_tensors(
+        self: "Scheduler",
+    ) -> Optional[Tuple[Dict, List, List]]:
+        """Start async recv of proxy tensors from the previous PP stage.
+        Returns None if this is the first rank (no recv needed),
+        otherwise returns (tensor_dict, handles, postprocess) from irecv_tensor_dict.
+        """
+        if self.pp_group.is_first_rank:
+            return None
+
+        tensor_dict, handles, postprocess = self.pp_group.irecv_tensor_dict(
+            all_gather_group=(
+                self.attn_tp_group if self.require_attn_tp_allgather else None
+            ),
+        )
+        return (tensor_dict, handles, postprocess)
+
+    def _pp_wait_proxy_tensors(
+        self: "Scheduler",
+        recv_state: Optional[Tuple[Dict, List, List]],
+    ) -> Optional["PPProxyTensors"]:
+        """Wait for async proxy tensor recv to complete."""
+        if recv_state is None:
+            return None
+
+        tensor_dict, handles, postprocess = recv_state
+
+        for h in handles:
+            h.wait()
+        for fn in postprocess:
+            fn()
+
+        return PPProxyTensors(tensor_dict)
 
     def _pp_pd_get_bootstrapped_ids(self: Scheduler):
         # communicate pre-consensus bootstrapp reqs


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Current the async mode pipeline parallelism mechanism is a sort of "fake" async: In `recv_tensor_dict`, each tensor is immediately waited on after calling irecv, resulting in serial reception and preventing overlap of communication and computation.

This PR refactors an authentic async PP mechanism with the following design:

- Introduce isend_tensor_dict: Send all isend calls and return a List[P2PWork]. The key addition is tensor.record_stream() to prevent CUDA tensors from being prematurely released (this exists in vllm but was not in the original sglang).

- Rewrite send_tensor_dict: Transform it into a simple wrapper around isend_tensor_dict + wait, maintaining API compatibility.
 
- Introduce irecv_tensor_dict: Initiate all irecv calls at once, returning a tuple of (tensor_dict, handles, postprocess). The postprocess is used for reconstructing in all_gather.
 
- Rewrite recv_tensor_dict: Transform it into a wrapper that combines irecv_tensor_dict + wait + postprocess.

The performance improved 5-7%. More comprehensive performance test will be done.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Acc no drops:
Server:
```
➜  python git:(refactor_async_pp) ✗ python -m sglang.launch_server --model-path Qwen/Qwen3-VL-8B-Instruct --tp-size 2 --pp-size 2
```

Client
```
➜  sglang_dev git:(refactor_async_pp) ✗ OPENAI_API_BASE=http://0.0.0.0:30000/v1 OPENAI_API_KEY="" python3 -m lmms_eval     --model openai_compatible     --model_args model_version=Qwen/Qwen3-VL-8B-Instruct  --tasks mmmu_val     --batch_size 16
2026-02-28 14:22:18 | INFO     | __main__:cli_evaluate:476 - Verbosity set to INFO
2026-02-28 14:22:21 | INFO     | __main__:cli_evaluate_single:565 - Evaluation tracker args: {}
2026-02-28 14:22:21 | INFO     | __main__:cli_evaluate_single:649 - Selected Tasks: ['mmmu_val']
2026-02-28 14:22:21 | INFO     | lmms_eval.evaluator:simple_evaluate:170 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-02-28 14:22:22 | INFO     | lmms_eval.evaluator:evaluate:515 - Running on rank 0 (local rank 0)
2026-02-28 14:22:22 | INFO     | lmms_eval.api.task:build_all_requests:428 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13380.05it/s]
2026-02-28 14:22:22 | INFO     | lmms_eval.evaluator:evaluate:609 - Running generate_until requests
Model Responding: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊| 899/900 [02:08<00:00,  9.95it/s]2026-02-28 14:24:30 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:136 - Metric summary - Total elapsed time: 2450.723s, Total gen tokens: 25464, Avg speed: 10.4 tokens/s
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [02:08<00:00,  7.01it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 9727.30it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.7}, 'Art': {'num': 30, 'acc': 0.73333}, 'Art_Theory': {'num': 30, 'acc': 0.9}, 'Design': {'num': 30, 'acc': 0.73333}, 'Music': {'num': 30, 'acc': 0.43333}, 'Overall-Business': {'num': 150, 'acc': 0.44}, 'Accounting': {'num': 30, 'acc': 0.4}, 'Economics': {'num': 30, 'acc': 0.56667}, 'Finance': {'num': 30, 'acc': 0.23333}, 'Manage': {'num': 30, 'acc': 0.43333}, 'Marketing': {'num': 30, 'acc': 0.56667}, 'Overall-Science': {'num': 150, 'acc': 0.44}, 'Biology': {'num': 30, 'acc': 0.53333}, 'Chemistry': {'num': 30, 'acc': 0.36667}, 'Geography': {'num': 30, 'acc': 0.53333}, 'Math': {'num': 30, 'acc': 0.26667}, 'Physics': {'num': 30, 'acc': 0.5}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.53333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.66667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.6}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.36667}, 'Pharmacy': {'num': 30, 'acc': 0.5}, 'Public_Health': {'num': 30, 'acc': 0.53333}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.675}, 'History': {'num': 30, 'acc': 0.63333}, 'Literature': {'num': 30, 'acc': 0.83333}, 'Sociology': {'num': 30, 'acc': 0.6}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.38571}, 'Agriculture': {'num': 30, 'acc': 0.53333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.2}, 'Computer_Science': {'num': 30, 'acc': 0.53333}, 'Electronics': {'num': 30, 'acc': 0.3}, 'Energy_and_Power': {'num': 30, 'acc': 0.4}, 'Materials': {'num': 30, 'acc': 0.33333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.4}, 'Overall': {'num': 900, 'acc': 0.50889}}
2026-02-28 14:24:31 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:238 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-8B-Instruct), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5089|±  |N/A   |


Throughput Summary

|      Metric      |  Value   |  Unit  |
|------------------|---------:|--------|
|total_gen_tokens  |25464.0000|tokens  |
|total_elapsed_time| 2450.7231|seconds |
|avg_speed         |   10.3904|tokens/s|
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
