### PR TITLE
Fix LoRA weight loading for Qwen3.5 models

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1524,7 +1524,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def init_lora_manager(self):
         self.lora_manager = LoRAManager(
             base_model=self.model,
-            base_hf_config=self.model_config.hf_config,
+            base_hf_config=self.model_config.hf_text_config,
             max_loras_per_batch=self.server_args.max_loras_per_batch,
             load_config=self.load_config,
             dtype=self.dtype,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -710,6 +710,42 @@ class Qwen3_5ForCausalLM(nn.Module):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.embed_tokens
 
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        """Return (input_dim, output_dim) for LoRA buffer allocation.
+
+        The default get_hidden_dim in lora/utils.py doesn't account for
+        Qwen3.5's attn_output_gate, which doubles the Q projection output
+        (Q + output gate are fused into qkv_proj). Without this override
+        the LoRA buffer for qkv_proj is undersized, causing a shape mismatch
+        at weight-load time.
+        """
+        config = self.config
+        head_dim = config.head_dim or (config.hidden_size // config.num_attention_heads)
+        attn_output_gate = getattr(config, "attn_output_gate", False)
+        q_heads_multiplier = 2 if attn_output_gate else 1
+        if module_name == "qkv_proj":
+            return (
+                config.hidden_size,
+                head_dim
+                * (
+                    config.num_attention_heads * q_heads_multiplier
+                    + config.num_key_value_heads * 2
+                ),
+            )
+        elif module_name == "o_proj":
+            return (
+                head_dim * config.num_attention_heads,
+                config.hidden_size,
+            )
+        elif module_name == "gate_up_proj":
+            return config.hidden_size, config.intermediate_size * 2
+        elif module_name == "down_proj":
+            return config.intermediate_size, config.hidden_size
+        else:
+            raise NotImplementedError(
+                f"get_hidden_dim not implemented for {module_name}"
+            )
+
     @torch.no_grad()
     def forward(
         self,
@@ -1045,6 +1081,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
         self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
 
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        # Delegate to the inner language model so the LoRA manager (which
+        # checks get_hidden_dim on this outer entry-point class) uses the
+        # correct dimensions that account for attn_output_gate.
+        return self.model.get_hidden_dim(module_name, layer_idx)
+
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
@@ -1136,6 +1178,12 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         self.is_mrope_enabled = "mrope_section" in rope_config
 
         self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+
+    def get_hidden_dim(self, module_name: str, layer_idx: int):
+        # Delegate to the inner language model so the LoRA manager (which
+        # checks get_hidden_dim on this outer entry-point class) uses the
+        # correct dimensions that account for attn_output_gate.
+        return self.model.get_hidden_dim(module_name, layer_idx)
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight


### PR DESCRIPTION
## Summary

- **Add `get_hidden_dim` override to Qwen3.5 model classes** — The default `get_hidden_dim` in `lora/utils.py` doesn't account for Qwen3.5's `attn_output_gate`, which doubles the Q projection output fused into `qkv_proj`. Without this override, the LoRA buffer for `qkv_proj` is undersized, causing a shape mismatch (e.g. `[3072, 16]` vs `[5120, 16]`) when loading LoRA weights at runtime.
- **Pass `hf_text_config` instead of `hf_config` to LoRA manager** — For multimodal wrapper models (e.g. `Qwen3_5ForConditionalGeneration`), `hf_config` is the top-level config which doesn't contain the text model dimensions. Using `hf_text_config` ensures the LoRA manager resolves the correct hidden sizes.
- The `get_hidden_dim` method is also added to `Qwen3_5ForConditionalGeneration` and `Qwen3_5MoeForConditionalGeneration`, delegating to the inner language model.

## Motivation

When attempting to load LoRA adapters on Qwen3.5 models, the runtime crashes with a tensor shape mismatch because the pre-allocated LoRA buffers are too small for `qkv_proj`. This is because Qwen3.5 fuses an attention output gate alongside Q into the `qkv_proj` weight, effectively multiplying the Q projection dimension by 2 when `attn_output_gate=True`.

## Changes

| File | Change |
|------|--------|
| `python/sglang/srt/model_executor/model_runner.py` | `hf_config` → `hf_text_config` in `init_lora_manager` |
| `python/sglang/srt/models/qwen3_5.py` | Add `get_hidden_dim()` to `Qwen3_5ForCausalLM`, `Qwen3_5ForConditionalGeneration`, `Qwen3_5MoeForConditionalGeneration` |

## Test plan

- [ ] Load a LoRA adapter on a Qwen3.5 text-only model — verify no shape mismatch
- [ ] Load a LoRA adapter on a Qwen3.5-VL multimodal model — verify correct dimension resolution
- [ ] Verify existing LoRA tests still pass for non-Qwen3.5 models (the `hf_text_config` change is a no-op when there is no multimodal wrapper)