### PR TITLE
Fix torch.compile/dynamo crash with Qwen3 QK-norm in piecewise CUDA g…

### DIFF
--- a/python/sglang/jit_kernel/norm.py
+++ b/python/sglang/jit_kernel/norm.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+logger = logging.getLogger(__name__)
+
 from sglang.jit_kernel.utils import (
     cache_once,
     is_arch_support_pdl,
@@ -62,9 +64,9 @@ def _jit_qknorm_across_heads_module(dtype: torch.dtype) -> Module:
     )
 
 
+@torch.compiler.assume_constant_result
 @cache_once
 def can_use_fused_inplace_qknorm(head_dim: int, dtype: torch.dtype) -> bool:
-    logger = logging.getLogger(__name__)
     if head_dim not in [64, 128, 256, 512, 1024]:
         logger.warning(f"Unsupported head_dim={head_dim} for JIT QK-Norm kernel")
         return False


### PR DESCRIPTION
…raph

When using `--enable-piecewise-cuda-graph --piecewise-cuda-graph-compiler inductor` with Qwen3 models (which use QK-norm), the server crashes during CUDA graph warmup with `torch._dynamo.exc.Unsupported`.

Root cause: `can_use_fused_inplace_qknorm()` calls `logging.getLogger(__name__)` inside the function body. When torch.compile/dynamo traces this function, it cannot handle the `logging.getLogger()` call (string comparison with `LoggingLoggerVariable` fails). Additionally, the function performs filesystem I/O via `_jit_qknorm_module()` which dynamo also cannot trace.

Fix:
1. Move `logger = logging.getLogger(__name__)` to module level so dynamo never encounters it during tracing.
2. Add `@torch.compiler.assume_constant_result` decorator so dynamo evaluates the function eagerly in Python and inlines the boolean result, avoiding tracing into filesystem/JIT operations entirely.

Tested with Qwen3-Embedding-0.6B on H200 with piecewise CUDA graph + inductor.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
