### PR TITLE
[AMD] Fix Qwen3-Coder-Next: Add missing k_scale/v_scale args to extend_attention_fwd in aiter_backend

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1765,6 +1765,8 @@ class AiterAttnBackend(AttentionBackend):
                     True,  # causal
                     self.forward_metadata.mask_indptr,
                     self.forward_metadata.max_extend_len,
+                    1.0,  # k_scale
+                    1.0,  # v_scale
                     layer.scaling,
                     logit_cap=layer.logit_cap,
                 )


### PR DESCRIPTION
## Summary

- Fix `TypeError: extend_attention_fwd() missing 1 required positional argument: 'v_scale'` crash in aiter_backend when running non-MLA speculative decoding (target_verify / draft_extend) paths: https://github.com/sgl-project/sglang/actions/runs/22648816293/job/65643197339#step:5:6363
- Add missing `k_scale=1.0, v_scale=1.0` positional args to the `extend_attention_fwd` call

## Motivation

\#18882 added `k_scale` and `v_scale` as required positional parameters to `extend_attention_fwd` in `triton_ops/extend_attention.py` and updated `triton_backend.py`, but missed the call site in `aiter_backend.py` for non-MLA target_verify/draft_extend paths (used by hybrid models like Qwen3-Coder-Next with MTP).

## Fixes

Nightly (AMD ROCm) failure: https://github.com/sgl-project/sglang/actions/runs/22648816293/job/65643197339#step:5:6363

```
TypeError: extend_attention_fwd() missing 1 required positional argument: 'v_scale'
```

## Test plan

- [x] Re-run `nightly-accuracy-8-gpu-mi35x` / `nightly-accuracy-8-gpu-mi35x-rocm720` to confirm Qwen3-Coder-Next MTP passes:
https://github.com/sgl-project/sglang/actions/runs/22649193163/job/65644407193