### PR TITLE
Fix Qwen3.5/Qwen3Next MTP EPLB compatibility

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -156,6 +156,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layer_id = layer_id
         self.alt_stream = alt_stream
+        self.is_nextn = is_nextn
         if self.tp_size > config.num_experts:
             raise ValueError(
                 f"Tensor parallel size {self.tp_size} is greater than "

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1221,6 +1221,10 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
         self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
 
+    @property
+    def routed_experts_weights_of_layer(self):
+        return self.model.routed_experts_weights_of_layer
+
     def get_embed_and_head(self):
         embed = self.model.embed_tokens.weight if self.pp_group.is_first_rank else None
         head = self.lm_head.weight if self.pp_group.is_last_rank else None

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -888,6 +888,27 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
     ) -> None:
         super().__init__(config=config, quant_config=quant_config, prefix=prefix)
 
+        self._routed_experts_weights_of_layer = LazyValue(
+            lambda: {
+                layer_id: layer.mlp.get_moe_weights()
+                for layer_id, layer in enumerate(self.layers)
+                if isinstance(layer.mlp, Qwen2MoeSparseMoeBlock)
+            }
+        )
+
+    @property
+    def routed_experts_weights_of_layer(self):
+        return self._routed_experts_weights_of_layer.value
+
+    @classmethod
+    def get_model_config_for_expert_location(cls, config):
+        text_config = getattr(config, "text_config", config)
+        return ModelConfigForExpertLocation(
+            num_layers=text_config.num_hidden_layers,
+            num_logical_experts=text_config.num_experts,
+            num_groups=None,
+        )
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)


### PR DESCRIPTION
## Summary
- Fix three bugs when EPLB is enabled with Qwen3.5/Qwen3Next MTP (speculative decoding):
  - MTP layers created `ExpertLocationDispatchInfo` with wrong layer IDs (MTP has different numbering)
  - Expert distribution recorder polluted by MTP forward passes (bad EPLB statistics)
  - `Qwen3_5MoeForCausalLM` missing `routed_experts_weights_of_layer` property and `get_model_config_for_expert_location`; MTP classes missing `get_model_config_for_expert_location`

## Changes
- Add `is_nextn` flag to `Qwen2MoeSparseMoeBlock` to suppress `ExpertLocationDispatchInfo` creation in `_forward_deepep`
- Thread `is_nextn` through Qwen3.5 and Qwen3Next decoder layers and model classes
- Wrap MTP model forward calls with `disable_this_region()` to prevent recorder pollution (matching existing pattern from `deepseek_nextn`, `glm4_moe_nextn`, etc.)
- Add `LazyValue`-based `routed_experts_weights_of_layer` property and `get_model_config_for_expert_location` classmethod to `Qwen3_5MoeForCausalLM`
- Add `get_model_config_for_expert_location` classmethod to `Qwen3_5ForCausalLMMTP`

## Test plan
- [ ] Verify `py_compile` passes on all 5 modified files (confirmed locally)
- [ ] Verify no new lint errors introduced (confirmed locally)
- [ ] Test Qwen3.5-MoE with EPLB enabled
- [ ] Test Qwen3Next with EPLB enabled
- [ ] Test Qwen3.5-MTP and Qwen3Next-MTP with EPLB enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)