### PR TITLE
[ROCm] Fix flashinfer import crash on HIP by catching AssertionError

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -30,7 +30,7 @@ try:
     from flashinfer.comm.mnnvl import MnnvlConfig
 
     use_flashinfer = True
-except ImportError:
+except (ImportError, AssertionError):
     use_flashinfer = False
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Summary

  On ROCm/HIP platforms, the sglang server fails to start due to an uncaught AssertionError during flashinfer module import. This one-line fix broadens the exception handling to allow graceful degradation.
## Reproduction

  Environment: ROCm 6.4.3, AMD Instinct MI300X (gfx942)
```
  python3 -m sglang.launch_server \
      --model-path Qwen/Qwen3-235B-A22B-FP8-dynamic \
      --tp-size 8 --trust-remote-code
```

  Error log (before fix):
```
  Traceback (most recent call last):
    File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
      exec(code, run_globals)
    File ".../sglang/launch_server.py", line 52, in <module>
      run_server(server_args)
    File ".../sglang/launch_server.py", line 33, in run_server
      from sglang.srt.entrypoints.http_server import launch_server
    File ".../sglang/srt/entrypoints/http_server.py", line 69, in <module>
      from sglang.srt.entrypoints.engine import (
    File ".../sglang/srt/entrypoints/engine.py", line 41, in <module>
      from sglang.srt.managers.data_parallel_controller import (
    File ".../sglang/srt/managers/data_parallel_controller.py", line 39, in <module>
      from sglang.srt.managers.scheduler import run_scheduler_process
    File ".../sglang/srt/managers/scheduler.py", line 156, in <module>
      from sglang.srt.managers.scheduler_dp_attn_mixin import SchedulerDPAttnMixin
    File ".../sglang/srt/managers/scheduler_dp_attn_mixin.py", line 8, in <module>
      from sglang.srt.batch_overlap.two_batch_overlap import TboDPAttentionPreparer
    File ".../sglang/srt/batch_overlap/two_batch_overlap.py", line 15, in <module>
      from sglang.srt.batch_overlap.operations_strategy import OperationsStrategy
    File ".../sglang/srt/batch_overlap/operations_strategy.py", line 8, in <module>
      from sglang.srt.layers.moe.token_dispatcher import DeepEPConfig
    File ".../sglang/srt/layers/moe/token_dispatcher/__init__.py", line 19, in <module>
      from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
    File ".../sglang/srt/layers/moe/token_dispatcher/flashinfer.py", line 28, in <module>
      from flashinfer.comm import MoeAlltoAll, moe_a2a_get_workspace_size_per_rank
    File ".../flashinfer/comm/__init__.py", line 1, in <module>
      from .cuda_ipc import CudaRTLibrary, create_shared_buffer, free_shared_buffer
    File ".../flashinfer/comm/cuda_ipc.py", line 194, in <module>
      cudart = CudaRTLibrary()
    File ".../flashinfer/comm/cuda_ipc.py", line 125, in __init__
      assert so_file is not None, "libcudart is not loaded in the current process"
  AssertionError: libcudart is not loaded in the current process
```