### PR TITLE
Fix bound when init_new an ForwardBatch 

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -455,8 +455,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             ret.global_num_tokens_cpu = global_num_tokens
             ret.global_num_tokens_for_logprob_cpu = global_num_tokens_for_logprob
 
+        # Use it before returning to avoid operator dispatch bottlenecks caused by host-to-device synchronization.
         def _post_set_device_attr():
             # For MLP sync
+            # TODO: The non_blocking flag here has no effect, but using pin_memory causes the process to hang.
             if batch.global_num_tokens is not None:
                 ret.global_num_tokens_gpu = torch.tensor(
                     global_num_tokens, dtype=torch.int64
@@ -722,10 +724,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                         )
                 mrope_positions_list[batch_idx] = mrope_positions
 
-        self.mrope_positions = torch.cat(
-            [pos for pos in mrope_positions_list],
-            dim=1,
-        ).to(dtype=torch.int64, device=model_runner.device, non_blocking=True)
+        self.mrope_positions = (
+            torch.cat(
+                [pos for pos in mrope_positions_list],
+                dim=1,
+            )
+            .pin_memory()
+            .to(dtype=torch.int64, device=model_runner.device, non_blocking=True)
+        )
 
     def _pad_tensor_to_size(self, tensor: torch.Tensor, size: int, *, value: int = 0):
         if value == 0:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -453,17 +453,21 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
             ret.original_global_num_tokens_cpu = batch.global_num_tokens
             ret.global_num_tokens_cpu = global_num_tokens
-            ret.global_num_tokens_gpu = torch.tensor(
-                global_num_tokens, dtype=torch.int64
-            ).to(device, non_blocking=True)
-
             ret.global_num_tokens_for_logprob_cpu = global_num_tokens_for_logprob
-            ret.global_num_tokens_for_logprob_gpu = torch.tensor(
-                global_num_tokens_for_logprob, dtype=torch.int64
-            ).to(device, non_blocking=True)
+
+        def _post_set_device_attr():
+            # For MLP sync
+            if batch.global_num_tokens is not None:
+                ret.global_num_tokens_gpu = torch.tensor(
+                    global_num_tokens, dtype=torch.int64
+                ).to(device, non_blocking=True)
+                ret.global_num_tokens_for_logprob_gpu = torch.tensor(
+                    global_num_tokens_for_logprob, dtype=torch.int64
+                ).to(device, non_blocking=True)
 
         if ret.forward_mode.is_idle():
             ret.positions = torch.empty((0,), dtype=torch.int64, device=device)
+            _post_set_device_attr()
             return ret
 
         # Override the positions with diffusion LLM or spec_info
@@ -529,6 +533,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
             model_runner.lora_manager.prepare_lora_batch(ret)
 
+        _post_set_device_attr()
         return ret
 
     def adjust_num_token_non_padded_for_attn_tp(self, server_args) -> None:


### PR DESCRIPTION
## Motivation

Based on the collected profiling data, there is a significant bubble between Decode stages, which has been traced back to the host-to-device operation within the init_new method of ForwardBatch.

```
python -m sglang.launch_server --model-path $MODEL_PATH \
    --host 127.0.0.1 --port 23388 --trust-remote-code --nnodes 1 --node-rank 0  \
    --attention-backend ascend --device npu \
    --max-running-requests 360 \
    --disable-radix-cache --dtype bfloat16 \
    --chunked-prefill-size -1 --max-prefill-tokens 40960 \
    --tp-size 4 --mem-fraction-static 0.8 \
    --cuda-graph-bs 10 20 40 60 70 \
    --mm-enable-dp-encoder --enable-dp-attention --dp-size 4 \
    --sampling-backend ascend --enable-multimodal --enable-dp-lm-head --mm-attention-backend ascend_attn
```


## Modifications

1. Attempted to add .pin_memory() to the original code to achieve true asynchronous transfers. However, this caused the system to hang, likely involving deeper issues with asynchronous scheduling and synchronization. Consequently, this approach was abandoned.
2. Through code review and fault injection testing (injecting incorrect values), it was determined that the bottleneck-inducing operation could be deferred. Therefore, the assignment logic was encapsulated into a function and executed just before init_new returns.
3. Building on the second point, further optimizations were made to the bounds in _compute_mrope_positions based on additional profiling data.


## Accuracy Tests

```
evalscope eval \
 --model Qwen3-VL-30B-A3B-Instruct  \
 --api-url http://127.0.0.1:23388/v1 \
 --api-key EMPTY \
 --eval-type openai_api \
 --generation-config '{"do_sample": true, "max_tokens": 2000, "seed": 3407 ,"top_p":0.8, "top_k":20, "temperature": 0.7, "n":1, "presence_penalty": 1.5,"repetition_penalty": 1, "timeout": 60, "stream": true, "extra_body": {"chat_template_kwargs": {"enable_thinking": false}}}' \
 --datasets mm_bench \
 --dataset-hub Local \
 --dataset-args '{"mm_bench": {"dataset_id": "/home/xjw/datasets/MMBench","subset_list": ["cn"]}}' \
 --eval-batch-size 30 \
 --ignore-errors --limit 500
```

before:

```
mm_bench report table:
+---------------------------+-----------+----------+----------+-------+---------+---------+
| Model                     | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===========================+===========+==========+==========+=======+=========+=========+
| Qwen3-VL-30B-A3B-Instruct | mm_bench  | mean_acc | cn       |   500 |   0.842 | default |
+---------------------------+-----------+----------+----------+-------+---------+---------+ 

2026-03-05 06:39:36 - evalscope - INFO: Skipping report analysis (`analysis_report=False`).
2026-03-05 06:39:36 - evalscope - INFO: Dump report to: ./outputs/20260305_063622/reports/Qwen3-VL-30B-A3B-Instruct/mm_bench.json 

2026-03-05 06:39:36 - evalscope - INFO: Benchmark mm_bench evaluation finished.
2026-03-05 06:39:36 - evalscope - INFO: Overall report table: 
+---------------------------+-----------+----------+----------+-------+---------+---------+
| Model                     | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===========================+===========+==========+==========+=======+=========+=========+
| Qwen3-VL-30B-A3B-Instruct | mm_bench  | mean_acc | cn       |   500 |   0.842 | default |
+---------------------------+-----------+----------+----------+-------+---------+---------+ 
```

after:

```
mm_bench report table:
+---------------------------+-----------+----------+----------+-------+---------+---------+
| Model                     | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===========================+===========+==========+==========+=======+=========+=========+
| Qwen3-VL-30B-A3B-Instruct | mm_bench  | mean_acc | cn       |   500 |    0.84 | default |
+---------------------------+-----------+----------+----------+-------+---------+---------+ 

2026-03-05 06:52:46 - evalscope - INFO: Skipping report analysis (`analysis_report=False`).
2026-03-05 06:52:46 - evalscope - INFO: Dump report to: ./outputs/20260305_064941/reports/Qwen3-VL-30B-A3B-Instruct/mm_bench.json 

2026-03-05 06:52:46 - evalscope - INFO: Benchmark mm_bench evaluation finished.
2026-03-05 06:52:46 - evalscope - INFO: Overall report table: 
+---------------------------+-----------+----------+----------+-------+---------+---------+
| Model                     | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===========================+===========+==========+==========+=======+=========+=========+
| Qwen3-VL-30B-A3B-Instruct | mm_bench  | mean_acc | cn       |   500 |    0.84 | default |
+---------------------------+-----------+----------+----------+-------+---------+---------+ 
```

## Benchmarking and Profiling

```
vllm bench serve --backend openai-chat \
 --model /home/weights/Qwen3-VL-30B-A3B-Instruct \
 --tokenizer /home/weights/Qwen3-VL-30B-A3B-Instruct \
 --served-model-name Qwen3-VL-30B-A3B-Instruct \
 --dataset-name random-mm \
 --random-input-len 0 \
 --random-output-len ${RAMDOM_OUTPUT_LEN} \
 --random-mm-base-items-per-request 1 \
 --random-mm-limit-mm-per-prompt '{"image": 1}' \
 --random-mm-bucket-config '{(1024,1024,1): 1}' \
 --request-rate 15 \
 --endpoint /v1/chat/completions \
 --host 127.0.0.1 --port 23388 \
 --seed 1024 \
 --percentile-metrics ttft,tpot,itl,e2el \
 --ignore-eos \
 --trust-remote-code \
 --temperature 0.01 \
 --max-concurrency ${MAX_CONCURRENCY} \
 --num-prompts ${NUM_PROMPTS}
```

Before:

```
============ Serving Benchmark Result ============
Successful requests:                     560       
Failed requests:                         0         
Maximum request concurrency:             280       
Request rate configured (RPS):           15.00     
Benchmark duration (s):                  144.28    
Total input tokens:                      0         
Total generated tokens:                  573440    
Request throughput (req/s):              3.88      
Output token throughput (tok/s):         3974.53   
Peak output token throughput (tok/s):    6058.00   
Peak concurrent requests:                313.00    
Total token throughput (tok/s):          3974.53   
---------------Time to First Token----------------
Mean TTFT (ms):                          10220.39  
Median TTFT (ms):                        10336.51  
P99 TTFT (ms):                           22678.07  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          55.01     
Median TPOT (ms):                        55.99     
P99 TPOT (ms):                           66.66     
---------------Inter-token Latency----------------
Mean ITL (ms):                           82.08     
Median ITL (ms):                         47.90     
P99 ITL (ms):                            566.79    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          66490.71  
Median E2EL (ms):                        70438.90  
P99 E2EL (ms):                           76658.74  
==================================================
```

7.05ms

<img width="403" height="177" alt="image" src="https://github.com/user-attachments/assets/4896566b-1d72-44ff-8050-774d762ca6ac" />



After:

```
============ Serving Benchmark Result ============
Successful requests:                     560       
Failed requests:                         0         
Maximum request concurrency:             280       
Request rate configured (RPS):           15.00     
Benchmark duration (s):                  143.30    
Total input tokens:                      0         
Total generated tokens:                  573440    
Request throughput (req/s):              3.91      
Output token throughput (tok/s):         4001.63   
Peak output token throughput (tok/s):    6193.00   
Peak concurrent requests:                463.00    
Total token throughput (tok/s):          4001.63   
---------------Time to First Token----------------
Mean TTFT (ms):                          15571.60  
Median TTFT (ms):                        9838.96   
P99 TTFT (ms):                           26097.53  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          49.27     
Median TPOT (ms):                        46.01     
P99 TPOT (ms):                           65.78     
---------------Inter-token Latency----------------
Mean ITL (ms):                           72.46     
Median ITL (ms):                         47.17     
P99 ITL (ms):                            147.18    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          65972.57  
Median E2EL (ms):                        69356.48  
P99 E2EL (ms):                           72111.78  
==================================================
```

1.31ms

<img width="418" height="154" alt="image" src="https://github.com/user-attachments/assets/9a803e7b-1f58-470f-9d00-2e7aadf84579" />




## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
6. After green CI and required approvals, ask Merge Oncalls to merge.
