### PR TITLE
Fix bootstrap_room OverflowError with uint64 tensor assignment

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -143,8 +143,10 @@ class MetadataBuffers:
                 (size, hidden_size), dtype=hidden_states_dtype, device=device
             )
             # Request validation: store bootstrap_room to detect metadata corruption
+            # Use int64 to avoid OverflowError when external routers
+            # (e.g., dynamo) pass large random bootstrap_room values.
             self.bootstrap_room = torch.zeros(
-                (size, 8), dtype=torch.uint64, device=device
+                (size, 8), dtype=torch.int64, device=device
             )
 
     def get_buf_infos(self):


### PR DESCRIPTION
Change MetadataBuffers.bootstrap_room dtype from torch.uint64 to torch.int64. PyTorch scalar assignment converts Python int via PyLong_AsLongLong (signed int64), which raises OverflowError for values near the int64 boundary. This is triggered when external routers (e.g., dynamo) generate large random bootstrap_room IDs.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using external routers (e.g., dynamo) that generate large random `bootstrap_room` IDs, the prefill scheduler crashes with:

```
File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3176, in run_scheduler_process
    scheduler.event_loop_overlap_disagg_prefill()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/prefill.py", line 415, in event_loop_overlap_disagg_prefill
    self.process_batch_result_disagg_prefill(tmp_batch, tmp_result)
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/prefill.py", line 504, in process_batch_result_disagg_prefill
    self.send_kv_chunk(req, last_chunk=True)
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/prefill.py", line 701, in send_kv_chunk
    self.disagg_metadata_buffers.set_buf(req)
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/utils.py", line 237, in set_buf
    self.bootstrap_room[req.metadata_buffer_index, 0] = (
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Overflow when unpacking long long
```

at `MetadataBuffers.set_buf()` when assigning `bootstrap_room` to the metadata tensor.


## Modifications

Change `MetadataBuffers.bootstrap_room` dtype from `torch.uint64` to `torch.int64`.

**Root cause**: PyTorch's scalar tensor assignment internally converts Python `int` via `PyLong_AsLongLong` (signed int64), which raises `OverflowError` for values >= 2^63. The `uint64` dtype doesn't help because the conversion happens before the value reaches the tensor storage.

**Why this is safe**: All known `bootstrap_room` generators (sglang internal counter, dynamo Python `random.randint(0, 2**63-1)`, dynamo Rust `rand::random_range(0..=i64::MAX)`) produce values in `[0, 2^63-1]`, which fits in `int64`.


Tested with dynamo 0.9.0 KV router on Qwen3.5-397B disaggregated serving (TP4 prefill + DEP4 decode). Previously crashed on the first request; now runs successfully.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
