### PR TITLE
[Diffuser] Fix duplicate is_neox_style check in _apply_rotary_emb

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -27,11 +27,7 @@ def _apply_rotary_emb(
     if is_neox_style:
         cos = cos.unsqueeze(-2)
         sin = sin.unsqueeze(-2)
-        if not interleaved:
-            x1, x2 = torch.chunk(x, 2, dim=-1)
-        else:
-            x1 = x[..., ::2]
-            x2 = x[..., 1::2]
+        x1, x2 = torch.chunk(x, 2, dim=-1)
         o1 = (x1.float() * cos - x2.float() * sin).type_as(x)
         o2 = (x2.float() * cos + x1.float() * sin).type_as(x)
         return torch.cat((o1, o2), dim=-1)

--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -27,7 +27,7 @@ def _apply_rotary_emb(
     if is_neox_style:
         cos = cos.unsqueeze(-2)
         sin = sin.unsqueeze(-2)
-        if is_neox_style:
+        if not interleaved:
             x1, x2 = torch.chunk(x, 2, dim=-1)
         else:
             x1 = x[..., ::2]


### PR DESCRIPTION
## Motivation

Fix https://github.com/sgl-project/sglang/issues/19747

In `_apply_rotary_emb()`, line 30 checks `if is_neox_style:` inside an
outer `if is_neox_style:` block (line 27). The inner check is always True,
making the `else` branch (interleaved splitting via `x[..., ::2]`) dead code.

For comparison, the LLM side implementation in
`srt/layers/rotary_embedding/utils.py` correctly uses a single
`if is_neox_style:` check to decide between chunk and interleaved splitting.

## Modifications

Replace `if is_neox_style:` on line 30 with `if not interleaved:`.

This makes the interleaved splitting path reachable when
`is_neox_style=True` and `interleaved=True` are both passed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
