### PR TITLE
Kp/fix kimi k2.5 tool call parser

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -247,12 +247,11 @@ class KimiK2ReasoningDetector(BaseReasoningFormatDetector):
     Detector for Kimi-K2/K2.5 reasoning format.
 
     The model may emit tool call tokens (<|tool_calls_section_begin|>) without
-    first closing the reasoning block with </think>. This detector treats tool
-    call tokens as an implicit end of reasoning so they pass through as
-    normal_text and reach the downstream tool call parser.
+    first closing the reasoning block with </think>. This detector uses the
+    base class tool_start_token mechanism to treat tool call tokens as an
+    implicit end of reasoning so they pass through as normal_text and reach
+    the downstream tool call parser.
     """
-
-    TOOL_CALL_TOKEN = "<|tool_calls_section_begin|>"
 
     def __init__(
         self,
@@ -266,88 +265,10 @@ class KimiK2ReasoningDetector(BaseReasoningFormatDetector):
             "</think>",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
+            tool_start_token="<|tool_calls_section_begin|>",
             continue_final_message=continue_final_message,
             previous_content=previous_content,
         )
-
-    def _split_on_tool_token(self, text: str):
-        """If text contains tool call tokens, split into (reasoning, tool_text)."""
-        idx = text.find(self.TOOL_CALL_TOKEN)
-        if idx == -1:
-            return None
-        return text[:idx], text[idx:]
-
-    def detect_and_parse(self, text: str) -> StreamingParseResult:
-        in_reasoning = self._in_reasoning or self.think_start_token in text
-        if not in_reasoning:
-            return StreamingParseResult(normal_text=text)
-
-        processed_text = text.replace(self.think_start_token, "").strip()
-
-        if self.think_end_token in processed_text:
-            splits = processed_text.split(self.think_end_token, maxsplit=1)
-            return StreamingParseResult(
-                normal_text=splits[1].strip(), reasoning_text=splits[0]
-            )
-
-        if self.think_end_token in self.previous_content:
-            return StreamingParseResult(normal_text=processed_text)
-
-        split = self._split_on_tool_token(processed_text)
-        if split is not None:
-            reasoning_part, tool_part = split
-            return StreamingParseResult(
-                normal_text=tool_part, reasoning_text=reasoning_part
-            )
-
-        return StreamingParseResult(reasoning_text=processed_text)
-
-    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
-        self._buffer += new_text
-        current_text = self._buffer
-
-        if any(
-            token.startswith(current_text) and token != current_text
-            for token in [self.think_start_token, self.think_end_token]
-        ):
-            return StreamingParseResult()
-
-        if not self.stripped_think_start and self.think_start_token in current_text:
-            current_text = current_text.replace(self.think_start_token, "")
-            self.stripped_think_start = True
-            self._in_reasoning = True
-
-        if self._in_reasoning and self.think_end_token in current_text:
-            end_idx = current_text.find(self.think_end_token)
-            reasoning_text = current_text[:end_idx]
-            self._buffer = ""
-            self._in_reasoning = False
-            normal_text = current_text[end_idx + len(self.think_end_token) :]
-            return StreamingParseResult(
-                normal_text=normal_text, reasoning_text=reasoning_text.rstrip()
-            )
-
-        if self._in_reasoning:
-            split = self._split_on_tool_token(current_text)
-            if split is not None:
-                reasoning_part, tool_part = split
-                self._buffer = ""
-                self._in_reasoning = False
-                return StreamingParseResult(
-                    normal_text=tool_part, reasoning_text=reasoning_part.rstrip()
-                )
-
-            if self.stream_reasoning:
-                self._buffer = ""
-                return StreamingParseResult(reasoning_text=current_text)
-            else:
-                return StreamingParseResult()
-
-        if not self._in_reasoning:
-            self._buffer = ""
-            return StreamingParseResult(normal_text=current_text)
-
-        return StreamingParseResult()
 
 
 class KimiDetector(BaseReasoningFormatDetector):

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -242,6 +242,114 @@ class Qwen3Detector(BaseReasoningFormatDetector):
         )
 
 
+class KimiK2ReasoningDetector(BaseReasoningFormatDetector):
+    """
+    Detector for Kimi-K2/K2.5 reasoning format.
+
+    The model may emit tool call tokens (<|tool_calls_section_begin|>) without
+    first closing the reasoning block with </think>. This detector treats tool
+    call tokens as an implicit end of reasoning so they pass through as
+    normal_text and reach the downstream tool call parser.
+    """
+
+    TOOL_CALL_TOKEN = "<|tool_calls_section_begin|>"
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+    ):
+        super().__init__(
+            "<think>",
+            "</think>",
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+        )
+
+    def _split_on_tool_token(self, text: str):
+        """If text contains tool call tokens, split into (reasoning, tool_text)."""
+        idx = text.find(self.TOOL_CALL_TOKEN)
+        if idx == -1:
+            return None
+        return text[:idx], text[idx:]
+
+    def detect_and_parse(self, text: str) -> StreamingParseResult:
+        in_reasoning = self._in_reasoning or self.think_start_token in text
+        if not in_reasoning:
+            return StreamingParseResult(normal_text=text)
+
+        processed_text = text.replace(self.think_start_token, "").strip()
+
+        if self.think_end_token in processed_text:
+            splits = processed_text.split(self.think_end_token, maxsplit=1)
+            return StreamingParseResult(
+                normal_text=splits[1].strip(), reasoning_text=splits[0]
+            )
+
+        if self.think_end_token in self.previous_content:
+            return StreamingParseResult(normal_text=processed_text)
+
+        split = self._split_on_tool_token(processed_text)
+        if split is not None:
+            reasoning_part, tool_part = split
+            return StreamingParseResult(
+                normal_text=tool_part, reasoning_text=reasoning_part
+            )
+
+        return StreamingParseResult(reasoning_text=processed_text)
+
+    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
+        self._buffer += new_text
+        current_text = self._buffer
+
+        if any(
+            token.startswith(current_text) and token != current_text
+            for token in [self.think_start_token, self.think_end_token]
+        ):
+            return StreamingParseResult()
+
+        if not self.stripped_think_start and self.think_start_token in current_text:
+            current_text = current_text.replace(self.think_start_token, "")
+            self.stripped_think_start = True
+            self._in_reasoning = True
+
+        if self._in_reasoning and self.think_end_token in current_text:
+            end_idx = current_text.find(self.think_end_token)
+            reasoning_text = current_text[:end_idx]
+            self._buffer = ""
+            self._in_reasoning = False
+            normal_text = current_text[end_idx + len(self.think_end_token) :]
+            return StreamingParseResult(
+                normal_text=normal_text, reasoning_text=reasoning_text.rstrip()
+            )
+
+        if self._in_reasoning:
+            split = self._split_on_tool_token(current_text)
+            if split is not None:
+                reasoning_part, tool_part = split
+                self._buffer = ""
+                self._in_reasoning = False
+                return StreamingParseResult(
+                    normal_text=tool_part, reasoning_text=reasoning_part.rstrip()
+                )
+
+            if self.stream_reasoning:
+                self._buffer = ""
+                return StreamingParseResult(reasoning_text=current_text)
+            else:
+                return StreamingParseResult()
+
+        if not self._in_reasoning:
+            self._buffer = ""
+            return StreamingParseResult(normal_text=current_text)
+
+        return StreamingParseResult()
+
+
 class KimiDetector(BaseReasoningFormatDetector):
     """
     Detector for Kimi Thinking model.
@@ -431,7 +539,7 @@ class ReasoningParser:
         "glm45": Glm45Detector,
         "gpt-oss": GptOssDetector,
         "kimi": KimiDetector,
-        "kimi_k2": Qwen3Detector,
+        "kimi_k2": KimiK2ReasoningDetector,
         "qwen3": Qwen3Detector,
         "qwen3-thinking": Qwen3Detector,
         "minimax": Qwen3Detector,

--- a/test/registered/parser/test_reasoning_parser.py
+++ b/test/registered/parser/test_reasoning_parser.py
@@ -848,9 +848,7 @@ class TestKimiK2ReasoningDetector(CustomTestCase):
         r2 = detector.parse_streaming_increment("thinking...")
         self.assertEqual(r2.reasoning_text, "thinking...")
 
-        r3 = detector.parse_streaming_increment(
-            "<|tool_calls_section_begin|>tool data"
-        )
+        r3 = detector.parse_streaming_increment("<|tool_calls_section_begin|>tool data")
         self.assertEqual(r3.reasoning_text, "")
         self.assertEqual(r3.normal_text, "<|tool_calls_section_begin|>tool data")
         self.assertFalse(detector._in_reasoning)
@@ -927,7 +925,9 @@ class TestKimiK2ReasoningDetector(CustomTestCase):
         )
         reasoning_text, remaining_text, tool_calls = self._run_pipeline_non_stream(text)
         self.assertIn("read the file", reasoning_text)
-        self.assertEqual(len(tool_calls), 1, "Tool calls should be parsed even without </think>")
+        self.assertEqual(
+            len(tool_calls), 1, "Tool calls should be parsed even without </think>"
+        )
         self.assertEqual(tool_calls[0].name, "ReadFile")
         self.assertEqual(tool_calls[0].parameters, '{"path": "/tmp/test.ts"}')
 
@@ -957,7 +957,11 @@ class TestKimiK2ReasoningDetector(CustomTestCase):
         ]
         reasoning_text, normal_text, tool_calls = self._run_pipeline_streaming(chunks)
         self.assertIn("read the file", reasoning_text)
-        self.assertEqual(len(tool_calls), 1, "Tool calls should be parsed even without </think> in streaming")
+        self.assertEqual(
+            len(tool_calls),
+            1,
+            "Tool calls should be parsed even without </think> in streaming",
+        )
         self.assertEqual(tool_calls[0]["name"], "ReadFile")
 
     def test_streaming_tool_token_split_across_chunks(self):

--- a/test/registered/parser/test_reasoning_parser.py
+++ b/test/registered/parser/test_reasoning_parser.py
@@ -1,10 +1,13 @@
 import unittest
 
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.parser.reasoning_parser import (
     BaseReasoningFormatDetector,
     DeepSeekR1Detector,
     Glm45Detector,
     KimiDetector,
+    KimiK2ReasoningDetector,
     Qwen3Detector,
     ReasoningParser,
     StreamingParseResult,
@@ -782,6 +785,180 @@ class TestBufferLossBugFix(CustomTestCase):
         self.assertEqual(result.reasoning_text, "")
         self.assertTrue(detector._in_reasoning)
         self.assertTrue(detector.stripped_think_start)
+
+
+class TestKimiK2ReasoningDetector(CustomTestCase):
+    """
+    Reproduce issue #18086: Kimi-K2 model generates tool call tokens
+    (<|tool_calls_section_begin|>) without first emitting </think>,
+    causing the reasoning parser to swallow tool call tokens.
+
+    These tests simulate the full pipeline: reasoning parser -> tool call parser,
+    covering the case where reasoning and tool call tokens are interleaved.
+    """
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="ReadFile",
+                    description="Read a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "File path",
+                            }
+                        },
+                        "required": ["path"],
+                    },
+                ),
+            ),
+        ]
+
+    def _run_pipeline_non_stream(self, full_text):
+        """Simulate the non-streaming pipeline: reasoning parse then tool call parse."""
+        reasoning_detector = KimiK2ReasoningDetector(stream_reasoning=False)
+        result = reasoning_detector.detect_and_parse(full_text)
+        reasoning_text = result.reasoning_text
+        text = result.normal_text
+
+        fc_parser = FunctionCallParser(tools=self.tools, tool_call_parser="kimi_k2")
+        remaining_text, tool_calls = fc_parser.parse_non_stream(text)
+        return reasoning_text, remaining_text, tool_calls
+
+    def _run_pipeline_streaming(self, chunks):
+        """Simulate the streaming pipeline: reasoning parse then tool call parse.
+
+        Returns (reasoning_text, normal_text, aggregated_tool_calls) where
+        aggregated_tool_calls is a list of dicts with "name" and "parameters"
+        grouped by tool_index (matching how the real server aggregates them).
+        """
+        reasoning_detector = KimiK2ReasoningDetector(
+            stream_reasoning=True, force_reasoning=False
+        )
+        fc_parser = FunctionCallParser(tools=self.tools, tool_call_parser="kimi_k2")
+
+        all_reasoning = []
+        all_normal = []
+        tool_calls = []
+
+        for chunk in chunks:
+            r_result = reasoning_detector.parse_streaming_increment(chunk)
+            if r_result.reasoning_text:
+                all_reasoning.append(r_result.reasoning_text)
+            delta = r_result.normal_text
+            if delta:
+                normal_text, calls = fc_parser.parse_stream_chunk(delta)
+                if normal_text:
+                    all_normal.append(normal_text)
+                for call_item in calls:
+                    if call_item.tool_index is not None:
+                        while len(tool_calls) <= call_item.tool_index:
+                            tool_calls.append({"name": "", "parameters": ""})
+                        tc = tool_calls[call_item.tool_index]
+                        if call_item.name:
+                            tc["name"] += call_item.name
+                        if call_item.parameters:
+                            tc["parameters"] += call_item.parameters
+
+        return "".join(all_reasoning), "".join(all_normal), tool_calls
+
+    def test_non_stream_normal_case_with_think_end(self):
+        """Normal case: model emits </think> before tool call tokens."""
+        text = (
+            "<think>Let me read the file.</think>"
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{"path": "/tmp/test.ts"}'
+            "<|tool_call_end|><|tool_calls_section_end|>"
+        )
+        reasoning_text, remaining_text, tool_calls = self._run_pipeline_non_stream(text)
+        self.assertIn("read the file", reasoning_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].name, "ReadFile")
+        self.assertEqual(tool_calls[0].parameters, '{"path": "/tmp/test.ts"}')
+
+    def test_non_stream_missing_think_end(self):
+        """Bug scenario: model skips </think> and goes directly to tool call tokens."""
+        text = (
+            "<think>Let me read the file."
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{"path": "/tmp/test.ts"}'
+            "<|tool_call_end|><|tool_calls_section_end|>"
+        )
+        reasoning_text, remaining_text, tool_calls = self._run_pipeline_non_stream(text)
+        self.assertIn("read the file", reasoning_text)
+        self.assertEqual(len(tool_calls), 1, "Tool calls should be parsed even without </think>")
+        self.assertEqual(tool_calls[0].name, "ReadFile")
+        self.assertEqual(tool_calls[0].parameters, '{"path": "/tmp/test.ts"}')
+
+    def test_streaming_normal_case_with_think_end(self):
+        """Streaming normal case: </think> is emitted before tool call tokens."""
+        chunks = [
+            "<think>",
+            "Let me read the file.",
+            "</think>",
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{",
+            '"path": "/tmp/test.ts"',
+            "}<|tool_call_end|><|tool_calls_section_end|>",
+        ]
+        reasoning_text, normal_text, tool_calls = self._run_pipeline_streaming(chunks)
+        self.assertIn("read the file", reasoning_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "ReadFile")
+
+    def test_streaming_missing_think_end(self):
+        """Bug scenario (streaming): model skips </think> and emits tool tokens directly."""
+        chunks = [
+            "<think>",
+            "Let me read the file.",
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{",
+            '"path": "/tmp/test.ts"',
+            "}<|tool_call_end|><|tool_calls_section_end|>",
+        ]
+        reasoning_text, normal_text, tool_calls = self._run_pipeline_streaming(chunks)
+        self.assertIn("read the file", reasoning_text)
+        self.assertEqual(len(tool_calls), 1, "Tool calls should be parsed even without </think> in streaming")
+        self.assertEqual(tool_calls[0]["name"], "ReadFile")
+
+    def test_streaming_tool_token_split_across_chunks(self):
+        """Tool call token is split across chunks while in reasoning mode."""
+        chunks = [
+            "<think>Thinking...",
+            "<|tool_calls_section_begin|>",
+            '<|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{"path": "/tmp/a.ts"}',
+            "<|tool_call_end|><|tool_calls_section_end|>",
+        ]
+        reasoning_text, normal_text, tool_calls = self._run_pipeline_streaming(chunks)
+        self.assertIn("Thinking", reasoning_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "ReadFile")
+
+    def test_non_stream_no_thinking_at_all(self):
+        """Model emits tool call tokens without any thinking block."""
+        text = (
+            "<|tool_calls_section_begin|>"
+            '<|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{"path": "/tmp/test.ts"}'
+            "<|tool_call_end|><|tool_calls_section_end|>"
+        )
+        reasoning_text, remaining_text, tool_calls = self._run_pipeline_non_stream(text)
+        self.assertEqual(reasoning_text, "")
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].name, "ReadFile")
+
+    def test_streaming_no_thinking_at_all(self):
+        """Streaming: model emits tool call tokens without any thinking block."""
+        chunks = [
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.ReadFile:0<|tool_call_argument_begin|>{",
+            '"path": "/tmp/test.ts"',
+            "}<|tool_call_end|><|tool_calls_section_end|>",
+        ]
+        reasoning_text, normal_text, tool_calls = self._run_pipeline_streaming(chunks)
+        self.assertEqual(reasoning_text, "")
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "ReadFile")
 
 
 if __name__ == "__main__":

--- a/test/registered/parser/test_reasoning_parser.py
+++ b/test/registered/parser/test_reasoning_parser.py
@@ -484,6 +484,9 @@ class TestReasoningParser(CustomTestCase):
         parser = ReasoningParser("glm45")
         self.assertIsInstance(parser.detector, Glm45Detector)
 
+        parser = ReasoningParser("kimi_k2")
+        self.assertIsInstance(parser.detector, KimiK2ReasoningDetector)
+
     def test_init_invalid_model(self):
         """Test initialization with invalid model type."""
         with self.assertRaises(ValueError) as context:
@@ -817,6 +820,40 @@ class TestKimiK2ReasoningDetector(CustomTestCase):
                 ),
             ),
         ]
+
+    def test_init(self):
+        """Test KimiK2ReasoningDetector initialization and tool_start_token."""
+        detector = KimiK2ReasoningDetector()
+        self.assertEqual(detector.think_start_token, "<think>")
+        self.assertEqual(detector.think_end_token, "</think>")
+        self.assertEqual(detector.tool_start_token, "<|tool_calls_section_begin|>")
+        self.assertFalse(detector._in_reasoning)
+        self.assertTrue(detector.stream_reasoning)
+
+    def test_detect_and_parse_tool_interrupt(self):
+        """Test that tool token interrupts reasoning without </think>."""
+        detector = KimiK2ReasoningDetector()
+        text = "<think>Let me think about this<|tool_calls_section_begin|>tool data"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "Let me think about this")
+        self.assertEqual(result.normal_text, "<|tool_calls_section_begin|>tool data")
+
+    def test_streaming_tool_interrupt(self):
+        """Test streaming tool interruption at the detector level."""
+        detector = KimiK2ReasoningDetector()
+        r1 = detector.parse_streaming_increment("<think>")
+        self.assertEqual(r1.reasoning_text, "")
+        self.assertTrue(detector._in_reasoning)
+
+        r2 = detector.parse_streaming_increment("thinking...")
+        self.assertEqual(r2.reasoning_text, "thinking...")
+
+        r3 = detector.parse_streaming_increment(
+            "<|tool_calls_section_begin|>tool data"
+        )
+        self.assertEqual(r3.reasoning_text, "")
+        self.assertEqual(r3.normal_text, "<|tool_calls_section_begin|>tool data")
+        self.assertFalse(detector._in_reasoning)
 
     def _run_pipeline_non_stream(self, full_text):
         """Simulate the non-streaming pipeline: reasoning parse then tool call parse."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR add support for Kimi K2.5 where tool calls can interrupt reasoning blocks without an explicit closing tag (similar behavior to GLM-4.5), for example 
not closing `</think>` before starting `<|tool_calls_section_begin|>`. This PR aims to solve https://github.com/sgl-project/sglang/issues/18086 and also is a natural extension to https://github.com/sgl-project/sglang/pull/17714

## Modifications

<!-- Detail the changes made in this pull request. -->
- Build off of the `BaseReasoningFormatDetector` changes in https://github.com/sgl-project/sglang/pull/17714
- Implemented a dedicated detector for KimiK2 reasoning`KimiK2ReasoningDetector`
- Register `KimiK2ReasoningDetector` for the `kimi_k2` model identifier in ReasoningParser. 
- Add `TestKimiK2ReasoningDetector` to test if the new reasoning detector can parse interrupt thinking blocks correctly

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified with these unit tests
```
python -m pytest test/registered/function_call/test_function_call_parser.py test/registered/parser/test_reasoning_parser.py -v
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
