### PR TITLE
Fix Qwen3.5 pipeline parallelism crash

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -712,9 +712,11 @@ class Qwen3_5ForCausalLM(nn.Module):
                 is_nextn=is_nextn,
             )
 
-        self.layers = make_layers(
+        self.layers, self.start_layer, self.end_layer = make_layers(
             config.num_hidden_layers,
             get_layer,
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
             prefix=f"{prefix}.layers",
         )
 
@@ -735,7 +737,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         if self.pp_group.is_last_rank:
             self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         else:
-            self.norm = PPMissingLayer()
+            self.norm = PPMissingLayer(return_tuple=True)
 
     def get_input_embeddings(self):
         return self.embed_tokens

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -938,6 +938,8 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
             shard_id: str,
             num_experts: int,
         ):
+            if name not in params_dict:
+                return False
             param = params_dict[name]
             weight_loader = param.weight_loader
             # let ep moe layer to gracefully handle expert_ids that do not belong to local moe rank
@@ -1263,6 +1265,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             shard_id: str,
             num_experts: int,
         ):
+            if name not in params_dict:
+                return False
             param = params_dict[name]
             weight_loader = param.weight_loader
             # let ep moe layer to gracefully handle expert_ids that do not belong to local moe rank


### PR DESCRIPTION
## Summary
- Fixes `AttributeError: 'Qwen3_5MoeForCausalLM' object has no attribute 'embed_tokens'` when using `--pp-size 2`
- Adds `PPMissingLayer()` placeholders for `embed_tokens` (non-first ranks) and `norm` (non-last ranks)
- Passes `pp_rank`/`pp_size` to `make_layers()` so only the local subset of decoder layers is created per rank
- Iterates `range(start_layer, end_layer)` in `forward()` instead of `range(len(self.layers))`

Follows the same PP pattern used by LLaMA, DeepSeekV2, and Qwen2MoE.

Fixes #19500

## Test plan
- [ ] `py_compile`, `isort --check`, `ruff check` all pass
- [ ] Verify model loads with `--pp-size 1` (no regression)
- [ ] Verify model loads with `--pp-size 2` (the fix)