### PR TITLE
[AMD][Bugfix] Fix get_global_server_args NameError on ROCm in fused_moe

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -469,7 +469,8 @@ def fused_experts_impl(
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
 
         use_fused_moe_sum_all_reduce = (
-            get_global_server_args().enable_fused_moe_sum_all_reduce
+            _is_cuda
+            and get_global_server_args().enable_fused_moe_sum_all_reduce
             and (not no_combine)
             and (curr_topk_ids.shape[1] > 2)
             and (not use_int8_w8a16)


### PR DESCRIPTION
## Motivation

The [ROCm 7.2 nightly run #146](https://github.com/sgl-project/sglang/actions/runs/22652935175) had 4 job failures caused by a `NameError` in `fused_moe.py`:

```
NameError: name 'get_global_server_args' is not defined
```

#19672 imported `get_global_server_args` inside the `if _is_cuda:` guard but called it unconditionally in `fused_experts_impl`, crashing on HIP/ROCm during CUDA graph capture for any MoE model.

| Affected Job | Model |
|---|---|
| `nightly-8-gpu-kimi-k25-rocm720` | moonshotai/Kimi-K2.5 |
| `nightly-8-gpu-mi35x-kimi-k25-rocm720` | moonshotai/Kimi-K2.5 |
| `nightly-accuracy-8-gpu-rocm720` | lmsys/gpt-oss-20b-bf16, lmsys/gpt-oss-120b-bf16 |
| `nightly-accuracy-2-gpu-rocm720` | neuralmagic/Mixtral-8x7B-Instruct-v0.1-FP8 |

## Modifications

**`python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py`**: Add `_is_cuda and` as the first condition in the `use_fused_moe_sum_all_reduce` expression. Python's short-circuit evaluation prevents calling the undefined `get_global_server_args()` on non-CUDA platforms, and correctly limits the fused MoE sum-all-reduce feature to CUDA where the `moe_sum_reduce` kernel is available.

## Accuracy Tests

Verify by re-running any affected nightly job via workflow_dispatch on the Actions tab, setting ref to this branch:

- `job_filter = nightly-8-gpu-kimi-k25-rocm720`
- `job_filter = nightly-accuracy-8-gpu-rocm720`
- `job_filter = nightly-accuracy-2-gpu-rocm720`
- `job_filter = nightly-8-gpu-mi35x-kimi-k25-rocm720`

No accuracy impact — the fix only gates a CUDA-specific optimization so it is never attempted on ROCm, restoring the previous behavior.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] N/A: No new unit tests needed (bugfix restoring previous behavior).
- [x] N/A: No documentation changes needed.
- [x] N/A: No speed impact (guards a CUDA-only path that was already unreachable on ROCm).