### PR TITLE
Fix ib_device_str parsing to accept Python dict format (#18337)

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -13,14 +13,55 @@ logger = logging.getLogger(__name__)
 _mooncake_transfer_engine: Optional["MooncakeTransferEngine"] = None
 
 
+def _normalize_to_json(s: str) -> str:
+    """Convert a Python dict-style string to valid JSON.
+
+    Handles two common deviations from JSON that appear in user-supplied config:
+    1. Single-quoted strings: {'0': 'ib0'} -> {"0": "ib0"}
+    2. Bare integer keys:     {0: "ib0"}   -> {"0": "ib0"}
+
+    The function only touches quote characters and bare-integer keys; it does
+    not evaluate or execute the string in any way.
+    """
+    # Replace single quotes with double quotes.
+    # We handle escaped single quotes (\\') inside single-quoted strings by
+    # matching the full token: either a single-quoted string or any other char.
+    result: list[str] = []
+    i = 0
+    while i < len(s):
+        if s[i] == "'":
+            # Scan for the closing single quote, handling escaped quotes
+            j = i + 1
+            while j < len(s) and s[j] != "'":
+                if s[j] == "\\":
+                    j += 1  # skip escaped character
+                j += 1
+            # s[i:j+1] is the single-quoted token including quotes
+            inner = s[i + 1 : j]
+            # Escape any double quotes that appear inside the value
+            inner = inner.replace('"', '\\"')
+            result.append('"' + inner + '"')
+            i = j + 1
+        else:
+            result.append(s[i])
+            i += 1
+    s = "".join(result)
+
+    # Quote bare integer keys: {0: ... , 1: ...} -> {"0": ... , "1": ...}
+    s = re.sub(r"(?<=[\{,])\s*(\d+)\s*:", r' "\1":', s)
+
+    return s
+
+
 def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optional[str]:
     """
     Parse IB device string and get IB devices for a specific GPU ID.
 
     Supports all the following formats:
     1. Old format: "ib0, ib1, ib2"
-    2. New format: {"0": "ib0, ib1", "1": "ib2, ib3"} (also accepts bare integer keys)
-    3. JSON file: path to a JSON file containing the mapping
+    2. JSON dict:  {"0": "ib0, ib1", "1": "ib2, ib3"}
+       Also tolerates Python dict syntax (single quotes, bare int keys).
+    3. JSON file:  path to a .json file containing the mapping
 
     Args:
         ib_device_str: The original IB device string or path to JSON file
@@ -54,11 +95,12 @@ def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optiona
         parsed_dict = json.loads(ib_device_str)
     except json.JSONDecodeError:
         if not is_json_file:
-            # Try converting bare integer keys to quoted strings so JSON can parse it
-            # e.g., {0: "ib0", 1: "ib1"} -> {"0": "ib0", "1": "ib1"}
+            # Input may be a Python dict literal (single quotes or bare int keys).
+            # Normalize to valid JSON and retry.
+            # e.g. {0: 'ib0', 1: 'ib1'} -> {"0": "ib0", "1": "ib1"}
             try:
-                quoted = re.sub(r"(?<=[\{,])\s*(\d+)\s*:", r' "\1":', ib_device_str)
-                parsed_dict = json.loads(quoted)
+                normalized = _normalize_to_json(ib_device_str)
+                parsed_dict = json.loads(normalized)
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -93,8 +135,9 @@ def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optiona
             )
 
     if is_json_file:
-        # It was supposed to be a JSON file but failed to parse
-        raise RuntimeError(f"Failed to parse JSON content from file {ib_device_str}")
+        # The file contents were neither valid JSON nor a fixable Python dict
+        # literal, so we cannot silently fall through to the old flat format.
+        raise RuntimeError(f"Failed to parse JSON content from file: {ib_device_str}")
 
     # Not a dict format, treat as old format - return same devices for all GPUs
     return ib_device_str

--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import logging
 import os
@@ -18,8 +19,9 @@ def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optiona
 
     Supports all the following formats:
     1. Old format: "ib0, ib1, ib2"
-    2. New format: {0: "ib0, ib1", 1: "ib2, ib3", 2: "ib4"}
-    3. JSON file: path to a JSON file containing the mapping
+    2. New format (JSON): {"0": "ib0, ib1", "1": "ib2, ib3", "2": "ib4"}
+    3. New format (Python dict): {0: "ib0, ib1", 1: "ib2, ib3", 2: "ib4"}
+    4. JSON file: path to a JSON file containing the mapping
 
     Args:
         ib_device_str: The original IB device string or path to JSON file
@@ -47,47 +49,55 @@ def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optiona
             # File reading failed, raise exception
             raise RuntimeError(f"Failed to read JSON file {ib_device_str}: {e}") from e
 
-    # Check if it's JSON format (new format)
+    # Try to parse as a dict mapping (JSON or Python dict syntax)
+    parsed_dict = None
     try:
-        parsed_json = json.loads(ib_device_str)
-        if isinstance(parsed_json, dict):
-            # Validate format - keys should be integers (or string rep), values should be strings
-            gpu_mapping = {}
-            for gpu_key, ib_devices in parsed_json.items():
-                if (
-                    isinstance(gpu_key, str)
-                    and gpu_key.isdigit()
-                    and isinstance(ib_devices, str)
-                ):
-                    gpu_mapping[int(gpu_key)] = ib_devices.strip()
-                elif isinstance(gpu_key, int) and isinstance(ib_devices, str):
-                    gpu_mapping[gpu_key] = ib_devices.strip()
-                else:
-                    raise ValueError(
-                        "Invalid format: keys must be integers (or string "
-                        "representations of integers) and values must be strings"
-                    )
+        parsed_dict = json.loads(ib_device_str)
+    except json.JSONDecodeError:
+        # JSON failed; try Python dict syntax (e.g., {0: "ib0, ib1"})
+        # which uses integer keys that are invalid in JSON
+        if not is_json_file:
+            try:
+                parsed_dict = ast.literal_eval(ib_device_str)
+            except (ValueError, SyntaxError):
+                pass
 
-            if not gpu_mapping:
-                raise ValueError("No valid GPU mappings found in JSON")
-
-            # Return devices for specific GPU
-            if gpu_id in gpu_mapping:
-                return gpu_mapping[gpu_id]
+    if isinstance(parsed_dict, dict):
+        # Validate format - keys should be integers (or string rep), values should be strings
+        gpu_mapping = {}
+        for gpu_key, ib_devices in parsed_dict.items():
+            if (
+                isinstance(gpu_key, str)
+                and gpu_key.isdigit()
+                and isinstance(ib_devices, str)
+            ):
+                gpu_mapping[int(gpu_key)] = ib_devices.strip()
+            elif isinstance(gpu_key, int) and isinstance(ib_devices, str):
+                gpu_mapping[gpu_key] = ib_devices.strip()
             else:
                 raise ValueError(
-                    f"No IB devices configured for GPU {gpu_id}. "
-                    f"Available GPUs: {list(gpu_mapping.keys())}"
+                    "Invalid format: keys must be integers (or string "
+                    "representations of integers) and values must be strings"
                 )
 
-    except json.JSONDecodeError:
-        if is_json_file:
-            # It was supposed to be a JSON file but failed to parse
-            raise RuntimeError(
-                f"Failed to parse JSON content from file {ib_device_str}"
+        if not gpu_mapping:
+            raise ValueError("No valid GPU mappings found in mapping")
+
+        # Return devices for specific GPU
+        if gpu_id in gpu_mapping:
+            return gpu_mapping[gpu_id]
+        else:
+            raise ValueError(
+                f"No IB devices configured for GPU {gpu_id}. "
+                f"Available GPUs: {list(gpu_mapping.keys())}"
             )
-        # Not JSON format, treat as old format - return same devices for all GPUs
-        return ib_device_str
+
+    if is_json_file:
+        # It was supposed to be a JSON file but failed to parse
+        raise RuntimeError(f"Failed to parse JSON content from file {ib_device_str}")
+
+    # Not a dict format, treat as old format - return same devices for all GPUs
+    return ib_device_str
 
 
 class MooncakeTransferEngine:

--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -1,7 +1,7 @@
-import ast
 import json
 import logging
 import os
+import re
 from typing import List, Optional
 
 from sglang.srt.environ import envs
@@ -19,9 +19,8 @@ def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optiona
 
     Supports all the following formats:
     1. Old format: "ib0, ib1, ib2"
-    2. New format (JSON): {"0": "ib0, ib1", "1": "ib2, ib3", "2": "ib4"}
-    3. New format (Python dict): {0: "ib0, ib1", 1: "ib2, ib3", 2: "ib4"}
-    4. JSON file: path to a JSON file containing the mapping
+    2. New format: {"0": "ib0, ib1", "1": "ib2, ib3"} (also accepts bare integer keys)
+    3. JSON file: path to a JSON file containing the mapping
 
     Args:
         ib_device_str: The original IB device string or path to JSON file
@@ -49,17 +48,18 @@ def get_ib_devices_for_gpu(ib_device_str: Optional[str], gpu_id: int) -> Optiona
             # File reading failed, raise exception
             raise RuntimeError(f"Failed to read JSON file {ib_device_str}: {e}") from e
 
-    # Try to parse as a dict mapping (JSON or Python dict syntax)
+    # Try to parse as JSON dict mapping
     parsed_dict = None
     try:
         parsed_dict = json.loads(ib_device_str)
     except json.JSONDecodeError:
-        # JSON failed; try Python dict syntax (e.g., {0: "ib0, ib1"})
-        # which uses integer keys that are invalid in JSON
         if not is_json_file:
+            # Try converting bare integer keys to quoted strings so JSON can parse it
+            # e.g., {0: "ib0", 1: "ib1"} -> {"0": "ib0", "1": "ib1"}
             try:
-                parsed_dict = ast.literal_eval(ib_device_str)
-            except (ValueError, SyntaxError):
+                quoted = re.sub(r"(?<=[\{,])\s*(\d+)\s*:", r' "\1":', ib_device_str)
+                parsed_dict = json.loads(quoted)
+            except (json.JSONDecodeError, TypeError):
                 pass
 
     if isinstance(parsed_dict, dict):


### PR DESCRIPTION
## Summary
`json.loads()` fails on `ib_device_str` values with integer keys. Added `ast.literal_eval` fallback to handle both JSON string-key format and Python dict integer-key format.

Closes #18337