### PR TITLE
Fix /health regression from early prebound socket listen

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1978,6 +1978,7 @@ def launch_server(
     # Reserve the HTTP port before launching subprocesses to fail fast if port is unavailable.
     # This prevents wasting time loading models only to discover port conflicts later.
     reserved_socket = _prebind_listening_socket(server_args.host, server_args.port)
+    multi_tokenizer_args_shm = None
 
     try:
         # Launch subprocesses
@@ -2052,6 +2053,10 @@ def launch_server(
         # Update logging configs
         set_uvicorn_logging_configs(server_args)
 
+        # Delay listen() until uvicorn startup to avoid accepting probe traffic
+        # while model/subprocess initialization is still in progress.
+        reserved_socket.listen(128)
+
         # Listen for HTTP requests
         if server_args.tokenizer_worker_num == 1:
             # Default case, one tokenizer process
@@ -2089,5 +2094,7 @@ def launch_server(
         reserved_socket.close()
 
         if server_args.tokenizer_worker_num > 1:
-            multi_tokenizer_args_shm.unlink()
-            _global_state.tokenizer_manager.socket_mapping.clear_all_sockets()
+            if multi_tokenizer_args_shm is not None:
+                multi_tokenizer_args_shm.unlink()
+            if _global_state is not None:
+                _global_state.tokenizer_manager.socket_mapping.clear_all_sockets()

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -416,7 +416,9 @@ def _prebind_listening_socket(host: str, port: int) -> socket.socket:
     This prevents port conflicts that could occur if another process (e.g., a
     subprocess spawned during model loading) binds to the same port before the
     HTTP server starts. By binding early, we ensure the port is available and
-    reserved for the HTTP server.
+    reserved for the HTTP server. The socket is intentionally not put into
+    listening mode here to avoid accepting probe connections before uvicorn is
+    ready to serve requests.
 
     Args:
         host: The host address to bind to.
@@ -444,14 +446,8 @@ def _prebind_listening_socket(host: str, port: int) -> socket.socket:
     # SO_REUSEADDR: Allows binding to a port in TIME_WAIT state
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-    # SO_REUSEPORT: Allows multiple processes to bind to the same port
-    # This is useful for multi-worker mode
-    if hasattr(socket, "SO_REUSEPORT"):
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-
     try:
         sock.bind((host or "", port))
-        sock.listen(128)  # Put socket in listening state for uvicorn
         sock.set_inheritable(True)
         logger.info(
             f"Successfully reserved port {port} on host '{host or ('::' if family == socket.AF_INET6 else '0.0.0.0')}'"


### PR DESCRIPTION
## Motivation

#17754 added early HTTP socket prebinding to fail fast on port conflicts, but it also put the socket into `listen()` during model/subprocess initialization. That allowed TCP connections for `/health` before uvicorn/FastAPI was ready to serve, causing health probe hangs/timeouts.

## Modifications

- `python/sglang/utils.py`
  - Updated `_prebind_listening_socket()` to reserve the port by `bind()` only (no early `listen()`)
  - Removed `SO_REUSEPORT` to preserve exclusive reservation semantics for conflict detection
- `python/sglang/srt/entrypoints/http_server.py`
  - Added `reserved_socket.listen(128)` immediately before `uvicorn.run(...)`, so listening starts only when the app is ready to serve
  - Added defensive cleanup guards in `finally` for `multi_tokenizer_args_shm` and `_global_state` to avoid early-failure cleanup errors

## Test Plan

Working

Before (Broken):
```
[2026-03-03 22:51:13] INFO: Uvicorn running on socket ('0.0.0.0', 30000)
[2026-03-03 22:51:20] TimeoutError: timed out  ← Health check hangs
[2026-03-03 22:51:20] Runner failed with exception: ReadTimeout
[2026-03-03 22:51:20] requests.exceptions.ReadTimeout: HTTPConnectionPool...
```

After (Fixed):
```
[2026-03-03 22:55:01] INFO: Uvicorn running on socket ('0.0.0.0', 30000)
[2026-03-03 22:55:05] GET /health HTTP/1.1" 503 Service Unavailable  ← Returns immediately
[2026-03-03 22:55:10] GET /health HTTP/1.1" 503 Service Unavailable  ← Retries work
[2026-03-03 22:55:39] The server is fired up and ready to roll!
[2026-03-03 22:55:44] GET /health HTTP/1.1" 200 OK  ← Success!
```

PTAL @Kangyan-Zhou