### PR TITLE
[JIT] Unified cache directory

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -55,7 +55,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_JIT_DEEPGEMM_PRECOMPILE` | Enable precompilation of DeepGEMM kernels | `"true"` |
 | `SGLANG_JIT_DEEPGEMM_COMPILE_WORKERS` | Number of workers for parallel DeepGEMM kernel compilation | `4` |
 | `SGLANG_IN_DEEPGEMM_PRECOMPILE_STAGE` | Indicator flag used during the DeepGEMM precompile script | `"false"` |
-| `SGLANG_DG_CACHE_DIR` | Directory for caching compiled DeepGEMM kernels | `~/.cache/deep_gemm` |
+| `SGLANG_DG_CACHE_DIR` | Directory for caching compiled DeepGEMM kernels | `<SGLANG_JIT_CACHE_ROOT>/deep_gemm` |
 | `SGLANG_DG_USE_NVRTC` | Use NVRTC (instead of Triton) for JIT compilation (Experimental) | `"false"` |
 | `SGLANG_USE_DEEPGEMM_BMM` | Use DeepGEMM for Batched Matrix Multiplication (BMM) operations | `"false"` |
 | `SGLANG_JIT_DEEPGEMM_FAST_WARMUP` | Precompile less kernels during warmup, which reduces the warmup time from 30min to less than 3min. Might cause performance degradation during runtime. | `"false"` |
@@ -171,6 +171,7 @@ SGLang supports various environment variables that can be used to configure its 
 
 | Environment Variable | Description | Default Value |
 | --- | --- | --- |
+| `SGLANG_JIT_CACHE_ROOT` | Root directory for all JIT-compiled caches (torch.compile, DeepGEMM, Triton, Inductor, GPU P2P). Subdirectories are created automatically. Replaces the deprecated `SGLANG_CACHE_DIR`. | `~/.cache/sglang` |
 | `SGLANG_WAIT_WEIGHTS_READY_TIMEOUT` | Timeout period for waiting on weights | `120` |
 | `SGLANG_DISABLE_OUTLINES_DISK_CACHE` | Disable Outlines disk cache | `false` |
 | `SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE` | Use SGLang's custom Triton kernel cache implementation for lower overheads (automatically enabled on CUDA) | `false` |

--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -393,14 +393,13 @@ class SGLangBackend:
         self.inductor_config["post_grad_custom_post_pass"] = self.post_grad_pass_manager
 
     def __call__(self, graph: fx.GraphModule, example_inputs) -> Callable:
-        base_cache_dir = os.path.expanduser(
-            os.getenv("SGLANG_CACHE_DIR", "~/.cache/sglang/")
-        )
+        from sglang.srt.environ import get_jit_cache_subdir
+
+        base_cache_dir = get_jit_cache_subdir("torch_compile_cache")
 
         cache_hash = self.compiler_manager.compute_hash()
         cache_dir = os.path.join(
             base_cache_dir,
-            "torch_compile_cache",
             cache_hash,
         )
 

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
@@ -258,9 +258,9 @@ def gpu_p2p_access_check(src: int, tgt: int) -> bool:
     if cuda_visible_devices is None:
         cuda_visible_devices = ",".join(str(i) for i in range(num_dev))
 
-    # VLLM_CACHE_ROOT -> SGLANG_CACHE_ROOT
-    # "~/.cache/vllm" -> "~/.cache/sglang"
-    SGLANG_CACHE_ROOT = os.path.expanduser("~/.cache/sglang")
+    from sglang.srt.environ import envs
+
+    SGLANG_CACHE_ROOT = envs.SGLANG_JIT_CACHE_ROOT.get()
     path = os.path.join(
         SGLANG_CACHE_ROOT, f"gpu_p2p_access_cache_for_{cuda_visible_devices}.json"
     )

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1093,6 +1093,10 @@ class Engine(EngineBase):
 
 def _set_envs_and_config(server_args: ServerArgs):
     # Set global environments
+    from sglang.srt.environ import configure_jit_cache_env_vars
+
+    configure_jit_cache_env_vars()
+
     if "NCCL_CUMEM_ENABLE" not in os.environ or server_args.enable_symm_mem:
         os.environ["NCCL_CUMEM_ENABLE"] = str(int(server_args.enable_symm_mem))
     if (

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -364,6 +364,9 @@ class Envs:
     # TBO
     SGLANG_TBO_DEBUG = EnvBool(False)
 
+    # Unified JIT cache root
+    SGLANG_JIT_CACHE_ROOT = EnvStr(os.path.expanduser("~/.cache/sglang"))
+
     # DeepGemm
     SGLANG_ENABLE_JIT_DEEPGEMM = EnvBool(True)
     SGLANG_JIT_DEEPGEMM_PRECOMPILE = EnvBool(True)
@@ -529,6 +532,26 @@ envs = Envs()
 EnvField._allow_set_name = False
 
 
+def get_jit_cache_subdir(name: str, *, override_env: str = None) -> str:
+    """Return <SGLANG_JIT_CACHE_ROOT>/<name>, or the value of *override_env* if set."""
+    if override_env is not None:
+        override_value = os.environ.get(override_env)
+        if override_value is not None:
+            return os.path.expanduser(override_value)
+    return os.path.join(envs.SGLANG_JIT_CACHE_ROOT.get(), name)
+
+
+def configure_jit_cache_env_vars():
+    """Set TRITON_CACHE_DIR / TORCHINDUCTOR_CACHE_DIR under SGLANG_JIT_CACHE_ROOT if not already set."""
+    root = envs.SGLANG_JIT_CACHE_ROOT.get()
+
+    if "TRITON_CACHE_DIR" not in os.environ:
+        os.environ["TRITON_CACHE_DIR"] = os.path.join(root, "triton")
+
+    if "TORCHINDUCTOR_CACHE_DIR" not in os.environ:
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = os.path.join(root, "inductor")
+
+
 def _print_deprecated_env(new_name: str, old_name: str):
     if old_name in os.environ:
         warnings.warn(
@@ -547,6 +570,7 @@ def _warn_deprecated_env_to_cli_flag(env_name: str, suggestion: str):
 
 
 def _convert_SGL_to_SGLANG():
+    _print_deprecated_env("SGLANG_JIT_CACHE_ROOT", "SGLANG_CACHE_DIR")
     _print_deprecated_env("SGLANG_LOG_GC", "SGLANG_GC_LOG")
     _print_deprecated_env(
         "SGLANG_ENABLE_FLASHINFER_FP8_GEMM", "SGLANG_ENABLE_FLASHINFER_GEMM"

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -11,7 +11,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     disable_symmetric_memory_context,
     restore_symmetric_memory_context,
 )
-from sglang.srt.environ import envs
+from sglang.srt.environ import envs, get_jit_cache_subdir
 from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import ceil_div, get_available_gpu_memory
@@ -29,9 +29,9 @@ _IS_FIRST_RANK_ON_NODE = envs.SGLANG_IS_FIRST_RANK_ON_NODE.get()
 _IN_PRECOMPILE_STAGE = envs.SGLANG_IN_DEEPGEMM_PRECOMPILE_STAGE.get()
 _FAST_WARMUP = envs.SGLANG_JIT_DEEPGEMM_FAST_WARMUP.get()
 
-# Force redirect deep_gemm cache_dir
-os.environ["DG_JIT_CACHE_DIR"] = os.getenv(
-    "SGLANG_DG_CACHE_DIR", os.path.join(os.path.expanduser("~"), ".cache", "deep_gemm")
+# Redirect deep_gemm cache_dir under SGLANG_JIT_CACHE_ROOT
+os.environ["DG_JIT_CACHE_DIR"] = get_jit_cache_subdir(
+    "deep_gemm", override_env="SGLANG_DG_CACHE_DIR"
 )
 
 # Refer to https://github.com/deepseek-ai/DeepGEMM/commit/d75b218b7b8f4a5dd5406ac87905039ead3ae42f

--- a/scripts/ci/cuda/warmup_deep_gemm.py
+++ b/scripts/ci/cuda/warmup_deep_gemm.py
@@ -22,11 +22,17 @@ import time
 from math import ceil
 from pathlib import Path
 
-# Configure DeepGEMM cache before importing deep_gemm
-os.environ["DG_JIT_CACHE_DIR"] = os.getenv(
-    "SGLANG_DG_CACHE_DIR",
-    os.path.join(os.path.expanduser("~"), ".cache", "deep_gemm"),
-)
+# Configure DeepGEMM cache before importing deep_gemm.
+_dg_cache_override = os.getenv("SGLANG_DG_CACHE_DIR")
+if _dg_cache_override is not None:
+    os.environ["DG_JIT_CACHE_DIR"] = os.path.expanduser(_dg_cache_override)
+else:
+    _jit_cache_root = os.path.expanduser(
+        os.getenv("SGLANG_JIT_CACHE_ROOT")
+        or os.getenv("SGLANG_CACHE_DIR")
+        or "~/.cache/sglang"
+    )
+    os.environ["DG_JIT_CACHE_DIR"] = os.path.join(_jit_cache_root, "deep_gemm")
 os.environ["DG_JIT_USE_NVRTC"] = os.getenv("SGL_DG_USE_NVRTC", "0")
 
 BLOCK_SIZE = 128

--- a/test/registered/utils/test_jit_cache_root.py
+++ b/test/registered/utils/test_jit_cache_root.py
@@ -1,0 +1,224 @@
+"""
+Unit tests for the unified JIT cache directory feature (SGLANG_JIT_CACHE_ROOT).
+
+Tests that all cache consumers correctly derive their paths from the unified
+root, backward-compat env vars are honoured, and external-library env vars
+(TRITON_CACHE_DIR, TORCHINDUCTOR_CACHE_DIR) are propagated.
+"""
+
+import os
+import tempfile
+import unittest
+
+from sglang.srt.environ import (
+    configure_jit_cache_env_vars,
+    envs,
+    get_jit_cache_subdir,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="default")
+
+
+class TestGetJitCacheSubdir(unittest.TestCase):
+    """Tests for the get_jit_cache_subdir() helper."""
+
+    def setUp(self):
+        # Save and clear relevant env vars before each test
+        self._saved = {}
+        for key in (
+            "SGLANG_JIT_CACHE_ROOT",
+            "SGLANG_CACHE_DIR",
+            "SGLANG_DG_CACHE_DIR",
+        ):
+            self._saved[key] = os.environ.pop(key, None)
+
+    def tearDown(self):
+        # Restore env vars
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_default_root(self):
+        """Without any env var set, subdir is under ~/.cache/sglang."""
+        result = get_jit_cache_subdir("deep_gemm")
+        expected = os.path.join(os.path.expanduser("~/.cache/sglang"), "deep_gemm")
+        self.assertEqual(result, expected)
+
+    def test_custom_root(self):
+        """SGLANG_JIT_CACHE_ROOT redirects all subdirectories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            envs.SGLANG_JIT_CACHE_ROOT.set(tmpdir)
+            try:
+                result = get_jit_cache_subdir("torch_compile_cache")
+                self.assertEqual(result, os.path.join(tmpdir, "torch_compile_cache"))
+            finally:
+                envs.SGLANG_JIT_CACHE_ROOT.clear()
+
+    def test_override_env_takes_precedence(self):
+        """When an override env var is explicitly set, it wins."""
+        custom_path = "/tmp/my_custom_dg_cache"
+        os.environ["SGLANG_DG_CACHE_DIR"] = custom_path
+        try:
+            result = get_jit_cache_subdir(
+                "deep_gemm", override_env="SGLANG_DG_CACHE_DIR"
+            )
+            self.assertEqual(result, custom_path)
+        finally:
+            del os.environ["SGLANG_DG_CACHE_DIR"]
+
+    def test_override_env_not_set_falls_back_to_root(self):
+        """When override env var is not set, falls back to SGLANG_JIT_CACHE_ROOT."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            envs.SGLANG_JIT_CACHE_ROOT.set(tmpdir)
+            try:
+                # SGLANG_DG_CACHE_DIR is NOT in os.environ
+                result = get_jit_cache_subdir(
+                    "deep_gemm", override_env="SGLANG_DG_CACHE_DIR"
+                )
+                self.assertEqual(result, os.path.join(tmpdir, "deep_gemm"))
+            finally:
+                envs.SGLANG_JIT_CACHE_ROOT.clear()
+
+    def test_override_env_with_tilde(self):
+        """Tilde in override env var is expanded."""
+        os.environ["SGLANG_DG_CACHE_DIR"] = "~/my_cache/dg"
+        try:
+            result = get_jit_cache_subdir(
+                "deep_gemm", override_env="SGLANG_DG_CACHE_DIR"
+            )
+            self.assertEqual(result, os.path.expanduser("~/my_cache/dg"))
+        finally:
+            del os.environ["SGLANG_DG_CACHE_DIR"]
+
+    def test_multiple_subdirs_share_root(self):
+        """Different subdirectories all live under the same root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            envs.SGLANG_JIT_CACHE_ROOT.set(tmpdir)
+            try:
+                dg = get_jit_cache_subdir("deep_gemm")
+                tc = get_jit_cache_subdir("torch_compile_cache")
+                self.assertTrue(dg.startswith(tmpdir))
+                self.assertTrue(tc.startswith(tmpdir))
+                self.assertNotEqual(dg, tc)
+            finally:
+                envs.SGLANG_JIT_CACHE_ROOT.clear()
+
+
+class TestConfigureJitCacheEnvVars(unittest.TestCase):
+    """Tests for configure_jit_cache_env_vars()."""
+
+    def setUp(self):
+        self._saved = {}
+        for key in (
+            "SGLANG_JIT_CACHE_ROOT",
+            "TRITON_CACHE_DIR",
+            "TORCHINDUCTOR_CACHE_DIR",
+        ):
+            self._saved[key] = os.environ.pop(key, None)
+
+    def tearDown(self):
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_sets_triton_cache_dir(self):
+        """configure_jit_cache_env_vars sets TRITON_CACHE_DIR when absent."""
+        configure_jit_cache_env_vars()
+        root = envs.SGLANG_JIT_CACHE_ROOT.get()
+        self.assertEqual(
+            os.environ["TRITON_CACHE_DIR"],
+            os.path.join(root, "triton"),
+        )
+
+    def test_sets_inductor_cache_dir(self):
+        """configure_jit_cache_env_vars sets TORCHINDUCTOR_CACHE_DIR when absent."""
+        configure_jit_cache_env_vars()
+        root = envs.SGLANG_JIT_CACHE_ROOT.get()
+        self.assertEqual(
+            os.environ["TORCHINDUCTOR_CACHE_DIR"],
+            os.path.join(root, "inductor"),
+        )
+
+    def test_does_not_override_existing_triton_cache_dir(self):
+        """If user already set TRITON_CACHE_DIR, we don't overwrite it."""
+        os.environ["TRITON_CACHE_DIR"] = "/my/triton"
+        configure_jit_cache_env_vars()
+        self.assertEqual(os.environ["TRITON_CACHE_DIR"], "/my/triton")
+
+    def test_does_not_override_existing_inductor_cache_dir(self):
+        """If user already set TORCHINDUCTOR_CACHE_DIR, we don't overwrite it."""
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = "/my/inductor"
+        configure_jit_cache_env_vars()
+        self.assertEqual(os.environ["TORCHINDUCTOR_CACHE_DIR"], "/my/inductor")
+
+    def test_custom_root_propagates_to_external(self):
+        """Custom SGLANG_JIT_CACHE_ROOT propagates to Triton/Inductor."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            envs.SGLANG_JIT_CACHE_ROOT.set(tmpdir)
+            try:
+                configure_jit_cache_env_vars()
+                self.assertEqual(
+                    os.environ["TRITON_CACHE_DIR"],
+                    os.path.join(tmpdir, "triton"),
+                )
+                self.assertEqual(
+                    os.environ["TORCHINDUCTOR_CACHE_DIR"],
+                    os.path.join(tmpdir, "inductor"),
+                )
+            finally:
+                envs.SGLANG_JIT_CACHE_ROOT.clear()
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    """Ensure legacy env vars still work."""
+
+    def setUp(self):
+        self._saved = {}
+        for key in (
+            "SGLANG_JIT_CACHE_ROOT",
+            "SGLANG_CACHE_DIR",
+            "SGLANG_DG_CACHE_DIR",
+        ):
+            self._saved[key] = os.environ.pop(key, None)
+
+    def tearDown(self):
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_torch_compile_default_path_unchanged(self):
+        """Default torch_compile cache path is still under ~/.cache/sglang/torch_compile_cache."""
+        result = get_jit_cache_subdir("torch_compile_cache")
+        expected = os.path.join(
+            os.path.expanduser("~/.cache/sglang"), "torch_compile_cache"
+        )
+        self.assertEqual(result, expected)
+
+    def test_gpu_p2p_default_path_unchanged(self):
+        """Default GPU P2P cache is still under ~/.cache/sglang."""
+        root = envs.SGLANG_JIT_CACHE_ROOT.get()
+        self.assertEqual(root, os.path.expanduser("~/.cache/sglang"))
+
+    def test_sglang_cache_dir_is_honored(self):
+        """Legacy SGLANG_CACHE_DIR is remapped to SGLANG_JIT_CACHE_ROOT."""
+        from sglang.srt.environ import _convert_SGL_to_SGLANG
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["SGLANG_CACHE_DIR"] = tmpdir
+            try:
+                _convert_SGL_to_SGLANG()
+                self.assertEqual(os.environ.get("SGLANG_JIT_CACHE_ROOT"), tmpdir)
+            finally:
+                os.environ.pop("SGLANG_CACHE_DIR", None)
+                os.environ.pop("SGLANG_JIT_CACHE_ROOT", None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
Add SGLANG_JIT_CACHE_ROOT to consolidate all JIT cache paths under a single root. Legacy env vars still work.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #19612

JIT cache files are scattered across multiple locations (`~/.cache/sglang`, `~/.cache/deep_gemm`, `/tmp/torchinductor_*`, `~/.triton/cache`). This makes cleanup hard and multi-tenant setups messy.

## Modifications

- Add `SGLANG_JIT_CACHE_ROOT` env var (default `~/.cache/sglang`), all JIT caches become subdirectories under it:
  - `torch_compile_cache/` — torch.compile
  - `deep_gemm/` — DeepGEMM
  - `triton/` — Triton
  - `inductor/` — TorchInductor
  - `gpu_p2p_access_cache_for_*.json` — GPU P2P check
- `SGLANG_CACHE_DIR` still works (deprecated, remapped automatically)
- `SGLANG_DG_CACHE_DIR` / `TRITON_CACHE_DIR` / `TORCHINDUCTOR_CACHE_DIR` still respected if explicitly set
- Updated `warmup_deep_gemm.py` CI script to match
- Added docs in `environment_variables.md`

## Accuracy Tests

N/A, no accuracy changes (only path resolution)


## Benchmarking and Profiling

N/A, no perf-sensitive changes (only path resolution)


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
