### PR TITLE
Increase max_concurrent_jobs in job queue

### DIFF
--- a/sgl-model-gateway/src/core/job_queue.rs
+++ b/sgl-model-gateway/src/core/job_queue.rs
@@ -112,7 +112,7 @@ impl Default for JobQueueConfig {
     fn default() -> Self {
         Self {
             queue_capacity: 1000,
-            max_concurrent_jobs: 10,
+            max_concurrent_jobs: 200,
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

(For Thinking Machines Lab) We are using sgl-model-gateway in IGW mode, allowing workers to re-register on an interval. We found an issue.

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This fixes an issue: We found that the non-configurable max_concurrent_jobs in the job queue is set too low by default for adding new workers, and it is not configurable.

When running SGL Model Gateway in IGW mode, you have `POST /workers` endpoint to add workers. This turns into an `AddWorker` job in the job queue, and the job waits for up to `worker_startup_timeout_secs` (default 1800s = 30m) for the worker to start up and be healthy.

This makes sense, SGLang server may 10-30 minutes to load weights start up for larger models and with lots of CUDA graphs. However, during those 30 minutes, it takes up an entire resource from the concurrent jobs `Semaphore`, which is currently limited to 10.

So if you're registering more than 10 workers, it'll start blocking the job queue because it can only process 1 failed registration per 3 minutes on average.

Additionally it will cause all future requests to `POST /workers` to queue up, and if there's a steady state of worker registrations (as if you're registering workers periodically to account for gateway failures/restarts), you'll fill up that entire queue of size 1000 and start stalling on requests with timeouts since they block when sending to the bounded channel.

## Modifications

<!-- Detail the changes made in this pull request. -->

Increased `max_concurrent_jobs` (semaphore size) from 10 to 200. This means that by default, the server can handle a steady state of 1 AddWorker job per (30 minutes) / (200 jobs) = 9 seconds, which is more reasonable than one job per 3 minutes.

In the future this could also be configurable. I think this shouldn't be set so low though by default, none of the background jobs seem compute-intensive.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
