### PR TITLE
Ipv6 pr

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1648,51 +1648,53 @@ def run_benchmark(args_: argparse.Namespace):
             "truss": 8080,
         }.get(args.backend, 30000)
 
+    # Wrap IPv6 addresses in brackets for URL construction
+    _host = f"[{args.host}]" if ":" in args.host else args.host
+    _host_base = f"http://{_host}:{args.port}"
+
     model_url = (
         f"{args.base_url}/v1/models"
         if args.base_url
-        else f"http://{args.host}:{args.port}/v1/models"
+        else f"{_host_base}/v1/models"
     )
 
     if args.backend in ["sglang", "sglang-native"]:
         api_url = (
             f"{args.base_url}/generate"
             if args.base_url
-            else f"http://{args.host}:{args.port}/generate"
+            else f"{_host_base}/generate"
         )
     elif args.backend in ["sglang-oai", "vllm", "lmdeploy"]:
         api_url = (
             f"{args.base_url}/v1/completions"
             if args.base_url
-            else f"http://{args.host}:{args.port}/v1/completions"
+            else f"{_host_base}/v1/completions"
         )
     elif args.backend in ["sglang-oai-chat", "vllm-chat", "lmdeploy-chat"]:
         api_url = (
             f"{args.base_url}/v1/chat/completions"
             if args.base_url
-            else f"http://{args.host}:{args.port}/v1/chat/completions"
+            else f"{_host_base}/v1/chat/completions"
         )
     elif args.backend == "trt":
         api_url = (
             f"{args.base_url}/v2/models/ensemble/generate_stream"
             if args.base_url
-            else f"http://{args.host}:{args.port}/v2/models/ensemble/generate_stream"
+            else f"{_host_base}/v2/models/ensemble/generate_stream"
         )
         if args.model is None:
             print("Please provide a model using `--model` when using `trt` backend.")
             sys.exit(1)
     elif args.backend == "gserver":
-        api_url = args.base_url if args.base_url else f"{args.host}:{args.port}"
+        api_url = args.base_url if args.base_url else f"{_host}:{args.port}"
         args.model = args.model or "default"
     elif args.backend == "truss":
         api_url = (
             f"{args.base_url}/v1/models/model:predict"
             if args.base_url
-            else f"http://{args.host}:{args.port}/v1/models/model:predict"
+            else f"{_host_base}/v1/models/model:predict"
         )
-    base_url = (
-        f"http://{args.host}:{args.port}" if args.base_url is None else args.base_url
-    )
+    base_url = _host_base if args.base_url is None else args.base_url
 
     # Wait for server to be ready
     if args.ready_check_timeout_sec > 0:

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1654,16 +1654,12 @@ def run_benchmark(args_: argparse.Namespace):
     _host_base = f"http://{_host}:{args.port}"
 
     model_url = (
-        f"{args.base_url}/v1/models"
-        if args.base_url
-        else f"{_host_base}/v1/models"
+        f"{args.base_url}/v1/models" if args.base_url else f"{_host_base}/v1/models"
     )
 
     if args.backend in ["sglang", "sglang-native"]:
         api_url = (
-            f"{args.base_url}/generate"
-            if args.base_url
-            else f"{_host_base}/generate"
+            f"{args.base_url}/generate" if args.base_url else f"{_host_base}/generate"
         )
     elif args.backend in ["sglang-oai", "vllm", "lmdeploy"]:
         api_url = (

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -44,6 +44,7 @@ from sglang.benchmark.utils import (
     remove_prefix,
     set_ulimit,
 )
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 _ROUTING_KEY_HEADER = "X-SMG-Routing-Key"
 
@@ -1649,7 +1650,7 @@ def run_benchmark(args_: argparse.Namespace):
         }.get(args.backend, 30000)
 
     # Wrap IPv6 addresses in brackets for URL construction
-    _host = f"[{args.host}]" if ":" in args.host else args.host
+    _host = maybe_wrap_ipv6_address(args.host)
     _host_base = f"http://{_host}:{args.port}"
 
     model_url = (

--- a/python/sglang/compile_deep_gemm.py
+++ b/python/sglang/compile_deep_gemm.py
@@ -25,6 +25,7 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 multiprocessing.set_start_method("spawn", force=True)
 
@@ -87,7 +88,7 @@ def launch_server_process_and_send_one_request(
 ):
     proc = multiprocessing.Process(target=launch_server_internal, args=(server_args,))
     proc.start()
-    base_url = f"http://{server_args.host}:{server_args.port}"
+    base_url = f"http://{maybe_wrap_ipv6_address(server_args.host)}:{server_args.port}"
     timeout = compile_args.timeout
 
     start_time = time.perf_counter()

--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -39,6 +39,7 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import (
     init_logger,
 )
 from sglang.multimodal_gen.test.test_utils import print_divider, print_value_formatted
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 logger = init_logger(__name__)
 
@@ -457,7 +458,7 @@ async def benchmark(args):
 
     # Construct base_url if not provided
     if args.base_url is None:
-        _host = f"[{args.host}]" if ":" in args.host else args.host
+        _host = maybe_wrap_ipv6_address(args.host)
         args.base_url = f"http://{_host}:{args.port}"
 
     # Wait for service

--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -457,7 +457,8 @@ async def benchmark(args):
 
     # Construct base_url if not provided
     if args.base_url is None:
-        args.base_url = f"http://{args.host}:{args.port}"
+        _host = f"[{args.host}]" if ":" in args.host else args.host
+        args.base_url = f"http://{_host}:{args.port}"
 
     # Wait for service
     wait_for_service(args.base_url)

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -44,7 +44,6 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBa
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import PortArgs, ServerArgs
 from sglang.multimodal_gen.runtime.utils.common import set_cuda_arch, set_musa_arch
-from sglang.srt.utils.common import format_tcp_address
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import (
     OffloadableDiTMixin,
     iter_materialized_weights,
@@ -58,6 +57,7 @@ from sglang.multimodal_gen.runtime.utils.perf_logger import (
     PerformanceLogger,
     capture_memory_snapshot,
 )
+from sglang.srt.utils.common import format_tcp_address
 
 logger = init_logger(__name__)
 

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -44,6 +44,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBa
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import PortArgs, ServerArgs
 from sglang.multimodal_gen.runtime.utils.common import set_cuda_arch, set_musa_arch
+from sglang.srt.utils.common import format_tcp_address
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import (
     OffloadableDiTMixin,
     iter_materialized_weights,
@@ -106,7 +107,7 @@ class GPUWorker:
             ring_degree=self.server_args.ring_degree,
             sp_size=self.server_args.sp_degree,
             dp_size=self.server_args.dp_size,
-            distributed_init_method=f"tcp://127.0.0.1:{self.master_port}",
+            distributed_init_method=format_tcp_address("::1", self.master_port),
             dist_timeout=self.server_args.dist_timeout,
         )
 

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -71,6 +71,8 @@ class SchedulerClient:
         self.scheduler_socket.setsockopt(zmq.RCVTIMEO, 6000000)
 
         scheduler_endpoint = self.server_args.scheduler_endpoint
+        if "[" in scheduler_endpoint:
+            self.scheduler_socket.setsockopt(zmq.IPV6, 1)
         self.scheduler_socket.connect(scheduler_endpoint)
         logger.debug(
             f"SchedulerClient connected to backend scheduler at {scheduler_endpoint}"
@@ -99,6 +101,8 @@ class SchedulerClient:
         ping_socket.setsockopt(zmq.RCVTIMEO, 2000)  # 2-second timeout for pings
 
         endpoint = self.server_args.scheduler_endpoint
+        if "[" in endpoint:
+            ping_socket.setsockopt(zmq.IPV6, 1)
 
         try:
             ping_socket.connect(endpoint)
@@ -158,6 +162,8 @@ class AsyncSchedulerClient:
         socket.setsockopt(zmq.RCVTIMEO, 6000000)
 
         endpoint = self.server_args.scheduler_endpoint
+        if "[" in endpoint:
+            socket.setsockopt(zmq.IPV6, 1)
         socket.connect(endpoint)
 
         try:
@@ -183,6 +189,8 @@ class AsyncSchedulerClient:
         ping_socket.setsockopt(zmq.RCVTIMEO, 2000)
 
         endpoint = self.server_args.scheduler_endpoint
+        if "[" in endpoint:
+            ping_socket.setsockopt(zmq.IPV6, 1)
 
         try:
             ping_socket.connect(endpoint)

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -289,7 +289,7 @@ class ServerArgs:
     master_port: int | None = None
 
     # http server endpoint config
-    host: str | None = "127.0.0.1"
+    host: str | None = "::1"
     port: int | None = 30000
 
     # TODO: webui and their endpoint, check if webui_port is available.
@@ -943,12 +943,14 @@ class ServerArgs:
     def scheduler_endpoint(self):
         """
         Internal endpoint for scheduler.
-        Prefers the configured host but normalizes localhost -> 127.0.0.1 to avoid ZMQ issues.
+        Prefers the configured host but normalizes localhost -> ::1 to avoid ZMQ issues.
         """
+        from sglang.srt.utils.common import format_tcp_address
+
         scheduler_host = self.host
         if scheduler_host is None or scheduler_host == "localhost":
-            scheduler_host = "127.0.0.1"
-        return f"tcp://{scheduler_host}:{self.scheduler_port}"
+            scheduler_host = "::1"
+        return format_tcp_address(scheduler_host, self.scheduler_port)
 
     def settle_port(
         self, port: int, port_inc: int = 42, max_attempts: int = 100

--- a/python/sglang/srt/connector/remote_instance.py
+++ b/python/sglang/srt/connector/remote_instance.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 
 from sglang.srt.connector import BaseConnector
 from sglang.srt.utils import init_custom_process_group
+from sglang.srt.utils.common import format_tcp_address
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ class RemoteInstanceConnector(BaseConnector):
         try:
             self._model_update_group = init_custom_process_group(
                 backend=backend,
-                init_method=f"tcp://{master_address}:{master_port}",
+                init_method=format_tcp_address(master_address, master_port),
                 world_size=world_size,
                 rank=group_rank,
                 group_name=group_name,

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -1152,8 +1152,8 @@ def _get_local_ip_by_remote() -> Optional[str]:
 
     try:
         hostname = socket.gethostname()
-        ip = socket.gethostbyname(hostname)
-        if ip and ip != "127.0.0.1" and ip != "0.0.0.0":
+        ip = socket.getaddrinfo(hostname, None)[0][4][0]
+        if ip and ip not in ("127.0.0.1", "0.0.0.0", "::1"):
             return ip
     except Exception:
         pass

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -1042,11 +1042,13 @@ def _create_zmq_rpc_broadcast(
 
     ctx = zmq.Context()
     sock = ctx.socket(zmq.REP)
+    local_ip = _get_local_ip_by_remote()
+    _is_ipv6 = local_ip and ":" in local_ip
+    if _is_ipv6:
+        sock.setsockopt(zmq.IPV6, 1)
+        local_ip = f"[{local_ip}]"
     sock.bind("tcp://*:0")
     bound_port = int(sock.getsockopt_string(zmq.LAST_ENDPOINT).rsplit(":", 1)[1])
-    local_ip = _get_local_ip_by_remote()
-    if local_ip and ":" in local_ip:
-        local_ip = f"[{local_ip}]"
     local_addr = f"tcp://{local_ip}:{bound_port}"
 
     def serve_loop():
@@ -1079,6 +1081,8 @@ def _create_zmq_rpc_broadcast(
         handles = []
         for i, addr in enumerate(all_addresses):
             req_socket = ctx.socket(zmq.REQ)
+            if "[" in addr:
+                req_socket.setsockopt(zmq.IPV6, 1)
             req_socket.connect(addr)
             handles.append(_ZmqRpcHandle(req_socket, debug_name=f"rank-{i}"))
         return _ZmqRpcBroadcast(handles)

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -1044,7 +1044,10 @@ def _create_zmq_rpc_broadcast(
     sock = ctx.socket(zmq.REP)
     sock.bind("tcp://*:0")
     bound_port = int(sock.getsockopt_string(zmq.LAST_ENDPOINT).rsplit(":", 1)[1])
-    local_addr = f"tcp://{_get_local_ip_by_remote()}:{bound_port}"
+    local_ip = _get_local_ip_by_remote()
+    if local_ip and ":" in local_ip:
+        local_ip = f"[{local_ip}]"
+    local_addr = f"tcp://{local_ip}:{bound_port}"
 
     def serve_loop():
         while True:

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -48,7 +48,9 @@ class AscendTransferEngine(MooncakeTransferEngine):
         else:
             logger.error(f"Unsupported DisaggregationMode: {disaggregation_mode}")
             raise ValueError(f"Unsupported DisaggregationMode: {disaggregation_mode}")
-        self.session_id = f"{maybe_wrap_ipv6_address(self.hostname)}:{self.engine.get_rpc_port()}"
+        self.session_id = (
+            f"{maybe_wrap_ipv6_address(self.hostname)}:{self.engine.get_rpc_port()}"
+        )
         self.initialize()
 
     def initialize(self) -> None:

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -8,6 +8,7 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
     MooncakeTransferEngine,
 )
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 try:
     from memfabric_hybrid import TransferEngine
@@ -47,7 +48,7 @@ class AscendTransferEngine(MooncakeTransferEngine):
         else:
             logger.error(f"Unsupported DisaggregationMode: {disaggregation_mode}")
             raise ValueError(f"Unsupported DisaggregationMode: {disaggregation_mode}")
-        self.session_id = f"{self.hostname}:{self.engine.get_rpc_port()}"
+        self.session_id = f"{maybe_wrap_ipv6_address(self.hostname)}:{self.engine.get_rpc_port()}"
         self.initialize()
 
     def initialize(self) -> None:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -42,6 +42,8 @@ from sglang.srt.utils import (
     get_zmq_socket_on_host,
     is_valid_ipv6_address,
     maybe_wrap_ipv6_address,
+    parse_host_port,
+    resolve_hostname,
 )
 
 logger = logging.getLogger(__name__)
@@ -255,13 +257,11 @@ class CommonKVManager(BaseKVManager):
         """Register prefill server info to bootstrap server via HTTP POST."""
         if self.dist_init_addr:
             # Multi-node case: bootstrap server's host is dist_init_addr
-            if self.dist_init_addr.startswith("["):  # [ipv6]:port or [ipv6]
-                if self.dist_init_addr.endswith("]"):
-                    host = self.dist_init_addr
-                else:
-                    host, _ = self.dist_init_addr.rsplit(":", 1)
-            else:
-                host = socket.gethostbyname(self.dist_init_addr.rsplit(":", 1)[0])
+            host, _ = parse_host_port(self.dist_init_addr)
+            # For non-IPv6, resolve hostname to IP
+            if not host.startswith("["):
+                host = resolve_hostname(host)
+                host = maybe_wrap_ipv6_address(host)
         else:
             # Single-node case: bootstrap server's host is the same as http server's host
             host = self.bootstrap_host

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import socket
 import threading
 import time
 from collections import defaultdict

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -65,6 +65,7 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = logging.getLogger(__name__)
@@ -365,7 +366,7 @@ class DecodePreallocQueue:
         if _is_fake_transfer(req, self.scheduler.server_args):
             return 0
 
-        bootstrap_addr = f"{req.bootstrap_host}:{req.bootstrap_port}"
+        bootstrap_addr = f"{maybe_wrap_ipv6_address(req.bootstrap_host)}:{req.bootstrap_port}"
 
         prefill_info = self.kv_manager.prefill_info_table.get(bootstrap_addr)
         if prefill_info is None:
@@ -389,7 +390,7 @@ class DecodePreallocQueue:
 
         kv_receiver = kv_receiver_class(
             mgr=self.kv_manager,
-            bootstrap_addr=f"{req.bootstrap_host}:{req.bootstrap_port}",
+            bootstrap_addr=f"{maybe_wrap_ipv6_address(req.bootstrap_host)}:{req.bootstrap_port}",
             bootstrap_room=req.bootstrap_room,
             prefill_dp_rank=prefill_dp_rank,
         )
@@ -498,7 +499,7 @@ class DecodePreallocQueue:
         if not self.pending_reqs:
             return
 
-        bootstrap_addr = f"{self.pending_reqs[0].bootstrap_host}:{self.pending_reqs[0].bootstrap_port}"
+        bootstrap_addr = f"{maybe_wrap_ipv6_address(self.pending_reqs[0].bootstrap_host)}:{self.pending_reqs[0].bootstrap_port}"
 
         # If a request is following the bootstrap room,
         # we need get the prefill info before resolving the prefill_dp_ranks

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -366,7 +366,9 @@ class DecodePreallocQueue:
         if _is_fake_transfer(req, self.scheduler.server_args):
             return 0
 
-        bootstrap_addr = f"{maybe_wrap_ipv6_address(req.bootstrap_host)}:{req.bootstrap_port}"
+        bootstrap_addr = (
+            f"{maybe_wrap_ipv6_address(req.bootstrap_host)}:{req.bootstrap_port}"
+        )
 
         prefill_info = self.kv_manager.prefill_info_table.get(bootstrap_addr)
         if prefill_info is None:

--- a/python/sglang/srt/disaggregation/encode_grpc_server.py
+++ b/python/sglang/srt/disaggregation/encode_grpc_server.py
@@ -30,6 +30,7 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import (
     format_tcp_address,
     get_zmq_socket,
+    maybe_wrap_ipv6_address,
     parse_host_port,
     random_uuid,
 )
@@ -259,7 +260,7 @@ async def serve_grpc_encoder(server_args: ServerArgs):
     )
     reflection.enable_server_reflection(SERVICE_NAMES, server)
 
-    listen_addr = f"{server_args.host}:{server_args.port}"
+    listen_addr = f"{maybe_wrap_ipv6_address(server_args.host)}:{server_args.port}"
     server.add_insecure_port(listen_addr)
 
     await server.start()

--- a/python/sglang/srt/disaggregation/encode_grpc_server.py
+++ b/python/sglang/srt/disaggregation/encode_grpc_server.py
@@ -27,7 +27,12 @@ from sglang.srt.disaggregation.encode_server import (
     launch_encoder,
 )
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import get_zmq_socket, random_uuid
+from sglang.srt.utils import (
+    format_tcp_address,
+    get_zmq_socket,
+    parse_host_port,
+    random_uuid,
+)
 
 logger = logging.getLogger(__name__)
 SGLangEncoderServicer = sglang_encoder_pb2_grpc.SglangEncoderServicer
@@ -208,9 +213,12 @@ async def serve_grpc_encoder(server_args: ServerArgs):
     port_args = PortArgs.init_new(server_args)
 
     if server_args.dist_init_addr:
-        dist_init_method = f"tcp://{server_args.dist_init_addr}"
+        host, port = parse_host_port(server_args.dist_init_addr)
+        dist_init_method = format_tcp_address(host, port)
     else:
-        dist_init_method = f"tcp://127.0.0.1:{port_args.nccl_port}"
+        dist_init_method = format_tcp_address(
+            server_args.host or "::1", port_args.nccl_port
+        )
 
     send_sockets: List[zmq.Socket] = []
     for rank in range(1, server_args.tp_size):

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -26,6 +26,7 @@ from sglang.srt.managers.multimodal_processor import get_mm_processor, import_pr
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import ImageData, get_local_ip_auto, get_zmq_socket_on_host
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 from sglang.srt.utils.hf_transformers_utils import get_processor
 
 logger = logging.getLogger(__name__)
@@ -254,7 +255,7 @@ class WaitingImageRequest:
                     payload = {
                         "req_id": req_id,
                         "receive_count": receive_count,
-                        "receive_url": f"{host_name}:{embedding_port}",
+                        "receive_url": f"{maybe_wrap_ipv6_address(host_name)}:{embedding_port}",
                     }
 
                     logger.info(f"Preparing to send  to {target_url}")

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -47,7 +47,6 @@ from sglang.srt.utils import (
     format_tcp_address,
     get_local_ip_auto,
     get_zmq_socket,
-    is_valid_ipv6_address,
     load_audio,
     load_image,
     load_video,

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -44,11 +44,13 @@ from sglang.srt.server_args import (
 )
 from sglang.srt.utils import (
     config_socket,
+    format_tcp_address,
     get_local_ip_auto,
     get_zmq_socket,
     load_audio,
     load_image,
     load_video,
+    parse_host_port,
     random_uuid,
 )
 
@@ -926,9 +928,12 @@ def launch_server(server_args: ServerArgs):
     ipc_path_prefix = random_uuid()
     port_args = PortArgs.init_new(server_args)
     if server_args.dist_init_addr:
-        dist_init_method = f"tcp://{server_args.dist_init_addr}"
+        host, port = parse_host_port(server_args.dist_init_addr)
+        dist_init_method = format_tcp_address(host, port)
     else:
-        dist_init_method = f"tcp://127.0.0.1:{port_args.nccl_port}"
+        dist_init_method = format_tcp_address(
+            server_args.host or "::1", port_args.nccl_port
+        )
     for rank in range(1, server_args.tp_size):
         schedule_path = f"ipc:///tmp/{ipc_path_prefix}_schedule_{rank}"
         send_sockets.append(

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -47,6 +47,7 @@ from sglang.srt.utils import (
     format_tcp_address,
     get_local_ip_auto,
     get_zmq_socket,
+    is_valid_ipv6_address,
     load_audio,
     load_image,
     load_video,
@@ -658,6 +659,8 @@ class MMEncoder:
         def send_with_socket():
             sock = self.sync_context.socket(zmq.PUSH)
             config_socket(sock, zmq.PUSH)
+            if "[" in endpoint:
+                sock.setsockopt(zmq.IPV6, 1)
             try:
                 sock.connect(endpoint)
                 if buffer is not None:

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -636,7 +636,7 @@ class MMEncoder:
         endpoint = (
             f"tcp://{url}"
             if url is not None
-            else f"tcp://{prefill_host}:{embedding_port}"
+            else format_tcp_address(prefill_host, embedding_port)
         )
         logger.info(f"{endpoint = }")
 

--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -254,11 +254,13 @@ class ZmqEventPublisher(EventPublisher):
         if self._pub is None:
             self._pub = self._ctx.socket(zmq.PUB)
             self._pub.set_hwm(self._hwm)
+            if "[" in self._endpoint:
+                self._pub.setsockopt(zmq.IPV6, 1)
             # Heuristic: bind if wildcard / * present, else connect.
             # bind stable, connect volatile convention
             if (
                 "*" in self._endpoint
-                or "::" in self._endpoint
+                or self._endpoint.startswith("tcp://[::]:") or self._endpoint == "tcp://[::]"
                 or self._endpoint.startswith("ipc://")
                 or self._endpoint.startswith("inproc://")
             ):
@@ -275,6 +277,8 @@ class ZmqEventPublisher(EventPublisher):
         # 3) works in our non‑blocking poll loop alongside PUB
         if self._replay_endpoint is not None:
             self._replay = self._ctx.socket(zmq.ROUTER)
+            if "[" in self._replay_endpoint:
+                self._replay.setsockopt(zmq.IPV6, 1)
             logger.debug(
                 f"ZmqEventPublisher socket replay_endpoint bind to {self._replay_endpoint}"
             )

--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -260,7 +260,8 @@ class ZmqEventPublisher(EventPublisher):
             # bind stable, connect volatile convention
             if (
                 "*" in self._endpoint
-                or self._endpoint.startswith("tcp://[::]:") or self._endpoint == "tcp://[::]"
+                or self._endpoint.startswith("tcp://[::]:")
+                or self._endpoint == "tcp://[::]"
                 or self._endpoint.startswith("ipc://")
                 or self._endpoint.startswith("inproc://")
             ):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -982,9 +982,18 @@ class MooncakeKVManager(CommonKVManager):
                         if arrived_response_num == expected_response_num:
                             self.update_status(bootstrap_room, KVPoll.Success)
                 elif status == KVPoll.Failed:
+                    prefill_addr = next(
+                        (
+                            addr
+                            for addr, rooms in self.addr_to_rooms_tracker.items()
+                            if bootstrap_room in rooms
+                        ),
+                        "unknown",
+                    )
                     self.record_failure(
                         bootstrap_room,
-                        "Failed to get kvcache from prefill instance, it might be dead",
+                        f"Failed to get kvcache from prefill instance at {prefill_addr} "
+                        f"(room={bootstrap_room}), it might be dead",
                     )
                     self.update_status(bootstrap_room, status)
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -35,7 +35,11 @@ from sglang.srt.disaggregation.utils import (
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import format_tcp_address, is_valid_ipv6_address
+from sglang.srt.utils import (
+    format_tcp_address,
+    is_valid_ipv6_address,
+    maybe_wrap_ipv6_address,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -853,11 +857,25 @@ class MooncakeKVManager(CommonKVManager):
                                 if self.session_failures[req.mooncake_session_id] >= 1:
                                     self.failed_sessions.add(req.mooncake_session_id)
                                     logger.error(
-                                        f"Session {req.mooncake_session_id} failed."
+                                        "Session %s failed: ret=%d, "
+                                        "endpoint=%s, dst_port=%s, "
+                                        "room=%s, chunk_idx=%d, "
+                                        "is_last=%s, num_failures=%d",
+                                        req.mooncake_session_id,
+                                        ret,
+                                        maybe_wrap_ipv6_address(req.endpoint),
+                                        req.dst_port,
+                                        kv_chunk.room,
+                                        kv_chunk_idx,
+                                        kv_chunk.is_last_chunk,
+                                        self.session_failures[
+                                            req.mooncake_session_id
+                                        ],
                                     )
                             self.record_failure(
                                 kv_chunk.room,
-                                f"Failed to send kv chunk of {kv_chunk.room} to {req.endpoint}:{req.dst_port}",
+                                f"Failed to send kv chunk of {kv_chunk.room} to "
+                                f"{maybe_wrap_ipv6_address(req.endpoint)}:{req.dst_port}",
                             )
                             self.update_status(kv_chunk.room, KVPoll.Failed)
                             self.sync_status_to_decode_endpoint(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -907,17 +907,27 @@ class MooncakeKVManager(CommonKVManager):
                                 if self.session_failures[req.mooncake_session_id] >= 1:
                                     self.failed_sessions.add(req.mooncake_session_id)
                                     logger.error(
-                                        "Session %s failed: ret=%d, "
-                                        "endpoint=%s, dst_port=%s, "
-                                        "room=%s, index_slice=%s, "
-                                        "is_last=%s, num_failures=%d",
+                                        "Session %s failed (ret=%d): "
+                                        "local_session=%s, "
+                                        "dst=%s:%s, "
+                                        "room=%s, "
+                                        "prefill_indices=%d, dst_indices=%d, "
+                                        "index_slice=%s, is_last=%s, "
+                                        "backend=%s, "
+                                        "num_failures=%d",
                                         req.mooncake_session_id,
                                         ret,
+                                        self.engine.get_session_id(),
                                         maybe_wrap_ipv6_address(req.endpoint),
                                         req.dst_port,
                                         kv_chunk.room,
+                                        len(kv_chunk.prefill_kv_indices),
+                                        len(chunked_dst_kv_indice),
                                         kv_chunk.index_slice,
                                         kv_chunk.is_last_chunk,
+                                        "mla"
+                                        if self.is_mla_backend
+                                        else "mha",
                                         self.session_failures[
                                             req.mooncake_session_id
                                         ],
@@ -925,7 +935,10 @@ class MooncakeKVManager(CommonKVManager):
                             self.record_failure(
                                 kv_chunk.room,
                                 f"Failed to send kv chunk of {kv_chunk.room} to "
-                                f"{maybe_wrap_ipv6_address(req.endpoint)}:{req.dst_port}",
+                                f"{maybe_wrap_ipv6_address(req.endpoint)}:{req.dst_port} "
+                                f"(ret={ret}, session={req.mooncake_session_id}, "
+                                f"prefill_indices={len(kv_chunk.prefill_kv_indices)}, "
+                                f"dst_indices={len(chunked_dst_kv_indice)})",
                             )
                             self.update_status(kv_chunk.room, KVPoll.Failed)
                             self.sync_status_to_decode_endpoint(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -616,9 +616,7 @@ class MooncakeKVManager(CommonKVManager):
             aux_index,
             len(data),
         )
-        socket = self._connect(
-            endpoint, is_ipv6=is_valid_ipv6_address(remote)
-        )
+        socket = self._connect(endpoint, is_ipv6=is_valid_ipv6_address(remote))
 
         try:
             socket.send_multipart(
@@ -987,12 +985,8 @@ class MooncakeKVManager(CommonKVManager):
                                         len(chunked_dst_kv_indice),
                                         kv_chunk.index_slice,
                                         kv_chunk.is_last_chunk,
-                                        "mla"
-                                        if self.is_mla_backend
-                                        else "mha",
-                                        self.session_failures[
-                                            req.mooncake_session_id
-                                        ],
+                                        "mla" if self.is_mla_backend else "mha",
+                                        self.session_failures[req.mooncake_session_id],
                                     )
                             self.record_failure(
                                 kv_chunk.room,
@@ -1466,8 +1460,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         ]
                     )
                     logger.warning(
-                        "Sent decode registration: bootstrap=%s, "
-                        "session_id=%s",
+                        "Sent decode registration: bootstrap=%s, " "session_id=%s",
                         bootstrap_addr,
                         self.session_id,
                     )

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -224,7 +224,7 @@ class MooncakeKVManager(CommonKVManager):
     def register_buffer_to_engine(self):
         # Batch register KV data buffers
         if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
-            logger.info(
+            logger.warning(
                 "Registering KV data buffers: num=%d, ptrs=[%s], lens=[%s]",
                 len(self.kv_args.kv_data_ptrs),
                 ", ".join(f"0x{p:x}" for p in self.kv_args.kv_data_ptrs[:4]),
@@ -236,7 +236,7 @@ class MooncakeKVManager(CommonKVManager):
 
         # Batch register auxiliary data buffers
         if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
-            logger.info(
+            logger.warning(
                 "Registering aux data buffers: num=%d, ptrs=[%s], lens=[%s]",
                 len(self.kv_args.aux_data_ptrs),
                 ", ".join(f"0x{p:x}" for p in self.kv_args.aux_data_ptrs[:4]),
@@ -248,7 +248,7 @@ class MooncakeKVManager(CommonKVManager):
 
         # Batch register state/extra pool data buffers
         if self.kv_args.state_data_ptrs and self.kv_args.state_data_lens:
-            logger.info(
+            logger.warning(
                 "Registering state data buffers: num=%d, ptrs=[%s], lens=[%s]",
                 len(self.kv_args.state_data_ptrs),
                 ", ".join(f"0x{p:x}" for p in self.kv_args.state_data_ptrs[:4]),
@@ -348,7 +348,7 @@ class MooncakeKVManager(CommonKVManager):
                 for layer_id in range(layers_current_pp_stage)
             ]
         assert layers_params is not None
-        logger.debug(
+        logger.warning(
             "send_kvcache: session=%s, num_layers=%d, "
             "num_prefill_blocks=%d, num_dst_blocks=%d, "
             "base_ptrs=[%s]",
@@ -607,7 +607,7 @@ class MooncakeKVManager(CommonKVManager):
         data: bytes,
     ):
         endpoint = format_tcp_address(remote, dst_port)
-        logger.debug(
+        logger.warning(
             "Sending aux data: endpoint=%s, room=%s, "
             "buffer_index=%d, aux_index=%d, data_len=%d",
             endpoint,
@@ -631,7 +631,7 @@ class MooncakeKVManager(CommonKVManager):
                     data,
                 ]
             )
-            logger.debug("Sent aux data: endpoint=%s, room=%s", endpoint, room)
+            logger.warning("Sent aux data: endpoint=%s, room=%s", endpoint, room)
         except Exception as e:
             logger.error(
                 "Failed to send aux data: endpoint=%s, room=%s, "
@@ -837,7 +837,7 @@ class MooncakeKVManager(CommonKVManager):
         self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
     ):
         endpoint = format_tcp_address(remote, dst_port)
-        logger.debug(
+        logger.warning(
             "Syncing status to decode: endpoint=%s, room=%s, "
             "status=%d, prefill_rank=%d",
             endpoint,
@@ -855,7 +855,7 @@ class MooncakeKVManager(CommonKVManager):
                     str(prefill_rank).encode("ascii"),
                 ]
             )
-            logger.debug(
+            logger.warning(
                 "Synced status to decode: endpoint=%s, room=%s", endpoint, room
             )
         except Exception as e:
@@ -1416,7 +1416,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
             bootstrap_addr = bootstrap_info.get("bootstrap_addr", "unknown")
             with lock:
-                logger.debug(
+                logger.warning(
                     "Sending decode registration: bootstrap=%s, "
                     "local_ip=%s, rank_port=%d, session_id=%s, "
                     "tp_rank=%d, attn_tp_size=%d, kv_item_len=%d",
@@ -1445,7 +1445,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                             packed_state_dim_per_tensor,
                         ]
                     )
-                    logger.debug(
+                    logger.warning(
                         "Sent decode registration: bootstrap=%s, "
                         "session_id=%s",
                         bootstrap_addr,
@@ -1481,7 +1481,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
             bootstrap_addr = bootstrap_info.get("bootstrap_addr", "unknown")
 
             with lock:
-                logger.debug(
+                logger.warning(
                     "Sending decode init: bootstrap=%s, "
                     "room=%s, session_id=%s, "
                     "is_dummy=%s, num_kv_indices=%d",
@@ -1511,7 +1511,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                             str(self.required_dst_info_num).encode("ascii"),
                         ]
                     )
-                    logger.debug(
+                    logger.warning(
                         "Sent decode init: bootstrap=%s, room=%s",
                         bootstrap_addr,
                         self.bootstrap_room,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -894,9 +894,24 @@ class MooncakeKVManager(CommonKVManager):
                         # Early exit if the request has failed
                         with self.session_lock:
                             if req.mooncake_session_id in self.failed_sessions:
+                                num_failures = self.session_failures.get(
+                                    req.mooncake_session_id, 0
+                                )
+                                logger.error(
+                                    "Skipping transfer to failed session %s "
+                                    "(num_failures=%d, room=%s, "
+                                    "endpoint=%s:%s)",
+                                    req.mooncake_session_id,
+                                    num_failures,
+                                    kv_chunk.room,
+                                    maybe_wrap_ipv6_address(req.endpoint),
+                                    req.dst_port,
+                                )
                                 self.record_failure(
                                     kv_chunk.room,
-                                    f"Decode instance could be dead, remote mooncake session {req.mooncake_session_id} is not alive",
+                                    f"Decode instance could be dead, remote mooncake session "
+                                    f"{req.mooncake_session_id} is not alive "
+                                    f"(num_failures={num_failures})",
                                 )
                                 self.update_status(kv_chunk.room, KVPoll.Failed)
                                 self.sync_status_to_decode_endpoint(
@@ -954,7 +969,7 @@ class MooncakeKVManager(CommonKVManager):
                                 if self.session_failures[req.mooncake_session_id] >= 1:
                                     self.failed_sessions.add(req.mooncake_session_id)
                                     logger.error(
-                                        "Session %s failed (ret=%d): "
+                                        "Marking session %s as failed (ret=%d): "
                                         "local_session=%s, "
                                         "dst=%s:%s, "
                                         "room=%s, "
@@ -1064,10 +1079,15 @@ class MooncakeKVManager(CommonKVManager):
                     with self.session_lock:
                         if mooncake_session_id in self.failed_sessions:
                             self.failed_sessions.remove(mooncake_session_id)
+                            logger.warning(
+                                "Cleared failed session state for %s",
+                                mooncake_session_id,
+                            )
                         if mooncake_session_id in self.session_failures:
                             del self.session_failures[mooncake_session_id]
-                    logger.debug(
-                        f"Register KVArgs from {mooncake_session_id} successfully"
+                    logger.warning(
+                        "Register KVArgs from %s successfully",
+                        mooncake_session_id,
                     )
                     continue
                 else:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -606,8 +606,18 @@ class MooncakeKVManager(CommonKVManager):
         aux_index: int,
         data: bytes,
     ):
+        endpoint = format_tcp_address(remote, dst_port)
+        logger.debug(
+            "Sending aux data: endpoint=%s, room=%s, "
+            "buffer_index=%d, aux_index=%d, data_len=%d",
+            endpoint,
+            room,
+            buffer_index,
+            aux_index,
+            len(data),
+        )
         socket = self._connect(
-            format_tcp_address(remote, dst_port), is_ipv6=is_valid_ipv6_address(remote)
+            endpoint, is_ipv6=is_valid_ipv6_address(remote)
         )
 
         socket.send_multipart(
@@ -813,8 +823,17 @@ class MooncakeKVManager(CommonKVManager):
     def sync_status_to_decode_endpoint(
         self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
     ):
+        endpoint = format_tcp_address(remote, dst_port)
+        logger.debug(
+            "Syncing status to decode: endpoint=%s, room=%s, "
+            "status=%d, prefill_rank=%d",
+            endpoint,
+            room,
+            status,
+            prefill_rank,
+        )
         self._connect(
-            format_tcp_address(remote, dst_port), is_ipv6=is_valid_ipv6_address(remote)
+            endpoint, is_ipv6=is_valid_ipv6_address(remote)
         ).send_multipart(
             [
                 str(room).encode("ascii"),
@@ -1368,6 +1387,18 @@ class MooncakeKVReceiver(CommonKVReceiver):
 
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
             with lock:
+                logger.debug(
+                    "Sending decode registration: bootstrap=%s, "
+                    "local_ip=%s, rank_port=%d, session_id=%s, "
+                    "tp_rank=%d, attn_tp_size=%d, kv_item_len=%d",
+                    bootstrap_info.get("bootstrap_addr", "unknown"),
+                    self.kv_mgr.local_ip,
+                    self.kv_mgr.rank_port,
+                    self.session_id,
+                    tp_rank,
+                    self.kv_mgr.attn_tp_size,
+                    kv_item_len,
+                )
                 sock.send_multipart(
                     [
                         "None".encode("ascii"),
@@ -1404,6 +1435,16 @@ class MooncakeKVReceiver(CommonKVReceiver):
             is_dummy = bootstrap_info["is_dummy"]
 
             with lock:
+                logger.debug(
+                    "Sending decode init: bootstrap=%s, "
+                    "room=%s, session_id=%s, "
+                    "is_dummy=%s, num_kv_indices=%d",
+                    bootstrap_info.get("bootstrap_addr", "unknown"),
+                    self.bootstrap_room,
+                    self.session_id,
+                    is_dummy,
+                    len(kv_indices),
+                )
                 sock.send_multipart(
                     [
                         str(self.bootstrap_room).encode("ascii"),

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -224,18 +224,36 @@ class MooncakeKVManager(CommonKVManager):
     def register_buffer_to_engine(self):
         # Batch register KV data buffers
         if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
+            logger.info(
+                "Registering KV data buffers: num=%d, ptrs=[%s], lens=[%s]",
+                len(self.kv_args.kv_data_ptrs),
+                ", ".join(f"0x{p:x}" for p in self.kv_args.kv_data_ptrs[:4]),
+                ", ".join(str(l) for l in self.kv_args.kv_data_lens[:4]),
+            )
             self.engine.batch_register(
                 self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens
             )
 
         # Batch register auxiliary data buffers
         if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
+            logger.info(
+                "Registering aux data buffers: num=%d, ptrs=[%s], lens=[%s]",
+                len(self.kv_args.aux_data_ptrs),
+                ", ".join(f"0x{p:x}" for p in self.kv_args.aux_data_ptrs[:4]),
+                ", ".join(str(l) for l in self.kv_args.aux_data_lens[:4]),
+            )
             self.engine.batch_register(
                 self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
             )
 
         # Batch register state/extra pool data buffers
         if self.kv_args.state_data_ptrs and self.kv_args.state_data_lens:
+            logger.info(
+                "Registering state data buffers: num=%d, ptrs=[%s], lens=[%s]",
+                len(self.kv_args.state_data_ptrs),
+                ", ".join(f"0x{p:x}" for p in self.kv_args.state_data_ptrs[:4]),
+                ", ".join(str(l) for l in self.kv_args.state_data_lens[:4]),
+            )
             self.engine.batch_register(
                 self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
             )
@@ -245,9 +263,28 @@ class MooncakeKVManager(CommonKVManager):
             return 0
 
         src_addrs, dst_addrs, lengths = zip(*transfer_blocks)
-        return self.engine.batch_transfer_sync(
+        ret = self.engine.batch_transfer_sync(
             mooncake_session_id, list(src_addrs), list(dst_addrs), list(lengths)
         )
+        if ret != 0:
+            # Log address ranges to help debug "address not found" errors
+            for i, (src, dst, length) in enumerate(transfer_blocks[:5]):
+                logger.error(
+                    "  transfer_block[%d]: src=0x%x..0x%x, dst=0x%x..0x%x, "
+                    "length=%d",
+                    i,
+                    src,
+                    src + length,
+                    dst,
+                    dst + length,
+                    length,
+                )
+            if len(transfer_blocks) > 5:
+                logger.error(
+                    "  ... and %d more transfer blocks",
+                    len(transfer_blocks) - 5,
+                )
+        return ret
 
     def _send_kvcache_generic(
         self,
@@ -311,6 +348,19 @@ class MooncakeKVManager(CommonKVManager):
                 for layer_id in range(layers_current_pp_stage)
             ]
         assert layers_params is not None
+        logger.debug(
+            "send_kvcache: session=%s, num_layers=%d, "
+            "num_prefill_blocks=%d, num_dst_blocks=%d, "
+            "base_ptrs=[%s]",
+            mooncake_session_id,
+            len(layers_params),
+            len(prefill_kv_blocks),
+            len(dst_kv_blocks),
+            ", ".join(
+                f"(src=0x{s:x}, dst=0x{d:x}, item_len={l})"
+                for s, d, l in layers_params[:3]
+            ),
+        )
 
         def set_transfer_blocks(
             src_ptr: int, dst_ptr: int, item_len: int
@@ -859,14 +909,14 @@ class MooncakeKVManager(CommonKVManager):
                                     logger.error(
                                         "Session %s failed: ret=%d, "
                                         "endpoint=%s, dst_port=%s, "
-                                        "room=%s, chunk_idx=%d, "
+                                        "room=%s, index_slice=%s, "
                                         "is_last=%s, num_failures=%d",
                                         req.mooncake_session_id,
                                         ret,
                                         maybe_wrap_ipv6_address(req.endpoint),
                                         req.dst_port,
                                         kv_chunk.room,
-                                        kv_chunk_idx,
+                                        kv_chunk.index_slice,
                                         kv_chunk.is_last_chunk,
                                         self.session_failures[
                                             req.mooncake_session_id

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -620,16 +620,29 @@ class MooncakeKVManager(CommonKVManager):
             endpoint, is_ipv6=is_valid_ipv6_address(remote)
         )
 
-        socket.send_multipart(
-            [
-                MooncakeKVManager.AUX_DATA_HEADER,
-                str(room).encode("ascii"),
-                str(buffer_index).encode("ascii"),
-                str(aux_index).encode("ascii"),
-                struct.pack(">I", len(data)),
-                data,
-            ]
-        )
+        try:
+            socket.send_multipart(
+                [
+                    MooncakeKVManager.AUX_DATA_HEADER,
+                    str(room).encode("ascii"),
+                    str(buffer_index).encode("ascii"),
+                    str(aux_index).encode("ascii"),
+                    struct.pack(">I", len(data)),
+                    data,
+                ]
+            )
+            logger.debug("Sent aux data: endpoint=%s, room=%s", endpoint, room)
+        except Exception as e:
+            logger.error(
+                "Failed to send aux data: endpoint=%s, room=%s, "
+                "buffer_index=%d, aux_index=%d, error=%s",
+                endpoint,
+                room,
+                buffer_index,
+                aux_index,
+                e,
+            )
+            raise
 
     def _handle_aux_data(self, msg: List[bytes]):
         """Handle AUX_DATA messages received by the decode thread."""
@@ -832,15 +845,30 @@ class MooncakeKVManager(CommonKVManager):
             status,
             prefill_rank,
         )
-        self._connect(
-            endpoint, is_ipv6=is_valid_ipv6_address(remote)
-        ).send_multipart(
-            [
-                str(room).encode("ascii"),
-                str(status).encode("ascii"),
-                str(prefill_rank).encode("ascii"),
-            ]
-        )
+        try:
+            self._connect(
+                endpoint, is_ipv6=is_valid_ipv6_address(remote)
+            ).send_multipart(
+                [
+                    str(room).encode("ascii"),
+                    str(status).encode("ascii"),
+                    str(prefill_rank).encode("ascii"),
+                ]
+            )
+            logger.debug(
+                "Synced status to decode: endpoint=%s, room=%s", endpoint, room
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to sync status to decode: endpoint=%s, room=%s, "
+                "status=%d, prefill_rank=%d, error=%s",
+                endpoint,
+                room,
+                status,
+                prefill_rank,
+                e,
+            )
+            raise
 
     def transfer_worker(
         self, queue: FastQueue, executor: concurrent.futures.ThreadPoolExecutor
@@ -1386,12 +1414,13 @@ class MooncakeKVReceiver(CommonKVReceiver):
             dst_kv_item_len = str(kv_item_len).encode("ascii")
 
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+            bootstrap_addr = bootstrap_info.get("bootstrap_addr", "unknown")
             with lock:
                 logger.debug(
                     "Sending decode registration: bootstrap=%s, "
                     "local_ip=%s, rank_port=%d, session_id=%s, "
                     "tp_rank=%d, attn_tp_size=%d, kv_item_len=%d",
-                    bootstrap_info.get("bootstrap_addr", "unknown"),
+                    bootstrap_addr,
                     self.kv_mgr.local_ip,
                     self.kv_mgr.rank_port,
                     self.session_id,
@@ -1399,22 +1428,38 @@ class MooncakeKVReceiver(CommonKVReceiver):
                     self.kv_mgr.attn_tp_size,
                     kv_item_len,
                 )
-                sock.send_multipart(
-                    [
-                        "None".encode("ascii"),
-                        self.kv_mgr.local_ip.encode("ascii"),
-                        str(self.kv_mgr.rank_port).encode("ascii"),
-                        self.session_id.encode("ascii"),
-                        packed_kv_data_ptrs,
-                        packed_aux_data_ptrs,
-                        packed_state_data_ptrs,
-                        dst_tp_rank,
-                        dst_attn_tp_size,
-                        dst_kv_item_len,
-                        packed_state_item_lens,
-                        packed_state_dim_per_tensor,
-                    ]
-                )
+                try:
+                    sock.send_multipart(
+                        [
+                            "None".encode("ascii"),
+                            self.kv_mgr.local_ip.encode("ascii"),
+                            str(self.kv_mgr.rank_port).encode("ascii"),
+                            self.session_id.encode("ascii"),
+                            packed_kv_data_ptrs,
+                            packed_aux_data_ptrs,
+                            packed_state_data_ptrs,
+                            dst_tp_rank,
+                            dst_attn_tp_size,
+                            dst_kv_item_len,
+                            packed_state_item_lens,
+                            packed_state_dim_per_tensor,
+                        ]
+                    )
+                    logger.debug(
+                        "Sent decode registration: bootstrap=%s, "
+                        "session_id=%s",
+                        bootstrap_addr,
+                        self.session_id,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to send decode registration: bootstrap=%s, "
+                        "session_id=%s, error=%s",
+                        bootstrap_addr,
+                        self.session_id,
+                        e,
+                    )
+                    raise
 
     def init(
         self,
@@ -1433,37 +1478,54 @@ class MooncakeKVReceiver(CommonKVReceiver):
         for bootstrap_info in self.bootstrap_infos:
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
             is_dummy = bootstrap_info["is_dummy"]
+            bootstrap_addr = bootstrap_info.get("bootstrap_addr", "unknown")
 
             with lock:
                 logger.debug(
                     "Sending decode init: bootstrap=%s, "
                     "room=%s, session_id=%s, "
                     "is_dummy=%s, num_kv_indices=%d",
-                    bootstrap_info.get("bootstrap_addr", "unknown"),
+                    bootstrap_addr,
                     self.bootstrap_room,
                     self.session_id,
                     is_dummy,
                     len(kv_indices),
                 )
-                sock.send_multipart(
-                    [
-                        str(self.bootstrap_room).encode("ascii"),
-                        self.kv_mgr.local_ip.encode("ascii"),
-                        str(self.kv_mgr.rank_port).encode("ascii"),
-                        self.session_id.encode("ascii"),
-                        kv_indices.tobytes() if not is_dummy else b"",
-                        str(aux_index).encode("ascii") if not is_dummy else b"",
-                        (
-                            np.array(
-                                state_indices,
-                                dtype=np.int32,
-                            ).tobytes()
-                            if not is_dummy and state_indices is not None
-                            else b""
-                        ),
-                        str(self.required_dst_info_num).encode("ascii"),
-                    ]
-                )
+                try:
+                    sock.send_multipart(
+                        [
+                            str(self.bootstrap_room).encode("ascii"),
+                            self.kv_mgr.local_ip.encode("ascii"),
+                            str(self.kv_mgr.rank_port).encode("ascii"),
+                            self.session_id.encode("ascii"),
+                            kv_indices.tobytes() if not is_dummy else b"",
+                            str(aux_index).encode("ascii") if not is_dummy else b"",
+                            (
+                                np.array(
+                                    state_indices,
+                                    dtype=np.int32,
+                                ).tobytes()
+                                if not is_dummy and state_indices is not None
+                                else b""
+                            ),
+                            str(self.required_dst_info_num).encode("ascii"),
+                        ]
+                    )
+                    logger.debug(
+                        "Sent decode init: bootstrap=%s, room=%s",
+                        bootstrap_addr,
+                        self.bootstrap_room,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to send decode init: bootstrap=%s, "
+                        "room=%s, session_id=%s, error=%s",
+                        bootstrap_addr,
+                        self.bootstrap_room,
+                        self.session_id,
+                        e,
+                    )
+                    raise
         self.init_time = time.time()
 
     def poll(self) -> KVPoll:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -52,6 +52,7 @@ from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, NSATokenToKVPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -218,7 +219,7 @@ class PrefillBootstrapQueue:
 
         req.disagg_kv_sender = kv_sender_class(
             mgr=self.kv_manager,
-            bootstrap_addr=f"{req.bootstrap_host}:{self.bootstrap_port}",
+            bootstrap_addr=f"{maybe_wrap_ipv6_address(req.bootstrap_host)}:{self.bootstrap_port}",
             bootstrap_room=req.bootstrap_room,
             dest_tp_ranks=dest_tp_ranks,
             pp_rank=self.pp_rank,

--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -113,7 +113,7 @@ class MooncakeTransferEngine:
         self.gpu_id = gpu_id if gpu_id is not None else 0
         self.ib_device = get_ib_devices_for_gpu(ib_device, self.gpu_id)
 
-        logger.info(
+        logger.warning(
             "Initializing MooncakeTransferEngine: hostname=%s, gpu_id=%d, "
             "ib_device=%s",
             self.hostname,
@@ -127,7 +127,7 @@ class MooncakeTransferEngine:
         self.session_id = (
             f"{maybe_wrap_ipv6_address(self.hostname)}:{self.engine.get_rpc_port()}"
         )
-        logger.info(
+        logger.warning(
             "MooncakeTransferEngine initialized: session_id=%s, rpc_port=%d",
             self.session_id,
             self.engine.get_rpc_port(),

--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -113,12 +113,24 @@ class MooncakeTransferEngine:
         self.gpu_id = gpu_id if gpu_id is not None else 0
         self.ib_device = get_ib_devices_for_gpu(ib_device, self.gpu_id)
 
+        logger.info(
+            "Initializing MooncakeTransferEngine: hostname=%s, gpu_id=%d, "
+            "ib_device=%s",
+            self.hostname,
+            self.gpu_id,
+            self.ib_device,
+        )
         self.initialize(
             hostname=self.hostname,
             device_name=self.ib_device,
         )
         self.session_id = (
             f"{maybe_wrap_ipv6_address(self.hostname)}:{self.engine.get_rpc_port()}"
+        )
+        logger.info(
+            "MooncakeTransferEngine initialized: session_id=%s, rpc_port=%d",
+            self.session_id,
+            self.engine.get_rpc_port(),
         )
 
     def register(self, ptr, length):
@@ -129,7 +141,11 @@ class MooncakeTransferEngine:
             ret_value = -1
 
         if ret_value != 0:
-            logger.debug("Mooncake memory registration %s failed.", ptr)
+            logger.warning(
+                "Mooncake memory registration failed: ptr=0x%x, length=%d",
+                ptr,
+                length,
+            )
 
     def deregister(self, ptr):
         try:
@@ -139,7 +155,7 @@ class MooncakeTransferEngine:
             ret_value = -1
 
         if ret_value != 0:
-            logger.debug("Mooncake memory deregistration %s failed.", ptr)
+            logger.warning("Mooncake memory deregistration failed: ptr=0x%x", ptr)
 
     def batch_register(self, ptrs: List[int], lengths: List[int]) -> int:
         """Batch register multiple memory regions."""
@@ -155,7 +171,10 @@ class MooncakeTransferEngine:
                 )
 
         if ret_value != 0:
-            logger.debug("Mooncake batch memory registration failed.")
+            logger.warning(
+                "Mooncake batch memory registration failed: num_ptrs=%d",
+                len(ptrs),
+            )
         return ret_value
 
     def batch_deregister(self, ptrs: List[int]) -> int:
@@ -167,7 +186,10 @@ class MooncakeTransferEngine:
             ret_value = -1
 
         if ret_value != 0:
-            logger.debug("Mooncake batch memory deregistration failed.")
+            logger.warning(
+                "Mooncake batch memory deregistration failed: num_ptrs=%d",
+                len(ptrs),
+            )
         return ret_value
 
     def initialize(
@@ -182,22 +204,35 @@ class MooncakeTransferEngine:
                 hostname += f":{get_free_port()}:npu_{self.gpu_id}"
             else:
                 hostname += f":{get_free_port()}:npu_{npu_phy_id}"
+            protocol = "ascend"
             ret_value = self.engine.initialize(
                 hostname,
                 "P2PHANDSHAKE",
-                "ascend",
+                protocol,
                 device_name if device_name is not None else "",
             )
         else:
+            protocol = "rdma"
             ret_value = self.engine.initialize(
                 hostname,
                 "P2PHANDSHAKE",
-                "rdma",
+                protocol,
                 device_name if device_name is not None else "",
             )
         if ret_value != 0:
-            logger.error("Mooncake Transfer Engine initialization failed.")
-            raise RuntimeError("Mooncake Transfer Engine initialization failed.")
+            logger.error(
+                "Mooncake Transfer Engine initialization failed: "
+                "hostname=%s, protocol=%s, device_name=%s, ret=%d",
+                hostname,
+                protocol,
+                device_name,
+                ret_value,
+            )
+            raise RuntimeError(
+                f"Mooncake Transfer Engine initialization failed: "
+                f"hostname={hostname}, protocol={protocol}, "
+                f"device_name={device_name}, ret={ret_value}"
+            )
 
     def transfer_sync(
         self, session_id: str, buffer: int, peer_buffer_address: int, length: int
@@ -207,15 +242,27 @@ class MooncakeTransferEngine:
             ret = self.engine.transfer_sync_write(
                 session_id, buffer, peer_buffer_address, length
             )
-        except Exception:
+        except Exception as e:
+            logger.error(
+                "Exception in transfer_sync_write: session_id=%s, "
+                "src=0x%x, dst=0x%x, length=%d, error=%s",
+                session_id,
+                buffer,
+                peer_buffer_address,
+                length,
+                e,
+            )
             ret = -1
 
         if ret < 0:
-            logger.debug(
-                "Failed to transfer data from %s to %s - %s.",
-                buffer,
+            logger.error(
+                "transfer_sync_write failed: session_id=%s, src=0x%x, "
+                "dst=0x%x, length=%d, ret=%d",
                 session_id,
+                buffer,
                 peer_buffer_address,
+                length,
+                ret,
             )
 
         return ret
@@ -232,22 +279,31 @@ class MooncakeTransferEngine:
             ret = self.engine.batch_transfer_sync_write(
                 session_id, buffers, peer_buffer_addresses, lengths
             )
-        except Exception:
-            ret = -1
+        except Exception as e:
             if not hasattr(self.engine, "batch_transfer_sync_write"):
                 raise RuntimeError(
                     "Mooncake's batch transfer requires mooncake-transfer-engine "
                     ">= 0.3.4.post2. Please upgrade Mooncake by "
                     "'pip install mooncake-transfer-engine --upgrade'"
                 )
+            logger.error(
+                "Exception in batch_transfer_sync_write: session_id=%s, "
+                "num_buffers=%d, total_bytes=%d, error=%s",
+                session_id,
+                len(buffers),
+                sum(lengths),
+                e,
+            )
+            ret = -1
 
         if ret < 0:
-            logger.debug(
-                "Failed to batch transfer data. Buffers: %s, Session: %s, "
-                "Peer addresses: %s",
-                buffers,
+            logger.error(
+                "batch_transfer_sync_write failed: session_id=%s, "
+                "num_buffers=%d, total_bytes=%d, ret=%d",
                 session_id,
-                peer_buffer_addresses,
+                len(buffers),
+                sum(lengths),
+                ret,
             )
         return ret
 

--- a/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
+++ b/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
@@ -191,9 +191,7 @@ class MessageQueue:
         self.n_remote_reader = n_remote_reader
 
         if connect_ip is None:
-            connect_ip = (
-                get_local_ip_auto("::") if n_remote_reader > 0 else "::1"
-            )
+            connect_ip = get_local_ip_auto("::") if n_remote_reader > 0 else "::1"
 
         context = Context()
 

--- a/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
+++ b/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
@@ -192,7 +192,7 @@ class MessageQueue:
 
         if connect_ip is None:
             connect_ip = (
-                get_local_ip_auto("0.0.0.0") if n_remote_reader > 0 else "127.0.0.1"
+                get_local_ip_auto("::") if n_remote_reader > 0 else "::1"
             )
 
         context = Context()
@@ -212,7 +212,7 @@ class MessageQueue:
             # see http://api.zeromq.org/3-3:zmq-setsockopt for more details
             self.local_socket.setsockopt(XPUB_VERBOSE, True)
             local_subscribe_port = get_open_port()
-            socket_addr = f"tcp://127.0.0.1:{local_subscribe_port}"
+            socket_addr = format_tcp_address("::1", local_subscribe_port)
             logger.debug("Binding to %s", socket_addr)
             self.local_socket.bind(socket_addr)
             self.current_idx = 0
@@ -276,7 +276,7 @@ class MessageQueue:
 
             self.local_socket = context.socket(SUB)
             self.local_socket.setsockopt_string(SUBSCRIBE, "")
-            socket_addr = f"tcp://127.0.0.1:{handle.local_subscribe_port}"
+            socket_addr = format_tcp_address("::1", handle.local_subscribe_port)
             logger.debug("Connecting to %s", socket_addr)
             self.local_socket.connect(socket_addr)
 

--- a/python/sglang/srt/elastic_ep/expert_backup_client.py
+++ b/python/sglang/srt/elastic_ep/expert_backup_client.py
@@ -15,6 +15,7 @@ from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
 from sglang.srt.managers.io_struct import UpdateExpertBackupReq
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_local_ip_auto
+from sglang.srt.utils.common import format_tcp_address
 
 PORT_BASE = envs.SGLANG_BACKUP_PORT_BASE.get()
 logger = logging.getLogger(__name__)
@@ -56,14 +57,14 @@ class ExpertBackupClient:
         for i in range(self.engine_num):
             self.recv_list[i] = context.socket(zmq.SUB)
             self.recv_list[i].connect(
-                f"tcp://{all_ips[i * get_world_size() // server_args.nnodes]}:{PORT_BASE + i * 2 + 1}"
+                format_tcp_address(all_ips[i * get_world_size() // server_args.nnodes], PORT_BASE + i * 2 + 1)
             )
             self.recv_list[i].setsockopt(zmq.SUBSCRIBE, b"")
 
             # Synchronization channel to notify the manager when this client is ready.
             self.ready_sockets[i] = context.socket(zmq.PUSH)
             self.ready_sockets[i].connect(
-                f"tcp://{all_ips[i * get_world_size() // server_args.nnodes]}:{PORT_BASE + i * 2}"
+                format_tcp_address(all_ips[i * get_world_size() // server_args.nnodes], PORT_BASE + i * 2)
             )
             self.ready_sockets[i].send_pyobj(UpdateExpertBackupReq())
 

--- a/python/sglang/srt/elastic_ep/expert_backup_client.py
+++ b/python/sglang/srt/elastic_ep/expert_backup_client.py
@@ -15,7 +15,7 @@ from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
 from sglang.srt.managers.io_struct import UpdateExpertBackupReq
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_local_ip_auto
-from sglang.srt.utils.common import format_tcp_address
+from sglang.srt.utils.common import format_tcp_address, is_valid_ipv6_address
 
 PORT_BASE = envs.SGLANG_BACKUP_PORT_BASE.get()
 logger = logging.getLogger(__name__)
@@ -55,16 +55,21 @@ class ExpertBackupClient:
         logger.info(f"all_ips: {all_ips}")
 
         for i in range(self.engine_num):
+            target_ip = all_ips[i * get_world_size() // server_args.nnodes]
             self.recv_list[i] = context.socket(zmq.SUB)
+            if is_valid_ipv6_address(target_ip):
+                self.recv_list[i].setsockopt(zmq.IPV6, 1)
             self.recv_list[i].connect(
-                format_tcp_address(all_ips[i * get_world_size() // server_args.nnodes], PORT_BASE + i * 2 + 1)
+                format_tcp_address(target_ip, PORT_BASE + i * 2 + 1)
             )
             self.recv_list[i].setsockopt(zmq.SUBSCRIBE, b"")
 
             # Synchronization channel to notify the manager when this client is ready.
             self.ready_sockets[i] = context.socket(zmq.PUSH)
+            if is_valid_ipv6_address(target_ip):
+                self.ready_sockets[i].setsockopt(zmq.IPV6, 1)
             self.ready_sockets[i].connect(
-                format_tcp_address(all_ips[i * get_world_size() // server_args.nnodes], PORT_BASE + i * 2)
+                format_tcp_address(target_ip, PORT_BASE + i * 2)
             )
             self.ready_sockets[i].send_pyobj(UpdateExpertBackupReq())
 

--- a/python/sglang/srt/elastic_ep/expert_backup_manager.py
+++ b/python/sglang/srt/elastic_ep/expert_backup_manager.py
@@ -18,6 +18,7 @@ from sglang.srt.server_args import (
     set_global_server_args_for_scheduler,
 )
 from sglang.srt.utils import get_local_ip_auto
+from sglang.srt.utils.common import format_tcp_address
 
 PORT_BASE = envs.SGLANG_BACKUP_PORT_BASE.get()
 logger = logging.getLogger(__name__)
@@ -48,11 +49,11 @@ class ExpertBackupManager:
         # Synchronization socket to avoid PUB/SUB slow joiner issues.
         self.recv_from_expert_backup_client = context.socket(zmq.PULL)
         self.recv_from_expert_backup_client.bind(
-            f"tcp://{get_local_ip_auto()}:{PORT_BASE + server_args.node_rank * 2}"
+            format_tcp_address(get_local_ip_auto(), PORT_BASE + server_args.node_rank * 2)
         )
         self.send_to_expert_backup_client = context.socket(zmq.PUB)
         self.send_to_expert_backup_client.bind(
-            f"tcp://{get_local_ip_auto()}:{PORT_BASE + server_args.node_rank * 2 + 1}"
+            format_tcp_address(get_local_ip_auto(), PORT_BASE + server_args.node_rank * 2 + 1)
         )
         self.backup_weights_from_disk()
         self.start_transfer_server()

--- a/python/sglang/srt/elastic_ep/expert_backup_manager.py
+++ b/python/sglang/srt/elastic_ep/expert_backup_manager.py
@@ -18,7 +18,7 @@ from sglang.srt.server_args import (
     set_global_server_args_for_scheduler,
 )
 from sglang.srt.utils import get_local_ip_auto
-from sglang.srt.utils.common import format_tcp_address
+from sglang.srt.utils.common import format_tcp_address, is_valid_ipv6_address
 
 PORT_BASE = envs.SGLANG_BACKUP_PORT_BASE.get()
 logger = logging.getLogger(__name__)
@@ -46,14 +46,17 @@ class ExpertBackupManager:
         self.idmn = (self.expert_num // self.engine_num) * self.engine_rank
         self.idmx = (self.expert_num // self.engine_num) * (self.engine_rank + 1)
         context = zmq.Context(2)
+        local_ip = get_local_ip_auto()
+        if is_valid_ipv6_address(local_ip):
+            context.setsockopt(zmq.IPV6, 1)
         # Synchronization socket to avoid PUB/SUB slow joiner issues.
         self.recv_from_expert_backup_client = context.socket(zmq.PULL)
         self.recv_from_expert_backup_client.bind(
-            format_tcp_address(get_local_ip_auto(), PORT_BASE + server_args.node_rank * 2)
+            format_tcp_address(local_ip, PORT_BASE + server_args.node_rank * 2)
         )
         self.send_to_expert_backup_client = context.socket(zmq.PUB)
         self.send_to_expert_backup_client.bind(
-            format_tcp_address(get_local_ip_auto(), PORT_BASE + server_args.node_rank * 2 + 1)
+            format_tcp_address(local_ip, PORT_BASE + server_args.node_rank * 2 + 1)
         )
         self.backup_weights_from_disk()
         self.start_transfer_server()

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -1393,7 +1393,7 @@ def _execute_grpc_server_warmup(server_args: ServerArgs):
     """Execute warmup for gRPC server by checking health and sending test request."""
     try:
         # Connect to the gRPC server
-        grpc_url = f"{server_args.host}:{server_args.port}"
+        grpc_url = f"{maybe_wrap_ipv6_address(server_args.host)}:{server_args.port}"
         channel = grpc.insecure_channel(
             grpc_url,
             options=[

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -54,6 +54,7 @@ from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from sglang.srt.sampling.sampling_params import SamplingParams as SGLSamplingParams
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 from sglang.utils import get_exception_traceback
 
 logger = logging.getLogger(__name__)
@@ -1112,7 +1113,7 @@ async def serve_grpc(
         bootstrap_server = start_disagg_service(server_args)
         if bootstrap_server:
             logger.info(
-                f"Bootstrap server started for disaggregation mode on {server_args.host}:{server_args.disaggregation_bootstrap_port}"
+                f"Bootstrap server started for disaggregation mode on {maybe_wrap_ipv6_address(server_args.host)}:{server_args.disaggregation_bootstrap_port}"
             )
 
     # Launch only the scheduler process(es) (no tokenizer/detokenizer needed for gRPC)
@@ -1209,7 +1210,7 @@ async def serve_grpc(
     reflection.enable_server_reflection(SERVICE_NAMES, server)
 
     # Start server
-    listen_addr = f"{server_args.host}:{server_args.port}"
+    listen_addr = f"{maybe_wrap_ipv6_address(server_args.host)}:{server_args.port}"
     if server_args.ssl_certfile and server_args.ssl_keyfile:
         if server_args.ssl_keyfile_password:
             raise ValueError(

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -9,6 +9,7 @@ from sglang.srt.entrypoints.EngineBase import EngineBase
 from sglang.srt.entrypoints.http_server import launch_server
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import MultiprocessingSerializer, kill_process_tree
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
@@ -56,7 +57,7 @@ class HttpServerEngineAdapter(EngineBase):
     def __init__(self, **kwargs):
         self.server_args = ServerArgs(**kwargs)
         print(
-            f"Launch HttpServerEngineAdapter at: {self.server_args.host}:{self.server_args.port}"
+            f"Launch HttpServerEngineAdapter at: {maybe_wrap_ipv6_address(self.server_args.host)}:{self.server_args.port}"
         )
         self.process = launch_server_process(self.server_args)
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -292,7 +292,7 @@ class DataParallelController:
         # Determine the endpoint for inter-node communication
         if server_args.dist_init_addr is None:
             endpoint = format_tcp_address(
-                server_args.host or "127.0.0.1",
+                server_args.host or "::1",
                 server_args.port + DP_ATTENTION_HANDSHAKE_PORT_DELTA,
             )
         else:

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -53,7 +53,6 @@ from sglang.srt.utils.common import (
     get_zmq_socket,
     kill_itself_when_parent_died,
     maybe_reindex_device_id,
-    maybe_wrap_ipv6_address,
     parse_host_port,
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -48,11 +48,13 @@ from sglang.srt.server_args import (
 from sglang.srt.utils import numa_utils
 from sglang.srt.utils.common import (
     bind_port,
-    configure_ipv6,
     configure_logger,
+    format_tcp_address,
     get_zmq_socket,
     kill_itself_when_parent_died,
     maybe_reindex_device_id,
+    maybe_wrap_ipv6_address,
+    parse_host_port,
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils.watchdog import Watchdog
@@ -289,13 +291,15 @@ class DataParallelController:
         """
         # Determine the endpoint for inter-node communication
         if server_args.dist_init_addr is None:
-            endpoint = f"tcp://127.0.0.1:{server_args.port + DP_ATTENTION_HANDSHAKE_PORT_DELTA}"
-        elif server_args.dist_init_addr.startswith("["):  # ipv6 address
-            port, host = configure_ipv6(server_args.dist_init_addr)
-            endpoint = f"tcp://{host}:{int(port) + DP_ATTENTION_HANDSHAKE_PORT_DELTA}"
+            endpoint = format_tcp_address(
+                server_args.host or "127.0.0.1",
+                server_args.port + DP_ATTENTION_HANDSHAKE_PORT_DELTA,
+            )
         else:
-            host, port = server_args.dist_init_addr.split(":")
-            endpoint = f"tcp://{host}:{int(port) + DP_ATTENTION_HANDSHAKE_PORT_DELTA}"
+            host, port = parse_host_port(server_args.dist_init_addr)
+            endpoint = format_tcp_address(
+                host, int(port) + DP_ATTENTION_HANDSHAKE_PORT_DELTA
+            )
 
         if server_args.node_rank == 0:
             # Node 0: Broadcast worker ports to all other nodes

--- a/python/sglang/srt/mem_cache/storage/hf3fs/mini_3fs_metadata_server.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/mini_3fs_metadata_server.py
@@ -15,6 +15,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from sglang.srt.mem_cache.storage.hf3fs.storage_hf3fs import Hf3fsMetadataInterface
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
 
 # --- Configuration ---
 logging.basicConfig(
@@ -304,7 +305,7 @@ class Hf3fsMetadataServer:
 
         import uvicorn
 
-        wrapped_host = f"[{host}]" if ":" in str(host) else host
+        wrapped_host = maybe_wrap_ipv6_address(str(host))
         logging.info(f"Starting metadata server on http://{wrapped_host}:{port}")
         if self.state.persistence_path:
             logging.info(

--- a/python/sglang/srt/mem_cache/storage/hf3fs/mini_3fs_metadata_server.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/mini_3fs_metadata_server.py
@@ -304,7 +304,8 @@ class Hf3fsMetadataServer:
 
         import uvicorn
 
-        logging.info(f"Starting metadata server on http://{host}:{port}")
+        wrapped_host = f"[{host}]" if ":" in str(host) else host
+        logging.info(f"Starting metadata server on http://{wrapped_host}:{port}")
         if self.state.persistence_path:
             logging.info(
                 f"Persistence is ENABLED. Saving to '{self.state.persistence_path}' every {self.state.save_interval} seconds."

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_embedding_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_embedding_store.py
@@ -16,8 +16,10 @@ class MooncakeEmbeddingStore(MooncakeBaseStore):
         MooncakeDistributedStore = self._import_mooncake_store()
         self.store = MooncakeDistributedStore()
         self.config = self._load_config(storage_config)
+        from sglang.srt.utils.common import maybe_wrap_ipv6_address
+
         ret_code = self.store.setup(
-            self.config.local_hostname,
+            maybe_wrap_ipv6_address(self.config.local_hostname),
             self.config.metadata_server,
             self.config.global_segment_size,
             16 * 1024 * 1024,  # Internal local buffer size

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -331,6 +331,12 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                         "Please set standalone_storage=False "
                         "or upgrade Mooncake by 'pip install mooncake --upgrade'."
                     )
+                logger.info(
+                    "Setting up Mooncake store (standalone) with "
+                    f"segment_size={mem_pool.size * mem_pool.size_per_token}, "
+                    f"local_buffer_size={DEFAULT_LOCAL_BUFFER_SIZE}, "
+                    f"client_server_address={self.config.client_server_address}"
+                )
                 ret_code = self.store.setup_dummy(
                     mem_pool.size * mem_pool.size_per_token,
                     DEFAULT_LOCAL_BUFFER_SIZE,  # Zero copy interface does not need local buffer
@@ -369,6 +375,17 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                     client_hostname = self.config.local_hostname
                     transfer_engine = None
 
+                logger.info(
+                    "Setting up Mooncake store with "
+                    f"client_hostname={client_hostname}, "
+                    f"metadata_server={self.config.metadata_server}, "
+                    f"global_segment_size={per_tp_global_segment_size}, "
+                    f"local_buffer_size={DEFAULT_LOCAL_BUFFER_SIZE}, "
+                    f"protocol={self.config.protocol}, "
+                    f"device_name={device_name}, "
+                    f"master_server_address={self.config.master_server_address}, "
+                    f"transfer_engine={'shared' if transfer_engine is not None else 'new'}"
+                )
                 ret_code = self.store.setup(
                     client_hostname,
                     self.config.metadata_server,

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -372,7 +372,11 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                         f"Reuse initialized mooncake transfer engine: {self._shared_mooncake_transfer_engine}"
                     )
                 else:
-                    client_hostname = self.config.local_hostname
+                    from sglang.srt.utils.common import maybe_wrap_ipv6_address
+
+                    client_hostname = maybe_wrap_ipv6_address(
+                        self.config.local_hostname
+                    )
                     transfer_engine = None
 
                 logger.info(

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -457,8 +457,10 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             raise
 
     def check_server(self):
-        master_server_ip = self.config.master_server_address.split(":")[0]
-        segments_url = f"http://{master_server_ip}:{self.config.master_metrics_port}/get_all_segments"
+        from sglang.srt.utils.common import maybe_wrap_ipv6_address, parse_host_port
+
+        master_server_ip, _ = parse_host_port(self.config.master_server_address)
+        segments_url = f"http://{maybe_wrap_ipv6_address(master_server_ip)}:{self.config.master_metrics_port}/get_all_segments"
         start_time = time.perf_counter()
 
         check_result = False

--- a/python/sglang/srt/model_executor/mindspore_runner.py
+++ b/python/sglang/srt/model_executor/mindspore_runner.py
@@ -14,6 +14,7 @@ from mindspore._c_expression import GroupOptions
 from mindspore.communication import create_group
 
 from sglang.srt.distributed.parallel_state import _groups
+from sglang.srt.utils.common import format_tcp_address, parse_host_port
 
 logger = logging.getLogger(__name__)
 
@@ -107,9 +108,10 @@ def reuse_hccl_comm():
 
 def init_ms_distributed(world_size, rank, local_rank, server_args, port):
     if server_args.dist_init_addr:
-        dist_init_method = f"tcp://{server_args.dist_init_addr}"
+        host, p = parse_host_port(server_args.dist_init_addr)
+        dist_init_method = format_tcp_address(host, p)
     else:
-        dist_init_method = f"tcp://{server_args.host}:{port}"
+        dist_init_method = format_tcp_address(server_args.host or "::1", port)
     set_ms_parallel_env(rank, local_rank, world_size, dist_init_method)
 
     ms.set_context(infer_boost="on", jit_level="O0")

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -673,9 +673,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.remote_instance_transfer_engine.initialize(
             local_ip, "P2PHANDSHAKE", "rdma", envs.MOONCAKE_DEVICE.get()
         )
-        self.remote_instance_transfer_engine_session_id = (
-            f"{maybe_wrap_ipv6_address(local_ip)}:{self.remote_instance_transfer_engine.get_rpc_port()}"
-        )
+        self.remote_instance_transfer_engine_session_id = f"{maybe_wrap_ipv6_address(local_ip)}:{self.remote_instance_transfer_engine.get_rpc_port()}"
 
     def model_specific_adjustment(self):
         server_args = self.server_args
@@ -1239,9 +1237,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             dist.barrier(group=self._weights_send_group[group_name])
             success = True
-            message = (
-                f"Succeeded to init group through {maybe_wrap_ipv6_address(master_address)}:{group_port} group."
-            )
+            message = f"Succeeded to init group through {maybe_wrap_ipv6_address(master_address)}:{group_port} group."
         except Exception as e:
             message = f"Failed to init group: {e}."
             logger.error(message)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -779,7 +779,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             dist_init_method = format_tcp_address(host, port)
         else:
             dist_init_method = format_tcp_address(
-                self.server_args.host or "127.0.0.1", self.dist_port
+                self.server_args.host or "::1", self.dist_port
             )
         set_custom_all_reduce(not self.server_args.disable_custom_all_reduce)
         set_mscclpp_all_reduce(self.server_args.enable_mscclpp)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -171,8 +171,14 @@ from sglang.srt.utils import (
     require_gathered_buffer,
     require_mlp_tp_gather,
     reserve_rope_cache_for_long_sequences,
+    resolve_hostname,
     set_cuda_arch,
     slow_rank_detector,
+)
+from sglang.srt.utils.common import (
+    format_tcp_address,
+    maybe_wrap_ipv6_address,
+    parse_host_port,
 )
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.offloader import (
@@ -769,9 +775,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if dist_init_method_override:
             dist_init_method = dist_init_method_override
         elif self.server_args.dist_init_addr:
-            dist_init_method = f"tcp://{self.server_args.dist_init_addr}"
+            host, port = parse_host_port(self.server_args.dist_init_addr)
+            dist_init_method = format_tcp_address(host, port)
         else:
-            dist_init_method = f"tcp://127.0.0.1:{self.dist_port}"
+            dist_init_method = format_tcp_address(
+                self.server_args.host or "127.0.0.1", self.dist_port
+            )
         set_custom_all_reduce(not self.server_args.disable_custom_all_reduce)
         set_mscclpp_all_reduce(self.server_args.enable_mscclpp)
         set_torch_symm_mem_all_reduce(self.server_args.enable_torch_symm_mem)
@@ -950,7 +959,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             == RemoteInstanceWeightLoaderBackend.NCCL
         ):
             if self.tp_rank == 0:
-                instance_ip = socket.gethostbyname(socket.gethostname())
+                instance_ip = resolve_hostname(socket.gethostname())
                 t = threading.Thread(
                     target=trigger_init_weights_send_group_for_remote_instance_request,
                     args=(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -674,7 +674,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             local_ip, "P2PHANDSHAKE", "rdma", envs.MOONCAKE_DEVICE.get()
         )
         self.remote_instance_transfer_engine_session_id = (
-            f"{local_ip}:{self.remote_instance_transfer_engine.get_rpc_port()}"
+            f"{maybe_wrap_ipv6_address(local_ip)}:{self.remote_instance_transfer_engine.get_rpc_port()}"
         )
 
     def model_specific_adjustment(self):
@@ -1231,7 +1231,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         try:
             self._weights_send_group[group_name] = init_custom_process_group(
                 backend=backend,
-                init_method=f"tcp://{master_address}:{group_port}",
+                init_method=format_tcp_address(master_address, group_port),
                 world_size=world_size,
                 rank=group_rank,
                 group_name=group_name,
@@ -1240,7 +1240,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             dist.barrier(group=self._weights_send_group[group_name])
             success = True
             message = (
-                f"Succeeded to init group through {master_address}:{group_port} group."
+                f"Succeeded to init group through {maybe_wrap_ipv6_address(master_address)}:{group_port} group."
             )
         except Exception as e:
             message = f"Failed to init group: {e}."
@@ -1285,7 +1285,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     group=send_group,
                 )
             success = True
-            message = f"Succeeded to send weights through {master_address}:{group_port} {group_name}."
+            message = f"Succeeded to send weights through {maybe_wrap_ipv6_address(master_address)}:{group_port} {group_name}."
         except Exception as e:
             message = f"Failed to send weights: {e}."
             logger.error(message)
@@ -1330,7 +1330,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         try:
             self._model_update_group[group_name] = init_custom_process_group(
                 backend=backend,
-                init_method=f"tcp://{master_address}:{master_port}",
+                init_method=format_tcp_address(master_address, master_port),
                 world_size=world_size,
                 rank=rank,
                 group_name=group_name,

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -110,6 +110,7 @@ from sglang.srt.utils import (
     get_device_capability,
     is_npu,
     is_pin_memory_available,
+    maybe_wrap_ipv6_address,
     rank0_log,
     resolve_hostname,
     set_weight_attrs,
@@ -2106,7 +2107,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             load_config.remote_instance_weight_loader_backend
             == RemoteInstanceWeightLoaderBackend.NCCL
         ):
-            model_weights = f"instance://{load_config.remote_instance_weight_loader_seed_instance_ip}:{load_config.remote_instance_weight_loader_send_weights_group_ports[load_config.tp_rank]}"
+            model_weights = f"instance://{maybe_wrap_ipv6_address(load_config.remote_instance_weight_loader_seed_instance_ip)}:{load_config.remote_instance_weight_loader_send_weights_group_ports[load_config.tp_rank]}"
             with create_remote_connector(model_weights, device_config.device) as client:
                 connector_type = get_connector_type(client)
                 if connector_type == ConnectorType.INSTANCE:
@@ -2142,7 +2143,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             success = self.load_model_from_remote_instance_by_transfer_engine(
                 model,
                 load_config.remote_instance_weight_loader_transfer_engine,
-                f"http://{load_config.remote_instance_weight_loader_seed_instance_ip}:{load_config.remote_instance_weight_loader_seed_instance_service_port}",
+                f"http://{maybe_wrap_ipv6_address(load_config.remote_instance_weight_loader_seed_instance_ip)}:{load_config.remote_instance_weight_loader_seed_instance_service_port}",
                 load_config.tp_rank,
             )
             if not success:

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -111,6 +111,7 @@ from sglang.srt.utils import (
     is_npu,
     is_pin_memory_available,
     rank0_log,
+    resolve_hostname,
     set_weight_attrs,
 )
 
@@ -2157,7 +2158,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
         self, model, client, model_config: ModelConfig, device_config: DeviceConfig
     ) -> nn.Module:
         load_config = self.load_config
-        instance_ip = socket.gethostbyname(socket.gethostname())
+        instance_ip = resolve_hostname(socket.gethostname())
         start_build_group_tic = time.time()
         client.build_group(
             gpu_id=device_config.gpu_id,

--- a/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
+++ b/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
@@ -9,6 +9,8 @@ from typing import List
 
 import requests
 
+from sglang.srt.utils.common import maybe_wrap_ipv6_address
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,7 +25,7 @@ def trigger_init_weights_send_group_for_remote_instance_request(
     remote_instance_weight_loader_send_weights_group_ports: List[int],
     remote_instance_weight_loader_client_id: str,
 ):
-    seed_instance_service_url = f"http://{remote_instance_weight_loader_seed_instance_ip}:{remote_instance_weight_loader_seed_instance_service_port}"
+    seed_instance_service_url = f"http://{maybe_wrap_ipv6_address(remote_instance_weight_loader_seed_instance_ip)}:{remote_instance_weight_loader_seed_instance_service_port}"
     # Only support loading weights from instance with same parallelism strategy.
     # Per TP rank pair between seed and dst instances will build a communication group for sending weights.
     # i.e. seed TP 0 <-> dst TP 0, seed TP 1 <-> dst TP 1, etc.
@@ -58,7 +60,7 @@ def trigger_transferring_weights_request(
     remote_instance_weight_loader_send_weights_group_ports: List[int],
     remote_instance_weight_loader_client_id: str,
 ):
-    seed_instance_service_url = f"http://{remote_instance_weight_loader_seed_instance_ip}:{remote_instance_weight_loader_seed_instance_service_port}"
+    seed_instance_service_url = f"http://{maybe_wrap_ipv6_address(remote_instance_weight_loader_seed_instance_ip)}:{remote_instance_weight_loader_seed_instance_service_port}"
     try:
         requests.post(
             f"{seed_instance_service_url}/send_weights_to_remote_instance",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -60,8 +60,10 @@ from sglang.srt.utils.common import (
     is_triton_kernels_available,
     is_valid_ipv6_address,
     json_list_type,
+    maybe_wrap_ipv6_address,
     nullable_str,
     parse_connector_type,
+    parse_host_port,
     torch_release,
     wait_port_available,
     xpu_has_xmx_support,
@@ -6137,12 +6139,16 @@ class PortArgs:
         else:
             # DP attention. Use TCP + port to handle both single-node and multi-node.
             if server_args.nnodes == 1 and server_args.dist_init_addr is None:
-                dist_init_addr = ("127.0.0.1", server_args.port + ZMQ_TCP_PORT_DELTA)
+                dist_init_addr = (
+                    maybe_wrap_ipv6_address(server_args.host or "127.0.0.1"),
+                    server_args.port + ZMQ_TCP_PORT_DELTA,
+                )
             elif server_args.dist_init_addr.startswith("["):  # ipv6 address
                 port_num, host = configure_ipv6(server_args.dist_init_addr)
                 dist_init_addr = (host, str(port_num))
             else:
-                dist_init_addr = server_args.dist_init_addr.split(":")
+                host, port_num = parse_host_port(server_args.dist_init_addr)
+                dist_init_addr = (host, str(port_num))
 
             assert (
                 len(dist_init_addr) == 2

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -302,7 +302,7 @@ class ServerArgs:
     model_impl: str = "auto"
 
     # HTTP server
-    host: str = "127.0.0.1"
+    host: str = "::1"
     port: int = 30000
     fastapi_root_path: str = ""
     grpc_mode: bool = False
@@ -6140,7 +6140,7 @@ class PortArgs:
             # DP attention. Use TCP + port to handle both single-node and multi-node.
             if server_args.nnodes == 1 and server_args.dist_init_addr is None:
                 dist_init_addr = (
-                    maybe_wrap_ipv6_address(server_args.host or "127.0.0.1"),
+                    maybe_wrap_ipv6_address(server_args.host or "::1"),
                     server_args.port + ZMQ_TCP_PORT_DELTA,
                 )
             elif server_args.dist_init_addr.startswith("["):  # ipv6 address

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2781,7 +2781,9 @@ def launch_dummy_health_check_server(host, port, enable_metrics):
             logger.error(f"Dummy health check server failed to start: {e}")
             raise
         finally:
-            logger.info(f"Dummy health check server stopped at {maybe_wrap_ipv6_address(host)}:{port}")
+            logger.info(
+                f"Dummy health check server stopped at {maybe_wrap_ipv6_address(host)}:{port}"
+            )
 
     thread = threading.Thread(
         target=run_server, daemon=True, name="health-check-server"

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -738,27 +738,33 @@ def wait_port_available(
 
 def is_port_available(port):
     """Return whether a port is available."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
+    # try ipv6 first, then fall back to ipv4
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind(("", port))
             s.listen(1)
             return True
-        except socket.error:
-            return False
-        except OverflowError:
-            return False
+    except (socket.error, OverflowError):
+        pass
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("", port))
+            s.listen(1)
+            return True
+    except (socket.error, OverflowError):
+        return False
 
 
 def get_free_port():
-    # try ipv4
+    # try ipv6 first, then fall back to ipv4
     try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
             s.bind(("", 0))
             return s.getsockname()[1]
     except OSError:
-        # try ipv6
-        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("", 0))
             return s.getsockname()[1]
 
@@ -1472,6 +1478,8 @@ def get_zmq_socket_on_host(
     socket = context.socket(socket_type)
     # Bind to random TCP port
     config_socket(socket, socket_type)
+    if host and host.find("[") != -1:
+        socket.setsockopt(zmq.IPV6, 1)
     bind_host = f"tcp://{host}" if host else "tcp://*"
     port = socket.bind_to_random_port(bind_host)
     return port, socket
@@ -1675,8 +1683,17 @@ def _get_fastapi_request_path(request) -> Tuple[str, bool]:
 
 def bind_port(port):
     """Bind to a specific port, assuming it's available."""
+    # try ipv6 first, then fall back to ipv4
+    try:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("", port))
+        sock.listen(1)
+        return sock
+    except OSError:
+        sock.close()
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  # Allows address reuse
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("", port))
     sock.listen(1)
     return sock
@@ -2618,21 +2635,27 @@ def get_open_port() -> int:
     if port is not None:
         port = int(port)
         while True:
+            # try ipv6 first, then fall back to ipv4
+            try:
+                with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+                    s.bind(("", port))
+                    return port
+            except OSError:
+                pass
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     s.bind(("", port))
                     return port
             except OSError:
-                port += 1  # Increment port number if already in use
+                port += 1
                 logger.info("Port %d is already in use, trying port %d", port - 1, port)
-    # try ipv4
+    # try ipv6 first, then fall back to ipv4
     try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
             s.bind(("", 0))
             return s.getsockname()[1]
     except OSError:
-        # try ipv6
-        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("", 0))
             return s.getsockname()[1]
 
@@ -2653,6 +2676,29 @@ def maybe_wrap_ipv6_address(address: str) -> str:
 
 def format_tcp_address(ip: str, port: int) -> str:
     return f"tcp://{maybe_wrap_ipv6_address(ip)}:{port}"
+
+
+def resolve_hostname(hostname: str) -> str:
+    """Resolve a hostname to an IP address using getaddrinfo (supports both IPv4 and IPv6)."""
+    infos = socket.getaddrinfo(hostname, None)
+    return infos[0][4][0]
+
+
+def parse_host_port(addr: str) -> Tuple[str, int]:
+    """Parse a host:port string, handling IPv6 addresses.
+
+    For bracketed IPv6 (e.g. ``[::1]:8000``), delegates to :func:`configure_ipv6`.
+    For plain ``host:port``, splits on the last colon.
+
+    Returns ``(host, port)`` where *host* is already wrapped in ``[]`` when the
+    address is IPv6.
+    """
+    if addr.startswith("["):
+        port, host = configure_ipv6(addr)
+        return host, port
+    else:
+        host, port_str = addr.rsplit(":", 1)
+        return host, int(port_str)
 
 
 def configure_ipv6(dist_init_addr):
@@ -2735,14 +2781,14 @@ def launch_dummy_health_check_server(host, port, enable_metrics):
             logger.error(f"Dummy health check server failed to start: {e}")
             raise
         finally:
-            logger.info(f"Dummy health check server stopped at {host}:{port}")
+            logger.info(f"Dummy health check server stopped at {maybe_wrap_ipv6_address(host)}:{port}")
 
     thread = threading.Thread(
         target=run_server, daemon=True, name="health-check-server"
     )
     thread.start()
     logger.info(
-        f"Dummy health check server started in background thread at {host}:{port}"
+        f"Dummy health check server started in background thread at {maybe_wrap_ipv6_address(host)}:{port}"
     )
 
 
@@ -2932,7 +2978,7 @@ def get_local_ip_by_nic(interface: str = None) -> Optional[str]:
         if netifaces.AF_INET in addresses:
             for addr_info in addresses[netifaces.AF_INET]:
                 ip = addr_info.get("addr")
-                if ip and ip != "127.0.0.1" and ip != "0.0.0.0":
+                if ip and ip not in ("127.0.0.1", "0.0.0.0", "::1"):
                     return ip
         if netifaces.AF_INET6 in addresses:
             for addr_info in addresses[netifaces.AF_INET6]:
@@ -2957,8 +3003,8 @@ def get_local_ip_by_remote() -> Optional[str]:
 
     try:
         hostname = socket.gethostname()
-        ip = socket.gethostbyname(hostname)
-        if ip and ip != "127.0.0.1" and ip != "0.0.0.0":
+        ip = resolve_hostname(hostname)
+        if ip and ip not in ("127.0.0.1", "0.0.0.0", "::1"):
             return ip
     except Exception:
         pass

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3004,9 +3004,19 @@ def get_local_ip_by_nic(interface: str = None) -> Optional[str]:
 
 
 def get_local_ip_by_remote() -> Optional[str]:
-    # try ipv4
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    # try ipv6 first (works on both dual-stack and ipv6-only networks)
     try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        # Google's public DNS server, see
+        # https://developers.google.com/speed/public-dns/docs/using#addresses
+        s.connect(("2001:4860:4860::8888", 80))  # Doesn't need to be reachable
+        return s.getsockname()[0]
+    except Exception:
+        pass
+
+    # fall back to ipv4
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect(("8.8.8.8", 80))  # Doesn't need to be reachable
         return s.getsockname()[0]
     except Exception:
@@ -3020,15 +3030,7 @@ def get_local_ip_by_remote() -> Optional[str]:
     except Exception:
         pass
 
-    # try ipv6
-    try:
-        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        # Google's public DNS server, see
-        # https://developers.google.com/speed/public-dns/docs/using#addresses
-        s.connect(("2001:4860:4860::8888", 80))  # Doesn't need to be reachable
-        return s.getsockname()[0]
-    except Exception:
-        logger.warning("Can not get local ip by remote")
+    logger.warning("Can not get local ip by remote")
     return None
 
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1478,10 +1478,19 @@ def get_zmq_socket_on_host(
     socket = context.socket(socket_type)
     # Bind to random TCP port
     config_socket(socket, socket_type)
-    if host and host.find("[") != -1:
+    is_ipv6 = host and "[" in host
+    if is_ipv6:
         socket.setsockopt(zmq.IPV6, 1)
     bind_host = f"tcp://{host}" if host else "tcp://*"
-    port = socket.bind_to_random_port(bind_host)
+    try:
+        port = socket.bind_to_random_port(bind_host)
+    except zmq.ZMQError:
+        # If binding to a specific address fails (e.g., address not assigned
+        # to any local interface), fall back to binding all interfaces.
+        logger.warning(
+            f"Failed to bind ZMQ socket to {bind_host}, falling back to tcp://*"
+        )
+        port = socket.bind_to_random_port("tcp://*")
     return port, socket
 
 

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -124,6 +124,8 @@ def dump_state_text(filename: str, states: list, mode: str = "w"):
 
 
 def normalize_base_url(host: str, port: int) -> str:
+    from sglang.srt.utils.common import is_valid_ipv6_address
+
     if host.startswith("http://") or host.startswith("https://"):
         warnings.warn(
             f"Including the scheme in --host ('{host}') is deprecated. "
@@ -132,7 +134,10 @@ def normalize_base_url(host: str, port: int) -> str:
             stacklevel=2,
         )
     else:
-        host = f"http://{host}"
+        if is_valid_ipv6_address(host):
+            host = f"http://[{host}]"
+        else:
+            host = f"http://{host}"
     return f"{host}:{port}"
 
 

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -402,15 +402,16 @@ def reserve_port(host, start=30000, end=40000):
     random.shuffle(candidates)
 
     for port in candidates:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            # Attempt to bind to the port on localhost
-            sock.bind((host, port))
-            return port, sock
-        except socket.error:
-            sock.close()  # Failed to bind, try next port
-            continue
+        # Try IPv6 first, fall back to IPv4
+        for family in (socket.AF_INET6, socket.AF_INET):
+            sock = socket.socket(family, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind((host, port))
+                return port, sock
+            except socket.error:
+                sock.close()
+                continue
     raise RuntimeError("No free port available.")
 
 


### PR DESCRIPTION
## Motivation

SGLang currently assumes IPv4 in many places — `socket.gethostbyname()` calls (IPv4-only), naive `host.split(":")` parsing that breaks on IPv6 colons, hard-coded `127.0.0.1` loopback, and bare IPv6 addresses in URLs withou
t bracket wrapping. This makes SGLang unusable on IPv6-only or dual-stack networks.

This PR adds comprehensive IPv6 support so that SGLang works correctly on both IPv4 and IPv6 networks without any special configuration.

## Modifications

The changes are organized into 7 logical groups:

### 1. Core IPv6 utilities (`srt/utils/common.py`)
- Add `resolve_hostname()` — uses `socket.getaddrinfo()` instead of `gethostbyname()` to support both IPv4 and IPv6
- Add `parse_host_port()` — safely parses `host:port` strings, handling bracketed IPv6 (`[::1]:8000`) and plain IPv4 (`127.0.0.1:8000`)
- Update `is_port_available()`, `get_free_port()`, `bind_port()`, `get_open_port()` to try IPv6 first with IPv4 fallback
- Add `zmq.IPV6` flag in `get_zmq_socket_on_host()` when the host is IPv6
- Exclude `::1` from local IP detection in `get_local_ip_by_remote()` and `get_local_ip_by_nic()`

### 2. Replace `gethostbyname` with IPv6-compatible alternatives
- `dumper.py` — uses inline `socket.getaddrinfo()` (avoids sglang imports)
- `loader.py`, `model_runner.py` — use `resolve_hostname()`
- `conn.py` (disaggregation) — simplified with `parse_host_port()` + `resolve_hostname()`

### 3. Fix host:port parsing
- `server_args.py` — use `parse_host_port()` instead of `.split(":")`
- `data_parallel_controller.py` — replace multi-branch parsing with `parse_host_port()` + `format_tcp_address()`
- `model_runner.py`, `encode_server.py`, `encode_grpc_server.py`, `remote_instance.py`, `mindspore_runner.py`, `mooncake_store.py` — use `parse_host_port()` / `format_tcp_address()` consistently

### 4. Wrap IPv6 addresses in brackets for URLs and address strings
- Apply `maybe_wrap_ipv6_address()` across 18 files wherever `host:port` strings are constructed for URLs, log messages, or network addresses
- Fix `normalize_base_url()` in `utils.py` to wrap IPv6 hosts in brackets
- Covers: `bench_serving.py`, `compile_deep_gemm.py`, server entrypoints, disaggregation modules, model loader, weight loader utils, etc.

### 5. Default to IPv6 loopback (`::1`) instead of `127.0.0.1`
- Change `ServerArgs.host` default from `"127.0.0.1"` to `"::1"` (works on both dual-stack and IPv6-only systems)
- Update `multimodal_gen/server_args.py`, `gpu_worker.py`, `shm_broadcast.py` similarly

### 6. Set `zmq.IPV6` flag on ZMQ sockets
- Enable IPv6 on all ZMQ PUB, SUB, PUSH, PULL, ROUTER, DEALER sockets that may bind/connect to IPv6 endpoints
- Files: `common.py`, `dumper.py`, `scheduler_client.py`, `kv_events.py`, `encode_server.py`, `expert_backup_client.py`, `expert_backup_manager.py`
- Fix `kv_events.py` `"::" in endpoint` heuristic that falsely matched IPv6 addresses

### 7. Enhanced Mooncake transfer engine logging
- Add detailed logging around transfer failures, session lifecycle, and ZMQ operations in `mooncake/conn.py` and `mooncake_transfer_engine.py` for debugging connectivity issues on IPv6 networks

## Accuracy Tests

This PR does not modify model forward code, kernels, or inference logic. All changes are to networking/address handling code paths. No accuracy impact.

## Benchmarking and Profiling

This PR does not affect inference speed. Changes are limited to:
- Server startup address binding (one-time cost)
- Log message formatting (negligible)
- Socket creation order (IPv6 first, IPv4 fallback — same total cost)

## Checklist

- [x] Format code according to the project style guide
- [ ] Add unit tests for `parse_host_port()` and `resolve_hostname()` utilities
- [ ] Update documentation for IPv6 default (`::1`) and configuration
- [x] No accuracy or speed impact (networking-only changes)
- [x] Follow the SGLang code style guidance