### PR TITLE
[FIX] [Qwen3.5] Fix NPU out of memory when deploying Qwen3.5 122B on A2(910B3)

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, List
 
 import torch
 import torch_npu
@@ -26,6 +26,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         head_dim: int,
         layer_num: int,
         device: str,
+        full_attention_layer_ids: List[int],
         enable_memory_saver: bool,
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
@@ -33,6 +34,9 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         enable_kv_cache_copy: bool = False,
     ):
         self.use_fia = get_bool_env_var("ASCEND_USE_FIA", "False")
+        self.full_attention_layer_id_mapping = {
+            id: i for i, id in enumerate(full_attention_layer_ids)
+        }
         super().__init__(
             size=size,
             page_size=page_size,
@@ -109,6 +113,13 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         ]
         return kv_data_ptrs, kv_data_lens, kv_item_lens
 
+    def _transfer_full_attention_id(self, layer_id: int):
+        if layer_id not in self.full_attention_layer_id_mapping:
+            raise ValueError(
+                f"{layer_id=} not in full attention layers: {self.full_attention_layer_id_mapping.keys()}"
+            )
+        return self.full_attention_layer_id_mapping[layer_id]
+
     def set_kv_buffer(
         self,
         layer: "RadixAttention",
@@ -123,6 +134,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
             layer_id = layer_id_override
         else:
             layer_id = layer.layer_id
+        layer_id = self._transfer_full_attention_id(layer_id)
         if cache_k.dtype != self.dtype:
             if k_scale is not None:
                 cache_k.div_(k_scale)
@@ -163,6 +175,17 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
                 slot_indices=loc,
             )
 
+    def get_kv_buffer(self, layer_id: int):
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return super().get_kv_buffer(layer_id)
+
+    def get_key_buffer(self, layer_id: int):
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return super().get_key_buffer(layer_id)
+
+    def get_value_buffer(self, layer_id: int):
+        layer_id = self._transfer_full_attention_id(layer_id)
+        return super().get_value_buffer(layer_id)
 
 class NPUMLATokenToKVPool(MLATokenToKVPool):
 

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -519,7 +519,16 @@ class ModelRunnerKVCacheMixin:
                         get_attention_tp_size()
                     ),
                     head_dim=self.model_config.head_dim,
-                    layer_num=self.num_effective_layers,
+                    full_attention_layer_ids=(
+                        [0]
+                        if self.is_draft_worker
+                        else [
+                            i
+                            for i in self.mambaish_config.full_attention_layer_ids
+                            if self.start_layer <= i < self.end_layer
+                        ]
+                    ),
+                    layer_num=len(self.mambaish_config.full_attention_layer_ids),
                     device=self.device,
                     enable_memory_saver=self.server_args.enable_memory_saver,
                     start_layer=self.start_layer,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When I deployed Qwen3.5-122b on A2(910B3) following the example,
https://github.com/sgl-project/sglang/blob/c6377bbbca276c0e8f63d0d978c69ceb095aa10a/docs/platforms/ascend_npu_qwen3_5_examples.md?plain=1#L95
I encountered NPU out of memory, because the linear attention layer also invoking the set_kv_buffer method.
https://github.com/sgl-project/sglang/blob/c6377bbbca276c0e8f63d0d978c69ceb095aa10a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py#L112

## error message

[2026-03-03 03:53:36 TP2] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 2; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.84 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
[2026-03-03 03:53:36 TP3] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 3; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.85 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
[2026-03-03 03:53:36 TP7] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 7; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.85 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
[2026-03-03 03:53:36 TP5] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 5; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.86 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
[2026-03-03 03:53:36 TP4] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 4; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.85 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
[2026-03-03 03:53:36 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 0; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.81 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py:3191: ResourceWarning: Unclosed socket <zmq.Socket(zmq.PULL) at 0xfffa4b464910>
  parent_process.send_signal(signal.SIGQUIT)
[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py:3191: ResourceWarning: Unclosed socket <zmq.Socket(zmq.DEALER) at 0xfffa4b2a6e40>
  parent_process.send_signal(signal.SIGQUIT)
/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py:3191: ResourceWarning: Unclosed socket <zmq.Socket(zmq.PUSH) at 0xfffa4b2a54e0>
  parent_process.send_signal(signal.SIGQUIT)
/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py:3191: ResourceWarning: Unclosed socket <zmq.Socket(zmq.PUSH) at 0xfffa4b2a44b0>
  parent_process.send_signal(signal.SIGQUIT)
/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py:3191: ResourceWarning: Unclosed socket <zmq.Socket(zmq.PUSH) at 0xfffa4b2a7bd0>
  parent_process.send_signal(signal.SIGQUIT)
/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py:3191: ResourceWarning: Unclosed context <zmq.Context() at 0xfffa4b267050>
  parent_process.send_signal(signal.SIGQUIT)
[2026-03-03 03:53:36 TP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 3130, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 368, in __init__
    self.init_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 564, in init_model_worker
    self.init_tp_model_worker()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 522, in init_tp_model_worker
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 247, in __init__
    self._init_model_runner()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 330, in _init_model_runner
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 413, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 590, in initialize
    self.init_memory_pool(min_per_gpu_memory)
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner_kv_cache_mixin.py", line 512, in init_memory_pool
    self.token_to_kv_pool = NPUMHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 36, in __init__
    super().__init__(
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/mem_cache/memory_pool.py", line 736, in __init__
    self._create_buffers()
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/sglang/srt/hardware_backend/npu/memory_pool_npu.py", line 57, in _create_buffers
    self.kv_buffer = torch.zeros(
                     ^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch_npu/contrib/transfer_to_npu.py", line 182, in decorated
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: NPU out of memory. Tried to allocate 52.99 GiB (NPU 1; 60.96 GiB total capacity; 41.16 GiB already allocated; 41.16 GiB current active; 18.84 GiB free; 41.73 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.

[2026-03-03 03:53:36] Received sigquit from a child process. It usually means the child failed.
Killed


## Reproduction
version: sglang 0.5.9

export SGLANG_SET_CPU_AFFINITY=1
unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
unset ASCEND_LAUNCH_BLOCKING
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh
export STREAMS_PER_DEVICE=32
export HCCL_BUFFSIZE=1000
export HCCL_OP_EXPANSION_MODE=AIV
export HCCL_SOCKET_IFNAME=lo
export GLOO_SOCKET_IFNAME=lo
python3 -m sglang.launch_server \
        --model-path qwen3p5-122b \
        --attention-backend ascend \
        --device npu \
        --tp-size 8 --nnodes 1 --node-rank 0 \
        --chunked-prefill-size 4096 --max-prefill-tokens 192000 \
        --disable-radix-cache \
        --trust-remote-code \
        --served-model-name qwen3p5-122b \
        --host 0.0.0.0 \
        --mem-fraction-static 0.9 \
        --port 8080 \
        --cuda-graph-bs 16 \
        --enable-multimodal \
        --mm-attention-backend ascend_attn \
        --context-length 192000 \
        --dtype bfloat16

## Modifications
Only full attn layers can set kv buffer



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
