### PR TITLE
Fix MLA decode path returning unwritten (padded) rows

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1704,7 +1704,8 @@ class AiterAttnBackend(AttentionBackend):
                         num_kv_splits=num_kv_splits,
                     )
 
-                    return o[q_mask]
+                    total_valid_q = int(qo_indptr[-1].item())
+                    return o[:total_valid_q]
                 else:
                     o = q.new_empty(
                         (q.shape[0], layer.tp_q_head_num, layer.v_head_dim),


### PR DESCRIPTION
## Summary

This PR fixes a correctness issue in the MLA decode path where we used `q_mask` from `pad_sequence_with_mask()` to select rows from the `mla_decode_fwd` output buffer.

The underlying MLA kernel only writes the first `qo_indptr[-1]` rows (packed/compacted output), leaving the remaining padded rows **unwritten**.  

Using `o[q_mask]` can therefore read **unwritten memory** (garbage / NaNs) and propagate NaNs into downstream computation.

**Fix:** return the packed prefix actually written by the kernel: `o[:qo_indptr[-1]]`

## Details / Root Cause

In the non-graph MLA decode path we currently do:

- pad queries with `pad_sequence_with_mask(...)` → produces `q_pad` and `q_mask`
- allocate `o` as `(bs * max_q_len, nhead, v_dim)`
- call `mla_decode_fwd(..., o, qo_indptr, ...)`
- return `o[q_mask]`

However, `mla_decode_fwd` (via `aiter.mla_decode_stage1_asm_fwd + stage2/reduce`) treats `qo_indptr[-1]` as `total_s` (total valid query rows) and writes **only** `o[0:qo_indptr[-1]]`.  
Rows in `o[qo_indptr[-1]:]` correspond to padding and are **not written**.

With `new_empty`, those unwritten rows may contain NaNs/Infs. Since `q_mask` can include indices ≥ `qo_indptr[-1]` (depending on padding layout), the returned tensor may include unwritten rows → **NaNs appear**.

Zero-initializing `o` masks the issue but does **not** address the incorrect selection.

Debug confirmation using sentinel fill showed:

- unwritten rows were exactly `[qo_indptr[-1] … bs*max_q_len-1]`
- NaNs went away with `new_zeros` because unwritten rows became zeros
- correct behavior is to return only the packed rows the kernel actually writes

Therefore, the output selection should match kernel semantics:

```python
total_valid_q = int(qo_indptr[-1].item())
return o[:total_valid_q]
```

## Patch
- Replace return o[q_mask] with o[:total_valid_q]
- Keep pad_sequence_with_mask(...) for q_pad creation (no change required there)

## Testing
- Reproduced NaNs in speculative/EAGLE path with DeepSeek-R1-MXFP4 + AITER decode (mla_decode_fwd) when returning o[q_mask].
- Verified with sentinel initialization (o.fill_(123)) that rows >= qo_indptr[-1] are never written by the kernel, and were being returned by mask selection.
- After the change, verified returned tensor contains no sentinel/unwritten rows and NaNs no longer occur.
- Ran GSM8K/GPQA accuracy test that previously triggered NaNs; test completes without NaNs.
- Change results in no impact on performance.
- Image below demonstrates the patch fixing the NaN issue via sed.
<img width="693" height="264" alt="{D5C4EA4B-31B0-4775-BE62-8D48C88A50FE}" src="https://github.com/user-attachments/assets/e1d67e10-97f7-49f6-b605-d4654cda6c4b" />
