### PR TITLE
Support mrope_position_delta cache

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -362,6 +362,7 @@ class MultimodalInputs:
     # QWen2-VL related
     mrope_positions: Optional[torch.Tensor] = None
     mrope_position_delta: Optional[torch.Tensor] = None
+    mrope_position_delta_cache: Optional[torch.Tensor] = None
 
     @staticmethod
     def from_dict(obj: dict):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -362,7 +362,7 @@ class MultimodalInputs:
     # QWen2-VL related
     mrope_positions: Optional[torch.Tensor] = None
     mrope_position_delta: Optional[torch.Tensor] = None
-    mrope_position_delta_cache: Optional[torch.Tensor] = None
+    mrope_position_delta_repeated_cache: Optional[torch.Tensor] = None
 
     @staticmethod
     def from_dict(obj: dict):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -654,10 +654,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         seq_len: int,
     ) -> torch.Tensor:
         # doing below compute on cpu to avoid frequent small kernels
-        mrope_position_deltas = mm_input.mrope_position_delta.flatten()
-        mrope_positions = (
-            (mrope_position_deltas + seq_len - 1).unsqueeze(0).repeat(3, 1)
-        )
+        if mm_input.mrope_position_delta_cache is None:
+            mm_input.mrope_position_delta_cache = (
+                (mm_input.mrope_position_delta - 1).flatten().unsqueeze(0).repeat(3, 1)
+            )
+        mrope_positions = mm_input.mrope_position_delta_cache + seq_len
         return mrope_positions
 
     def _compute_mrope_positions(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -654,11 +654,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         seq_len: int,
     ) -> torch.Tensor:
         # doing below compute on cpu to avoid frequent small kernels
-        if mm_input.mrope_position_delta_cache is None:
-            mm_input.mrope_position_delta_cache = (
+        if mm_input.mrope_position_delta_repeated_cache is None:
+            mm_input.mrope_position_delta_repeated_cache = (
                 (mm_input.mrope_position_delta - 1).flatten().unsqueeze(0).repeat(3, 1)
             )
-        mrope_positions = mm_input.mrope_position_delta_cache + seq_len
+        mrope_positions = mm_input.mrope_position_delta_repeated_cache + seq_len
         return mrope_positions
 
     def _compute_mrope_positions(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Add a cache for mrope_position_delta to reduce redundant calculations.

## Modifications

<!-- Detail the changes made in this pull request. -->
add field mrope_position_delta_repeated in MultimodalInputs
Calculate mrope_position_delta_repeated when it is None.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
hardware：Ascend910
launch server command
```
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000

export SGLANG_SET_CPU_AFFINITY=1
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh

export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600

LOCAL_HOST1=`hostname -I|awk -F " " '{print$1}'`
LOCAL_HOST2=`hostname -I|awk -F " " '{print$2}'`
export HCCL_BUFFSIZE=400
export HCCL_SOCKET_IFNAME=lo
export GLOO_SOCKET_IFNAME=lo
export HCCL_OP_EXPANSION_MODE="AIV"

export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export PYTHONPATH=$PATH/sglang/python:$PYTHONPATH

python -m sglang.launch_server \
    --model-path $PATH/Qwen3-VL-8B-Instruct \
    --host 127.0.0.1 \
    --port 32000 \
    --tp 2 \
    --max-prefill-tokens 40960 \
    --chunked-prefill-size 40960 \
    --mem-fraction-static 0.88 \
    --max-running-requests 512 \
    --disable-radix-cache \
    --cuda-graph-bs 10 20 40 80 100 110 120 130 140 160 180 200\
    --trust-remote-code \
    --enable-multimodal \
    --mm-attention-backend ascend_attn \
    --sampling-backend ascend \
    --context-length 32768 \
    --attention-backend ascend \
    --mm-enable-dp-encoder  \
    --enable-dp-attention --dp-size 2
```
accuracy command
```
evalscope eval \
 --model $PATH/Qwen3-VL-8B-Instruct \
 --api-url http://127.0.0.1:32000/v1/chat/completions \
 --api-key EMPTY \
 --eval-type openai_api \
 --generation-config '{"do_sample": true, "max_tokens": 8000, "seed": 3407 ,"top_p":0.8, "top_k":20, "temperature": 0.7, "n":1, "presence_penalty": 1.5,"repetition_penalty": 1, "timeout": 60, "stream": true, "extra_body": {"chat_template_kwargs": {"enable_thinking": false}}}' \
 --datasets mm_bench \
 --dataset-hub Local \
 --dataset-args '{"mm_bench": {"dataset_id": "$PATH/MMBench","subset_list": ["cn"]}}' \
 --eval-batch-size 2 \
 --ignore-errors \
 --limit 100
```
before
<img width="613" height="78" alt="image" src="https://github.com/user-attachments/assets/0e385a18-e989-4bb5-b6a1-a745f523d550" />


after
<img width="614" height="93" alt="image" src="https://github.com/user-attachments/assets/90709edb-6793-4fce-8db4-424160370102" />

## Benchmarking and Profiling
before
decode stage bubble 8.3ms
<img width="223" height="331" alt="image" src="https://github.com/user-attachments/assets/a2494c08-f499-4def-968e-0b53f6d98be0" />
after
decode stage bubble <1ms
<img width="236" height="446" alt="image" src="https://github.com/user-attachments/assets/48a71627-1e60-4f76-8b7e-95266b377283" />





<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
