### PR TITLE
[model-gateway] Add native /classify endpoint for reward model routing

### DIFF
--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -385,6 +385,7 @@ pub mod metrics_labels {
     pub const ENDPOINT_RERANK: &str = "rerank";
     pub const ENDPOINT_EMBEDDINGS: &str = "embeddings";
     pub const ENDPOINT_CLASSIFY: &str = "classify";
+    pub const ENDPOINT_CLASSIFY_NATIVE: &str = "classify_native";
 
     // Worker types
     pub const WORKER_REGULAR: &str = "regular";

--- a/sgl-model-gateway/src/routers/grpc/utils.rs
+++ b/sgl-model-gateway/src/routers/grpc/utils.rs
@@ -1026,6 +1026,8 @@ pub(crate) fn route_to_endpoint(route: &str) -> &'static str {
         "/v1/completions" => metrics_labels::ENDPOINT_COMPLETIONS,
         "/v1/rerank" => metrics_labels::ENDPOINT_RERANK,
         "/v1/responses" => metrics_labels::ENDPOINT_RESPONSES,
+        "/classify" => metrics_labels::ENDPOINT_CLASSIFY_NATIVE,
+        "/v1/classify" => metrics_labels::ENDPOINT_CLASSIFY,
         _ => "other",
     }
 }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -800,6 +800,16 @@ impl RouterTrait for Router {
             .await
     }
 
+    async fn route_classify_native(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &GenerateRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        self.route_typed_request(headers, body, "/classify", model_id)
+            .await
+    }
+
     async fn route_classify(
         &self,
         headers: Option<&HeaderMap>,

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -176,6 +176,16 @@ pub trait RouterTrait: Send + Sync + Debug {
         (StatusCode::NOT_IMPLEMENTED, "Embeddings not implemented").into_response()
     }
 
+    /// Route native classify requests (SGLang native /classify for reward models)
+    async fn route_classify_native(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &GenerateRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "Native classify not implemented").into_response()
+    }
+
     /// Route classification requests (OpenAI-compatible /v1/classify)
     async fn route_classify(
         &self,

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -691,6 +691,25 @@ impl RouterTrait for RouterManager {
         }
     }
 
+    async fn route_classify_native(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &GenerateRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        let router = self.select_router_for_request(headers, model_id);
+
+        if let Some(router) = router {
+            router.route_classify_native(headers, body, model_id).await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                "No router available for classify request",
+            )
+                .into_response()
+        }
+    }
+
     async fn route_classify(
         &self,
         headers: Option<&HeaderMap>,

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -248,6 +248,18 @@ async fn v1_embeddings(
         .await
 }
 
+async fn classify(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    Json(body): Json<GenerateRequest>,
+) -> Response {
+    let model_id = body.model.as_deref();
+    state
+        .router
+        .route_classify_native(Some(&headers), &body, model_id)
+        .await
+}
+
 async fn v1_classify(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
@@ -559,6 +571,7 @@ pub fn build_app(
         .route("/v1/rerank", post(v1_rerank))
         .route("/v1/responses", post(v1_responses))
         .route("/v1/embeddings", post(v1_embeddings))
+        .route("/classify", post(classify))
         .route("/v1/classify", post(v1_classify))
         .route("/v1/responses/{response_id}", get(v1_responses_get))
         .route(

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -1884,3 +1884,172 @@ mod rerank_tests {
         ctx.shutdown().await;
     }
 }
+
+mod classify_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_classify_native_success() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19001,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "This is a test input",
+            "model": "test-reward-model"
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/classify")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Mock worker returns {"embedding": [score]}
+        assert!(body_json.get("embedding").is_some());
+        let embedding = body_json["embedding"].as_array().unwrap();
+        assert_eq!(embedding.len(), 1);
+        // Default mock score for text without "good" is -1.359375
+        let score = embedding[0].as_f64().unwrap();
+        assert!((score - (-1.359375)).abs() < 1e-6);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_classify_native_worker_failure() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19002,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 1.0, // Always fail
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "This is a test input",
+            "model": "test-reward-model"
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/classify")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        // Worker failure should propagate as a server error
+        assert!(resp.status().is_server_error());
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_classify_native_not_404() {
+        // Smoke test: /classify must be registered and not return 404
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19003,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hello",
+            "model": "m"
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/classify")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "/classify route must be registered"
+        );
+
+        ctx.shutdown().await;
+    }
+}
+
+mod route_registration_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_all_protected_routes_are_registered() {
+        // Smoke test: every protected POST endpoint should NOT return 404.
+        // A 404 means the route was never registered in build_app().
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19010,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let minimal_generate = json!({"text": "hi", "model": "m"});
+        let minimal_chat = json!({"messages": [{"role": "user", "content": "hi"}], "model": "m"});
+        let minimal_rerank = json!({"query": "q", "documents": ["d"], "model": "m"});
+        let minimal_classify = json!({"text": "hi", "model": "m"});
+
+        let routes_and_payloads: Vec<(&str, serde_json::Value)> = vec![
+            ("/generate", minimal_generate.clone()),
+            ("/classify", minimal_classify.clone()),
+            ("/v1/chat/completions", minimal_chat.clone()),
+            ("/v1/completions", minimal_generate.clone()),
+            ("/rerank", minimal_rerank.clone()),
+            ("/flush_cache", json!({})),
+        ];
+
+        for (route, payload) in routes_and_payloads {
+            let req = Request::builder()
+                .method("POST")
+                .uri(route)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap();
+
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_ne!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "Route {} must be registered (got 404)",
+                route
+            );
+        }
+
+        ctx.shutdown().await;
+    }
+}

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -87,6 +87,7 @@ impl MockWorker {
             .route("/generate", post(generate_handler))
             .route("/v1/chat/completions", post(chat_completions_handler))
             .route("/v1/completions", post(completions_handler))
+            .route("/classify", post(classify_handler))
             .route("/v1/rerank", post(rerank_handler))
             .route("/v1/responses", post(responses_handler))
             .route("/v1/responses/{response_id}", get(responses_get_handler))
@@ -1212,6 +1213,36 @@ fn response_exists_for_port(port: u16, response_id: &str) -> bool {
     map.get(&port)
         .map(|set| set.contains(response_id))
         .unwrap_or(false)
+}
+
+// Minimal classify handler returning mock reward scores
+async fn classify_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    Json(payload): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let config = config.read().await;
+
+    // Simulate response delay
+    if config.response_delay_ms > 0 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(config.response_delay_ms)).await;
+    }
+
+    // Simulate failure rate
+    if rand::random::<f32>() < config.fail_rate {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "Simulated failure").into_response();
+    }
+
+    // Return mock reward score (mimics SGLang /classify response for reward models)
+    let text = payload
+        .get("text")
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+    let score: f64 = if text.contains("good") { 2.5 } else { -1.359375 };
+
+    (StatusCode::OK, Json(serde_json::json!({
+        "embedding": [score]
+    })))
+        .into_response()
 }
 
 // Minimal rerank handler returning mock results; router shapes final response


### PR DESCRIPTION
## Motivation

See #15240.

The router has `/v1/classify` but not the native `/classify` route. Requests to `/classify` through the router return 404.

The native endpoint is needed because `/v1/classify` applies softmax, which always maps a single raw score to 1.0, useless for reward models that rely on the raw value.

## Modifications

- Register `/classify` route in `server.rs`, delegates to `route_classify_native`
- Add `route_classify_native` to `RouterTrait` (default: NOT_IMPLEMENTED), implement in HTTP router and `RouterManager`
- Add `/classify` and `/v1/classify` to `route_to_endpoint` metrics mapping
- Mock `/classify` handler in test worker, classify tests and a route registration smoke test

## Accuracy Tests

N/A, routing only.

## Benchmarking and Profiling

N/A, same codepath.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).