### PR TITLE
[CI] Add DeepGEMM warmup to stage-c-test-deepep-4-gpu

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1482,6 +1482,18 @@ jobs:
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
+      - name: Warmup DeepGEMM JIT Compilation
+        timeout-minutes: 25
+        run: |
+          python3 scripts/ci/cuda/warmup_deep_gemm.py \
+            lmsys/sglang-ci-dsv3-test:4
+
+      - name: Warmup Server CUDA Graphs
+        timeout-minutes: 25
+        run: |
+          python3 scripts/ci/cuda/warmup_server.py \
+            lmsys/sglang-ci-dsv3-test:4
+
       - name: Run test
         timeout-minutes: 20
         run: |


### PR DESCRIPTION
## Summary
- The `stage-c-test-deepep-4-gpu` job times out (20 min) because DeepGEMM JIT compilation consumes ~10 min across 3 server launches during the test
- The 8-GPU DeepEP test already has warmup steps that avoid this — this PR adds the same pattern to the 4-GPU test
- Adds two warmup steps before "Run test": `warmup_deep_gemm.py` and `warmup_server.py` with `lmsys/sglang-ci-dsv3-test:4`

**Failure example**: https://github.com/sgl-project/sglang/actions/runs/22595582756/job/65626168622?pr=19470

## Test plan
- [ ] `stage-c-test-deepep-4-gpu` passes within 20 min timeout
- [ ] Warmup steps complete successfully (should be fast with `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=true`)