### PR TITLE
[Feature] Implement image number limitation for image processors

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -173,6 +173,7 @@ class MultimodalSpecialTokens:
 
 class BaseMultimodalProcessor(ABC):
     models = []
+    IMAGE_NUM_LIMITATION = 5
 
     def __init__(
         self, hf_config, server_args, _processor, transport_mode, *args, **kwargs
@@ -619,6 +620,15 @@ class BaseMultimodalProcessor(ABC):
 
         return is_precomputed, images, videos, audios
 
+    def _get_image_limit(self) -> int:
+        """Return the effective image limit. CLI override takes priority."""
+        if (
+            self.server_args.limit_mm_data_per_request
+            and "image" in self.server_args.limit_mm_data_per_request
+        ):
+            return self.server_args.limit_mm_data_per_request["image"]
+        return self.IMAGE_NUM_LIMITATION
+
     def load_mm_data(
         self,
         prompt: str,
@@ -632,6 +642,15 @@ class BaseMultimodalProcessor(ABC):
     ) -> BaseMultiModalProcessorOutput:
 
         BaseMultimodalProcessor.validate_mm_data(image_data, video_data, audio_data)
+
+        # Check image count against processor limit
+        if image_data:
+            limit = self._get_image_limit()
+            if len(image_data) > limit:
+                raise ValueError(
+                    f"Number of images ({len(image_data)}) exceeds "
+                    f"the limit ({limit}) for this processor."
+                )
 
         multimodal_tokens_pattern = multimodal_tokens.get_combined_regex()
         if isinstance(prompt, list) and return_text:

--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -26,6 +26,7 @@ class InternVLProcessor(BaseMultimodalProcessor):
     IMAGENET_MEAN = [0.485, 0.456, 0.406]
     IMAGENET_STD = [0.229, 0.224, 0.225]
     IMAGE_MAX_NUM = 12
+    IMAGE_NUM_LIMITATION = 12
 
     DEFAULT_VIDEO_NUM_FRAMES = 32
     VIDEO_MAX_NUM = 1

--- a/test/unit/test_image_num_limitation.py
+++ b/test/unit/test_image_num_limitation.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for IMAGE_NUM_LIMITATION in BaseMultimodalProcessor.
+
+Covers:
+    - Default image limit enforcement
+    - Subclass override of IMAGE_NUM_LIMITATION
+    - CLI override via server_args.limit_mm_data_per_request
+    - No error when image_data is None or within limit
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+
+
+class ConcreteProcessor(BaseMultimodalProcessor):
+    """Minimal concrete subclass for testing (ABC can't be instantiated directly)."""
+
+    async def process_mm_data_async(self, **kwargs):
+        return {}
+
+
+class HighLimitProcessor(BaseMultimodalProcessor):
+    """Processor with a higher image limit (like InternVL)."""
+
+    IMAGE_NUM_LIMITATION = 12
+
+    async def process_mm_data_async(self, **kwargs):
+        return {}
+
+
+def make_processor(cls=ConcreteProcessor, limit_mm_data_per_request=None):
+    """Helper to create a processor with mocked dependencies."""
+    server_args = Mock()
+    server_args.limit_mm_data_per_request = limit_mm_data_per_request
+    return cls(
+        hf_config=Mock(),
+        server_args=server_args,
+        _processor=Mock(),
+        transport_mode="ipc",
+        skip_mm_pool=True,
+    )
+
+
+class TestGetImageLimit:
+    """Tests for _get_image_limit() priority logic."""
+
+    def test_default_limit(self):
+        proc = make_processor()
+        assert proc._get_image_limit() == 5
+
+    def test_subclass_override(self):
+        proc = make_processor(cls=HighLimitProcessor)
+        assert proc._get_image_limit() == 12
+
+    def test_cli_override_takes_priority(self):
+        proc = make_processor(limit_mm_data_per_request={"image": 20})
+        assert proc._get_image_limit() == 20
+
+    def test_cli_override_on_subclass(self):
+        proc = make_processor(
+            cls=HighLimitProcessor,
+            limit_mm_data_per_request={"image": 3},
+        )
+
+        assert proc._get_image_limit() == 3
+
+    def test_cli_with_no_image_key_falls_back_to_default(self):
+        proc = make_processor(limit_mm_data_per_request={"video": 2})
+        assert proc._get_image_limit() == 5
+
+
+class TestImageNumLimitation:
+    """Tests for image count validation in load_mm_data()."""
+
+    def test_within_limit_no_error(self):
+        proc = make_processor()
+        # 3 images, limit is 5 - should not raise
+        image_data = ["img1.jpg", "img2.jpg", "img3.jpg"]
+        multimodal_tokens = Mock(spec=MultimodalSpecialTokens)
+        multimodal_tokens.get_combined_regex.return_value = Mock(
+            match=Mock(return_value=None)
+        )
+        # load_mm_data will fail later (no real processor), but should NOT
+        # fail at the image count check. We catch the later error.
+
+        try:
+            proc.load_mm_data(
+                prompt="describe these",
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+            )
+        except ValueError as e:
+            if "exceeds" in str(e):
+                pytest.fail(f"Should not raise limit error for 3 images: {e}")
+        except Exception:
+            pass  # Other errors from mocked dependencies are expected
+
+    def test_exceeds_limit_raises_error(self):
+        proc = make_processor()
+        image_data = [f"image{i}.jpg" for i in range(10)]
+        multimodal_tokens = Mock(spec=MultimodalSpecialTokens)
+        with pytest.raises(ValueError, match="exceeds"):
+            proc.load_mm_data(
+                prompt="describe these",
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+            )
+
+    def test_no_images_no_error(self):
+        proc = make_processor()
+        multimodal_tokens = Mock(spec=MultimodalSpecialTokens)
+        multimodal_tokens.get_combined_regex.return_value = Mock(
+            match=Mock(return_value=None)
+        )
+        try:
+            proc.load_mm_data(
+                prompt="hello",
+                multimodal_tokens=multimodal_tokens,
+                image_data=None,
+            )
+        except ValueError as e:
+            if "exceeds" in str(e):
+                pytest.fail(f"Should not raise limit error for None: {e}")
+        except Exception:
+            pass
+
+    def test_high_limit_processor_allows_more(self):
+        proc = make_processor(cls=HighLimitProcessor)
+        image_data = [f"img{i}.jpg" for i in range(10)]
+        multimodal_tokens = Mock(spec=MultimodalSpecialTokens)
+        multimodal_tokens.get_combined_regex.return_value = Mock(
+            match=Mock(return_value=None)
+        )
+        try:
+            proc.load_mm_data(
+                prompt="describe these",
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+            )
+        except ValueError as e:
+            if "exceeds" in str(e):
+                pytest.fail(f"Should not raise for 10 images with limit 12: {e}")
+        except Exception:
+            pass
+
+    def test_cli_override_allows_more(self):
+        proc = make_processor(limit_mm_data_per_request={"image": 20})
+        image_data = [f"img{i}.jpg" for i in range(15)]
+        multimodal_tokens = Mock(spec=MultimodalSpecialTokens)
+        multimodal_tokens.get_combined_regex.return_value = Mock(
+            match=Mock(return_value=None)
+        )
+
+        try:
+            proc.load_mm_data(
+                prompt="describe these",
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+            )
+        except ValueError as e:
+            if "exceeds" in str(e):
+                pytest.fail(f"Should not raise for 15 images with CLI limit 20: {e}")
+        except Exception:
+            pass


### PR DESCRIPTION
## Motivation

Fixes #8540

Currently, there is no default limitation on the number of images during multimodal data processing. The only existing check (`_validate_mm_limits` in TokenizerManager) only runs if the admin explicitly sets `--limit-mm-data-per-request`, which defaults to `None`. Without this, a user could send an excessive number of images, each consuming ~1GB GPU memory via the fast image processor, potentially causing OOM.

This PR adds a per-processor default image limit as a safety net.

## Modifications

**`python/sglang/srt/multimodal/processors/base_processor.py`:**
- Added `IMAGE_NUM_LIMITATION = 5` class constant to `BaseMultimodalProcessor`
- Added `_get_image_limit()` helper method that returns the effective limit (CLI override takes priority over processor default)
- Added image count validation in `load_mm_data()` before any images are downloaded

**`python/sglang/srt/multimodal/processors/internvl.py`:**
- Added `IMAGE_NUM_LIMITATION = 12` override (InternVL supports more images)

**`test/unit/test_image_num_limitation.py`:**
- Unit tests covering: default limit, subclass override, CLI override priority, within-limit pass-through, exceeds-limit rejection

## Priority Order

`--limit-mm-data-per-request` CLI flag > processor `IMAGE_NUM_LIMITATION` constant > no protection

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)