### PR TITLE
Fix Qwen2-VL weight loading for finetuned checkpoints (#19438)

### DIFF
--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -585,6 +585,14 @@ class Qwen2VLForConditionalGeneration(nn.Module):
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 continue
 
+            # Remap weight names for finetuned checkpoints (e.g. transformers
+            # v4.52+) that use "model.language_model." or "model.visual."
+            # prefixes instead of the original "model." / "visual." layout.
+            if name.startswith("model.language_model."):
+                name = name.replace("model.language_model.", "model.", 1)
+            elif name.startswith("model.visual."):
+                name = name.replace("model.visual.", "visual.", 1)
+
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue


### PR DESCRIPTION
## Summary
Added weight key prefix remapping for finetuned Qwen2-VL checkpoints that use `model.language_model.` and `model.visual.` prefixes. Follows the same pattern used in qwen3_5.py.

Closes #19438