### PR TITLE
[diffusion]: add width/height passthrough for OpenAI image API

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -119,6 +119,8 @@ async def generations(
             request_id,
             prompt=request.prompt,
             size=request.size,
+            width=request.width,
+            height=request.height,
             num_outputs_per_prompt=max(1, min(int(request.n or 1), 10)),
             output_file_name=f"{request_id}.{ext}",
             output_path=output_dir,

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -30,6 +30,9 @@ class ImageGenerationsRequest(BaseModel):
     quality: Optional[str] = "auto"
     response_format: Optional[str] = "url"  # url | b64_json
     size: Optional[str] = "1024x1024"  # e.g., 1024x1024
+    # SGLang extension: explicit dimensions (takes precedence over `size`).
+    width: Optional[int] = None
+    height: Optional[int] = None
     style: Optional[str] = "vivid"
     background: Optional[str] = "auto"  # transparent | opaque | auto
     output_format: Optional[str] = None  # png | jpeg | webp

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -30,7 +30,7 @@ class ImageGenerationsRequest(BaseModel):
     quality: Optional[str] = "auto"
     response_format: Optional[str] = "url"  # url | b64_json
     size: Optional[str] = "1024x1024"  # e.g., 1024x1024
-    # SGLang extension: explicit dimensions (takes precedence over `size`).
+    # Optional explicit output dimensions.
     width: Optional[int] = None
     height: Optional[int] = None
     style: Optional[str] = "vivid"

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -30,14 +30,13 @@ class ImageGenerationsRequest(BaseModel):
     quality: Optional[str] = "auto"
     response_format: Optional[str] = "url"  # url | b64_json
     size: Optional[str] = "1024x1024"  # e.g., 1024x1024
-    # Optional explicit output dimensions.
-    width: Optional[int] = None
-    height: Optional[int] = None
     style: Optional[str] = "vivid"
     background: Optional[str] = "auto"  # transparent | opaque | auto
     output_format: Optional[str] = None  # png | jpeg | webp
     user: Optional[str] = None
     # SGLang extensions
+    width: Optional[int] = None
+    height: Optional[int] = None
     num_inference_steps: Optional[int] = None
     guidance_scale: Optional[float] = None
     true_cfg_scale: Optional[float] = (

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -109,8 +109,11 @@ def build_sampling_params(request_id: str, **kwargs) -> SamplingParams:
     if size:
         w, h = _parse_size(size)
         if w is not None:
-            kwargs.setdefault("width", w)
-            kwargs.setdefault("height", h)
+            # treat None dimensions as unset so parsed size can fill them
+            if kwargs.get("width") is None:
+                kwargs["width"] = w
+            if kwargs.get("height") is None:
+                kwargs["height"] = h
 
     # filter out None values to let SamplingParams defaults apply
     kwargs = {k: v for k, v in kwargs.items() if v is not None}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->   This PR applies the minimal fix for diffusion router memory behavior  by allowing explicit `width`/`height` in OpenAI image generations requests and passing them through to sampling.

 `/v1/images/generations` was only using `size`, while the  flow passed explicit dimensions. That led to requests running with the endpoint default shape path instead of the intended dimensions.
 
For example:  when a request provides size such as 512x512 and width / height are unset, the parsed 512x512 dimensions are actually used instead of falling back to the default 1024x1024.

Related: https://github.com/zhaochenyang20/sglang-diffusion-routing/issues/38

## Modifications

<!-- Detail the changes made in this pull request. -->   
- Add optional `width` and `height` fields to `ImageGenerationsRequest`.
- Pass `width` and `height` into `build_sampling_params` in `/v1/images/generations`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
