### PR TITLE
Use int32 for KV cache index tensors (#17649)

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -35,7 +35,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
 
         # Pre-calculate total size
         total_size = sum(req.extend_input_len for req in reqs)
-        out_cache_loc = torch.empty(total_size, dtype=torch.int64, device=self.device)
+        out_cache_loc = torch.empty(total_size, dtype=torch.int32, device=self.device)
 
         # Fill the tensor in one pass
         offset = 0

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1404,14 +1404,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
 
         if not decoder_out_cache_loc:
-            self.out_cache_loc = torch.zeros(0, dtype=torch.int64).to(
+            self.out_cache_loc = torch.zeros(0, dtype=torch.int32).to(
                 self.device, non_blocking=True
             )
         else:
             self.out_cache_loc = torch.cat(decoder_out_cache_loc)
 
         if not encoder_out_cache_loc:
-            self.encoder_out_cache_loc = torch.zeros(0, dtype=torch.int64).to(
+            self.encoder_out_cache_loc = torch.zeros(0, dtype=torch.int32).to(
                 self.device, non_blocking=True
             )
         else:
@@ -1907,7 +1907,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens = torch.empty(0, dtype=torch.int64, device=self.device)
         self.seq_lens_cpu = torch.empty(0, dtype=torch.int64)
         self.orig_seq_lens = torch.empty(0, dtype=torch.int32, device=self.device)
-        self.out_cache_loc = torch.empty(0, dtype=torch.int64, device=self.device)
+        self.out_cache_loc = torch.empty(0, dtype=torch.int32, device=self.device)
         self.req_pool_indices = torch.empty(0, dtype=torch.int32, device=self.device)
         self.seq_lens_sum = 0
         self.extend_num_tokens = 0

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1205,7 +1205,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     seq_lens: torch.Tensor = None  # shape: [b], int64
     seq_lens_cpu: torch.Tensor = None  # shape: [b], int64
     # The output locations of the KV cache
-    out_cache_loc: torch.Tensor = None  # shape: [b], int64
+    out_cache_loc: torch.Tensor = None  # shape: [b], int32
     output_ids: torch.Tensor = None  # shape: [b], int64
 
     # For hybrid GDN prefix cache

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -131,11 +131,11 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def clear(self):
         # The padded slot 0 is used for writing dummy outputs from padded tokens.
         self.free_pages = torch.arange(
-            1, self.size + 1, dtype=torch.int64, device=self.device
+            1, self.size + 1, dtype=torch.int32, device=self.device
         )
         self.is_not_in_free_group = True
         self.free_group = []
-        self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
+        self.release_pages = torch.empty((0,), dtype=torch.int32, device=self.device)
 
     def available_size(self):
         # To avoid minor "len(free_pages) * 1" overhead
@@ -427,7 +427,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.merge_and_sort_free()
 
         out_indices = torch.empty(
-            (extend_num_tokens,), dtype=torch.int64, device=self.device
+            (extend_num_tokens,), dtype=torch.int32, device=self.device
         )
 
         if extend_num_tokens < tl.core.TRITON_MAX_TENSOR_NUMEL:
@@ -481,7 +481,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.need_sort and bs > len(self.free_pages):
             self.merge_and_sort_free()
 
-        out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
+        out_indices = torch.empty((bs,), dtype=torch.int32, device=self.device)
         alloc_decode_kernel[(bs,)](
             seq_lens,
             last_loc,
@@ -524,11 +524,11 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def clear(self):
         # The padded slot 0 is used for writing dummy outputs from padded tokens.
         self.free_pages = torch.arange(
-            1, self.num_pages + 1, dtype=torch.int64, device=self.device
+            1, self.num_pages + 1, dtype=torch.int32, device=self.device
         )
         self.is_not_in_free_group = True
         self.free_group = []
-        self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
+        self.release_pages = torch.empty((0,), dtype=torch.int32, device=self.device)
 
     def get_cpu_copy(self, indices):
         return self._kvcache.get_cpu_copy(indices)

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -456,7 +456,7 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
         locs = batch.seq_lens.clone()
 
     batch.req_to_token_pool.write(
-        (batch.req_pool_indices, locs), out_cache_loc.to(torch.int32)
+        (batch.req_pool_indices, locs), out_cache_loc
     )
 
     return out_cache_loc

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -455,9 +455,7 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     else:
         locs = batch.seq_lens.clone()
 
-    batch.req_to_token_pool.write(
-        (batch.req_pool_indices, locs), out_cache_loc
-    )
+    batch.req_to_token_pool.write((batch.req_pool_indices, locs), out_cache_loc)
 
     return out_cache_loc
 

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -143,7 +143,7 @@ class SWAKVPool(KVCache):
 
         # Note: kv_indices could have -1 values (from alloc_extend), which will be mapped to -1
         # since the last item of full_to_swa_index_mapping is -1.
-        return self.full_to_swa_index_mapping[kv_indices].to(torch.int32)
+        return self.full_to_swa_index_mapping[kv_indices]
 
     def set_kv_buffer(
         self,
@@ -279,10 +279,10 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             [
                 torch.zeros(
                     size + self.page_size,
-                    dtype=torch.int64,
+                    dtype=torch.int32,
                     device=device,
                 ),
-                torch.tensor([-1], dtype=torch.int64, device=device),
+                torch.tensor([-1], dtype=torch.int32, device=device),
             ]
         )
 

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -529,7 +529,7 @@ class CPUGraphRunner:
             self.seq_lens = torch.full(
                 (self.max_bs,), self.seq_len_fill_value, dtype=torch.int64
             )
-            self.out_cache_loc = torch.zeros((self.max_num_token,), dtype=torch.int64)
+            self.out_cache_loc = torch.zeros((self.max_num_token,), dtype=torch.int32)
             self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
             self.mrope_positions = torch.zeros((3, self.max_bs), dtype=torch.int64)
             self.num_token_non_padded = torch.zeros((1,), dtype=torch.int64)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -577,7 +577,7 @@ class CudaGraphRunner:
                 attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
 
     def _cache_loc_dtype(self):
-        return torch.int64
+        return torch.int32
 
     def can_run(self, forward_batch: ForwardBatch):
         if self.require_mlp_tp_gather:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1924,7 +1924,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             seq_len_fill_value=seq_len_fill_value,
             encoder_len_fill_value=0,
             num_tokens_per_bs=num_tokens_per_bs,
-            cache_loc_dtype=torch.int64,
+            cache_loc_dtype=torch.int32,
             enable_mamba_track=False,
         )
         buffers.num_token_non_padded[...] = num_tokens

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -57,7 +57,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     PPProxyTensors,
 )
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
-from sglang.srt.utils import get_available_gpu_memory, is_npu, log_info_on_rank0
+from sglang.srt.utils import get_available_gpu_memory, log_info_on_rank0
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +211,7 @@ class PiecewiseCudaGraphRunner:
                 (self.max_num_tokens,), dtype=self._cache_loc_dtype()
             )
             out_cache_loc_swa = (
-                torch.zeros((self.max_num_tokens,), dtype=torch.int64)
+                torch.zeros((self.max_num_tokens,), dtype=torch.int32)
                 if model_runner.is_hybrid_swa
                 else None
             )
@@ -407,7 +407,7 @@ class PiecewiseCudaGraphRunner:
             )
 
     def _cache_loc_dtype(self):
-        return torch.int64 if not is_npu() else torch.int32
+        return torch.int32
 
     def can_run(self, forward_batch: ForwardBatch):
         # Disable piecewise cuda graph for input embeddings

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -168,7 +168,7 @@ class EAGLEDraftCudaGraphRunner:
             )
 
     def _cache_loc_dtype(self):
-        return torch.int64
+        return torch.int32
 
     def can_run(self, forward_batch: ForwardBatch):
         if self.require_mlp_tp_gather:

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -247,7 +247,7 @@ class EAGLEDraftExtendCudaGraphRunner:
         return torch.cuda.CUDAGraph()
 
     def _cache_loc_dtype(self):
-        return torch.int64
+        return torch.int32
 
     def _capture_init(self, run_once_fn):
         for _ in range(2):

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -471,7 +471,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
                 to_free_slots = torch.empty(
                     (to_free_num_slots.sum().item(),),
-                    dtype=torch.int64,
+                    dtype=torch.int32,
                     device=to_free_num_slots.device,
                 )
 
@@ -563,7 +563,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 else:
                     batch.out_cache_loc = torch.empty(
                         len(unfinished_index) + sum(draft_input_accept_length_cpu),
-                        dtype=torch.int64,
+                        dtype=torch.int32,
                         device=predict.device,
                     )
                     accept_length_filter = create_accept_length_filter(

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -154,7 +154,7 @@ class EagleDraftInputV2Mixin:
             # Assign cache locations
             batch.out_cache_loc = torch.empty(
                 (bs * topk * num_steps,),
-                dtype=torch.int64,
+                dtype=torch.int32,
                 device=batch.input_ids.device,
             )
             # FIXME(lsyin): align with the default code path
@@ -468,7 +468,7 @@ def assign_extend_cache_locs_func(
     if _is_cuda or _is_hip:
         out_cache_loc = torch.empty(
             (batch_size * draft_token_num,),
-            dtype=torch.int64,
+            dtype=torch.int32,
             device=device,
         )
         assign_extend_cache_locs[(batch_size,)](

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -908,11 +908,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         tgt_cache_loc = torch.zeros(
             size,
-            dtype=torch.int64,
+            dtype=torch.int32,
             device=self.device,
         )
         accepted_out_cache_loc = torch.zeros(
-            size, dtype=torch.int64, device=self.device
+            size, dtype=torch.int32, device=self.device
         )
         assign_extend_cache_locs[(bs,)](
             batch.req_pool_indices,

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -653,10 +653,10 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
                 (self.offsets[-1],), dtype=torch.int64
             )
             self.cuda_graph_buffers["out_cache_loc"] = torch.ones(
-                (self.offsets[-1],), dtype=torch.int64
+                (self.offsets[-1],), dtype=torch.int32
             )
             self.cuda_graph_buffers["swa_out_cache_loc"] = torch.ones(
-                (self.offsets[-1],), dtype=torch.int64
+                (self.offsets[-1],), dtype=torch.int32
             )
             self.cuda_graph_buffers["positions"] = torch.zeros(
                 (self.offsets[-1],), dtype=torch.int64


### PR DESCRIPTION
## Summary

KV cache allocators created index tensors as int64 which were then explicitly cast to int32 at usage sites. Since cache indices never exceed int32 range, changed allocators to produce int32 from the start and removed all downstream casts.

Closes #17649