### PR TITLE
fix(grpc): use context.abort() with proper status codes instead of in-band errors

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -201,15 +201,12 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 if isinstance(output, list):
                     for batch_output in output:
                         if "error" in batch_output:
-                            yield sglang_scheduler_pb2.GenerateResponse(
-                                request_id=request.request_id,
-                                error=sglang_scheduler_pb2.GenerateError(
-                                    message=batch_output["error"],
-                                    http_status_code=(
-                                        "500" if "abort" not in batch_output else "499"
-                                    ),
-                                ),
+                            code = (
+                                grpc.StatusCode.CANCELLED
+                                if "abort" in batch_output
+                                else grpc.StatusCode.INTERNAL
                             )
+                            await context.abort(code, batch_output["error"])
                         else:
                             # All non-error batch outputs are final responses
                             yield self._create_completion_response(
@@ -218,15 +215,12 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 else:
                     # Handle single response (for streaming or n=1 non-streaming)
                     if "error" in output:
-                        yield sglang_scheduler_pb2.GenerateResponse(
-                            request_id=request.request_id,
-                            error=sglang_scheduler_pb2.GenerateError(
-                                message=output["error"],
-                                http_status_code=(
-                                    "500" if "abort" not in output else "499"
-                                ),
-                            ),
+                        code = (
+                            grpc.StatusCode.CANCELLED
+                            if "abort" in output
+                            else grpc.StatusCode.INTERNAL
                         )
+                        await context.abort(code, output["error"])
                     elif request.stream:
                         yield self._create_chunk_response(request.request_id, output)
                         if output.get("finished", False):
@@ -239,24 +233,22 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                             request.request_id, output
                         )
 
+        except grpc.aio.AbortError:
+            raise
+        except ValueError as e:
+            logger.warning(f"Generate invalid request {request.request_id}: {e}")
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
         except Exception as e:
             logger.error(
                 f"Generate failed for request {request.request_id}: {e}\n"
                 f"{get_exception_traceback()}"
             )
-            yield sglang_scheduler_pb2.GenerateResponse(
-                request_id=request.request_id,
-                error=sglang_scheduler_pb2.GenerateError(
-                    message=str(e),
-                    http_status_code="500",
-                    details=get_exception_traceback(),
-                ),
-            )
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
     async def Embed(
         self,
         request: sglang_scheduler_pb2.EmbedRequest,
-        _context: grpc.aio.ServicerContext,
+        context: grpc.aio.ServicerContext,
     ) -> sglang_scheduler_pb2.EmbedResponse:
         """Handle embedding requests."""
         logger.info(f"Receive embedding request: {request.request_id}")
@@ -281,19 +273,17 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 ),
             )
 
+        except grpc.aio.AbortError:
+            raise
+        except ValueError as e:
+            logger.warning(f"Embed invalid request {request.request_id}: {e}")
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
         except Exception as e:
             logger.error(
                 f"Embed failed for request {request.request_id}: {e}\n"
                 f"{get_exception_traceback()}"
             )
-            return sglang_scheduler_pb2.EmbedResponse(
-                request_id=request.request_id,
-                error=sglang_scheduler_pb2.EmbedError(
-                    message=str(e),
-                    code="INTERNAL_ERROR",
-                    details=get_exception_traceback(),
-                ),
-            )
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
     async def HealthCheck(
         self,

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -31,6 +31,7 @@ from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationM
 from sglang.srt.grpc.grpc_request_manager import GrpcRequestManager
 from sglang.srt.grpc.health_servicer import SGLangHealthServicer
 from sglang.srt.grpc.scheduler_launcher import launch_scheduler_process_only
+from sglang.srt.grpc.utils import abort_code_from_output
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.io_struct import (
     GetLoadsReqOutput,
@@ -201,12 +202,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 if isinstance(output, list):
                     for batch_output in output:
                         if "error" in batch_output:
-                            code = (
-                                grpc.StatusCode.CANCELLED
-                                if "abort" in batch_output
-                                else grpc.StatusCode.INTERNAL
+                            await context.abort(
+                                abort_code_from_output(batch_output),
+                                batch_output["error"],
                             )
-                            await context.abort(code, batch_output["error"])
                         else:
                             # All non-error batch outputs are final responses
                             yield self._create_completion_response(
@@ -215,12 +214,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 else:
                     # Handle single response (for streaming or n=1 non-streaming)
                     if "error" in output:
-                        code = (
-                            grpc.StatusCode.CANCELLED
-                            if "abort" in output
-                            else grpc.StatusCode.INTERNAL
+                        await context.abort(
+                            abort_code_from_output(output),
+                            output["error"],
                         )
-                        await context.abort(code, output["error"])
                     elif request.stream:
                         yield self._create_chunk_response(request.request_id, output)
                         if output.get("finished", False):

--- a/python/sglang/srt/grpc/utils.py
+++ b/python/sglang/srt/grpc/utils.py
@@ -1,0 +1,21 @@
+"""gRPC utility functions."""
+
+from http import HTTPStatus
+
+import grpc
+
+_HTTP_TO_GRPC_CODE = {
+    HTTPStatus.BAD_REQUEST: grpc.StatusCode.INVALID_ARGUMENT,
+    HTTPStatus.SERVICE_UNAVAILABLE: grpc.StatusCode.UNAVAILABLE,
+    HTTPStatus.INTERNAL_SERVER_ERROR: grpc.StatusCode.INTERNAL,
+}
+
+
+def abort_code_from_output(output: dict) -> grpc.StatusCode:
+    """Map a scheduler error output to the appropriate gRPC status code."""
+    finish_reason = output.get("meta_info", {}).get("finish_reason")
+    if isinstance(finish_reason, dict):
+        status_code = finish_reason.get("status_code")
+        if status_code is not None:
+            return _HTTP_TO_GRPC_CODE.get(status_code, grpc.StatusCode.INTERNAL)
+    return grpc.StatusCode.INTERNAL


### PR DESCRIPTION
## Motivation

The gRPC server was returning errors as in-band `GenerateResponse.error` / `EmbedResponse.error` messages instead of using proper gRPC status codes via `context.abort()`. This caused two problems:

1. **Wrong status codes**: Scheduler abort errors (e.g., input too long → `FINISH_ABORT` with `HTTPStatus.BAD_REQUEST`) were always mapped to `CANCELLED` or `INTERNAL`, because the code checked `"abort" in output` which was never true (no top-level `"abort"` key exists in the output dict).

2. **In-band errors invisible to routers**: gRPC routers (like SMG) couldn't distinguish client errors from server errors for circuit breaker classification and retry logic, since the gRPC stream itself appeared successful.

## Modifications

**`python/sglang/srt/entrypoints/grpc_server.py`**:
- Replace in-band `GenerateResponse.error` yields with `context.abort()` for scheduler errors, `ValueError`, and generic exceptions
- Replace in-band `EmbedResponse.error` returns with `context.abort()`
- Add `except grpc.aio.AbortError: raise` to prevent double-wrapping aborts
- Add `except ValueError` → `INVALID_ARGUMENT` for request validation errors
- Streaming/non-streaming response handling fix for `n=1` non-streaming case

**`python/sglang/srt/grpc/utils.py`** (new file):
- `abort_code_from_output()`: Maps scheduler error output to proper gRPC status code by extracting `status_code` from `finish_reason` in the output dict
- `_HTTP_TO_GRPC_CODE`: Maps `HTTPStatus.BAD_REQUEST` → `INVALID_ARGUMENT`, `SERVICE_UNAVAILABLE` → `UNAVAILABLE`, `INTERNAL_SERVER_ERROR` → `INTERNAL`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).