### PR TITLE
[Bugfix] For cp: Fixed hang problem in prefix cache and kvcache support fp8 in-seq-split mode

### DIFF
--- a/docs/basic_usage/deepseek_v32.md
+++ b/docs/basic_usage/deepseek_v32.md
@@ -316,8 +316,7 @@ The first mode can be enabled by `--nsa-prefill-cp-mode in-seq-split`. This mode
 
 Note that in sequence splitting mode has the following restrictions:
 - The batch size is restricted to 1 for prefill batches
-- Multi-node/PD disaggregation is still not supported
-- `moe_dense_tp_size=1`, `kv_cache_dtype = "bf16"`, `moe_a2a_backend = "deepep"`
+- `moe_dense_tp_size=1`, `moe_a2a_backend = "deepep"`
 - To ensure `cp_size > 1`, the passed in `tp_size` must be larger than `dp_size`
 
 For more details, please refer to PR https://github.com/sgl-project/sglang/pull/12065.

--- a/python/sglang/srt/layers/attention/nsa/utils.py
+++ b/python/sglang/srt/layers/attention/nsa/utils.py
@@ -54,7 +54,7 @@ def can_nsa_prefill_cp_round_robin_split(forward_batch: "ForwardBatch"):
         return False
     cp_size = get_attention_cp_size()
     seq_len = sum(forward_batch.extend_seq_lens_cpu)
-    return is_nsa_prefill_cp_round_robin_split() and seq_len > 0 and cp_size > 1
+    return is_nsa_prefill_cp_round_robin_split() and seq_len > 0 and seq_len >= cp_size and cp_size > 1
 
 
 def nsa_cp_round_robin_split_data(input_: Union[torch.Tensor, List]):
@@ -167,6 +167,7 @@ def can_cp_split(seq_len: int, cp_size: int, use_nsa: bool, forward_batch):
         and use_nsa
         and forward_batch.forward_mode.is_context_parallel_extend()
         and is_nsa_enable_prefill_cp()
+        and sum(forward_batch.extend_seq_lens_cpu) >= cp_size
     ):
         return True
     else:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1219,9 +1219,8 @@ class ServerArgs:
                             self.moe_dense_tp_size = 1
                             self.moe_a2a_backend = "deepep"
                             self.ep_size = self.tp_size
-                            self.kv_cache_dtype = "bf16"
                             logger.warning(
-                                "For in-seq split mode, we have the following restrictions: moe_dense_tp_size == 1, moe_a2a_backend == deepep, ep_size == tp_size, kv_cache_dtype == bf16, batch_size == 1"
+                                "For in-seq split mode, we have the following restrictions: moe_dense_tp_size == 1, moe_a2a_backend == deepep, ep_size == tp_size, batch_size == 1"
                             )
                         else:
                             self.enable_dp_attention = True


### PR DESCRIPTION
## Motivation

1. For cp(round-robin-split mode) :

Problem: When cp+prefix cache is enabled, it will cause a hang problem after a period of pressure testing.
<img width="942" height="916" alt="image" src="https://github.com/user-attachments/assets/a41de075-af7a-41c0-802f-d2f04d202e51" />

Reason: When the prefix-cache is triggered, the actual number of tokens that are not hit is < cp_size. In this case, the splitting will cause the following cp_rank to appear empty, and the program will die.

Solution: Strengthen the trigger condition of entering cp split, only the actual token >= cp triggers cp, which has no effect on performance.

2. For cp(in-seq-split mode) : delete self.kv_cache_dtype = "bf16" let kvcache supports fp8


**Reoccurrence of the problem Start command**
Start command：
```
python -m sglang.launch_server \
  --model DeepSeek-V3.2-1201/ \
  --tp 8 \
  --dp 1 \
  --attn-cp-size 8 \
  --enable-dp-attention \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 1 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 2 \
  --mem-fraction-static 0.9 \
  --enable-nsa-prefill-context-parallel \
  --moe-dense-tp-size 1 \
  --nsa-prefill-cp-mode "round-robin-split" \
  --host 0.0.0.0 \
  --port 30000
```
curl command:
```
curl http://127.0.0.1:30000/v1/completions  -H "Content-Type: application/json" -d '{"model": "DeepSeek-V3.2-1201", "prompt": "Solve this problem step by step: What is 15% of 240? Solve this problem step by step: What is 15% of 240? Solve this problem step by step: What is 15% of 240? Solve this problem step by step: What is 15% of 240? Solve this problem step", "max_tokens": 10, "temperature": 0, "stream": true }'
```

**running test_deepseek_v32_cp_single_node.py result**
```
Accuracy: 0.975
Invalid: 0.000
Latency: 35.429 s
Output throughput: 548.753 token/s
/usr/lib/python3.12/subprocess.py:1127: ResourceWarning: subprocess 756327 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
✓ Accuracy 0.975 >= baseline 0.935

Waiting 20 seconds for resource cleanup...

============================================================
DeepSeek-V3.2-Exp CP Single Node Results Summary
Dataset: gsm8k
Baseline: 0.935
============================================================

Model 1: /DeepSeek-V3.2-1201
  Accuracy: PASS
  Score: 0.975

Model 2: /DeepSeek-V3.2-1201
  Accuracy: PASS
  Score: 0.975

============================================================
OVERALL: ALL TESTS PASSED
============================================================

.
----------------------------------------------------------------------
Ran 1 test in 378.743s

OK
```