### PR TITLE
[CI] Register test_quant_config_parsing.py in CI suite

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1482,6 +1482,18 @@ jobs:
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
+      - name: Warmup DeepGEMM JIT Compilation
+        timeout-minutes: 25
+        run: |
+          python3 scripts/ci/cuda/warmup_deep_gemm.py \
+            lmsys/sglang-ci-dsv3-test:4
+
+      - name: Warmup Server CUDA Graphs
+        timeout-minutes: 25
+        run: |
+          python3 scripts/ci/cuda/warmup_server.py \
+            lmsys/sglang-ci-dsv3-test:4
+
       - name: Run test
         timeout-minutes: 20
         run: |

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -2,10 +2,10 @@ import unittest
 from unittest.mock import MagicMock
 
 from sglang.srt.configs.model_config import ModelConfig
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=5, suite="stage-b-test-small-1-gpu")
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 
 
 class TestQuantLogString(CustomTestCase):

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -2,16 +2,13 @@ import unittest
 from unittest.mock import MagicMock
 
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, suite="stage-b-test-small-1-gpu")
 
 
-class MockHfConfig:
-    def __init__(self, quant_config=None):
-        self.quantization_config = quant_config
-        self.architectures = ["LlamaForCausalLM"]
-        self.model_type = "llama"
-
-
-class TestQuantLogString(unittest.TestCase):
+class TestQuantLogString(CustomTestCase):
     def test_qwen_fp8_config(self):
         # Example from Qwen/Qwen3-4B-Thinking-2507-FP8
         quant_config = {


### PR DESCRIPTION
## Summary
- `test_quant_config_parsing.py` (added in #18651) was placed in `test/srt/` without being registered in any CI suite, breaking the `run_suite.py` sanity check across **all CI jobs** on every open PR
- Moves the file to `test/registered/quant/` and registers it in cpu only test stage (pure CPU mock test, ~5s)

## Test plan
- [ ] `run_suite.py` sanity check passes (no more "test files are not in test suite" errors)
- [ ] `stage-a-cpu-only` includes and passes `test_quant_config_parsing.py`