### PR TITLE
Support OpenAI input_audio content type for base64 audio (#19235)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -453,11 +453,26 @@ class ChatCompletionMessageContentAudioPart(BaseModel):
     audio_url: ChatCompletionMessageContentAudioURL
 
 
+class ChatCompletionMessageContentInputAudio(BaseModel):
+    """OpenAI input_audio content: base64-encoded audio with format."""
+
+    data: str
+    format: Literal["wav", "mp3"]
+
+
+class ChatCompletionMessageContentInputAudioPart(BaseModel):
+    """OpenAI input_audio content part for base64 audio in chat completions."""
+
+    type: Literal["input_audio"]
+    input_audio: ChatCompletionMessageContentInputAudio
+
+
 ChatCompletionMessageContentPart = Union[
     ChatCompletionMessageContentTextPart,
     ChatCompletionMessageContentImagePart,
     ChatCompletionMessageContentVideoPart,
     ChatCompletionMessageContentAudioPart,
+    ChatCompletionMessageContentInputAudioPart,
 ]
 
 # Rerank content types for multimodal reranking (e.g., Qwen3-VL-Reranker)

--- a/python/sglang/srt/parser/conversation.py
+++ b/python/sglang/srt/parser/conversation.py
@@ -665,6 +665,13 @@ def generate_chat_conv(
                     elif content.type == "audio_url":
                         real_content += audio_token
                         conv.append_audio(content.audio_url.url)
+                    elif content.type == "input_audio":
+                        # OpenAI input_audio: base64-encoded audio
+                        real_content += audio_token
+                        audio_format = content.input_audio.format
+                        audio_b64 = content.input_audio.data
+                        data_uri = f"data:audio/{audio_format};base64,{audio_b64}"
+                        conv.append_audio(data_uri)
                 if add_token_as_needed:
                     real_content = _get_full_multimodal_text_prompt(
                         conv.image_token, num_image_url, real_content

--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -194,6 +194,15 @@ def process_content_for_template_format(
                     audio_data.append(chunk["audio_url"]["url"])
                     # Normalize to simple 'audio' type
                     processed_content_parts.append({"type": "audio"})
+                elif chunk_type == "input_audio":
+                    # OpenAI input_audio: base64-encoded audio with format
+                    # Convert to data URI that load_audio() understands
+                    audio_obj = chunk.get("input_audio") or {}
+                    audio_format = audio_obj.get("format", "wav")
+                    audio_b64 = audio_obj.get("data", "")
+                    data_uri = f"data:audio/{audio_format};base64,{audio_b64}"
+                    audio_data.append(data_uri)
+                    processed_content_parts.append({"type": "audio"})
                 elif chunk_type == "text":
                     # For v32 encoding, collect text parts separately
                     if use_dpsk_v32_encoding:


### PR DESCRIPTION
## Summary
Added `input_audio` content type support in the OpenAI-compatible chat completions endpoint. Base64-encoded audio is converted to a data URI that the existing `load_audio()` function handles natively. Closes #19235