### PR TITLE
Fix weight_packed AttributeError in GLM4MoELite (#19392)

### DIFF
--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -133,10 +133,14 @@ class Glm4MoeLiteMLP(nn.Module):
             return x
 
         # Some quantization wrappers store the underlying parameter as `weight_packed`.
-        if not hasattr(self.gate_up_proj, "weight"):
-            self.gate_up_proj.weight = getattr(self.gate_up_proj, "weight_packed")
-        if not hasattr(self.down_proj, "weight"):
-            self.down_proj.weight = getattr(self.down_proj, "weight_packed")
+        if not hasattr(self.gate_up_proj, "weight") and hasattr(
+            self.gate_up_proj, "weight_packed"
+        ):
+            self.gate_up_proj.weight = self.gate_up_proj.weight_packed
+        if not hasattr(self.down_proj, "weight") and hasattr(
+            self.down_proj, "weight_packed"
+        ):
+            self.down_proj.weight = self.down_proj.weight_packed
 
         if (
             gemm_output_zero_allocator is not None


### PR DESCRIPTION
## Summary
Added `hasattr` guard before accessing `weight_packed` on `gate_up_proj` and `down_proj` in `Glm4MoeLiteMLP.forward`. Follows the same fix already applied to `deepseek_v2.py` in PR #16907.

Closes #19392