### PR TITLE
Use ORJSONResponse for /generate endpoint

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -650,7 +650,7 @@ async def generate_request(obj: GenerateReqInput, request: Request):
             ret = await _global_state.tokenizer_manager.generate_request(
                 obj, request
             ).__anext__()
-            return ret
+            return ORJSONResponse(ret)
         except ValueError as e:
             logger.error(f"[http_server] Error: {e}")
             return _create_error_response(e)


### PR DESCRIPTION
## Summary

- The non-streaming `/generate` endpoint returns a plain dict, which FastAPI serializes with stdlib `json.dumps`
- For large logprob responses (~6MB with `top_logprobs_num=50` on 4096-token sequences), `json.dumps` takes ~1100ms per request — far exceeding GPU compute time (~85ms for a 0.6B model)
- Switch to `ORJSONResponse` (`orjson.dumps`: ~14ms for the same payload) for a ~10x throughput improvement on logprob-heavy workloads
- All other endpoints already use `ORJSONResponse`; `/generate` was the only one returning a raw dict

## Benchmark

Qwen3-0.6B, `top_logprobs_num=50`, 200 samples of ~4096 tokens, prefill-only (`max_new_tokens=0`):

| | Before | After |
|---|---|---|
| Throughput (c=16) | ~3,500 tok/s | 36,160 tok/s |
| Throughput (c=64) | ~3,500 tok/s | 38,112 tok/s |

Verified numerical parity: logprob values from `ORJSONResponse` are identical to the original `JSONResponse` output.

## Tested with

- [x] Benchmark with concurrencies 16/64/256, 0 failures
- [x] Parity test: send same request to original and modified server, deep-compare all logprob values — identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)