### PR TITLE
[JIT Kernel] Migrate fast_topk to JIT

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_fast_topk.py
+++ b/python/sglang/jit_kernel/benchmark/bench_fast_topk.py
@@ -1,0 +1,88 @@
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import (
+    DEFAULT_DEVICE,
+    get_benchmark_range,
+    run_benchmark,
+)
+from sglang.jit_kernel.fast_topk import fast_topk_v2 as jit_fast_topk_v2
+
+try:
+    from sgl_kernel import fast_topk_v2 as aot_fast_topk_v2
+
+    AOT_AVAILABLE = True
+except ImportError:
+    aot_fast_topk_v2 = None
+    AOT_AVAILABLE = False
+
+TOPK = 2048
+
+B_LIST = get_benchmark_range(
+    full_range=[1, 4, 16, 64, 128],
+    ci_range=[4, 16],
+)
+
+LENGTH_LIST = get_benchmark_range(
+    full_range=[4096, 8192, 16384, 32768],
+    ci_range=[4096, 8192],
+)
+
+configs = list(itertools.product(B_LIST, LENGTH_LIST))
+
+line_vals = ["jit", "pytorch"]
+line_names = ["SGL JIT Kernel", "PyTorch"]
+styles = [("blue", "-"), ("red", "--")]
+
+if AOT_AVAILABLE:
+    line_vals.insert(1, "aot")
+    line_names.insert(1, "SGL AOT Kernel")
+    styles.insert(1, ("green", "-."))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "length"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=line_vals,
+        line_names=line_names,
+        styles=styles,
+        ylabel="us",
+        plot_name="fast-topk-performance",
+        args={},
+    )
+)
+def benchmark(batch_size, length, provider):
+    device = DEFAULT_DEVICE
+    input_stride = length
+    score = torch.randn(
+        batch_size, input_stride, dtype=torch.float32, device=device
+    )
+    lengths = torch.full(
+        (batch_size,), length, dtype=torch.int32, device=device
+    )
+
+    if provider == "jit":
+
+        def fn():
+            return jit_fast_topk_v2(score, lengths, TOPK)
+
+    elif provider == "aot":
+
+        def fn():
+            return aot_fast_topk_v2(score, lengths, TOPK)
+
+    else:
+
+        def fn():
+            return torch.topk(score, TOPK, dim=-1)
+
+    return run_benchmark(fn)
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/elementwise/fast_topk.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fast_topk.cuh
@@ -13,7 +13,7 @@
 
 namespace {
 
-static constexpr int TopK = 2048;
+static constexpr int kTopK = 2048;
 static constexpr int kThreadsPerBlock = 1024;
 static constexpr size_t kSmem = 8 * 1024 * sizeof(uint32_t);  // 32KB
 
@@ -30,7 +30,7 @@ __device__ void naive_topk_cuda(
     int32_t* __restrict__ indice,
     int32_t length) {
   const auto tid = threadIdx.x;
-  for (int i = tid; i < TopK; i += kThreadsPerBlock) {
+  for (int i = tid; i < kTopK; i += kThreadsPerBlock) {
     indice[i] = (i < length) ? i : -1;
   }
 }
@@ -41,7 +41,7 @@ __device__ void naive_topk_transform(
     int32_t* __restrict__ dst_page_table,
     const int32_t* __restrict__ src_page_table) {
   const auto tid = threadIdx.x;
-  for (auto i = tid; i < TopK; i += kThreadsPerBlock) {
+  for (auto i = tid; i < kTopK; i += kThreadsPerBlock) {
     dst_page_table[i] = (i < length) ? src_page_table[i] : -1;
   }
 }
@@ -52,7 +52,7 @@ __device__ void naive_topk_transform_ragged(
     int32_t* __restrict__ topk_indices_ragged,
     int32_t offset) {
   const auto tid = threadIdx.x;
-  for (auto i = tid; i < TopK; i += kThreadsPerBlock) {
+  for (auto i = tid; i < kTopK; i += kThreadsPerBlock) {
     topk_indices_ragged[i] =
         (i < length) ? static_cast<int32_t>(i) + offset : -1;
   }
@@ -76,27 +76,27 @@ __device__ void fast_topk_cuda_tl(
     int* __restrict__ index,
     int row_start,
     int length) {
-  int topk = TopK;
-  constexpr auto BLOCK_SIZE = 1024;
-  constexpr auto RADIX = 256;
-  constexpr auto SMEM_INPUT_SIZE =
+  int topk = kTopK;
+  constexpr auto kBlockSize = 1024;
+  constexpr auto kRadix = 256;
+  constexpr auto kSmemInputSize =
       static_cast<int>(kSmem / (2 * sizeof(int)));
 
-  alignas(128) __shared__ int s_histogram_buf[2][RADIX + 128];
+  alignas(128) __shared__ int s_histogram_buf[2][kRadix + 128];
   alignas(128) __shared__ int s_counter;
   alignas(128) __shared__ int s_threshold_bin_id;
   alignas(128) __shared__ int s_num_input[2];
 
   auto& s_histogram = s_histogram_buf[0];
-  extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
+  extern __shared__ int s_input_idx[][kSmemInputSize];
 
   const int tx = threadIdx.x;
 
   // stage 1: 8bit coarse histogram
-  if (tx < RADIX + 1) s_histogram[tx] = 0;
+  if (tx < kRadix + 1) s_histogram[tx] = 0;
   __syncthreads();
 
-  for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+  for (int idx = tx; idx < length; idx += kBlockSize) {
     const auto bin = convert_to_uint8(input[idx + row_start]);
     ::atomicAdd(&s_histogram[bin], 1);
   }
@@ -105,12 +105,12 @@ __device__ void fast_topk_cuda_tl(
   const auto run_cumsum = [&] {
 #pragma unroll 8
     for (int i = 0; i < 8; ++i) {
-      static_assert(1 << 8 == RADIX);
-      if (__builtin_expect(tx < RADIX, 1)) {
+      static_assert(1 << 8 == kRadix);
+      if (__builtin_expect(tx < kRadix, 1)) {
         const auto j = 1 << i;
         const auto k = i & 1;
         auto value = s_histogram_buf[k][tx];
-        if (tx < RADIX - j) {
+        if (tx < kRadix - j) {
           value += s_histogram_buf[k][tx + j];
         }
         s_histogram_buf[k ^ 1][tx] = value;
@@ -120,7 +120,7 @@ __device__ void fast_topk_cuda_tl(
   };
 
   run_cumsum();
-  if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+  if (tx < kRadix && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
     s_threshold_bin_id = tx;
     s_num_input[0] = 0;
     s_counter = 0;
@@ -131,7 +131,7 @@ __device__ void fast_topk_cuda_tl(
   topk -= s_histogram[threshold_bin + 1];
 
   if (topk == 0) {
-    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+    for (int idx = tx; idx < length; idx += kBlockSize) {
       const auto bin =
           static_cast<int>(convert_to_uint8(input[idx + row_start]));
       if (bin > threshold_bin) {
@@ -143,12 +143,12 @@ __device__ void fast_topk_cuda_tl(
     return;
   } else {
     __syncthreads();
-    if (tx < RADIX + 1) {
+    if (tx < kRadix + 1) {
       s_histogram[tx] = 0;
     }
     __syncthreads();
 
-    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+    for (int idx = tx; idx < length; idx += kBlockSize) {
       const auto raw_input = input[idx + row_start];
       const auto bin =
           static_cast<int>(convert_to_uint8(raw_input));
@@ -157,7 +157,7 @@ __device__ void fast_topk_cuda_tl(
         index[pos] = idx;
       } else if (bin == threshold_bin) {
         const auto pos = ::atomicAdd(&s_num_input[0], 1);
-        if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
+        if (__builtin_expect(pos < kSmemInputSize, 1)) {
           s_input_idx[0][pos] = idx;
           const auto bin2 = convert_to_uint32(raw_input);
           const auto sub_bin = (bin2 >> 24) & 0xFF;
@@ -175,12 +175,12 @@ __device__ void fast_topk_cuda_tl(
     const auto r_idx = round % 2;
 
     const auto _raw_num_input = s_num_input[r_idx];
-    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE))
+    const auto num_input = (_raw_num_input < int(kSmemInputSize))
                                ? _raw_num_input
-                               : int(SMEM_INPUT_SIZE);
+                               : int(kSmemInputSize);
 
     run_cumsum();
-    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+    if (tx < kRadix && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
       s_threshold_bin_id = tx;
       s_num_input[r_idx ^ 1] = 0;
       s_last_remain = topk - s_histogram[tx + 1];
@@ -191,7 +191,7 @@ __device__ void fast_topk_cuda_tl(
     topk -= s_histogram[threshold_bin + 1];
 
     if (topk == 0) {
-      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+      for (int i = tx; i < num_input; i += kBlockSize) {
         const auto idx = s_input_idx[r_idx][i];
         const auto offset = 24 - round * 8;
         const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) &
@@ -205,11 +205,11 @@ __device__ void fast_topk_cuda_tl(
       break;
     } else {
       __syncthreads();
-      if (tx < RADIX + 1) {
+      if (tx < kRadix + 1) {
         s_histogram[tx] = 0;
       }
       __syncthreads();
-      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+      for (int i = tx; i < num_input; i += kBlockSize) {
         const auto idx = s_input_idx[r_idx][i];
         const auto raw_input = input[idx + row_start];
         const auto offset = 24 - round * 8;
@@ -222,11 +222,11 @@ __device__ void fast_topk_cuda_tl(
           if (round == 3) {
             const auto pos = ::atomicAdd(&s_last_remain, -1);
             if (pos > 0) {
-              index[TopK - pos] = idx;
+              index[kTopK - pos] = idx;
             }
           } else {
             const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
-            if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
+            if (__builtin_expect(pos < kSmemInputSize, 1)) {
               s_input_idx[r_idx ^ 1][pos] = idx;
               const auto bin2 = convert_to_uint32(raw_input);
               const auto sub_bin = (bin2 >> (offset - 8)) & 0xFF;
@@ -246,9 +246,9 @@ void topk_kernel(const FastTopKParams params) {
   const auto row_start =
       params.row_starts == nullptr ? 0 : params.row_starts[bid];
   const auto length = params.lengths[bid];
-  const auto indice = params.indices + bid * TopK;
+  const auto indice = params.indices + bid * kTopK;
   const auto score = params.input + bid * params.input_stride;
-  if (length <= TopK) {
+  if (length <= kTopK) {
     return naive_topk_cuda(score, indice, length);
   } else {
     return fast_topk_cuda_tl(score, indice, row_start, length);
@@ -265,15 +265,15 @@ void topk_transform_decode_kernel(
   const auto tid = threadIdx.x;
   const auto length = params.lengths[bid];
   const auto src_page_entry = src_page_table + bid * src_stride;
-  const auto dst_page_entry = dst_page_table + bid * TopK;
+  const auto dst_page_entry = dst_page_table + bid * kTopK;
   const auto score = params.input + bid * params.input_stride;
-  if (length <= TopK) {
+  if (length <= kTopK) {
     return naive_topk_transform(score, length, dst_page_entry, src_page_entry);
   } else {
-    __shared__ int s_indices[TopK];
+    __shared__ int s_indices[kTopK];
     fast_topk_cuda_tl(score, s_indices, 0, length);
-    static_assert(TopK % kThreadsPerBlock == 0);
-    static_assert(TopK / kThreadsPerBlock == 2);
+    static_assert(kTopK % kThreadsPerBlock == 0);
+    static_assert(kTopK / kThreadsPerBlock == 2);
     const auto idx_0 = tid;
     dst_page_entry[idx_0] = src_page_entry[s_indices[idx_0]];
     const auto idx_1 = tid + kThreadsPerBlock;
@@ -294,7 +294,7 @@ void topk_transform_prefill_kernel(
   const auto length = params.lengths[bid];
   const auto row_start =
       params.row_starts == nullptr ? 0 : params.row_starts[bid];
-  const auto dst_page_entry = dst_page_table + bid * TopK;
+  const auto dst_page_entry = dst_page_table + bid * kTopK;
   const auto score = params.input + bid * params.input_stride;
 
   __shared__ const int32_t* s_src_page_entry;
@@ -316,13 +316,13 @@ void topk_transform_prefill_kernel(
   __syncthreads();
   const auto src_page_entry = s_src_page_entry;
 
-  if (length <= TopK) {
+  if (length <= kTopK) {
     return naive_topk_transform(score, length, dst_page_entry, src_page_entry);
   } else {
-    __shared__ int s_indices[TopK];
+    __shared__ int s_indices[kTopK];
     fast_topk_cuda_tl(score, s_indices, row_start, length);
-    static_assert(TopK % kThreadsPerBlock == 0);
-    static_assert(TopK / kThreadsPerBlock == 2);
+    static_assert(kTopK % kThreadsPerBlock == 0);
+    static_assert(kTopK / kThreadsPerBlock == 2);
     const auto idx_0 = tid;
     dst_page_entry[idx_0] = src_page_entry[s_indices[idx_0]];
     const auto idx_1 = tid + kThreadsPerBlock;
@@ -340,17 +340,17 @@ void topk_transform_prefill_ragged_kernel(
   const auto row_start =
       params.row_starts == nullptr ? 0 : params.row_starts[bid];
   const auto length = params.lengths[bid];
-  const auto dst_indices_entry = topk_indices_ragged + bid * TopK;
+  const auto dst_indices_entry = topk_indices_ragged + bid * kTopK;
   const auto score = params.input + bid * params.input_stride;
   const auto offset = topk_indices_offset[bid];
 
-  if (length <= TopK) {
+  if (length <= kTopK) {
     return naive_topk_transform_ragged(score, length, dst_indices_entry, offset);
   } else {
-    __shared__ int s_indices[TopK];
+    __shared__ int s_indices[kTopK];
     fast_topk_cuda_tl(score, s_indices, row_start, length);
-    static_assert(TopK % kThreadsPerBlock == 0);
-    static_assert(TopK / kThreadsPerBlock == 2);
+    static_assert(kTopK % kThreadsPerBlock == 0);
+    static_assert(kTopK / kThreadsPerBlock == 2);
     const auto idx_0 = tid;
     dst_indices_entry[idx_0] = s_indices[idx_0] + offset;
     const auto idx_1 = tid + kThreadsPerBlock;

--- a/python/sglang/jit_kernel/csrc/elementwise/fast_topk.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fast_topk.cuh
@@ -1,0 +1,516 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+static constexpr int TopK = 2048;
+static constexpr int kThreadsPerBlock = 1024;
+static constexpr size_t kSmem = 8 * 1024 * sizeof(uint32_t);  // 32KB
+
+struct FastTopKParams {
+  const float* __restrict__ input;
+  const int32_t* __restrict__ row_starts;
+  int32_t* __restrict__ indices;
+  int32_t* __restrict__ lengths;
+  int64_t input_stride;
+};
+
+__device__ void naive_topk_cuda(
+    const float* __restrict__ score,
+    int32_t* __restrict__ indice,
+    int32_t length) {
+  const auto tid = threadIdx.x;
+  for (int i = tid; i < TopK; i += kThreadsPerBlock) {
+    indice[i] = (i < length) ? i : -1;
+  }
+}
+
+__device__ void naive_topk_transform(
+    const float* __restrict__ score,
+    int32_t length,
+    int32_t* __restrict__ dst_page_table,
+    const int32_t* __restrict__ src_page_table) {
+  const auto tid = threadIdx.x;
+  for (auto i = tid; i < TopK; i += kThreadsPerBlock) {
+    dst_page_table[i] = (i < length) ? src_page_table[i] : -1;
+  }
+}
+
+__device__ void naive_topk_transform_ragged(
+    const float* __restrict__ score,
+    int32_t length,
+    int32_t* __restrict__ topk_indices_ragged,
+    int32_t offset) {
+  const auto tid = threadIdx.x;
+  for (auto i = tid; i < TopK; i += kThreadsPerBlock) {
+    topk_indices_ragged[i] =
+        (i < length) ? static_cast<int32_t>(i) + offset : -1;
+  }
+}
+
+__device__ __forceinline__ auto convert_to_uint8(float x) -> uint8_t {
+  __half h = __float2half_rn(x);
+  uint16_t bits = __half_as_ushort(h);
+  uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits)
+                                 : static_cast<uint16_t>(bits | 0x8000);
+  return static_cast<uint8_t>(key >> 8);
+}
+
+__device__ __forceinline__ auto convert_to_uint32(float x) -> uint32_t {
+  uint32_t bits = __float_as_uint(x);
+  return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+}
+
+__device__ void fast_topk_cuda_tl(
+    const float* __restrict__ input,
+    int* __restrict__ index,
+    int row_start,
+    int length) {
+  int topk = TopK;
+  constexpr auto BLOCK_SIZE = 1024;
+  constexpr auto RADIX = 256;
+  constexpr auto SMEM_INPUT_SIZE =
+      static_cast<int>(kSmem / (2 * sizeof(int)));
+
+  alignas(128) __shared__ int s_histogram_buf[2][RADIX + 128];
+  alignas(128) __shared__ int s_counter;
+  alignas(128) __shared__ int s_threshold_bin_id;
+  alignas(128) __shared__ int s_num_input[2];
+
+  auto& s_histogram = s_histogram_buf[0];
+  extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
+
+  const int tx = threadIdx.x;
+
+  // stage 1: 8bit coarse histogram
+  if (tx < RADIX + 1) s_histogram[tx] = 0;
+  __syncthreads();
+
+  for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+    const auto bin = convert_to_uint8(input[idx + row_start]);
+    ::atomicAdd(&s_histogram[bin], 1);
+  }
+  __syncthreads();
+
+  const auto run_cumsum = [&] {
+#pragma unroll 8
+    for (int i = 0; i < 8; ++i) {
+      static_assert(1 << 8 == RADIX);
+      if (__builtin_expect(tx < RADIX, 1)) {
+        const auto j = 1 << i;
+        const auto k = i & 1;
+        auto value = s_histogram_buf[k][tx];
+        if (tx < RADIX - j) {
+          value += s_histogram_buf[k][tx + j];
+        }
+        s_histogram_buf[k ^ 1][tx] = value;
+      }
+      __syncthreads();
+    }
+  };
+
+  run_cumsum();
+  if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+    s_threshold_bin_id = tx;
+    s_num_input[0] = 0;
+    s_counter = 0;
+  }
+  __syncthreads();
+
+  const auto threshold_bin = s_threshold_bin_id;
+  topk -= s_histogram[threshold_bin + 1];
+
+  if (topk == 0) {
+    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+      const auto bin =
+          static_cast<int>(convert_to_uint8(input[idx + row_start]));
+      if (bin > threshold_bin) {
+        const auto pos = ::atomicAdd(&s_counter, 1);
+        index[pos] = idx;
+      }
+    }
+    __syncthreads();
+    return;
+  } else {
+    __syncthreads();
+    if (tx < RADIX + 1) {
+      s_histogram[tx] = 0;
+    }
+    __syncthreads();
+
+    for (int idx = tx; idx < length; idx += BLOCK_SIZE) {
+      const auto raw_input = input[idx + row_start];
+      const auto bin =
+          static_cast<int>(convert_to_uint8(raw_input));
+      if (bin > threshold_bin) {
+        const auto pos = ::atomicAdd(&s_counter, 1);
+        index[pos] = idx;
+      } else if (bin == threshold_bin) {
+        const auto pos = ::atomicAdd(&s_num_input[0], 1);
+        if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
+          s_input_idx[0][pos] = idx;
+          const auto bin2 = convert_to_uint32(raw_input);
+          const auto sub_bin = (bin2 >> 24) & 0xFF;
+          ::atomicAdd(&s_histogram[sub_bin], 1);
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  // stage 2: refine with 8bit radix passes
+#pragma unroll 4
+  for (int round = 0; round < 4; ++round) {
+    __shared__ int s_last_remain;
+    const auto r_idx = round % 2;
+
+    const auto _raw_num_input = s_num_input[r_idx];
+    const auto num_input = (_raw_num_input < int(SMEM_INPUT_SIZE))
+                               ? _raw_num_input
+                               : int(SMEM_INPUT_SIZE);
+
+    run_cumsum();
+    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+      s_threshold_bin_id = tx;
+      s_num_input[r_idx ^ 1] = 0;
+      s_last_remain = topk - s_histogram[tx + 1];
+    }
+    __syncthreads();
+
+    const auto threshold_bin2 = s_threshold_bin_id;
+    topk -= s_histogram[threshold_bin2 + 1];
+
+    if (topk == 0) {
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto offset = 24 - round * 8;
+        const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) &
+                         0xFF;
+        if (bin > threshold_bin2) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        }
+      }
+      __syncthreads();
+      break;
+    } else {
+      __syncthreads();
+      if (tx < RADIX + 1) {
+        s_histogram[tx] = 0;
+      }
+      __syncthreads();
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto raw_input = input[idx + row_start];
+        const auto offset = 24 - round * 8;
+        const auto bin =
+            (convert_to_uint32(raw_input) >> offset) & 0xFF;
+        if (bin > threshold_bin2) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          index[pos] = idx;
+        } else if (bin == threshold_bin2) {
+          if (round == 3) {
+            const auto pos = ::atomicAdd(&s_last_remain, -1);
+            if (pos > 0) {
+              index[TopK - pos] = idx;
+            }
+          } else {
+            const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
+            if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
+              s_input_idx[r_idx ^ 1][pos] = idx;
+              const auto bin2 = convert_to_uint32(raw_input);
+              const auto sub_bin = (bin2 >> (offset - 8)) & 0xFF;
+              ::atomicAdd(&s_histogram[sub_bin], 1);
+            }
+          }
+        }
+      }
+      __syncthreads();
+    }
+  }
+}
+
+__global__ __launch_bounds__(kThreadsPerBlock)
+void topk_kernel(const FastTopKParams params) {
+  const auto bid = static_cast<uint64_t>(blockIdx.x);
+  const auto row_start =
+      params.row_starts == nullptr ? 0 : params.row_starts[bid];
+  const auto length = params.lengths[bid];
+  const auto indice = params.indices + bid * TopK;
+  const auto score = params.input + bid * params.input_stride;
+  if (length <= TopK) {
+    return naive_topk_cuda(score, indice, length);
+  } else {
+    return fast_topk_cuda_tl(score, indice, row_start, length);
+  }
+}
+
+__global__ __launch_bounds__(kThreadsPerBlock)
+void topk_transform_decode_kernel(
+    const FastTopKParams params,
+    int32_t* __restrict__ dst_page_table,
+    const int32_t* __restrict__ src_page_table,
+    const int64_t src_stride) {
+  const auto bid = static_cast<uint64_t>(blockIdx.x);
+  const auto tid = threadIdx.x;
+  const auto length = params.lengths[bid];
+  const auto src_page_entry = src_page_table + bid * src_stride;
+  const auto dst_page_entry = dst_page_table + bid * TopK;
+  const auto score = params.input + bid * params.input_stride;
+  if (length <= TopK) {
+    return naive_topk_transform(score, length, dst_page_entry, src_page_entry);
+  } else {
+    __shared__ int s_indices[TopK];
+    fast_topk_cuda_tl(score, s_indices, 0, length);
+    static_assert(TopK % kThreadsPerBlock == 0);
+    static_assert(TopK / kThreadsPerBlock == 2);
+    const auto idx_0 = tid;
+    dst_page_entry[idx_0] = src_page_entry[s_indices[idx_0]];
+    const auto idx_1 = tid + kThreadsPerBlock;
+    dst_page_entry[idx_1] = src_page_entry[s_indices[idx_1]];
+  }
+}
+
+__global__ __launch_bounds__(kThreadsPerBlock)
+void topk_transform_prefill_kernel(
+    const FastTopKParams params,
+    int32_t* __restrict__ dst_page_table,
+    const int32_t* __restrict__ src_page_table,
+    const int64_t src_stride,
+    const int32_t* __restrict__ cu_seqlens_q,
+    const int64_t prefill_bs) {
+  const auto bid = static_cast<uint64_t>(blockIdx.x);
+  const auto tid = threadIdx.x;
+  const auto length = params.lengths[bid];
+  const auto row_start =
+      params.row_starts == nullptr ? 0 : params.row_starts[bid];
+  const auto dst_page_entry = dst_page_table + bid * TopK;
+  const auto score = params.input + bid * params.input_stride;
+
+  __shared__ const int32_t* s_src_page_entry;
+  if (__builtin_expect(prefill_bs <= kThreadsPerBlock, 1)) {
+    if (tid < prefill_bs) {
+      if (bid >= static_cast<uint64_t>(cu_seqlens_q[tid]) &&
+          bid < static_cast<uint64_t>(cu_seqlens_q[tid + 1])) {
+        s_src_page_entry = src_page_table + tid * src_stride;
+      }
+    }
+  } else {
+    for (int64_t i = tid; i < prefill_bs; i += kThreadsPerBlock) {
+      if (bid >= static_cast<uint64_t>(cu_seqlens_q[i]) &&
+          bid < static_cast<uint64_t>(cu_seqlens_q[i + 1])) {
+        s_src_page_entry = src_page_table + i * src_stride;
+      }
+    }
+  }
+  __syncthreads();
+  const auto src_page_entry = s_src_page_entry;
+
+  if (length <= TopK) {
+    return naive_topk_transform(score, length, dst_page_entry, src_page_entry);
+  } else {
+    __shared__ int s_indices[TopK];
+    fast_topk_cuda_tl(score, s_indices, row_start, length);
+    static_assert(TopK % kThreadsPerBlock == 0);
+    static_assert(TopK / kThreadsPerBlock == 2);
+    const auto idx_0 = tid;
+    dst_page_entry[idx_0] = src_page_entry[s_indices[idx_0]];
+    const auto idx_1 = tid + kThreadsPerBlock;
+    dst_page_entry[idx_1] = src_page_entry[s_indices[idx_1]];
+  }
+}
+
+__global__ __launch_bounds__(kThreadsPerBlock)
+void topk_transform_prefill_ragged_kernel(
+    const FastTopKParams params,
+    int32_t* __restrict__ topk_indices_ragged,
+    const int32_t* __restrict__ topk_indices_offset) {
+  const auto bid = static_cast<uint64_t>(blockIdx.x);
+  const auto tid = threadIdx.x;
+  const auto row_start =
+      params.row_starts == nullptr ? 0 : params.row_starts[bid];
+  const auto length = params.lengths[bid];
+  const auto dst_indices_entry = topk_indices_ragged + bid * TopK;
+  const auto score = params.input + bid * params.input_stride;
+  const auto offset = topk_indices_offset[bid];
+
+  if (length <= TopK) {
+    return naive_topk_transform_ragged(score, length, dst_indices_entry, offset);
+  } else {
+    __shared__ int s_indices[TopK];
+    fast_topk_cuda_tl(score, s_indices, row_start, length);
+    static_assert(TopK % kThreadsPerBlock == 0);
+    static_assert(TopK / kThreadsPerBlock == 2);
+    const auto idx_0 = tid;
+    dst_indices_entry[idx_0] = s_indices[idx_0] + offset;
+    const auto idx_1 = tid + kThreadsPerBlock;
+    dst_indices_entry[idx_1] = s_indices[idx_1] + offset;
+  }
+}
+
+// Host wrapper: fast_topk
+void fast_topk(
+    tvm::ffi::TensorView score,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView lengths,
+    tvm::ffi::TensorView row_starts,
+    bool has_row_starts) {
+  using namespace host;
+
+  auto B = SymbolicSize{"batch"};
+  auto L = SymbolicSize{"input_stride"};
+  auto K = SymbolicSize{"topk"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({B, L}).with_dtype<fp32_t>().with_device(device).verify(score);
+  TensorMatcher({B, K}).with_dtype<int32_t>().with_device(device).verify(indices);
+  TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(lengths);
+
+  const auto batch = static_cast<int64_t>(B.unwrap());
+  const auto input_stride = static_cast<int64_t>(L.unwrap());
+  const auto dev = device.unwrap();
+
+  FastTopKParams params{
+      .input = static_cast<const float*>(score.data_ptr()),
+      .row_starts = has_row_starts
+                        ? static_cast<const int32_t*>(row_starts.data_ptr())
+                        : nullptr,
+      .indices = static_cast<int32_t*>(indices.data_ptr()),
+      .lengths = static_cast<int32_t*>(lengths.data_ptr()),
+      .input_stride = input_stride,
+  };
+
+  LaunchKernel(
+      dim3(static_cast<unsigned>(batch)),
+      dim3(kThreadsPerBlock),
+      dev,
+      kSmem)(topk_kernel, params);
+}
+
+// Host wrapper: fast_topk_transform
+void fast_topk_transform(
+    tvm::ffi::TensorView score,
+    tvm::ffi::TensorView lengths,
+    tvm::ffi::TensorView dst_page_table,
+    tvm::ffi::TensorView src_page_table,
+    tvm::ffi::TensorView cu_seqlens_q,
+    tvm::ffi::TensorView row_starts,
+    bool has_row_starts,
+    bool is_decode) {
+  using namespace host;
+
+  auto B = SymbolicSize{"batch"};
+  auto L = SymbolicSize{"input_stride"};
+  auto K = SymbolicSize{"topk"};
+  auto PBS = SymbolicSize{"prefill_bs_plus_1"};
+  auto SRC_S = SymbolicSize{"src_stride"};
+  auto SRC_B = SymbolicSize{"src_batch"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({B, L}).with_dtype<fp32_t>().with_device(device).verify(score);
+  TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(lengths);
+  TensorMatcher({B, K}).with_dtype<int32_t>().with_device(device).verify(dst_page_table);
+  TensorMatcher({SRC_B, SRC_S}).with_dtype<int32_t>().with_device(device).verify(src_page_table);
+  TensorMatcher({PBS}).with_dtype<int32_t>().with_device(device).verify(cu_seqlens_q);
+
+  const auto batch = static_cast<int64_t>(B.unwrap());
+  const auto input_stride = static_cast<int64_t>(L.unwrap());
+  const auto prefill_bs = static_cast<int64_t>(PBS.unwrap()) - 1;
+  const auto src_stride = static_cast<int64_t>(SRC_S.unwrap());
+  const auto dev = device.unwrap();
+
+  FastTopKParams params{
+      .input = static_cast<const float*>(score.data_ptr()),
+      .row_starts = has_row_starts
+                        ? static_cast<const int32_t*>(row_starts.data_ptr())
+                        : nullptr,
+      .indices = nullptr,
+      .lengths = static_cast<int32_t*>(lengths.data_ptr()),
+      .input_stride = input_stride,
+  };
+
+  const auto grid = dim3(static_cast<unsigned>(batch));
+  const auto block = dim3(kThreadsPerBlock);
+
+  if (is_decode) {
+    LaunchKernel(grid, block, dev, kSmem)(
+        topk_transform_decode_kernel,
+        params,
+        static_cast<int32_t*>(dst_page_table.data_ptr()),
+        static_cast<const int32_t*>(src_page_table.data_ptr()),
+        src_stride);
+  } else {
+    LaunchKernel(grid, block, dev, kSmem)(
+        topk_transform_prefill_kernel,
+        params,
+        static_cast<int32_t*>(dst_page_table.data_ptr()),
+        static_cast<const int32_t*>(src_page_table.data_ptr()),
+        src_stride,
+        static_cast<const int32_t*>(cu_seqlens_q.data_ptr()),
+        prefill_bs);
+  }
+}
+
+// Host wrapper: fast_topk_transform_ragged
+void fast_topk_transform_ragged(
+    tvm::ffi::TensorView score,
+    tvm::ffi::TensorView lengths,
+    tvm::ffi::TensorView topk_indices_ragged,
+    tvm::ffi::TensorView topk_indices_offset,
+    tvm::ffi::TensorView row_starts,
+    bool has_row_starts) {
+  using namespace host;
+
+  auto B = SymbolicSize{"batch"};
+  auto L = SymbolicSize{"input_stride"};
+  auto K = SymbolicSize{"topk"};
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+
+  TensorMatcher({B, L}).with_dtype<fp32_t>().with_device(device).verify(score);
+  TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(lengths);
+  TensorMatcher({B, K})
+      .with_dtype<int32_t>()
+      .with_device(device)
+      .verify(topk_indices_ragged);
+  TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(
+      topk_indices_offset);
+
+  const auto batch = static_cast<int64_t>(B.unwrap());
+  const auto input_stride = static_cast<int64_t>(L.unwrap());
+  const auto dev = device.unwrap();
+
+  FastTopKParams params{
+      .input = static_cast<const float*>(score.data_ptr()),
+      .row_starts = has_row_starts
+                        ? static_cast<const int32_t*>(row_starts.data_ptr())
+                        : nullptr,
+      .indices = nullptr,
+      .lengths = static_cast<int32_t*>(lengths.data_ptr()),
+      .input_stride = input_stride,
+  };
+
+  LaunchKernel(
+      dim3(static_cast<unsigned>(batch)),
+      dim3(kThreadsPerBlock),
+      dev,
+      kSmem)(
+      topk_transform_prefill_ragged_kernel,
+      params,
+      static_cast<int32_t*>(topk_indices_ragged.data_ptr()),
+      static_cast<const int32_t*>(topk_indices_offset.data_ptr()));
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/elementwise/fast_topk.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fast_topk.cuh
@@ -187,8 +187,8 @@ __device__ void fast_topk_cuda_tl(
     }
     __syncthreads();
 
-    const auto threshold_bin2 = s_threshold_bin_id;
-    topk -= s_histogram[threshold_bin2 + 1];
+    const auto threshold_bin = s_threshold_bin_id;
+    topk -= s_histogram[threshold_bin + 1];
 
     if (topk == 0) {
       for (int i = tx; i < num_input; i += BLOCK_SIZE) {
@@ -196,7 +196,7 @@ __device__ void fast_topk_cuda_tl(
         const auto offset = 24 - round * 8;
         const auto bin = (convert_to_uint32(input[idx + row_start]) >> offset) &
                          0xFF;
-        if (bin > threshold_bin2) {
+        if (bin > threshold_bin) {
           const auto pos = ::atomicAdd(&s_counter, 1);
           index[pos] = idx;
         }
@@ -215,10 +215,10 @@ __device__ void fast_topk_cuda_tl(
         const auto offset = 24 - round * 8;
         const auto bin =
             (convert_to_uint32(raw_input) >> offset) & 0xFF;
-        if (bin > threshold_bin2) {
+        if (bin > threshold_bin) {
           const auto pos = ::atomicAdd(&s_counter, 1);
           index[pos] = idx;
-        } else if (bin == threshold_bin2) {
+        } else if (bin == threshold_bin) {
           if (round == 3) {
             const auto pos = ::atomicAdd(&s_last_remain, -1);
             if (pos > 0) {

--- a/python/sglang/jit_kernel/fast_topk.py
+++ b/python/sglang/jit_kernel/fast_topk.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+TOPK = 2048
+
+
+@cache_once
+def _jit_fast_topk_module() -> Module:
+    return load_jit(
+        "fast_topk",
+        cuda_files=["elementwise/fast_topk.cuh"],
+        cuda_wrappers=[
+            ("fast_topk", "fast_topk"),
+            ("fast_topk_transform", "fast_topk_transform"),
+            ("fast_topk_transform_ragged", "fast_topk_transform_ragged"),
+        ],
+    )
+
+
+def _dummy_row_starts(device: torch.device) -> torch.Tensor:
+    return torch.zeros(1, dtype=torch.int32, device=device)
+
+
+@register_custom_op(
+    op_name="jit_fast_topk",
+    mutates_args=["indices"],
+)
+def _fast_topk_op(
+    score: torch.Tensor,
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+    row_starts: torch.Tensor,
+    has_row_starts: bool,
+) -> None:
+    module = _jit_fast_topk_module()
+    module.fast_topk(score, indices, lengths, row_starts, has_row_starts)
+
+
+def fast_topk_v2(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    topk: int,
+    row_starts: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    assert topk == TOPK
+    assert score.dim() == 2
+    topk_indices = score.new_empty((score.size(0), topk), dtype=torch.int32)
+    has_row_starts = row_starts is not None
+    _fast_topk_op(
+        score,
+        topk_indices,
+        lengths,
+        row_starts if has_row_starts else _dummy_row_starts(score.device),
+        has_row_starts,
+    )
+    return topk_indices
+
+
+@register_custom_op(
+    op_name="jit_fast_topk_transform",
+    mutates_args=["dst_page_table"],
+)
+def _fast_topk_transform_op(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    dst_page_table: torch.Tensor,
+    src_page_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    row_starts: torch.Tensor,
+    has_row_starts: bool,
+    is_decode: bool,
+) -> None:
+    module = _jit_fast_topk_module()
+    module.fast_topk_transform(
+        score, lengths, dst_page_table, src_page_table,
+        cu_seqlens_q, row_starts, has_row_starts, is_decode,
+    )
+
+
+def fast_topk_transform_fused(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    page_table_size_1: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    topk: int,
+    row_starts: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    assert topk == TOPK
+    assert score.dim() == 2
+    src_page_table = page_table_size_1
+    dst_page_table = score.new_empty((score.shape[0], topk), dtype=torch.int32)
+    prefill_bs = cu_seqlens_q.size(0) - 1
+    B = score.size(0)
+    has_row_starts = row_starts is not None
+    is_decode = not has_row_starts and prefill_bs == B
+    _fast_topk_transform_op(
+        score, lengths, dst_page_table, src_page_table,
+        cu_seqlens_q,
+        row_starts if has_row_starts else _dummy_row_starts(score.device),
+        has_row_starts,
+        is_decode,
+    )
+    return dst_page_table
+
+
+@register_custom_op(
+    op_name="jit_fast_topk_transform_ragged",
+    mutates_args=["topk_indices_ragged"],
+)
+def _fast_topk_transform_ragged_op(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    topk_indices_ragged: torch.Tensor,
+    topk_indices_offset: torch.Tensor,
+    row_starts: torch.Tensor,
+    has_row_starts: bool,
+) -> None:
+    module = _jit_fast_topk_module()
+    module.fast_topk_transform_ragged(
+        score, lengths, topk_indices_ragged, topk_indices_offset,
+        row_starts, has_row_starts,
+    )
+
+
+def fast_topk_transform_ragged_fused(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    topk_indices_offset: torch.Tensor,
+    topk: int,
+    row_starts: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    assert topk == TOPK
+    assert score.dim() == 2
+    topk_indices_ragged = score.new_empty(
+        (score.shape[0], topk), dtype=torch.int32
+    )
+    has_row_starts = row_starts is not None
+    _fast_topk_transform_ragged_op(
+        score, lengths, topk_indices_ragged, topk_indices_offset,
+        row_starts if has_row_starts else _dummy_row_starts(score.device),
+        has_row_starts,
+    )
+    return topk_indices_ragged

--- a/python/sglang/jit_kernel/tests/test_fast_topk.py
+++ b/python/sglang/jit_kernel/tests/test_fast_topk.py
@@ -1,7 +1,11 @@
 import pytest
 import torch
 
-from sglang.jit_kernel.fast_topk import fast_topk_v2
+from sglang.jit_kernel.fast_topk import (
+    fast_topk_transform_fused,
+    fast_topk_transform_ragged_fused,
+    fast_topk_v2,
+)
 
 TOPK = 2048
 
@@ -71,6 +75,89 @@ def test_fast_topk_with_row_starts(batch_size):
         result_set = set(result[i].cpu().tolist())
         ref_set = set(ref_idx.cpu().tolist())
         assert result_set == ref_set, f"Row {i}: mismatch"
+
+
+@pytest.mark.parametrize("num_requests", [1, 4])
+def test_fast_topk_transform_decode(num_requests):
+    device = "cuda"
+    input_stride = 8192
+    B = num_requests  # decode: 1 query per request
+    max_pages = input_stride
+
+    score = torch.randn(B, input_stride, dtype=torch.float32, device=device)
+    lengths = torch.full((B,), input_stride, dtype=torch.int32, device=device)
+    # page table: identity mapping for simplicity
+    src_page_table = torch.arange(max_pages, dtype=torch.int32, device=device)
+    src_page_table = src_page_table.unsqueeze(0).expand(B, -1).contiguous()
+    cu_seqlens_q = torch.arange(B + 1, dtype=torch.int32, device=device)
+
+    dst = fast_topk_transform_fused(
+        score, lengths, src_page_table, cu_seqlens_q, TOPK
+    )
+
+    # With identity page table, dst should equal raw topk indices
+    ref_indices = fast_topk_v2(score, lengths, TOPK)
+    for i in range(B):
+        dst_set = set(dst[i].cpu().tolist())
+        ref_set = set(ref_indices[i].cpu().tolist())
+        assert dst_set == ref_set, f"Row {i}: decode transform mismatch"
+
+
+@pytest.mark.parametrize("num_requests", [1, 2])
+def test_fast_topk_transform_prefill(num_requests):
+    device = "cuda"
+    input_stride = 8192
+    queries_per_request = 3
+    B = num_requests * queries_per_request
+    max_pages = input_stride
+
+    score = torch.randn(B, input_stride, dtype=torch.float32, device=device)
+    lengths = torch.full((B,), input_stride, dtype=torch.int32, device=device)
+    src_page_table = torch.arange(max_pages, dtype=torch.int32, device=device)
+    src_page_table = src_page_table.unsqueeze(0).expand(num_requests, -1).contiguous()
+    cu_seqlens_q = torch.arange(
+        0, B + 1, queries_per_request, dtype=torch.int32, device=device
+    )
+    # Ensure last element is B
+    cu_seqlens_q = torch.cat([
+        cu_seqlens_q[:-1],
+        torch.tensor([B], dtype=torch.int32, device=device),
+    ])
+
+    dst = fast_topk_transform_fused(
+        score, lengths, src_page_table, cu_seqlens_q, TOPK
+    )
+
+    ref_indices = fast_topk_v2(score, lengths, TOPK)
+    for i in range(B):
+        dst_set = set(dst[i].cpu().tolist())
+        ref_set = set(ref_indices[i].cpu().tolist())
+        assert dst_set == ref_set, f"Row {i}: prefill transform mismatch"
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_fast_topk_transform_ragged(batch_size):
+    device = "cuda"
+    input_stride = 8192
+
+    score = torch.randn(batch_size, input_stride, dtype=torch.float32, device=device)
+    lengths = torch.full((batch_size,), input_stride, dtype=torch.int32, device=device)
+    # Each row has offset = row_index * input_stride
+    topk_indices_offset = torch.arange(
+        0, batch_size * input_stride, input_stride,
+        dtype=torch.int32, device=device,
+    )
+
+    dst = fast_topk_transform_ragged_fused(
+        score, lengths, topk_indices_offset, TOPK
+    )
+
+    ref_indices = fast_topk_v2(score, lengths, TOPK)
+    for i in range(batch_size):
+        offset = topk_indices_offset[i].item()
+        dst_set = set(dst[i].cpu().tolist())
+        ref_set = set((ref_indices[i] + offset).cpu().tolist())
+        assert dst_set == ref_set, f"Row {i}: ragged transform mismatch"
 
 
 if __name__ == "__main__":

--- a/python/sglang/jit_kernel/tests/test_fast_topk.py
+++ b/python/sglang/jit_kernel/tests/test_fast_topk.py
@@ -1,0 +1,77 @@
+import pytest
+import torch
+
+from sglang.jit_kernel.fast_topk import fast_topk_v2
+
+TOPK = 2048
+
+
+def _reference_topk(score, lengths, row_starts=None):
+    B = score.size(0)
+    indices = torch.full((B, TOPK), -1, dtype=torch.int32, device=score.device)
+    for i in range(B):
+        length = lengths[i].item()
+        row_start = 0 if row_starts is None else row_starts[i].item()
+        if length <= TOPK:
+            indices[i, :length] = torch.arange(length, dtype=torch.int32)
+        else:
+            vals = score[i, row_start : row_start + length]
+            _, top_idx = torch.topk(vals, TOPK)
+            indices[i] = top_idx.int()
+    return indices
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16])
+def test_fast_topk_short(batch_size):
+    device = "cuda"
+    input_stride = 4096
+    score = torch.randn(batch_size, input_stride, dtype=torch.float32, device=device)
+    lengths = torch.full((batch_size,), 1024, dtype=torch.int32, device=device)
+
+    result = fast_topk_v2(score, lengths, TOPK)
+    ref = _reference_topk(score, lengths)
+
+    for i in range(batch_size):
+        length = lengths[i].item()
+        result_set = set(result[i, :length].cpu().tolist())
+        ref_set = set(ref[i, :length].cpu().tolist())
+        assert result_set == ref_set, f"Row {i}: mismatch"
+        assert torch.all(result[i, length:] == -1)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_fast_topk_long(batch_size):
+    device = "cuda"
+    input_stride = 8192
+    score = torch.randn(batch_size, input_stride, dtype=torch.float32, device=device)
+    lengths = torch.full((batch_size,), input_stride, dtype=torch.int32, device=device)
+
+    result = fast_topk_v2(score, lengths, TOPK)
+
+    for i in range(batch_size):
+        _, ref_idx = torch.topk(score[i], TOPK)
+        result_set = set(result[i].cpu().tolist())
+        ref_set = set(ref_idx.cpu().tolist())
+        assert result_set == ref_set, f"Row {i}: mismatch"
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_fast_topk_with_row_starts(batch_size):
+    device = "cuda"
+    input_stride = 8192
+    score = torch.randn(batch_size, input_stride, dtype=torch.float32, device=device)
+    lengths = torch.full((batch_size,), 4096, dtype=torch.int32, device=device)
+    row_starts = torch.zeros(batch_size, dtype=torch.int32, device=device)
+
+    result = fast_topk_v2(score, lengths, TOPK, row_starts=row_starts)
+
+    for i in range(batch_size):
+        length = lengths[i].item()
+        _, ref_idx = torch.topk(score[i, :length], TOPK)
+        result_set = set(result[i].cpu().tolist())
+        ref_set = set(ref_idx.cpu().tolist())
+        assert result_set == ref_set, f"Row {i}: mismatch"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -224,7 +224,7 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
         batch_idx_list: List[int] = None,
         topk_indices_offset_override: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        from sgl_kernel import (
+        from sglang.jit_kernel.fast_topk import (
             fast_topk_transform_fused,
             fast_topk_transform_ragged_fused,
             fast_topk_v2,


### PR DESCRIPTION
## Motivation

Migrate `fast_topk` kernel to JIT compilation (#17865).

## Modifications

Under `python/sglang/jit_kernel/`:
- `csrc/elementwise/fast_topk.cuh` — CUDA kernel (ported from `sgl-kernel/csrc/elementwise/topk.cu`)
- `fast_topk.py` — Python wrapper
- `tests/test_fast_topk.py` — Unit tests
- `benchmark/bench_fast_topk.py` — Benchmark (JIT vs PyTorch)

And
- `python/sglang/srt/layers/attention/nsa_backend.py` — Switch import to JIT

## Accuracy Tests

Pass all 13 tests defined in `python/sglang/jit_kernel/tests/test_fast_topk.py`

## Benchmarking and Profiling

```
GPU: NVIDIA GeForce RTX 5060 Laptop GPU
Driver: 580.126.20 | CUDA: 12.8 | PyTorch: 2.9.1+cu128
Script: python/sglang/jit_kernel/benchmark/bench_fast_topk.py

fast-topk-performance (unit: us):
   B × L            JIT    PyTorch
   1 × 4096         4.6    26.5
   1 × 8192         7.1    40.1
   4 × 4096         4.8    27.4
   4 × 8192         7.4    43.6
   16 × 4096        4.9    27.1
   16 × 8192        7.5    41.6
   64 × 8192       22.5    98.2
   128 × 8192      42.7   146.8
```

JIT kernel is 3-6x faster than PyTorch across all shapes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
