### PR TITLE
[Feature] Enable spec v2 for Qwen3.5

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -608,7 +608,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         device = model_runner.device
         mm_inputs = batch.multimodal_inputs
 
-        if batch.forward_mode.is_draft_extend():  # draft_extend_after_decode
+        if batch.forward_mode.is_draft_extend(
+            include_v2=True
+        ):  # draft_extend_after_decode
             mrope_deltas = []
             extend_lens = []
             for batch_idx in range(batch_size):
@@ -682,7 +684,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                         mm_input, self.seq_lens_cpu[batch_idx]
                     )
                     mrope_positions_list[batch_idx] = mrope_positions
-            elif self.forward_mode.is_extend():
+            elif self.forward_mode.is_extend(include_draft_extend_v2=True):
                 extend_seq_len, extend_prefix_len = (
                     batch.extend_seq_lens[batch_idx],
                     batch.extend_prefix_lens[batch_idx],

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -465,6 +465,7 @@ class EagleDraftWorker(BaseDraftWorker):
         batch: ModelWorkerBatch,
         target_hidden_states: torch.Tensor,
         next_token_ids: torch.Tensor,
+        mm_input_embeds: Optional[torch.Tensor] = None,
     ):
         """
         Run draft model extend to correctly fill the KV cache.
@@ -498,6 +499,8 @@ class EagleDraftWorker(BaseDraftWorker):
 
         # Run forward
         forward_batch = ForwardBatch.init_new(batch, self.draft_runner)
+        if mm_input_embeds is not None:
+            forward_batch.mm_input_embeds = mm_input_embeds
         logits_output = self.draft_runner.forward(forward_batch).logits_output
 
         # Update spec_info for the next draft step
@@ -668,6 +671,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         model_worker_batch,
                         batch_output.logits_output.hidden_states,
                         batch_output.next_token_ids,
+                        batch_output.logits_output.mm_input_embeds,
                     )
                 )
                 return batch_output


### PR DESCRIPTION
# [Feature] Enable spec v2 for Qwen3.5

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR enables speculative decoding v2 for Qwen3.5 (MTP path).
Just test Qwen/Qwen3.5-27B(dense model)

Main goals:
- Make `spec v2` path compatible with Qwen3.5 prefill/extend flow.
- Keep output quality comparable to `spec v1`.
- Improve throughput/latency characteristics under serving load.

## Modifications

- `python/sglang/srt/model_executor/forward_batch_info.py`
  - Enable spec-v2-aware branching in mRoPE position computation:
    - `is_draft_extend(include_v2=True)`
    - `is_extend(include_draft_extend_v2=True)`
  - This ensures draft-extend-v2 is handled in the same mRoPE position construction path as extend/draft-extend logic where needed.

- `python/sglang/srt/speculative/eagle_worker_v2.py`
  - Extend `_draft_extend_for_prefill(...)` with optional `mm_input_embeds`.
  - Propagate `mm_input_embeds` into `ForwardBatch` before running draft forward.
  - Pass `batch_output.logits_output.mm_input_embeds` from target prefill to draft prefill in `forward_batch_generation(...)`.

## Accuracy Tests

GSM8K few-shot command:
```bash
python -m sglang.test.few_shot_gsm8k \
  --host 127.0.0.1 \
  --port <PORT> \
  --num-questions <N> \
  --parallel <P>
```

### TP setting (same as your first group, 200 questions)
| Setting | Spec V1 | Spec V2 | Delta (V2 vs V1) |
|---|---:|---:|---:|
| `--num-questions 200 --parallel 1` Accuracy | 0.365 | 0.355 | -1.0  |
| `--num-questions 200 --parallel 1` Invalid | 0.000 | 0.000 | 0 |
| `--num-questions 200 --parallel 1` Latency (s) | 474.560 | 466.403 | -1.72% |
| `--num-questions 200 --parallel 1` Output tok/s | 149.001 | 152.263 | +2.19% |
| `--num-questions 200 --parallel 200` Accuracy | 0.385 | 0.395 | +1.0  |
| `--num-questions 200 --parallel 200` Invalid | 0.000 | 0.000 | 0 |
| `--num-questions 200 --parallel 200` Latency (s) | 44.690 | 41.980 | -6.06% |
| `--num-questions 200 --parallel 200` Output tok/s | 1590.969 | 1657.156 | +4.16% |

### TP=8 (50 questions, parallel=50)
| Setting | Spec V1 | Spec V2 | Delta (V2 vs V1) |
|---|---:|---:|---:|
| Accuracy | 0.380 | 0.360 | -2.0  |
| Invalid | 0.000 | 0.000 | 0 |
| Latency (s) | 5.291 | 3.949 | -25.36% |
| Output tok/s | 3347.952 | 4278.589 | +27.80% |

Summary:
- Accuracy is broadly comparable across runs.
- Throughput and latency are consistently improved with spec v2 in tested settings.

## Benchmarking and Profiling

Decode-heavy serving benchmark command:
```bash
python3 -m sglang.bench_serving \
  --backend sglang --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen3.5-27B \
  --dataset-name random \
  --num-prompts 512 \
  --random-input-len 2500 \
  --random-range-ratio 1 \
  --random-output-len 600 \
  --max-concurrency 32 \
  --request-rate 0.7
```

Key results:

| Metric | Spec V1 | Spec V2 | Delta (V2 vs V1) |
|---|---:|---:|---:|
| Output token throughput (tok/s) | 410.48 | 410.57 | +0.02% |
| Peak output token throughput (tok/s) | 1328.00 | 1381.00 | +3.99% |
| Mean TPOT (ms) | 9.56 | 9.12 | -4.60% |
| Mean ITL (ms) | 9.56 | 9.12 | -4.60% |
| Max ITL (ms) | 2190.80 | 1697.28 | -22.53% |
| Mean E2E latency (ms) | 6078.17 | 5878.61 | -3.28% |
| Mean TTFT (ms) | 351.01 | 414.85 | +18.19% |

Interpretation:
- Decode phase efficiency improves (better TPOT/ITL, lower E2E, higher peak output throughput).
- TTFT regresses in this workload and should be tracked in follow-up tuning.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.