### PR TITLE
TP indexer weight in NSA attention

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -36,6 +36,9 @@ if is_npu():
 from sglang.srt.distributed import (
     get_attn_context_model_parallel_rank,
     get_attn_context_model_parallel_world_size,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
 )
 from sglang.srt.distributed.parallel_state import get_pp_group
 from sglang.srt.layers import deep_gemm_wrapper
@@ -45,7 +48,8 @@ from sglang.srt.layers.attention.nsa.utils import (
     is_nsa_prefill_cp_in_seq_split,
 )
 from sglang.srt.layers.communicator import ScatterMode
-from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.layers.linear import ReplicatedLinear, RowParallelLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
@@ -177,6 +181,12 @@ class Indexer(MultiPlatformOp):
         else:
             self.cp_size = None
             self.cp_rank = None
+
+        self.enable_tp_weights_proj = not is_dp_attention_enabled()
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
         if _is_cuda:
             self.sm_count = deep_gemm.get_num_sms()
             self.half_device_sm_count = ceil_align(self.sm_count // 2, 8)
@@ -200,13 +210,26 @@ class Indexer(MultiPlatformOp):
             quant_config=quant_config,
             prefix=add_prefix("wk", prefix),
         )
-        self.weights_proj = ReplicatedLinear(
-            self.hidden_size,
-            self.n_heads,
-            bias=False,
-            params_dtype=torch.bfloat16 if _is_cuda else torch.float32,
-            prefix=add_prefix("weights_proj", prefix),
-        )
+        if self.enable_tp_weights_proj:
+            self.weights_proj = RowParallelLinear(
+                self.hidden_size,
+                self.n_heads,
+                bias=False,
+                input_is_parallel=False,
+                reduce_results=False,
+                params_dtype=torch.bfloat16 if _is_cuda else torch.float32,
+                prefix=add_prefix("weights_proj", prefix),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
+        else:
+            self.weights_proj = ReplicatedLinear(
+                self.hidden_size,
+                self.n_heads,
+                bias=False,
+                params_dtype=torch.bfloat16 if _is_cuda else torch.float32,
+                prefix=add_prefix("weights_proj", prefix),
+            )
         self.k_norm = LayerNorm(self.head_dim, dtype=torch.float32)
         self.rotary_emb = get_rope_wrapper(
             rope_head_dim,
@@ -239,18 +262,27 @@ class Indexer(MultiPlatformOp):
     def _weights_proj_bf16_in_fp32_out(self, x: torch.Tensor) -> torch.Tensor:
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
             weight = self.weights_proj.weight
+            if self.enable_tp_weights_proj:
+                shard_size = weight.shape[1]
+                x = x[:, self.tp_rank * shard_size : (self.tp_rank + 1) * shard_size]
+                x = x.contiguous()
             out = torch.empty(
                 (x.shape[0], weight.shape[0]),
                 dtype=torch.float32,
                 device=x.device,
             )
             deep_gemm_wrapper.gemm_nt_bf16bf16f32(x, weight, out)
+            if self.enable_tp_weights_proj and self.tp_size > 1:
+                out = tensor_model_parallel_all_reduce(out)
             return out
 
         if _is_hip:
             x = x.to(self.weights_proj.weight.dtype)
         weights, _ = self.weights_proj(x)
-        return weights.float()
+        weights = weights.float()
+        if self.enable_tp_weights_proj and self.tp_size > 1:
+            weights = tensor_model_parallel_all_reduce(weights)
+        return weights
 
     @torch.compile(dynamic=True) if not _is_hip else lambda f: f
     def _project_and_scale_head_gates(self, x: torch.Tensor):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Tested at BS = 4, ISL=2048 OSL=1024
Before:
<img width="1667" height="920" alt="Screenshot 2026-02-28 at 11 24 45 PM" src="https://github.com/user-attachments/assets/f9d07ac9-4c8b-4f9f-be13-307b6c235c13" />
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   19.292    |  2048  |   1.000    |     106.01      |
+-------------+--------+------------+-----------------+
```

After:
<img width="1686" height="935" alt="Screenshot 2026-02-28 at 11 25 09 PM" src="https://github.com/user-attachments/assets/8004512c-ba98-46b6-a23a-fdb12d5d5ec4" />
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   18.979    |  2048  |   1.000    |     107.91      |
+-------------+--------+------------+-----------------+
```

Only seems to be around 2%. Currently, the all-reduce in TP=4 will take the same time as the size of the indexer... 

1. We could find some better alternative to small message all-reduce. 
2. Use better performing BF16 x BF16 with FP32 accum to replace DeepGEMM implementation, from Flashinfer.
3. Or, it just may not be a great candidate for RPLinear in general, since it may degrade at larger BS in TP

<!-- Describe the purpose and goals of this pull request. -->

Before:
<img width="1456" height="369" alt="Screenshot 2026-03-03 at 4 57 48 PM" src="https://github.com/user-attachments/assets/c882e537-b9ff-43eb-b69c-c8f007be89a6" />

After:
<img width="1455" height="372" alt="Screenshot 2026-03-03 at 5 29 59 PM" src="https://github.com/user-attachments/assets/d54c2e2b-19ff-4a19-8976-036ba684bce2" />



## Accuracy Tests

Add more detailed eval. Output of send one looked ok.