### PR TITLE
Fix streaming completions sending empty logprobs instead of None

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -646,11 +646,10 @@ class OpenAIServingChat(OpenAIServingBase):
                     total_output_logprobs = len(
                         content["meta_info"]["output_token_logprobs"]
                     )
-                    # When finish_reason is set and all logprobs have been sent,
-                    # any remaining text is just buffered text being flushed by the
-                    # detokenizer (it holds back text at word boundaries). Return None
-                    # for logprobs since no new tokens were generated for this text.
-                    if n_prev_token < total_output_logprobs or finish_reason is None:
+                    # Only populate logprobs when there are actual new tokens
+                    # to report. The detokenizer may flush buffered text in
+                    # chunks where no new tokens were generated, so skip those.
+                    if n_prev_token < total_output_logprobs:
                         choice_logprobs = self._process_streaming_logprobs(
                             content, n_prev_token
                         )

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -242,19 +242,11 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     output_logprobs_slice = content["meta_info"][
                         "output_token_logprobs"
                     ][n_prev_token:]
-                    finish_reason_for_logprobs = content["meta_info"]["finish_reason"]
 
-                    # When finish_reason is set and all logprobs have been sent,
-                    # any remaining text is just buffered text being flushed by the
-                    # detokenizer (it holds back text at word boundaries). Return None
-                    # for logprobs since no new tokens were generated for this text.
-                    if (
-                        len(output_logprobs_slice) == 0
-                        and finish_reason_for_logprobs is not None
-                        and input_token_logprobs is None
-                    ):
-                        logprobs = None
-                    else:
+                    # Only populate logprobs when there are actual tokens to
+                    # report. The detokenizer may flush buffered text in chunks
+                    # where no new tokens were generated, so skip those.
+                    if output_logprobs_slice or input_token_logprobs is not None:
                         logprobs = to_openai_style_logprobs(
                             input_token_logprobs=input_token_logprobs,
                             input_top_logprobs=input_top_logprobs,


### PR DESCRIPTION
## Motivation

Fixes CI failure in `stage-b-test-small-1-gpu (3)`: https://github.com/sgl-project/sglang/actions/runs/22467070918/job/65075451687

`test_completion_stream` fails with `IndexError: list index out of range` at `response.choices[0].logprobs.tokens[0]` because the server sends `LogProbs` objects with empty lists instead of `None`.

## Summary
- Fix server-side bug in streaming completions where `LogProbs` objects with empty lists (`tokens=[], top_logprobs=[]`) were sent instead of `None` when the detokenizer flushed buffered text without new tokens
- The condition introduced in #17687 reasoned about `finish_reason` as a proxy for whether there's data to send, which missed the mid-generation flush case
- Simplify the condition in both `serving_completions.py` and `serving_chat.py` to directly check whether there are actual tokens to report, rather than reasoning about `finish_reason`
- Also fix the same latent bug in `serving_chat.py` where `or finish_reason is None` would produce empty logprobs on mid-generation flushes
- Remove now-unused `finish_reason_for_logprobs` variable

## Test plan
- [x] Existing `test_completion_stream` in `test/registered/openai_server/basic/test_openai_server.py` covers this -- it was the test that caught the bug
- [ ] CI: `stage-b-test-small-1-gpu` suite should pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)