### PR TITLE
Fix `profile_activities` parameter name in `bench_one_batch_server_internal.py`

### DIFF
--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -541,7 +541,7 @@ def run_one_case(
         profile_link: str = run_profile(
             url=url,
             num_steps=profile_steps,
-            profile_activities=profile_activities,
+            activities=profile_activities,
             output_dir=profile_output_dir,
             profile_by_stage=profile_by_stage,
             profile_prefix=profile_prefix,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

#12981 introduced `profile_activities` parameter but passed it incorrectly to `run_profile()` which expects `activities`

```
Error profiling, some profile traces may not be dumped: run_profile() got an unexpected keyword argument 'profile_activities'
```

@Kangyan-Zhou 