### PR TITLE
Sanitize exception messages in HTTP error responses (#18348)

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -21,9 +21,11 @@ import asyncio
 import dataclasses
 import logging
 import os
+import secrets
 import tempfile
 import threading
 import time
+import traceback
 from contextlib import asynccontextmanager
 from http import HTTPStatus
 from typing import (
@@ -1719,7 +1721,57 @@ async def vertex_generate(vertex_req: VertexGenerateReqInput, raw_request: Reque
     return ORJSONResponse({"predictions": ret})
 
 
+@app.exception_handler(Exception)
+async def general_exception_handler(request: Request, exc: Exception):
+    """Catch-all handler for unhandled exceptions."""
+    if _global_state and hasattr(_global_state, "tokenizer_manager"):
+        server_args = _global_state.tokenizer_manager.server_args
+        if (
+            isinstance(server_args, ServerArgs)
+            and server_args.enable_debug_error_responses
+        ):
+            return ORJSONResponse(
+                {"error": {"message": str(exc)}},
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+    message = _sanitize_error_message(exc)
+    return ORJSONResponse(
+        {"error": {"message": message}},
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
+
+
+def _sanitize_error_message(e: Exception) -> str:
+    """Generate a sanitized error message with a unique error_id for correlation."""
+    error_id = secrets.token_hex(6)
+    logger.error(
+        "Internal error [error_id=%s]: %s\n%s",
+        error_id,
+        e,
+        traceback.format_exc(),
+    )
+    return (
+        f"Internal server error. Please contact the administrator. Error ID: {error_id}"
+    )
+
+
 def _create_error_response(e):
+    if isinstance(e, Exception) and not isinstance(e, (ValueError, TypeError)):
+        if _global_state and hasattr(_global_state, "tokenizer_manager"):
+            server_args = _global_state.tokenizer_manager.server_args
+            if (
+                isinstance(server_args, ServerArgs)
+                and server_args.enable_debug_error_responses
+            ):
+                return ORJSONResponse(
+                    {"error": {"message": str(e)}},
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+        message = _sanitize_error_message(e)
+        return ORJSONResponse(
+            {"error": {"message": message}},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
     return ORJSONResponse(
         {"error": {"message": str(e)}}, status_code=HTTPStatus.BAD_REQUEST
     )

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1744,11 +1744,12 @@ async def general_exception_handler(request: Request, exc: Exception):
 def _sanitize_error_message(e: Exception) -> str:
     """Generate a sanitized error message with a unique error_id for correlation."""
     error_id = secrets.token_hex(6)
+    tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
     logger.error(
         "Internal error [error_id=%s]: %s\n%s",
         error_id,
         e,
-        traceback.format_exc(),
+        tb,
     )
     return (
         f"Internal server error. Please contact the administrator. Error ID: {error_id}"

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import secrets
+import traceback
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
@@ -120,12 +122,7 @@ class OpenAIServingBase(ABC):
                 status_code=400,
             )
         except Exception as e:
-            logger.exception(f"Error in request: {e}")
-            return self.create_error_response(
-                message=f"Internal server error: {str(e)}",
-                err_type="InternalServerError",
-                status_code=500,
-            )
+            return self._sanitize_internal_error(e)
 
     @abstractmethod
     def _request_id_prefix(self) -> str:
@@ -200,6 +197,30 @@ class OpenAIServingBase(ABC):
     def _validate_request(self, _: OpenAIServingRequest) -> Optional[str]:
         """Validate request"""
         pass
+
+    def _sanitize_internal_error(self, e: Exception) -> ORJSONResponse:
+        """Sanitize internal errors, logging full details server-side."""
+        error_id = secrets.token_hex(6)
+        logger.error(
+            "Internal error [error_id=%s]: %s\n%s",
+            error_id,
+            e,
+            traceback.format_exc(),
+        )
+        if (
+            isinstance(self.tokenizer_manager.server_args, ServerArgs)
+            and self.tokenizer_manager.server_args.enable_debug_error_responses
+        ):
+            return self.create_error_response(
+                message=str(e),
+                err_type="InternalServerError",
+                status_code=500,
+            )
+        return self.create_error_response(
+            message=f"Internal server error. Please contact the administrator. Error ID: {error_id}",
+            err_type="InternalServerError",
+            status_code=500,
+        )
 
     def create_error_response(
         self,

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -201,11 +201,12 @@ class OpenAIServingBase(ABC):
     def _sanitize_internal_error(self, e: Exception) -> ORJSONResponse:
         """Sanitize internal errors, logging full details server-side."""
         error_id = secrets.token_hex(6)
+        tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
         logger.error(
             "Internal error [error_id=%s]: %s\n%s",
             error_id,
             e,
-            traceback.format_exc(),
+            tb,
         )
         if (
             isinstance(self.tokenizer_manager.server_args, ServerArgs)

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -393,10 +393,16 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 isinstance(self.tokenizer_manager.server_args, ServerArgs)
                 and self.tokenizer_manager.server_args.enable_debug_error_responses
             ):
-                error = self.create_streaming_error_response(str(e))
+                error = self.create_streaming_error_response(
+                    str(e),
+                    err_type="InternalServerError",
+                    status_code=500,
+                )
             else:
                 error = self.create_streaming_error_response(
-                    f"Internal server error. Please contact the administrator. Error ID: {error_id}"
+                    f"Internal server error. Please contact the administrator. Error ID: {error_id}",
+                    err_type="InternalServerError",
+                    status_code=500,
                 )
             yield f"data: {error}\n\n"
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -382,11 +382,12 @@ class OpenAIServingCompletion(OpenAIServingBase):
 
         except Exception as e:
             error_id = secrets.token_hex(6)
+            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
             logger.error(
                 "Streaming error [error_id=%s]: %s\n%s",
                 error_id,
                 e,
-                traceback.format_exc(),
+                tb,
             )
             if (
                 isinstance(self.tokenizer_manager.server_args, ServerArgs)
@@ -395,7 +396,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 error = self.create_streaming_error_response(str(e))
             else:
                 error = self.create_streaming_error_response(
-                    f"Internal server error. Error ID: {error_id}"
+                    f"Internal server error. Please contact the administrator. Error ID: {error_id}"
                 )
             yield f"data: {error}\n\n"
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+import secrets
 import time
+import traceback
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
 
@@ -29,6 +31,7 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.code_completion_parser import (
     generate_completion_prompt_from_request,
 )
+from sglang.srt.server_args import ServerArgs
 from sglang.utils import convert_json_schema_to_str
 
 if TYPE_CHECKING:
@@ -378,7 +381,22 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 yield f"data: {final_usage_data}\n\n"
 
         except Exception as e:
-            error = self.create_streaming_error_response(str(e))
+            error_id = secrets.token_hex(6)
+            logger.error(
+                "Streaming error [error_id=%s]: %s\n%s",
+                error_id,
+                e,
+                traceback.format_exc(),
+            )
+            if (
+                isinstance(self.tokenizer_manager.server_args, ServerArgs)
+                and self.tokenizer_manager.server_args.enable_debug_error_responses
+            ):
+                error = self.create_streaming_error_response(str(e))
+            else:
+                error = self.create_streaming_error_response(
+                    f"Internal server error. Error ID: {error_id}"
+                )
             yield f"data: {error}\n\n"
 
         yield "data: [DONE]\n\n"

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -364,7 +364,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 )
                 return result
             except Exception as e:
-                return self.create_error_response(str(e))
+                return self._sanitize_internal_error(e)
         return self.create_error_response("Unknown error")
 
     async def _make_request(
@@ -735,7 +735,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             )
         except Exception as e:
             logger.exception("Background request failed for %s", request.request_id)
-            response = self.create_error_response(str(e))
+            response = self._sanitize_internal_error(e)
 
         if isinstance(response, ORJSONResponse):
             # If the request has failed, update the status to "failed"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -413,6 +413,7 @@ class ServerArgs:
     completion_template: Optional[str] = None
     file_storage_path: str = "sglang_storage"
     enable_cache_report: bool = False
+    enable_debug_error_responses: bool = False
     reasoning_parser: Optional[str] = None
     tool_call_parser: Optional[str] = None
     tool_server: Optional[str] = None
@@ -3853,6 +3854,11 @@ class ServerArgs:
             "--enable-cache-report",
             action="store_true",
             help="Return number of cached tokens in usage.prompt_tokens_details for each openai request.",
+        )
+        parser.add_argument(
+            "--enable-debug-error-responses",
+            action="store_true",
+            help="Return raw exception details in HTTP error responses instead of sanitized messages. For development use only.",
         )
         parser.add_argument(
             "--reasoning-parser",


### PR DESCRIPTION
## Summary

Exception messages in HTTP responses can leak internal details. Added centralized error sanitization with error_id correlation, with opt-in --enable-debug-error-responses flag for development.

Closes #18348