### PR TITLE
[Feature] Optimizations for class Qwen3VLMoeVisionModel (Conv3d to Linear) in Qwen3VL

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -147,20 +147,26 @@ class Qwen3VLVisionPatchEmbed(nn.Module):
             stride=kernel_size,
             bias=True,
         )
+        k = self.in_channels * self.temporal_patch_size * self.patch_size**2
+        self.linear = nn.Linear(
+            in_features=k,
+            out_features=self.embed_dim,
+            bias=True,
+            dtype=self.proj.weight.dtype,
+        )
+
+    def copy_conv3d_weight_to_linear(self):
+        # Call this after weight loading
+        with torch.no_grad():
+            self.linear.weight.copy_(self.proj.weight.view(self.embed_dim, -1))
+            self.linear.bias.copy_(self.proj.bias)
+        del self.proj
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        target_dtype = self.proj.weight.dtype
-        hidden_states = hidden_states.view(
-            -1,
-            self.in_channels,
-            self.temporal_patch_size,
-            self.patch_size,
-            self.patch_size,
-        )
-        hidden_states = self.proj(hidden_states.to(dtype=target_dtype)).view(
-            -1, self.embed_dim
-        )
-        return hidden_states
+        # After copy_conv3d_weight_to_linear(), self.linear exists and
+        # self.proj has been deleted.  Input x is already 2-D:
+        #   (num_patches, C * T * P * P)
+        return self.linear(hidden_states)
 
 
 class Qwen3_VisionBlock(nn.Module):
@@ -407,10 +413,16 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
     @property
     def dtype(self) -> torch.dtype:
+        # After Conv3d to Linear conversion, self.proj is deleted and
+        # self.linear takes its place.
+        if hasattr(self.patch_embed, "linear"):
+            return self.patch_embed.linear.weight.dtype
         return self.patch_embed.proj.weight.dtype
 
     @property
     def device(self) -> torch.device:
+        if hasattr(self.patch_embed, "linear"):
+            return self.patch_embed.linear.weight.device
         return self.patch_embed.proj.weight.device
 
     def rot_pos_emb(
@@ -911,6 +923,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
         return loaded_params
 
     def _prepare_graph_inputs(self, x: torch.Tensor, grid_thw: torch.Tensor) -> tuple[
@@ -1424,6 +1437,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+        self.visual.patch_embed.copy_conv3d_weight_to_linear()
 
 
 EntryClass = Qwen3VLForConditionalGeneration

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -355,6 +355,8 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
                     else:
                         logger.warning(f"Parameter {name} not found in params_dict")
 
+        self.visual.patch_embed.copy_conv3d_weight_to_linear()
+
         # TODO mimic deepseek
         # Lazy initialization of expert weights cache to avoid slowing down load_weights
         # if not hasattr(self, "routed_experts_weights_of_layer"):

--- a/test/registered/vlm/test_qwen3vl_conv3d_to_linear.py
+++ b/test/registered/vlm/test_qwen3vl_conv3d_to_linear.py
@@ -1,0 +1,127 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang.srt.configs.qwen3_vl import Qwen3VLConfig
+from sglang.srt.distributed.parallel_state import (
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.layers.dp_attention import initialize_dp_attention
+from sglang.srt.layers.quantization.unquant import (
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from sglang.srt.models.qwen3_vl import Qwen3VLMoeVisionModel
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, suite="stage-b-test-large-1-gpu")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_default_device_npu():
+    prev_device = torch.get_default_device()
+    torch.set_default_device("npu")
+    try:
+        yield
+    finally:
+        torch.set_default_device(prev_device)
+
+
+def _build_model():
+    server_args = ServerArgs(model_path="dummy", device="npu")
+    model_config = Qwen3VLConfig(
+        hidden_size=64,
+        num_heads=1,
+        num_position_embeddings=2304,
+        patch_size=16,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        deepstack_visual_indexes=[5, 11, 17],
+        in_channels=3,
+        depth=24,
+        intermediate_size=256,
+        hidden_act="gelu_pytorch_tanh",
+        out_hidden_size=2560,
+    )
+    set_global_server_args_for_scheduler(server_args)
+    init_distributed_environment(
+        backend="gloo",
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method="tcp://127.0.0.1:2646",
+    )
+    initialize_model_parallel()
+    initialize_dp_attention(
+        server_args=server_args,
+        model_config=model_config,
+    )
+    model = Qwen3VLMoeVisionModel(
+        model_config,
+        quant_config=None,
+        norm_eps=1e-6,
+        prefix="visual",
+    )
+    return model, model_config
+
+
+def test_conv3d_to_linear():
+    assert issubclass(UnquantizedLinearMethod, LinearMethodBase)
+
+    model, model_config = _build_model()
+
+    batch_size = 8
+    in_channels = model_config.in_channels
+    temporal_patch_size = model_config.temporal_patch_size
+    patch_size = model_config.patch_size
+    embed_dim = model_config.hidden_size
+    kernel_size = [temporal_patch_size, patch_size, patch_size]
+    flat_patch_dim = in_channels * temporal_patch_size * patch_size**2
+
+    input_data = torch.randn(
+        batch_size,
+        flat_patch_dim,
+        device=model.patch_embed.linear.weight.device,
+        dtype=model.patch_embed.linear.weight.dtype,
+    )
+
+    with torch.inference_mode():
+        linear_output = model.patch_embed(input_data)
+
+        conv3d = nn.Conv3d(
+            in_channels,
+            embed_dim,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+            device=model.patch_embed.linear.weight.device,
+            dtype=model.patch_embed.linear.weight.dtype,
+        )
+        conv3d.weight.copy_(
+            model.patch_embed.linear.weight.view(
+                embed_dim,
+                in_channels,
+                temporal_patch_size,
+                patch_size,
+                patch_size,
+            )
+        )
+        conv3d.bias.copy_(model.patch_embed.linear.bias)
+
+        input_5d = input_data.view(
+            batch_size,
+            in_channels,
+            temporal_patch_size,
+            patch_size,
+            patch_size,
+        )
+        conv3d_output = conv3d(input_5d).view(batch_size, embed_dim)
+
+    torch.testing.assert_close(
+        linear_output,
+        conv3d_output,
+        atol=1e-4,
+        rtol=1e-4,
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

+ This PR is part of (https://github.com/sgl-project/sglang/issues/18784 and https://github.com/sgl-project/sglang/pull/18559). Corresponding information and performance data is also there.

## Modifications

+ Use `Linear` rather than `Conv3d` to compute the `Qwen3VLVisionPatchEmbed`.
+ Add unit test `test/srt/test_conv3d_to_linear_unittest.py` to ensure the replacement is equivalent.

## Accuracy Tests

1. By unit test `test/srt/test_conv3d_to_linear_unittest.py`.

2. `lm-eval` shows no drop between main branch and this PR, which get the same score:

+ Command:
```bash
lm-eval run --model sglang --model_args pretrained=/workspace/Qwen3-VL-8B-Instruct,dtype=auto,tp_size=1 --tasks gpqa_diamond_zeroshot gpqa_extended_zeroshot gpqa_main_zeroshot gpqa_diamond_n_shot gpqa_extended_n_shot gpqa_main_n_shot
```

+ **before this optimization (main branch baseline)**

| Tasks                  | Version | Filter | n-shot | Metric   |     |  Value |     | Stderr |
| ---------------------- | ------: | ------ | -----: | -------- | --- | -----: | --- | -----: |
| gpqa_diamond_n_shot    |       2 | none   |      0 | acc      | ↑   | 0.3687 | ±   | 0.0344 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3687 | ±   | 0.0344 |
| gpqa_diamond_zeroshot  |       1 | none   |      0 | acc      | ↑   | 0.3788 | ±   | 0.0346 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3788 | ±   | 0.0346 |
| gpqa_extended_n_shot   |       2 | none   |      0 | acc      | ↑   | 0.3791 | ±   | 0.0208 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3791 | ±   | 0.0208 |
| gpqa_extended_zeroshot |       1 | none   |      0 | acc      | ↑   | 0.3773 | ±   | 0.0208 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3773 | ±   | 0.0208 |
| gpqa_main_n_shot       |       2 | none   |      0 | acc      | ↑   | 0.3862 | ±   | 0.0230 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3862 | ±   | 0.0230 |
| gpqa_main_zeroshot     |       1 | none   |      0 | acc      | ↑   | 0.4085 | ±   | 0.0232 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.4085 | ±   | 0.0232 |

+ **After the optimization (this PR)**

| Tasks                  | Version | Filter | n-shot | Metric   |     |  Value |     | Stderr |
| ---------------------- | ------: | ------ | -----: | -------- | --- | -----: | --- | -----: |
| gpqa_diamond_n_shot    |       2 | none   |      0 | acc      | ↑   | 0.3687 | ±   | 0.0344 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3687 | ±   | 0.0344 |
| gpqa_diamond_zeroshot  |       1 | none   |      0 | acc      | ↑   | 0.3788 | ±   | 0.0346 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3788 | ±   | 0.0346 |
| gpqa_extended_n_shot   |       2 | none   |      0 | acc      | ↑   | 0.3791 | ±   | 0.0208 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3791 | ±   | 0.0208 |
| gpqa_extended_zeroshot |       1 | none   |      0 | acc      | ↑   | 0.3773 | ±   | 0.0208 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3773 | ±   | 0.0208 |
| gpqa_main_n_shot       |       2 | none   |      0 | acc      | ↑   | 0.3862 | ±   | 0.0230 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.3862 | ±   | 0.0230 |
| gpqa_main_zeroshot     |       1 | none   |      0 | acc      | ↑   | 0.4085 | ±   | 0.0232 |
|                        |         | none   |      0 | acc_norm | ↑   | 0.4085 | ±   | 0.0232 |

+ `lmms_eval` shows no drop between main branch and this PR, which get the similar score:

+ Command:
```bash
python3 -m lmms_eval --model sglang --model_args model_path=/workspace/Qwen3-VL-8B-Instruct --tasks mmmu_val
```

+ **Before this optimization (main branch baseline)**

```
{'Overall-Art and Design': {'num': 120, 'acc': 0.68333}, 'Art': {'num': 30, 'acc': 0.66667}, 'Art_Theory': {'num': 30, 'acc': 0.9}, 'Design': {'num': 30, 'acc': 0.73333}, 'Music': {'num': 30, 'acc': 0.43333}, 'Overall-Business': {'num': 150, 'acc': 0.40667}, 'Accounting': {'num': 30, 'acc': 0.3}, 'Economics': {'num': 30, 'acc': 0.5}, 'Finance': {'num': 30, 'acc': 0.26667}, 'Manage': {'num': 30, 'acc': 0.5}, 'Marketing': {'num': 30, 'acc': 0.46667}, 'Overall-Science': {'num': 150, 'acc': 0.45333}, 'Biology': {'num': 30, 'acc': 0.53333}, 'Chemistry': {'num': 30, 'acc': 0.36667}, 'Geography': {'num': 30, 'acc': 0.53333}, 'Math': {'num': 30, 'acc': 0.3}, 'Physics': {'num': 30, 'acc': 0.53333}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.53333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.66667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.66667}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.36667}, 'Pharmacy': {'num': 30, 'acc': 0.5}, 'Public_Health': {'num': 30, 'acc': 0.46667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.675}, 'History': {'num': 30, 'acc': 0.6}, 'Literature': {'num': 30, 'acc': 0.83333}, 'Sociology': {'num': 30, 'acc': 0.63333}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.38095}, 'Agriculture': {'num': 30, 'acc': 0.53333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.3}, 'Computer_Science': {'num': 30, 'acc': 0.5}, 'Electronics': {'num': 30, 'acc': 0.3}, 'Energy_and_Power': {'num': 30, 'acc': 0.3}, 'Materials': {'num': 30, 'acc': 0.4}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.33333}, 'Overall': {'num': 900, 'acc': 0.50222}}
2026-03-16T05:00:15.655750+0000 | save_results_aggregated | INFO - Output path not provided, skipping saving results aggregated
sglang (model_path=/workspace/Qwen3-VL-8B-Instruct), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 1

LMMs-Eval: Probing Intelligence in the Real World
> The unified evaluation toolkit for frontier models.

branch: main
commit: v0.6-72-g88b23e2b

| Tasks  |Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------|-----:|--------|---|-----:|---|------|
|mmmu_val|none  |     0|mmmu_acc|↑  |0.5022|±  |N/A   |
```

+ **After this optimization (this PR)**

```
{'Overall-Art and Design': {'num': 120, 'acc': 0.68333}, 'Art': {'num': 30, 'acc': 0.66667}, 'Art_Theory': {'num': 30, 'acc': 0.9}, 'Design': {'num': 30, 'acc': 0.73333}, 'Music': {'num': 30, 'acc': 0.43333}, 'Overall-Business': {'num': 150, 'acc': 0.40667}, 'Accounting': {'num': 30, 'acc': 0.3}, 'Economics': {'num': 30, 'acc': 0.5}, 'Finance': {'num': 30, 'acc': 0.26667}, 'Manage': {'num': 30, 'acc': 0.5}, 'Marketing': {'num': 30, 'acc': 0.46667}, 'Overall-Science': {'num': 150, 'acc': 0.45333}, 'Biology': {'num': 30, 'acc': 0.53333}, 'Chemistry': {'num': 30, 'acc': 0.36667}, 'Geography': {'num': 30, 'acc': 0.53333}, 'Math': {'num': 30, 'acc': 0.3}, 'Physics': {'num': 30, 'acc': 0.53333}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.53333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.66667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.66667}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.36667}, 'Pharmacy': {'num': 30, 'acc': 0.5}, 'Public_Health': {'num': 30, 'acc': 0.46667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.675}, 'History': {'num': 30, 'acc': 0.6}, 'Literature': {'num': 30, 'acc': 0.83333}, 'Sociology': {'num': 30, 'acc': 0.63333}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.38095}, 'Agriculture': {'num': 30, 'acc': 0.53333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.3}, 'Computer_Science': {'num': 30, 'acc': 0.5}, 'Electronics': {'num': 30, 'acc': 0.3}, 'Energy_and_Power': {'num': 30, 'acc': 0.3}, 'Materials': {'num': 30, 'acc': 0.4}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.33333}, 'Overall': {'num': 900, 'acc': 0.50222}}
2026-03-16T05:11:01.956747+0000 | save_results_aggregated | INFO - Output path not provided, skipping saving results aggregated
sglang (model_path=/workspace/Qwen3-VL-8B-Instruct), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 1

LMMs-Eval: Probing Intelligence in the Real World
> The unified evaluation toolkit for frontier models.

branch: main
commit: v0.6-72-g88b23e2b

| Tasks  |Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------|-----:|--------|---|-----:|---|------|
|mmmu_val|none  |     0|mmmu_acc|↑  |0.5022|±  |N/A   |
```

## Benchmarking and Profiling

+ Part of the performance data is in the original issue, here we file more detailed data.
+ We use H100 GPU to run Qwen3-VL-8B model (the larger the model is, the more significant the performance improvement earns), sending requests with one JPEG image of different resolution
+ Add code below (in `forward()` of `class Qwen3VLMoeVisionModel`) to count the time.

```Python
        # original code
        x = x.to(device=self.device, dtype=self.dtype)

        # timming code
        for _ in range(10):
            y = self.patch_embed(x)
        patch_embed_start = torch.cuda.Event(enable_timing=True)
        patch_embed_end = torch.cuda.Event(enable_timing=True)
        patch_embed_start.record()
        for _ in range(30):
            y = self.patch_embed(x)
        patch_embed_end.record()
        torch.cuda.synchronize(x.device)
        patch_embed_elapsed_ms = patch_embed_start.elapsed_time(patch_embed_end) / 30
        print(f"###[{x.shape[0]}]: {patch_embed_elapsed_ms:.3f} ms")
```

+ The results before / after this PR are shown below. Averagely 6.9x acceleration is earned, and the larger the image is, the better performance is earned.
+ In our old scenario (Qwen3-VL-235B + TP8 + DP1, one request with 20 images of 960x1280), approximately 11.0x acceleration was earned.

| size      | conv3d/ms | linear/ms | SpeedUp |
|:----------|----------:|----------:|--------:|
| 32x32     |     0.122 |     0.070 |    1.74 |
| 64x64     |     0.122 |     0.070 |    1.74 |
| 96x96     |     0.123 |     0.070 |    1.76 |
| 128x128   |     0.123 |     0.071 |    1.73 |
| 160x160   |     0.123 |     0.071 |    1.73 |
| 192x192   |     0.124 |     0.071 |    1.75 |
| 224x224   |     0.129 |     0.071 |    1.82 |
| 256x256   |     0.136 |     0.073 |    1.86 |
| 288x288   |     0.136 |     0.072 |    1.89 |
| 320x320   |     0.175 |     0.070 |    2.50 |
| 352x352   |     0.228 |     0.069 |    3.30 |
| 384x384   |     0.279 |     0.083 |    3.36 |
| 416x416   |     0.261 |     0.076 |    3.43 |
| 448x448   |     0.270 |     0.069 |    3.91 |
| 480x480   |     0.308 |     0.074 |    4.16 |
| 512x512   |     0.334 |     0.069 |    4.84 |
| 544x544   |     0.375 |     0.069 |    5.43 |
| 576x576   |     0.414 |     0.069 |    6.00 |
| 608x608   |     0.499 |     0.070 |    7.13 |
| 640x640   |     0.619 |     0.070 |    8.84 |
| 672x672   |     0.646 |     0.070 |    9.23 |
| 704x704   |     0.663 |     0.069 |    9.61 |
| 736x736   |     0.672 |     0.069 |    9.74 |
| 768x768   |     0.707 |     0.070 |   10.10 |
| 800x800   |     0.747 |     0.068 |   10.99 |
| 832x832   |     0.875 |     0.069 |   12.68 |
| 864x864   |     0.847 |     0.069 |   12.28 |
| 896x896   |     1.028 |     0.069 |   14.90 |
| 928x928   |     1.065 |     0.070 |   15.21 |
| 960x960   |     1.127 |     0.071 |   15.87 |
| 992x992   |     1.174 |     0.071 |   16.54 |
| 1024x1024 |     1.235 |     0.084 |   14.70 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
