### PR TITLE
Fix ROCm GLM-4.5V-FP8 startup with unpadded MoE weights and padded FP8 fallback

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -351,6 +351,12 @@ def fused_experts_impl(
     padded_size = padding_size
     if not (use_fp8_w8a8 or use_int8_w8a8) or block_shape is not None or _use_aiter:
         padded_size = 0
+    elif hidden_states.shape[1] == w1.shape[2]:
+        # Some ROCm FP8 MoE checkpoints load unpadded expert weights even when
+        # SGLANG_MOE_PADDING is enabled globally. In that case the runtime
+        # shape already matches the true hidden size and subtracting
+        # `padding_size` would reject a valid layout.
+        padded_size = 0
 
     # Check constraints.
     if use_int4_w4a16:

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1541,6 +1541,23 @@ Raises:
 """
 if _is_hip:
 
+    def _copy_with_optional_row_padding(
+        dst: torch.Tensor,
+        src: torch.Tensor,
+        pad_value: float = 0.0,
+    ) -> None:
+        if dst.shape == src.shape:
+            dst.copy_(src)
+            return
+
+        assert dst.ndim == src.ndim == 2
+        assert dst.shape[0] >= src.shape[0] and dst.shape[1] == src.shape[1], (
+            f"Unexpected padded copy shapes: dst={tuple(dst.shape)}, src={tuple(src.shape)}"
+        )
+        dst[: src.shape[0]].copy_(src)
+        if dst.shape[0] > src.shape[0]:
+            dst[src.shape[0] :].fill_(pad_value)
+
     def _native_dynamic_per_token_quant_fp8(output, input, scale):
         """Native PyTorch fallback for dynamic per-token FP8 quantization when vLLM is unavailable."""
         M, N = input.shape
@@ -1549,10 +1566,10 @@ if _is_hip:
         absmax = input.abs().max(dim=1, keepdim=True).values
         absmax = torch.clamp(absmax, min=eps)
         scale_val = absmax / fp8_max
-        scale.copy_(scale_val)
+        _copy_with_optional_row_padding(scale, scale_val, pad_value=1.0)
         # Quantize
         output_data = torch.clamp(input / scale_val, fp8_min, fp8_max).to(fp8_dtype)
-        output.copy_(output_data)
+        _copy_with_optional_row_padding(output, output_data, pad_value=0.0)
 
     def _native_dynamic_per_tensor_quant_fp8(output, input, scale):
         """Native PyTorch fallback for dynamic per-tensor FP8 quantization when vLLM is unavailable."""
@@ -1564,13 +1581,13 @@ if _is_hip:
         scale.view(-1).copy_(scale_val.view(-1))
         # Quantize
         output_data = torch.clamp(input / scale_val, fp8_min, fp8_max).to(fp8_dtype)
-        output.copy_(output_data)
+        _copy_with_optional_row_padding(output, output_data, pad_value=0.0)
 
     def _native_static_quant_fp8(output, input, scale):
         """Native PyTorch fallback for static FP8 quantization when vLLM is unavailable."""
         # Use tensor directly instead of .item() to avoid CPU-GPU sync
         output_data = torch.clamp(input / scale, fp8_min, fp8_max).to(fp8_dtype)
-        output.copy_(output_data)
+        _copy_with_optional_row_padding(output, output_data, pad_value=0.0)
 
     def scaled_fp8_quant(
         input: torch.Tensor,

--- a/python/sglang/test/test_custom_ops.py
+++ b/python/sglang/test/test_custom_ops.py
@@ -3,11 +3,14 @@
 import pytest
 import torch
 
+from sglang.srt.layers.quantization import fp8_kernel
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz, scaled_fp8_quant
 from sglang.srt.utils import is_cuda, is_hip
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_use_aiter = getattr(fp8_kernel, "_use_aiter", False)
+_has_vllm = getattr(fp8_kernel, "_has_vllm", False)
 _is_fp8_fnuz = is_fp8_fnuz()
 fp8_dtype = torch.float8_e4m3fnuz if _is_fp8_fnuz else torch.float8_e4m3fn
 
@@ -141,6 +144,14 @@ if _is_cuda or _is_hip:
         torch.testing.assert_close(
             scale_per_token[:original_rows], scale_per_token_without_padding
         )
+        if _is_hip:
+            assert scale_per_token.shape[0] == padding_size
+            assert torch.isfinite(scale_per_token).all()
+            if not _use_aiter and not _has_vllm:
+                # The native HIP fallback explicitly fills padded rows.
+                assert torch.all(y_dynamic[original_rows:] == 0.0)
+                assert torch.all(y_static[original_rows:] == 0.0)
+                assert torch.all(y_per_token[original_rows:] == 0.0)
 
 
 if __name__ == "__main__":

--- a/test/registered/moe/test_fused_moe.py
+++ b/test/registered/moe/test_fused_moe.py
@@ -1,9 +1,11 @@
 import unittest
+from unittest import mock
 
 import torch
 from tqdm import tqdm
 
 from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.moe.fused_moe_triton import fused_moe as fused_moe_module
 from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
@@ -238,6 +240,70 @@ class TestFusedMOE(CustomTestCase):
                                             )
                                             empty_gpu_cache()
                                         pbar.update(1)
+
+    @unittest.skipUnless(_is_hip, "ROCm-only regression test")
+    def test_fp8_unpadded_weights_with_global_moe_padding(self):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+        m, n, k, e, topk = 16, 64, 256, 8, 2
+        dtype = torch.bfloat16
+        rtol, atol = self.get_tolerance(dtype)
+
+        a = self.create_random_gpu_tensor((m, k), dtype)
+        w1 = self.create_random_gpu_tensor((e, 2 * n, k), dtype).to(
+            torch.float8_e4m3fn
+        )
+        w2 = self.create_random_gpu_tensor((e, k, n), dtype).to(torch.float8_e4m3fn)
+        score = self.create_random_gpu_tensor((m, e), dtype)
+        w1_scale = self.create_random_gpu_tensor(e, torch.float32)
+        w2_scale = self.create_random_gpu_tensor(e, torch.float32)
+        a1_scale = self.create_random_gpu_tensor(1, torch.float32)
+        a2_scale = self.create_random_gpu_tensor(1, torch.float32)
+
+        if _is_fp8_fnuz:
+            w1, w1_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                weight=w1,
+                weight_scale=w1_scale,
+                input_scale=a1_scale,
+            )
+            w2, w2_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                weight=w2,
+                weight_scale=w2_scale,
+                input_scale=a2_scale,
+            )
+
+        topk_output = select_experts(
+            hidden_states=a,
+            router_logits=score,
+            topk_config=TopKConfig(top_k=topk, renormalize=False),
+        )
+
+        torch_output = self.torch_naive_moe(
+            a,
+            w1,
+            w2,
+            score,
+            topk,
+            w1_scale,
+            w2_scale,
+            a1_scale,
+            a2_scale,
+        )
+
+        with mock.patch.object(fused_moe_module, "padding_size", 128):
+            sglang_output = fused_moe(
+                a,
+                w1,
+                w2,
+                topk_output,
+                use_fp8_w8a8=True,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
+            )
+
+        torch.testing.assert_close(sglang_output, torch_output, rtol=rtol, atol=atol)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This fixes two ROCm regressions that blocked `GLM-4.5V-FP8` startup on MI300X when launching with:

```bash
SGLANG_USE_AITER=0 python3 -m sglang.launch_server \
  --model-path /models/models--zai-org--GLM-4.5V-FP8/snapshots/3ca028eac7af91c53109dcfa865e5c8da7b1faf3 \
  --tp-size 4 \
  --reasoning-parser glm45 \
  --tool-call-parser glm45
```

## Root Cause

There were two independent failures on ROCm:

1. `fused_moe_triton/fused_moe.py`
   - The Triton MoE path subtracted the global ROCm `SGLANG_MOE_PADDING` from the expert hidden dimension unconditionally for FP8/INT8 paths.
   - Some GLM-4.5V FP8 checkpoints load unpadded MoE weights, so the runtime hidden size already matches `w1.shape[2]`.
   - That made valid weights fail with:
     - `AssertionError: Hidden size mismatch`

2. `quantization/fp8_kernel.py`
   - The HIP native FP8 fallback writes into padded `output` / `scale` buffers when `num_token_padding` is used.
   - It previously used direct `copy_` from unpadded tensors, which fails once the padded row count is larger than the real input row count.
   - This surfaced later during graph capture as:
     - `RuntimeError: The size of tensor a (17) must match the size of tensor b (16)`

## Fix

1. In `fused_moe.py`, disable the effective MoE padding adjustment when the loaded weights are already unpadded and `hidden_states.shape[1] == w1.shape[2]`.
2. In `fp8_kernel.py`, add a small HIP helper to copy row-major tensors into padded destination buffers and explicitly fill any padded tail rows.

## Tests

Added targeted regression coverage:

- `python/sglang/test/test_custom_ops.py`
  - Extends the FP8 padding test on HIP.
  - Checks the padded API shape contract and fallback-specific padded-row behavior when the native HIP fallback is active.

- `test/registered/moe/test_fused_moe.py`
  - Adds a ROCm-only regression that forces `padding_size=128` and verifies FP8 fused MoE still matches the naive reference when weights are already unpadded.

## Validation

Targeted tests run on MI300X:

```bash
pytest -q test/registered/moe/test_fused_moe.py -k 'unpadded_weights_with_global_moe_padding'
env SGLANG_USE_AITER=0 pytest -q python/sglang/test/test_custom_ops.py -k 'scaled_fp8_quant_with_padding'
```

Both passed.

End-to-end validation on MI300X also passed:

1. Launched `GLM-4.5V-FP8` with `SGLANG_USE_AITER=0` and `--tp-size 4`
2. Completed:
   - checkpoint load
   - KV cache allocation
   - CUDA graph capture
   - server startup
3. Verified:
   - `GET /model_info` returned `200`
   - `POST /v1/chat/completions` returned a valid response

## Notes

- This PR is intentionally scoped to the two ROCm regressions above.
- There are pre-existing exact-equality differences in some broader FP8 tests under `SGLANG_USE_AITER=0`; those are separate from this fix and are not changed here.
