### PR TITLE
[diffusion] LoRA : add LoRA support for diffusers backend

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -339,7 +339,11 @@ class GPUWorker:
             target: Which transformer(s) to apply the LoRA to. Can be a string or a list of strings.
             strength: LoRA strength(s) for merge, default 1.0. Can be a float or a list of floats.
         """
-        if not isinstance(self.pipeline, LoRAPipeline):
+        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
+            DiffusersPipeline,
+        )
+
+        if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         self.pipeline.set_lora(lora_nickname, lora_path, target, strength)
         return OutputBatch()
@@ -354,7 +358,11 @@ class GPUWorker:
             target: Which transformer(s) to merge.
             strength: LoRA strength for merge, default 1.0.
         """
-        if not isinstance(self.pipeline, LoRAPipeline):
+        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
+            DiffusersPipeline,
+        )
+
+        if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         self.pipeline.merge_lora_weights(target, strength)
         return OutputBatch()
@@ -366,7 +374,11 @@ class GPUWorker:
         Args:
             target: Which transformer(s) to unmerge.
         """
-        if not isinstance(self.pipeline, LoRAPipeline):
+        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
+            DiffusersPipeline,
+        )
+
+        if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         self.pipeline.unmerge_lora_weights(target)
         return OutputBatch()
@@ -375,11 +387,14 @@ class GPUWorker:
         """
         List loaded LoRA adapters and current application status per module.
         """
+        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
+            DiffusersPipeline,
+        )
         from sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline import (
             LoRAPipeline,
         )
 
-        if not isinstance(self.pipeline, LoRAPipeline):
+        if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         status = self.pipeline.get_lora_status()
         return OutputBatch(output=status)

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -34,6 +34,9 @@ from sglang.multimodal_gen.runtime.loader.weights_updater import (
     WeightsUpdater,
     get_updatable_modules,
 )
+from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
+    DiffusersPipeline,
+)
 from sglang.multimodal_gen.runtime.pipelines_core import (
     ComposedPipelineBase,
     LoRAPipeline,
@@ -339,10 +342,6 @@ class GPUWorker:
             target: Which transformer(s) to apply the LoRA to. Can be a string or a list of strings.
             strength: LoRA strength(s) for merge, default 1.0. Can be a float or a list of floats.
         """
-        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
-            DiffusersPipeline,
-        )
-
         if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         self.pipeline.set_lora(lora_nickname, lora_path, target, strength)
@@ -358,10 +357,6 @@ class GPUWorker:
             target: Which transformer(s) to merge.
             strength: LoRA strength for merge, default 1.0.
         """
-        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
-            DiffusersPipeline,
-        )
-
         if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         self.pipeline.merge_lora_weights(target, strength)
@@ -374,10 +369,6 @@ class GPUWorker:
         Args:
             target: Which transformer(s) to unmerge.
         """
-        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
-            DiffusersPipeline,
-        )
-
         if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         self.pipeline.unmerge_lora_weights(target)
@@ -387,13 +378,6 @@ class GPUWorker:
         """
         List loaded LoRA adapters and current application status per module.
         """
-        from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import (
-            DiffusersPipeline,
-        )
-        from sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline import (
-            LoRAPipeline,
-        )
-
         if not isinstance(self.pipeline, (LoRAPipeline, DiffusersPipeline)):
             return OutputBatch(error="Lora is not enabled")
         status = self.pipeline.get_lora_status()

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -38,7 +38,10 @@ from sglang.multimodal_gen.runtime.platforms import (
     current_platform,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
-from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
+from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
+    maybe_download_lora,
+    maybe_download_model,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -379,9 +382,24 @@ class DiffusersPipeline(ComposedPipelineBase):
         self.post_init_called = False
         self.executor = executor or SyncExecutor(server_args=server_args)
 
+        # LoRA state
+        self._lora_loaded: bool = False
+        self._lora_fused: bool = False
+        self._lora_nickname: str | None = None
+        self._lora_path: str | None = None
+        self._lora_strength: float = 1.0
+
         logger.info("Loading diffusers pipeline from %s", model_path)
         self.diffusers_pipe = self._load_diffusers_pipeline(model_path, server_args)
         self._detect_pipeline_type()
+
+        # Apply startup LoRA if configured
+        if server_args.lora_path is not None:
+            self.set_lora(
+                server_args.lora_nickname,
+                server_args.lora_path,
+                strength=server_args.lora_scale,
+            )
 
     def _load_diffusers_pipeline(self, model_path: str, server_args: ServerArgs) -> Any:
         """Load the diffusers pipeline.
@@ -594,6 +612,92 @@ class DiffusersPipeline(ComposedPipelineBase):
             "Detected pipeline type: %s",
             "video" if self.is_video_pipeline else "image",
         )
+
+    # ------------------------------------------------------------------ #
+    # LoRA support (native diffusers API)                                  #
+    # ------------------------------------------------------------------ #
+
+    def is_lora_effective(self) -> bool:
+        return self._lora_fused
+
+    def is_lora_set(self) -> bool:
+        return self._lora_loaded
+
+    def set_lora(
+        self,
+        lora_nickname: str,
+        lora_path: str | None = None,
+        target: str = "all",
+        strength: float = 1.0,
+    ) -> None:
+        """Load and fuse LoRA weights using the native diffusers API."""
+        lora_local_path = maybe_download_lora(lora_path)
+        if self._lora_loaded:
+            self.diffusers_pipe.unload_lora_weights()
+            self._lora_loaded = False
+            self._lora_fused = False
+
+        self.diffusers_pipe.load_lora_weights(
+            lora_local_path, adapter_name=lora_nickname
+        )
+        self._lora_loaded = True
+        self._lora_nickname = lora_nickname
+        self._lora_path = lora_path
+        self._lora_strength = strength
+
+        if hasattr(self.diffusers_pipe, "fuse_lora"):
+            self.diffusers_pipe.fuse_lora(lora_scale=strength)
+            self._lora_fused = True
+        else:
+            logger.warning(
+                "Pipeline %s does not support fuse_lora(); "
+                "LoRA weights loaded as side-weighted adapters.",
+                type(self.diffusers_pipe).__name__,
+            )
+
+    def merge_lora_weights(self, target: str = "all", strength: float = 1.0) -> None:
+        """Fuse (merge) LoRA weights into the model at the given scale."""
+        if not self._lora_loaded:
+            logger.warning("No LoRA loaded, cannot merge")
+            return
+        if not hasattr(self.diffusers_pipe, "fuse_lora"):
+            logger.warning(
+                "Pipeline %s does not support fuse_lora().",
+                type(self.diffusers_pipe).__name__,
+            )
+            return
+        if self._lora_fused:
+            self.diffusers_pipe.unfuse_lora()
+        self.diffusers_pipe.fuse_lora(lora_scale=strength)
+        self._lora_fused = True
+        self._lora_strength = strength
+
+    def unmerge_lora_weights(self, target: str = "all") -> None:
+        """Unfuse (unmerge) LoRA weights from the model."""
+        if not self._lora_fused:
+            logger.warning("LoRA is not fused, nothing to unmerge")
+            return
+        self.diffusers_pipe.unfuse_lora()
+        self._lora_fused = False
+
+    def get_lora_status(self) -> dict:
+        """Return loaded and active LoRA adapter status (mirrors LoRAPipeline shape)."""
+        loaded = (
+            [{"nickname": self._lora_nickname, "path": self._lora_path}]
+            if self._lora_loaded
+            else []
+        )
+        active = {}
+        if self._lora_fused and self._lora_nickname:
+            active["transformer"] = [
+                {
+                    "nickname": self._lora_nickname,
+                    "path": self._lora_path,
+                    "merged": True,
+                    "strength": self._lora_strength,
+                }
+            ]
+        return {"loaded_adapters": loaded, "active": active}
 
     def load_modules(
         self,

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -382,12 +382,12 @@ class DiffusersPipeline(ComposedPipelineBase):
         self.post_init_called = False
         self.executor = executor or SyncExecutor(server_args=server_args)
 
-        # LoRA state
+        # LoRA state – supports multiple adapters
         self._lora_loaded: bool = False
         self._lora_fused: bool = False
-        self._lora_nickname: str | None = None
-        self._lora_path: str | None = None
-        self._lora_strength: float = 1.0
+        self._lora_nicknames: list[str] = []
+        self._lora_paths: list[str | None] = []
+        self._lora_strengths: list[float] = []
 
         logger.info("Loading diffusers pipeline from %s", model_path)
         self.diffusers_pipe = self._load_diffusers_pipeline(model_path, server_args)
@@ -625,28 +625,71 @@ class DiffusersPipeline(ComposedPipelineBase):
 
     def set_lora(
         self,
-        lora_nickname: str,
-        lora_path: str | None = None,
-        target: str = "all",
-        strength: float = 1.0,
+        lora_nickname: str | list[str],
+        lora_path: str | None | list[str | None] = None,
+        target: str | list[str] = "all",
+        strength: float | list[float] = 1.0,
     ) -> None:
-        """Load and fuse LoRA weights using the native diffusers API."""
-        lora_local_path = maybe_download_lora(lora_path)
+        """Load and fuse LoRA weights using the native diffusers API.
+
+        Supports both single and multiple LoRA adapters.  When lists are
+        provided, each adapter is loaded individually and then all adapters
+        are activated together via ``set_adapters`` with per-adapter scales.
+        """
+        # ── normalise inputs to lists ─────────────────────────────────────
+        nicknames = (
+            [lora_nickname] if isinstance(lora_nickname, str) else list(lora_nickname)
+        )
+        if lora_path is None or isinstance(lora_path, str):
+            paths: list[str | None] = [lora_path] * len(nicknames)
+        else:
+            paths = list(lora_path)
+        if isinstance(strength, (int, float)):
+            strengths = [float(strength)] * len(nicknames)
+        else:
+            strengths = [float(s) for s in strength]
+
+        if len(nicknames) != len(paths):
+            raise ValueError(
+                f"lora_nickname length ({len(nicknames)}) != lora_path length ({len(paths)})"
+            )
+        if len(nicknames) != len(strengths):
+            raise ValueError(
+                f"lora_nickname length ({len(nicknames)}) != strength length ({len(strengths)})"
+            )
+
+        # ── unload previous adapters ──────────────────────────────────────
         if self._lora_loaded:
+            if self._lora_fused and hasattr(self.diffusers_pipe, "unfuse_lora"):
+                self.diffusers_pipe.unfuse_lora()
             self.diffusers_pipe.unload_lora_weights()
             self._lora_loaded = False
             self._lora_fused = False
+            self._lora_nicknames = []
+            self._lora_paths = []
+            self._lora_strengths = []
 
-        self.diffusers_pipe.load_lora_weights(
-            lora_local_path, adapter_name=lora_nickname
-        )
+        # ── load each adapter ─────────────────────────────────────────────
+        for nick, path in zip(nicknames, paths):
+            lora_local_path = maybe_download_lora(path)
+            self.diffusers_pipe.load_lora_weights(lora_local_path, adapter_name=nick)
+            logger.info("Loaded LoRA adapter %s from %s", nick, path)
+
         self._lora_loaded = True
-        self._lora_nickname = lora_nickname
-        self._lora_path = lora_path
-        self._lora_strength = strength
+        self._lora_nicknames = nicknames
+        self._lora_paths = paths
+        self._lora_strengths = strengths
+
+        # ── activate & fuse ───────────────────────────────────────────────
+        if len(nicknames) > 1 and hasattr(self.diffusers_pipe, "set_adapters"):
+            # multi-adapter: activate all with individual scales
+            self.diffusers_pipe.set_adapters(nicknames, adapter_weights=strengths)
 
         if hasattr(self.diffusers_pipe, "fuse_lora"):
-            self.diffusers_pipe.fuse_lora(lora_scale=strength)
+            self.diffusers_pipe.fuse_lora(
+                adapter_names=nicknames,
+                lora_scale=strengths[0] if len(strengths) == 1 else 1.0,
+            )
             self._lora_fused = True
         else:
             logger.warning(
@@ -668,9 +711,12 @@ class DiffusersPipeline(ComposedPipelineBase):
             return
         if self._lora_fused:
             self.diffusers_pipe.unfuse_lora()
-        self.diffusers_pipe.fuse_lora(lora_scale=strength)
+        self.diffusers_pipe.fuse_lora(
+            adapter_names=self._lora_nicknames,
+            lora_scale=strength,
+        )
         self._lora_fused = True
-        self._lora_strength = strength
+        self._lora_strengths = [strength] * len(self._lora_nicknames)
 
     def unmerge_lora_weights(self, target: str = "all") -> None:
         """Unfuse (unmerge) LoRA weights from the model."""
@@ -682,20 +728,22 @@ class DiffusersPipeline(ComposedPipelineBase):
 
     def get_lora_status(self) -> dict:
         """Return loaded and active LoRA adapter status (mirrors LoRAPipeline shape)."""
-        loaded = (
-            [{"nickname": self._lora_nickname, "path": self._lora_path}]
-            if self._lora_loaded
-            else []
-        )
+        loaded = [
+            {"nickname": n, "path": p}
+            for n, p in zip(self._lora_nicknames, self._lora_paths)
+        ]
         active = {}
-        if self._lora_fused and self._lora_nickname:
+        if self._lora_fused and self._lora_nicknames:
             active["transformer"] = [
                 {
-                    "nickname": self._lora_nickname,
-                    "path": self._lora_path,
+                    "nickname": n,
+                    "path": p,
                     "merged": True,
-                    "strength": self._lora_strength,
+                    "strength": s,
                 }
+                for n, p, s in zip(
+                    self._lora_nicknames, self._lora_paths, self._lora_strengths
+                )
             ]
         return {"loaded_adapters": loaded, "active": active}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
#19494 , there're users who want to use diffusers as backend for LoRA in consumers GPU, and this PR will add support.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
diffusers backend already support LoRA and it's hard to re-use existing LoRA pipeline as diffusers is not compatible. So here we will implement LoRA directly in diffusers pipeline
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Server
`PYTHONPATH=/data/junhao/sglang/python:$PYTHONPATH CUDA_VISIBLE_DEVICES=5 sglang serve --model-path Qwen/Qwen-Image-Edit-2511 --lora-path prithivMLmods/Qwen-Image-Edit-2511-Anime --backend diffusers --port 30010
`

Client
```
curl -sS -X GET "http://localhost:30010/v1/list_loras"
{"loaded_adapters":[{"nickname":"default","path":"prithivMLmods/Qwen-Image-Edit-2511-Anime"}],"active":{"transformer":[{"nickname":"default","path":"prithivMLmods/Qwen-Image-Edit-2511-Anime","merged":true,"strength":1.0}]}}
```

```
"""
Test script for diffusers backend LoRA support.

Tests:
  1. Base model generation (no LoRA)
  2. Single LoRA adapter
  3. Switch to a different single LoRA adapter
  4. Multi-LoRA (two adapters loaded together)
"""

from sglang.multimodal_gen import DiffGenerator

MODEL_PATH = "Tongyi-MAI/Z-Image-Turbo"
LORA_1_NICKNAME = "elusarca"
LORA_1_PATH = "reverentelusarca/elusarca-anime-style-lora-z-image-turbo"
LORA_2_NICKNAME = "pixel_art"
LORA_2_PATH = "tarn59/pixel_art_style_lora_z_image_turbo"

PROMPT = (
    "elusarca anime style. 1girl, solo, white hair, double bun, blue eyes, "
    "blue shirt, sitting, leaning on hand, coffee mug, desk, office, tired."
)

INPUT_DATA = {
    "prompt": PROMPT,
    "seed": 1024,
    "save_output": True,
    "width": 720,
    "height": 1280,
}


def main():
    # ── Initialize generator ──────────────────────────────────────────────
    print("=" * 60)
    print("[1/4] Initializing DiffGenerator (no LoRA) …")
    print("=" * 60)
    generator = DiffGenerator.from_pretrained(model_path=MODEL_PATH, backend="diffusers")

    # ── Case 1: Base model (no LoRA) ──────────────────────────────────────
    print("\n" + "=" * 60)
    print("[1/4] Generating with base model (no LoRA) …")
    print("=" * 60)
    output = generator.generate(INPUT_DATA)
    print(f"  ✓ Base output: {output}\n")

    # ── Case 2: Single LoRA ──────────────────────────────────────────────
    print("=" * 60)
    print(f"[2/4] Setting single LoRA: {LORA_1_NICKNAME} …")
    print("=" * 60)
    generator.set_lora(LORA_1_NICKNAME, LORA_1_PATH)
    output = generator.generate(INPUT_DATA)
    print(f"  ✓ Single LoRA output: {output}\n")

    # ── Case 3: Switch to a different LoRA ───────────────────────────────
    print("=" * 60)
    print(f"[3/4] Switching to LoRA: {LORA_2_NICKNAME} …")
    print("=" * 60)
    generator.set_lora(LORA_2_NICKNAME, LORA_2_PATH)
    output = generator.generate(INPUT_DATA)
    print(f"  ✓ Switched LoRA output: {output}\n")

    # ── Case 4: Multi-LoRA ───────────────────────────────────────────────
    print("=" * 60)
    print(f"[4/4] Setting multi-LoRA: [{LORA_1_NICKNAME}, {LORA_2_NICKNAME}] …")
    print("=" * 60)
    generator.set_lora(
        [LORA_1_NICKNAME, LORA_2_NICKNAME],
        [LORA_1_PATH, LORA_2_PATH],
    )
    output = generator.generate(INPUT_DATA)
    print(f"  ✓ Multi-LoRA output: {output}\n")

    print("=" * 60)
    print("All tests completed!")
    print("=" * 60)

    generator.shutdown()


if __name__ == "__main__":
    main()
```


The test results shown in the image above are as follows:

without Lora
<img width="720" height="1280" alt="without-lora" src="https://github.com/user-attachments/assets/eb66cf6e-e5ad-4746-8ab0-d5203294bcf1" />

Single lora with reverentelusarca/elusarca-anime-style-lora-z-image-turbo:
<img width="720" height="1280" alt="lora-1" src="https://github.com/user-attachments/assets/a0a9ae44-46b4-4441-809c-9f7a5179dee8" />


Single lora with tarn59/pixel_art_style_lora_z_image_turbo

<img width="720" height="1280" alt="lora2" src="https://github.com/user-attachments/assets/75dcdc64-28f8-46df-a8cf-829ee7cd6b43" />


multiple lora with both
<img width="720" height="1280" alt="lora-3" src="https://github.com/user-attachments/assets/39065286-c46b-48b2-b836-6c7f54ae4e5a" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
