### PR TITLE
Fix: suppress noisy torch.compile logs (Fixes #19734)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -75,7 +75,10 @@ from sglang.multimodal_gen.runtime.platforms import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
-from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.logging_utils import (
+    init_logger,
+    torch_compile_log_context,
+)
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
 from sglang.multimodal_gen.utils import dict_to_3d_list, masks_like
@@ -1058,22 +1061,45 @@ class DenoisingStage(PipelineStage):
                             timestep_value=t_int,
                             timesteps=timesteps_cpu,
                         )
-                        noise_pred = self._predict_noise_with_cfg(
-                            current_model=current_model,
-                            latent_model_input=latent_model_input,
-                            timestep=timestep,
-                            batch=batch,
-                            timestep_index=i,
-                            attn_metadata=attn_metadata,
-                            target_dtype=target_dtype,
-                            current_guidance_scale=current_guidance_scale,
-                            image_kwargs=image_kwargs,
-                            pos_cond_kwargs=pos_cond_kwargs,
-                            neg_cond_kwargs=neg_cond_kwargs,
-                            server_args=server_args,
-                            guidance=guidance,
-                            latents=latents,
-                        )
+                        if server_args.enable_torch_compile:
+                            module_name = current_model.__class__.__name__
+                            with torch_compile_log_context(
+                                module_name=module_name,
+                                log_level=server_args.log_level,
+                            ):
+                                noise_pred = self._predict_noise_with_cfg(
+                                    current_model=current_model,
+                                    latent_model_input=latent_model_input,
+                                    timestep=timestep,
+                                    batch=batch,
+                                    timestep_index=i,
+                                    attn_metadata=attn_metadata,
+                                    target_dtype=target_dtype,
+                                    current_guidance_scale=current_guidance_scale,
+                                    image_kwargs=image_kwargs,
+                                    pos_cond_kwargs=pos_cond_kwargs,
+                                    neg_cond_kwargs=neg_cond_kwargs,
+                                    server_args=server_args,
+                                    guidance=guidance,
+                                    latents=latents,
+                                )
+                        else:
+                            noise_pred = self._predict_noise_with_cfg(
+                                current_model=current_model,
+                                latent_model_input=latent_model_input,
+                                timestep=timestep,
+                                batch=batch,
+                                timestep_index=i,
+                                attn_metadata=attn_metadata,
+                                target_dtype=target_dtype,
+                                current_guidance_scale=current_guidance_scale,
+                                image_kwargs=image_kwargs,
+                                pos_cond_kwargs=pos_cond_kwargs,
+                                neg_cond_kwargs=neg_cond_kwargs,
+                                server_args=server_args,
+                                guidance=guidance,
+                                latents=latents,
+                            )
 
                         # Save noise_pred to batch for external access (e.g., ComfyUI)
                         if server_args.comfyui_mode:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -63,7 +63,10 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
-from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.logging_utils import (
+    init_logger,
+    torch_compile_log_context,
+)
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
@@ -181,6 +184,22 @@ class MOVADenoisingStage(PipelineStage):
             attn_metadata=attn_metadata,
             forward_batch=forward_batch,
         ):
+            server_args = get_global_server_args()
+            if server_args.enable_torch_compile:
+                with torch_compile_log_context(
+                    module_name=visual_dit.__class__.__name__,
+                    log_level=server_args.log_level,
+                ):
+                    return self.inference_single_step(
+                        visual_dit=visual_dit,
+                        visual_latents=visual_latents,
+                        audio_latents=audio_latents,
+                        y=y,
+                        context=context,
+                        timestep=timestep,
+                        audio_timestep=audio_timestep,
+                        video_fps=video_fps,
+                    )
             return self.inference_single_step(
                 visual_dit=visual_dit,
                 visual_latents=visual_latents,

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -894,7 +894,11 @@ class ServerArgs:
             "--log-level",
             type=str,
             default=ServerArgs.log_level,
-            help="The logging level of all loggers.",
+            help=(
+                "The logging level of all loggers. "
+                "Also controls torch.compile internal log handling: "
+                "info silences compile noise on console; non-info redirects compile stdout/stderr to file."
+            ),
         )
         parser.add_argument(
             "--backend",

--- a/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
@@ -10,7 +10,9 @@ import datetime
 import logging
 import os
 import sys
+import threading
 import time
+import warnings
 from contextlib import contextmanager
 from functools import lru_cache, partial
 from logging import Logger
@@ -279,6 +281,164 @@ def init_logger(name: str) -> _SGLDiffusionLogger:
 
 
 logger = init_logger(__name__)
+
+
+_TORCH_COMPILE_LOG_FILE_PATH: str | None = None
+_TORCH_COMPILE_LOG_FD: int | None = None
+_TORCH_COMPILE_WRITTEN_MODULE_HEADERS: set[str] = set()
+_TORCH_COMPILE_REDIRECT_LOCK = threading.RLock()
+
+
+def _resolve_log_level_name(log_level: str | None = None) -> str:
+    if log_level is not None:
+        return str(log_level).strip().lower()
+    root = logging.getLogger()
+    return logging.getLevelName(root.getEffectiveLevel()).lower()
+
+
+def _get_process_rank() -> int:
+    try:
+        return int(os.environ.get("RANK", "0"))
+    except ValueError:
+        return 0
+
+
+def _get_torch_compile_log_path() -> str:
+    global _TORCH_COMPILE_LOG_FILE_PATH
+    if _TORCH_COMPILE_LOG_FILE_PATH is not None:
+        return _TORCH_COMPILE_LOG_FILE_PATH
+
+    log_dir = os.environ.get(
+        "SGLANG_TORCH_COMPILE_LOG_DIR",
+        os.path.join(os.getcwd(), "outputs", "torch_compile_logs"),
+    )
+    os.makedirs(log_dir, exist_ok=True)
+
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    rank = _get_process_rank()
+    _TORCH_COMPILE_LOG_FILE_PATH = os.path.join(
+        log_dir,
+        f"torch_compile_{ts}_pid{os.getpid()}_rank{rank}.log",
+    )
+    return _TORCH_COMPILE_LOG_FILE_PATH
+
+
+def _get_torch_compile_log_fd() -> int:
+    global _TORCH_COMPILE_LOG_FD
+    if _TORCH_COMPILE_LOG_FD is None:
+        _TORCH_COMPILE_LOG_FD = os.open(
+            _get_torch_compile_log_path(),
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+    return _TORCH_COMPILE_LOG_FD
+
+
+def _write_torch_compile_session_header_once(module_name: str | None) -> None:
+    if not get_is_main_process():
+        return
+
+    key = module_name or "unknown_module"
+    if key in _TORCH_COMPILE_WRITTEN_MODULE_HEADERS:
+        return
+
+    ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    line = (
+        f"\n===== torch.compile session: module={key}, pid={os.getpid()},"
+        f" rank={_get_process_rank()}, at={ts} =====\n"
+    )
+    os.write(_get_torch_compile_log_fd(), line.encode("utf-8", errors="replace"))
+    _TORCH_COMPILE_WRITTEN_MODULE_HEADERS.add(key)
+
+
+@contextmanager
+def _redirect_stdout_stderr_to_fd(target_fd: int):
+    try:
+        stdout_fd = sys.stdout.fileno()
+        stderr_fd = sys.stderr.fileno()
+    except Exception:
+        # Some runtime wrappers may provide non-fd streams.
+        # Fall back to no-op to avoid blocking the denoising loop.
+        yield
+        return
+
+    stdout_dup = os.dup(stdout_fd)
+    stderr_dup = os.dup(stderr_fd)
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(target_fd, stdout_fd)
+        os.dup2(target_fd, stderr_fd)
+        yield
+    finally:
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:
+            pass
+        os.dup2(stdout_dup, stdout_fd)
+        os.dup2(stderr_dup, stderr_fd)
+        os.close(stdout_dup)
+        os.close(stderr_dup)
+
+
+@contextmanager
+def torch_compile_log_context(
+    module_name: str | None = None, log_level: str | None = None
+):
+    """
+    Unified torch.compile logging control.
+
+    Policy:
+    - log-level == info: silence compile internal noise from stdout/stderr and
+      additionally suppress noisy python loggers/warnings.
+    - log-level != info: redirect compile stdout/stderr to file on main process;
+      non-main processes are silenced to avoid duplicated logs.
+    """
+    level_name = _resolve_log_level_name(log_level)
+    is_info_mode = level_name == "info"
+
+    if is_info_mode:
+        target_fd = os.open(os.devnull, os.O_WRONLY)
+        should_close_target_fd = True
+    else:
+        if get_is_main_process():
+            _write_torch_compile_session_header_once(module_name)
+            target_fd = _get_torch_compile_log_fd()
+            should_close_target_fd = False
+        else:
+            target_fd = os.open(os.devnull, os.O_WRONLY)
+            should_close_target_fd = True
+
+    loggers_to_suppress = [
+        "torch",
+        "torch._dynamo",
+        "torch._inductor",
+        "torch.fx.experimental.symbolic_shapes",
+        "triton",
+        "triton.runtime",
+        "triton.compiler",
+    ]
+    original_levels = None
+
+    with _TORCH_COMPILE_REDIRECT_LOCK:
+        try:
+            with _redirect_stdout_stderr_to_fd(target_fd):
+                if is_info_mode:
+                    original_levels = suppress_loggers(
+                        loggers_to_suppress, logging.ERROR
+                    )
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        yield
+                else:
+                    yield
+        finally:
+            if original_levels is not None:
+                for logger_name, level in original_levels.items():
+                    logging.getLogger(logger_name).setLevel(level)
+            if should_close_target_fd:
+                os.close(target_fd)
 
 
 def _trace_calls(log_path, root_dir, frame, event, arg=None):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR addresses the issue of massive, noisy logs generated by `torch.compile` and Triton autotuning (e.g., `final peak_memory=XXX`) during diffusion model serving (Fixes #19734). 

The core goal is to clean up the console output without introducing any new CLI arguments. By unifying the logging behavior under the existing `--log-level` flag, this PR ensures a quiet console by default, preserves traceability for debugging, and guarantees stability across multi-GPU and concurrent environments.

## Modifications

<!-- Detail the changes made in this pull request. -->

**1. Unified Log Management (`logging_utils.py`)**
* Introduced a unified context manager `torch_compile_log_context()` to handle all compile logs based on `--log-level`:
    * **`info` (Default):** Suppresses noise by redirecting outputs to `null`, combined with logger and warnings suppression.
    * **Non-`info` (e.g., `debug`):** Redirects `stdout`/`stderr` to dedicated compile log files for troubleshooting.
* **Deep Capture:** Utilized File Descriptor (FD) level redirection (`dup2`) to successfully capture lower-level C/CUDA/Triton outputs.
* **Distributed Friendly:** Implemented a multi-process/multi-GPU strategy where only the main process writes to the log file, while other ranks remain silent to prevent duplication. Log filenames include timestamp, PID, and rank to avoid overwriting.
* **Concurrency Stability:** Added a global Reentrant Lock (`RLock`) to prevent concurrent requests from overriding FDs, and added a fallback to `no-op` if `stdout`/`stderr` lacks `fileno()`.

**2. Targeted Context Application (`denoising.py`)**
* Wrapped only the `_predict_noise_with_cfg()` model forward pass window within the denoising loop. This ensures the actual compilation noise is captured properly (even for late-triggering autotune outputs) without swallowing the `tqdm` progress bar or other standard loop outputs.

**3. MOVA Path Alignment**
* Applied the same `torch_compile_log_context()` to the MOVA-specific denoising paths to ensure consistent logging behavior across different pipeline branches.

**4. Parameter and Documentation Synchronization**
* Tied the compile logging behavior strictly to the existing `--log-level` argument, deliberately avoiding the addition of redundant CLI switches.
* Updated CLI documentation to reflect these changes for better user discoverability.

## Examples

Test via
```bash
SERVER_ARGS=(
  --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers
  --text-encoder-cpu-offload
  --pin-cpu-memory
  --num-gpus 4
  --ulysses-degree=2
  --ring-degree=2
  --port 30000
) 
sglang serve "${SERVER_ARGS[@]}" --enable-torch-compile --log-level debug
curl -sS -X POST "http://localhost:30000/v1/videos"   -H "Content-Type: application/json"   -H "Authorization: Bearer sk-proj-1234567890"   -d '{
        "prompt": "A calico cat playing a piano on stage",
        "size": "832x480", "num-inference-steps":10 
      }'
```

The console log prints
```bash
[2026-03-05 02:02:55] INFO:     127.0.0.1:59880 - "POST /v1/videos HTTP/1.1" 200 OK
[03-05 02:02:55] Running pipeline stages: ['input_validation_stage', 'text_encoding_stage', 'latent_preparation_stage', 'timestep_preparation_stage', 'denoising_stage', 'decoding_stage']
[03-05 02:02:55] [InputValidationStage] started...
[03-05 02:02:55] [InputValidationStage] finished in 0.0001 seconds
[03-05 02:02:55] [TextEncodingStage] started...
[03-05 02:02:59] [TextEncodingStage] finished in 3.5784 seconds
[03-05 02:02:59] [LatentPreparationStage] started...
[03-05 02:02:59] [LatentPreparationStage] finished in 0.0011 seconds
[03-05 02:02:59] [TimestepPreparationStage] started...
[03-05 02:02:59] [TimestepPreparationStage] finished in 0.0005 seconds
[03-05 02:02:59] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████| 50/50 [04:06<00:00,  4.94s/it]
[03-05 02:07:06] [DenoisingStage] average time per step: 4.9397 seconds
[03-05 02:07:06] [DenoisingStage] finished in 246.9884 seconds
[03-05 02:07:06] [DecodingStage] started...
[03-05 02:07:11] [DecodingStage] finished in 5.1708 seconds
[03-05 02:07:11] Peak GPU memory: 12.07 GB, Peak allocated: 7.93 GB, Memory pool overhead: 4.15 GB (34.3%), Remaining GPU memory at peak: 35.91 GB. Components that could stay resident (based on the last request workload): ['text_encoder', 'vae', 'transformer']. Related offload server args to disable: --dit-layerwise-offload, --text-encoder-cpu-offload, --vae-cpu-offload
[03-05 02:07:12] Output saved to outputs/6069b8cb-4eef-4c70-9b76-dd90d9d87161.mp4
[03-05 02:07:12] Pixel data generated successfully in 256.59 seconds
[03-05 02:07:12] Completed batch processing. Generated 1 outputs in 256.59 seconds
[03-05 02:07:12] Peak memory usage: 12364.00 MB
```

The compile log is redirected to a local file under the output directory `outputs/torch_compile_logs`:

```bash
===== torch.compile session: module=WanTransformer3DModel, pid=2118866, rank=0, at=2026-03-05 01:53:26 =====
final peak_memory=0
final peak_memory=0
final peak_memory=0
/home/wanghy/miniconda3/envs/sglang/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py:1692: UserWarning: Dynamo detected a call to a `functools.lru_cache`-wrapped function. Dynamo ignores the cache wrapper and directly traces the wrapped function. Silent incorrectness is only a *potential* risk, not something we have observed. Enable TORCH_LOGS="+dynamo" for a DEBUG stack trace.
  torch._dynamo.utils.warn_once(msg)
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=28753920
final peak_memory=28753920
final peak_memory=28753920
[03-05 01:55:51] Loading all available dialects
/home/wanghy/miniconda3/envs/sglang/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py:1598: UserWarning: Dynamo does not know how to trace the builtin `<unknown module>.datetime.now.` This function is either a Python builtin (e.g. _warnings.warn) or a third-party C/C++ Python extension (perhaps created with pybind).
If it is a Python builtin, please file an issue on GitHub so the PyTorch team can add support for it and see the next case for a workaround.
If it is a third-party C/C++ Python extension, please either wrap it into a PyTorch-understood custom operator (see https://pytorch.org/tutorials/advanced/custom_ops_landing_page.html for more details) or, if it is traceable, use `torch.compiler.allow_in_graph`.
  torch._dynamo.utils.warn_once(explanation + "\n" + "\n".join(hints))
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=28753920
final peak_memory=28753920
final peak_memory=28753920
final peak_memory=28753920
final peak_memory=28753920
final peak_memory=28753920
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=28753924
final peak_memory=28753924
final peak_memory=28753924
[03-05 01:56:01] Loading all available dialects
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
[03-05 01:56:03] Loading all available dialects
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=4
final peak_memory=4
final peak_memory=4
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
final peak_memory=0
[03-05 01:56:05] Loading all available dialects
```

## Accuracy Tests

## Benchmarking and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
