### PR TITLE
[Bugfix] Remove spurious device arg from cutlass_fp4_group_mm calls

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -463,7 +463,6 @@ def cutlass_moe_fp4(
         w1_blockscale,
         w1_alphas,
         out_dtype,
-        device,
         params.to_gemm1_args(),
     )
     del rep_a_fp4, rep_a_blockscale
@@ -488,7 +487,6 @@ def cutlass_moe_fp4(
         w2_blockscale,
         w2_alphas,
         out_dtype,
-        device,
         params.to_gemm2_args(),
     )
     del int_fp4, int_blockscale


### PR DESCRIPTION
## Motivation

PR #19437 migrated `cutlass_fp4_group_mm` from the AOT `sgl_kernel` C++ extension to a JIT Python wrapper in `sglang.jit_kernel.nvfp4`. The old C++ function accepted 8 positional arguments (including `device`), but the new JIT wrapper only takes 7 — it infers `device` from `a_fp4.device` internally.

The two call sites in `cutlass_moe.py` (`cutlass_moe_fp4()`) were not updated to remove the `device` argument, causing a runtime crash on any NVFP4 MoE model:

```
TypeError: cutlass_fp4_group_mm() takes 7 positional arguments but 8 were given
```

**Affected models**: any NVFP4 quantized MoE model (e.g. GLM-5-NVFP4-MTP, Qwen3.5-397B-A17B-NVFP4).

## Modifications

Removed the spurious `device` positional argument from both `cutlass_fp4_group_mm()` call sites in `cutlass_moe_fp4()` (lines 466 and 491).

## Checklist
- [x] `cutlass_moe_fp4` c1 call: removed `device` arg
- [x] `cutlass_moe_fp4` c2 call: removed `device` arg
- [x] Verified fix resolves the TypeError on RTX 5090 (sm_120f) with GLM-5-NVFP4-MTP