### PR TITLE
[VLM] Support cos sin cache for Ernie4.5-VL

### DIFF
--- a/python/sglang/srt/models/ernie45_vl.py
+++ b/python/sglang/srt/models/ernie45_vl.py
@@ -30,6 +30,7 @@ from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
@@ -120,14 +121,16 @@ class Ernie4_5_VisionBlock(nn.Module):
         self,
         x: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        position_embeddings: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
     ) -> torch.Tensor:
         hidden_states = self.norm1(x)
         hidden_states = rearrange(hidden_states, "s b ... -> b s ...")
         attn = self.attn(
             hidden_states,
             cu_seqlens=cu_seqlens,
-            position_embeddings=position_embeddings,
+            rotary_pos_emb_cos=rotary_pos_emb_cos,
+            rotary_pos_emb_sin=rotary_pos_emb_sin,
         )
         attn = rearrange(attn, "b s ... -> s b ...")
         x = x + attn
@@ -388,7 +391,13 @@ class Ernie4_5_VisionTransformer(nn.Module):
 
         norm_layer = partial(nn.LayerNorm, eps=norm_eps)
         head_dim = embed_dim // num_heads
-        self.rotary_pos_emb = Ernie4_5_VisionRotaryEmbedding(head_dim // 2)
+        self.rotary_pos_emb = get_rope(
+            head_size=head_dim,
+            rotary_dim=head_dim // 2,
+            max_position=8192,
+            base=10000.0,
+            is_neox_style=True,
+        )
         self.blocks = nn.ModuleList(
             [
                 Ernie4_5_VisionBlock(
@@ -413,7 +422,9 @@ class Ernie4_5_VisionTransformer(nn.Module):
     def device(self) -> torch.device:
         return self.blocks[0].mlp.fc2.weight.device
 
-    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+    def rot_pos_emb(
+        self, grid_thw: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         pos_ids = []
         for i in range(grid_thw.size(0)):
             t, h, w = grid_thw[i].tolist()
@@ -440,11 +451,15 @@ class Ernie4_5_VisionTransformer(nn.Module):
                 .flatten()
             )
             pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
-        pos_ids = torch.cat(pos_ids, dim=0)
+        pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
         max_grid_size = grid_thw[:, 1:].max()
-        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
-        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
-        return rotary_pos_emb
+
+        # Use pre-computed cos_sin_cache from RotaryEmbedding
+        cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
+
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
+        return cos_combined, sin_combined, pos_ids
 
     def forward(
         self,
@@ -456,9 +471,11 @@ class Ernie4_5_VisionTransformer(nn.Module):
         x = self.patch_embed(x)
 
         # compute position embedding
-        rotary_pos_emb = self.rot_pos_emb(grid_thw)
-        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
-        position_embeddings = (emb.cos(), emb.sin())
+        rotary_pos_emb_cos, rotary_pos_emb_sin, image_type_ids = self.rot_pos_emb(
+            grid_thw
+        )
+        rotary_pos_emb_cos = torch.cat([rotary_pos_emb_cos, rotary_pos_emb_cos], dim=-1)
+        rotary_pos_emb_sin = torch.cat([rotary_pos_emb_sin, rotary_pos_emb_sin], dim=-1)
         # compute cu_seqlens
         cu_seqlens = torch.repeat_interleave(
             grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
@@ -468,7 +485,12 @@ class Ernie4_5_VisionTransformer(nn.Module):
         # transformers
         x = x.unsqueeze(1)
         for blk in self.blocks:
-            x = blk(x, cu_seqlens=cu_seqlens, position_embeddings=position_embeddings)
+            x = blk(
+                x,
+                cu_seqlens=cu_seqlens,
+                rotary_pos_emb_cos=rotary_pos_emb_cos,
+                rotary_pos_emb_sin=rotary_pos_emb_sin,
+            )
 
         final_output = self.ln(x)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR refactors the rotary positional embedding implementation to expose an explicit cos/sin cache interface and reuse it in the 2D vision RoPE code path. Instead of recomputing frequencies and calling cos() / sin() repeatedly, we precompute and cache the 1D cos/sin values once, then index into this cache for both text RoPE and the 2D grid RoPE used by the vision encoder.
The framework has already been implemented in #15205 , this PR is to enforce this enhancement into more VLMs.

Performance improved TTFT 3%.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

lmms_eval no drops:

Main:
```
root@c7e9bb6a6789:/sgl-workspace/sglang# python3 -m lmms_eval --model openai_compatible   --model_args model_version=baidu/ERNIE-4.5-VL-28B-A3B  --tasks mmmu_val   --batch_size 16

| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|Stderr_CLT|Stderr_Clustered|
|--------|------:|------|-----:|--------|---|-----:|---|------|----------|----------------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.2644|±  |N/A   |N/A       |N/A             |
```

PR:
```
➜  bench_script python3 -m lmms_eval --model openai_compatible   --model_args model_version=baidu/ERNIE-4.5-VL-28B-A3B   --tasks mmmu_val   --batch_size 16
2026-03-03 04:14:29 | INFO     | __main__:cli_evaluate:476 - Verbosity set to INFO
2026-03-03 04:14:32 | INFO     | __main__:cli_evaluate_single:565 - Evaluation tracker args: {}
2026-03-03 04:14:32 | INFO     | __main__:cli_evaluate_single:649 - Selected Tasks: ['mmmu_val']
2026-03-03 04:14:32 | INFO     | lmms_eval.evaluator:simple_evaluate:170 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-03-03 04:14:33 | INFO     | lmms_eval.evaluator:evaluate:515 - Running on rank 0 (local rank 0)
2026-03-03 04:14:33 | INFO     | lmms_eval.api.task:build_all_requests:428 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13835.13it/s]
2026-03-03 04:14:33 | INFO     | lmms_eval.evaluator:evaluate:609 - Running generate_until requests
Model Responding: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▍| 897/900 [07:59<00:01,  1.89it/s]2026-03-03 04:22:33 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:136 - Metric summary - Total elapsed time: 14580.099s, Total gen tokens: 112510, Avg speed: 7.7 tokens/s
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [07:59<00:00,  1.88it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 8850.28it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.33333}, 'Art': {'num': 30, 'acc': 0.23333}, 'Art_Theory': {'num': 30, 'acc': 0.23333}, 'Design': {'num': 30, 'acc': 0.5}, 'Music': {'num': 30, 'acc': 0.36667}, 'Overall-Business': {'num': 150, 'acc': 0.24}, 'Accounting': {'num': 30, 'acc': 0.23333}, 'Economics': {'num': 30, 'acc': 0.3}, 'Finance': {'num': 30, 'acc': 0.13333}, 'Manage': {'num': 30, 'acc': 0.2}, 'Marketing': {'num': 30, 'acc': 0.33333}, 'Overall-Science': {'num': 150, 'acc': 0.20667}, 'Biology': {'num': 30, 'acc': 0.2}, 'Chemistry': {'num': 30, 'acc': 0.1}, 'Geography': {'num': 30, 'acc': 0.3}, 'Math': {'num': 30, 'acc': 0.2}, 'Physics': {'num': 30, 'acc': 0.23333}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.27333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.26667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.23333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.3}, 'Pharmacy': {'num': 30, 'acc': 0.3}, 'Public_Health': {'num': 30, 'acc': 0.26667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.26667}, 'History': {'num': 30, 'acc': 0.4}, 'Literature': {'num': 30, 'acc': 0.36667}, 'Sociology': {'num': 30, 'acc': 0.13333}, 'Psychology': {'num': 30, 'acc': 0.16667}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.28571}, 'Agriculture': {'num': 30, 'acc': 0.26667}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.46667}, 'Computer_Science': {'num': 30, 'acc': 0.23333}, 'Electronics': {'num': 30, 'acc': 0.03333}, 'Energy_and_Power': {'num': 30, 'acc': 0.36667}, 'Materials': {'num': 30, 'acc': 0.23333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.4}, 'Overall': {'num': 900, 'acc': 0.26667}}
fatal: not a git repository (or any of the parent directories): .git
2026-03-03 04:22:33 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:238 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=baidu/ERNIE-4.5-VL-28B-A3B), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.2667|±  |N/A   |
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
