### PR TITLE
Fix streaming delta emitting role:null, content:null (#18335)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -871,9 +871,10 @@ class DeltaMessage(BaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
-        if self.hidden_states is None:
-            data.pop("hidden_states", None)
-        return data
+        # Exclude None fields from delta messages to comply with the OpenAI
+        # streaming spec.  Without this, reasoning-content chunks would emit
+        # "role": null, "content": null which breaks OpenAI-compatible clients.
+        return {k: v for k, v in data.items() if v is not None}
 
 
 class ChatCompletionResponseStreamChoice(BaseModel):


### PR DESCRIPTION
## Summary
`DeltaMessage._serialize` was including None-valued fields in the serialized output, causing streaming chunks to emit `role: null, content: null` which breaks OpenAI-compatible clients. Fixed by filtering out None fields. Closes #18335