### PR TITLE
[quant] Auto-disable DEEPGEMM_SCALE_UE8M0 for non-ue8m0 checkpoints on Blackwell

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1004,14 +1004,17 @@ class ModelConfig:
                         f"({self.quantization})."
                     )
 
-            # Check if the scale_fmt is ue8m0, and warn user if deepgemm is enabled for non-ue8m0 models on blackwell
+            # Check if the scale_fmt is ue8m0, and auto-disable DEEPGEMM_SCALE_UE8M0
+            # for non-ue8m0 models on Blackwell to prevent NaN
             self.use_scale_ue8m0 = quant_cfg.get("scale_fmt", None) == "ue8m0"
             from sglang.srt.layers import deep_gemm_wrapper
 
             if not self.use_scale_ue8m0 and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
                 logger.warning(
-                    "DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell."
+                    "DeepGemm scale format auto-corrected: checkpoint does not use ue8m0 scales. "
+                    "Setting DEEPGEMM_SCALE_UE8M0=False to prevent NaN on Blackwell."
                 )
+                deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 = False
 
         if self.quantization is not None:
             if self.quantization not in supported_quantization:

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1004,17 +1004,14 @@ class ModelConfig:
                         f"({self.quantization})."
                     )
 
-            # Check if the scale_fmt is ue8m0, and auto-disable DEEPGEMM_SCALE_UE8M0
-            # for non-ue8m0 models on Blackwell to prevent NaN
+            # Check if the scale_fmt is ue8m0, and warn user if deepgemm is enabled for non-ue8m0 models on blackwell
             self.use_scale_ue8m0 = quant_cfg.get("scale_fmt", None) == "ue8m0"
             from sglang.srt.layers import deep_gemm_wrapper
 
             if not self.use_scale_ue8m0 and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
                 logger.warning(
-                    "DeepGemm scale format auto-corrected: checkpoint does not use ue8m0 scales. "
-                    "Setting DEEPGEMM_SCALE_UE8M0=False to prevent NaN on Blackwell."
+                    "DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell."
                 )
-                deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 = False
 
         if self.quantization is not None:
             if self.quantization not in supported_quantization:

--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -1,7 +1,7 @@
 import logging
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import get_device_sm, is_blackwell_supported
+from sglang.srt.utils import get_device_sm, is_sm100_supported
 
 logger = logging.getLogger(__name__)
 
@@ -21,5 +21,5 @@ def _compute_enable_deep_gemm():
 
 ENABLE_JIT_DEEPGEMM = _compute_enable_deep_gemm()
 
-DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and is_blackwell_supported()
+DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and is_sm100_supported()
 DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL


### PR DESCRIPTION
## Motivation

On Blackwell GPUs (SM120), `DEEPGEMM_SCALE_UE8M0` is unconditionally set to `True` in `configurer.py`:

```python
DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and is_blackwell_supported()
DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL  # Always True on Blackwell
```

This assumes all FP8 models on Blackwell use **ue8m0** scale format. However, **NVFP4-quantized models** (loaded with `--quantization modelopt_fp4`) use **float8_e4m3fn** scales, not ue8m0. When DeepGemm treats float8_e4m3fn scales as ue8m0, it produces **NaN outputs** — the model is completely broken.

## What model we tested on

We are running **GLM-5-NVFP4-MTP** (a GLM-4 family model quantized to NVFP4 via NVIDIA ModelOpt) on **8× Blackwell GPUs** with:

```bash
python3 -m sglang.launch_server \
  --model-path /mnt/GLM-5-NVFP4-MTP \
  --tp 8 \
  --attention-backend flashinfer \
  --moe-runner-backend deep_gemm \
  --kv-cache-dtype bf16 \
  --quantization modelopt_fp4 \
  --mem-fraction-static 0.85 \
  --cuda-graph-max-bs 32 \
  --max-running-requests 64 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4
```

Without this fix, the server starts but produces NaN in all outputs. With this fix, it works correctly.

## The bug

The detection logic already exists in `model_config.py` — it reads `scale_fmt` from the checkpoint's quantization config and correctly identifies when a model does **not** use ue8m0 scales:

```python
self.use_scale_ue8m0 = quant_cfg.get("scale_fmt", None) == "ue8m0"
if not self.use_scale_ue8m0 and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
    logger.warning("DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. ...")
```

But it **only logs a warning** and never actually corrects the flag. The warning is printed, but `DEEPGEMM_SCALE_UE8M0` remains `True`, and all downstream code (MoE runners, FP8 quantization utils, token dispatchers) continues to use ue8m0 scale handling — causing NaN.

## The fix

One line added: when a non-ue8m0 checkpoint is detected, set `deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 = False`.

This is safe because:
1. All consumers access the flag via `deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0` (module attribute access, not local copies), so the mutation is visible everywhere
2. `model_config` is parsed **before** model initialization and inference, so timing is correct
3. This is **exactly the same pattern** already used in `longcat_flash.py:803` (`deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 = False`) for a specific model — this PR just applies it generically for all models

## Impact

- **Fixes**: All NVFP4/modelopt_fp4 models on Blackwell that were producing NaN (GLM-5-NVFP4-MTP, and likely any other non-ue8m0 FP8 model)
- **No regression for ue8m0 models**: The condition only triggers when `scale_fmt != "ue8m0"`, so native Blackwell ue8m0 models (e.g. DeepSeek-V3) are unaffected
- **Eliminates the need for manual workarounds** like `sed -i "s/DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL/DEEPGEMM_SCALE_UE8M0 = False/"` that users currently have to apply

## Test plan

- [x] Verified on GLM-5-NVFP4-MTP with `--quantization modelopt_fp4` on 8× Blackwell — NaN gone, outputs correct
- [ ] Existing ue8m0 models (DeepSeek-V3 FP8) should be unaffected (condition does not trigger)