### PR TITLE
Fix glob pattern matching in is_layer_skipped for FP8 models (#19589)

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from copy import deepcopy
+from fnmatch import fnmatchcase
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
 
@@ -43,6 +44,17 @@ def get_scalar_types():
 ScalarType, scalar_types = get_scalar_types()
 
 
+def _ignored_layer_matches(prefix: str, ignored: str) -> bool:
+    """Check if a layer prefix matches an ignored-layer pattern.
+
+    Supports glob wildcards (*) via fnmatch when the pattern contains '*',
+    otherwise falls back to the original substring semantics.
+    """
+    if "*" in ignored:
+        return fnmatchcase(prefix, ignored)
+    return ignored in prefix
+
+
 def is_layer_skipped(
     prefix: str,
     ignored_layers: List[str],
@@ -65,7 +77,8 @@ def is_layer_skipped(
         is_skipped = None
         for shard_prefix in shard_prefixes:
             is_shard_skipped = any(
-                ignored in shard_prefix for ignored in ignored_layers
+                _ignored_layer_matches(shard_prefix, ignored)
+                for ignored in ignored_layers
             )
 
             if is_skipped is None:
@@ -77,7 +90,9 @@ def is_layer_skipped(
                     "to have the same precision."
                 )
     else:
-        is_skipped = any(ignored in prefix for ignored in ignored_layers)
+        is_skipped = any(
+            _ignored_layer_matches(prefix, ignored) for ignored in ignored_layers
+        )
         if "gate_up_proj" in prefix:
             prefix_gate = prefix.replace("gate_up_proj", "gate_proj")
             prefix_up = prefix.replace("gate_up_proj", "up_proj")

--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -47,10 +47,10 @@ ScalarType, scalar_types = get_scalar_types()
 def _ignored_layer_matches(prefix: str, ignored: str) -> bool:
     """Check if a layer prefix matches an ignored-layer pattern.
 
-    Supports glob wildcards (*) via fnmatch when the pattern contains '*',
-    otherwise falls back to the original substring semantics.
+    Supports glob wildcards (*, ?, [) via fnmatch when the pattern contains
+    glob characters, otherwise falls back to the original substring semantics.
     """
-    if "*" in ignored:
+    if any(c in ignored for c in "*?["):
         return fnmatchcase(prefix, ignored)
     return ignored in prefix
 


### PR DESCRIPTION
## Summary
`is_layer_skipped()` used plain substring matching which doesn't handle glob `*` patterns in `modules_to_not_convert`. Added `fnmatch` support so patterns like `model.language_model.layers.*.linear_attn.in_proj_a` work correctly for Qwen3.5-122B-A10B-FP8.

Closes #19589