### PR TITLE
[AMD][Feature] support fp4 dispatch and fp8 combine in moriep

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -75,6 +75,8 @@ SGLang supports various environment variables that can be used to configure its 
 | Environment Variable | Description | Default Value |
 | --- | --- | --- |
 | `SGLANG_MORI_FP8_DISP` | Use FP8 for dispatch | `"false"` |
+| `SGLANG_MORI_FP4_DISP` | Use MXFP4 for dispatch | `"false"` |
+| `SGLANG_MORI_FP8_COMB` | Use FP8 for combine | `"false"` |
 | `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` | Maximum number of dispatch tokens per rank for MORI-EP buffer allocation | `4096` |
 | `SGLANG_MORI_DISPATCH_INTER_KERNEL_SWITCH_THRESHOLD` | Threshold for switching between `InterNodeV1` and `InterNodeV1LL` kernel types. `InterNodeV1LL` is used if `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` is less than or equal to this threshold; otherwise, `InterNodeV1` is used. | `256` |
 | `SGLANG_MORI_QP_PER_TRANSFER` | Number of RDMA Queue Pairs (QPs) used per transfer operation | `1` |

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.moe.fused_moe_triton.layer import (
     FusedMoE,
     moe_forward_piecewise_cuda_graph_impl,
 )
-from sglang.srt.layers.moe.rocm_moe_utils import upscale
+from sglang.srt.layers.moe.rocm_moe_utils import upscale, upscale_mxfp4
 from sglang.srt.layers.moe.token_dispatcher.deepep import (
     DeepEPLLCombineInput,
     DeepEPNormalCombineInput,
@@ -653,11 +653,36 @@ class MoriEPMoE(DeepEPMoE):
 
         quant_type = QuantType.No
 
-        if not is_fp8_quant and dispatch_scale is not None:
-            dispatch_a1 = upscale(
-                dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
-            )
-            dispatch_scale = None
+        if (
+            not is_fp8_quant
+            and dispatch_scale is not None
+            and dispatch_a1.dtype != torch.float4_e2m1fn_x2
+        ):
+            if is_quark_w4a4:
+                # W4A4 model with FP8 dispatch: must dequant FP8->BF16 first,
+                # because the FP4 per_1x32 quantization path needs BF16 input
+                dispatch_a1 = upscale(
+                    dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
+                )
+                dispatch_scale = None
+            else:
+                # Non-W4A4 model with FP8 dispatch: pass FP8 hidden_states + scale
+                # directly to fused_moe, avoiding unnecessary dequant->requant round-trip
+                quant_type = QuantType.per_128x128
+
+        if dispatch_a1.dtype == torch.float4_e2m1fn_x2 and dispatch_scale is not None:
+            if is_fp8_quant:
+                # FP8 weights + FP4 dispatch is not supported by fused_moe kernels
+                # (no kernel for q_dtype_a=fp4x2, q_dtype_w=fp8).
+                # Must dequant FP4->BF16 first; fused_moe will re-quant to FP8 internally.
+                dispatch_a1 = upscale_mxfp4(
+                    dispatch_a1, dispatch_scale, dispatch_recv_token_num, output_dtype
+                )
+                dispatch_scale = None
+            elif quant_type == QuantType.No:
+                # Skip upscale_mxfp4: pass FP4 hidden_states + scale directly to fused_moe
+                # fused_moe with QuantType.per_1x32 can accept pre-quantized fp4x2 input
+                quant_type = QuantType.per_1x32
 
         if is_quark_w4a4:
             if hasattr(torch, "float4_e2m1fn_x2"):
@@ -677,7 +702,10 @@ class MoriEPMoE(DeepEPMoE):
             if hasattr(self, "w2_weight_scale_inv"):
                 w2_scale = self.w2_weight_scale_inv
 
-            quant_type = QuantType.per_128x128
+            # Only set per_128x128 if quant_type was not already set by
+            # a prior dispatch path (e.g. FP4 dispatch sets per_1x32)
+            if quant_type == QuantType.No:
+                quant_type = QuantType.per_128x128
 
         # [KK TODO] should to call the apply of quant method to handle fused moe
         hidden_states = fused_moe(

--- a/python/sglang/srt/layers/moe/rocm_moe_utils.py
+++ b/python/sglang/srt/layers/moe/rocm_moe_utils.py
@@ -187,3 +187,143 @@ def upscale(hidden_state, hidden_state_scale, recv_token_num, output_dtype):
     )
 
     return Out
+
+
+@triton.jit
+def upscale_fp4x2_block32_kernel(
+    A_u8_ptr,  # *uint8  (view from float4_e2m1fn_x2)
+    S_u8_ptr,  # *uint8  (view from float8_e8m0fnu), shape (M, N_fp4/32)
+    Out_ptr,  # *fp16/fp32/bf16, shape (M, N_fp4)
+    N_FP4: tl.constexpr,
+    recv_token_num,
+    stride_am,
+    stride_an,  # A strides (in uint8 elements) for (M, packed_N)
+    stride_sm,
+    stride_sn,  # S strides (in uint8 elements) for (M, N_FP4/32)
+    stride_om,
+    stride_on,  # Out strides (in output elements) for (M, N_FP4)
+    BLOCK_N: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,  # tl.float16 / tl.float32 / tl.bfloat16
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    recv_token_num_val = tl.load(recv_token_num)
+    if pid_m >= recv_token_num_val:
+        return
+
+    offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offs < N_FP4
+
+    # --------------------------
+    # Load packed fp4x2 byte
+    # --------------------------
+    byte_idx = offs >> 1  # offs // 2
+    is_hi = (offs & 1) != 0  # select high nibble?
+
+    a_ptrs = A_u8_ptr + pid_m * stride_am + byte_idx * stride_an
+    a_byte = tl.load(a_ptrs, mask=mask, other=0).to(tl.int32)
+
+    lo = a_byte & 0xF
+    hi = (a_byte >> 4) & 0xF
+    code = tl.where(is_hi, hi, lo).to(tl.int32)  # 0..15
+
+    # --------------------------
+    # Decode float4_e2m1fn
+    # layout: [sign|exp(2)|mant(1)]
+    # bias=1, finite-only
+    # --------------------------
+    sign = (code >> 3) & 0x1
+    exp = (code >> 1) & 0x3
+    mant = code & 0x1
+
+    mant_f = mant.to(tl.float32) * 0.5
+    is_sub = exp == 0
+
+    # normal: 2^(exp-bias) * (1 + mant/2), bias=1
+    e_norm = (exp - 1).to(tl.float32)
+    val_norm = tl.exp2(e_norm) * (1.0 + mant_f)
+
+    # subnorm/zero: mant/2 * 2^(1-bias) = mant/2
+    val_sub = mant_f
+
+    val = tl.where(is_sub, val_sub, val_norm)
+    val = tl.where(sign != 0, -val, val)  # apply sign
+
+    # --------------------------
+    # Per-token block32 scale: scale_idx = offs // 32
+    # scale dtype: float8_e8m0fnu stored in uint8
+    # decode: e==0 -> 0
+    #         e in [1..254] -> 2^(e-127)
+    #         e==255 -> clamp to 254
+    # --------------------------
+    scale_idx = offs >> 5  # offs // 32
+
+    s_ptrs = S_u8_ptr + pid_m * stride_sm + scale_idx * stride_sn
+    e = tl.load(s_ptrs, mask=mask, other=0).to(tl.int32)
+
+    e = tl.minimum(e, 254)  # clamp 255->254
+    is_zero = e == 0
+    exp_s = (e - 127).to(tl.float32)
+    s = tl.exp2(exp_s)
+    s = tl.where(is_zero, 0.0, s)
+
+    out = (val * s).to(OUT_DTYPE)
+
+    out_ptrs = Out_ptr + pid_m * stride_om + offs * stride_on
+    tl.store(out_ptrs, out, mask=mask)
+
+
+def upscale_mxfp4(hidden_state, hidden_state_scale, recv_token_num, output_dtype):
+    """
+    hidden_state: (M, packed_N) torch.float4_e2m1fn_x2
+    hidden_state_scale: (M, packed_N*2/32) = (M, N_fp4/32) torch.float8_e8m0fnu
+    output: (M, N_fp4) output_dtype
+    """
+    assert hidden_state.dtype == torch.float4_e2m1fn_x2, hidden_state.dtype
+    assert hidden_state_scale.dtype == torch.float8_e8m0fnu, hidden_state_scale.dtype
+    assert hidden_state.is_contiguous() or True  # stride-based load OK
+
+    M, packed_N = hidden_state.shape
+    N_fp4 = packed_N * 2
+
+    # scale second dim must be N_fp4/32
+    assert hidden_state_scale.shape[0] == M
+    assert hidden_state_scale.shape[1] == (N_fp4 // 32), (
+        hidden_state_scale.shape,
+        N_fp4,
+    )
+
+    # Triton doesn't (reliably) accept torch.float4/float8 pointers directly.
+    # Use raw uint8 views.
+    A_u8 = hidden_state.view(torch.uint8)
+    S_u8 = hidden_state_scale.view(torch.uint8)
+
+    Out = torch.empty((M, N_fp4), dtype=output_dtype, device=hidden_state.device)
+
+    BLOCK_N = 256
+    grid = (M, triton.cdiv(N_fp4, BLOCK_N))
+
+    OUT_TL = (
+        tl.float16
+        if output_dtype == torch.float16
+        else tl.bfloat16 if output_dtype == torch.bfloat16 else tl.float32
+    )
+
+    upscale_fp4x2_block32_kernel[grid](
+        A_u8,
+        S_u8,
+        Out,
+        N_FP4=N_fp4,
+        recv_token_num=recv_token_num,
+        stride_am=A_u8.stride(0),
+        stride_an=A_u8.stride(1),
+        stride_sm=S_u8.stride(0),
+        stride_sn=S_u8.stride(1),
+        stride_om=Out.stride(0),
+        stride_on=Out.stride(1),
+        BLOCK_N=BLOCK_N,
+        OUT_DTYPE=OUT_TL,
+        num_warps=4,
+    )
+    return Out

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -225,7 +225,7 @@ def init_mori_op(
     rdma_block_num = cfg.rdma_block_num
 
     hidden_dim = hidden_size
-    scale_dim = hidden_size
+    scale_dim = 1
     data_type = fp8_dtype
     scale_type_size = torch.float32.itemsize
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -170,6 +170,19 @@ def get_ep_dispatch_configs(num_max_dispatch_tokens_per_rank: int = 4096):
     }
 
 
+@lru_cache(maxsize=2)
+def _get_mori_dispatch_quant_flags():
+    fp8_dispatch = get_bool_env_var("SGLANG_MORI_FP8_DISP", "False")
+    fp4_dispatch = get_bool_env_var("SGLANG_MORI_FP4_DISP", "False")
+    if fp8_dispatch and fp4_dispatch:
+        logger.warning(
+            "Both SGLANG_MORI_FP8_DISP and SGLANG_MORI_FP4_DISP are set to True. "
+            "Using SGLANG_MORI_FP4_DISP and ignoring SGLANG_MORI_FP8_DISP."
+        )
+        fp8_dispatch = False
+    return fp8_dispatch, fp4_dispatch
+
+
 # init_mori_op only needs do once in model initial stage
 # use lru_cache to reuse the same mori_op instance to avoid the init overhead for mori
 @lru_cache(maxsize=2)
@@ -211,17 +224,41 @@ def init_mori_op(
     block_num = cfg.block_num
     rdma_block_num = cfg.rdma_block_num
 
+    hidden_dim = hidden_size
+    scale_dim = hidden_size
+    data_type = fp8_dtype
+    scale_type_size = torch.float32.itemsize
+
+    fp8_dispatch, fp4_dispatch = _get_mori_dispatch_quant_flags()
+
+    if fp8_dispatch:
+        scale_dim = hidden_size // 128
+    elif fp4_dispatch:
+        # FP4 kernel still takes the original hidden size and do quantization internally, so hidden_dim is not reduced. The reason is that for FP4 quantization, we need to keep the original hidden size to calculate the quantization scale correctly. don't use packed hidden size for FP4 kernel.
+        hidden_dim = hidden_size
+        scale_dim = hidden_size // 32
+        data_type = torch.float4_e2m1fn_x2
+        scale_type_size = torch.float8_e8m0fnu.itemsize
+
+        if mode == EpMode.INTRA_NODE:
+            if num_max_dispatch_tokens_per_rank < 128:
+                block_num = 225
+                warp_num_per_block = 5
+            else:
+                block_num = 256
+                warp_num_per_block = 16
+
+    combine_quant_type = "none"
+    if get_bool_env_var("SGLANG_MORI_FP8_COMB", "False"):
+        combine_quant_type = "fp8_direct_cast"
+
     mori_config = mori.ops.EpDispatchCombineConfig(
         rank=rank,
         world_size=world_size,
-        data_type=fp8_dtype,
-        hidden_dim=hidden_size,
-        scale_dim=(
-            hidden_size // 128
-            if get_bool_env_var("SGLANG_MORI_FP8_DISP", "False")
-            else 1
-        ),
-        scale_type_size=torch.float32.itemsize,
+        data_type=data_type,
+        hidden_dim=hidden_dim,
+        scale_dim=scale_dim,
+        scale_type_size=scale_type_size,
         max_token_type_size=params_dtype.itemsize,
         max_num_inp_token_per_rank=num_max_dispatch_tokens_per_rank,
         num_experts_per_rank=num_local_experts,
@@ -232,6 +269,7 @@ def init_mori_op(
         gpu_per_node=gpu_per_node,
         rdma_block_num=rdma_block_num,
         num_qp_per_pe=2,
+        quant_type=combine_quant_type,
     )
     mori_op = mori.ops.EpDispatchCombineOp(mori_config)
     return mori_op
@@ -346,7 +384,8 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
         self.async_finish = async_finish
         self.quant_config = {}
         # [kk TODO] need to support mxfp4 type
-        self.quant_func = get_hip_quant(QuantType.per_1x128)
+        self.fp8_quant_func = get_hip_quant(QuantType.per_1x128)
+        self.fp4_quant_func = get_hip_quant(QuantType.per_1x32)
         self.enable_dual_stream = is_tbo_enabled()
         self._comm_stream = None
         if self.enable_dual_stream:
@@ -378,17 +417,17 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
         topk_ids,
         previous_event,
     ):
-        num_token = hidden_states.shape[0]
+        num_tokens = hidden_states.shape[0]
         output_dtype = hidden_states.dtype
         scale = None
 
-        fp8_dispatch = get_bool_env_var("SGLANG_MORI_FP8_DISP", "False")
+        fp8_dispatch, fp4_dispatch = _get_mori_dispatch_quant_flags()
 
         if fp8_dispatch:
             # FP8 quant
-            if num_token > 0:
+            if num_tokens > 0:
                 # NOTE: aiter is able to handle token=0 case in UT. But for some reason it failed at e2e case. Root cause TBD.
-                hidden_states, scale = self.quant_func(
+                hidden_states, scale = self.fp8_quant_func(
                     hidden_states, quant_dtype=fp8_dtype
                 )
             else:
@@ -398,6 +437,22 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
                 scale = torch.empty(
                     (0, self.hidden_size // 128),
                     dtype=torch.float32,
+                    device=hidden_states.device,
+                )
+
+        elif fp4_dispatch:
+            # FP4 quant
+            if num_tokens > 0:
+                hidden_states, scale = self.fp4_quant_func(hidden_states, shuffle=False)
+            else:
+                hidden_states = torch.empty(
+                    (0, self.hidden_size // 2),
+                    dtype=torch.float4_e2m1fn_x2,
+                    device=hidden_states.device,
+                )
+                scale = torch.empty(
+                    (0, self.hidden_size // 32),
+                    dtype=torch.float8_e8m0fnu,
                     device=hidden_states.device,
                 )
 
@@ -571,7 +626,8 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.quant_config = {}
-        self.quant_func = get_hip_quant(QuantType.per_1x128)
+        self.fp8_quant_func = get_hip_quant(QuantType.per_1x128)
+        self.fp4_quant_func = get_hip_quant(QuantType.per_1x32)
 
     def dispatch_a(
         self,
@@ -589,13 +645,13 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
         output_dtype = hidden_states.dtype
         scale = None
 
-        fp8_dispatch = get_bool_env_var("SGLANG_MORI_FP8_DISP", "False")
+        fp8_dispatch, fp4_dispatch = _get_mori_dispatch_quant_flags()
 
         if fp8_dispatch:
             # FP8 quant
             if num_tokens > 0:
                 # NOTE: aiter is able to handle token=0 case in UT. But for some reason it failed at e2e case. Root cause TBD.
-                hidden_states, scale = self.quant_func(
+                hidden_states, scale = self.fp8_quant_func(
                     hidden_states, quant_dtype=fp8_dtype
                 )
             else:
@@ -605,6 +661,22 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
                 scale = torch.empty(
                     (0, self.hidden_size // 128),
                     dtype=torch.float32,
+                    device=hidden_states.device,
+                )
+
+        elif fp4_dispatch:
+            # FP4 quant
+            if num_tokens > 0:
+                hidden_states, scale = self.fp4_quant_func(hidden_states, shuffle=False)
+            else:
+                hidden_states = torch.empty(
+                    (0, self.hidden_size // 2),
+                    dtype=torch.float4_e2m1fn_x2,
+                    device=hidden_states.device,
+                )
+                scale = torch.empty(
+                    (0, self.hidden_size // 32),
+                    dtype=torch.float8_e8m0fnu,
                     device=hidden_states.device,
                 )
 


### PR DESCRIPTION
@Duyi-Wang @ZhaiFeiyue @billishyahao 

## Motivation

MXFP4 quantization further reduces communication throughput and load, thereby accelerating model inference speed.

## Modifications

In MoriEP, MXFP4 dispatch were introduced to reduce communication latency.

## Accuracy Tests

### amd/DeepSeek-R1-0528-MXFP4

#### FP8 dispatch + BF16 combine
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9575|±  |0.0056|
|gpqa |       |                |     5|           |   |0.7811|   |      |


#### FP8 dispatch + FP8 combine
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9196|±  |0.0075|
|     |       |strict-match    |     5|exact_match|↑  |0.9204|±  |0.0075|

#### FP4 dispatch + BF16 combine
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9538|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9545|±  |0.0057|

#### FP4 dispatch + FP8 combine

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9151|±  |0.0077|
|     |       |strict-match    |     5|exact_match|↑  |0.9158|±  |0.0076|

### deepseek-ai/DeepSeek-R1-0528
#### FP8 dispatch(w/o upscale) + BF16 combine 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9674|±  |0.0049|
|     |       |strict-match    |     5|exact_match|↑  |0.9674|±  |0.0049|

#### FP8 dispatch(w/o upscale) + FP8 combine 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9272|±  |0.0072|
|     |       |strict-match    |     5|exact_match|↑  |0.9280|±  |0.0071|

#### FP4 dispatch(w/ upscale) + BF16 combine 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9606|±  |0.0054|
|     |       |strict-match    |     5|exact_match|↑  |0.9606|±  |0.0054|

#### FP4 dispatch(w/ upscale) + FP8 combine 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9333|±  |0.0069|
|     |       |strict-match    |     5|exact_match|↑  |0.9325|±  |0.0069|

## Benchmarking and Profiling
### amd/DeepSeek-R1-0528-MXFP4

#### FP4 dispatch(w/ upscale) + BF16 combine (baseline)
| BS | ISL | OSL | Output Throughput (tok/s) | Total Throughput (tok/s) | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | P99 ITL (ms) |
|----|-----|-----|---------------------------|--------------------------|----------------|-------------------|---------------|----------------|-------------------|---------------|---------------|-----------------|--------------|
| 1  | 1024 | 1024 | 13.04 | 26.09 | 235.90 | 233.10 | 245.54 | 76.51 | 76.18 | 77.70 | 76.51 | 76.26 | 78.58 |
| 8  | 1024 | 1024 | 100.58 | 201.16 | 239.99 | 239.90 | 245.74 | 79.38 | 79.38 | 79.42 | 79.38 | 79.38 | 81.09 |
| 16 | 1024 | 1024 | 193.11 | 386.21 | 429.76 | 437.17 | 576.82 | 82.51 | 82.51 | 82.65 | 82.51 | 82.43 | 84.17 |
| 64 | 1024 | 1024 | 659.19 | 1318.39 | 824.10 | 960.53 | 1119.39 | 96.36 | 96.32 | 96.87 | 96.36 | 96.08 | 101.00 |

#### FP4 dispatch(w/o upscale) + BF16 combine
| BS | ISL | OSL | Output Throughput (tok/s) | Total Throughput (tok/s) | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | P99 ITL (ms) |
|----|-----|-----|---------------------------|--------------------------|----------------|-------------------|---------------|----------------|-------------------|---------------|---------------|-----------------|--------------|
| 1  | 1024 | 1024 | 24.73 | 49.46 | 158.50 | 157.55 | 163.06 | 40.32 | 41.05 | 41.10 | 40.32 | 40.53 | 42.10 |
| 8  | 1024 | 1024 | 182.34 | 364.68 | 255.58 | 272.90 | 314.52 | 43.66 | 42.81 | 52.70 | 43.66 | 42.68 | 44.15 |
| 16 | 1024 | 1024 | 315.88 | 631.77 | 326.72 | 337.68 | 400.93 | 50.37 | 51.10 | 51.20 | 50.37 | 50.47 | 52.77 |
| 64 | 1024 | 1024 | 974.91 | 1949.82 | 830.58 | 858.41 | 1154.69 | 64.88 | 64.74 | 66.00 | 64.88 | 64.58 | 69.06 |

### deepseek-ai/DeepSeek-R1-0528
#### FP8 dispatch(w/ upscale) + BF16 combine 
| BS | ISL | OSL | Output Throughput (tok/s) | Total Throughput (tok/s) | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | P99 ITL (ms) |
|----|-----|-----|---------------------------|--------------------------|----------------|-------------------|---------------|----------------|-------------------|---------------|---------------|-----------------|--------------|
| 1  | 1024 | 1024 | 47.01 | 94.02 | 147.00 | 146.70 | 150.53 | 21.15 | 21.15 | 21.21 | 21.15 | 21.14 | 22.05 |
| 8  | 1024 | 1024 | 391.47 | 782.95 | 395.91 | 328.28 | 882.87 | 20.07 | 20.03 | 20.47 | 20.07 | 19.97 | 20.96 |
| 16 | 1024 | 1024 | 705.66 | 1411.32 | 1126.41 | 1008.63 | 2171.72 | 21.59 | 21.48 | 23.13 | 21.59 | 21.45 | 22.98 |
| 64 | 1024 | 1024 | 2096.21 | 4192.42 | 2088.90 | 1968.44 | 3564.50 | 28.50 | 28.20 | 30.60 | 28.50 | 27.94 | 31.85 |

#### FP8 dispatch(w/o upscale) + BF16 combine 
| BS | ISL | OSL | Output Throughput (tok/s) | Total Throughput (tok/s) | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) | Mean ITL (ms) | Median ITL (ms) | P99 ITL (ms) |
|----|-----|-----|---------------------------|--------------------------|----------------|-------------------|---------------|----------------|-------------------|---------------|---------------|-----------------|--------------|
| 1  | 1024 | 1024 | 46.98 | 93.96 | 149.28 | 148.23 | 153.83 | 21.16 | 21.19 | 21.22 | 21.16 | 21.16 | 22.12 |
| 8  | 1024 | 1024 | 393.59 | 787.19 | 315.34 | 329.95 | 413.27 | 20.03 | 20.01 | 20.17 | 20.03 | 19.95 | 21.12 |
| 16 | 1024 | 1024 | 736.29 | 1472.58 | 495.18 | 541.04 | 560.43 | 21.26 | 21.22 | 21.53 | 21.26 | 21.19 | 22.72 |
| 64 | 1024 | 1024 | 2132.65 | 4265.30 | 2233.78 | 2518.91 | 3510.25 | 27.84 | 27.82 | 29.83 | 27.84 | 27.25 | 31.39 |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
