### PR TITLE
[EPLB] Add topology-aware expert replica placement

### DIFF
--- a/python/sglang/srt/eplb/eplb_algorithms/__init__.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/__init__.py
@@ -13,6 +13,7 @@ class EplbAlgorithm(Enum):
     deepseek_vec = auto()
     deepseek_vec_hierarchical = auto()
     elasticity_aware = auto()
+    topology_aware = auto()
     # TODO may have more algorithm later
 
 
@@ -60,6 +61,15 @@ def rebalance_experts(
                 if ElasticEPStateManager.instance() is not None
                 else ElasticEPStateManager.healthy_rank_state()
             ),
+        )
+
+    if algorithm == EplbAlgorithm.topology_aware:
+        return deepseek.rebalance_experts_topology_aware_entry(
+            weight=tokens_per_expert.sum(dim=0),
+            num_replicas=num_physical_experts,
+            num_groups=num_groups,
+            num_nodes=num_nodes,
+            num_gpus=num_physical_experts // num_local_physical_experts,
         )
 
     raise NotImplementedError

--- a/python/sglang/srt/eplb/eplb_algorithms/deepseek.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/deepseek.py
@@ -218,4 +218,193 @@ def rebalance_experts(
     return phy2log, log2phy, logcnt
 
 
-__all__ = ["rebalance_experts"]
+def rebalance_experts_topology_aware(
+    weight: torch.Tensor,
+    num_physical_experts: int,
+    num_groups: int,
+    num_nodes: int,
+    num_gpus: int,
+):
+    """
+    Topology-aware expert rebalancing that distributes replicas across nodes
+    to reduce inter-node traffic. Unlike hierarchical, which replicates only
+    within each node, this algorithm places replicas on different nodes so
+    that the runtime router can prefer NVLink (same-node) over RDMA.
+
+    Parameters:
+        weight: [num_moe_layers, num_logical_experts]
+        num_physical_experts: number of physical experts after replication
+        num_groups: number of expert groups
+        num_nodes: number of server nodes
+        num_gpus: number of GPUs, must be a multiple of num_nodes
+
+    Returns:
+        phy2log: [num_moe_layers, num_physical_experts]
+        phyrank: [num_moe_layers, num_physical_experts]
+        logcnt: [num_moe_layers, num_logical_experts]
+    """
+    num_layers, num_logical_experts = weight.shape
+    assert num_logical_experts % num_groups == 0
+    group_size = num_logical_experts // num_groups
+    assert num_groups % num_nodes == 0
+    groups_per_node = num_groups // num_nodes
+    assert num_gpus % num_nodes == 0
+    gpus_per_node = num_gpus // num_nodes
+    assert num_physical_experts % num_gpus == 0
+    phy_experts_per_gpu = num_physical_experts // num_gpus
+    num_log_per_node = num_logical_experts // num_nodes
+    num_phy_per_node = num_physical_experts // num_nodes
+
+    def inverse(perm: torch.Tensor) -> torch.Tensor:
+        inv = torch.empty_like(perm)
+        inv.scatter_(
+            1,
+            perm,
+            torch.arange(perm.size(1), dtype=torch.int64, device=perm.device).expand(
+                perm.shape
+            ),
+        )
+        return inv
+
+    # Step 1: pack groups to nodes (identical to hierarchical)
+    tokens_per_group = weight.unflatten(-1, (num_groups, group_size)).sum(-1)
+    group_pack_index, group_rank_in_pack = balanced_packing(tokens_per_group, num_nodes)
+    log2mlog = (
+        (
+            (group_pack_index * groups_per_node + group_rank_in_pack) * group_size
+        ).unsqueeze(-1)
+        + torch.arange(group_size, dtype=torch.int64, device=group_pack_index.device)
+    ).flatten(-2)
+    mlog2log = inverse(log2mlog)
+
+    tokens_per_mlog_full = weight.gather(-1, mlog2log)
+
+    # Step 2: topology-aware replication across nodes + Step 3: pack to GPUs
+    num_redundant = num_physical_experts - num_logical_experts
+    final_phy2mlog = torch.zeros(num_layers, num_physical_experts, dtype=torch.int64)
+    final_phyrank = torch.zeros(num_layers, num_physical_experts, dtype=torch.int64)
+    final_logcnt = torch.zeros(num_layers, num_logical_experts, dtype=torch.int64)
+
+    for layer in range(num_layers):
+        w = tokens_per_mlog_full[layer]
+        cnt = torch.ones(num_logical_experts, dtype=torch.int64)
+        remaining = [phy_experts_per_gpu * gpus_per_node - num_log_per_node] * num_nodes
+        node_has = [
+            set(range(n * num_log_per_node, (n + 1) * num_log_per_node))
+            for n in range(num_nodes)
+        ]
+
+        # Each node starts with its initial experts
+        # node_experts[n] = list of (mlog_idx, rank)
+        node_experts = [
+            [(m, 0) for m in range(n * num_log_per_node, (n + 1) * num_log_per_node)]
+            for n in range(num_nodes)
+        ]
+
+        for _ in range(num_redundant):
+            scores = w.float() / cnt.float()
+            best_expert = scores.argmax().item()
+
+            # Priority 1: node without this expert, most remaining capacity
+            best_node = -1
+            best_remaining = -1
+            for n in range(num_nodes):
+                if remaining[n] > 0 and best_expert not in node_has[n]:
+                    if remaining[n] > best_remaining:
+                        best_remaining = remaining[n]
+                        best_node = n
+
+            # Priority 2: any node with remaining capacity
+            if best_node < 0:
+                best_remaining = -1
+                for n in range(num_nodes):
+                    if remaining[n] > 0 and remaining[n] > best_remaining:
+                        best_remaining = remaining[n]
+                        best_node = n
+
+            if best_node >= 0:
+                node_has[best_node].add(best_expert)
+                remaining[best_node] -= 1
+                node_experts[best_node].append((best_expert, cnt[best_expert].item()))
+                cnt[best_expert] += 1
+
+        final_logcnt[layer] = cnt
+
+        # Step 3: pack within each node to GPUs using balanced_packing
+        offset = 0
+        for n in range(num_nodes):
+            experts_on_node = node_experts[n]
+            num_on_node = len(experts_on_node)
+            assert num_on_node == num_phy_per_node
+
+            # Build weight for packing: weight of each phy expert = w[mlog] / cnt[mlog]
+            phy_weights = torch.zeros(1, num_on_node)
+            phy_mlogs = []
+            phy_ranks = []
+            for j, (mlog, rank) in enumerate(experts_on_node):
+                phy_weights[0, j] = w[mlog].float() / cnt[mlog].float()
+                phy_mlogs.append(mlog)
+                phy_ranks.append(rank)
+
+            pack_index, rank_in_pack = balanced_packing(phy_weights, gpus_per_node)
+            phy2pphy = pack_index[0] * phy_experts_per_gpu + rank_in_pack[0]
+
+            for j in range(num_on_node):
+                pphy_idx = offset + phy2pphy[j].item()
+                final_phy2mlog[layer, pphy_idx] = phy_mlogs[j]
+                final_phyrank[layer, pphy_idx] = phy_ranks[j]
+
+            offset += num_phy_per_node
+
+    # Convert mlog back to log
+    final_phy2log = mlog2log.gather(-1, final_phy2mlog)
+
+    final_logcnt_log = final_logcnt.gather(-1, log2mlog)
+    return final_phy2log, final_phyrank, final_logcnt_log
+
+
+def rebalance_experts_topology_aware_entry(
+    weight: torch.Tensor,
+    num_replicas: int,
+    num_groups: int,
+    num_nodes: int,
+    num_gpus: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Entry point for topology-aware expert rebalancing.
+
+    Parameters:
+        weight: [layers, num_logical_experts]
+        num_replicas: number of physical experts
+        num_groups: number of expert groups
+        num_nodes: number of server nodes
+        num_gpus: number of GPUs
+
+    Returns:
+        phy2log: [layers, num_replicas]
+        log2phy: [layers, num_logical_experts, X]
+        logcnt: [layers, num_logical_experts]
+    """
+    num_layers, num_logical_experts = weight.shape
+    weight = weight.float().cpu()
+    phy2log, phyrank, logcnt = rebalance_experts_topology_aware(
+        weight, num_replicas, num_groups, num_nodes, num_gpus
+    )
+    maxlogcnt = logcnt.max().item()
+    log2phy: torch.Tensor = torch.full(
+        (num_layers, num_logical_experts, maxlogcnt),
+        -1,
+        dtype=torch.int64,
+        device=logcnt.device,
+    )
+    log2phy.view(num_layers, -1).scatter_(
+        -1,
+        phy2log * maxlogcnt + phyrank,
+        torch.arange(num_replicas, dtype=torch.int64, device=log2phy.device).expand(
+            num_layers, -1
+        ),
+    )
+    return phy2log, log2phy, logcnt
+
+
+__all__ = ["rebalance_experts", "rebalance_experts_topology_aware_entry"]

--- a/python/sglang/srt/eplb/utils.py
+++ b/python/sglang/srt/eplb/utils.py
@@ -1,0 +1,90 @@
+import torch
+
+
+def inter_node_traffic_ratio(
+    phy2log: torch.Tensor,
+    weight: torch.Tensor,
+    num_nodes: int,
+) -> torch.Tensor:
+    """
+    Estimate the fraction of token traffic that must go inter-node.
+
+    For each expert, count how many distinct nodes host it (coverage K out of N).
+    Traffic that must go inter-node = weight[expert] * (1 - K/N).
+    Returns the weighted fraction per layer.
+
+    Parameters:
+        phy2log: [num_layers, num_physical_experts]
+        weight: [num_layers, num_logical_experts]
+        num_nodes: number of server nodes
+
+    Returns:
+        ratio: [num_layers], fraction of traffic that is inter-node
+    """
+    num_layers, num_physical_experts = phy2log.shape
+    num_logical_experts = weight.shape[1]
+    num_phy_per_node = num_physical_experts // num_nodes
+
+    ratios = torch.zeros(num_layers)
+    for layer in range(num_layers):
+        total_weight = weight[layer].sum().item()
+        if total_weight == 0:
+            continue
+        inter_node_weight = 0.0
+        for expert in range(num_logical_experts):
+            # Count how many distinct nodes host this expert
+            nodes_hosting = set()
+            for node in range(num_nodes):
+                start = node * num_phy_per_node
+                end = start + num_phy_per_node
+                if expert in phy2log[layer, start:end].tolist():
+                    nodes_hosting.add(node)
+            coverage = len(nodes_hosting) / num_nodes
+            inter_node_weight += weight[layer, expert].item() * (1.0 - coverage)
+        ratios[layer] = inter_node_weight / total_weight
+
+    return ratios
+
+
+def inter_rank_imbalance_ratio(
+    phy2log: torch.Tensor,
+    weight: torch.Tensor,
+    logcnt: torch.Tensor,
+    num_gpus: int,
+) -> torch.Tensor:
+    """
+    Compute the load imbalance ratio across GPUs.
+
+    Per-GPU load = sum of weight[expert] / count[expert] for each physical expert
+    assigned to that GPU. Returns max(gpu_load) / mean(gpu_load) per layer.
+    A value of 1.0 means perfect balance.
+
+    Parameters:
+        phy2log: [num_layers, num_physical_experts]
+        weight: [num_layers, num_logical_experts]
+        logcnt: [num_layers, num_logical_experts]
+        num_gpus: total number of GPUs
+
+    Returns:
+        ratio: [num_layers], imbalance ratio (>= 1.0)
+    """
+    num_layers, num_physical_experts = phy2log.shape
+    phy_per_gpu = num_physical_experts // num_gpus
+
+    ratios = torch.zeros(num_layers)
+    for layer in range(num_layers):
+        gpu_loads = torch.zeros(num_gpus)
+        for gpu in range(num_gpus):
+            start = gpu * phy_per_gpu
+            end = start + phy_per_gpu
+            for phy_idx in range(start, end):
+                expert = phy2log[layer, phy_idx].item()
+                cnt = logcnt[layer, expert].item()
+                gpu_loads[gpu] += weight[layer, expert].item() / cnt
+        mean_load = gpu_loads.mean().item()
+        if mean_load > 0:
+            ratios[layer] = gpu_loads.max().item() / mean_load
+        else:
+            ratios[layer] = 1.0
+
+    return ratios

--- a/test/srt/test_eplb_topology_aware.py
+++ b/test/srt/test_eplb_topology_aware.py
@@ -1,0 +1,214 @@
+"""
+CPU-only unit tests for the topology-aware EPLB algorithm.
+No GPU or server required.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.eplb.eplb_algorithms.deepseek import (
+    rebalance_experts_hierarchical,
+    rebalance_experts_topology_aware,
+)
+from sglang.srt.eplb.eplb_algorithms.deepseek import (
+    rebalance_experts_topology_aware_entry,
+)
+from sglang.srt.eplb.utils import inter_node_traffic_ratio
+
+# Common test configuration: 2 nodes, 4 GPUs, 8 logical experts, 16 physical
+NUM_LAYERS = 2
+NUM_LOGICAL = 8
+NUM_PHYSICAL = 16
+NUM_GROUPS = 4
+NUM_NODES = 2
+NUM_GPUS = 4
+
+
+def _make_skewed_weight():
+    """Create weights where expert 0 is much hotter than others."""
+    w = torch.ones(NUM_LAYERS, NUM_LOGICAL)
+    w[:, 0] = 100.0  # expert 0 is very hot
+    return w
+
+
+class TestTopologyAwareOutputShapes(unittest.TestCase):
+    def test_output_shapes(self):
+        weight = _make_skewed_weight()
+        phy2log, phyrank, logcnt = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        self.assertEqual(phy2log.shape, (NUM_LAYERS, NUM_PHYSICAL))
+        self.assertEqual(phyrank.shape, (NUM_LAYERS, NUM_PHYSICAL))
+        self.assertEqual(logcnt.shape, (NUM_LAYERS, NUM_LOGICAL))
+
+    def test_entry_point_shapes(self):
+        weight = _make_skewed_weight()
+        phy2log, log2phy, logcnt = rebalance_experts_topology_aware_entry(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        self.assertEqual(phy2log.shape, (NUM_LAYERS, NUM_PHYSICAL))
+        self.assertEqual(log2phy.shape[0], NUM_LAYERS)
+        self.assertEqual(log2phy.shape[1], NUM_LOGICAL)
+        self.assertEqual(logcnt.shape, (NUM_LAYERS, NUM_LOGICAL))
+
+
+class TestTopologyAwareValidity(unittest.TestCase):
+    def test_valid_expert_indices(self):
+        weight = _make_skewed_weight()
+        phy2log, _, _ = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        self.assertTrue((phy2log >= 0).all())
+        self.assertTrue((phy2log < NUM_LOGICAL).all())
+
+    def test_logcnt_sum(self):
+        weight = _make_skewed_weight()
+        _, _, logcnt = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        for layer in range(NUM_LAYERS):
+            self.assertEqual(logcnt[layer].sum().item(), NUM_PHYSICAL)
+
+    def test_every_expert_covered(self):
+        weight = _make_skewed_weight()
+        _, _, logcnt = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        self.assertTrue((logcnt >= 1).all())
+
+
+class TestTopologyAwarePlacement(unittest.TestCase):
+    def test_hot_expert_cross_node(self):
+        """Hot expert should be replicated onto both nodes."""
+        weight = _make_skewed_weight()
+        phy2log, _, _ = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        num_phy_per_node = NUM_PHYSICAL // NUM_NODES
+        for layer in range(NUM_LAYERS):
+            hot_expert = 0
+            # Find which nodes have the hot expert
+            nodes_with_hot = set()
+            for node in range(NUM_NODES):
+                start = node * num_phy_per_node
+                end = start + num_phy_per_node
+                if hot_expert in phy2log[layer, start:end].tolist():
+                    nodes_with_hot.add(node)
+            self.assertGreater(
+                len(nodes_with_hot),
+                1,
+                f"Layer {layer}: hot expert 0 should be on both nodes, "
+                f"but only on nodes {nodes_with_hot}",
+            )
+
+    def test_lower_inter_node_traffic(self):
+        """Topology-aware should have <= inter-node traffic than hierarchical."""
+        weight = _make_skewed_weight()
+        topo_phy2log, _, topo_logcnt = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        hier_phy2log, _, hier_logcnt = rebalance_experts_hierarchical(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        topo_ratio = inter_node_traffic_ratio(topo_phy2log, weight, NUM_NODES)
+        hier_ratio = inter_node_traffic_ratio(hier_phy2log, weight, NUM_NODES)
+        for layer in range(NUM_LAYERS):
+            self.assertLessEqual(
+                topo_ratio[layer].item(),
+                hier_ratio[layer].item() + 1e-6,
+                f"Layer {layer}: topology-aware inter-node traffic "
+                f"({topo_ratio[layer]:.4f}) should be <= hierarchical "
+                f"({hier_ratio[layer]:.4f})",
+            )
+
+
+class TestTopologyAwareEdgeCases(unittest.TestCase):
+    def test_single_node(self):
+        """With 1 node, should degenerate correctly."""
+        weight = _make_skewed_weight()
+        phy2log, phyrank, logcnt = rebalance_experts_topology_aware(
+            weight,
+            num_physical_experts=16,
+            num_groups=4,
+            num_nodes=1,
+            num_gpus=4,
+        )
+        self.assertEqual(phy2log.shape, (NUM_LAYERS, 16))
+        self.assertEqual(logcnt.sum(dim=-1).tolist(), [16, 16])
+        self.assertTrue((logcnt >= 1).all())
+
+    def test_uniform_weights(self):
+        """Uniform weights should give balanced replication (logcnt close to equal)."""
+        weight = torch.ones(NUM_LAYERS, NUM_LOGICAL)
+        _, _, logcnt = rebalance_experts_topology_aware(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        # With uniform weights, each expert should get exactly 2 replicas
+        expected = NUM_PHYSICAL // NUM_LOGICAL
+        self.assertTrue(
+            (logcnt == expected).all(),
+            f"Expected all logcnt={expected}, got {logcnt}",
+        )
+
+    def test_no_redundancy(self):
+        """When num_phy == num_log, logcnt should be all 1s."""
+        weight = _make_skewed_weight()
+        _, _, logcnt = rebalance_experts_topology_aware(
+            weight,
+            num_physical_experts=8,
+            num_groups=4,
+            num_nodes=2,
+            num_gpus=4,
+        )
+        self.assertTrue(
+            (logcnt == 1).all(),
+            f"Expected all logcnt=1 with no redundancy, got {logcnt}",
+        )
+
+
+class TestLog2PhyConsistency(unittest.TestCase):
+    def test_log2phy_consistency(self):
+        """Round-trip: every entry in log2phy should map back correctly via phy2log."""
+        weight = _make_skewed_weight()
+        phy2log, log2phy, logcnt = rebalance_experts_topology_aware_entry(
+            weight, NUM_PHYSICAL, NUM_GROUPS, NUM_NODES, NUM_GPUS
+        )
+        for layer in range(NUM_LAYERS):
+            for expert in range(NUM_LOGICAL):
+                cnt = logcnt[layer, expert].item()
+                for r in range(cnt):
+                    phy_idx = log2phy[layer, expert, r].item()
+                    self.assertNotEqual(phy_idx, -1)
+                    self.assertEqual(
+                        phy2log[layer, phy_idx].item(),
+                        expert,
+                        f"Layer {layer}, expert {expert}, rank {r}: "
+                        f"phy2log[{phy_idx}]={phy2log[layer, phy_idx].item()} != {expert}",
+                    )
+
+
+class TestMetrics(unittest.TestCase):
+    def test_metrics_perfect_coverage(self):
+        """If every expert is on every node, inter-node ratio should be 0."""
+        num_nodes = 2
+        num_log = 4
+        # Each node has all 4 experts
+        phy2log = torch.tensor([[0, 1, 2, 3, 0, 1, 2, 3]])
+        weight = torch.ones(1, num_log)
+        ratio = inter_node_traffic_ratio(phy2log, weight, num_nodes)
+        self.assertAlmostEqual(ratio[0].item(), 0.0, places=5)
+
+    def test_metrics_no_coverage(self):
+        """If experts are disjoint across nodes, inter-node ratio should be 0.5."""
+        num_nodes = 2
+        # Node 0 has experts 0,1; Node 1 has experts 2,3
+        phy2log = torch.tensor([[0, 1, 2, 3]])
+        weight = torch.ones(1, 4)
+        ratio = inter_node_traffic_ratio(phy2log, weight, num_nodes)
+        # Each expert is on 1/2 nodes, so inter-node fraction = 1 - 1/2 = 0.5
+        self.assertAlmostEqual(ratio[0].item(), 0.5, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_eplb_topology_aware.py
+++ b/test/srt/test_eplb_topology_aware.py
@@ -10,8 +10,6 @@ import torch
 from sglang.srt.eplb.eplb_algorithms.deepseek import (
     rebalance_experts_hierarchical,
     rebalance_experts_topology_aware,
-)
-from sglang.srt.eplb.eplb_algorithms.deepseek import (
     rebalance_experts_topology_aware_entry,
 )
 from sglang.srt.eplb.utils import inter_node_traffic_ratio


### PR DESCRIPTION
Implements #19487. Distributes redundant expert replicas across nodes instead of within them, enabling NVLink access instead of RDMA. No runtime changes needed.

**Changes:** `topology_aware` enum + dispatch, `rebalance_experts_topology_aware()` algorithm, `eplb/utils.py` metrics, 13 CPU-only unit tests (all passing).

**Algorithm:** (1) Pack groups to nodes, (2) place each redundant copy on a node lacking it, (3) pack to GPUs per node.

Closes #19487