### PR TITLE
fix: avoid aliased tensor in fused add+norm for EXAONE4 post-LN in forward_split_prefill

### DIFF
--- a/python/sglang/srt/models/exaone4.py
+++ b/python/sglang/srt/models/exaone4.py
@@ -521,9 +521,7 @@ class Exaone4ForCausalLM(nn.Module):
 
         if end == self.model.config.num_hidden_layers:
             # norm
-            hidden_states, _ = self.model.norm(
-                forward_batch.hidden_states, forward_batch.residual
-            )
+            hidden_states = self.model.norm(forward_batch.hidden_states)
             forward_batch.hidden_states = hidden_states
             # logits process
             result = self.logits_processor(


### PR DESCRIPTION
## Summary
- EXAONE4 uses **post-LN** architecture where each decoder layer returns `hidden_states` and `residual` pointing to the **same tensor object** (`residual = hidden_states`)
- The `forward_split_prefill` path called `self.model.norm(hidden_states, residual)` with two args, passing both aliased tensors to `fused_add_rmsnorm`
- This is inconsistent with the regular `forward` path (line 386) which correctly calls `self.norm(hidden_states)` with a single argument
- Fix: match the regular forward path's single-arg norm call

## Root cause
In EXAONE4's post-LN decoder layer, the final lines are:
```python
hidden_states = self.post_feedforward_layernorm(hidden_states)
hidden_states = hidden_states + residual
residual = hidden_states  # same object
return hidden_states, residual
```
When `forward_split_prefill` passes both to `fused_add_rmsnorm`, it computes `residual += hidden_states` in-place on aliased memory.

## Test plan
- Run EXAONE4 inference with chunked prefill / pipeline parallelism
- Compare logits between `forward` and `forward_split_prefill` paths