### PR TITLE
[FIX] [SGLang-Diffusion] Suppress noisy torch.compile logs during first forward pass

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -10,6 +10,7 @@ This module defines the base class for pipelines that are composed of multiple s
 import os
 import re
 from abc import ABC, abstractmethod
+from contextlib import nullcontext
 from typing import Any, Callable, Literal, cast
 
 import torch
@@ -39,7 +40,10 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     maybe_download_model,
     verify_model_config_and_directory,
 )
-from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.logging_utils import (
+    init_logger,
+    suppress_torch_compile_noise,
+)
 
 logger = init_logger(__name__)
 
@@ -87,6 +91,7 @@ class ComposedPipelineBase(ABC):
         self.model_path: str = model_path
         self._stages: list[PipelineStage] = []
         self._stage_name_mapping: dict[str, PipelineStage] = {}
+        self._torch_compile_first_run_done = False
         self.executor = executor or self.build_executor(server_args=server_args)
 
         if required_config_modules is not None:
@@ -621,4 +626,14 @@ class ComposedPipelineBase(ABC):
                 main_process_only=True,
             )
 
-        return self.executor.execute_with_profiling(self.stages, batch, server_args)
+        should_suppress = (
+            server_args.enable_torch_compile
+            and not self._torch_compile_first_run_done
+        )
+        if should_suppress:
+            self._torch_compile_first_run_done = True
+
+        with suppress_torch_compile_noise() if should_suppress else nullcontext():
+            return self.executor.execute_with_profiling(
+                self.stages, batch, server_args
+            )

--- a/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
@@ -11,6 +11,7 @@ import logging
 import os
 import sys
 import time
+import warnings
 from contextlib import contextmanager
 from functools import lru_cache, partial
 from logging import Logger
@@ -393,6 +394,73 @@ def suppress_loggers(loggers_to_suppress: list[str], level: int = logging.WARNIN
     return original_levels
 
 
+def _should_suppress_torch_logs() -> bool:
+    """Return False if the user explicitly opted into torch compile verbosity."""
+    if os.environ.get("TORCH_LOGS"):
+        return False
+    if get_log_level() <= logging.DEBUG:
+        return False
+    return True
+
+
+@contextmanager
+def suppress_torch_compile_noise():
+    """Suppress noisy output from the first torch.compile forward pass.
+
+    Combines three layers of suppression:
+    1. Logger-level: silence torch._dynamo / torch._inductor / torch._functorch
+    2. warnings.filterwarnings: suppress Dynamo/Inductor UserWarnings
+    3. fd-level stdout *and* stderr redirect: catch bare ``print()`` calls
+       from inductor (e.g. ``final peak_memory=...`` on stdout) and
+       ``sys.stderr.write()`` from autotune (``Autotune Choices Stats`` on
+       stderr)
+
+    Respects user opt-in: if ``TORCH_LOGS`` is set or log level is DEBUG,
+    this context manager is a no-op.
+    """
+    if not _should_suppress_torch_logs():
+        yield
+        return
+
+    torch_logger_names = [
+        "torch._dynamo",
+        "torch._inductor",
+        "torch._functorch",
+    ]
+    saved_levels = suppress_loggers(torch_logger_names, level=logging.ERROR)
+
+    saved_filters = warnings.filters[:]
+    warnings.filterwarnings("ignore", category=UserWarning, module=r"torch\._dynamo.*")
+    warnings.filterwarnings(
+        "ignore", category=UserWarning, module=r"torch\._inductor.*"
+    )
+
+    stdout_fd = sys.stdout.fileno()
+    stderr_fd = sys.stderr.fileno()
+    stdout_dup = os.dup(stdout_fd)
+    stderr_dup = os.dup(stderr_fd)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(devnull_fd, stdout_fd)
+        os.dup2(devnull_fd, stderr_fd)
+        yield
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(stdout_dup, stdout_fd)
+        os.dup2(stderr_dup, stderr_fd)
+        os.close(stdout_dup)
+        os.close(stderr_dup)
+        os.close(devnull_fd)
+
+        warnings.filters[:] = saved_filters
+
+        for name, level in saved_levels.items():
+            logging.getLogger(name).setLevel(level)
+
+
 def globally_suppress_loggers():
     # globally suppress some obsessive loggers
     target_names = [
@@ -404,6 +472,15 @@ def globally_suppress_loggers():
         "filelock",
         "urllib3",
     ]
+
+    if _should_suppress_torch_logs():
+        target_names.extend(
+            [
+                "torch._dynamo",
+                "torch._inductor",
+                "torch._functorch",
+            ]
+        )
 
     for name in target_names:
         logging.getLogger(name).setLevel(logging.ERROR)


### PR DESCRIPTION
Fix https://github.com/sgl-project/sglang/issues/19734

## Before:

```
Loading required modules: 100%|██████████| 7/7 [00:22<00:00,  3.28s/it]
[03-03 10:37:57] Creating pipeline stages...
[03-03 10:37:57] Compiling transformer with mode: max-autotune-no-cudagraphs
[03-03 10:37:57] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[03-03 10:37:57] Pipeline instantiated
[03-03 10:37:57] Worker 0: Initialized device, model, and distributed environment.
[03-03 10:37:57] Worker 0: Scheduler loop started.
[03-03 10:37:57] Starting FastAPI server.
[2026-03-03 10:37:57] [32mINFO[0m:     Started server process [[36m3830105[0m]
[2026-03-03 10:37:57] [32mINFO[0m:     Waiting for application startup.
[03-03 10:37:57] ZMQ Broker is listening for offline jobs on tcp://*:30001
[2026-03-03 10:37:57] [32mINFO[0m:     Application startup complete.
[2026-03-03 10:37:57] [32mINFO[0m:     Uvicorn running on [1mhttp://127.0.0.1:30000[0m (Press CTRL+C to quit)
[03-03 10:38:34] HTTP Request: HEAD https://huggingface.co/zai-org/GLM-Image/resolve/main/model_index.json "HTTP/1.1 307 Temporary Redirect"
[03-03 10:38:34] HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-Image/2c433cc0cbc293bde2ac8ca9624f279b5d23fcf4/model_index.json "HTTP/1.1 200 OK"
[03-03 10:38:34] Running pipeline stages: ['glm_image_before_denoising_stage', 'denoising_stage', 'decoding_stage']
[03-03 10:38:34] [GlmImageBeforeDenoisingStage] started...
[03-03 10:39:01] generate_prior_tokens time: 27.10214400291443
[03-03 10:39:02] [GlmImageBeforeDenoisingStage] finished in 28.1987 seconds
[03-03 10:39:02] [DenoisingStage] started...

  0%|          | 0/30 [00:00<?, ?it/s]Autotune Choices Stats:
{"num_choices": 21, "num_triton_choices": 19, "best_kernel": "triton_mm_12", "best_kernel_desc": "ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=4", "best_time": 0.02038400061428547, "best_triton_pos": 0}
AUTOTUNE addmm(4096x4096, 4096x64, 64x4096)
strides: [0, 1], [64, 1], [1, 64]
dtypes: torch.bfloat16, torch.bfloat16, torch.bfloat16
  triton_mm_12 0.0204 ms 100.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=4
  triton_mm_11 0.0206 ms 99.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_18 0.0217 ms 93.8% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_8 0.0220 ms 92.5% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=4
  triton_mm_17 0.0223 ms 91.4% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_13 0.0224 ms 91.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_6 0.0225 ms 90.6% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=2, num_warps=4
  triton_mm_9 0.0226 ms 90.2% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_16 0.0226 ms 90.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_15 0.0232 ms 87.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=2, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 0.2397 seconds and 0.0378 seconds precompiling for 21 choices
Autotune Choices Stats:
{"num_choices": 19, "num_triton_choices": 17, "best_kernel": "bias_addmm", "best_time": 0.020864000543951988, "best_triton_pos": 1, "best_triton_time": 0.02127999998629093, "best_triton_kernel": "triton_mm_27", "best_triton_kernel_desc": "ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=16, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=4"}
AUTOTUNE addmm(1x4096, 1x4096, 4096x4096)
strides: [0, 1], [0, 1], [1, 4096]
dtypes: torch.bfloat16, torch.bfloat16, torch.bfloat16
  bias_addmm 0.0209 ms 100.0% 
  triton_mm_27 0.0213 ms 98.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=16, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=4
  addmm 0.0228 ms 91.7% 
  triton_mm_23 0.0237 ms 87.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=16, BLOCK_N=32, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=2
  triton_mm_31 0.0245 ms 85.2% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=16, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=4
  triton_mm_35 0.0279 ms 74.8% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=16, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_26 0.0369 ms 56.5% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=16, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_21 0.0387 ms 54.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=16, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=4
  triton_mm_30 0.0393 ms 53.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=16, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_20 0.0394 ms 53.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=16, BLOCK_N=32, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=2, num_warps=2
SingleProcess AUTOTUNE benchmarking takes 0.1977 seconds and 0.0037 seconds precompiling for 19 choices
/root/sglang-dev/python/.venv/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py:1598: UserWarning: Dynamo does not know how to trace the builtin `posix.lstat.` This function is either a Python builtin (e.g. _warnings.warn) or a third-party C/C++ Python extension (perhaps created with pybind).
If it is a Python builtin, please file an issue on GitHub so the PyTorch team can add support for it and see the next case for a workaround.
If it is a third-party C/C++ Python extension, please either wrap it into a PyTorch-understood custom operator (see https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html for more details) or, if it is traceable, use `torch.compiler.allow_in_graph`.
  torch._dynamo.utils.warn_once(explanation + "\n" + "\n".join(hints))
Autotune Choices Stats:
{"num_choices": 20, "num_triton_choices": 19, "best_kernel": "mm", "best_time": 0.17612800002098083, "best_triton_pos": 1, "best_triton_time": 0.1950719952583313, "best_triton_kernel": "triton_mm_53", "best_triton_kernel_desc": "ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4"}
AUTOTUNE mm(4096x4096, 4096x4096)
strides: [4096, 1], [1, 4096]
dtypes: torch.bfloat16, torch.bfloat16
  mm 0.1761 ms 100.0% 
  triton_mm_53 0.1951 ms 90.3% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_54 0.2138 ms 82.4% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_52 0.2366 ms 74.4% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_48 0.2551 ms 69.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=4
  triton_mm_47 0.2664 ms 66.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_45 0.3258 ms 54.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_46 0.3455 ms 51.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=8
  triton_mm_49 0.3457 ms 50.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_50 0.3515 ms 50.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 0.6882 seconds and 0.3378 seconds precompiling for 20 choices
/root/sglang-dev/python/.venv/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py:1692: UserWarning: Dynamo detected a call to a `functools.lru_cache`-wrapped function. Dynamo ignores the cache wrapper and directly traces the wrapped function. Silent incorrectness is only a *potential* risk, not something we have observed. Enable TORCH_LOGS="+dynamo" for a DEBUG stack trace.
  torch._dynamo.utils.warn_once(msg)
/root/sglang-dev/python/.venv/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py:1598: UserWarning: Dynamo does not know how to trace the builtin `<unknown module>.datetime.now.` This function is either a Python builtin (e.g. _warnings.warn) or a third-party C/C++ Python extension (perhaps created with pybind).
If it is a Python builtin, please file an issue on GitHub so the PyTorch team can add support for it and see the next case for a workaround.
If it is a third-party C/C++ Python extension, please either wrap it into a PyTorch-understood custom operator (see https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html for more details) or, if it is traceable, use `torch.compiler.allow_in_graph`.
  torch._dynamo.utils.warn_once(explanation + "\n" + "\n".join(hints))
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=33554432
final peak_memory=33554432
final peak_memory=33554432
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=24576
final peak_memory=24576
final peak_memory=24576
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
Autotune Choices Stats:
{"num_choices": 20, "num_triton_choices": 19, "best_kernel": "mm", "best_time": 0.6659200191497803, "best_triton_pos": 1, "best_triton_time": 0.7682880163192749, "best_triton_kernel": "triton_mm_110", "best_triton_kernel_desc": "ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4"}
AUTOTUNE mm(4096x16384, 16384x4096)
strides: [16384, 1], [1, 16384]
dtypes: torch.bfloat16, torch.bfloat16
  mm 0.6659 ms 100.0% 
  triton_mm_110 0.7683 ms 86.7% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_111 0.7843 ms 84.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_109 0.9183 ms 72.5% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_105 0.9186 ms 72.5% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=4
  triton_mm_104 1.1501 ms 57.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_102 1.3105 ms 50.8% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_106 1.3801 ms 48.3% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_103 1.4572 ms 45.7% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=8
  triton_mm_107 1.4656 ms 45.4% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 0.8519 seconds and 0.2630 seconds precompiling for 20 choices
Autotune Choices Stats:
{"num_choices": 20, "num_triton_choices": 19, "best_kernel": "mm", "best_time": 0.7091839909553528, "best_triton_pos": 1, "best_triton_time": 0.8140479922294617, "best_triton_kernel": "triton_mm_91", "best_triton_kernel_desc": "ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4"}
AUTOTUNE mm(4096x4096, 4096x16384)
strides: [4096, 1], [1, 4096]
dtypes: torch.bfloat16, torch.bfloat16
  mm 0.7092 ms 100.0% 
  triton_mm_91 0.8140 ms 87.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_92 0.8938 ms 79.3% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_90 0.9195 ms 77.1% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_86 1.0108 ms 70.2% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=4
  triton_mm_85 1.1542 ms 61.4% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_88 1.3737 ms 51.6% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=8
  triton_mm_83 1.4088 ms 50.3% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_87 1.4109 ms 50.3% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=3, num_warps=4
  triton_mm_84 1.4401 ms 49.2% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, USE_FAST_ACCUM=False, num_stages=4, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 0.8648 seconds and 0.0001 seconds precompiling for 20 choices

  3%|▎         | 1/30 [00:37<18:11, 37.64s/it]
  7%|▋         | 2/30 [00:37<07:17, 15.61s/it]
 10%|█         | 3/30 [00:38<03:51,  8.58s/it]
 13%|█▎        | 4/30 [00:38<02:17,  5.27s/it]
 17%|█▋        | 5/30 [00:38<01:26,  3.44s/it]
 20%|██        | 6/30 [00:38<00:56,  2.35s/it]
 23%|██▎       | 7/30 [00:38<00:37,  1.65s/it]
 27%|██▋       | 8/30 [00:39<00:26,  1.19s/it]
 30%|███       | 9/30 [00:39<00:18,  1.13it/s]
 33%|███▎      | 10/30 [00:39<00:13,  1.48it/s]
 37%|███▋      | 11/30 [00:39<00:10,  1.87it/s]
 40%|████      | 12/30 [00:39<00:07,  2.30it/s]
 43%|████▎     | 13/30 [00:40<00:06,  2.73it/s]
 47%|████▋     | 14/30 [00:40<00:05,  3.14it/s]
 50%|█████     | 15/30 [00:40<00:04,  3.48it/s]
 53%|█████▎    | 16/30 [00:40<00:03,  3.77it/s]
 57%|█████▋    | 17/30 [00:40<00:03,  4.05it/s]
 60%|██████    | 18/30 [00:41<00:02,  4.25it/s]
 63%|██████▎   | 19/30 [00:41<00:02,  4.39it/s]
 67%|██████▋   | 20/30 [00:41<00:02,  4.47it/s]
 70%|███████   | 21/30 [00:41<00:01,  4.55it/s]
 73%|███████▎  | 22/30 [00:42<00:01,  4.62it/s]
 77%|███████▋  | 23/30 [00:42<00:01,  4.67it/s]
 80%|████████  | 24/30 [00:42<00:01,  4.69it/s]
 83%|████████▎ | 25/30 [00:42<00:01,  4.69it/s]
 87%|████████▋ | 26/30 [00:42<00:00,  4.69it/s]
 90%|█████████ | 27/30 [00:43<00:00,  4.73it/s]
 93%|█████████▎| 28/30 [00:43<00:00,  4.76it/s]
 97%|█████████▋| 29/30 [00:43<00:00,  4.75it/s]
100%|██████████| 30/30 [00:43<00:00,  4.72it/s]
100%|██████████| 30/30 [00:43<00:00,  1.46s/it]
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=268525568
final peak_memory=268525568
final peak_memory=268525568
final peak_memory=24576
final peak_memory=24576
final peak_memory=24576
final peak_memory=268525568
final peak_memory=268525568
final peak_memory=268525568
final peak_memory=65536
final peak_memory=65536
final peak_memory=65536
final peak_memory=33554432
final peak_memory=33554432
final peak_memory=33554432
[03-03 10:39:46] [DenoisingStage] average time per step: 1.4573 seconds
[03-03 10:39:46] [DenoisingStage] finished in 43.7280 seconds
[03-03 10:39:46] [DecodingStage] started...
[03-03 10:39:46] [DecodingStage] finished in 0.3671 seconds
[03-03 10:39:46] Peak GPU memory: 41.14 GB, Peak allocated: 37.33 GB, Memory pool overhead: 3.81 GB (9.3%), Remaining GPU memory at peak: 99.26 GB. Components that could stay resident (based on the last request workload): ['text_encoder', 'transformer']. Related offload server args to disable: --dit-cpu-offload, --text-encoder-cpu-offload
[03-03 10:39:46] Output saved to [1;36moutputs/c7055bc9-328f-4899-ab70-999921245a71.jpg[0;0m
[03-03 10:39:46] Pixel data generated successfully in [92m72.34[0;0m seconds
[03-03 10:39:46] Completed batch processing. Generated 1 outputs in [92m72.34[0;0m seconds
[03-03 10:39:46] Peak memory usage: 42124.00 MB
[2026-03-03 10:39:46] [32mINFO[0m:     127.0.0.1:45572 - "[1mPOST /v1/images/generations HTTP/1.1[0m" [32m200 OK[0m
```

## After

```
Loading required modules: 100%|██████████| 7/7 [00:17<00:00,  2.50s/it]
[03-03 11:18:53] Creating pipeline stages...
[03-03 11:18:53] Compiling transformer with mode: max-autotune-no-cudagraphs
[03-03 11:18:53] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[03-03 11:18:53] Pipeline instantiated
[03-03 11:18:53] Worker 0: Initialized device, model, and distributed environment.
[03-03 11:18:53] Worker 0: Scheduler loop started.
[03-03 11:18:53] Starting FastAPI server.
[2026-03-03 11:18:53] [32mINFO[0m:     Started server process [[36m3912631[0m]
[2026-03-03 11:18:53] [32mINFO[0m:     Waiting for application startup.
[03-03 11:18:53] ZMQ Broker is listening for offline jobs on tcp://*:30001
[2026-03-03 11:18:53] [32mINFO[0m:     Application startup complete.
[2026-03-03 11:18:53] [32mINFO[0m:     Uvicorn running on [1mhttp://127.0.0.1:30000[0m (Press CTRL+C to quit)
[03-03 11:19:24] HTTP Request: HEAD https://huggingface.co/zai-org/GLM-Image/resolve/main/model_index.json "HTTP/1.1 307 Temporary Redirect"
[03-03 11:19:24] HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-Image/2c433cc0cbc293bde2ac8ca9624f279b5d23fcf4/model_index.json "HTTP/1.1 200 OK"
[03-03 11:19:24] Running pipeline stages: ['glm_image_before_denoising_stage', 'denoising_stage', 'decoding_stage']
[03-03 11:20:38] Peak GPU memory: 41.18 GB, Peak allocated: 37.65 GB, Memory pool overhead: 3.52 GB (8.6%), Remaining GPU memory at peak: 99.22 GB. Components that could stay resident (based on the last request workload): ['text_encoder', 'transformer']. Related offload server args to disable: --dit-cpu-offload, --text-encoder-cpu-offload
[03-03 11:20:38] Output saved to [1;36moutputs/8e60b534-bd89-40b7-b65b-83f353e5dada.jpg[0;0m
[03-03 11:20:38] Pixel data generated successfully in [92m74.59[0;0m seconds
[03-03 11:20:38] Completed batch processing. Generated 1 outputs in [92m74.59[0;0m seconds
[03-03 11:20:38] Peak memory usage: 42166.00 MB
[2026-03-03 11:20:38] [32mINFO[0m:     127.0.0.1:52316 - "[1mPOST /v1/images/generations HTTP/1.1[0m" [32m200 OK[0m
[03-03 11:20:47] Running pipeline stages: ['glm_image_before_denoising_stage', 'denoising_stage', 'decoding_stage']
[03-03 11:20:47] [GlmImageBeforeDenoisingStage] started...
[03-03 11:21:14] generate_prior_tokens time: 26.93856930732727
[03-03 11:21:14] [GlmImageBeforeDenoisingStage] finished in 26.9930 seconds
[03-03 11:21:14] [DenoisingStage] started...
```

## How to reproduce

```
rm -rf /tmp/torchinductor_root/

sglang serve --model-path zai-org/GLM-Image --enable-torch-compile

curl -sS -X POST "http://localhost:30000/v1/images/generations" \ 
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "A calico cat playing a piano on stage",
    "size": "1024x1024",
    "n": 1,
    "response_format": "b64_json"
  }'
```