### PR TITLE
[NPU]Releasing redundant memory of w13_weight and nz when the ascend_fuseep feature is enabled

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -529,13 +529,11 @@ class NpuFuseEPMoE(DeepEPMoE):
         return weight.view(*original_shape[:dim], -1, *original_shape[dim + 1 :])
 
     def _process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        cpu_w13 = layer.w13_weight.transpose(1, 2).cpu()
-        w13 = self.reshape_w13_weight(cpu_w13, -1).npu()
-        w13 = npu_format_cast(w13)
-        layer.w13_weight = torch.nn.Parameter(w13, requires_grad=False)
+        cpu_w13 = layer.w13_weight.data.transpose(1, 2).cpu()
+        layer.w13_weight.data = self.reshape_w13_weight(cpu_w13, -1).npu()
+        layer.w13_weight.data = npu_format_cast(layer.w13_weight.data)
 
-        w2 = npu_format_cast(layer.w2_weight)
-        layer.w2_weight = torch.nn.Parameter(w2, requires_grad=False)
+        layer.w2_weight.data = npu_format_cast(layer.w2_weight.data)
 
         w13_scale = layer.w13_weight_scale.data.squeeze(-1).contiguous()
         w13_scale = self.permute_w13_weight_scale(w13_scale, 128)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Releasing redundant memory of w13_weight and nz when the ascend_fuseep feature is enabled

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Test model：qwen3-480B-w8a8
P：
python -m sglang.launch_server --model-path ${MODEL_PATH}  --disaggregation-mode prefill --host ${P_IP[$i]} \
        --port 8000 --disaggregation-bootstrap-port $((8995+$i)) --trust-remote-code --nnodes 1 --node-rank 0 \
        --tp-size 16 --mem-fraction-static 0.7 --attention-backend ascend --device npu --quantization modelslim \
        --disaggregation-transfer-backend ascend --max-running-requests 24 --disable-radix-cache \
        --chunked-prefill-size 16384 --max-prefill-tokens 28680 --moe-a2a-backend deepep --deepep-mode normal \
        --dp-size 2 --enable-dp-attention --dtype bfloat16

D:
python -m sglang.launch_server --model-path ${MODEL_PATH} --disaggregation-mode decode --host ${D_IP[$i]} \
        --port 8001 --trust-remote-code --dist-init-addr ${D_IP[0]}:5000 --nnodes 2 --node-rank $i --tp-size 32 --dp-size 4 \
        --mem-fraction-static 0.75 --max-running-requests 544 --attention-backend ascend --device npu --quantization modelslim \
        --moe-a2a-backend ascend_fuseep --enable-dp-attention --deepep-mode low_latency --enable-dp-lm-head \
        --cuda-graph-bs 48 64 72 88 96 104 112 120 128 136 --disaggregation-transfer-backend ascend --watchdog-timeout 9000 --context-length 8192 \
        --tokenizer-worker-num 4 --prefill-round-robin-balance --dtype bfloat16  --load-balance-method round_robin


before：
<img width="1067" height="89" alt="image" src="https://github.com/user-attachments/assets/b5dff6ab-ca16-4251-a933-9a703dbc977c" />



after：
<img width="802" height="179" alt="image" src="https://github.com/user-attachments/assets/0f29691e-f6d4-40c8-8482-39dc13dec3dc" />



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
