### PR TITLE
[PD] Add graceful RDMA shutdown for Mooncake/NIXL disaggregation connectors

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -112,10 +112,10 @@ class CommonKVManager(BaseKVManager):
         self.local_ip = get_local_ip_auto()
 
         # bind zmq socket
-        context = zmq.Context()
+        self._zmq_context = zmq.Context()
         zmq_bind_host = maybe_wrap_ipv6_address(self.local_ip)
         self.rank_port, self.server_socket = get_zmq_socket_on_host(
-            context, zmq.PULL, host=zmq_bind_host
+            self._zmq_context, zmq.PULL, host=zmq_bind_host
         )
         logger.debug(f"kv manager bind to {zmq_bind_host}:{self.rank_port}")
 
@@ -162,6 +162,20 @@ class CommonKVManager(BaseKVManager):
             raise ValueError(
                 f"Unsupported DisaggregationMode: {self.disaggregation_mode}"
             )
+
+    def shutdown(self):
+        """Close ZMQ socket and context to unblock threads waiting on recv_multipart().
+
+        Subclasses should call super().shutdown() before performing backend-specific cleanup.
+        """
+        try:
+            self.server_socket.close(linger=0)
+        except Exception as e:
+            logger.warning(f"Failed to close ZMQ server socket: {e}")
+        try:
+            self._zmq_context.term()
+        except Exception as e:
+            logger.warning(f"Failed to terminate ZMQ context: {e}")
 
     def check_status(self, bootstrap_room: int) -> KVPoll:
         return self.request_status[bootstrap_room]

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -233,6 +233,49 @@ class MooncakeKVManager(CommonKVManager):
                 self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
             )
 
+    def shutdown(self):
+        """Deregister RDMA memory and close ZMQ sockets for clean process exit.
+
+        Without explicit deregistration, Mooncake's C++ TransferEngine destructor
+        must tear down RDMA resources (queue pairs, memory regions) during process
+        exit. In Kubernetes, this can cause pod sandbox teardown to hang, resulting
+        in FailedKillPod errors. Explicitly deregistering memory and closing ZMQ
+        sockets allows the process to exit cleanly.
+        """
+        logger.info("MooncakeKVManager shutting down...")
+
+        # 1. Close ZMQ sockets to unblock threads waiting on recv_multipart()
+        super().shutdown()
+
+        # 2. Shut down thread pool executors first to stop in-flight transfers
+        #    before deregistering the memory they may be reading from.
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            for executor in getattr(self, "executors", []):
+                try:
+                    executor.shutdown(wait=False)
+                except Exception as e:
+                    logger.warning(f"Failed to shut down thread pool executor: {e}")
+
+        # 3. Deregister RDMA memory regions (mirror registration conditions)
+        if self.engine is not None:
+            try:
+                if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
+                    self.engine.batch_deregister(self.kv_args.kv_data_ptrs)
+            except Exception as e:
+                logger.warning(f"Failed to deregister KV data buffers: {e}")
+            try:
+                if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
+                    self.engine.batch_deregister(self.kv_args.aux_data_ptrs)
+            except Exception as e:
+                logger.warning(f"Failed to deregister aux data buffers: {e}")
+            try:
+                if self.kv_args.state_data_ptrs and self.kv_args.state_data_lens:
+                    self.engine.batch_deregister(self.kv_args.state_data_ptrs)
+            except Exception as e:
+                logger.warning(f"Failed to deregister state data buffers: {e}")
+
+        logger.info("MooncakeKVManager shutdown complete.")
+
     def _transfer_data(self, mooncake_session_id, transfer_blocks):
         if not transfer_blocks:
             return 0
@@ -943,7 +986,7 @@ class MooncakeKVManager(CommonKVManager):
                     if len(self.transfer_infos[room]) == required_dst_info_num:
                         self.update_status(room, KVPoll.WaitingForInput)
 
-        threading.Thread(target=bootstrap_thread).start()
+        threading.Thread(target=bootstrap_thread, daemon=True).start()
 
     def start_decode_thread(self):
         def decode_thread():
@@ -1030,8 +1073,8 @@ class MooncakeKVManager(CommonKVManager):
                             if bootstrap_addr in self.session_pool:
                                 del self.session_pool[bootstrap_addr]
 
-        threading.Thread(target=decode_thread).start()
-        threading.Thread(target=heartbeat_checker).start()
+        threading.Thread(target=decode_thread, daemon=True).start()
+        threading.Thread(target=heartbeat_checker, daemon=True).start()
 
     def add_transfer_request(
         self,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -879,7 +879,26 @@ class NixlKVManager(CommonKVManager):
                     logger.debug(f"{room=} is bootstrapped")
                     self.update_status(room, KVPoll.WaitingForInput)
 
-        threading.Thread(target=bootstrap_thread).start()
+        threading.Thread(target=bootstrap_thread, daemon=True).start()
+
+    def shutdown(self):
+        """Deregister NIXL RDMA memory and close ZMQ sockets for clean process exit."""
+        logger.info("NixlKVManager shutting down...")
+
+        # 1. Close ZMQ sockets to unblock threads waiting on recv_multipart()
+        super().shutdown()
+
+        # 2. Deregister RDMA memory regions via NIXL agent
+        if hasattr(self, "agent") and self.agent is not None:
+            for desc_name in ("kv_descs", "aux_descs", "state_descs"):
+                descs = getattr(self, desc_name, None)
+                if descs is not None:
+                    try:
+                        self.agent.deregister_memory(descs)
+                    except Exception as e:
+                        logger.warning(f"Failed to deregister {desc_name}: {e}")
+
+        logger.info("NixlKVManager shutdown complete.")
 
 
 class NixlKVSender(CommonKVSender):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """A scheduler that manages a tensor parallel GPU worker."""
 
+import atexit
 import faulthandler
 import logging
 import os
@@ -3139,6 +3140,35 @@ def run_scheduler_process(
             )
 
         pipe_writer.send(result_dict)
+
+        # Register RDMA cleanup for disaggregation modes only.
+        # This ensures RDMA memory is deregistered and ZMQ sockets are closed
+        # when the scheduler process exits, preventing Kubernetes pod sandbox
+        # teardown hangs (FailedKillPod).
+        if scheduler.disaggregation_mode != DisaggregationMode.NULL:
+
+            def _shutdown_kv_manager():
+                try:
+                    kv_mgr = None
+                    if hasattr(scheduler, "disagg_prefill_bootstrap_queue"):
+                        kv_mgr = scheduler.disagg_prefill_bootstrap_queue.kv_manager
+                    elif hasattr(scheduler, "disagg_decode_prealloc_queue"):
+                        kv_mgr = scheduler.disagg_decode_prealloc_queue.kv_manager
+                    if kv_mgr is not None and hasattr(kv_mgr, "shutdown"):
+                        kv_mgr.shutdown()
+                except Exception as e:
+                    logger.warning(f"Error during KV manager shutdown: {e}")
+
+            atexit.register(_shutdown_kv_manager)
+
+            # Register SIGTERM handler so atexit handlers run on graceful shutdown.
+            # Without this, SIGTERM uses the default handler (immediate exit) which
+            # skips atexit/destructors, leaving RDMA resources unreleased.
+            def _sigterm_handler(signum, frame):
+                logger.info("Scheduler received SIGTERM, exiting gracefully...")
+                sys.exit(143)  # 128 + SIGTERM(15)
+
+            signal.signal(signal.SIGTERM, _sigterm_handler)
 
         # Dispatch to the appropriate event loop based on the disaggregation mode
         disaggregation_mode: DisaggregationMode = scheduler.disaggregation_mode


### PR DESCRIPTION
## Motivation

When Kubernetes sends SIGTERM to SGLang pods running PD disaggregation, the `sigterm_watchdog` in `TokenizerManager` calls `kill_process_tree()` which sends **SIGKILL** to scheduler child processes. SIGKILL bypasses all Python cleanup (`atexit`, `__del__`, C++ destructors), so Mooncake/NIXL RDMA memory regions are never deregistered. This causes the pod sandbox teardown to hang, resulting in `FailedKillPod` errors:

```
Warning  FailedKillPod  85s  kubelet  error killing pod: failed to "KillPodSandbox"
  with KillPodSandboxError: "rpc error: code = DeadlineExceeded
  desc = stream terminated by RST_STREAM with error code: CANCEL"
```

Additionally, non-daemon threads (`bootstrap_thread`, `decode_thread`, `heartbeat_checker`) blocked on ZMQ `recv_multipart()` prevent the Python interpreter from exiting even when SIGTERM is received.

This PR is complementary to #16484 — that PR changes the parent process to send SIGTERM instead of SIGKILL to children; this PR ensures the children actually clean up RDMA resources when they receive SIGTERM.

## Modifications

### 1. `python/sglang/srt/disaggregation/common/conn.py`
- Store ZMQ context as instance variable for later cleanup
- Add `CommonKVManager.shutdown()` that closes ZMQ socket (`linger=0`) and terminates context, unblocking threads stuck on `recv_multipart()`

### 2. `python/sglang/srt/disaggregation/mooncake/conn.py`
- Mark `bootstrap_thread`, `decode_thread`, `heartbeat_checker` as `daemon=True`
- Add `MooncakeKVManager.shutdown()` that:
  1. Closes ZMQ sockets (via super)
  2. Shuts down thread pool executors
  3. Deregisters all RDMA memory (kv, aux, state buffers) via `batch_deregister()`

### 3. `python/sglang/srt/disaggregation/nixl/conn.py`
- Mark `bootstrap_thread` as `daemon=True`
- Add `NixlKVManager.shutdown()` that deregisters RDMA memory via `agent.deregister_memory()`

### 4. `python/sglang/srt/managers/scheduler.py`
- Register `atexit` handler (disaggregation modes only) that calls `kv_manager.shutdown()`
- Add SIGTERM handler that calls `sys.exit(143)` so `atexit` handlers run

## Test plan
- [ ] Test SIGTERM on a running PD disaggregation deployment and verify RDMA memory is deregistered (check logs for "MooncakeKVManager shutdown complete")
- [ ] Verify pod terminates cleanly without `FailedKillPod` errors in Kubernetes
- [ ] Verify non-disaggregation mode is unaffected (no SIGTERM handler registered)
- [ ] Run existing disaggregation tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)