### PR TITLE
[Fix] streaming chat error handling and tool args remainder logic

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -873,7 +873,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
                 yield f"data: {usage_chunk.model_dump_json()}\n\n"
 
-        except ValueError as e:
+        except Exception as e:
             error = self.create_streaming_error_response(str(e))
             yield f"data: {error}\n\n"
 
@@ -1394,8 +1394,8 @@ class OpenAIServingChat(OpenAIServingBase):
 
         # Check if there are remaining arguments to send
         remaining_call = (
-            expected_call.replace(actual_call, "", 1)
-            if actual_call in expected_call
+            expected_call[len(actual_call) :]
+            if expected_call.startswith(actual_call)
             else ""
         )
 


### PR DESCRIPTION
# fix: streaming chat error handling and tool args remainder logic

When I read SGLang codes, I found some minor issues.
- Catch Exception instead of ValueError in _generate_chat_stream so KeyError (e.g. missing output_token_logprobs on abort) and other non-ValueError exceptions return a proper SSE error chunk instead of breaking the stream. Aligns with serving_completions.py (see [#19514](https://github.com/sgl-project/sglang/pull/19514)).
- In _check_for_unstreamed_tool_args, compute remaining_call via startswith + slicing instead of str.replace so only a true prefix is removed; replace(actual, '', 1) can corrupt output when actual appears as a non-prefix substring.

---

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When streaming chat completions are aborted or when `meta_info` is incomplete (e.g. missing `output_token_logprobs` when `logprobs=True`), the handler only catches `ValueError`. Other exceptions such as `KeyError` propagate and break the SSE stream without returning a proper error chunk to the client. [#19514](https://github.com/sgl-project/sglang/pull/19514) fixed `KeyError: 'prompt_tokens'` by using `.get()` for `prompt_tokens`/`completion_tokens`; the same try block still uses direct key access for `output_token_logprobs` and other fields, so broadening the catch to `Exception` ensures any such failure is returned as an SSE error instead of dropping the connection.

Separately, `_check_for_unstreamed_tool_args` uses `str.replace(actual_call, "", 1)` to compute the remainder of tool-call arguments. That removes the first occurrence of `actual_call` anywhere in the string; if `actual_call` is not a prefix (e.g. same substring appears in the middle of the JSON), the result is invalid. Using `startswith` + slicing expresses the intended “prefix remainder” and avoids corrupt output in edge cases.

## Modifications

- **serving_chat.py**  
  - In `_generate_chat_stream`: change `except ValueError as e:` to `except Exception as e:` so all exceptions in the streaming try block are turned into a proper SSE error response (consistent with `serving_completions.py`).
  - In `_check_for_unstreamed_tool_args`: replace  
    `expected_call.replace(actual_call, "", 1) if actual_call in expected_call else ""`  
    with  
    `expected_call[len(actual_call):] if expected_call.startswith(actual_call) else ""`  
    so only a true prefix is removed.

## Accuracy Tests

N/A — Changes only affect error handling and edge-case remainder logic; no impact on model outputs.

## Benchmarking and Profiling

N/A — No impact on inference speed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
