### PR TITLE
Add request_id metadata to MoE expert distribution output (#17774)

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -392,7 +392,7 @@ class _DetailSinglePassGatherer(_SinglePassGatherer):
         super().on_forward_pass_start(forward_batch)
         assert self._metadata is None
         self._metadata = dict(
-            rids=forward_batch.rids,
+            rids=self._rids,
             input_ids=forward_batch.input_ids.cpu().tolist(),
             positions=forward_batch.positions.cpu().tolist(),
             extend_seq_lens=forward_batch.extend_seq_lens_cpu,
@@ -689,7 +689,10 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
         if self._enable:
             rids = single_pass_data.get("rids")
             return self._append_utilization_rate(
-                forward_pass_id, single_pass_data["global_physical_count"], outputs, rids=rids
+                forward_pass_id,
+                single_pass_data["global_physical_count"],
+                outputs,
+                rids=rids,
             )
 
     def reset(self):

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -330,9 +330,10 @@ class _SinglePassGatherer(ABC):
     def __init__(self, expert_location_metadata: ExpertLocationMetadata, rank: int):
         self._expert_location_metadata = expert_location_metadata
         self._rank = rank
+        self._rids: Optional[List[str]] = None
 
     def on_forward_pass_start(self, forward_batch: ForwardBatch):
-        pass
+        self._rids = forward_batch.rids
 
     def on_select_experts(self, layer_idx: int, topk_ids: torch.Tensor):
         pass
@@ -388,10 +389,10 @@ class _DetailSinglePassGatherer(_SinglePassGatherer):
         # TODO assert shared experts fusion is disabled, o/w data is wrong
 
     def on_forward_pass_start(self, forward_batch: ForwardBatch):
+        super().on_forward_pass_start(forward_batch)
         assert self._metadata is None
         self._metadata = dict(
-            # TODO pr-chain
-            # rids=forward_batch.rids,
+            rids=forward_batch.rids,
             input_ids=forward_batch.input_ids.cpu().tolist(),
             positions=forward_batch.positions.cpu().tolist(),
             extend_seq_lens=forward_batch.extend_seq_lens_cpu,
@@ -424,6 +425,7 @@ class _DetailSinglePassGatherer(_SinglePassGatherer):
         self._topk_ids_of_layer[...] = -1
         self._misc_objects.clear()
         self._metadata = None
+        self._rids = None
 
     def collect(self) -> Dict:
         num_tokens = len(self._metadata["input_ids"])
@@ -459,6 +461,7 @@ class _LayerBasedCpuSinglePassGatherer(_SinglePassGatherer):
 
     def reset(self):
         self._objects_of_layer.clear()
+        self._rids = None
 
     def _collect_objects(self, pad_len: int) -> torch.Tensor:
         data = [
@@ -491,6 +494,7 @@ class _LayerBasedGpuSinglePassGatherer(_SinglePassGatherer):
 
     def reset(self):
         self._data[...] = 0
+        self._rids = None
 
     def collect(self) -> Dict:
         if self._enable_global_physical_experts:
@@ -504,7 +508,7 @@ class _LayerBasedGpuSinglePassGatherer(_SinglePassGatherer):
                 num_physical_experts=self._expert_location_metadata.num_physical_experts,
             )
 
-        return dict(global_physical_count=global_physical_count)
+        return dict(global_physical_count=global_physical_count, rids=self._rids)
 
 
 class _SelectExpertsSinglePassGatherer(_LayerBasedGpuSinglePassGatherer):
@@ -550,7 +554,7 @@ class _DeepepNormalSinglePassGatherer(_LayerBasedCpuSinglePassGatherer):
             num_local_physical_experts=self._expert_location_metadata.num_local_physical_experts,
             num_physical_experts=self._expert_location_metadata.num_physical_experts,
         )
-        return dict(global_physical_count=global_physical_count)
+        return dict(global_physical_count=global_physical_count, rids=self._rids)
 
 
 class _DeepepLowLatencySinglePassGatherer(_LayerBasedGpuSinglePassGatherer):
@@ -683,8 +687,9 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
     ):
         super().append(forward_pass_id, gatherer_key, single_pass_data, outputs)
         if self._enable:
+            rids = single_pass_data.get("rids")
             return self._append_utilization_rate(
-                forward_pass_id, single_pass_data["global_physical_count"], outputs
+                forward_pass_id, single_pass_data["global_physical_count"], outputs, rids=rids
             )
 
     def reset(self):
@@ -697,6 +702,7 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
         forward_pass_id: int,
         single_pass_global_physical_count: torch.Tensor,
         outputs: Dict[str, Any],
+        rids: Optional[List[str]] = None,
     ):
         gpu_physical_count = compute_gpu_physical_count(
             single_pass_global_physical_count,
@@ -728,6 +734,7 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
                 logger.info(
                     f"[Expert Balancedness] "
                     f"forward_pass_id={forward_pass_id} "
+                    f"rids={rids} "
                     f"current_pass_balancedness={utilization_rate_cpu:.03f} "
                     f"{''.join(f'last_{size}_average_balancedness={value:.03f} ' for size, value in self._history.mean().items())} "
                     f"gpu_physical_count_sum={gpu_physical_count_sum}"


### PR DESCRIPTION
## Summary

MoE expert distribution logs lacked request IDs, making per-request debugging impossible. Threaded request_id from ForwardBatch through all gatherer types to the distribution output.

Closes #17774