### PR TITLE
support logprobs for spec v2

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -407,6 +407,8 @@ class SchedulerOutputProcessorMixin:
             result.next_token_ids,
             result.can_run_cuda_graph,
         )
+        next_token_logprobs = None
+        spec_v2_logprob_pt = 0
 
         if batch.spec_algorithm.is_none():
             next_token_ids = next_token_ids.tolist()
@@ -414,6 +416,12 @@ class SchedulerOutputProcessorMixin:
                 next_token_logprobs = logits_output.next_token_logprobs.tolist()
         elif batch.is_spec_v2:
             next_token_ids = self._resolve_spec_overlap_token_ids(result, batch)
+            if (
+                batch.return_logprob
+                and logits_output is not None
+                and logits_output.next_token_logprobs is not None
+            ):
+                next_token_logprobs = logits_output.next_token_logprobs.tolist()
 
         self.num_generated_tokens += len(batch.reqs)
         if not batch.spec_algorithm.is_none():
@@ -429,6 +437,12 @@ class SchedulerOutputProcessorMixin:
         # Check finish condition
         for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
             req: Req
+            if batch.is_spec_v2 and next_token_logprobs is not None:
+                spec_v2_start = spec_v2_logprob_pt
+                spec_v2_logprob_pt += len(next_token_id)
+                spec_v2_end = spec_v2_logprob_pt
+            else:
+                spec_v2_start = spec_v2_end = None
 
             if self.enable_overlap and (req.finished() or req.is_retracted):
                 # NOTE: This (req.finished() or req.is_retracted) should only happen when overlap scheduling is enabled.
@@ -489,6 +503,30 @@ class SchedulerOutputProcessorMixin:
                     )
                     req.output_token_ids_logprobs_idx.append(
                         logits_output.next_token_token_ids_logprobs_idx[i]
+                    )
+            elif (
+                req.return_logprob
+                and batch.is_spec_v2
+                and spec_v2_start is not None
+                and spec_v2_end is not None
+            ):
+                req.output_token_logprobs_val.extend(
+                    next_token_logprobs[spec_v2_start:spec_v2_end]
+                )
+                req.output_token_logprobs_idx.extend(next_token_id)
+                if (
+                    req.top_logprobs_num > 0
+                    and logits_output.next_token_top_logprobs_val is not None
+                ):
+                    req.output_top_logprobs_val.extend(
+                        logits_output.next_token_top_logprobs_val[
+                            spec_v2_start:spec_v2_end
+                        ]
+                    )
+                    req.output_top_logprobs_idx.extend(
+                        logits_output.next_token_top_logprobs_idx[
+                            spec_v2_start:spec_v2_end
+                        ]
                     )
 
             if req.return_hidden_states and logits_output.hidden_states is not None:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_a2a_backend_context,
     speculative_moe_backend_context,
 )
+from sglang.srt.layers.utils.logprob import get_top_logprobs
 from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -498,6 +499,9 @@ class EagleDraftWorker(BaseDraftWorker):
 
         # Run forward
         forward_batch = ForwardBatch.init_new(batch, self.draft_runner)
+        # Spec v2 logprobs are computed in verify(); draft prefill should not
+        # request logits-processor logprobs
+        forward_batch.return_logprob = False
         logits_output = self.draft_runner.forward(forward_batch).logits_output
 
         # Update spec_info for the next draft step
@@ -533,6 +537,8 @@ class EagleDraftWorker(BaseDraftWorker):
                 self.draft_runner,
                 self.cuda_graph_runner_for_draft_extend,
             )
+        # Keep logprob computation in verify(); draft-extend is KV maintenance
+        forward_batch.return_logprob = False
 
         if self.plan_stream:
             torch.get_device_module(self.device).current_stream().wait_stream(
@@ -784,6 +790,44 @@ class EAGLEWorkerV2(BaseSpecWorker):
             accept_length,
             accept_index,
         ) = verify_input.sample(batch, logits_output, vocab_mask)
+        if batch.return_logprob:
+            accepted_indices = accept_index[accept_index != -1].to(torch.int64)
+            accepted_logits = logits_output.next_token_logits[accepted_indices]
+            if envs.SGLANG_RETURN_ORIGINAL_LOGPROB.get():
+                logprobs = torch.nn.functional.log_softmax(accepted_logits, dim=-1)
+            else:
+                temperatures = batch.sampling_info.temperatures[
+                    accepted_indices // verify_input.draft_token_num
+                ]
+                logprobs = torch.nn.functional.log_softmax(
+                    accepted_logits / temperatures, dim=-1
+                )
+
+            accepted_token_ids = predict[accepted_indices].to(torch.int64)
+            logits_output.next_token_logprobs = logprobs[
+                torch.arange(
+                    accepted_token_ids.shape[0], device=accepted_token_ids.device
+                ),
+                accepted_token_ids,
+            ]
+
+            if any(x > 0 for x in batch.top_logprobs_nums):
+                top_logprobs_nums_repeat_interleaved = [
+                    num
+                    for num, num_tokens in zip(
+                        batch.top_logprobs_nums,
+                        accept_length.tolist(),
+                        strict=True,
+                    )
+                    for _ in range(num_tokens)
+                ]
+                (
+                    logits_output.next_token_top_logprobs_val,
+                    logits_output.next_token_top_logprobs_idx,
+                ) = get_top_logprobs(logprobs, top_logprobs_nums_repeat_interleaved)
+            else:
+                logits_output.next_token_top_logprobs_val = None
+                logits_output.next_token_top_logprobs_idx = None
         new_seq_lens = batch.seq_lens + accept_length
 
         # Update mamba state for hybrid GDN models after verification

--- a/test/registered/spec/eagle/test_eagle_infer_beta.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta.py
@@ -1,6 +1,8 @@
 import unittest
 from types import SimpleNamespace
 
+import requests
+
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -91,6 +93,35 @@ class TestEagleServerBase(CustomTestCase, MatchedStopMixin):
             metrics["accuracy"], 0.23
         )  # 0.3333 for 60 questions; 0.234 for 1319 questions
         assert self.process.poll() is None
+
+    def test_openai_completion_logprobs(self):
+        max_tokens = 8
+        response = requests.post(
+            self.base_url + "/v1/completions",
+            json={
+                "model": self.model,
+                "prompt": "The capital city of France is",
+                "max_tokens": max_tokens,
+                "temperature": 0,
+                "logprobs": 1,
+            },
+        )
+        self.assertEqual(response.status_code, 200, msg=response.text)
+
+        response_json = response.json()
+        self.assertIn("choices", response_json)
+        self.assertGreater(len(response_json["choices"]), 0)
+
+        logprobs = response_json["choices"][0]["logprobs"]
+        self.assertEqual(len(logprobs["token_logprobs"]), len(logprobs["tokens"]))
+        self.assertEqual(len(logprobs["top_logprobs"]), len(logprobs["tokens"]))
+        self.assertGreater(len(logprobs["token_logprobs"]), 0)
+
+        usage = response_json.get("usage")
+        if usage is not None:
+            self.assertEqual(
+                len(logprobs["token_logprobs"]), usage["completion_tokens"]
+            )
 
 
 class TestEagleServerPage(TestEagleServerBase):


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->   This PR implements overlap-safe logprob support for spec v2 (EAGLE) by following the forward/scheduler split.

 Spec v2 did not compute output logprobs in eagle_worker_v2.verify() and the scheduler decode output path did not collect spec-v2 flattened logprob payload per request. This caused logprob failures for spec v2 requests. #19761 #17349

## Modifications

<!-- Detail the changes made in this pull request. -->
  1. In eagle_worker_v2.verify(), after sample() returns predict/accept_length/accept_index, compute accepted-token logprobs on GPU using log_softmax and accepted-index gather, then populate:
 
  - logits_output.next_token_logprobs
  - logits_output.next_token_top_logprobs_val
  - logits_output.next_token_top_logprobs_idx
 
  2. In scheduler decode output processing (process_batch_result_decode), add spec-v2 logprob collection from CPU-copied logits output using a per-request pointer over flattened accepted-token outputs.
  3. Ensure draft prefill and draft-extend paths do not request logits-processor logprob computation; spec-v2 returned logprobs are produced in verify as designed.
  4. Add test coverage for OpenAI completions logprobs in spec-v2 EAGLE test suite.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
