### PR TITLE
[Feature] Unified JIT / precompilation cache directory

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -160,6 +160,7 @@ SGLang supports various environment variables that can be used to configure its 
 
 | Environment Variable | Description | Default Value |
 | --- | --- | --- |
+| `SGLANG_JIT_CACHE_ROOT` | Unified root directory for all JIT / precompilation caches (Triton, Inductor, torch\_compile, DeepGEMM, GPU P2P). Subdirectories are created automatically. Individual overrides (`SGLANG_CACHE_DIR`, `SGLANG_DG_CACHE_DIR`) take precedence when set. | `$XDG_CACHE_HOME/sglang` or `~/.cache/sglang` |
 | `SGLANG_WAIT_WEIGHTS_READY_TIMEOUT` | Timeout period for waiting on weights | `120` |
 | `SGLANG_DISABLE_OUTLINES_DISK_CACHE` | Disable Outlines disk cache | `true` |
 | `SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE` | Use SGLang's custom Triton kernel cache implementation for lower overheads (automatically enabled on CUDA) | `false` |

--- a/docs/references/torch_compile_cache.md
+++ b/docs/references/torch_compile_cache.md
@@ -5,6 +5,27 @@ If you want to deploy a model on many different machines, you can ship the torch
 
 This is based on https://pytorch.org/tutorials/recipes/torch_compile_caching_tutorial.html
 
+## Unified cache root (recommended)
+
+All JIT and precompilation caches (Triton, Inductor, torch\_compile, DeepGEMM) are stored under a single configurable root directory controlled by `SGLANG_JIT_CACHE_ROOT` (default: `~/.cache/sglang`).
+
+```
+SGLANG_JIT_CACHE_ROOT=/data/sglang_cache python3 -m sglang.launch_server --model meta-llama/Llama-3.1-8B-Instruct --enable-torch-compile
+```
+
+The layout under the root is:
+
+```
+$SGLANG_JIT_CACHE_ROOT/
+  torch_compile/    # SGLang torch.compile hash-based cache
+  deep_gemm/        # DeepGEMM JIT kernels
+```
+
+Triton and Inductor caches are managed inside the `torch_compile/<hash>/` subtree automatically.
+
+## Legacy per-component overrides
+
+You can still use `TORCHINDUCTOR_CACHE_DIR` or other per-component env vars. They take precedence over the unified root.
 
 1. Generate the cache by setting TORCHINDUCTOR_CACHE_DIR and running the model once.
 ```

--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -395,14 +395,15 @@ class SGLangBackend:
 
     def __call__(self, graph: fx.GraphModule, example_inputs) -> Callable:
         rank0_log(f"SGLangBackend __call__")
-        base_cache_dir = os.path.expanduser(
-            os.getenv("SGLANG_CACHE_DIR", "~/.cache/sglang/")
+        from sglang.srt.environ import get_jit_cache_subdir
+
+        base_cache_dir = get_jit_cache_subdir(
+            "torch_compile", override_env="SGLANG_CACHE_DIR"
         )
 
         cache_hash = self.compiler_manager.compute_hash()
         cache_dir = os.path.join(
             base_cache_dir,
-            "torch_compile_cache",
             cache_hash,
         )
 

--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -397,15 +397,22 @@ class SGLangBackend:
         rank0_log(f"SGLangBackend __call__")
         from sglang.srt.environ import get_jit_cache_subdir
 
-        base_cache_dir = get_jit_cache_subdir(
-            "torch_compile", override_env="SGLANG_CACHE_DIR"
-        )
-
         cache_hash = self.compiler_manager.compute_hash()
-        cache_dir = os.path.join(
-            base_cache_dir,
-            cache_hash,
-        )
+        sglang_cache_dir_override = os.environ.get("SGLANG_CACHE_DIR")
+
+        if sglang_cache_dir_override:
+            base_cache_dir = os.path.expanduser(sglang_cache_dir_override)
+            cache_dir = os.path.join(
+                base_cache_dir,
+                "torch_compile_cache",
+                cache_hash,
+            )
+        else:
+            base_cache_dir = get_jit_cache_subdir("torch_compile")
+            cache_dir = os.path.join(
+                base_cache_dir,
+                cache_hash,
+            )
 
         os.makedirs(cache_dir, exist_ok=True)
         rank = 0

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
@@ -257,9 +257,9 @@ def gpu_p2p_access_check(src: int, tgt: int) -> bool:
     if cuda_visible_devices is None:
         cuda_visible_devices = ",".join(str(i) for i in range(num_dev))
 
-    # VLLM_CACHE_ROOT -> SGLANG_CACHE_ROOT
-    # "~/.cache/vllm" -> "~/.cache/sglang"
-    SGLANG_CACHE_ROOT = os.path.expanduser("~/.cache/sglang")
+    from sglang.srt.environ import envs
+
+    SGLANG_CACHE_ROOT = envs.SGLANG_JIT_CACHE_ROOT.get()
     path = os.path.join(
         SGLANG_CACHE_ROOT, f"gpu_p2p_access_cache_for_{cuda_visible_devices}.json"
     )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -347,6 +347,14 @@ class Envs:
     # TBO
     SGLANG_TBO_DEBUG = EnvBool(False)
 
+    # Unified JIT / precompilation cache root
+    SGLANG_JIT_CACHE_ROOT = EnvStr(
+        os.path.join(
+            os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")),
+            "sglang",
+        )
+    )
+
     # DeepGemm
     SGLANG_ENABLE_JIT_DEEPGEMM = EnvBool(True)
     SGLANG_JIT_DEEPGEMM_PRECOMPILE = EnvBool(True)
@@ -495,6 +503,20 @@ class Envs:
 
 envs = Envs()
 EnvField._allow_set_name = False
+
+
+def get_jit_cache_subdir(subdir: str, override_env: str = None) -> str:
+    """Return the path for a JIT cache subdirectory under SGLANG_JIT_CACHE_ROOT.
+
+    If *override_env* is given and that environment variable is set, its value
+    is used instead of the derived path.
+    """
+    if override_env:
+        val = os.environ.get(override_env)
+        if val:
+            return os.path.expanduser(val)
+    root = envs.SGLANG_JIT_CACHE_ROOT.get()
+    return os.path.join(root, subdir)
 
 
 def _print_deprecated_env(new_name: str, old_name: str):

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -11,7 +11,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     disable_symmetric_memory_context,
     restore_symmetric_memory_context,
 )
-from sglang.srt.environ import envs
+from sglang.srt.environ import envs, get_jit_cache_subdir
 from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import ceil_div, get_available_gpu_memory
@@ -30,8 +30,8 @@ _IN_PRECOMPILE_STAGE = envs.SGLANG_IN_DEEPGEMM_PRECOMPILE_STAGE.get()
 _FAST_WARMUP = envs.SGLANG_JIT_DEEPGEMM_FAST_WARMUP.get()
 
 # Force redirect deep_gemm cache_dir
-os.environ["DG_JIT_CACHE_DIR"] = os.getenv(
-    "SGLANG_DG_CACHE_DIR", os.path.join(os.path.expanduser("~"), ".cache", "deep_gemm")
+os.environ["DG_JIT_CACHE_DIR"] = get_jit_cache_subdir(
+    "deep_gemm", override_env="SGLANG_DG_CACHE_DIR"
 )
 
 # Refer to https://github.com/deepseek-ai/DeepGEMM/commit/d75b218b7b8f4a5dd5406ac87905039ead3ae42f

--- a/test/registered/utils/test_jit_cache_root.py
+++ b/test/registered/utils/test_jit_cache_root.py
@@ -1,0 +1,135 @@
+import os
+import unittest
+
+from sglang.srt.environ import envs, get_jit_cache_subdir
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="default")
+
+
+class TestGetJitCacheSubdir(unittest.TestCase):
+    """Verify the priority logic of get_jit_cache_subdir().
+
+    Priority (highest to lowest):
+      1. Per-component override env var (e.g. SGLANG_DG_CACHE_DIR)
+      2. SGLANG_JIT_CACHE_ROOT / <subdir>
+      3. Default root (~/.cache/sglang) / <subdir>
+    """
+
+    def setUp(self):
+        self._env_backup = {}
+        self._keys = [
+            "SGLANG_JIT_CACHE_ROOT",
+            "SGLANG_DG_CACHE_DIR",
+            "SGLANG_CACHE_DIR",
+            "XDG_CACHE_HOME",
+            "_TEST_OVERRIDE",
+        ]
+        for k in self._keys:
+            self._env_backup[k] = os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k in self._keys:
+            if self._env_backup[k] is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = self._env_backup[k]
+
+    def test_default_root(self):
+        """No env vars set -> uses ~/.cache/sglang/<subdir>."""
+        result = get_jit_cache_subdir("deep_gemm")
+        expected = os.path.join(os.path.expanduser("~/.cache"), "sglang", "deep_gemm")
+        self.assertEqual(result, expected)
+
+    def test_custom_root(self):
+        """SGLANG_JIT_CACHE_ROOT set -> uses that root."""
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/data/my_cache"
+        result = get_jit_cache_subdir("deep_gemm")
+        self.assertEqual(result, "/data/my_cache/deep_gemm")
+
+    def test_xdg_cache_home(self):
+        """XDG_CACHE_HOME set (without SGLANG_JIT_CACHE_ROOT) -> uses XDG path.
+
+        Note: XDG_CACHE_HOME is read at import time for the default value,
+        so this test verifies the SGLANG_JIT_CACHE_ROOT override instead.
+        """
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/xdg_root/sglang"
+        result = get_jit_cache_subdir("triton")
+        self.assertEqual(result, "/xdg_root/sglang/triton")
+
+    def test_override_env_takes_precedence(self):
+        """Per-component override env var wins over SGLANG_JIT_CACHE_ROOT."""
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/data/root"
+        os.environ["_TEST_OVERRIDE"] = "/custom/override_path"
+        result = get_jit_cache_subdir("deep_gemm", override_env="_TEST_OVERRIDE")
+        self.assertEqual(result, "/custom/override_path")
+
+    def test_override_env_empty_falls_through(self):
+        """Empty override env var is ignored -> falls through to root."""
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/data/root"
+        os.environ["_TEST_OVERRIDE"] = ""
+        result = get_jit_cache_subdir("deep_gemm", override_env="_TEST_OVERRIDE")
+        self.assertEqual(result, "/data/root/deep_gemm")
+
+    def test_override_env_not_set_falls_through(self):
+        """Unset override env var -> falls through to root."""
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/data/root"
+        os.environ.pop("_TEST_OVERRIDE", None)
+        result = get_jit_cache_subdir("deep_gemm", override_env="_TEST_OVERRIDE")
+        self.assertEqual(result, "/data/root/deep_gemm")
+
+    def test_no_override_env_param(self):
+        """override_env=None -> always uses root."""
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/data/root"
+        result = get_jit_cache_subdir("torch_compile")
+        self.assertEqual(result, "/data/root/torch_compile")
+
+    def test_override_with_tilde(self):
+        """Override env var with ~ is expanded."""
+        os.environ["_TEST_OVERRIDE"] = "~/my_cache/dg"
+        result = get_jit_cache_subdir("deep_gemm", override_env="_TEST_OVERRIDE")
+        self.assertEqual(result, os.path.expanduser("~/my_cache/dg"))
+        self.assertNotIn("~", result)
+
+    def test_different_subdirs(self):
+        """Different subdir names produce different paths."""
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/cache"
+        self.assertEqual(get_jit_cache_subdir("triton"), "/cache/triton")
+        self.assertEqual(get_jit_cache_subdir("inductor"), "/cache/inductor")
+        self.assertEqual(get_jit_cache_subdir("torch_compile"), "/cache/torch_compile")
+        self.assertEqual(get_jit_cache_subdir("deep_gemm"), "/cache/deep_gemm")
+
+
+class TestSGLangJitCacheRootEnvVar(unittest.TestCase):
+    """Test that the SGLANG_JIT_CACHE_ROOT EnvStr descriptor works correctly."""
+
+    def setUp(self):
+        self._backup = os.environ.pop("SGLANG_JIT_CACHE_ROOT", None)
+
+    def tearDown(self):
+        if self._backup is None:
+            os.environ.pop("SGLANG_JIT_CACHE_ROOT", None)
+        else:
+            os.environ["SGLANG_JIT_CACHE_ROOT"] = self._backup
+
+    def test_default_value(self):
+        os.environ.pop("SGLANG_JIT_CACHE_ROOT", None)
+        result = envs.SGLANG_JIT_CACHE_ROOT.get()
+        self.assertTrue(
+            result.endswith("/sglang"), f"Expected path ending in /sglang, got {result}"
+        )
+        self.assertNotIn("~", result)
+
+    def test_explicit_value(self):
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/tmp/test_cache"
+        self.assertEqual(envs.SGLANG_JIT_CACHE_ROOT.get(), "/tmp/test_cache")
+
+    def test_is_set(self):
+        os.environ.pop("SGLANG_JIT_CACHE_ROOT", None)
+        self.assertFalse(envs.SGLANG_JIT_CACHE_ROOT.is_set())
+        os.environ["SGLANG_JIT_CACHE_ROOT"] = "/tmp/x"
+        self.assertTrue(envs.SGLANG_JIT_CACHE_ROOT.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
Introduce `SGLANG_JIT_CACHE_ROOT` env var so all JIT and precompilation caches (torch_compile, DeepGEMM, GPU P2P) live under a single configurable root (default: `~/.cache/sglang`, respects `XDG_CACHE_HOME`).

Per component overrides (`SGLANG_CACHE_DIR`, `SGLANG_DG_CACHE_DIR`, etc) still take precedence when set, preserving backward compatibility.

## Motivation

relate #19612 

currently, `JIT` and `pre-compilation` cache paths are fragmented across multiple env vars and default locations:

- **torch_compile**: `SGLANG_CACHE_DIR` → `~/.cache/sglang/`
- **DeepGEMM**: `SGLANG_DG_CACHE_DIR` / `DG_JIT_CACHE_DIR` → `~/.cache/deep_gemm`
- **GPU P2P access cache**: hardcoded `~/.cache/sglang`
- **Triton/Inductor**: managed inside `torch_compile` subtree, but Inductor defaults to `/tmp`

This makes it hard for users and operators to manage cache location, size, and persistence in one place, especially on shared nodes or when reusing caches across runs/machines.

## Modifications

Env variables:
- **`python/sglang/srt/environ.py`**: Add `SGLANG_JIT_CACHE_ROOT` env var (default: `$XDG_CACHE_HOME/sglang` or `~/.cache/sglang`) and `get_jit_cache_subdir()` helper that derives subdirectory paths with optional per-component override support.
- **`python/sglang/srt/compilation/backend.py`**: Use `get_jit_cache_subdir("torch_compile", override_env="SGLANG_CACHE_DIR")` instead of hardcoded `SGLANG_CACHE_DIR` with manual path join.
- **`python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py`**: Use `get_jit_cache_subdir("deep_gemm", override_env="SGLANG_DG_CACHE_DIR")` instead of inline `os.getenv` with manual fallback.
- **`scripts/ci/cuda/warmup_deep_gemm.py`**: Mirror the same resolution logic inline (this standalone CI script cannot import sglang without pulling in torch).
- **`python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py`**: Replace hardcoded `~/.cache/sglang` with `envs.SGLANG_JIT_CACHE_ROOT.get()`.

Doc description:
- **`docs/references/environment_variables.md`**: Add `SGLANG_JIT_CACHE_ROOT` to the Storage & Caching table.
- **`docs/references/torch_compile_cache.md`**: Add "Unified cache root" section documenting usage and directory layout.

Unit tests have been added to verify the priority of env variables:
- **`test/registered/utils/test_jit_cache_root.py`**: Add 12 unit tests covering the full priority logic of `get_jit_cache_subdir()` (default root, custom root, per-component override precedence, empty/unset override fallthrough, tilde expansion, multiple subdirs) and the `SGLANG_JIT_CACHE_ROOT` env var descriptor.

## Accuracy Tests

This change only affects cache directory paths, not model computation or outputs.

## Benchmarking and Profiling

No impact on inference speed. This is a configuration change only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
