### PR TITLE
feat: support Kimi K2.5 for Eagle3

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -786,5 +786,25 @@ class KimiK25ForConditionalGeneration(nn.Module):
             num_groups=text_config.n_group,
         )
 
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None) -> None:
+        """Set the layers to capture for EAGLE3 speculative decoding."""
+        if not hasattr(self.language_model, "set_eagle3_layers_to_capture"):
+            raise AttributeError("language_model does not support EAGLE3 speculative decoding.")
+
+        self.language_model.set_eagle3_layers_to_capture(layer_ids)
+
+    def get_embed_and_head(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Get embedding and LM head weights for speculative decoding."""
+        if not hasattr(self.language_model, "get_embed_and_head"):
+            raise AttributeError("language_model does not support get_embed_and_head().")
+
+        return self.language_model.get_embed_and_head()
+
+    def set_embed_and_head(self, embed: torch.Tensor, head: torch.Tensor) -> None:
+        """Set embedding and LM head weights for speculative decoding."""
+        if not hasattr(self.language_model, "set_embed_and_head"):
+            raise AttributeError("language_model does not support set_embed_and_head().")
+            
+        self.language_model.set_embed_and_head(embed, head)
 
 EntryClass = [KimiK25ForConditionalGeneration]

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -804,7 +804,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
         """Set embedding and LM head weights for speculative decoding."""
         if not hasattr(self.language_model, "set_embed_and_head"):
             raise AttributeError("language_model does not support set_embed_and_head().")
-            
+
         self.language_model.set_embed_and_head(embed, head)
 
 EntryClass = [KimiK25ForConditionalGeneration]

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -786,25 +786,34 @@ class KimiK25ForConditionalGeneration(nn.Module):
             num_groups=text_config.n_group,
         )
 
-    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None) -> None:
+    def set_eagle3_layers_to_capture(
+        self, layer_ids: Optional[List[int]] = None
+    ) -> None:
         """Set the layers to capture for EAGLE3 speculative decoding."""
         if not hasattr(self.language_model, "set_eagle3_layers_to_capture"):
-            raise AttributeError("language_model does not support EAGLE3 speculative decoding.")
+            raise AttributeError(
+                "language_model does not support EAGLE3 speculative decoding."
+            )
 
         self.language_model.set_eagle3_layers_to_capture(layer_ids)
 
     def get_embed_and_head(self) -> Tuple[torch.Tensor, torch.Tensor]:
         """Get embedding and LM head weights for speculative decoding."""
         if not hasattr(self.language_model, "get_embed_and_head"):
-            raise AttributeError("language_model does not support get_embed_and_head().")
+            raise AttributeError(
+                "language_model does not support get_embed_and_head()."
+            )
 
         return self.language_model.get_embed_and_head()
 
     def set_embed_and_head(self, embed: torch.Tensor, head: torch.Tensor) -> None:
         """Set embedding and LM head weights for speculative decoding."""
         if not hasattr(self.language_model, "set_embed_and_head"):
-            raise AttributeError("language_model does not support set_embed_and_head().")
+            raise AttributeError(
+                "language_model does not support set_embed_and_head()."
+            )
 
         self.language_model.set_embed_and_head(embed, head)
+
 
 EntryClass = [KimiK25ForConditionalGeneration]


### PR DESCRIPTION
feat: Integrate Kimi K2.5 with Eagle3 and benchmark performance on H200

This commit introduces initial support for the Kimi K2.5 model on the Eagle3 platform.
The primary goal is to optimize inference efficiency and performance of Kimi K2.5
within the Eagle3 ecosystem, aiming for robust results across various benchmarks.

**Eagle3 Draft Model:** [https://huggingface.co/AQ-MedAI/Kimi-K25-eagle3/tree/main](https://huggingface.co/AQ-MedAI/Kimi-K25-eagle3/tree/main)

## Benchmarking Results

Below are the average token acceptance lengths for Kimi K2.5 on Eagle3 across different benchmarks:

**Speculative Decoding Configuration:**
*   `--speculative-num-steps 3`: Configures the number of speculative decoding steps.
*   `--speculative-eagle-topk 1`: Sets the `top-k` value for the Eagle draft model during speculative decoding.
*   `--speculative-num-draft-tokens 4`: Specifies the number of draft tokens generated in each speculative step.

```python
python3 -m sglang.launch_server  \
    --model-path /models/Kimi-K25 \
    --host 0.0.0.0 --port 30012  \
    --trust-remote-code  \
    --mem-fraction-static 0.9 \
    --tp-size 8  \
    --speculative-algorithm EAGLE3  \
    --speculative-draft-model-path AQ-MedAI/Kimi-K25-eagle3 \
    --speculative-num-steps 3  \
    --speculative-eagle-topk 1   \
    --speculative-num-draft-tokens 4
```

| Benchmark | Domain | Average Acceptance Length (Tokens) |
| :-------- | :----- | :-------------------------------: |
| **HumanEval** | Code Generation | **2.625** |
| **GSM8K** | Mathematical Reasoning | **2.746** |
| **Math500** | Complex Mathematics | **2.596** |
| **MMStar** | Vision-and-Text Multimodal | **2.219** |

## Performance Profiling Visuals

Detailed benchmarking and performance profiling have been conducted. The following visualizations provide insight into Kimi K2.5's operation on Eagle3:

<img width="1200" height="700" alt="image" src="https://github.com/user-attachments/assets/76e68514-051e-44ab-9982-2165021794ab" />

<img width="1200" height="700" alt="image" src="https://github.com/user-attachments/assets/1208e95e-9000-463d-aaed-96f2ba9faa71" />

<img width="1200" height="700" alt="image" src="https://github.com/user-attachments/assets/696fa3c5-7707-490d-8226-737cc1522a03" />
