### PR TITLE
[Fix] Correct GPTQ Marlin MoE w2 scales size and dtype for Qwen3.5 INT4

### DIFF
--- a/python/sglang/srt/layers/quantization/gptq.py
+++ b/python/sglang/srt/layers/quantization/gptq.py
@@ -1312,9 +1312,9 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         if self.quant_config.group_size != -1:
             scales_size13 = hidden_size // self.quant_config.group_size
             if self.quant_config.desc_act:
-                w2_scales_size = intermediate_size_per_partition
-            else:
                 w2_scales_size = intermediate_size_per_partition * layer.moe_tp_size
+            else:
+                w2_scales_size = intermediate_size_per_partition
             scales_size2 = w2_scales_size // self.quant_config.group_size
             strategy = FusedMoeWeightScaleSupported.GROUP.value
         else:
@@ -1353,7 +1353,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
                 num_experts,
                 scales_size13,
                 2 * intermediate_size_per_partition,
-                dtype=torch.half,
+                dtype=params_dtype,
             ),
             requires_grad=False,
         )
@@ -1361,7 +1361,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_scales, extra_weight_attrs)
         # down_proj scales
         w2_scales = torch.nn.Parameter(
-            torch.empty(num_experts, scales_size2, hidden_size, dtype=torch.half),
+            torch.empty(num_experts, scales_size2, hidden_size, dtype=params_dtype),
             requires_grad=False,
         )
         layer.register_parameter("w2_scales", w2_scales)


### PR DESCRIPTION
Fix two issues in GPTQMarlinMoEMethod.create_weights:
  1. w2 scales size was incorrectly multiplied by moe_tp_size for non-desc_act models, causing shape mismatch when loading Qwen3.5
   GPTQ-INT4 weights.
  2. w13_scales and w2_scales dtype was hardcoded to torch.half instead of using params_dtype, causing dtype mismatch for bf16
  models.

  Motivation

  PR #9269 ([7/N] MoE Refactor) refactored GPTQMarlinMoEMethod.create_weights and removed the intermediate_size variable,
  replacing it with intermediate_size_per_partition * layer.moe_tp_size. However, the desc_act conditional branches were swapped
  during the refactor:

  - desc_act=True should use full size (partition * tp_size) but was set to partition
  - desc_act=False should use partition size but was set to partition * tp_size

  This causes shape mismatch errors when loading GPTQ-INT4 MoE models (e.g., Qwen3.5) with TP > 1.

  Additionally, w13_scales and w2_scales were hardcoded to torch.half, which causes dtype mismatch when running with bf16.