### PR TITLE
[smg] Extract tokenizer_path from /model_info into discovered labels

### DIFF
--- a/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
@@ -267,6 +267,11 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
                 // Fetch from /model_info for model-related metadata
                 if let Ok(model_info) = get_model_info(&config.url, config.api_key.as_deref()).await
                 {
+                    if let Some(tokenizer_path) =
+                        model_info.tokenizer_path.filter(|s| !s.is_empty())
+                    {
+                        labels.insert("tokenizer_path".to_string(), tokenizer_path);
+                    }
                     if let Some(model_type) = model_info.model_type.filter(|s| !s.is_empty()) {
                         labels.insert("model_type".to_string(), model_type);
                     }


### PR DESCRIPTION
## Summary
- The metadata discovery step (`discover_metadata.rs`) fetches `/model_info` from engine backends but was not extracting the `tokenizer_path` field into the discovered labels map
- This caused the tokenizer registration fallback chain in `submit_tokenizer_job.rs` to skip `tokenizer_path` (missing from labels) and fall through to `model_path` (e.g., `/data/models/zai-org/GLM-5-FP8`)
- The gateway then tried to fetch this local filesystem path from HuggingFace, resulting in a 404 error: `Failed to fetch model '/data/models/zai-org/GLM-5-FP8' from HuggingFace`
- Fix: extract `tokenizer_path` from `/model_info` response into labels, so the tokenizer registration uses the correct path (e.g., `zai-org/GLM-5-FP8`) which can differ from `model_path` when `--tokenizer-path` is set on the engine

## Test plan
- [ ] Deploy gateway with this fix against engines where `--tokenizer-path` differs from `--model-path`
- [ ] Verify gateway logs show `Submitting tokenizer registration job for model X from <tokenizer_path>` instead of `from <model_path>`
- [ ] Verify no `Failed to load tokenizer` errors in gateway logs
- [ ] Verify `/v1/models` endpoint returns correct model info

🤖 Generated with [Claude Code](https://claude.com/claude-code)