### PR TITLE
[Debug] Add torch._assert_async to Eagle spec decoding gather paths

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -975,7 +975,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          python -m unittest registered.spec.eagle.test_eagle_infer_b.TestEAGLEServerBasic -v
+          python -m pytest registered/spec/eagle/test_eagle_infer_b.py::TestEAGLEServerBasic -x -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -1022,12 +1022,15 @@ jobs:
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
+          git clone https://github.com/merrymercy/human-eval.git
+          cd human-eval
+          pip install -e . --no-build-isolation
 
       - name: Run test
         timeout-minutes: 30
         run: |
           cd test/
-          python -m unittest registered.spec.eagle.test_eagle_infer_b -v
+          python -m pytest registered/spec/eagle/test_eagle_infer_b.py -x -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -975,7 +975,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          python -m pytest registered/spec/eagle/test_eagle_infer_beta.py -x --timeout=1800 -v
+          python -m pytest registered/spec/eagle/test_eagle_infer_beta.py -x -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -1027,7 +1027,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd test/
-          python -m pytest registered/spec/eagle/test_eagle_infer_b.py -x --timeout=1800 -v
+          python -m pytest registered/spec/eagle/test_eagle_infer_b.py -x -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -975,7 +975,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          python -m unittest registered.spec.eagle.test_eagle_infer_beta -v
+          python -m unittest registered.spec.eagle.test_eagle_infer_b -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -975,7 +975,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          python -m pytest registered/spec/eagle/test_eagle_infer_beta.py -x -v
+          python -m unittest registered.spec.eagle.test_eagle_infer_beta -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -1027,7 +1027,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd test/
-          python -m pytest registered/spec/eagle/test_eagle_infer_b.py -x -v
+          python -m unittest registered.spec.eagle.test_eagle_infer_b -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -975,7 +975,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          python -m unittest registered.spec.eagle.test_eagle_infer_b -v
+          python -m unittest registered.spec.eagle.test_eagle_infer_b.TestEAGLEServerBasic -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -944,9 +944,9 @@ jobs:
       IS_BLACKWELL: "1"
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 1
       matrix:
-        partition: [0, 1, 2, 3, 4, 5, 6, 7]
+        partition: [0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -975,11 +975,7 @@ jobs:
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
-          python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 8 $CONTINUE_ON_ERROR_FLAG
+          python -m pytest registered/spec/eagle/test_eagle_infer_beta.py -x --timeout=1800 -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -1005,9 +1001,9 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     strategy:
       fail-fast: false
-      max-parallel: ${{ fromJson(needs.check-changes.outputs.max_parallel) }}
+      max-parallel: 1
       matrix:
-        partition: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        partition: [0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1031,11 +1027,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
-          python3 run_suite.py --hw cuda --suite stage-b-test-large-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 14 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
+          python -m pytest registered/spec/eagle/test_eagle_infer_b.py -x --timeout=1800 -v
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -377,6 +377,10 @@ class EAGLEDraftCudaGraphRunner:
             buffers.seq_lens.fill_(self.seq_len_fill_value)
             buffers.out_cache_loc.zero_()
             buffers.positions.zero_()
+            buffers.input_ids.zero_()
+            buffers.hidden_states.zero_()
+            buffers.topk_p.zero_()
+            buffers.topk_index.zero_()
 
         num_tokens = bs * self.num_tokens_per_bs
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -437,6 +437,8 @@ class EAGLEDraftExtendCudaGraphRunner:
             buffers.seq_lens.fill_(self.seq_len_fill_value)
             buffers.out_cache_loc.zero_()
             buffers.positions.zero_()
+            buffers.input_ids.zero_()
+            buffers.hidden_states.zero_()
             buffers.accept_length.fill_(self.num_tokens_per_bs)
             buffers.extend_seq_lens.fill_(self.num_tokens_per_bs)
 
@@ -530,15 +532,24 @@ class EAGLEDraftExtendCudaGraphRunner:
         self._replay(forward_batch)
         out = self.output_buffers[bs]
 
-        # G3: check raw graph output (full padded batch)
+        # H1: check valid portion of graph output
         torch._assert_async(
-            ~torch.isnan(out.next_token_logits).any(),
-            "G3: raw graph output next_token_logits has NaN (full padded batch)",
+            ~torch.isnan(out.next_token_logits[:num_tokens]).any(),
+            "H1: graph output next_token_logits has NaN in VALID slots",
         )
+        # H2: check padded portion of graph output
+        if bs * self.num_tokens_per_bs > num_tokens:
+            padded_logits = out.next_token_logits[num_tokens:]
+            has_nan_in_pad = torch.isnan(padded_logits).any()
+            torch._assert_async(
+                ~has_nan_in_pad,
+                "H2: graph output next_token_logits has NaN in PADDED slots only (benign)",
+            )
+        # H3: valid hidden_states
         if out.hidden_states is not None:
             torch._assert_async(
-                ~torch.isnan(out.hidden_states).any(),
-                "G3: raw graph output hidden_states has NaN (full padded batch)",
+                ~torch.isnan(out.hidden_states[:num_tokens]).any(),
+                "H3: graph output hidden_states has NaN in VALID slots",
             )
 
         if self.forward_mode == ForwardMode.DRAFT_EXTEND_V2:

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import bisect
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -222,6 +223,8 @@ class EAGLEDraftExtendCudaGraphRunner:
             )
 
     def can_run(self, forward_batch: ForwardBatch):
+        if os.environ.get("SGLANG_FORCE_EAGER_DRAFT_EXTEND", "0") == "1":
+            return False
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -449,12 +449,31 @@ class EAGLEDraftExtendCudaGraphRunner:
             buffers.extend_seq_lens[:raw_bs].fill_(self.num_tokens_per_bs)
         buffers.out_cache_loc[:num_tokens].copy_(forward_batch.out_cache_loc)
         buffers.positions[:num_tokens].copy_(forward_batch.positions)
+        # G1: check hidden_states input before copy
+        torch._assert_async(
+            ~torch.isnan(forward_batch.spec_info.hidden_states).any(),
+            "G1: spec_info.hidden_states has NaN before copy into cuda graph buffer",
+        )
         if (
             forward_batch.spec_info.hidden_states.shape[1]
             == buffers.hidden_states.shape[1]
         ):
             buffers.hidden_states[:num_tokens].copy_(
                 forward_batch.spec_info.hidden_states
+            )
+            # G2: verify copy succeeded
+            torch._assert_async(
+                ~torch.isnan(buffers.hidden_states[:num_tokens]).any(),
+                "G2: buffers.hidden_states has NaN after copy",
+            )
+        else:
+            # G2b: hidden_states shape mismatch — copy skipped!
+            import logging
+
+            logging.warning(
+                f"G2b: hidden_states shape mismatch! "
+                f"spec_info={forward_batch.spec_info.hidden_states.shape}, "
+                f"buffer={buffers.hidden_states.shape}. Copy SKIPPED."
             )
         if forward_batch.spec_info.accept_length is not None:
             buffers.accept_length[:raw_bs].copy_(forward_batch.spec_info.accept_length)
@@ -510,6 +529,17 @@ class EAGLEDraftExtendCudaGraphRunner:
         self.bs = bs
         self._replay(forward_batch)
         out = self.output_buffers[bs]
+
+        # G3: check raw graph output (full padded batch)
+        torch._assert_async(
+            ~torch.isnan(out.next_token_logits).any(),
+            "G3: raw graph output next_token_logits has NaN (full padded batch)",
+        )
+        if out.hidden_states is not None:
+            torch._assert_async(
+                ~torch.isnan(out.hidden_states).any(),
+                "G3: raw graph output hidden_states has NaN (full padded batch)",
+            )
 
         if self.forward_mode == ForwardMode.DRAFT_EXTEND_V2:
             # DRAFT_EXTEND_V2: all tokens calculations whether accepted or not.

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -24,9 +24,24 @@ def organize_draft_results(
 ):
     score_list = torch.cat(score_list, dim=1).flatten(1)
     ss_token_list = torch.cat(token_list, dim=1)
+    # C10: shape consistency
+    assert score_list.shape[1] == ss_token_list.shape[1], (
+        f"C10: shape mismatch: score_list.shape={score_list.shape}, "
+        f"ss_token_list.shape={ss_token_list.shape}"
+    )
     top_scores = torch.topk(score_list, num_draft_token - 1, dim=-1)
     top_scores_index = top_scores.indices
     top_scores_index = torch.sort(top_scores_index).values
+    # C11: top_scores_index upper bound for gather-B
+    torch._assert_async(
+        (top_scores_index < ss_token_list.shape[1]).all(),
+        "C11: top_scores_index OOB for gather-B",
+    )
+    # C12: top_scores_index non-negative
+    torch._assert_async(
+        (top_scores_index >= 0).all(),
+        "C12: top_scores_index has negative values",
+    )
     draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
 
     if len(parents_list) > 1:

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1019,6 +1019,15 @@ class EAGLEWorker(TpModelWorker):
                 logits_output.topk_index,
             )
             forward_batch.spec_info.hidden_states = logits_output.hidden_states
+            # E5: cuda graph path outputs
+            torch._assert_async(
+                ~torch.isnan(forward_batch.spec_info.topk_p).any(),
+                "E5: topk_p has NaN from cuda_graph draft_extend",
+            )
+            torch._assert_async(
+                ~torch.isnan(forward_batch.spec_info.hidden_states).any(),
+                "E5: hidden_states has NaN from cuda_graph draft_extend",
+            )
         else:
             forward_batch.can_run_dp_cuda_graph = False
             if not forward_batch.forward_mode.is_idle():
@@ -1047,8 +1056,32 @@ class EAGLEWorker(TpModelWorker):
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput
     ):
+        # E1: logits from draft extend before softmax
+        torch._assert_async(
+            ~torch.isnan(logits_output.next_token_logits).any(),
+            "E1: next_token_logits has NaN in capture_for_decode",
+        )
+        torch._assert_async(
+            ~torch.isinf(logits_output.next_token_logits).any(),
+            "E1: next_token_logits has Inf in capture_for_decode",
+        )
         probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+        # E2: probs after softmax
+        torch._assert_async(
+            ~torch.isnan(probs).any(),
+            "E2: probs has NaN in capture_for_decode",
+        )
         draft_input.topk_p, draft_input.topk_index = fast_topk(probs, self.topk, dim=-1)
+        # E3: topk_p from fast_topk
+        torch._assert_async(
+            ~torch.isnan(draft_input.topk_p).any(),
+            "E3: topk_p has NaN after fast_topk in capture_for_decode",
+        )
+        # E4: hidden_states from draft extend
+        torch._assert_async(
+            ~torch.isnan(logits_output.hidden_states).any(),
+            "E4: hidden_states has NaN in capture_for_decode",
+        )
         draft_input.hidden_states = logits_output.hidden_states
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -622,6 +622,15 @@ class EAGLEWorker(TpModelWorker):
             spec_info.topk_index,
             spec_info.hidden_states,
         )
+        # D1: initial inputs from target model verify
+        torch._assert_async(
+            ~torch.isnan(topk_p).any(),
+            "D1: initial topk_p from spec_info has NaN",
+        )
+        torch._assert_async(
+            ~torch.isnan(hidden_states).any(),
+            "D1: initial hidden_states from spec_info has NaN",
+        )
         if self.hot_token_id is not None:
             topk_index = self.hot_token_id[topk_index]
         # TODO: We only need self.speculative_num_steps - 1 cache loc
@@ -666,12 +675,29 @@ class EAGLEWorker(TpModelWorker):
             forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
             spec_info.hidden_states = hidden_states
 
+            # D2: hidden_states input to draft model
+            torch._assert_async(
+                ~torch.isnan(hidden_states).any(),
+                "D2: hidden_states input to draft model has NaN",
+            )
+
             # Run forward
             logits_output = self.draft_model_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
             if self.server_args.enable_nan_detection:
                 detect_nan(logits_output)
+
+            # D3: logits before softmax
+            torch._assert_async(
+                ~torch.isnan(logits_output.next_token_logits).any(),
+                "D3: next_token_logits has NaN before softmax",
+            )
+            torch._assert_async(
+                ~torch.isinf(logits_output.next_token_logits).any(),
+                "D3: next_token_logits has Inf before softmax",
+            )
+
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)
             # C4: probs no NaN
             torch._assert_async(
@@ -701,6 +727,11 @@ class EAGLEWorker(TpModelWorker):
                 )
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
+            # D4: hidden_states output from draft model
+            torch._assert_async(
+                ~torch.isnan(hidden_states).any(),
+                "D4: hidden_states output from draft model has NaN",
+            )
 
         parent_list, top_scores_index, draft_tokens = organize_draft_results(
             score_list, token_list, parents_list, self.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1006,10 +1006,8 @@ class EAGLEWorker(TpModelWorker):
             forward_batch.seq_lens_sum = batch.seq_lens.sum().item()
 
         # Run
-        can_cuda_graph = (
-            self.cuda_graph_runner_for_draft_extend
-            and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
-        )
+        # DEBUG: force eager to test if NaN is cuda graph specific
+        can_cuda_graph = False
         if can_cuda_graph:
             logits_output = self.cuda_graph_runner_for_draft_extend.replay(
                 forward_batch

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1006,8 +1006,10 @@ class EAGLEWorker(TpModelWorker):
             forward_batch.seq_lens_sum = batch.seq_lens.sum().item()
 
         # Run
-        # DEBUG: force eager to test if NaN is cuda graph specific
-        can_cuda_graph = False
+        can_cuda_graph = (
+            self.cuda_graph_runner_for_draft_extend
+            and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
+        )
         if can_cuda_graph:
             logits_output = self.cuda_graph_runner_for_draft_extend.replay(
                 forward_batch

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -673,8 +673,32 @@ class EAGLEWorker(TpModelWorker):
             if self.server_args.enable_nan_detection:
                 detect_nan(logits_output)
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+            # C4: probs no NaN
+            torch._assert_async(
+                ~torch.isnan(probs).any(),
+                "C4: probs has NaN after softmax in draft_forward",
+            )
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            # C1: fast_topk index in valid range
+            torch._assert_async(
+                (topk_index < probs.shape[-1]).all(),
+                "C1: fast_topk returned index >= vocab_size",
+            )
+            torch._assert_async(
+                (topk_index >= 0).all(),
+                "C1b: fast_topk returned negative index",
+            )
+            # C2: fast_topk values no NaN
+            torch._assert_async(
+                ~torch.isnan(topk_p).any(),
+                "C2: fast_topk returned NaN probability",
+            )
             if self.hot_token_id is not None:
+                # C3: hot_token_id indexing bounds
+                torch._assert_async(
+                    (topk_index < self.hot_token_id.shape[0]).all(),
+                    "C3: topk_index OOB for hot_token_id lookup",
+                )
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -430,8 +430,32 @@ class EagleDraftWorker(BaseDraftWorker):
             if self.server_args.enable_nan_detection:
                 detect_nan(logits_output)
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+            # C4: probs no NaN
+            torch._assert_async(
+                ~torch.isnan(probs).any(),
+                "C4: probs has NaN after softmax in draft_forward",
+            )
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            # C1: fast_topk index in valid range
+            torch._assert_async(
+                (topk_index < probs.shape[-1]).all(),
+                "C1: fast_topk returned index >= vocab_size",
+            )
+            torch._assert_async(
+                (topk_index >= 0).all(),
+                "C1b: fast_topk returned negative index",
+            )
+            # C2: fast_topk values no NaN
+            torch._assert_async(
+                ~torch.isnan(topk_p).any(),
+                "C2: fast_topk returned NaN probability",
+            )
             if self.hot_token_id is not None:
+                # C3: hot_token_id indexing bounds
+                torch._assert_async(
+                    (topk_index < self.hot_token_id.shape[0]).all(),
+                    "C3: topk_index OOB for hot_token_id lookup",
+                )
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
 
@@ -442,11 +466,26 @@ class EagleDraftWorker(BaseDraftWorker):
         ss_token_list = torch.cat(
             token_list, dim=1
         )  # b, (self.topk + (num_steps-1) * self.topk)
+        # C10: shape consistency
+        assert score_list.shape[1] == ss_token_list.shape[1], (
+            f"C10: shape mismatch: score_list.shape={score_list.shape}, "
+            f"ss_token_list.shape={ss_token_list.shape}"
+        )
         top_scores = torch.topk(
             score_list, self.speculative_num_draft_tokens - 1, dim=-1
         )
         top_scores_index = top_scores.indices
         top_scores_index = torch.sort(top_scores_index).values
+        # C11: top_scores_index upper bound for gather-B
+        torch._assert_async(
+            (top_scores_index < ss_token_list.shape[1]).all(),
+            "C11: top_scores_index OOB for gather-B",
+        )
+        # C12: top_scores_index non-negative
+        torch._assert_async(
+            (top_scores_index >= 0).all(),
+            "C12: top_scores_index has negative values",
+        )
         draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
 
         if len(parents_list) > 1:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import os
 import time
 from typing import List, Optional, Tuple
 
@@ -628,13 +627,14 @@ class EagleDraftWorker(BaseDraftWorker):
         )
 
         # Prepare for draft extend in a separate stream
+        # DEBUG: pass None to force attention backend init for eager path
         with self.plan_stream_ctx:
             forward_batch = draft_input.prepare_for_extend_to_fill_draft_kvcache(
                 batch,
                 batch_result.next_token_ids,
                 self.speculative_num_draft_tokens,
                 self.draft_runner,
-                self.cuda_graph_runner_for_draft_extend,
+                None,  # DEBUG: was self.cuda_graph_runner_for_draft_extend
             )
 
         if self.plan_stream:
@@ -646,14 +646,8 @@ class EagleDraftWorker(BaseDraftWorker):
             forward_batch.spec_info.accept_length = batch_result.accept_lens
 
         # Run draft extend batch in the main compute stream
-        _force_eager_draft_extend = (
-            os.environ.get("SGLANG_FORCE_EAGER_DRAFT_EXTEND", "0") == "1"
-        )
-        can_cuda_graph = (
-            not _force_eager_draft_extend
-            and self.cuda_graph_runner_for_draft_extend
-            and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
-        )
+        # DEBUG: force eager to test if NaN is cuda graph specific
+        can_cuda_graph = False
         if can_cuda_graph:
             draft_logits_output = self.cuda_graph_runner_for_draft_extend.replay(
                 forward_batch

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -602,6 +602,17 @@ class EagleDraftWorker(BaseDraftWorker):
     def _draft_extend_for_decode(
         self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
     ):
+        # F1: target model hidden_states (input to draft extend)
+        torch._assert_async(
+            ~torch.isnan(batch_result.logits_output.hidden_states).any(),
+            "F1: target model hidden_states has NaN (input to draft extend)",
+        )
+        # F1b: target model logits
+        torch._assert_async(
+            ~torch.isnan(batch_result.logits_output.next_token_logits).any(),
+            "F1b: target model next_token_logits has NaN",
+        )
+
         # Batch 2: Draft extend
         draft_input = EagleDraftInput(
             hidden_states=batch_result.logits_output.hidden_states,
@@ -642,10 +653,20 @@ class EagleDraftWorker(BaseDraftWorker):
             draft_logits_output = self.cuda_graph_runner_for_draft_extend.replay(
                 forward_batch
             )
+            # F3: raw logits from cuda graph path (before select_index)
+            torch._assert_async(
+                ~torch.isnan(draft_logits_output.next_token_logits).any(),
+                "F3: raw next_token_logits has NaN from cuda_graph draft_extend",
+            )
         else:
             draft_logits_output = self.draft_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
+            # F2: raw logits from eager path (before select_index)
+            torch._assert_async(
+                ~torch.isnan(draft_logits_output.next_token_logits).any(),
+                "F2: raw next_token_logits has NaN from eager draft_extend",
+            )
 
         # Reorganize the spec info for the next batch
         draft_logits_output.next_token_logits = draft_logits_output.next_token_logits[
@@ -654,7 +675,7 @@ class EagleDraftWorker(BaseDraftWorker):
         draft_logits_output.hidden_states = draft_logits_output.hidden_states[
             select_index
         ]
-        # E1: logits before softmax (decode path)
+        # E1: logits after select_index (decode path)
         torch._assert_async(
             ~torch.isnan(draft_logits_output.next_token_logits).any(),
             "E1: next_token_logits has NaN in _draft_extend_for_decode",

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -658,6 +658,12 @@ class EagleDraftWorker(BaseDraftWorker):
                 ~torch.isnan(draft_logits_output.next_token_logits).any(),
                 "F3: raw next_token_logits has NaN from cuda_graph draft_extend",
             )
+            # G4: graph output hidden_states
+            if draft_logits_output.hidden_states is not None:
+                torch._assert_async(
+                    ~torch.isnan(draft_logits_output.hidden_states).any(),
+                    "G4: hidden_states has NaN from cuda_graph draft_extend",
+                )
         else:
             draft_logits_output = self.draft_runner.forward(
                 forward_batch, skip_attn_backend_init=True

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import time
 from typing import List, Optional, Tuple
 
@@ -246,6 +247,9 @@ class EagleDraftWorker(BaseDraftWorker):
         """Capture cuda graphs."""
         self.cuda_graph_runner = None
         self.cuda_graph_runner_for_draft_extend = None
+        self.disable_draft_extend_cuda_graph = (
+            os.environ.get("SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH", "0") == "1"
+        )
 
         if self.server_args.disable_cuda_graph:
             return
@@ -275,7 +279,11 @@ class EagleDraftWorker(BaseDraftWorker):
         }
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
-        if self.draft_extend_attn_backend and (
+        if self.disable_draft_extend_cuda_graph:
+            logger.info(
+                "Draft extend cuda graph disabled by SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH"
+            )
+        elif self.draft_extend_attn_backend and (
             _is_npu
             or (
                 _is_cuda
@@ -627,14 +635,18 @@ class EagleDraftWorker(BaseDraftWorker):
         )
 
         # Prepare for draft extend in a separate stream
-        # DEBUG: pass None to force attention backend init for eager path
+        _draft_extend_graph_runner = (
+            None
+            if self.disable_draft_extend_cuda_graph
+            else self.cuda_graph_runner_for_draft_extend
+        )
         with self.plan_stream_ctx:
             forward_batch = draft_input.prepare_for_extend_to_fill_draft_kvcache(
                 batch,
                 batch_result.next_token_ids,
                 self.speculative_num_draft_tokens,
                 self.draft_runner,
-                None,  # DEBUG: was self.cuda_graph_runner_for_draft_extend
+                _draft_extend_graph_runner,
             )
 
         if self.plan_stream:
@@ -645,9 +657,21 @@ class EagleDraftWorker(BaseDraftWorker):
         if forward_batch.spec_info.accept_length is None:
             forward_batch.spec_info.accept_length = batch_result.accept_lens
 
+        # I1: check draft extend forward_batch inputs after prepare
+        torch._assert_async(
+            ~torch.isnan(forward_batch.spec_info.hidden_states).any(),
+            "I1: forward_batch hidden_states has NaN after prepare",
+        )
+        torch._assert_async(
+            ~torch.isinf(forward_batch.spec_info.hidden_states).any(),
+            "I1: forward_batch hidden_states has Inf after prepare",
+        )
+
         # Run draft extend batch in the main compute stream
-        # DEBUG: force eager to test if NaN is cuda graph specific
-        can_cuda_graph = False
+        can_cuda_graph = (
+            _draft_extend_graph_runner
+            and _draft_extend_graph_runner.can_run(forward_batch)
+        )
         if can_cuda_graph:
             draft_logits_output = self.cuda_graph_runner_for_draft_extend.replay(
                 forward_batch

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -387,6 +387,15 @@ class EagleDraftWorker(BaseDraftWorker):
             spec_info.topk_index,
             spec_info.hidden_states,
         )
+        # D1: initial inputs from target model verify
+        torch._assert_async(
+            ~torch.isnan(topk_p).any(),
+            "D1: initial topk_p from spec_info has NaN",
+        )
+        torch._assert_async(
+            ~torch.isnan(hidden_states).any(),
+            "D1: initial hidden_states from spec_info has NaN",
+        )
         if self.hot_token_id is not None:
             topk_index = self.hot_token_id[topk_index]
 
@@ -423,12 +432,29 @@ class EagleDraftWorker(BaseDraftWorker):
             forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
             spec_info.hidden_states = hidden_states
 
+            # D2: hidden_states input to draft model
+            torch._assert_async(
+                ~torch.isnan(hidden_states).any(),
+                "D2: hidden_states input to draft model has NaN",
+            )
+
             # Run forward
             logits_output = self.draft_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
             if self.server_args.enable_nan_detection:
                 detect_nan(logits_output)
+
+            # D3: logits before softmax
+            torch._assert_async(
+                ~torch.isnan(logits_output.next_token_logits).any(),
+                "D3: next_token_logits has NaN before softmax",
+            )
+            torch._assert_async(
+                ~torch.isinf(logits_output.next_token_logits).any(),
+                "D3: next_token_logits has Inf before softmax",
+            )
+
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)
             # C4: probs no NaN
             torch._assert_async(
@@ -458,6 +484,11 @@ class EagleDraftWorker(BaseDraftWorker):
                 )
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
+            # D4: hidden_states output from draft model
+            torch._assert_async(
+                ~torch.isnan(hidden_states).any(),
+                "D4: hidden_states output from draft model has NaN",
+            )
 
         # Organize the results
         score_list = torch.cat(score_list, dim=1).flatten(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -571,9 +571,30 @@ class EagleDraftWorker(BaseDraftWorker):
         logits_output = self.draft_runner.forward(forward_batch).logits_output
 
         # Update spec_info for the next draft step
+        # E1: logits before softmax (prefill path)
+        torch._assert_async(
+            ~torch.isnan(logits_output.next_token_logits).any(),
+            "E1: next_token_logits has NaN in _draft_extend_for_prefill",
+        )
+        torch._assert_async(
+            ~torch.isinf(logits_output.next_token_logits).any(),
+            "E1: next_token_logits has Inf in _draft_extend_for_prefill",
+        )
         probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+        torch._assert_async(
+            ~torch.isnan(probs).any(),
+            "E2: probs has NaN in _draft_extend_for_prefill",
+        )
         next_draft_input.topk_p, next_draft_input.topk_index = fast_topk(
             probs, self.topk, dim=-1
+        )
+        torch._assert_async(
+            ~torch.isnan(next_draft_input.topk_p).any(),
+            "E3: topk_p has NaN after fast_topk in _draft_extend_for_prefill",
+        )
+        torch._assert_async(
+            ~torch.isnan(logits_output.hidden_states).any(),
+            "E4: hidden_states has NaN in _draft_extend_for_prefill",
         )
         next_draft_input.hidden_states = logits_output.hidden_states
         return next_draft_input
@@ -633,9 +654,30 @@ class EagleDraftWorker(BaseDraftWorker):
         draft_logits_output.hidden_states = draft_logits_output.hidden_states[
             select_index
         ]
+        # E1: logits before softmax (decode path)
+        torch._assert_async(
+            ~torch.isnan(draft_logits_output.next_token_logits).any(),
+            "E1: next_token_logits has NaN in _draft_extend_for_decode",
+        )
+        torch._assert_async(
+            ~torch.isinf(draft_logits_output.next_token_logits).any(),
+            "E1: next_token_logits has Inf in _draft_extend_for_decode",
+        )
         probs = torch.softmax(draft_logits_output.next_token_logits, dim=-1)
+        torch._assert_async(
+            ~torch.isnan(probs).any(),
+            "E2: probs has NaN in _draft_extend_for_decode",
+        )
         ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
+        torch._assert_async(
+            ~torch.isnan(ret_topk_p).any(),
+            "E3: topk_p has NaN after fast_topk in _draft_extend_for_decode",
+        )
         ret_hidden_states = draft_logits_output.hidden_states
+        torch._assert_async(
+            ~torch.isnan(ret_hidden_states).any(),
+            "E4: hidden_states has NaN in _draft_extend_for_decode",
+        )
 
         # Construct the return values
         next_draft_input = batch_result.next_draft_input

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import time
 from typing import List, Optional, Tuple
 
@@ -645,8 +646,12 @@ class EagleDraftWorker(BaseDraftWorker):
             forward_batch.spec_info.accept_length = batch_result.accept_lens
 
         # Run draft extend batch in the main compute stream
+        _force_eager_draft_extend = (
+            os.environ.get("SGLANG_FORCE_EAGER_DRAFT_EXTEND", "0") == "1"
+        )
         can_cuda_graph = (
-            self.cuda_graph_runner_for_draft_extend
+            not _force_eager_draft_extend
+            and self.cuda_graph_runner_for_draft_extend
             and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
         )
         if can_cuda_graph:

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -26,6 +26,7 @@ from sglang.srt.utils import is_cuda, is_hip, is_npu, next_power_of_2
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
+_disable_spec_compile = os.environ.get("SGLANG_SPEC_DISABLE_COMPILE", "0") == "1"
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
@@ -463,7 +464,7 @@ def create_accept_length_filter(
     return accept_length_filter
 
 
-@torch.compile(dynamic=True, disable=_is_npu)
+@torch.compile(dynamic=True, disable=_is_npu or _disable_spec_compile)
 def select_top_k_tokens(
     i: int,
     topk_p: torch.Tensor,
@@ -488,6 +489,11 @@ def select_top_k_tokens(
         )
     else:
         # The later decode steps
+        # C5: topk_p non-negative
+        torch._assert_async((topk_p >= 0).all(), "C5: topk_p has negative values")
+        # C6: topk_p no NaN
+        torch._assert_async(~torch.isnan(topk_p).any(), "C6: topk_p has NaN")
+
         expand_scores = torch.mul(
             scores.unsqueeze(2), topk_p.reshape(-1, topk, topk)
         )  # (b, topk, 1) x (b, topk ,topk) -> (b, topk, topk)
@@ -497,12 +503,32 @@ def select_top_k_tokens(
         scores = topk_cs_p  # shape: (b, topk)
 
         topk_index = topk_index.reshape(-1, topk**2)
+
+        # C7: topk_cs_index upper bound for gather-A
+        torch._assert_async(
+            (topk_cs_index < topk_index.shape[1]).all(),
+            "C7: topk_cs_index OOB for gather-A",
+        )
+        # C8: topk_cs_index non-negative
+        torch._assert_async(
+            (topk_cs_index >= 0).all(), "C8: topk_cs_index has negative values"
+        )
+
         input_ids = torch.gather(topk_index, index=topk_cs_index, dim=1).flatten()
 
         if hidden_states.shape[0] > 0:
             selected_input_index = topk_cs_index.flatten() // topk + torch.arange(
                 0, hidden_states.shape[0], step=topk, device=topk_index.device
             ).repeat_interleave(topk)
+            # C9: selected_input_index bounds
+            torch._assert_async(
+                (selected_input_index >= 0).all(),
+                "C9: selected_input_index has negative values",
+            )
+            torch._assert_async(
+                (selected_input_index < hidden_states.shape[0]).all(),
+                "C9: selected_input_index OOB for hidden_states",
+            )
             hidden_states = hidden_states[selected_input_index, :]
 
         tree_info = (

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
-
-# pane 1
-# TARGET_STAGE=stage-b-test-large-1-gpu bash retry_eagle_ci.sh 2>&1 | tee retry_large.log
-
-# pane 2
-# TARGET_STAGE=stage-b-test-small-1-gpu bash retry_eagle_ci.sh 2>&1 | tee retry_small.log
-
-
 set -euo pipefail
 
 export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
@@ -15,57 +7,71 @@ cd "$(dirname "$0")"
 REPO="sgl-project/sglang"
 BRANCH="${BRANCH:-$(git branch --show-current)}"
 WORKFLOW="pr-test.yml"
-TARGET_STAGE="${TARGET_STAGE:-stage-b-test-large-1-gpu}"
 MAX_ITERATIONS="${MAX_ITERATIONS:-100}"
 SLEEP_BETWEEN="${SLEEP_BETWEEN:-30}"
+STAGES=("stage-b-test-large-1-gpu" "stage-b-test-small-1-gpu")
 
-echo "Eagle CI Retry | branch=$BRANCH stage=$TARGET_STAGE max=$MAX_ITERATIONS"
+echo "Eagle CI Retry | branch=$BRANCH stages=${STAGES[*]} max=$MAX_ITERATIONS"
 
 for i in $(seq 1 "$MAX_ITERATIONS"); do
-    # 1. Trigger
     echo "#$i  TRIGGER  $(date '+%H:%M:%S')"
-    gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
-        -f target_stage="$TARGET_STAGE" 2>/dev/null
 
-    # 2. Find run ID
+    # Trigger both stages
+    RUN_IDS=()
+    for stage in "${STAGES[@]}"; do
+        gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
+            -f target_stage="$stage" 2>/dev/null
+        sleep 5
+    done
+
+    # Find run IDs
     sleep 15
-    RUN_ID=""
-    for _ in $(seq 1 12); do
-        RUN_ID=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
-            --branch "$BRANCH" --limit 1 --json databaseId \
-            -q '.[0].databaseId' 2>/dev/null || true)
-        [[ -n "$RUN_ID" ]] && break
+    RUN_IDS=()
+    for _ in "${STAGES[@]}"; do
+        RUN_IDS=()
+        RUNS=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+            --branch "$BRANCH" --limit "${#STAGES[@]}" --json databaseId,status \
+            -q '.[].databaseId' 2>/dev/null || true)
+        while IFS= read -r rid; do
+            [[ -n "$rid" ]] && RUN_IDS+=("$rid")
+        done <<< "$RUNS"
+        [[ ${#RUN_IDS[@]} -ge ${#STAGES[@]} ]] && break
         sleep 10
     done
-    if [[ -z "$RUN_ID" ]]; then
-        echo "#$i  ERROR  run not found  $(date '+%H:%M:%S')"
-        sleep "$SLEEP_BETWEEN"
-        continue
-    fi
 
-    RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
-    echo "#$i  START   $RUN_URL  $(date '+%H:%M:%S')"
-
-    # 3. Poll until done
-    while true; do
-        STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status,conclusion \
-            -q '[.status,.conclusion] | join(",")' 2>/dev/null || echo "unknown,")
-        case "$STATUS" in
-            completed,success)
-                echo "#$i  PASS    $RUN_URL  $(date '+%H:%M:%S')"
-                break
-                ;;
-            completed,*)
-                CONCLUSION="${STATUS#completed,}"
-                echo "#$i  FAIL($CONCLUSION)  $RUN_URL  $(date '+%H:%M:%S')"
-                echo "CRASH DETECTED on iteration $i — $(date '+%Y-%m-%d %H:%M:%S')"
-                exit 0
-                ;;
-            *)
-                sleep 60
-                ;;
-        esac
+    for idx in "${!RUN_IDS[@]}"; do
+        echo "#$i  START   [${STAGES[$idx]:-?}] https://github.com/$REPO/actions/runs/${RUN_IDS[$idx]}  $(date '+%H:%M:%S')"
     done
+
+    # Poll all runs until done
+    CRASHED=false
+    for rid in "${RUN_IDS[@]}"; do
+        RUN_URL="https://github.com/$REPO/actions/runs/$rid"
+        while true; do
+            STATUS=$(gh run view "$rid" --repo "$REPO" --json status,conclusion \
+                -q '[.status,.conclusion] | join(",")' 2>/dev/null || echo "unknown,")
+            case "$STATUS" in
+                completed,success)
+                    echo "#$i  PASS    $RUN_URL  $(date '+%H:%M:%S')"
+                    break
+                    ;;
+                completed,*)
+                    CONCLUSION="${STATUS#completed,}"
+                    echo "#$i  FAIL($CONCLUSION)  $RUN_URL  $(date '+%H:%M:%S')"
+                    CRASHED=true
+                    break
+                    ;;
+                *)
+                    sleep 60
+                    ;;
+            esac
+        done
+    done
+
+    if $CRASHED; then
+        echo "CRASH DETECTED on iteration $i — $(date '+%Y-%m-%d %H:%M:%S')"
+        exit 0
+    fi
 
     sleep "$SLEEP_BETWEEN"
 done

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -15,6 +15,7 @@ echo "Eagle CI Retry | branch=$BRANCH stage=$TARGET_STAGE max=$MAX_ITERATIONS"
 
 for i in $(seq 1 "$MAX_ITERATIONS"); do
     # 1. Trigger
+    echo "#$i  TRIGGER  $(date '+%H:%M:%S')"
     gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
         -f target_stage="$TARGET_STAGE" 2>/dev/null
 
@@ -28,17 +29,22 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
         [[ -n "$RUN_ID" ]] && break
         sleep 10
     done
-    [[ -z "$RUN_ID" ]] && echo "#$i  ERROR: run not found" && sleep "$SLEEP_BETWEEN" && continue
+    if [[ -z "$RUN_ID" ]]; then
+        echo "#$i  ERROR  run not found  $(date '+%H:%M:%S')"
+        sleep "$SLEEP_BETWEEN"
+        continue
+    fi
 
     RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
+    echo "#$i  START   $RUN_URL  $(date '+%H:%M:%S')"
 
-    # 3. Poll until done (silent)
+    # 3. Poll until done
     while true; do
         STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status,conclusion \
             -q '[.status,.conclusion] | join(",")' 2>/dev/null || echo "unknown,")
         case "$STATUS" in
             completed,success)
-                echo "#$i  PASS  $RUN_URL  $(date '+%H:%M:%S')"
+                echo "#$i  PASS    $RUN_URL  $(date '+%H:%M:%S')"
                 break
                 ;;
             completed,*)

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -50,20 +50,25 @@ run_ci() {
 
         sleep 15
         RUN_IDS=()
-        for _ in "${STAGES[@]}"; do
+        RUN_NAMES=()
+        for attempt in $(seq 1 5); do
             RUN_IDS=()
-            RUNS=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
-                --branch "$BRANCH" --limit "${#STAGES[@]}" --json databaseId,status \
-                -q '.[].databaseId' 2>/dev/null || true)
-            while IFS= read -r rid; do
-                [[ -n "$rid" ]] && RUN_IDS+=("$rid")
-            done <<< "$RUNS"
+            RUN_NAMES=()
+            LINES=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+                --branch "$BRANCH" --limit "${#STAGES[@]}" \
+                --json databaseId,displayTitle \
+                -q '.[] | "\(.databaseId) \(.displayTitle)"' 2>/dev/null || true)
+            while IFS= read -r line; do
+                [[ -z "$line" ]] && continue
+                RUN_IDS+=("${line%% *}")
+                RUN_NAMES+=("${line#* }")
+            done <<< "$LINES"
             [[ ${#RUN_IDS[@]} -ge ${#STAGES[@]} ]] && break
             sleep 10
         done
 
         for idx in "${!RUN_IDS[@]}"; do
-            echo "#$i  START   [${STAGES[$idx]:-?}] https://github.com/$REPO/actions/runs/${RUN_IDS[$idx]}  $(date '+%H:%M:%S')"
+            echo "#$i  START   [${RUN_NAMES[$idx]:-?}] https://github.com/$REPO/actions/runs/${RUN_IDS[$idx]}  $(date '+%H:%M:%S')"
         done
 
         CRASHED=false

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# pane 1
+# TARGET_STAGE=stage-b-test-large-1-gpu bash retry_eagle_ci.sh 2>&1 | tee retry_large.log
+
+# pane 2
+# TARGET_STAGE=stage-b-test-small-1-gpu bash retry_eagle_ci.sh 2>&1 | tee retry_small.log
+
+
 set -euo pipefail
 
 export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -1,80 +1,108 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
-export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
 cd "$(dirname "$0")"
+
+MODE="${MODE:-local}"
+TEST_MODULE="${TEST_MODULE:-registered.spec.eagle.test_eagle_infer_b}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-100}"
+SLEEP_BETWEEN="${SLEEP_BETWEEN:-5}"
 
 REPO="sgl-project/sglang"
 BRANCH="${BRANCH:-$(git branch --show-current)}"
 WORKFLOW="pr-test.yml"
-MAX_ITERATIONS="${MAX_ITERATIONS:-100}"
-SLEEP_BETWEEN="${SLEEP_BETWEEN:-30}"
 STAGES=("stage-b-test-large-1-gpu" "stage-b-test-small-1-gpu")
 
-echo "Eagle CI Retry | branch=$BRANCH stages=${STAGES[*]} max=$MAX_ITERATIONS"
+echo "Eagle Retry | mode=$MODE test=$TEST_MODULE max=$MAX_ITERATIONS"
+echo "Started at $(date '+%Y-%m-%d %H:%M:%S')"
+echo "---"
 
-for i in $(seq 1 "$MAX_ITERATIONS"); do
-    echo "#$i  TRIGGER  $(date '+%H:%M:%S')"
+run_local() {
+    for i in $(seq 1 "$MAX_ITERATIONS"); do
+        echo "#$i  START  $(date '+%H:%M:%S')"
+        cd test/
+        python -m unittest "$TEST_MODULE" -v 2>&1
+        EXIT_CODE=$?
+        cd ..
 
-    # Trigger both stages
-    RUN_IDS=()
-    for stage in "${STAGES[@]}"; do
-        gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
-            -f target_stage="$stage" 2>/dev/null
-        sleep 5
+        if [ $EXIT_CODE -ne 0 ]; then
+            echo "#$i  CRASH  exit=$EXIT_CODE  $(date '+%H:%M:%S')"
+            echo "CRASH DETECTED on iteration $i — $(date '+%Y-%m-%d %H:%M:%S')"
+            exit 0
+        fi
+
+        echo "#$i  PASS   $(date '+%H:%M:%S')"
+        sleep "$SLEEP_BETWEEN"
     done
+    echo "No crash after $MAX_ITERATIONS iterations."
+    exit 1
+}
 
-    # Find run IDs
-    sleep 15
-    RUN_IDS=()
-    for _ in "${STAGES[@]}"; do
-        RUN_IDS=()
-        RUNS=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
-            --branch "$BRANCH" --limit "${#STAGES[@]}" --json databaseId,status \
-            -q '.[].databaseId' 2>/dev/null || true)
-        while IFS= read -r rid; do
-            [[ -n "$rid" ]] && RUN_IDS+=("$rid")
-        done <<< "$RUNS"
-        [[ ${#RUN_IDS[@]} -ge ${#STAGES[@]} ]] && break
-        sleep 10
-    done
+run_ci() {
+    for i in $(seq 1 "$MAX_ITERATIONS"); do
+        echo "#$i  TRIGGER  $(date '+%H:%M:%S')"
 
-    for idx in "${!RUN_IDS[@]}"; do
-        echo "#$i  START   [${STAGES[$idx]:-?}] https://github.com/$REPO/actions/runs/${RUN_IDS[$idx]}  $(date '+%H:%M:%S')"
-    done
-
-    # Poll all runs until done
-    CRASHED=false
-    for rid in "${RUN_IDS[@]}"; do
-        RUN_URL="https://github.com/$REPO/actions/runs/$rid"
-        while true; do
-            STATUS=$(gh run view "$rid" --repo "$REPO" --json status,conclusion \
-                -q '[.status,.conclusion] | join(",")' 2>/dev/null || echo "unknown,")
-            case "$STATUS" in
-                completed,success)
-                    echo "#$i  PASS    $RUN_URL  $(date '+%H:%M:%S')"
-                    break
-                    ;;
-                completed,*)
-                    CONCLUSION="${STATUS#completed,}"
-                    echo "#$i  FAIL($CONCLUSION)  $RUN_URL  $(date '+%H:%M:%S')"
-                    CRASHED=true
-                    break
-                    ;;
-                *)
-                    sleep 60
-                    ;;
-            esac
+        for stage in "${STAGES[@]}"; do
+            gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
+                -f target_stage="$stage" 2>/dev/null
+            sleep 5
         done
+
+        sleep 15
+        RUN_IDS=()
+        for _ in "${STAGES[@]}"; do
+            RUN_IDS=()
+            RUNS=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+                --branch "$BRANCH" --limit "${#STAGES[@]}" --json databaseId,status \
+                -q '.[].databaseId' 2>/dev/null || true)
+            while IFS= read -r rid; do
+                [[ -n "$rid" ]] && RUN_IDS+=("$rid")
+            done <<< "$RUNS"
+            [[ ${#RUN_IDS[@]} -ge ${#STAGES[@]} ]] && break
+            sleep 10
+        done
+
+        for idx in "${!RUN_IDS[@]}"; do
+            echo "#$i  START   [${STAGES[$idx]:-?}] https://github.com/$REPO/actions/runs/${RUN_IDS[$idx]}  $(date '+%H:%M:%S')"
+        done
+
+        CRASHED=false
+        for rid in "${RUN_IDS[@]}"; do
+            RUN_URL="https://github.com/$REPO/actions/runs/$rid"
+            while true; do
+                STATUS=$(gh run view "$rid" --repo "$REPO" --json status,conclusion \
+                    -q '[.status,.conclusion] | join(",")' 2>/dev/null || echo "unknown,")
+                case "$STATUS" in
+                    completed,success)
+                        echo "#$i  PASS    $RUN_URL  $(date '+%H:%M:%S')"
+                        break
+                        ;;
+                    completed,*)
+                        CONCLUSION="${STATUS#completed,}"
+                        echo "#$i  FAIL($CONCLUSION)  $RUN_URL  $(date '+%H:%M:%S')"
+                        CRASHED=true
+                        break
+                        ;;
+                    *)
+                        sleep 60
+                        ;;
+                esac
+            done
+        done
+
+        if $CRASHED; then
+            echo "CRASH DETECTED on iteration $i — $(date '+%Y-%m-%d %H:%M:%S')"
+            exit 0
+        fi
+
+        sleep "$SLEEP_BETWEEN"
     done
+    echo "No crash after $MAX_ITERATIONS iterations."
+    exit 1
+}
 
-    if $CRASHED; then
-        echo "CRASH DETECTED on iteration $i — $(date '+%Y-%m-%d %H:%M:%S')"
-        exit 0
-    fi
-
-    sleep "$SLEEP_BETWEEN"
-done
-
-echo "No crash after $MAX_ITERATIONS iterations."
-exit 1
+case "$MODE" in
+    local) run_local ;;
+    ci)    run_ci ;;
+    *)     echo "Unknown MODE=$MODE (use 'local' or 'ci')"; exit 1 ;;
+esac

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
+cd "$(dirname "$0")"
+
 REPO="sgl-project/sglang"
 BRANCH="${BRANCH:-$(git branch --show-current)}"
 WORKFLOW="pr-test.yml"

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="sgl-project/sglang"
+BRANCH="${BRANCH:-$(git branch --show-current)}"
+WORKFLOW="pr-test.yml"
+TARGET_STAGE="${TARGET_STAGE:-stage-b-test-large-1-gpu}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-100}"
+SLEEP_BETWEEN="${SLEEP_BETWEEN:-30}"
+
+echo "========================================"
+echo "Eagle CI Retry — until crash"
+echo "  Repo:         $REPO"
+echo "  Branch:       $BRANCH"
+echo "  Workflow:     $WORKFLOW"
+echo "  Target stage: $TARGET_STAGE"
+echo "  Max iters:    $MAX_ITERATIONS"
+echo "========================================"
+
+for i in $(seq 1 "$MAX_ITERATIONS"); do
+    echo ""
+    echo "=== Iteration $i / $MAX_ITERATIONS  $(date '+%Y-%m-%d %H:%M:%S') ==="
+
+    # 1. Trigger workflow
+    echo "Triggering workflow..."
+    gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
+        -f target_stage="$TARGET_STAGE"
+
+    # 2. Wait for the run to appear
+    sleep 15
+    RUN_ID=""
+    for attempt in $(seq 1 12); do
+        RUN_ID=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+            --branch "$BRANCH" --limit 1 --json databaseId,status \
+            -q '.[0].databaseId' 2>/dev/null || true)
+        if [[ -n "$RUN_ID" ]]; then
+            break
+        fi
+        echo "  Waiting for run to appear (attempt $attempt)..."
+        sleep 10
+    done
+
+    if [[ -z "$RUN_ID" ]]; then
+        echo "ERROR: Could not find run after trigger. Retrying..."
+        sleep "$SLEEP_BETWEEN"
+        continue
+    fi
+
+    RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
+    echo "Run $RUN_ID: $RUN_URL"
+
+    # 3. Watch until completion
+    echo "Watching run..."
+    if gh run watch "$RUN_ID" --repo "$REPO" --exit-status 2>&1; then
+        echo "PASS on iteration $i. Sleeping ${SLEEP_BETWEEN}s before retry..."
+        sleep "$SLEEP_BETWEEN"
+    else
+        echo ""
+        echo "========================================"
+        echo "CRASH DETECTED on iteration $i!"
+        echo "  Run: $RUN_URL"
+        echo "  Time: $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "========================================"
+        echo ""
+        echo "View logs:  gh run view $RUN_ID --repo $REPO --log"
+        echo "View jobs:  gh run view $RUN_ID --repo $REPO"
+        exit 0
+    fi
+done
+
+echo ""
+echo "No crash after $MAX_ITERATIONS iterations."
+exit 1

--- a/retry_eagle_ci.sh
+++ b/retry_eagle_ci.sh
@@ -11,66 +11,50 @@ TARGET_STAGE="${TARGET_STAGE:-stage-b-test-large-1-gpu}"
 MAX_ITERATIONS="${MAX_ITERATIONS:-100}"
 SLEEP_BETWEEN="${SLEEP_BETWEEN:-30}"
 
-echo "========================================"
-echo "Eagle CI Retry — until crash"
-echo "  Repo:         $REPO"
-echo "  Branch:       $BRANCH"
-echo "  Workflow:     $WORKFLOW"
-echo "  Target stage: $TARGET_STAGE"
-echo "  Max iters:    $MAX_ITERATIONS"
-echo "========================================"
+echo "Eagle CI Retry | branch=$BRANCH stage=$TARGET_STAGE max=$MAX_ITERATIONS"
 
 for i in $(seq 1 "$MAX_ITERATIONS"); do
-    echo ""
-    echo "=== Iteration $i / $MAX_ITERATIONS  $(date '+%Y-%m-%d %H:%M:%S') ==="
-
-    # 1. Trigger workflow
-    echo "Triggering workflow..."
+    # 1. Trigger
     gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" \
-        -f target_stage="$TARGET_STAGE"
+        -f target_stage="$TARGET_STAGE" 2>/dev/null
 
-    # 2. Wait for the run to appear
+    # 2. Find run ID
     sleep 15
     RUN_ID=""
-    for attempt in $(seq 1 12); do
+    for _ in $(seq 1 12); do
         RUN_ID=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
-            --branch "$BRANCH" --limit 1 --json databaseId,status \
+            --branch "$BRANCH" --limit 1 --json databaseId \
             -q '.[0].databaseId' 2>/dev/null || true)
-        if [[ -n "$RUN_ID" ]]; then
-            break
-        fi
-        echo "  Waiting for run to appear (attempt $attempt)..."
+        [[ -n "$RUN_ID" ]] && break
         sleep 10
     done
-
-    if [[ -z "$RUN_ID" ]]; then
-        echo "ERROR: Could not find run after trigger. Retrying..."
-        sleep "$SLEEP_BETWEEN"
-        continue
-    fi
+    [[ -z "$RUN_ID" ]] && echo "#$i  ERROR: run not found" && sleep "$SLEEP_BETWEEN" && continue
 
     RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID"
-    echo "Run $RUN_ID: $RUN_URL"
 
-    # 3. Watch until completion
-    echo "Watching run..."
-    if gh run watch "$RUN_ID" --repo "$REPO" --exit-status 2>&1; then
-        echo "PASS on iteration $i. Sleeping ${SLEEP_BETWEEN}s before retry..."
-        sleep "$SLEEP_BETWEEN"
-    else
-        echo ""
-        echo "========================================"
-        echo "CRASH DETECTED on iteration $i!"
-        echo "  Run: $RUN_URL"
-        echo "  Time: $(date '+%Y-%m-%d %H:%M:%S')"
-        echo "========================================"
-        echo ""
-        echo "View logs:  gh run view $RUN_ID --repo $REPO --log"
-        echo "View jobs:  gh run view $RUN_ID --repo $REPO"
-        exit 0
-    fi
+    # 3. Poll until done (silent)
+    while true; do
+        STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status,conclusion \
+            -q '[.status,.conclusion] | join(",")' 2>/dev/null || echo "unknown,")
+        case "$STATUS" in
+            completed,success)
+                echo "#$i  PASS  $RUN_URL  $(date '+%H:%M:%S')"
+                break
+                ;;
+            completed,*)
+                CONCLUSION="${STATUS#completed,}"
+                echo "#$i  FAIL($CONCLUSION)  $RUN_URL  $(date '+%H:%M:%S')"
+                echo "CRASH DETECTED on iteration $i — $(date '+%Y-%m-%d %H:%M:%S')"
+                exit 0
+                ;;
+            *)
+                sleep 60
+                ;;
+        esac
+    done
+
+    sleep "$SLEEP_BETWEEN"
 done
 
-echo ""
 echo "No crash after $MAX_ITERATIONS iterations."
 exit 1

--- a/test/registered/spec/eagle/test_eagle_infer_b.py
+++ b/test/registered/spec/eagle/test_eagle_infer_b.py
@@ -28,6 +28,44 @@ register_cuda_ci(est_time=1100, suite="stage-b-test-large-1-gpu")
 class TestEAGLEServerBasic(EagleServerBase):
     extra_args = ["--chunked-prefill-size", 128, "--max-running-requests", 8]
 
+    def test_radix_attention_with_zero_decode(self):
+        """Debug: decode_len=0 can cause max_new_tokens=0 requests that finish
+        immediately after prefill.  If spec-decode init already added them to
+        the batch, this may leave stale entries."""
+        nodes = []
+        # Explicitly include decode_len=0 cases
+        for i in range(50):
+            nodes.append({"input_ids": [37] * random.randint(10, 200), "decode_len": 0})
+        # Mix with normal requests
+        for i in range(350):
+            nodes.append(
+                {
+                    "input_ids": [37] * random.randint(10, 200),
+                    "decode_len": random.randint(1, 256),
+                }
+            )
+        random.shuffle(nodes)
+
+        data = {
+            "input_ids": [n["input_ids"] for n in nodes],
+            "sampling_params": [
+                {"max_new_tokens": n["decode_len"], "temperature": 0} for n in nodes
+            ],
+        }
+        res = requests.post(self.base_url + "/generate", json=data)
+        self.assertEqual(res.status_code, 200)
+        self.assertIsNone(self.process.poll())
+
+    def test_radix_attention_stress(self):
+        """Debug: loop radix_attention to increase repro probability.
+        Also catches stale state leaked from earlier test methods
+        (e.g. TestEAGLERetract with max_total_tokens=4500)."""
+        for i in range(10):
+            print(f"=== radix_attention stress run {i} ===")
+            requests.get(self.base_url + "/flush_cache")
+            run_radix_attention_test(self.base_url)
+            self.assertIsNone(self.process.poll())
+
     # FIXME(lsyin): move the test methods to kits
     def test_request_abort(self):
         concurrency = 4


### PR DESCRIPTION
## Summary

- Add `torch._assert_async` check points across the Eagle spec decoding pipeline to catch the intermittent `torch.gather` OOB crash (`vectorized_gather_kernel` warp assert) that occurs under high concurrency (`test_radix_attention` with 400 prompts).
- Add `SGLANG_SPEC_DISABLE_COMPILE` env var to allow A/B comparison of `torch.compile` vs eager mode.
- CI temporarily narrowed to only run `test_eagle_infer_b.py` for focused v1 + flashinfer crash reproduction.

## Original Crash Evidence

- Run 1 (`test_eagle_infer_b.py`, v1 + flashinfer): https://github.com/sgl-project/sglang/actions/runs/22563140024/job/65354046439?pr=16438#step:5:11571
- Run 2 (`test_eagle_infer_beta.py`, v2 + triton): https://github.com/sgl-project/sglang/actions/runs/22375037149/job/64763600255#step:5:5862

## Two Bugs Identified

| Bug | Test | Code path | Attention backend | Frequency | Status |
|---|---|---|---|---|---|
| #19717 | `test_eagle_infer_beta.py` | v2 (`eagle_worker_v2.py`) | triton | medium | **Filed as issue** |
| (this PR) | `test_eagle_infer_b.py` | v1 (`eagle_worker.py`) | flashinfer | very rare | **Reproducing** |

## Debug Progress (v2 + triton — filed as #19717)

### Round 1: C4 fired — NaN probs cause gather OOB

```
draft model outputs NaN logits → softmax(NaN) = NaN probs
  → fast_topk(NaN) = garbage indices → torch.gather OOB → CUDA warp assert
```

**`torch.compile` is NOT the root cause.** Gather OOB is a downstream symptom of NaN.

### Round 2: D1 fired — NaN already in spec_info.topk_p

NaN is present at `draft_forward` entry. Problem is in the **verify / draft extend** phase.

### Round 3: E1 fired — draft extend model outputs NaN logits

`E1: next_token_logits has NaN in _draft_extend_for_decode` — the draft extend model's `next_token_logits` already contains NaN.

### Round 4: F3 fired — CUDA graph draft extend replay produces NaN

- **F1/F1b did NOT fire** → target model outputs are clean
- **F3 fired** → CUDA graph replay converts clean inputs into NaN outputs

### Round 5: G3 fired — graph output has NaN (full padded batch)

- **G1/G2 did NOT fire** → hidden_states input is clean, copy succeeded
- **G3 fired** → graph model.forward() itself produces NaN from clean hidden_states

### Round 6: H1 fired — NaN in valid slots

- Zeroing padded slots did NOT fix it
- **H1 fired** → NaN is in **valid token computations**, not padding leakage
- **Root cause**: triton backend's eager `init_forward_metadata` lacks dedicated `DRAFT_EXTEND_V2` handling (uses generic `else` branch with `extend_prefix_lens`/`extend_seq_lens`), while CUDA graph paths have dedicated branches using `accept_lens` for `qo_indptr`

## Current Focus: v1 + flashinfer rare crash

CI now runs `test_eagle_infer_b.py` on both runners. All `torch._assert_async` instrumentation (C/D/E/F/G/H/I series) is retained. When the crash reproduces, the first firing assert will reveal the NaN origin in the v1 + flashinfer path.

## Test plan

- [x] Round 1: C4 fired — NaN probs after softmax
- [x] Round 2: D1 fired — NaN in initial topk_p from spec_info
- [x] Round 3: E1 fired — draft extend outputs NaN logits
- [x] Round 4: F3 fired — CUDA graph replay produces NaN from clean inputs
- [x] Round 5: G3 fired — graph model.forward() produces NaN, hidden_states input clean
- [x] Round 6: H1 fired — NaN in valid slots, not padding → filed as #19717
- [ ] Round 7: v1 + flashinfer crash reproduction via CI