### PR TITLE
[Bugfix] Add missing auto_create_handle_loop to communicator methods

### DIFF
--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -344,10 +344,12 @@ class TokenizerCommunicatorMixin:
         )
 
     async def flush_cache(self: TokenizerManager) -> FlushCacheReqOutput:
+        self.auto_create_handle_loop()
         return (await self.flush_cache_communicator(FlushCacheReqInput()))[0]
 
     async def clear_hicache_storage(self: TokenizerManager) -> ClearHiCacheReqOutput:
         """Clear the hierarchical cache storage."""
+        self.auto_create_handle_loop()
         # Delegate to the scheduler to handle HiCacheStorage clearing
         return (await self.clear_hicache_storage_communicator(ClearHiCacheReqInput()))[
             0
@@ -361,6 +363,7 @@ class TokenizerCommunicatorMixin:
         hicache_write_policy: Optional[str] = None,
     ) -> AttachHiCacheStorageReqOutput:
         """Attach (enable) HiCache storage backend at runtime."""
+        self.auto_create_handle_loop()
         results = await self.attach_hicache_storage_communicator(
             AttachHiCacheStorageReqInput(
                 hicache_storage_backend=hicache_storage_backend,
@@ -392,6 +395,7 @@ class TokenizerCommunicatorMixin:
         self: TokenizerManager,
     ) -> DetachHiCacheStorageReqOutput:
         """Detach (disable) HiCache storage backend at runtime."""
+        self.auto_create_handle_loop()
         results = await self.detach_hicache_storage_communicator(
             DetachHiCacheStorageReqInput()
         )
@@ -855,6 +859,7 @@ class TokenizerCommunicatorMixin:
         await self.slow_down_communicator(obj)
 
     async def get_internal_state(self: TokenizerManager) -> List[Dict[Any, Any]]:
+        self.auto_create_handle_loop()
         req = GetInternalStateReq()
         responses: List[GetInternalStateReqOutput] = (
             await self.get_internal_state_communicator(req)
@@ -865,6 +870,7 @@ class TokenizerCommunicatorMixin:
     async def set_internal_state(
         self: TokenizerManager, obj: SetInternalStateReq
     ) -> List[bool]:
+        self.auto_create_handle_loop()
         responses: List[SetInternalStateReqOutput] = (
             await self.set_internal_state_communicator(obj)
         )
@@ -873,9 +879,11 @@ class TokenizerCommunicatorMixin:
     async def dumper_control(
         self: TokenizerManager, obj: DumperControlReqInput
     ) -> List[DumperControlReqOutput]:
+        self.auto_create_handle_loop()
         return await self.dumper_control_communicator(obj)
 
     async def get_load(self: TokenizerManager) -> List[GetLoadReqOutput]:
+        self.auto_create_handle_loop()
         req = GetLoadReqInput()
         return await self.get_load_communicator(req)
 
@@ -894,6 +902,7 @@ class TokenizerCommunicatorMixin:
         Returns:
             List of GetLoadsReqOutput, one per scheduler (filtered by dp_rank if specified)
         """
+        self.auto_create_handle_loop()
         req = GetLoadsReqInput(
             include=include if include else ["all"],
             dp_rank=dp_rank,


### PR DESCRIPTION
## Summary

- Several communicator methods in `TokenizerCommunicatorMixin` (e.g., `get_internal_state`, `flush_cache`, `get_load`) were missing the `self.auto_create_handle_loop()` call that ensures the ZMQ response-receiving loop is running.
- Without this call, **if users use --skip-server-warmup in the server launch args**, which skips one forward run for server warmup, these methods hang indefinitely when invoked before any inference request has been processed, because the `handle_loop` asyncio task is never started, causing confusion.

## Motivation

In PD disaggregation mode, the router calls `/server_info` (which invokes `get_internal_state()`) immediately after a worker pod starts — before any inference request arrives. Since `auto_create_handle_loop()` is only called from `generate_request()`, the `handle_loop` that receives scheduler responses via ZMQ is never created, causing `get_internal_state()` to wait forever.

This also affects `flush_cache`, `get_load`, `get_loads`, `set_internal_state`, `dumper_control`, and the HiCache management endpoints — any communicator method called on an idle server will hang.

## Fix

Add `self.auto_create_handle_loop()` to the 10 communicator methods that were missing it, matching the pattern already used by `generate_request()`, `slow_down()`, and other working methods.

The call is idempotent — it returns immediately if the handle_loop is already running.

## Test plan

- Verified on a live PD disaggregation cluster (2 engines + 4 decoders) that `/server_info` hangs before the fix
- Confirmed that triggering a generate request (which calls `auto_create_handle_loop`) unblocks the pending `/server_info`
- After applying the fix, `/server_info` responds immediately on freshly started pods without any prior inference traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)