### PR TITLE
Fix tool_choice stall on multi-call prompts (#17998)

### DIFF
--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -225,7 +225,6 @@ def get_json_schema_constraint(
                 return {
                     "type": "array",
                     "minItems": 1,
-                    "maxItems": 1,
                     "items": _get_tool_schema(tool),
                 }
         return None

--- a/test/registered/function_call/test_json_schema_constraint.py
+++ b/test/registered/function_call/test_json_schema_constraint.py
@@ -102,7 +102,7 @@ class TestJsonSchemaConstraint(unittest.TestCase):
 
         self.assertEqual(schema["type"], "array")
         self.assertEqual(schema["minItems"], 1)
-        self.assertEqual(schema["maxItems"], 1)
+        self.assertNotIn("maxItems", schema)
 
         # Should only have schema for the specific tool
         item_schema = schema["items"]
@@ -121,7 +121,7 @@ class TestJsonSchemaConstraint(unittest.TestCase):
 
         self.assertEqual(schema["type"], "array")
         self.assertEqual(schema["minItems"], 1)
-        self.assertEqual(schema["maxItems"], 1)
+        self.assertNotIn("maxItems", schema)
 
         # Should only have schema for the specific tool
         item_schema = schema["items"]


### PR DESCRIPTION
## Summary

When `tool_choice` specifies a function name, the JSON schema included `maxItems: 1` which masked the comma token after the first tool call, causing the model to loop on whitespace until max_tokens. Removed the constraint so multiple calls to the same function work correctly.

Closes #17998