### PR TITLE
Fix CPU backend crash from unconditional sgl_kernel import (#18507)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -48,33 +48,33 @@ _is_cuda = is_cuda()
 _is_cpu = is_cpu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
-_has_sgl_kernel = False
+try:
+    import sgl_kernel  # noqa: F401
 
-if _is_cuda:
+    _has_sgl_kernel = True
+except ImportError:
+    _has_sgl_kernel = False
+
+if _is_cuda and _has_sgl_kernel:
+    from sgl_kernel import sgl_per_token_quant_fp8
+
+    from sglang.jit_kernel.per_tensor_quant_fp8 import (
+        per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,
+    )
+
+    # Temporary
     try:
-        from sgl_kernel import sgl_per_token_quant_fp8
+        from sgl_kernel import sgl_per_token_group_quant_8bit
 
-        from sglang.jit_kernel.per_tensor_quant_fp8 import (
-            per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,
-        )
-
-        # Temporary
-        try:
-            from sgl_kernel import sgl_per_token_group_quant_8bit
-
-            enable_sgl_per_token_group_quant_8bit = True
-        except ImportError:
-            from sgl_kernel import sgl_per_token_group_quant_fp8
-
-            enable_sgl_per_token_group_quant_8bit = False
-
-        from sglang.jit_kernel.per_token_group_quant_8bit import (
-            per_token_group_quant_8bit as sgl_per_token_group_quant_8bit_jit,
-        )
-
-        _has_sgl_kernel = True
+        enable_sgl_per_token_group_quant_8bit = True
     except ImportError:
-        pass
+        from sgl_kernel import sgl_per_token_group_quant_fp8
+
+        enable_sgl_per_token_group_quant_8bit = False
+
+    from sglang.jit_kernel.per_token_group_quant_8bit import (
+        per_token_group_quant_8bit as sgl_per_token_group_quant_8bit_jit,
+    )
 
 if _is_hip:
     _has_vllm = False

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -48,26 +48,33 @@ _is_cuda = is_cuda()
 _is_cpu = is_cpu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
+_has_sgl_kernel = False
+
 if _is_cuda:
-    from sgl_kernel import sgl_per_token_quant_fp8
-
-    from sglang.jit_kernel.per_tensor_quant_fp8 import (
-        per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,
-    )
-
-    # Temporary
     try:
-        from sgl_kernel import sgl_per_token_group_quant_8bit
+        from sgl_kernel import sgl_per_token_quant_fp8
 
-        enable_sgl_per_token_group_quant_8bit = True
+        from sglang.jit_kernel.per_tensor_quant_fp8 import (
+            per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,
+        )
+
+        # Temporary
+        try:
+            from sgl_kernel import sgl_per_token_group_quant_8bit
+
+            enable_sgl_per_token_group_quant_8bit = True
+        except ImportError:
+            from sgl_kernel import sgl_per_token_group_quant_fp8
+
+            enable_sgl_per_token_group_quant_8bit = False
+
+        from sglang.jit_kernel.per_token_group_quant_8bit import (
+            per_token_group_quant_8bit as sgl_per_token_group_quant_8bit_jit,
+        )
+
+        _has_sgl_kernel = True
     except ImportError:
-        from sgl_kernel import sgl_per_token_group_quant_fp8
-
-        enable_sgl_per_token_group_quant_8bit = False
-
-    from sglang.jit_kernel.per_token_group_quant_8bit import (
-        per_token_group_quant_8bit as sgl_per_token_group_quant_8bit_jit,
-    )
+        pass
 
 if _is_hip:
     _has_vllm = False
@@ -2054,7 +2061,7 @@ def triton_scaled_mm(
     return result.to(out_dtype)
 
 
-if _is_cuda:
+if _is_cuda and _has_sgl_kernel:
     if enable_sgl_per_token_group_quant_8bit:
 
         @torch.library.register_fake("sgl_kernel::sgl_per_token_group_quant_8bit")

--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -133,6 +133,8 @@ def convert_to_channelwise(
 def requantize_with_max_scale(
     weight: torch.Tensor, weight_scale: torch.Tensor, logical_widths: List[int]
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    if not weight.is_cuda:
+        raise NotImplementedError("requantize_with_max_scale requires CUDA")
     from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
 
     # Max scale to be used for requanitzation.

--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Tuple, Union
 import numpy
 import torch
 
-from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
-
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
 
@@ -135,6 +133,8 @@ def convert_to_channelwise(
 def requantize_with_max_scale(
     weight: torch.Tensor, weight_scale: torch.Tensor, logical_widths: List[int]
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
+
     # Max scale to be used for requanitzation.
     max_w_scale = weight_scale.max()
 


### PR DESCRIPTION
## Summary

Guard sgl_kernel imports with try/except in fp8_kernel.py and make scaled_fp8_quant a lazy import in utils.py, so the CPU backend can start without sgl_kernel installed.

Closes #18507