### PR TITLE
[Bugfix] Correct PyTorch Vectorized API method name in CPU Flash Attention

### DIFF
--- a/sgl-kernel/csrc/cpu/flash_attn.h
+++ b/sgl-kernel/csrc/cpu/flash_attn.h
@@ -118,7 +118,7 @@ struct flash_attn_softmax {
 
     // s_delta <- exp(s_i - m_i)
     at::vec::map<float>(
-        [m_i](Vec x) { return (x - Vec(m_i)).fexp_u20(); }, s_delta + row * BLOCK_N, s_i + row * BLOCK_N, n_size);
+        [m_i](Vec x) { return (x - Vec(m_i)).exp_u20(); }, s_delta + row * BLOCK_N, s_i + row * BLOCK_N, n_size);
 
     // s' <- s' * m_delta + sum(s_delta)
     s_prime[row] *= m_delta;


### PR DESCRIPTION
## Summary

Fixes #19574

The CPU Flash Attention implementation was using `fexp_u20()` method on `Vectorized<float>`, but the correct PyTorch Vectorized API method is `exp_u20()`, not `fexp_u20()`.

## Changes

- `sgl-kernel/csrc/cpu/flash_attn.h`: Changed `.fexp_u20()` to `.exp_u20()` on line 122

## Root Cause

There was a naming mismatch between the sgl-kernel code and the PyTorch Vectorized API. The method `fexp_u20` doesn't exist on `at::vec::CPU_CAPABILITY::Vectorized<float>` - the correct method name is `exp_u20`.

Note: `_mm512_fexp_u20_ps` in `vec.h` is a custom AVX512 intrinsic function defined in sgl-kernel and is correctly used in the AVX512-specific code path. Only the generic Vectorized API call was incorrect.

## Reproduction (before fix)

```bash
docker build --no-cache \
    -t sglang-cpu:qwen3.5-v1 \
    -f xeon.Dockerfile \
    --build-arg VER_SGLANG=main \
    --build-arg SGLANG_REPO=https://github.com/sgl-project/sglang.git \
    --build-arg MAX_JOBS=8 .
```

This would fail with:
```
error: 'class at::vec::CPU_CAPABILITY::Vectorized<float>' has no member named 'fexp_u20'; did you mean 'exp_u20'?
```

## Verification

After fix, the CPU Docker image should build successfully.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29235710238](https://github.com/sgl-project/sglang/actions/runs/29235710238)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29235710092](https://github.com/sgl-project/sglang/actions/runs/29235710092)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->