### PR TITLE
[AMD] Port tree speculative sampling kernel to HIP

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -49,8 +49,11 @@ if is_cuda():
     )
 elif is_hip():
     from sgl_kernel import tree_speculative_sampling_target_only
+
     from sglang.srt.speculative.spec_utils import (
         top_k_renorm_prob_fallback as top_k_renorm_prob,
+    )
+    from sglang.srt.speculative.spec_utils import (
         top_p_renorm_prob_fallback as top_p_renorm_prob,
     )
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -39,13 +39,19 @@ from sglang.srt.speculative.spec_utils import (
     get_src_tgt_cache_loc,
     get_target_cache_loc,
 )
-from sglang.srt.utils import is_cuda, next_power_of_2
+from sglang.srt.utils import is_cuda, is_hip, next_power_of_2
 
 if is_cuda():
     from sgl_kernel import (
         top_k_renorm_prob,
         top_p_renorm_prob,
         tree_speculative_sampling_target_only,
+    )
+elif is_hip():
+    from sgl_kernel import tree_speculative_sampling_target_only
+    from sglang.srt.speculative.spec_utils import (
+        top_k_renorm_prob_fallback as top_k_renorm_prob,
+        top_p_renorm_prob_fallback as top_p_renorm_prob,
     )
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -48,6 +48,12 @@ if is_cuda():
         top_p_renorm_prob,
         tree_speculative_sampling_target_only,
     )
+elif is_hip():
+    from sgl_kernel import tree_speculative_sampling_target_only
+    from sglang.srt.speculative.spec_utils import (
+        top_k_renorm_prob_fallback as top_k_renorm_prob,
+        top_p_renorm_prob_fallback as top_p_renorm_prob,
+    )
 
 
 @triton.jit

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -50,8 +50,11 @@ if is_cuda():
     )
 elif is_hip():
     from sgl_kernel import tree_speculative_sampling_target_only
+
     from sglang.srt.speculative.spec_utils import (
         top_k_renorm_prob_fallback as top_k_renorm_prob,
+    )
+    from sglang.srt.speculative.spec_utils import (
         top_p_renorm_prob_fallback as top_p_renorm_prob,
     )
 

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -44,7 +44,11 @@ if is_cuda():
         verify_tree_greedy,
     )
 elif is_hip():
-    from sgl_kernel import verify_tree_greedy
+    from sgl_kernel import tree_speculative_sampling_target_only, verify_tree_greedy
+    from sglang.srt.speculative.spec_utils import (
+        top_k_renorm_prob_fallback as top_k_renorm_prob,
+        top_p_renorm_prob_fallback as top_p_renorm_prob,
+    )
 
 
 @dataclass

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -45,8 +45,11 @@ if is_cuda():
     )
 elif is_hip():
     from sgl_kernel import tree_speculative_sampling_target_only, verify_tree_greedy
+
     from sglang.srt.speculative.spec_utils import (
         top_k_renorm_prob_fallback as top_k_renorm_prob,
+    )
+    from sglang.srt.speculative.spec_utils import (
         top_p_renorm_prob_fallback as top_p_renorm_prob,
     )
 

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -47,7 +47,37 @@ SIMULATE_ACC_LEN = envs.SGLANG_SIMULATE_ACC_LEN.get()  # turn off if < 0
 SIMULATE_ACC_METHOD = envs.SGLANG_SIMULATE_ACC_METHOD.get()
 
 TREE_TRAVERSE_TIME_THRESHOLD = 1  # TODO: set this properly
-TREE_SPEC_KERNEL_AVAILABLE = _is_cuda  # This kernel is only available for CUDA now
+TREE_SPEC_KERNEL_AVAILABLE = _is_cuda or _is_hip
+
+
+def top_k_renorm_prob_fallback(probs: torch.Tensor, top_k) -> torch.Tensor:
+    """PyTorch fallback for top-k probability renormalization (used on AMD/HIP)."""
+    if isinstance(top_k, int):
+        k = top_k
+    else:
+        k = top_k.max().item()
+    topk_vals, _ = torch.topk(probs, k=k, dim=-1)
+    if isinstance(top_k, torch.Tensor):
+        threshold = topk_vals.gather(-1, (top_k - 1).clamp(min=0).unsqueeze(-1).long())
+    else:
+        threshold = topk_vals[:, -1:]
+    probs = probs.masked_fill(probs < threshold, 0.0)
+    return probs / probs.sum(dim=-1, keepdim=True).clamp(min=1e-8)
+
+
+def top_p_renorm_prob_fallback(probs: torch.Tensor, top_p) -> torch.Tensor:
+    """PyTorch fallback for top-p probability renormalization (used on AMD/HIP)."""
+    sorted_probs, sorted_indices = torch.sort(probs, descending=True, dim=-1)
+    cumsum = torch.cumsum(sorted_probs, dim=-1)
+    if isinstance(top_p, torch.Tensor):
+        mask = (cumsum - sorted_probs) > top_p.unsqueeze(-1)
+    else:
+        mask = (cumsum - sorted_probs) > top_p
+    sorted_probs[mask] = 0.0
+    sorted_probs = sorted_probs / sorted_probs.sum(dim=-1, keepdim=True).clamp(min=1e-8)
+    result = torch.zeros_like(probs)
+    result.scatter_(1, sorted_indices, sorted_probs)
+    return result
 
 
 def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:

--- a/sgl-kernel/csrc/common_extension_rocm.cc
+++ b/sgl-kernel/csrc/common_extension_rocm.cc
@@ -133,6 +133,14 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
    * From csrc/speculative
    */
   m.def(
+      "tree_speculative_sampling_target_only(Tensor! predicts, Tensor! accept_index, Tensor! accept_token_num, "
+      "Tensor candidates, Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
+      "Tensor uniform_samples, Tensor uniform_samples_for_final_sampling, Tensor target_probs, Tensor draft_probs, "
+      "float threshold_single, float threshold_acc, "
+      "bool deterministic) -> ()");
+  m.impl("tree_speculative_sampling_target_only", torch::kCUDA, &tree_speculative_sampling_target_only);
+
+  m.def(
       "verify_tree_greedy(Tensor! predicts, Tensor! accept_index, Tensor! accept_token_num, "
       "Tensor candidates, Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
       "Tensor target_predict) -> ()");

--- a/sgl-kernel/csrc/speculative/speculative_sampling_hip.cu
+++ b/sgl-kernel/csrc/speculative/speculative_sampling_hip.cu
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2025 by SGLang team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <hip/hip_runtime.h>
+#include <hipcub/hipcub.hpp>
+
+#include "pytorch_extension_utils_rocm.h"
+
+namespace {
+
+constexpr uint32_t BLOCK_THREADS = 1024;
+
+template <uint32_t BLOCK_SIZE>
+struct SamplingTempStorage {
+  union {
+    typename hipcub::BlockReduce<float, BLOCK_SIZE>::TempStorage reduce;
+    typename hipcub::BlockScan<float, BLOCK_SIZE, hipcub::BLOCK_SCAN_RAKING>::TempStorage scan;
+  } block_prim;
+  union {
+    float value;
+  } block_aggregate;
+  int sampled_id;
+};
+
+template <uint32_t BLOCK_SIZE>
+__global__ void TreeSpecSamplingTargetOnlyKernel(
+    int32_t* __restrict__ predicts,
+    int32_t* __restrict__ accept_index,
+    int32_t* __restrict__ accept_token_num,
+    const int64_t* __restrict__ candidates,
+    const int64_t* __restrict__ retrive_index,
+    const int64_t* __restrict__ retrive_next_token,
+    const int64_t* __restrict__ retrive_next_sibling,
+    const float* __restrict__ uniform_samples,
+    const float* __restrict__ uniform_samples_for_final_sampling,
+    float* __restrict__ target_probs,
+    float* __restrict__ draft_probs,
+    uint32_t batch_size,
+    uint32_t num_speculative_tokens,
+    uint32_t num_draft_tokens,
+    uint32_t d,
+    float threshold_single,
+    float threshold_acc) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+
+  extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_SIZE>)) uint8_t smem[];
+  auto& temp_storage = reinterpret_cast<SamplingTempStorage<BLOCK_SIZE>&>(smem);
+
+  // --- Part 1: Tree traversal with accept/reject ---
+  float prob_acc = 0.0f;
+  uint32_t cur_prob_offset = bx * num_draft_tokens * d;
+  float coin = uniform_samples[bx * num_draft_tokens];
+  int64_t last_accepted_retrive_idx = retrive_index[bx * num_draft_tokens];
+  accept_index[bx * num_speculative_tokens] = static_cast<int32_t>(last_accepted_retrive_idx);
+  uint32_t num_accepted_tokens = 0;
+  int64_t cur_index = 0;
+
+  for (uint32_t j = 1; j < num_speculative_tokens; ++j) {
+    cur_index = retrive_next_token[bx * num_draft_tokens + cur_index];
+    while (cur_index != -1) {
+      int64_t draft_index = retrive_index[bx * num_draft_tokens + cur_index];
+      int64_t draft_token_id = candidates[bx * num_draft_tokens + cur_index];
+      float target_prob_single = target_probs[cur_prob_offset + draft_token_id];
+      prob_acc += target_prob_single;
+
+      if (coin <= prob_acc / threshold_acc || target_prob_single >= threshold_single) {
+        prob_acc = 0.f;
+        cur_prob_offset = (bx * num_draft_tokens + static_cast<uint32_t>(cur_index)) * d;
+        coin = uniform_samples[bx * num_draft_tokens + cur_index];
+        predicts[last_accepted_retrive_idx] = static_cast<int32_t>(draft_token_id);
+        ++num_accepted_tokens;
+        accept_index[bx * num_speculative_tokens + num_accepted_tokens] = static_cast<int32_t>(draft_index);
+        last_accepted_retrive_idx = draft_index;
+        break;
+      } else {
+        draft_probs[cur_prob_offset + draft_token_id] = target_probs[cur_prob_offset + draft_token_id];
+        cur_index = retrive_next_sibling[bx * num_draft_tokens + cur_index];
+      }
+    }
+    if (cur_index == -1) break;
+  }
+  accept_token_num[bx] = static_cast<int32_t>(num_accepted_tokens);
+
+  coin = uniform_samples_for_final_sampling[bx];
+
+  // --- Part 2: Sample from relu(target_probs - draft_probs) ---
+  // Each thread handles elements at indices: tx, tx + BLOCK_SIZE, tx + 2*BLOCK_SIZE, ...
+  const bool has_draft = (num_accepted_tokens != num_speculative_tokens - 1);
+  const uint32_t num_iters = (d + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+  // First pass: compute total sum of relu(q - p)
+  float total_sum = 0.0f;
+  for (uint32_t i = 0; i < num_iters; ++i) {
+    uint32_t idx = i * BLOCK_SIZE + tx;
+    float relu_val = 0.0f;
+    if (idx < d) {
+      float q = target_probs[cur_prob_offset + idx];
+      float p = has_draft ? draft_probs[cur_prob_offset + idx] : 0.0f;
+      relu_val = fmaxf(q - p, 0.0f);
+    }
+    float block_sum = hipcub::BlockReduce<float, BLOCK_SIZE>(temp_storage.block_prim.reduce).Sum(relu_val);
+    __syncthreads();
+    if (tx == 0) {
+      total_sum += block_sum;
+    }
+  }
+  if (tx == 0) {
+    temp_storage.block_aggregate.value = total_sum;
+  }
+  temp_storage.sampled_id = static_cast<int>(d - 1);
+  __syncthreads();
+  total_sum = temp_storage.block_aggregate.value;
+  float u = coin * total_sum;
+
+  // Second pass: inclusive prefix-sum scan to find sampled token (CDF inversion)
+  float running_total = 0.0f;
+  for (uint32_t i = 0; i < num_iters; ++i) {
+    uint32_t idx = i * BLOCK_SIZE + tx;
+    float relu_val = 0.0f;
+    if (idx < d) {
+      float q = target_probs[cur_prob_offset + idx];
+      float p = has_draft ? draft_probs[cur_prob_offset + idx] : 0.0f;
+      relu_val = fmaxf(q - p, 0.0f);
+    }
+
+    float prefix_sum;
+    hipcub::BlockScan<float, BLOCK_SIZE, hipcub::BLOCK_SCAN_RAKING>(temp_storage.block_prim.scan)
+        .InclusiveSum(relu_val, prefix_sum);
+    __syncthreads();
+
+    float cumulative = running_total + prefix_sum;
+    if (relu_val > 0.0f && cumulative > u && (cumulative - relu_val) <= u && idx < d) {
+      atomicMin(&temp_storage.sampled_id, static_cast<int>(idx));
+    }
+    __syncthreads();
+
+    if (tx == BLOCK_SIZE - 1) {
+      temp_storage.block_aggregate.value = cumulative;
+    }
+    __syncthreads();
+    running_total = temp_storage.block_aggregate.value;
+
+    if (running_total > u) break;
+  }
+  __syncthreads();
+  predicts[last_accepted_retrive_idx] = temp_storage.sampled_id;
+}
+
+}  // namespace
+
+void tree_speculative_sampling_target_only(
+    at::Tensor predicts,
+    at::Tensor accept_index,
+    at::Tensor accept_token_num,
+    at::Tensor candidates,
+    at::Tensor retrive_index,
+    at::Tensor retrive_next_token,
+    at::Tensor retrive_next_sibling,
+    at::Tensor uniform_samples,
+    at::Tensor uniform_samples_for_final_sampling,
+    at::Tensor target_probs,
+    at::Tensor draft_probs,
+    double threshold_single,
+    double threshold_acc,
+    bool deterministic) {
+  CHECK_INPUT(candidates);
+  CHECK_INPUT(retrive_index);
+  CHECK_INPUT(retrive_next_token);
+  CHECK_INPUT(retrive_next_sibling);
+  CHECK_INPUT(uniform_samples);
+  CHECK_INPUT(uniform_samples_for_final_sampling);
+  CHECK_INPUT(target_probs);
+  auto device = target_probs.device();
+  CHECK_EQ(candidates.device(), device);
+  CHECK_EQ(retrive_index.device(), device);
+  CHECK_EQ(retrive_next_token.device(), device);
+  CHECK_EQ(retrive_next_sibling.device(), device);
+  CHECK_EQ(uniform_samples.device(), device);
+  CHECK_EQ(uniform_samples_for_final_sampling.device(), device);
+  CHECK_EQ(target_probs.device(), device);
+  CHECK_DIM(1, predicts);
+  CHECK_DIM(2, accept_index);
+  CHECK_DIM(1, accept_token_num);
+  CHECK_DIM(2, candidates);
+  CHECK_DIM(2, retrive_index);
+  CHECK_DIM(2, retrive_next_token);
+  CHECK_DIM(2, retrive_next_sibling);
+  CHECK_DIM(2, uniform_samples);
+  CHECK_DIM(3, target_probs);
+  CHECK_DIM(3, draft_probs);
+  unsigned int batch_size = uniform_samples.size(0);
+  unsigned int num_spec_step = accept_index.size(1);
+  unsigned int num_draft_tokens = candidates.size(1);
+  unsigned int vocab_size = target_probs.size(2);
+  CHECK_EQ(batch_size, candidates.size(0));
+  CHECK_EQ(batch_size, retrive_index.size(0));
+  CHECK_EQ(batch_size, retrive_next_token.size(0));
+  CHECK_EQ(batch_size, retrive_next_sibling.size(0));
+  CHECK_EQ(batch_size, target_probs.size(0));
+  CHECK_EQ(num_draft_tokens, retrive_index.size(1));
+  CHECK_EQ(num_draft_tokens, retrive_next_token.size(1));
+  CHECK_EQ(num_draft_tokens, retrive_next_sibling.size(1));
+  CHECK_EQ(num_draft_tokens, uniform_samples.size(1));
+  CHECK_EQ(num_draft_tokens, target_probs.size(1));
+  CHECK_EQ(vocab_size, target_probs.size(2));
+  CHECK_EQ(batch_size, accept_index.size(0));
+  CHECK_EQ(batch_size, accept_token_num.size(0));
+  if (predicts.scalar_type() != at::kInt) {
+    throw std::runtime_error("Expected 'predicts' to be of type int (torch.int32).");
+  }
+  if (accept_index.scalar_type() != at::kInt) {
+    throw std::runtime_error("Expected 'accept_index' to be of type int (torch.int32).");
+  }
+  if (accept_token_num.scalar_type() != at::kInt) {
+    throw std::runtime_error("Expected 'accept_token_num' to be of type int (torch.int32).");
+  }
+  if (candidates.scalar_type() != at::kLong) {
+    throw std::runtime_error("Expected 'candidates' to be of type long (torch.int64).");
+  }
+  if (retrive_index.scalar_type() != at::kLong) {
+    throw std::runtime_error("Expected 'retrive_index' to be of type long (torch.int64).");
+  }
+  if (retrive_next_token.scalar_type() != at::kLong) {
+    throw std::runtime_error("Expected 'retrive_next_token' to be of type long (torch.int64).");
+  }
+  if (retrive_next_sibling.scalar_type() != at::kLong) {
+    throw std::runtime_error("Expected 'retrive_next_sibling' to be of type long (torch.int64).");
+  }
+  if (uniform_samples.scalar_type() != at::kFloat) {
+    throw std::runtime_error("Expected 'uniform_samples' to be of type float (torch.float32).");
+  }
+  if (uniform_samples_for_final_sampling.scalar_type() != at::kFloat) {
+    throw std::runtime_error(
+        "Expected 'uniform_samples_for_final_sampling' to be of type float (torch.float32).");
+  }
+  if (target_probs.scalar_type() != at::kFloat) {
+    throw std::runtime_error("Expected 'target_probs' to be of type float (torch.float32).");
+  }
+  if (draft_probs.scalar_type() != at::kFloat) {
+    throw std::runtime_error("Expected 'draft_probs' to be of type float (torch.float32).");
+  }
+  CHECK_GE(threshold_single, 0);
+  CHECK_GE(1, threshold_single);
+  CHECK_GE(threshold_acc, 0);
+  CHECK_GE(1, threshold_acc);
+
+  float capped_threshold_acc = fmaxf(static_cast<float>(threshold_acc), 1e-9f);
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS>);
+  dim3 nblks(batch_size);
+  dim3 nthrs(BLOCK_THREADS);
+
+  hipLaunchKernelGGL(
+      (TreeSpecSamplingTargetOnlyKernel<BLOCK_THREADS>),
+      nblks,
+      nthrs,
+      smem_size,
+      stream,
+      static_cast<int32_t*>(predicts.data_ptr()),
+      static_cast<int32_t*>(accept_index.data_ptr()),
+      static_cast<int32_t*>(accept_token_num.data_ptr()),
+      static_cast<int64_t*>(candidates.data_ptr()),
+      static_cast<int64_t*>(retrive_index.data_ptr()),
+      static_cast<int64_t*>(retrive_next_token.data_ptr()),
+      static_cast<int64_t*>(retrive_next_sibling.data_ptr()),
+      static_cast<float*>(uniform_samples.data_ptr()),
+      static_cast<float*>(uniform_samples_for_final_sampling.data_ptr()),
+      static_cast<float*>(target_probs.data_ptr()),
+      static_cast<float*>(draft_probs.data_ptr()),
+      batch_size,
+      num_spec_step,
+      num_draft_tokens,
+      vocab_size,
+      static_cast<float>(threshold_single),
+      capped_threshold_acc);
+
+  auto status = hipGetLastError();
+  TORCH_CHECK(
+      status == hipSuccess,
+      "TreeSpecSamplingTargetOnlyKernel failed with error: ",
+      hipGetErrorString(status));
+}

--- a/sgl-kernel/csrc/speculative/speculative_sampling_hip.cu
+++ b/sgl-kernel/csrc/speculative/speculative_sampling_hip.cu
@@ -17,6 +17,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <hip/hip_runtime.h>
+
 #include <hipcub/hipcub.hpp>
 
 #include "pytorch_extension_utils_rocm.h"
@@ -246,8 +247,7 @@ void tree_speculative_sampling_target_only(
     throw std::runtime_error("Expected 'uniform_samples' to be of type float (torch.float32).");
   }
   if (uniform_samples_for_final_sampling.scalar_type() != at::kFloat) {
-    throw std::runtime_error(
-        "Expected 'uniform_samples_for_final_sampling' to be of type float (torch.float32).");
+    throw std::runtime_error("Expected 'uniform_samples_for_final_sampling' to be of type float (torch.float32).");
   }
   if (target_probs.scalar_type() != at::kFloat) {
     throw std::runtime_error("Expected 'target_probs' to be of type float (torch.float32).");
@@ -292,8 +292,5 @@ void tree_speculative_sampling_target_only(
       capped_threshold_acc);
 
   auto status = hipGetLastError();
-  TORCH_CHECK(
-      status == hipSuccess,
-      "TreeSpecSamplingTargetOnlyKernel failed with error: ",
-      hipGetErrorString(status));
+  TORCH_CHECK(status == hipSuccess, "TreeSpecSamplingTargetOnlyKernel failed with error: ", hipGetErrorString(status));
 }

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -52,6 +52,7 @@ sources = [
     "csrc/moe/moe_topk_softmax_kernels.cu",
     "csrc/moe/moe_topk_sigmoid_kernels.cu",
     "csrc/speculative/eagle_utils.cu",
+    "csrc/speculative/speculative_sampling_hip.cu",
     "csrc/kvcacheio/transfer.cu",
     "csrc/memory/weak_ref_tensor.cpp",
     "csrc/elementwise/pos_enc.cu",

--- a/test/registered/spec/utils/test_tree_speculative_sampling.py
+++ b/test/registered/spec/utils/test_tree_speculative_sampling.py
@@ -1,0 +1,167 @@
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.speculative.spec_utils import (
+    top_k_renorm_prob_fallback,
+    top_p_renorm_prob_fallback,
+)
+from sglang.srt.utils import get_device
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=5, suite="stage-b-test-small-1-gpu-amd")
+
+
+class TestTreeSpeculativeSampling(CustomTestCase):
+
+    def _run_tree_spec_sampling(self, threshold_single, threshold_acc):
+        from sgl_kernel import tree_speculative_sampling_target_only
+
+        device = get_device()
+
+        candidates = torch.tensor(
+            [[0, 1, 2, 3, 4, 5], [7, 8, 9, 10, 11, 12]],
+            dtype=torch.int64,
+            device=device,
+        )
+        retrive_index = torch.tensor(
+            [[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11]],
+            dtype=torch.int64,
+            device=device,
+        )
+        retrive_next_token = torch.tensor(
+            [[1, 2, -1, 4, 5, -1], [4, 2, 3, -1, 5, -1]],
+            dtype=torch.int64,
+            device=device,
+        )
+        retrive_next_sibling = torch.tensor(
+            [[-1, 3, -1, -1, -1, -1], [-1, -1, -1, -1, 1, -1]],
+            dtype=torch.int64,
+            device=device,
+        )
+
+        target_logits = torch.full((2, 6, 20), 1, dtype=torch.float32, device=device)
+        target_logits[0, 0, 3] = 10
+        target_logits[0, 3, 4] = 10
+        target_logits[0, 4, 5] = 10
+        target_logits[1, 0, 11] = 10
+        target_logits[1, 4, 12] = 10
+
+        for i in range(target_logits.shape[0]):
+            for j in range(target_logits.shape[1]):
+                if torch.max(target_logits[i, j]) < 10:
+                    target_logits[i, j, 18] = 10
+
+        temperatures = torch.tensor([0.01, 0.01], dtype=torch.float32, device=device)
+        bs, num_draft_tokens = candidates.shape
+        num_spec_step = 4
+
+        predicts = torch.full((12,), -1, dtype=torch.int32, device=device)
+        accept_index = torch.full(
+            (bs, num_spec_step), -1, dtype=torch.int32, device=device
+        )
+        accept_token_num = torch.full((bs,), 0, dtype=torch.int32, device=device)
+
+        expanded_temperature = temperatures.unsqueeze(1).unsqueeze(1)
+        target_probs = F.softmax(target_logits / expanded_temperature, dim=-1)
+        draft_probs = torch.zeros_like(target_probs)
+        coins = torch.rand(bs, num_draft_tokens, device=device, dtype=torch.float32)
+        coins_for_final_sampling = torch.rand(bs, device=device, dtype=torch.float32)
+
+        tree_speculative_sampling_target_only(
+            predicts=predicts,
+            accept_index=accept_index,
+            accept_token_num=accept_token_num,
+            candidates=candidates,
+            retrive_index=retrive_index,
+            retrive_next_token=retrive_next_token,
+            retrive_next_sibling=retrive_next_sibling,
+            uniform_samples=coins,
+            uniform_samples_for_final_sampling=coins_for_final_sampling,
+            target_probs=target_probs,
+            draft_probs=draft_probs,
+            threshold_single=threshold_single,
+            threshold_acc=threshold_acc,
+            deterministic=True,
+        )
+
+        return predicts, accept_index, accept_token_num
+
+    def test_threshold_one(self):
+        predicts, accept_index, accept_token_num = self._run_tree_spec_sampling(1, 1)
+        self.assertEqual(
+            predicts.tolist(),
+            [3, -1, -1, 4, 5, 18, 11, -1, -1, -1, 12, 18],
+        )
+        self.assertEqual(
+            accept_index.tolist(),
+            [[0, 3, 4, 5], [6, 10, 11, -1]],
+        )
+        self.assertEqual(accept_token_num.tolist(), [3, 2])
+
+    def test_threshold_zero(self):
+        predicts, accept_index, accept_token_num = self._run_tree_spec_sampling(0, 0)
+        self.assertEqual(
+            predicts.tolist(),
+            [1, 2, 18, -1, -1, -1, 11, -1, -1, -1, 12, 18],
+        )
+        self.assertEqual(
+            accept_index.tolist(),
+            [[0, 1, 2, -1], [6, 10, 11, -1]],
+        )
+        self.assertEqual(accept_token_num.tolist(), [2, 2])
+
+
+class TestRenormProbFallbacks(CustomTestCase):
+
+    def test_top_k_renorm_scalar(self):
+        device = get_device()
+        probs = torch.tensor(
+            [[0.1, 0.3, 0.05, 0.4, 0.15]], dtype=torch.float32, device=device
+        )
+        result = top_k_renorm_prob_fallback(probs, top_k=2)
+        # Only the top-2 values (0.3, 0.4) should remain and be renormalized
+        self.assertEqual((result > 0).sum().item(), 2)
+        self.assertAlmostEqual(result.sum().item(), 1.0, places=5)
+
+    def test_top_k_renorm_tensor(self):
+        device = get_device()
+        probs = torch.tensor(
+            [[0.1, 0.3, 0.05, 0.4, 0.15], [0.5, 0.2, 0.1, 0.1, 0.1]],
+            dtype=torch.float32,
+            device=device,
+        )
+        top_k = torch.tensor([2, 3], device=device)
+        result = top_k_renorm_prob_fallback(probs, top_k=top_k)
+        self.assertAlmostEqual(result[0].sum().item(), 1.0, places=5)
+        self.assertAlmostEqual(result[1].sum().item(), 1.0, places=5)
+
+    def test_top_p_renorm_scalar(self):
+        device = get_device()
+        probs = torch.tensor(
+            [[0.4, 0.3, 0.15, 0.1, 0.05]], dtype=torch.float32, device=device
+        )
+        result = top_p_renorm_prob_fallback(probs, top_p=0.8)
+        # Top-p=0.8: cumsum of sorted [0.4, 0.3, 0.15] = 0.85 > 0.8
+        # So at most 3 tokens should survive
+        self.assertLessEqual((result > 0).sum().item(), 3)
+        self.assertAlmostEqual(result.sum().item(), 1.0, places=5)
+
+    def test_top_p_renorm_tensor(self):
+        device = get_device()
+        probs = torch.tensor(
+            [[0.4, 0.3, 0.15, 0.1, 0.05], [0.5, 0.2, 0.1, 0.1, 0.1]],
+            dtype=torch.float32,
+            device=device,
+        )
+        top_p = torch.tensor([0.8, 0.6], device=device)
+        result = top_p_renorm_prob_fallback(probs, top_p=top_p)
+        self.assertAlmostEqual(result[0].sum().item(), 1.0, places=5)
+        self.assertAlmostEqual(result[1].sum().item(), 1.0, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

Tree speculative sampling (used by EAGLE and n-gram speculative decoding) currently relies on FlashInfer's CUDA implementation, which is unavailable on ROCm. This means speculative decoding is silently disabled on AMD GPUs -- `TREE_SPEC_KERNEL_AVAILABLE` was hardcoded to `_is_cuda` only. This PR adds a standalone HIP kernel so that speculative decoding works on MI300X.

## Modifications

The core change is a new file `sgl-kernel/csrc/speculative/speculative_sampling_hip.cu` containing a HIP-native implementation of `TreeSpecSamplingTargetOnlyKernel`. The kernel is written from scratch against `hipcub` rather than trying to port FlashInfer's CUB-based implementation, since FlashInfer itself has no HIP support. The algorithm is identical to the CUDA path:

1. Tree traversal with threshold-based accept/reject (same branching logic and threshold parameters as the CUDA kernel).
2. Final-token sampling via CDF inversion over `relu(target_probs - draft_probs)`, using `hipcub::BlockReduce` for the normalization sum and `hipcub::BlockScan` for the inclusive prefix sum. `atomicMin` on shared memory resolves the sampled index when multiple threads cross the threshold simultaneously.

The shared memory layout uses a union of `BlockReduce::TempStorage` and `BlockScan::TempStorage` (same pattern as FlashInfer's kernel) to keep shared memory usage minimal.

On the Python side, `spec_utils.py` now sets `TREE_SPEC_KERNEL_AVAILABLE = _is_cuda or _is_hip`, and provides PyTorch fallback implementations of `top_k_renorm_prob` and `top_p_renorm_prob` for HIP (these are normally FlashInfer functions that don't exist on ROCm). The fallbacks are simple -- `torch.topk` + mask + renormalize for top-k, and `torch.sort` + cumsum + mask for top-p. They're correct but not performance-critical since they run once per verification step on a (batch_size, vocab_size) tensor.

The conditional imports in `eagle_info.py`, `eagle_info_v2.py`, and `ngram_info.py` now have an `elif is_hip()` branch that pulls `tree_speculative_sampling_target_only` from `sgl_kernel` and aliases the fallback renormalization functions. The CUDA path is untouched.

Build system changes: added the new `.cu` file to `setup_rocm.py`'s source list and registered the op in `common_extension_rocm.cc` with the same `m.def`/`m.impl` signature as the CUDA registration.

Unit tests in `test/registered/spec/utils/test_tree_speculative_sampling.py` cover the kernel with threshold=(1,1) and threshold=(0,0) cases, plus the `top_k_renorm_prob_fallback` and `top_p_renorm_prob_fallback` with both scalar and per-batch tensor inputs. Registered for both CUDA and AMD CI, following the same pattern as `test_build_eagle_tree.py`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).