### PR TITLE
[JIT Kernel] Migrate per_token_quant_fp8 to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_per_token_quant_fp8.py
+++ b/python/sglang/jit_kernel/benchmark/bench_per_token_quant_fp8.py
@@ -1,0 +1,113 @@
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import (
+    DEFAULT_DEVICE,
+    DEFAULT_DTYPE,
+    get_benchmark_range,
+    run_benchmark,
+)
+from sglang.jit_kernel.per_token_quant_fp8 import (
+    per_token_quant_fp8 as jit_per_token_quant_fp8,
+)
+
+try:
+    from sgl_kernel import sgl_per_token_quant_fp8 as aot_per_token_quant_fp8
+
+    AOT_AVAILABLE = True
+except ImportError:
+    aot_per_token_quant_fp8 = None
+    AOT_AVAILABLE = False
+
+
+def check_correctness():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel AOT not available, skipping correctness check")
+        return
+    m, k = 16, 2048
+    input_tensor = torch.randn(m, k, dtype=DEFAULT_DTYPE, device=DEFAULT_DEVICE)
+    output_q_jit = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEFAULT_DEVICE)
+    output_s_jit = torch.empty(m, dtype=torch.float32, device=DEFAULT_DEVICE)
+    output_q_aot = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEFAULT_DEVICE)
+    output_s_aot = torch.empty(m, dtype=torch.float32, device=DEFAULT_DEVICE)
+    jit_per_token_quant_fp8(input_tensor, output_q_jit, output_s_jit)
+    aot_per_token_quant_fp8(input_tensor, output_q_aot, output_s_aot)
+    torch.testing.assert_close(output_q_jit, output_q_aot, rtol=0, atol=0)
+    torch.testing.assert_close(output_s_jit, output_s_aot, rtol=0, atol=0)
+    print("Correctness check passed (JIT vs AOT)")
+
+
+M_LIST = get_benchmark_range(
+    full_range=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+    ci_range=[16, 128],
+)
+
+K_LIST = get_benchmark_range(
+    full_range=[2048, 4096, 7168],
+    ci_range=[2048, 4096],
+)
+
+configs = list(itertools.product(M_LIST, K_LIST))
+
+line_vals = ["jit", "pytorch"]
+line_names = ["SGL JIT Kernel", "PyTorch"]
+styles = [("blue", "-"), ("red", "--")]
+
+if AOT_AVAILABLE:
+    line_vals.insert(1, "aot")
+    line_names.insert(1, "SGL AOT Kernel")
+    styles.insert(1, ("green", "-."))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["m", "k"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=line_vals,
+        line_names=line_names,
+        styles=styles,
+        ylabel="us",
+        plot_name="per-token-quant-fp8-performance",
+        args={},
+    )
+)
+def benchmark(m, k, provider):
+    FP8_E4M3_MAX = 448.0
+    input_tensor = torch.randn(m, k, dtype=DEFAULT_DTYPE, device=DEFAULT_DEVICE)
+    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEFAULT_DEVICE)
+    output_s = torch.empty(m, dtype=torch.float32, device=DEFAULT_DEVICE)
+
+    if provider == "jit":
+
+        def fn():
+            jit_per_token_quant_fp8(input_tensor, output_q, output_s)
+
+    elif provider == "aot":
+
+        def fn():
+            aot_per_token_quant_fp8(input_tensor, output_q, output_s)
+
+    else:  # pytorch
+
+        def fn():
+            absmax = input_tensor.float().abs().max(dim=-1, keepdim=True).values
+            scale = absmax / FP8_E4M3_MAX
+            output_s.copy_(scale.squeeze(-1))
+            scale_inv = torch.where(
+                scale == 0, torch.zeros_like(scale), 1.0 / scale
+            )
+            quantized = (input_tensor.float() * scale_inv).clamp(
+                -FP8_E4M3_MAX, FP8_E4M3_MAX
+            )
+            output_q.copy_(quantized.to(output_q.dtype))
+
+    return run_benchmark(fn)
+
+
+if __name__ == "__main__":
+    check_correctness()
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/benchmark/bench_per_token_quant_fp8.py
+++ b/python/sglang/jit_kernel/benchmark/bench_per_token_quant_fp8.py
@@ -5,9 +5,8 @@ import triton
 import triton.testing
 
 from sglang.jit_kernel.benchmark.utils import (
-    DEFAULT_DEVICE,
-    DEFAULT_DTYPE,
     get_benchmark_range,
+    is_in_ci,
     run_benchmark,
 )
 from sglang.jit_kernel.per_token_quant_fp8 import (
@@ -22,17 +21,21 @@ except ImportError:
     aot_per_token_quant_fp8 = None
     AOT_AVAILABLE = False
 
+IS_CI = is_in_ci()
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+
 
 def check_correctness():
     if not AOT_AVAILABLE:
         print("sgl_kernel AOT not available, skipping correctness check")
         return
     m, k = 16, 2048
-    input_tensor = torch.randn(m, k, dtype=DEFAULT_DTYPE, device=DEFAULT_DEVICE)
-    output_q_jit = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEFAULT_DEVICE)
-    output_s_jit = torch.empty(m, dtype=torch.float32, device=DEFAULT_DEVICE)
-    output_q_aot = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEFAULT_DEVICE)
-    output_s_aot = torch.empty(m, dtype=torch.float32, device=DEFAULT_DEVICE)
+    input_tensor = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    output_q_jit = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEVICE)
+    output_s_jit = torch.empty(m, dtype=torch.float32, device=DEVICE)
+    output_q_aot = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEVICE)
+    output_s_aot = torch.empty(m, dtype=torch.float32, device=DEVICE)
     jit_per_token_quant_fp8(input_tensor, output_q_jit, output_s_jit)
     aot_per_token_quant_fp8(input_tensor, output_q_aot, output_s_aot)
     torch.testing.assert_close(output_q_jit, output_q_aot, rtol=0, atol=0)
@@ -52,14 +55,14 @@ K_LIST = get_benchmark_range(
 
 configs = list(itertools.product(M_LIST, K_LIST))
 
-line_vals = ["jit", "pytorch"]
-line_names = ["SGL JIT Kernel", "PyTorch"]
-styles = [("blue", "-"), ("red", "--")]
+LINE_VALS = ["jit", "pytorch"]
+LINE_NAMES = ["SGL JIT Kernel", "PyTorch"]
+STYLES = [("blue", "-"), ("red", "--")]
 
 if AOT_AVAILABLE:
-    line_vals.insert(1, "aot")
-    line_names.insert(1, "SGL AOT Kernel")
-    styles.insert(1, ("green", "-."))
+    LINE_VALS.insert(1, "aot")
+    LINE_NAMES.insert(1, "SGL AOT Kernel")
+    STYLES.insert(1, ("green", "-."))
 
 
 @triton.testing.perf_report(
@@ -67,9 +70,9 @@ if AOT_AVAILABLE:
         x_names=["m", "k"],
         x_vals=configs,
         line_arg="provider",
-        line_vals=line_vals,
-        line_names=line_names,
-        styles=styles,
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
         ylabel="us",
         plot_name="per-token-quant-fp8-performance",
         args={},
@@ -77,35 +80,34 @@ if AOT_AVAILABLE:
 )
 def benchmark(m, k, provider):
     FP8_E4M3_MAX = 448.0
-    input_tensor = torch.randn(m, k, dtype=DEFAULT_DTYPE, device=DEFAULT_DEVICE)
-    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEFAULT_DEVICE)
-    output_s = torch.empty(m, dtype=torch.float32, device=DEFAULT_DEVICE)
+    input_tensor = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEVICE)
+    output_s = torch.empty(m, dtype=torch.float32, device=DEVICE)
 
-    if provider == "jit":
+    def jit_fn():
+        jit_per_token_quant_fp8(input_tensor, output_q, output_s)
 
-        def fn():
-            jit_per_token_quant_fp8(input_tensor, output_q, output_s)
+    def aot_fn():
+        aot_per_token_quant_fp8(input_tensor, output_q, output_s)
 
-    elif provider == "aot":
+    def pytorch_fn():
+        absmax = input_tensor.float().abs().max(dim=-1, keepdim=True).values
+        scale = absmax / FP8_E4M3_MAX
+        output_s.copy_(scale.squeeze(-1))
+        scale_inv = torch.where(
+            scale == 0, torch.zeros_like(scale), 1.0 / scale
+        )
+        quantized = (input_tensor.float() * scale_inv).clamp(
+            -FP8_E4M3_MAX, FP8_E4M3_MAX
+        )
+        output_q.copy_(quantized.to(output_q.dtype))
 
-        def fn():
-            aot_per_token_quant_fp8(input_tensor, output_q, output_s)
-
-    else:  # pytorch
-
-        def fn():
-            absmax = input_tensor.float().abs().max(dim=-1, keepdim=True).values
-            scale = absmax / FP8_E4M3_MAX
-            output_s.copy_(scale.squeeze(-1))
-            scale_inv = torch.where(
-                scale == 0, torch.zeros_like(scale), 1.0 / scale
-            )
-            quantized = (input_tensor.float() * scale_inv).clamp(
-                -FP8_E4M3_MAX, FP8_E4M3_MAX
-            )
-            output_q.copy_(quantized.to(output_q.dtype))
-
-    return run_benchmark(fn)
+    FN_MAP = {
+        "jit": jit_fn,
+        "aot": aot_fn,
+        "pytorch": pytorch_fn,
+    }
+    return run_benchmark(FN_MAP[provider])
 
 
 if __name__ == "__main__":

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
@@ -59,26 +59,14 @@ __global__ void per_token_quant_fp8_kernel(const DType* __restrict__ input,
     AlignedVector<DType, kVecSize> in_vec;
     in_vec.load(token_input, i);
 
-    fp8_e4m3_t out_arr[kVecSize];
+    AlignedVector<fp8_e4m3_t, kVecSize> out_vec;
 #pragma unroll
     for (int j = 0; j < kVecSize; ++j) {
       float val = static_cast<float>(in_vec[j]) * scale_inv;
       val = math::max(math::min(val, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
-      out_arr[j] = static_cast<fp8_e4m3_t>(val);
+      out_vec[j] = static_cast<fp8_e4m3_t>(val);
     }
-
-    if constexpr (kVecSize == 16) {
-      *reinterpret_cast<uint4*>(token_output + i * kVecSize) = *reinterpret_cast<uint4*>(out_arr);
-    } else if constexpr (kVecSize == 8) {
-      *reinterpret_cast<uint2*>(token_output + i * kVecSize) = *reinterpret_cast<uint2*>(out_arr);
-    } else if constexpr (kVecSize == 4) {
-      *reinterpret_cast<unsigned int*>(token_output + i * kVecSize) = *reinterpret_cast<unsigned int*>(out_arr);
-    } else {
-#pragma unroll
-      for (int k = 0; k < kVecSize; ++k) {
-        token_output[i * kVecSize + k] = out_arr[k];
-      }
-    }
+    out_vec.store(token_output, i);
   }
 }
 
@@ -114,44 +102,25 @@ void per_token_quant_fp8(tvm::ffi::TensorView input,
   constexpr int kBlockSize = 256;
   constexpr int kMaxVecSize = 32 / sizeof(DType);
 
-  if (hidden_dim % kMaxVecSize == 0) {
-    constexpr int kVecSize = kMaxVecSize;
+  const auto* input_ptr = static_cast<const DType*>(input.data_ptr());
+  auto* output_q_ptr = static_cast<fp8_e4m3_t*>(output_q.data_ptr());
+  auto* output_s_ptr = static_cast<float*>(output_s.data_ptr());
+
+  auto launch = [&](auto kernel) {
     LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
-        per_token_quant_fp8_kernel<DType, kVecSize>,
-        static_cast<const DType*>(input.data_ptr()),
-        static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
-        static_cast<float*>(output_s.data_ptr()),
-        hidden_dim,
-        num_tokens);
+        kernel, input_ptr, output_q_ptr, output_s_ptr, hidden_dim, num_tokens);
+  };
+
+  if (hidden_dim % kMaxVecSize == 0) {
+    launch(per_token_quant_fp8_kernel<DType, kMaxVecSize>);
   } else if constexpr (kMaxVecSize > 8) {
     if (hidden_dim % 8 == 0) {
-      constexpr int kVecSize = 8;
-      LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
-          per_token_quant_fp8_kernel<DType, kVecSize>,
-          static_cast<const DType*>(input.data_ptr()),
-          static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
-          static_cast<float*>(output_s.data_ptr()),
-          hidden_dim,
-          num_tokens);
+      launch(per_token_quant_fp8_kernel<DType, 8>);
     } else {
-      constexpr int kVecSize = 4;
-      LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
-          per_token_quant_fp8_kernel<DType, kVecSize>,
-          static_cast<const DType*>(input.data_ptr()),
-          static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
-          static_cast<float*>(output_s.data_ptr()),
-          hidden_dim,
-          num_tokens);
+      launch(per_token_quant_fp8_kernel<DType, 4>);
     }
   } else {
-    constexpr int kVecSize = 4;
-    LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
-        per_token_quant_fp8_kernel<DType, kVecSize>,
-        static_cast<const DType*>(input.data_ptr()),
-        static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
-        static_cast<float*>(output_s.data_ptr()),
-        hidden_dim,
-        num_tokens);
+    launch(per_token_quant_fp8_kernel<DType, 4>);
   }
 }
 

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
@@ -1,0 +1,158 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/cta.cuh>
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+template <typename DType, int kVecSize>
+__global__ void per_token_quant_fp8_kernel(const DType* __restrict__ input,
+                                           fp8_e4m3_t* __restrict__ output_q,
+                                           float* __restrict__ output_s,
+                                           const int64_t hidden_dim,
+                                           const int64_t num_tokens) {
+  using namespace device;
+
+  const int64_t token_idx = blockIdx.x;
+  if (token_idx >= num_tokens) return;
+
+  const DType* token_input = input + token_idx * hidden_dim;
+  fp8_e4m3_t* token_output = output_q + token_idx * hidden_dim;
+
+  const int32_t num_vec_elems = hidden_dim / kVecSize;
+  const int tid = threadIdx.x;
+  const int block_dim = blockDim.x;
+
+  float max_value = 0.0f;
+
+  for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
+    AlignedVector<DType, kVecSize> vec;
+    vec.load(token_input, i);
+#pragma unroll
+    for (int j = 0; j < kVecSize; ++j) {
+      max_value = math::max(max_value, math::abs(static_cast<float>(vec[j])));
+    }
+  }
+
+  __shared__ float smem[kWarpThreads];
+  cta::reduce_max(max_value, smem);
+  __syncthreads();
+
+  const float absmax = smem[0];
+  const float scale = absmax / math::FP8_E4M3_MAX;
+  if (tid == 0) {
+    output_s[token_idx] = scale;
+  }
+  const float scale_inv = (scale == 0.0f) ? 0.0f : 1.0f / scale;
+
+  for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
+    AlignedVector<DType, kVecSize> in_vec;
+    in_vec.load(token_input, i);
+
+    fp8_e4m3_t out_arr[kVecSize];
+#pragma unroll
+    for (int j = 0; j < kVecSize; ++j) {
+      float val = static_cast<float>(in_vec[j]) * scale_inv;
+      val = math::max(math::min(val, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
+      out_arr[j] = static_cast<fp8_e4m3_t>(val);
+    }
+
+    if constexpr (kVecSize == 16) {
+      *reinterpret_cast<uint4*>(token_output + i * kVecSize) = *reinterpret_cast<uint4*>(out_arr);
+    } else if constexpr (kVecSize == 8) {
+      *reinterpret_cast<uint2*>(token_output + i * kVecSize) = *reinterpret_cast<uint2*>(out_arr);
+    } else if constexpr (kVecSize == 4) {
+      *reinterpret_cast<unsigned int*>(token_output + i * kVecSize) = *reinterpret_cast<unsigned int*>(out_arr);
+    } else {
+#pragma unroll
+      for (int k = 0; k < kVecSize; ++k) {
+        token_output[i * kVecSize + k] = out_arr[k];
+      }
+    }
+  }
+}
+
+template <typename DType>
+void per_token_quant_fp8(tvm::ffi::TensorView input,
+                         tvm::ffi::TensorView output_q,
+                         tvm::ffi::TensorView output_s) {
+  using namespace host;
+
+  auto M = SymbolicSize{"num_tokens"};
+  auto D = SymbolicSize{"hidden_dim"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({M, D})  //
+      .with_dtype<DType>()
+      .with_device(device)
+      .verify(input);
+  TensorMatcher({M, D})  //
+      .with_dtype<fp8_e4m3_t>()
+      .with_device(device)
+      .verify(output_q);
+  TensorMatcher({M})  //
+      .with_dtype<fp32_t>()
+      .with_device(device)
+      .verify(output_s);
+
+  const auto num_tokens = static_cast<int64_t>(M.unwrap());
+  const auto hidden_dim = static_cast<int64_t>(D.unwrap());
+
+  RuntimeCheck(hidden_dim % 4 == 0, "per_token_quant_fp8: hidden_dim must be divisible by 4, got ", hidden_dim);
+
+  constexpr int kBlockSize = 256;
+  constexpr int kMaxVecSize = 32 / sizeof(DType);
+
+  if (hidden_dim % kMaxVecSize == 0) {
+    constexpr int kVecSize = kMaxVecSize;
+    LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
+        per_token_quant_fp8_kernel<DType, kVecSize>,
+        static_cast<const DType*>(input.data_ptr()),
+        static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
+        static_cast<float*>(output_s.data_ptr()),
+        hidden_dim,
+        num_tokens);
+  } else if constexpr (kMaxVecSize > 8) {
+    if (hidden_dim % 8 == 0) {
+      constexpr int kVecSize = 8;
+      LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
+          per_token_quant_fp8_kernel<DType, kVecSize>,
+          static_cast<const DType*>(input.data_ptr()),
+          static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
+          static_cast<float*>(output_s.data_ptr()),
+          hidden_dim,
+          num_tokens);
+    } else {
+      constexpr int kVecSize = 4;
+      LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
+          per_token_quant_fp8_kernel<DType, kVecSize>,
+          static_cast<const DType*>(input.data_ptr()),
+          static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
+          static_cast<float*>(output_s.data_ptr()),
+          hidden_dim,
+          num_tokens);
+    }
+  } else {
+    constexpr int kVecSize = 4;
+    LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
+        per_token_quant_fp8_kernel<DType, kVecSize>,
+        static_cast<const DType*>(input.data_ptr()),
+        static_cast<fp8_e4m3_t*>(output_q.data_ptr()),
+        static_cast<float*>(output_s.data_ptr()),
+        hidden_dim,
+        num_tokens);
+  }
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
@@ -3,6 +3,8 @@
 
 #include <sgl_kernel/cta.cuh>
 #include <sgl_kernel/math.cuh>
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/type.cuh>
 #include <sgl_kernel/utils.cuh>
 #include <sgl_kernel/vec.cuh>
 #include <sgl_kernel/warp.cuh>
@@ -21,10 +23,12 @@ __global__ void per_token_quant_fp8_kernel(const DType* __restrict__ input,
                                            float* __restrict__ output_s,
                                            const int64_t hidden_dim) {
   using namespace device;
+  using packed_dt = packed_t<DType>;
+  constexpr int kPackedVecSize = kVecSize / 2;
 
   const int64_t token_idx = blockIdx.x;
 
-  const DType* token_input = input + token_idx * hidden_dim;
+  const auto* token_input = reinterpret_cast<const packed_dt*>(input + token_idx * hidden_dim);
   fp8_e4m3_t* token_output = output_q + token_idx * hidden_dim;
 
   const int32_t num_vec_elems = hidden_dim / kVecSize;
@@ -34,11 +38,12 @@ __global__ void per_token_quant_fp8_kernel(const DType* __restrict__ input,
   float max_value = 0.0f;
 
   for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
-    AlignedVector<DType, kVecSize> vec;
+    AlignedVector<packed_dt, kPackedVecSize> vec;
     vec.load(token_input, i);
 #pragma unroll
-    for (int j = 0; j < kVecSize; ++j) {
-      max_value = math::max(max_value, math::abs(static_cast<float>(vec[j])));
+    for (int j = 0; j < kPackedVecSize; ++j) {
+      fp32x2_t val = cast<fp32x2_t>(vec[j]);
+      max_value = math::max(max_value, math::max(math::abs(val.x), math::abs(val.y)));
     }
   }
 
@@ -54,15 +59,107 @@ __global__ void per_token_quant_fp8_kernel(const DType* __restrict__ input,
   const float scale_inv = (scale == 0.0f) ? 0.0f : 1.0f / scale;
 
   for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
-    AlignedVector<DType, kVecSize> in_vec;
+    AlignedVector<packed_dt, kPackedVecSize> in_vec;
     in_vec.load(token_input, i);
 
     AlignedVector<fp8_e4m3_t, kVecSize> out_vec;
 #pragma unroll
-    for (int j = 0; j < kVecSize; ++j) {
-      float val = static_cast<float>(in_vec[j]) * scale_inv;
-      val = math::max(math::min(val, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
-      out_vec[j] = static_cast<fp8_e4m3_t>(val);
+    for (int j = 0; j < kPackedVecSize; ++j) {
+      fp32x2_t val = cast<fp32x2_t>(in_vec[j]);
+      val.x = math::max(math::min(val.x * scale_inv, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
+      val.y = math::max(math::min(val.y * scale_inv, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
+      out_vec[2 * j] = static_cast<fp8_e4m3_t>(val.x);
+      out_vec[2 * j + 1] = static_cast<fp8_e4m3_t>(val.y);
+    }
+    out_vec.store(token_output, i);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Warp-local kernel: 8 tokens per CTA (one warp per token).
+// Uses shared memory to cache input when hidden_dim is small, avoiding
+// a second global memory read in Pass 2.
+// ---------------------------------------------------------------------------
+template <typename DType, int kVecSize, bool kUseSmem>
+__global__ void per_token_quant_fp8_warp_kernel(const DType* __restrict__ input,
+                                                fp8_e4m3_t* __restrict__ output_q,
+                                                float* __restrict__ output_s,
+                                                const int64_t hidden_dim,
+                                                const int64_t num_tokens) {
+  using namespace device;
+  using packed_dt = packed_t<DType>;
+  constexpr int kPackedVecSize = kVecSize / 2;
+  constexpr int kTokensPerCTA = 8;
+
+  const int warp_id = threadIdx.x / kWarpThreads;
+  const int lane_id = threadIdx.x & (kWarpThreads - 1);
+  const int64_t token_id = blockIdx.x * kTokensPerCTA + warp_id;
+  if (token_id >= num_tokens) return;
+
+  const auto* token_input = reinterpret_cast<const packed_dt*>(input + token_id * hidden_dim);
+  fp8_e4m3_t* token_output = output_q + token_id * hidden_dim;
+
+  // Shared memory: each warp gets its own padded slice
+  extern __shared__ char smem_buffer[];
+  constexpr int kSmemPadding = 32;
+  const int warp_smem_stride = (hidden_dim * sizeof(DType) + kSmemPadding - 1) / kSmemPadding * kSmemPadding;
+  auto* shared_input = reinterpret_cast<DType*>(smem_buffer + warp_id * warp_smem_stride);
+
+  const int32_t num_vec_elems = hidden_dim / kVecSize;
+  float max_value = 0.0f;
+
+  // Pass 1: Load from global, optionally cache to smem, compute absmax
+  for (int32_t i = lane_id; i < num_vec_elems; i += kWarpThreads) {
+    AlignedVector<packed_dt, kPackedVecSize> vec;
+    vec.load(token_input, i);
+
+    if constexpr (kUseSmem) {
+#pragma unroll
+      for (int j = 0; j < kPackedVecSize; ++j) {
+        reinterpret_cast<packed_dt*>(shared_input)[i * kPackedVecSize + j] = vec[j];
+      }
+    }
+
+#pragma unroll
+    for (int j = 0; j < kPackedVecSize; ++j) {
+      fp32x2_t val = cast<fp32x2_t>(vec[j]);
+      max_value = math::max(max_value, math::max(math::abs(val.x), math::abs(val.y)));
+    }
+  }
+
+  if constexpr (kUseSmem) {
+    __syncwarp();
+  }
+
+  max_value = warp::reduce_max(max_value);
+
+  const float scale = max_value / math::FP8_E4M3_MAX;
+  if (lane_id == 0) {
+    output_s[token_id] = scale;
+  }
+  const float scale_inv = (scale == 0.0f) ? 0.0f : 1.0f / scale;
+
+  // Pass 2: Quantize (read from smem or re-read global)
+  for (int32_t i = lane_id; i < num_vec_elems; i += kWarpThreads) {
+    AlignedVector<packed_dt, kPackedVecSize> in_vec;
+
+    if constexpr (kUseSmem) {
+#pragma unroll
+      for (int j = 0; j < kPackedVecSize; ++j) {
+        in_vec[j] = reinterpret_cast<packed_dt*>(shared_input)[i * kPackedVecSize + j];
+      }
+    } else {
+      in_vec.load(token_input, i);
+    }
+
+    AlignedVector<fp8_e4m3_t, kVecSize> out_vec;
+#pragma unroll
+    for (int j = 0; j < kPackedVecSize; ++j) {
+      fp32x2_t val = cast<fp32x2_t>(in_vec[j]);
+      val.x = math::max(math::min(val.x * scale_inv, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
+      val.y = math::max(math::min(val.y * scale_inv, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX);
+      out_vec[2 * j] = static_cast<fp8_e4m3_t>(val.x);
+      out_vec[2 * j + 1] = static_cast<fp8_e4m3_t>(val.y);
     }
     out_vec.store(token_output, i);
   }
@@ -80,10 +177,12 @@ void per_token_quant_fp8(tvm::ffi::TensorView input,
   device.set_options<kDLCUDA>();
 
   TensorMatcher({M, D})  //
+      .with_strides({D, 1})
       .with_dtype<DType>()
       .with_device(device)
       .verify(input);
   TensorMatcher({M, D})  //
+      .with_strides({D, 1})
       .with_dtype<fp8_e4m3_t>()
       .with_device(device)
       .verify(output_q);
@@ -97,29 +196,73 @@ void per_token_quant_fp8(tvm::ffi::TensorView input,
 
   RuntimeCheck(hidden_dim % 4 == 0, "per_token_quant_fp8: hidden_dim must be divisible by 4, got ", hidden_dim);
 
-  constexpr int kBlockSize = 256;
-  constexpr int kMaxVecSize = 32 / sizeof(DType);
+  constexpr int kMaxVecSize = device::kMaxVecBytes / sizeof(DType);
+  constexpr int kTokensPerCTA = 8;
+  constexpr int kWarpSize = 32;
+  constexpr int kWarpBlockSize = kTokensPerCTA * kWarpSize;  // 256
+  constexpr int kSmallBatchBlockSize = 256;
+  constexpr std::size_t kSmemThreshold = 48 * 1024;  // 48 KB
 
   const auto* input_ptr = static_cast<const DType*>(input.data_ptr());
   auto* output_q_ptr = static_cast<fp8_e4m3_t*>(output_q.data_ptr());
   auto* output_s_ptr = static_cast<float*>(output_s.data_ptr());
 
-  auto launch = [&](auto kernel) {
-    LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
+  const auto dl_device = device.unwrap();
+  const auto sm_count = runtime::get_sm_count(dl_device.device_id);
+  const bool use_warp_kernel = (num_tokens >= static_cast<int64_t>(sm_count) * 2 * kTokensPerCTA);
+
+  // Shared memory sizing for warp kernel
+  constexpr int kSmemPadding = 32;
+  const int warp_smem_stride = (hidden_dim * sizeof(DType) + kSmemPadding - 1) / kSmemPadding * kSmemPadding;
+  const std::size_t dynamic_smem_bytes = static_cast<std::size_t>(warp_smem_stride) * kTokensPerCTA;
+  const bool use_smem = (hidden_dim < 2048) && (dynamic_smem_bytes < kSmemThreshold);
+
+  auto launch_warp = [&](auto kernel, std::size_t smem) {
+    const dim3 grid((num_tokens + kTokensPerCTA - 1) / kTokensPerCTA);
+    LaunchKernel(grid, kWarpBlockSize, dl_device, smem)(
+        kernel, input_ptr, output_q_ptr, output_s_ptr, hidden_dim, num_tokens);
+  };
+
+  auto launch_small_batch = [&](auto kernel) {
+    LaunchKernel(num_tokens, kSmallBatchBlockSize, dl_device)(
         kernel, input_ptr, output_q_ptr, output_s_ptr, hidden_dim);
   };
 
+  #define DISPATCH_WARP_KERNEL(VECSIZE)                                                        \
+    if (use_smem) {                                                                            \
+      launch_warp(per_token_quant_fp8_warp_kernel<DType, VECSIZE, true>, dynamic_smem_bytes);  \
+    } else {                                                                                   \
+      launch_warp(per_token_quant_fp8_warp_kernel<DType, VECSIZE, false>, 0);                  \
+    }
+
   if (hidden_dim % kMaxVecSize == 0) {
-    launch(per_token_quant_fp8_kernel<DType, kMaxVecSize>);
+    if (use_warp_kernel) {
+      DISPATCH_WARP_KERNEL(kMaxVecSize);
+    } else {
+      launch_small_batch(per_token_quant_fp8_kernel<DType, kMaxVecSize>);
+    }
   } else if constexpr (kMaxVecSize > 8) {
     if (hidden_dim % 8 == 0) {
-      launch(per_token_quant_fp8_kernel<DType, 8>);
+      if (use_warp_kernel) {
+        DISPATCH_WARP_KERNEL(8);
+      } else {
+        launch_small_batch(per_token_quant_fp8_kernel<DType, 8>);
+      }
     } else {
-      launch(per_token_quant_fp8_kernel<DType, 4>);
+      if (use_warp_kernel) {
+        DISPATCH_WARP_KERNEL(4);
+      } else {
+        launch_small_batch(per_token_quant_fp8_kernel<DType, 4>);
+      }
     }
   } else {
-    launch(per_token_quant_fp8_kernel<DType, 4>);
+    if (use_warp_kernel) {
+      DISPATCH_WARP_KERNEL(4);
+    } else {
+      launch_small_batch(per_token_quant_fp8_kernel<DType, 4>);
+    }
   }
+  #undef DISPATCH_WARP_KERNEL
 }
 
 }  // namespace

--- a/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/per_token_quant_fp8.cuh
@@ -19,12 +19,10 @@ template <typename DType, int kVecSize>
 __global__ void per_token_quant_fp8_kernel(const DType* __restrict__ input,
                                            fp8_e4m3_t* __restrict__ output_q,
                                            float* __restrict__ output_s,
-                                           const int64_t hidden_dim,
-                                           const int64_t num_tokens) {
+                                           const int64_t hidden_dim) {
   using namespace device;
 
   const int64_t token_idx = blockIdx.x;
-  if (token_idx >= num_tokens) return;
 
   const DType* token_input = input + token_idx * hidden_dim;
   fp8_e4m3_t* token_output = output_q + token_idx * hidden_dim;
@@ -108,7 +106,7 @@ void per_token_quant_fp8(tvm::ffi::TensorView input,
 
   auto launch = [&](auto kernel) {
     LaunchKernel(num_tokens, kBlockSize, device.unwrap())(
-        kernel, input_ptr, output_q_ptr, output_s_ptr, hidden_dim, num_tokens);
+        kernel, input_ptr, output_q_ptr, output_s_ptr, hidden_dim);
   };
 
   if (hidden_dim % kMaxVecSize == 0) {

--- a/python/sglang/jit_kernel/per_token_quant_fp8.py
+++ b/python/sglang/jit_kernel/per_token_quant_fp8.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_per_token_quant_fp8_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "per_token_quant_fp8",
+        *args,
+        cuda_files=["gemm/per_token_quant_fp8.cuh"],
+        cuda_wrappers=[("per_token_quant_fp8", f"per_token_quant_fp8<{args}>")],
+    )
+
+
+@register_custom_op(
+    op_name="jit_per_token_quant_fp8",
+    mutates_args=["output_q", "output_s"],
+)
+def per_token_quant_fp8(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+) -> None:
+    module = _jit_per_token_quant_fp8_module(input.dtype)
+    module.per_token_quant_fp8(input, output_q, output_s.view(-1))

--- a/python/sglang/jit_kernel/tests/test_per_token_quant_fp8.py
+++ b/python/sglang/jit_kernel/tests/test_per_token_quant_fp8.py
@@ -1,0 +1,57 @@
+import itertools
+
+import pytest
+import torch
+
+from sglang.jit_kernel.per_token_quant_fp8 import per_token_quant_fp8
+
+
+M_LIST = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+K_LIST = [512, 1024, 2048, 4096, 7168]
+DTYPE_LIST = [torch.float16, torch.bfloat16, torch.float32]
+
+configs = list(itertools.product(M_LIST, K_LIST, DTYPE_LIST))
+
+
+def _reference_per_token_quant_fp8(input_tensor):
+    FP8_E4M3_MAX = 448.0
+    absmax = input_tensor.float().abs().max(dim=-1, keepdim=True).values
+    scale = absmax / FP8_E4M3_MAX
+    scale_inv = torch.where(scale == 0, torch.zeros_like(scale), 1.0 / scale)
+    quantized = (input_tensor.float() * scale_inv).clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
+    return quantized, scale.squeeze(-1)
+
+
+@pytest.mark.parametrize("m, k, dtype", configs)
+def test_per_token_quant_fp8(m, k, dtype):
+    input_tensor = torch.randn(m, k, dtype=dtype, device="cuda")
+    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device="cuda")
+    output_s = torch.empty(m, dtype=torch.float32, device="cuda")
+
+    per_token_quant_fp8(input_tensor, output_q, output_s)
+
+    ref_q, ref_s = _reference_per_token_quant_fp8(input_tensor)
+
+    torch.testing.assert_close(output_s, ref_s, rtol=1e-5, atol=1e-6)
+
+    output_q_float = output_q.float()
+    ref_q_fp8 = ref_q.to(torch.float8_e4m3fn).float()
+    torch.testing.assert_close(output_q_float, ref_q_fp8, rtol=0.15, atol=64.0)
+
+
+@pytest.mark.parametrize("m", [1, 16, 64])
+def test_per_token_quant_fp8_scale_shape(m):
+    k = 1024
+    dtype = torch.float16
+    input_tensor = torch.randn(m, k, dtype=dtype, device="cuda")
+    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device="cuda")
+    output_s = torch.empty(m, 1, dtype=torch.float32, device="cuda")
+
+    per_token_quant_fp8(input_tensor, output_q, output_s)
+
+    ref_q, ref_s = _reference_per_token_quant_fp8(input_tensor)
+    torch.testing.assert_close(output_s.view(-1), ref_s, rtol=1e-5, atol=1e-6)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/python/sglang/jit_kernel/tests/test_per_token_quant_fp8.py
+++ b/python/sglang/jit_kernel/tests/test_per_token_quant_fp8.py
@@ -4,10 +4,18 @@ import pytest
 import torch
 
 from sglang.jit_kernel.per_token_quant_fp8 import per_token_quant_fp8
+from sglang.jit_kernel.utils import get_ci_test_range
 
 
-M_LIST = [1, 2, 4, 8, 16, 32, 64, 128, 256]
-K_LIST = [512, 1024, 2048, 4096, 7168]
+DEVICE = "cuda"
+M_LIST = get_ci_test_range(
+    [1, 2, 4, 8, 16, 32, 64, 128, 256],
+    [1, 16, 256],
+)
+K_LIST = get_ci_test_range(
+    [512, 1024, 2048, 4096, 7168],
+    [512, 4096],
+)
 DTYPE_LIST = [torch.float16, torch.bfloat16, torch.float32]
 
 configs = list(itertools.product(M_LIST, K_LIST, DTYPE_LIST))
@@ -24,9 +32,9 @@ def _reference_per_token_quant_fp8(input_tensor):
 
 @pytest.mark.parametrize("m, k, dtype", configs)
 def test_per_token_quant_fp8(m, k, dtype):
-    input_tensor = torch.randn(m, k, dtype=dtype, device="cuda")
-    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device="cuda")
-    output_s = torch.empty(m, dtype=torch.float32, device="cuda")
+    input_tensor = torch.randn(m, k, dtype=dtype, device=DEVICE)
+    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEVICE)
+    output_s = torch.empty(m, dtype=torch.float32, device=DEVICE)
 
     per_token_quant_fp8(input_tensor, output_q, output_s)
 
@@ -43,9 +51,9 @@ def test_per_token_quant_fp8(m, k, dtype):
 def test_per_token_quant_fp8_scale_shape(m):
     k = 1024
     dtype = torch.float16
-    input_tensor = torch.randn(m, k, dtype=dtype, device="cuda")
-    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device="cuda")
-    output_s = torch.empty(m, 1, dtype=torch.float32, device="cuda")
+    input_tensor = torch.randn(m, k, dtype=dtype, device=DEVICE)
+    output_q = torch.empty(m, k, dtype=torch.float8_e4m3fn, device=DEVICE)
+    output_s = torch.empty(m, 1, dtype=torch.float32, device=DEVICE)
 
     per_token_quant_fp8(input_tensor, output_q, output_s)
 

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -49,7 +49,9 @@ _is_cpu = is_cpu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_cuda:
-    from sgl_kernel import sgl_per_token_quant_fp8
+    from sglang.jit_kernel.per_token_quant_fp8 import (
+        per_token_quant_fp8 as sgl_per_token_quant_fp8,
+    )
 
     from sglang.jit_kernel.per_tensor_quant_fp8 import (
         per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,


### PR DESCRIPTION
## Motivation

Migrate `per_token_quant_fp8` kernel to JIT compilation (#17865).

## Modifications

Under `python/sglang/jit_kernel/`:
- `csrc/gemm/per_token_quant_fp8.cuh` — CUDA kernel (ported from `sgl-kernel/csrc/gemm/per_token_quant_fp8.cu`)
- `per_token_quant_fp8.py` — Python wrapper
- `tests/test_per_token_quant_fp8.py` — Unit tests
- `benchmark/bench_per_token_quant_fp8.py` — Benchmark (JIT vs AOT vs PyTorch)

And
- `python/sglang/srt/layers/quantization/fp8_kernel.py` — Switch import to JIT

## Accuracy Tests

Pass all tests defined in `python/sglang/jit_kernel/tests/test_per_token_quant_fp8.py`

## Benchmarking and Profiling

```
GPU: NVIDIA GeForce RTX 5060 Laptop GPU
Driver: 580.126.20 | CUDA: 12.8 | PyTorch: 2.9.1+cu128
Script: python/sglang/jit_kernel/benchmark/bench_per_token_quant_fp8.py

per-token-quant-fp8-performance (unit: us):
   M × K (dtype)       JIT    AOT    PyTorch  AOT->JIT
   1 × 512, fp16       4.6    5.1    37.3     -9.8%
   1 × 4096, bf16      4.7    5.2    51.2     -9.6%
   16 × 2048, fp16     4.8    5.3    54.7     -9.4%
   64 × 4096, fp32     7.1    7.0    120.8    +1.4%
   128 × 7168, bf16    8.6    8.2    224.6    +4.9%
   256 × 7168, fp16    12.3   12.1   410.2    +1.7%
```

JIT and AOT performance are essentially the same, no regression observed. Both are significantly faster than PyTorch.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


