### PR TITLE
[JIT Kernel] Migrate kimi_k2_moe_fused_gate to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
@@ -1,0 +1,111 @@
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import (
+    DEFAULT_DEVICE,
+    get_benchmark_range,
+    run_benchmark,
+)
+from sglang.jit_kernel.kimi_k2_moe_fused_gate import (
+    kimi_k2_moe_fused_gate as jit_kimi_k2_moe_fused_gate,
+)
+
+try:
+    from sgl_kernel import kimi_k2_moe_fused_gate as aot_kimi_k2_moe_fused_gate
+
+    AOT_AVAILABLE = True
+except ImportError:
+    aot_kimi_k2_moe_fused_gate = None
+    AOT_AVAILABLE = False
+
+NUM_EXPERTS = 384
+
+
+def check_correctness():
+    if not AOT_AVAILABLE:
+        print("sgl_kernel AOT not available, skipping correctness check")
+        return
+    m, topk = 16, 4
+    input_tensor = torch.randn(m, NUM_EXPERTS, dtype=torch.float32, device=DEFAULT_DEVICE)
+    bias = torch.randn(NUM_EXPERTS, dtype=torch.float32, device=DEFAULT_DEVICE) * 0.1
+    jit_out, jit_idx = jit_kimi_k2_moe_fused_gate(input_tensor, bias, topk, True, 1.0, False)
+    aot_out, aot_idx = aot_kimi_k2_moe_fused_gate(input_tensor, bias, topk, True, 1.0, False)
+    torch.testing.assert_close(jit_out, aot_out, rtol=0, atol=0)
+    torch.testing.assert_close(jit_idx, aot_idx, rtol=0, atol=0)
+    print("Correctness check passed (JIT vs AOT)")
+
+
+M_LIST = get_benchmark_range(
+    full_range=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+    ci_range=[16, 128],
+)
+
+TOPK_LIST = get_benchmark_range(
+    full_range=[2, 4, 6],
+    ci_range=[2, 4],
+)
+
+configs = list(itertools.product(M_LIST, TOPK_LIST))
+
+line_vals = ["jit", "pytorch"]
+line_names = ["SGL JIT Kernel", "PyTorch"]
+styles = [("blue", "-"), ("red", "--")]
+
+if AOT_AVAILABLE:
+    line_vals.insert(1, "aot")
+    line_names.insert(1, "SGL AOT Kernel")
+    styles.insert(1, ("green", "-."))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["m", "topk"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=line_vals,
+        line_names=line_names,
+        styles=styles,
+        ylabel="us",
+        plot_name="kimi-k2-moe-fused-gate-performance",
+        args={},
+    )
+)
+def benchmark(m, topk, provider):
+    input_tensor = torch.randn(
+        m, NUM_EXPERTS, dtype=torch.float32, device=DEFAULT_DEVICE
+    )
+    bias = torch.randn(NUM_EXPERTS, dtype=torch.float32, device=DEFAULT_DEVICE) * 0.1
+
+    if provider == "jit":
+
+        def fn():
+            return jit_kimi_k2_moe_fused_gate(
+                input_tensor, bias, topk, True, 1.0, False
+            )
+
+    elif provider == "aot":
+
+        def fn():
+            return aot_kimi_k2_moe_fused_gate(
+                input_tensor, bias, topk, True, 1.0, False
+            )
+
+    else:  # pytorch
+
+        def fn():
+            sigmoid_vals = torch.sigmoid(input_tensor)
+            biased = sigmoid_vals + bias.unsqueeze(0)
+            _, top_idx = torch.topk(biased, topk, dim=-1)
+            scores = torch.gather(sigmoid_vals, 1, top_idx)
+            score_sum = scores.sum(dim=-1, keepdim=True)
+            return scores / score_sum.clamp(min=1e-6), top_idx
+
+    return run_benchmark(fn)
+
+
+if __name__ == "__main__":
+    check_correctness()
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
@@ -1,0 +1,187 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cfloat>
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+static constexpr int kNumExperts = 384;
+static constexpr int kWarpSize = 32;
+static constexpr int kWarpsPerToken = 12;  // 384 / 32
+static constexpr int kThreadsPerBlock = kWarpsPerToken * kWarpSize;
+
+// One block per token, 384 threads (one per expert).
+// Sigmoid + bias -> iterative topk -> renormalize.
+__global__ void kimi_k2_moe_fused_gate_kernel(
+    const float* __restrict__ input,
+    const float* __restrict__ bias,
+    float* __restrict__ output,
+    int32_t* __restrict__ indices,
+    int64_t num_rows,
+    int64_t topk,
+    bool renormalize,
+    float routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  const int64_t row_idx = blockIdx.x;
+  if (row_idx >= num_rows) return;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / kWarpSize;
+  const int lane_id = tid % kWarpSize;
+
+  __shared__ float shared_scores[kNumExperts];
+  __shared__ float shared_original_scores[kNumExperts];
+  __shared__ int selected_experts[8];
+  __shared__ float warp_maxs[kWarpsPerToken];
+  __shared__ int warp_experts[kWarpsPerToken];
+
+  if (tid < kNumExperts) {
+    float input_val = input[row_idx * kNumExperts + tid];
+    float bias_val = bias[tid];
+    float sigmoid_val = 1.0f / (1.0f + expf(-input_val));
+    float biased_val = sigmoid_val + bias_val;
+    shared_scores[tid] = biased_val;
+    shared_original_scores[tid] = sigmoid_val;
+  }
+  __syncthreads();
+
+  for (int k = 0; k < topk; k++) {
+    float my_val = (tid < kNumExperts) ? shared_scores[tid] : -FLT_MAX;
+    int my_expert = tid;
+
+    float warp_max_val = my_val;
+    int warp_max_expert = my_expert;
+
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, warp_max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, warp_max_expert, offset);
+      if (other_val > warp_max_val) {
+        warp_max_val = other_val;
+        warp_max_expert = other_expert;
+      }
+    }
+
+    if (lane_id == 0) {
+      warp_maxs[warp_id] = warp_max_val;
+      warp_experts[warp_id] = warp_max_expert;
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+      float final_max = (lane_id < kWarpsPerToken) ? warp_maxs[lane_id] : -FLT_MAX;
+      int final_expert = (lane_id < kWarpsPerToken) ? warp_experts[lane_id] : -1;
+
+#pragma unroll
+      for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+        float other_val = __shfl_down_sync(0xFFFFFFFF, final_max, offset);
+        int other_expert = __shfl_down_sync(0xFFFFFFFF, final_expert, offset);
+        if (other_val > final_max) {
+          final_max = other_val;
+          final_expert = other_expert;
+        }
+      }
+
+      if (lane_id == 0) {
+        selected_experts[k] = final_expert;
+      }
+    }
+    __syncthreads();
+
+    int selected = selected_experts[k];
+    if (tid == selected) {
+      shared_scores[tid] = -FLT_MAX;
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    for (int k = 0; k < topk; k++) {
+      int expert_id = selected_experts[k];
+      if (expert_id >= 0 && expert_id < kNumExperts) {
+        output[row_idx * topk + k] = shared_original_scores[expert_id];
+        indices[row_idx * topk + k] = expert_id;
+      } else {
+        output[row_idx * topk + k] = 0.0f;
+        indices[row_idx * topk + k] = 0;
+      }
+    }
+
+    if (renormalize) {
+      float sum = 0.0f;
+      for (int k = 0; k < topk; k++) {
+        sum += output[row_idx * topk + k];
+      }
+      if (sum > 0.0f) {
+        for (int k = 0; k < topk; k++) {
+          int64_t idx = row_idx * topk + k;
+          output[idx] /= sum;
+          if (apply_routed_scaling_factor_on_output) {
+            output[idx] *= routed_scaling_factor;
+          }
+        }
+      }
+    }
+  }
+}
+
+void kimi_k2_moe_fused_gate(tvm::ffi::TensorView input,
+                            tvm::ffi::TensorView bias,
+                            tvm::ffi::TensorView output,
+                            tvm::ffi::TensorView indices,
+                            int64_t topk,
+                            bool renormalize,
+                            float routed_scaling_factor,
+                            bool apply_routed_scaling_factor_on_output) {
+  using namespace host;
+
+  auto M = SymbolicSize{"num_rows"};
+  auto E = SymbolicSize{"num_experts"};
+  auto K = SymbolicSize{"topk"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({M, E})
+      .with_dtype<fp32_t>()
+      .with_device(device)
+      .verify(input);
+  TensorMatcher({E})
+      .with_dtype<fp32_t>()
+      .with_device(device)
+      .verify(bias);
+  TensorMatcher({M, K})
+      .with_dtype<fp32_t>()
+      .with_device(device)
+      .verify(output);
+  TensorMatcher({M, K})
+      .with_dtype<int32_t>()
+      .with_device(device)
+      .verify(indices);
+
+  const auto num_rows = static_cast<int64_t>(M.unwrap());
+  const auto num_experts = static_cast<int64_t>(E.unwrap());
+
+  RuntimeCheck(num_experts == kNumExperts,
+               "kimi_k2_moe_fused_gate: only supports 384 experts, got ", num_experts);
+  RuntimeCheck(topk <= 8, "kimi_k2_moe_fused_gate: topk must be <= 8, got ", topk);
+
+  LaunchKernel(num_rows, kThreadsPerBlock, device.unwrap())(
+      kimi_k2_moe_fused_gate_kernel,
+      static_cast<const float*>(input.data_ptr()),
+      static_cast<const float*>(bias.data_ptr()),
+      static_cast<float*>(output.data_ptr()),
+      static_cast<int32_t*>(indices.data_ptr()),
+      num_rows,
+      topk,
+      renormalize,
+      routed_scaling_factor,
+      apply_routed_scaling_factor_on_output);
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
+++ b/python/sglang/jit_kernel/csrc/moe/kimi_k2_moe_fused_gate.cuh
@@ -13,12 +13,20 @@ namespace {
 
 static constexpr int kNumExperts = 384;
 static constexpr int kWarpSize = 32;
-static constexpr int kWarpsPerToken = 12;  // 384 / 32
-static constexpr int kThreadsPerBlock = kWarpsPerToken * kWarpSize;
 
-// One block per token, 384 threads (one per expert).
-// Sigmoid + bias -> iterative topk -> renormalize.
-__global__ void kimi_k2_moe_fused_gate_kernel(
+// Small token kernel constants
+static constexpr int kSmallTokenThreshold = 512;
+static constexpr int kWarpsPerToken = 12;  // 384 / 32
+static constexpr int kThreadsPerBlockSmall = kWarpsPerToken * kWarpSize;  // 384
+
+// Large token kernel constants
+static constexpr int kWarpsPerCTA = 6;
+static constexpr int kVPT = 12;      // 384 / 32
+static constexpr int kVecSize = 4;   // float4 vectorized loads
+
+// Small token kernel: one block per token, 384 threads (one per expert).
+// Sigmoid + bias -> iterative warp-level topk + merge -> renormalize.
+__global__ void kimi_k2_moe_fused_gate_kernel_small_token(
     const float* __restrict__ input,
     const float* __restrict__ bias,
     float* __restrict__ output,
@@ -131,6 +139,111 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
   }
 }
 
+// Large token kernel: each block handles kWarpsPerCTA tokens with vectorized loads.
+// Each warp independently processes one token.
+__global__ void kimi_k2_moe_fused_gate_kernel_large_token(
+    const float* __restrict__ input,
+    const float* __restrict__ bias,
+    float* __restrict__ output,
+    int32_t* __restrict__ indices,
+    int64_t num_rows,
+    int64_t topk,
+    bool renormalize,
+    float routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  const int64_t row_idx = blockIdx.x * kWarpsPerCTA + threadIdx.y;
+  if (row_idx >= num_rows) return;
+
+  const int lane_id = threadIdx.x;
+  const int warp_id = threadIdx.y;
+
+  __shared__ float shared_scores[kNumExperts * kWarpsPerCTA];
+  __shared__ float shared_original_scores[kNumExperts * kWarpsPerCTA];
+
+  float* warp_scores = shared_scores + warp_id * kNumExperts;
+  float* warp_original_scores = shared_original_scores + warp_id * kNumExperts;
+
+  // Vectorized loading: each lane loads VPT/VEC_SIZE = 3 float4 chunks
+  static constexpr int kVecPerLane = kVPT / kVecSize;  // 3
+  const float4* input_vec = reinterpret_cast<const float4*>(input + row_idx * kNumExperts);
+  const float4* bias_vec = reinterpret_cast<const float4*>(bias);
+
+#pragma unroll
+  for (int i = 0; i < kVecPerLane; i++) {
+    int vec_idx = lane_id * kVecPerLane + i;
+    float4 input_val = input_vec[vec_idx];
+    float4 bias_val = bias_vec[vec_idx];
+
+#pragma unroll
+    for (int j = 0; j < kVecSize; j++) {
+      int expert = vec_idx * kVecSize + j;
+      float inp = reinterpret_cast<const float*>(&input_val)[j];
+      float b = reinterpret_cast<const float*>(&bias_val)[j];
+      float sigmoid_val = 1.0f / (1.0f + expf(-inp));
+      float biased_val = sigmoid_val + b;
+      warp_scores[expert] = biased_val;
+      warp_original_scores[expert] = sigmoid_val;
+    }
+  }
+
+  __syncthreads();
+
+  for (int k = 0; k < topk; k++) {
+    float max_val = -FLT_MAX;
+    int max_expert = -1;
+
+    for (int expert = lane_id; expert < kNumExperts; expert += kWarpSize) {
+      if (warp_scores[expert] > max_val) {
+        max_val = warp_scores[expert];
+        max_expert = expert;
+      }
+    }
+
+    for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, max_expert, offset);
+
+      if (other_val > max_val || (other_val == max_val && other_expert < max_expert)) {
+        max_val = other_val;
+        max_expert = other_expert;
+      }
+    }
+
+    if (lane_id == 0) {
+      int64_t output_idx = row_idx * topk + k;
+      if (max_expert != -1) {
+        output[output_idx] = warp_original_scores[max_expert];
+        indices[output_idx] = max_expert;
+        warp_scores[max_expert] = -FLT_MAX;
+      } else {
+        output[output_idx] = 0.0f;
+        indices[output_idx] = 0;
+      }
+    }
+
+    __syncwarp();
+  }
+
+  __syncthreads();
+
+  if (renormalize && lane_id == 0) {
+    float sum = 0.0f;
+    for (int k = 0; k < topk; k++) {
+      sum += output[row_idx * topk + k];
+    }
+
+    if (sum > 0.0f) {
+      for (int k = 0; k < topk; k++) {
+        int64_t idx = row_idx * topk + k;
+        output[idx] /= sum;
+        if (apply_routed_scaling_factor_on_output) {
+          output[idx] *= routed_scaling_factor;
+        }
+      }
+    }
+  }
+}
+
 void kimi_k2_moe_fused_gate(tvm::ffi::TensorView input,
                             tvm::ffi::TensorView bias,
                             tvm::ffi::TensorView output,
@@ -171,17 +284,34 @@ void kimi_k2_moe_fused_gate(tvm::ffi::TensorView input,
                "kimi_k2_moe_fused_gate: only supports 384 experts, got ", num_experts);
   RuntimeCheck(topk <= 8, "kimi_k2_moe_fused_gate: topk must be <= 8, got ", topk);
 
-  LaunchKernel(num_rows, kThreadsPerBlock, device.unwrap())(
-      kimi_k2_moe_fused_gate_kernel,
-      static_cast<const float*>(input.data_ptr()),
-      static_cast<const float*>(bias.data_ptr()),
-      static_cast<float*>(output.data_ptr()),
-      static_cast<int32_t*>(indices.data_ptr()),
-      num_rows,
-      topk,
-      renormalize,
-      routed_scaling_factor,
-      apply_routed_scaling_factor_on_output);
+  auto dev = device.unwrap();
+
+  if (num_rows <= kSmallTokenThreshold) {
+    LaunchKernel(dim3(num_rows), dim3(kThreadsPerBlockSmall), dev)(
+        kimi_k2_moe_fused_gate_kernel_small_token,
+        static_cast<const float*>(input.data_ptr()),
+        static_cast<const float*>(bias.data_ptr()),
+        static_cast<float*>(output.data_ptr()),
+        static_cast<int32_t*>(indices.data_ptr()),
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  } else {
+    int64_t num_blocks = (num_rows + kWarpsPerCTA - 1) / kWarpsPerCTA;
+    LaunchKernel(dim3(num_blocks), dim3(kWarpSize, kWarpsPerCTA), dev)(
+        kimi_k2_moe_fused_gate_kernel_large_token,
+        static_cast<const float*>(input.data_ptr()),
+        static_cast<const float*>(bias.data_ptr()),
+        static_cast<float*>(output.data_ptr()),
+        static_cast<int32_t*>(indices.data_ptr()),
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output);
+  }
 }
 
 }  // namespace

--- a/python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/kimi_k2_moe_fused_gate.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_kimi_k2_moe_fused_gate_module() -> Module:
+    return load_jit(
+        "kimi_k2_moe_fused_gate",
+        cuda_files=["moe/kimi_k2_moe_fused_gate.cuh"],
+        cuda_wrappers=[("kimi_k2_moe_fused_gate", "kimi_k2_moe_fused_gate")],
+    )
+
+
+@register_custom_op(
+    op_name="jit_kimi_k2_moe_fused_gate",
+    mutates_args=["output", "indices"],
+)
+def _kimi_k2_moe_fused_gate_op(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    output: torch.Tensor,
+    indices: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+) -> None:
+    module = _jit_kimi_k2_moe_fused_gate_module()
+    module.kimi_k2_moe_fused_gate(
+        input, bias, output, indices,
+        topk, renormalize, routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+
+
+def kimi_k2_moe_fused_gate(
+    input: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_routed_scaling_factor_on_output: bool,
+) -> list[torch.Tensor]:
+    num_rows = input.size(0)
+    output = torch.empty(num_rows, topk, dtype=torch.float32, device=input.device)
+    indices = torch.empty(num_rows, topk, dtype=torch.int32, device=input.device)
+
+    _kimi_k2_moe_fused_gate_op(
+        input, bias, output, indices,
+        topk, renormalize, routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+
+    return [output, indices]

--- a/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
@@ -1,0 +1,84 @@
+import itertools
+
+import pytest
+import torch
+
+from sglang.jit_kernel.kimi_k2_moe_fused_gate import kimi_k2_moe_fused_gate
+
+
+NUM_EXPERTS = 384
+
+M_LIST = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+TOPK_LIST = [1, 2, 4, 6]
+RENORMALIZE_LIST = [True, False]
+
+configs = list(itertools.product(M_LIST, TOPK_LIST, RENORMALIZE_LIST))
+
+
+def _reference_kimi_k2_moe_fused_gate(
+    input_tensor, bias, topk, renormalize, routed_scaling_factor,
+    apply_routed_scaling_factor_on_output
+):
+    sigmoid_vals = torch.sigmoid(input_tensor)
+    biased_scores = sigmoid_vals + bias.unsqueeze(0)
+
+    _, top_indices = torch.topk(biased_scores, topk, dim=-1)
+
+    output_scores = torch.gather(sigmoid_vals, 1, top_indices)
+
+    if renormalize:
+        score_sum = output_scores.sum(dim=-1, keepdim=True)
+        output_scores = output_scores / score_sum.clamp(min=torch.finfo(score_sum.dtype).eps)
+        if apply_routed_scaling_factor_on_output:
+            output_scores *= routed_scaling_factor
+
+    return output_scores, top_indices.int()
+
+
+@pytest.mark.parametrize("m, topk, renormalize", configs)
+def test_kimi_k2_moe_fused_gate(m, topk, renormalize):
+    routed_scaling_factor = 2.0
+    apply_scaling = True
+
+    input_tensor = torch.randn(m, NUM_EXPERTS, dtype=torch.float32, device="cuda")
+    bias = torch.randn(NUM_EXPERTS, dtype=torch.float32, device="cuda") * 0.1
+
+    output, indices = kimi_k2_moe_fused_gate(
+        input_tensor, bias, topk, renormalize,
+        routed_scaling_factor, apply_scaling,
+    )
+
+    ref_output, ref_indices = _reference_kimi_k2_moe_fused_gate(
+        input_tensor, bias, topk, renormalize,
+        routed_scaling_factor, apply_scaling,
+    )
+
+    # Expert selection order may differ; compare as sets per row
+    for i in range(m):
+        jit_set = set(indices[i].tolist())
+        ref_set = set(ref_indices[i].tolist())
+        assert jit_set == ref_set, (
+            f"Row {i}: JIT selected {jit_set} but ref selected {ref_set}"
+        )
+
+    # Sort by expert index for score comparison
+    jit_sorted = torch.sort(indices, dim=-1)
+    ref_sorted = torch.sort(ref_indices, dim=-1)
+    jit_scores_sorted = torch.gather(output, 1, jit_sorted.indices)
+    ref_scores_sorted = torch.gather(ref_output, 1, ref_sorted.indices)
+
+    torch.testing.assert_close(
+        jit_scores_sorted, ref_scores_sorted, rtol=1e-4, atol=1e-4
+    )
+
+
+def test_kimi_k2_moe_fused_gate_wrong_experts():
+    input_tensor = torch.randn(4, 256, dtype=torch.float32, device="cuda")
+    bias = torch.randn(256, dtype=torch.float32, device="cuda")
+
+    with pytest.raises(Exception):
+        kimi_k2_moe_fused_gate(input_tensor, bias, 2, False, 1.0, False)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
+++ b/python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py
@@ -8,7 +8,7 @@ from sglang.jit_kernel.kimi_k2_moe_fused_gate import kimi_k2_moe_fused_gate
 
 NUM_EXPERTS = 384
 
-M_LIST = [1, 2, 4, 8, 16, 32, 64, 128, 256]
+M_LIST = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
 TOPK_LIST = [1, 2, 4, 6]
 RENORMALIZE_LIST = [True, False]
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -84,7 +84,7 @@ if _is_cuda:
         fused_topk_deepseek = None
 
     try:
-        from sgl_kernel import kimi_k2_moe_fused_gate
+        from sglang.jit_kernel.kimi_k2_moe_fused_gate import kimi_k2_moe_fused_gate
     except ImportError as e:
         pass
 


### PR DESCRIPTION
## Motivation

Migrate `kimi_k2_moe_fused_gate` kernel to JIT compilation (#17865).

## Modifications

Under `python/sglang/jit_kernel/`:
- `csrc/moe/kimi_k2_moe_fused_gate.cuh` — CUDA kernel (ported from `sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu`, both small_token and large_token variants)
- `kimi_k2_moe_fused_gate.py` — Python wrapper
- `tests/test_kimi_k2_moe_fused_gate.py` — Unit tests (JIT vs PyTorch)
- `benchmark/bench_kimi_k2_moe_fused_gate.py` — Benchmark (JIT vs AOT)

And
- `python/sglang/srt/layers/moe/topk.py` — Switch import to JIT

## Accuracy Tests

Pass all tests defined in `python/sglang/jit_kernel/tests/test_kimi_k2_moe_fused_gate.py`

## Benchmarking and Profiling

```
GPU: NVIDIA GeForce RTX 5060 Laptop GPU
Driver: 580.126.20 | CUDA: 12.8 | PyTorch: 2.9.1+cu128
Script: python/sglang/jit_kernel/benchmark/bench_kimi_k2_moe_fused_gate.py

kimi-k2-moe-fused-gate-performance (unit: us):
   M × topk         JIT      AOT      AOT->JIT
   1 × 2            1.70     1.70     0.0%
   8 × 6            3.15     3.11     +1.3%
   32 × 4           2.79     2.74     +1.8%
   128 × 6          8.83     8.84     -0.1%
   256 × 2          7.07     6.89     +2.6%
   512 × 6         27.04    27.67     -2.3%
   1024 × 2         9.11     9.10     +0.1%
   1024 × 6        14.60    14.82     -1.5%
```

Both small_token (m <= 512) and large_token (m > 512) kernel variants are ported; no regression observed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
