### PR TITLE
[OPT]Skip the first delayer to maximize the BS of the decoding.

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -148,6 +148,8 @@ class PrefillDelayer:
                 max_running_requests - global_running_batch.max().item()
                 < global_max_prefill_bs.max().item()
             ):
+                # When the "max_decode_bs - running_bs < max_prefill_bs" condition is met,
+                # the first merge_batch causes the decoding to fail to reach the maximum batch size.
                 if self.skip_first_delayer:
                     self.skip_first_delayer = False
                     pass

--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -66,6 +66,7 @@ class PrefillDelayer:
         self._metrics_collector = metrics_collector
 
         self._curr_state: Optional[_State] = None
+        self.skip_first_delayer = True
 
         assert (
             server_args.disaggregation_mode == "null"
@@ -146,16 +147,19 @@ class PrefillDelayer:
             if (
                 max_running_requests - global_running_batch.max().item()
                 < global_max_prefill_bs.max().item()
-                and not self.enable_dp_attention
             ):
-                next_state = prev_state or _State()
-                next_state = next_state.bump_delayed_count()
-                return _NegotiateOutput(
-                    next_state=next_state,
-                    output_allow=False,
-                    output_reason="delay",
-                    **debug_info,
-                )
+                if self.skip_first_delayer:
+                    self.skip_first_delayer = False
+                    pass
+                else:
+                    next_state = prev_state or _State()
+                    next_state = next_state.bump_delayed_count()
+                    return _NegotiateOutput(
+                        next_state=next_state,
+                        output_allow=False,
+                        output_reason="delay",
+                        **debug_info,
+                    )
             exist_previous_wait = prev_state is not None
             return _NegotiateOutput(
                 next_state=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Skip the first delayer to maximize the BS of the decoding.

## Modifications

When the "max_running_requests - global_running_batch.max().item() < global_max_prefill_bs.max().item()" condition is met, the first merge_batch causes the decoding to fail to reach the maximum batch size.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
before:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 576       
Successful requests:                     2304      
Benchmark duration (s):                  546.57    
Total input tokens:                      4608000   
Total input text tokens:                 4608000   
Total input vision tokens:               0         
Total generated tokens:                  4608000   
Total generated tokens (retokenized):    4606411   
Request throughput (req/s):              4.22      
Input token throughput (tok/s):          8430.83   
Output token throughput (tok/s):         8430.83   
Peak output token throughput (tok/s):    17659.00  
Peak concurrent requests:                603       
Total token throughput (tok/s):          16861.66  
Concurrency:                             497.90    
Accept length:                           2.81      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   118114.21 
Median E2E Latency (ms):                 110944.13 
---------------Time to First Token----------------
Mean TTFT (ms):                          11399.15  
Median TTFT (ms):                        8300.18   
P99 TTFT (ms):                           31113.79  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.38     
Median TPOT (ms):                        50.54     
P99 TPOT (ms):                           98.05     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           53.38     
Median ITL (ms):                         33.46     
P95 ITL (ms):                            109.23    
P99 ITL (ms):                            615.20    
Max ITL (ms):                            26878.35

after:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 576       
Successful requests:                     2304      
Benchmark duration (s):                  575.86    
Total input tokens:                      4608000   
Total input text tokens:                 4608000   
Total input vision tokens:               0         
Total generated tokens:                  4608000   
Total generated tokens (retokenized):    4606878   
Request throughput (req/s):              4.00      
Input token throughput (tok/s):          8001.90   
Output token throughput (tok/s):         8001.90   
Peak output token throughput (tok/s):    17814.00  
Peak concurrent requests:                599       
Total token throughput (tok/s):          16003.80  
Concurrency:                             492.18    
Accept length:                           2.81      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   123016.95 
Median E2E Latency (ms):                 117426.63 
---------------Time to First Token----------------
Mean TTFT (ms):                          22517.17  
Median TTFT (ms):                        21300.92  
P99 TTFT (ms):                           48963.68  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          50.28     
Median TPOT (ms):                        47.13     
P99 TPOT (ms):                           94.95     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           50.28     
Median ITL (ms):                         32.06     
P95 ITL (ms):                            106.79    
P99 ITL (ms):                            278.02    
Max ITL (ms):                            24673.69  


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
