### PR TITLE
[Diffusion] Add native `/v1/diffusion/generate` endpoint for trajectory metadata

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_api.py
@@ -60,11 +60,9 @@ class DiffusionGenerateRequest(BaseModel):
     num_outputs_per_prompt: Optional[int] = 1
     enable_teacache: Optional[bool] = False
 
-    # Extended metadata flags
-    return_trajectory_latents: bool = False
-    return_trajectory_decoded: bool = False
-    # TODO: enable after PR #18806 lands and OutputBatch gains log_prob fields
-    # return_log_probs: bool = False
+    # Extended metadata flags (default False — no latency impact when unused)
+    get_latents: bool = False
+    get_log_probs: bool = False
 
     # Output control
     output_quality: Optional[str] = "default"
@@ -85,13 +83,12 @@ class TrajectoryData(BaseModel):
         arr = np.load(io.BytesIO(base64.b64decode(blob)))
     """
 
-    trajectory_latents: Optional[str] = None
-    trajectory_latents_shape: Optional[List[int]] = None
-    trajectory_latents_dtype: Optional[str] = None
-    trajectory_timesteps: Optional[List[str]] = None
-    trajectory_decoded: Optional[List[str]] = None
-    # TODO: add after PR #18806
-    # trajectory_log_probs: Optional[str] = None
+    latents: Optional[str] = None
+    latents_shape: Optional[List[int]] = None
+    latents_dtype: Optional[str] = None
+    timesteps: Optional[List[str]] = None
+    log_probs: Optional[str] = None
+    log_probs_shape: Optional[List[int]] = None
 
 
 class DiffusionGenerateResponse(BaseModel):
@@ -121,32 +118,35 @@ def _tensor_to_b64_npy(t: torch.Tensor) -> str:
 def _build_trajectory(result) -> Optional[TrajectoryData]:
     """Extract trajectory fields from an OutputBatch into serialized form."""
     has_latents = result.trajectory_latents is not None
-    has_decoded = result.trajectory_decoded is not None
-    if not has_latents and not has_decoded:
+    has_log_probs = getattr(result, "trajectory_log_probs", None) is not None
+    if not has_latents and not has_log_probs:
         return None
 
-    traj_latents_b64 = None
-    traj_latents_shape = None
-    traj_latents_dtype = None
+    latents_b64 = None
+    latents_shape = None
+    latents_dtype = None
     if has_latents:
-        traj_latents_b64 = _tensor_to_b64_npy(result.trajectory_latents)
-        traj_latents_shape = list(result.trajectory_latents.shape)
-        traj_latents_dtype = str(result.trajectory_latents.dtype)
+        latents_b64 = _tensor_to_b64_npy(result.trajectory_latents)
+        latents_shape = list(result.trajectory_latents.shape)
+        latents_dtype = str(result.trajectory_latents.dtype)
 
-    traj_timesteps_b64 = None
+    timesteps_b64 = None
     if result.trajectory_timesteps is not None:
-        traj_timesteps_b64 = [_tensor_to_b64_npy(t) for t in result.trajectory_timesteps]
+        timesteps_b64 = [_tensor_to_b64_npy(t) for t in result.trajectory_timesteps]
 
-    traj_decoded_b64 = None
-    if has_decoded:
-        traj_decoded_b64 = [_tensor_to_b64_npy(t) for t in result.trajectory_decoded]
+    log_probs_b64 = None
+    log_probs_shape = None
+    if has_log_probs:
+        log_probs_b64 = _tensor_to_b64_npy(result.trajectory_log_probs)
+        log_probs_shape = list(result.trajectory_log_probs.shape)
 
     return TrajectoryData(
-        trajectory_latents=traj_latents_b64,
-        trajectory_latents_shape=traj_latents_shape,
-        trajectory_latents_dtype=traj_latents_dtype,
-        trajectory_timesteps=traj_timesteps_b64,
-        trajectory_decoded=traj_decoded_b64,
+        latents=latents_b64,
+        latents_shape=latents_shape,
+        latents_dtype=latents_dtype,
+        timesteps=timesteps_b64,
+        log_probs=log_probs_b64,
+        log_probs_shape=log_probs_shape,
     )
 
 
@@ -182,8 +182,8 @@ async def generate(request: DiffusionGenerateRequest):
             true_cfg_scale=request.true_cfg_scale,
             num_outputs_per_prompt=request.num_outputs_per_prompt,
             enable_teacache=request.enable_teacache,
-            return_trajectory_latents=request.return_trajectory_latents,
-            return_trajectory_decoded=request.return_trajectory_decoded,
+            return_trajectory_latents=request.get_latents,
+            return_trajectory_decoded=request.get_latents,
             output_path=output_dir,
             output_file_name=request_id,
             output_quality=request.output_quality,

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_api.py
@@ -1,0 +1,236 @@
+"""Native SGLang-D API for diffusion generation with extended metadata.
+
+Exposes trajectory data (latents, timesteps, decoded frames) and log_probs
+that the OpenAI-compatible endpoints intentionally omit. Intended for RL
+training pipelines and workloads that need intermediate diffusion outputs.
+"""
+
+import base64
+import io
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from sglang.multimodal_gen.configs.sample.sampling_params import generate_request_id
+from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
+    build_sampling_params,
+    process_generation_batch,
+    temp_dir_if_disabled,
+)
+from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
+from sglang.multimodal_gen.runtime.server_args import get_global_server_args
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+router = APIRouter(prefix="/v1/diffusion", tags=["diffusion-native"])
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class DiffusionGenerateRequest(BaseModel):
+    """Native SGLang-D generation request with trajectory and log_prob support."""
+
+    prompt: str
+    negative_prompt: Optional[str] = None
+    image_path: Optional[str] = None
+
+    # Dimensions
+    size: Optional[str] = None  # "WxH" convenience string
+    width: Optional[int] = None
+    height: Optional[int] = None
+    num_frames: Optional[int] = None
+    fps: Optional[int] = None
+
+    # Generation parameters
+    seed: Optional[int] = 1024
+    generator_device: Optional[str] = "cuda"
+    num_inference_steps: Optional[int] = None
+    guidance_scale: Optional[float] = None
+    guidance_scale_2: Optional[float] = None
+    true_cfg_scale: Optional[float] = None
+    num_outputs_per_prompt: Optional[int] = 1
+    enable_teacache: Optional[bool] = False
+
+    # Extended metadata flags
+    return_trajectory_latents: bool = False
+    return_trajectory_decoded: bool = False
+    # TODO: enable after PR #18806 lands and OutputBatch gains log_prob fields
+    # return_log_probs: bool = False
+
+    # Output control
+    output_quality: Optional[str] = "default"
+    output_compression: Optional[int] = None
+    enable_frame_interpolation: Optional[bool] = False
+    frame_interpolation_exp: Optional[int] = 1
+    frame_interpolation_scale: Optional[float] = 1.0
+    frame_interpolation_model_path: Optional[str] = None
+    diffusers_kwargs: Optional[Dict[str, Any]] = None
+
+
+class TrajectoryData(BaseModel):
+    """Serialized trajectory arrays as base64-encoded ``.npy`` blobs.
+
+    Client deserialization::
+
+        import base64, io, numpy as np
+        arr = np.load(io.BytesIO(base64.b64decode(blob)))
+    """
+
+    trajectory_latents: Optional[str] = None
+    trajectory_latents_shape: Optional[List[int]] = None
+    trajectory_latents_dtype: Optional[str] = None
+    trajectory_timesteps: Optional[List[str]] = None
+    trajectory_decoded: Optional[List[str]] = None
+    # TODO: add after PR #18806
+    # trajectory_log_probs: Optional[str] = None
+
+
+class DiffusionGenerateResponse(BaseModel):
+    id: str
+    created: int = Field(default_factory=lambda: int(time.time()))
+    output_b64: Optional[str] = None
+    output_format: Optional[str] = None
+    file_path: Optional[str] = None
+    peak_memory_mb: Optional[float] = None
+    inference_time_s: Optional[float] = None
+    trajectory: Optional[TrajectoryData] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tensor_to_b64_npy(t: torch.Tensor) -> str:
+    """Serialize a torch.Tensor to a base64-encoded ``.npy`` blob."""
+    arr = t.detach().cpu().float().numpy()
+    buf = io.BytesIO()
+    np.save(buf, arr)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _build_trajectory(result) -> Optional[TrajectoryData]:
+    """Extract trajectory fields from an OutputBatch into serialized form."""
+    has_latents = result.trajectory_latents is not None
+    has_decoded = result.trajectory_decoded is not None
+    if not has_latents and not has_decoded:
+        return None
+
+    traj_latents_b64 = None
+    traj_latents_shape = None
+    traj_latents_dtype = None
+    if has_latents:
+        traj_latents_b64 = _tensor_to_b64_npy(result.trajectory_latents)
+        traj_latents_shape = list(result.trajectory_latents.shape)
+        traj_latents_dtype = str(result.trajectory_latents.dtype)
+
+    traj_timesteps_b64 = None
+    if result.trajectory_timesteps is not None:
+        traj_timesteps_b64 = [_tensor_to_b64_npy(t) for t in result.trajectory_timesteps]
+
+    traj_decoded_b64 = None
+    if has_decoded:
+        traj_decoded_b64 = [_tensor_to_b64_npy(t) for t in result.trajectory_decoded]
+
+    return TrajectoryData(
+        trajectory_latents=traj_latents_b64,
+        trajectory_latents_shape=traj_latents_shape,
+        trajectory_latents_dtype=traj_latents_dtype,
+        trajectory_timesteps=traj_timesteps_b64,
+        trajectory_decoded=traj_decoded_b64,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/generate", response_model=DiffusionGenerateResponse)
+async def generate(request: DiffusionGenerateRequest):
+    """Generate image/video with optional trajectory metadata."""
+    request_id = generate_request_id()
+    server_args = get_global_server_args()
+
+    with temp_dir_if_disabled(server_args.output_path) as output_dir:
+        # Build SamplingParams with output_path set upfront so _adjust()
+        # correctly sets save_output=True and generates a valid file path.
+        sampling = build_sampling_params(
+            request_id,
+            prompt=request.prompt,
+            negative_prompt=request.negative_prompt,
+            image_path=request.image_path,
+            size=request.size,
+            width=request.width,
+            height=request.height,
+            num_frames=request.num_frames,
+            fps=request.fps,
+            seed=request.seed,
+            generator_device=request.generator_device,
+            num_inference_steps=request.num_inference_steps,
+            guidance_scale=request.guidance_scale,
+            guidance_scale_2=request.guidance_scale_2,
+            true_cfg_scale=request.true_cfg_scale,
+            num_outputs_per_prompt=request.num_outputs_per_prompt,
+            enable_teacache=request.enable_teacache,
+            return_trajectory_latents=request.return_trajectory_latents,
+            return_trajectory_decoded=request.return_trajectory_decoded,
+            output_path=output_dir,
+            output_file_name=request_id,
+            output_quality=request.output_quality,
+            output_compression=request.output_compression,
+            enable_frame_interpolation=request.enable_frame_interpolation,
+            frame_interpolation_exp=request.frame_interpolation_exp,
+            frame_interpolation_scale=request.frame_interpolation_scale,
+            frame_interpolation_model_path=request.frame_interpolation_model_path,
+        )
+
+        batch = prepare_request(server_args=server_args, sampling_params=sampling)
+        if request.diffusers_kwargs:
+            batch.extra["diffusers_kwargs"] = request.diffusers_kwargs
+
+        save_file_path_list, result = await process_generation_batch(
+            async_scheduler_client, batch
+        )
+
+        # Read output file as base64
+        output_b64 = None
+        file_path = save_file_path_list[0] if save_file_path_list else None
+        output_format = None
+        if file_path and os.path.exists(file_path):
+            with open(file_path, "rb") as f:
+                output_b64 = base64.b64encode(f.read()).decode("ascii")
+            ext = os.path.splitext(file_path)[1].lstrip(".")
+            output_format = ext if ext else None
+
+        is_persistent = server_args.output_path is not None
+
+        # Serialize trajectory data from OutputBatch
+        trajectory = _build_trajectory(result)
+
+    return DiffusionGenerateResponse(
+        id=request_id,
+        output_b64=output_b64,
+        output_format=output_format,
+        file_path=file_path if is_persistent else None,
+        peak_memory_mb=(
+            result.peak_memory_mb
+            if result.peak_memory_mb and result.peak_memory_mb > 0
+            else None
+        ),
+        inference_time_s=(
+            result.metrics.total_duration_s
+            if result.metrics and result.metrics.total_duration_s > 0
+            else None
+        ),
+        trajectory=trajectory,
+    )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -222,5 +222,9 @@ def create_app(server_args: ServerArgs):
     app.include_router(mesh_api.router)
     app.include_router(weights_api.router)
 
+    from sglang.multimodal_gen.runtime.entrypoints import diffusion_api
+
+    app.include_router(diffusion_api.router)
+
     app.state.server_args = server_args
     return app


### PR DESCRIPTION
Related Issue: #19827

## Motivation

SGLang-D currently only exposes OpenAI-compatible endpoints (`/v1/images/generations`, `/v1/videos`). The OpenAI image/video API schema has no standard fields for `latents` or `log_probs`, so these values are silently dropped before the HTTP response — even though the pipeline already computes them when requested.

This is a **blocking issue for RL training workloads**: every RL pipeline runs against the server, and without HTTP-level access to trajectory latents and log probs, the `log_prob` feature added in #18806 is effectively unusable in production.

This PR introduces a **native SGLang-D API** at `POST /v1/diffusion/generate`, following the same pattern as SGLang's native LLM API (`/generate`) that coexists with the OpenAI-compatible endpoints.

## Modifications

### New file: `python/sglang/multimodal_gen/runtime/entrypoints/diffusion_api.py`

Adds a native generation endpoint with two extended metadata flags:

```python
# Request
{
  "prompt": "A cat walking",
  "get_latents": false,   # default: false — no latency impact when unused
  "get_log_probs": false  # default: false — populated after PR #18806 lands
}

# Response
{
  "id": "...",
  "output_b64": "<base64-encoded mp4/png>",
  "output_format": "mp4",
  "peak_memory_mb": 12304.0,
  "inference_time_s": 336.46,
  "trajectory": {
    "latents": "<base64-encoded .npy blob>",
    "latents_shape": [1, 50, 16, 21, 60, 104],
    "latents_dtype": "torch.float32",
    "timesteps": ["<b64>", ...],
    "log_probs": null,       # populated after PR #18806
    "log_probs_shape": null
  }
}
```

Tensors are serialized as base64-encoded NumPy `.npy` blobs. Client deserialization:

```python
import base64, io, numpy as np
arr = np.load(io.BytesIO(base64.b64decode(response["trajectory"]["latents"])))
```

### Modified file: `python/sglang/multimodal_gen/runtime/entrypoints/http_server.py`

Added 3 lines in `create_app()` to register the new router. **No existing code changed.**

```python
from sglang.multimodal_gen.runtime.entrypoints import diffusion_api
app.include_router(diffusion_api.router)
```

### Design notes

- **Zero impact on existing endpoints**: `/v1/images/generations`, `/v1/videos`, `/v1/meshes` are completely untouched.
- **No latency overhead when flags are `false`**: trajectory data is never collected or serialized unless explicitly requested.
- **`get_log_probs` structure is ready**: the field is accepted and returns `null` today. Once PR #18806 adds `trajectory_log_probs` to `OutputBatch`, enabling it requires uncommenting ~3 lines.
- All pipeline plumbing (`build_sampling_params`, `prepare_request`, `process_generation_batch`) is reused from existing code.

## Accuracy Tests

This PR adds a new endpoint and does not modify any model forward code, kernel, or pipeline logic. No accuracy regression is possible.

Functional test on NVIDIA A40, `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`:

```bash
# Basic generation (no trajectory)
curl -X POST http://localhost:30000/v1/diffusion/generate \
  -H "Content-Type: application/json" \
  -d '{"prompt": "A cat walking"}'
# -> HTTP 200, output_b64 present, trajectory: null

# With latents
curl -X POST http://localhost:30000/v1/diffusion/generate \
  -H "Content-Type: application/json" \
  -d '{"prompt": "A cat walking", "get_latents": true}'
# -> HTTP 200, trajectory.latents present (base64 npy)
```

Server log confirms two successful `200 OK` responses:

```
[2026-03-04 08:55:48] INFO: "POST /v1/diffusion/generate HTTP/1.1" 200 OK
[2026-03-04 09:00:44] INFO: "POST /v1/diffusion/generate HTTP/1.1" 200 OK
```

## Benchmarking and Profiling

**No performance impact on the existing OpenAI endpoints.** The new endpoint is only invoked when explicitly called.

For the native endpoint itself, observed on A40 with `Wan2.1-T2V-1.3B` (81 frames, 50 steps):

| Run | Denoising | Decoding | Total |
|-----|-----------|----------|-------|
| 1 (cold, `get_latents=false`) | 305.6s | 17.4s | 336.5s |
| 2 (warm, `get_latents=true`) | 261.0s | 12.1s | 282.4s |

Peak GPU memory: **12.02 GB** (peak allocated 8.67 GB). When `get_latents=false`, trajectory serialization is skipped entirely — no overhead.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
