### PR TITLE
[WIP][2/2] Add mixed tensor-parallelism for ModelExpress P2P loading

### DIFF
--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -76,6 +76,8 @@ class LoadConfig:
     remote_instance_weight_loader_send_weights_group_ports: Optional[List[int]] = None
     remote_instance_weight_loader_backend: Optional[str] = None
     remote_instance_weight_loader_transfer_engine: Optional[Any] = None
+    model_express_url: Optional[str] = None
+    model_express_model_name: Optional[str] = None
 
     # ModelOpt-specific loading options
     modelopt_checkpoint_restore_path: Optional[str] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -726,22 +726,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             output_dim = getattr(param, "output_dim", None) if param is not None else None
             input_dim = getattr(param, "input_dim", None) if param is not None else None
 
-            # Infer shard_dim from param attrs first, then fall back to module type.
-            # FP8 quant creates weights without output_dim/input_dim attrs.
-            # For column-parallel modules: .weight and .weight_scale are both
-            # sharded on dim 0 (per-channel scales follow output dim).
-            # For row-parallel modules: .weight is sharded on dim 1,
-            # but .weight_scale is replicated (full output dim).
+            # Infer shard_dim: must respect the module type because FP8 quant
+            # sets both output_dim=0 and input_dim=1 on ALL weight params
+            # (column-parallel and row-parallel alike). For RowParallelLinear
+            # the actual shard dim is input_dim, not output_dim.
             module = param_to_module.get(name)
-            if output_dim is not None:
+            is_row_par = module is not None and self._is_row_parallel(module)
+            is_col_par = module is not None and self._is_column_parallel(module)
+
+            if is_row_par and input_dim is not None and name.endswith(".weight"):
+                shard_dim = input_dim
+            elif output_dim is not None:
                 shard_dim = output_dim
             elif input_dim is not None:
                 shard_dim = input_dim
-            elif module is not None and self._is_column_parallel(module) and (
+            elif is_col_par and (
                 name.endswith(".weight") or name.endswith(".weight_scale")
             ):
                 shard_dim = 0
-            elif name.endswith(".weight") and module is not None and self._is_row_parallel(module):
+            elif name.endswith(".weight") and is_row_par:
                 shard_dim = 1
             else:
                 shard_dim = -1  # replicated

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -677,6 +677,81 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"{local_ip}:{self.remote_instance_transfer_engine.get_rpc_port()}"
         )
 
+    def _publish_model_express_metadata(self):
+        """Publish TransferEngine metadata to ModelExpress server (seed mode)."""
+        from modelexpress.client import MxClient
+        from modelexpress import p2p_pb2
+
+        model_name = (
+            self.server_args.model_express_model_name
+            or self.server_args.model_path
+        )
+        mx_url = self.server_args.model_express_url
+        session_id = self.remote_instance_transfer_engine_session_id
+        weight_info = self.remote_instance_transfer_engine_weight_info
+
+        if not session_id or weight_info is None:
+            logger.warning(
+                "ModelExpress source: skipping publish -- "
+                "TransferEngine not initialized or no weight info"
+            )
+            return
+
+        # Build tensor descriptors from weight_info dict
+        # Use actual per-tensor element_size to derive dtype (FP8 models have mixed dtypes)
+        element_size_to_dtype = {1: "float8_e4m3fn", 2: "bfloat16", 4: "float32", 8: "float64"}
+        tensors = []
+        for name, (addr, numel, element_size) in weight_info.items():
+            tensors.append(p2p_pb2.TensorDescriptor(
+                name=name,
+                addr=addr,
+                size=numel * element_size,
+                device_id=self.gpu_id,
+                dtype=element_size_to_dtype.get(element_size, "unknown"),
+            ))
+
+        worker = p2p_pb2.WorkerMetadata(
+            worker_rank=self.tp_rank,
+            transfer_engine_session_id=session_id,
+            tensors=tensors,
+        )
+
+        mx_client = MxClient(server_url=mx_url)
+        logger.info(
+            "ModelExpress source: publishing metadata for model=%s, "
+            "tp_rank=%d, session=%s, %d tensors",
+            model_name, self.tp_rank, session_id, len(tensors),
+        )
+        mx_client.publish_metadata(model_name, [worker])
+        mx_client.publish_ready(
+            model_name,
+            worker_id=self.tp_rank,
+            session_id=mx_client.session_id,
+            metadata_hash="",
+        )
+        logger.info(
+            "ModelExpress source: published ready for model=%s, tp_rank=%d",
+            model_name, self.tp_rank,
+        )
+        mx_client.close()
+
+    def _get_model_dtype_str(self) -> str:
+        """Return the model dtype as a string for tensor descriptors."""
+        import torch
+        dtype_map = {
+            torch.float16: "float16",
+            torch.bfloat16: "bfloat16",
+            torch.float32: "float32",
+            torch.float64: "float64",
+            torch.int8: "int8",
+            torch.uint8: "uint8",
+        }
+        if hasattr(torch, "float8_e4m3fn"):
+            dtype_map[torch.float8_e4m3fn] = "float8_e4m3fn"
+        if hasattr(torch, "float8_e5m2"):
+            dtype_map[torch.float8_e5m2] = "float8_e5m2"
+        return dtype_map.get(self.model_config.dtype, str(self.model_config.dtype))
+
     def model_specific_adjustment(self):
         server_args = self.server_args
 
@@ -941,6 +1016,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             remote_instance_weight_loader_send_weights_group_ports=self.server_args.remote_instance_weight_loader_send_weights_group_ports,
             remote_instance_weight_loader_backend=self.server_args.remote_instance_weight_loader_backend,
             remote_instance_weight_loader_transfer_engine=self.remote_instance_transfer_engine,
+            model_express_url=self.server_args.model_express_url,
+            model_express_model_name=self.server_args.model_express_model_name or self.server_args.model_path,
             modelopt_config=modelopt_config,
             rl_quant_profile=self.server_args.rl_quant_profile,
             draft_model_idx=self.draft_model_idx,
@@ -992,6 +1069,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     self.loader.remote_instance_transfer_engine_weight_info
                 )
         monkey_patch_vllm_parallel_state(reverse=True)
+
+        # Publish metadata to ModelExpress if running as seed source
+        if self.server_args.model_express_source:
+            # Seed loads via DefaultModelLoader (load_format=auto), which doesn't
+            # call register_memory_region(). Do it here so weight_info is populated.
+            if (
+                self.remote_instance_transfer_engine_weight_info is None
+                and self.remote_instance_transfer_engine is not None
+            ):
+                from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
+                    register_memory_region,
+                )
+
+                self.remote_instance_transfer_engine_weight_info = (
+                    register_memory_region(
+                        self.model, self.remote_instance_transfer_engine
+                    )
+                )
+            self._publish_model_express_metadata()
 
         get_offloader().post_init()
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -698,8 +698,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return
 
         # Build tensor descriptors from weight_info dict
-        # Use actual per-tensor element_size to derive dtype (FP8 models have mixed dtypes)
-        element_size_to_dtype = {1: "float8_e4m3fn", 2: "bfloat16", 4: "float32", 8: "float64"}
         tensors = []
         for name, (addr, numel, element_size) in weight_info.items():
             tensors.append(p2p_pb2.TensorDescriptor(
@@ -707,7 +705,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 addr=addr,
                 size=numel * element_size,
                 device_id=self.gpu_id,
-                dtype=element_size_to_dtype.get(element_size, "unknown"),
             ))
 
         worker = p2p_pb2.WorkerMetadata(
@@ -717,40 +714,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
 
         mx_client = MxClient(server_url=mx_url)
-        logger.info(
-            "ModelExpress source: publishing metadata for model=%s, "
-            "tp_rank=%d, session=%s, %d tensors",
-            model_name, self.tp_rank, session_id, len(tensors),
-        )
-        mx_client.publish_metadata(model_name, [worker])
-        mx_client.publish_ready(
-            model_name,
-            worker_id=self.tp_rank,
-            session_id=mx_client.session_id,
-            metadata_hash="",
-        )
-        logger.info(
-            "ModelExpress source: published ready for model=%s, tp_rank=%d",
-            model_name, self.tp_rank,
-        )
-        mx_client.close()
-
-    def _get_model_dtype_str(self) -> str:
-        """Return the model dtype as a string for tensor descriptors."""
-        import torch
-        dtype_map = {
-            torch.float16: "float16",
-            torch.bfloat16: "bfloat16",
-            torch.float32: "float32",
-            torch.float64: "float64",
-            torch.int8: "int8",
-            torch.uint8: "uint8",
-        }
-        if hasattr(torch, "float8_e4m3fn"):
-            dtype_map[torch.float8_e4m3fn] = "float8_e4m3fn"
-        if hasattr(torch, "float8_e5m2"):
-            dtype_map[torch.float8_e5m2] = "float8_e5m2"
-        return dtype_map.get(self.model_config.dtype, str(self.model_config.dtype))
+        try:
+            logger.info(
+                "ModelExpress source: publishing metadata for model=%s, "
+                "tp_rank=%d, session=%s, %d tensors",
+                model_name, self.tp_rank, session_id, len(tensors),
+            )
+            mx_client.publish_metadata(model_name, [worker])
+            mx_client.publish_ready(
+                model_name,
+                worker_id=self.tp_rank,
+                session_id=mx_client.session_id,
+                metadata_hash="",
+            )
+            logger.info(
+                "ModelExpress source: published ready for model=%s, tp_rank=%d",
+                model_name, self.tp_rank,
+            )
+        finally:
+            mx_client.close()
 
     def model_specific_adjustment(self):
         server_args = self.server_args

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -677,6 +677,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"{local_ip}:{self.remote_instance_transfer_engine.get_rpc_port()}"
         )
 
+    @staticmethod
+    def _is_column_parallel(module):
+        from sglang.srt.layers.linear import ColumnParallelLinear
+        return isinstance(module, ColumnParallelLinear)
+
+    @staticmethod
+    def _is_row_parallel(module):
+        from sglang.srt.layers.linear import RowParallelLinear
+        return isinstance(module, RowParallelLinear)
+
     def _publish_model_express_metadata(self):
         """Publish TransferEngine metadata to ModelExpress server (seed mode)."""
         from modelexpress.client import MxClient
@@ -697,14 +707,89 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
-        # Build tensor descriptors from weight_info dict
+        # Build param-to-module map for shard metadata extraction
+        param_to_module = {}
+        for module_name, module in self.model.named_modules():
+            for param_name, _ in module.named_parameters(recurse=False):
+                full_name = f"{module_name}.{param_name}" if module_name else param_name
+                param_to_module[full_name] = module
+
+        # Build name-to-param map for attribute lookup
+        named_params = dict(self.model.named_parameters())
+
+        # Build tensor descriptors with shard metadata for mixed-TP support
         tensors = []
         for name, (addr, numel, element_size) in weight_info.items():
+            # Determine shard_dim from parameter attributes
+            # set_weight_attrs() in linear.py attaches output_dim/input_dim to the param
+            param = named_params.get(name)
+            output_dim = getattr(param, "output_dim", None) if param is not None else None
+            input_dim = getattr(param, "input_dim", None) if param is not None else None
+
+            # Infer shard_dim from param attrs first, then fall back to module type.
+            # FP8 quant creates weights without output_dim/input_dim attrs.
+            # For column-parallel modules: .weight and .weight_scale are both
+            # sharded on dim 0 (per-channel scales follow output dim).
+            # For row-parallel modules: .weight is sharded on dim 1,
+            # but .weight_scale is replicated (full output dim).
+            module = param_to_module.get(name)
+            if output_dim is not None:
+                shard_dim = output_dim
+            elif input_dim is not None:
+                shard_dim = input_dim
+            elif module is not None and self._is_column_parallel(module) and (
+                name.endswith(".weight") or name.endswith(".weight_scale")
+            ):
+                shard_dim = 0
+            elif name.endswith(".weight") and module is not None and self._is_row_parallel(module):
+                shard_dim = 1
+            else:
+                shard_dim = -1  # replicated
+
+            # Get effective TP from parent module
+            effective_tp = 1
+            shard_index = 0
+            if shard_dim >= 0 and module is not None:
+                effective_tp = getattr(module, "tp_size", 1)
+                shard_index = getattr(module, "tp_rank", self.tp_rank)
+
+            # Compute full unsharded shape based on contiguous storage layout.
+            # FP8 process_weights_after_loading applies .t() which creates a
+            # non-contiguous view. RDMA reads from the underlying contiguous
+            # storage, so full_shape must reflect the storage layout.
+            full_shape = []
+            local_shape = []
+            if param is not None:
+                if param.is_contiguous():
+                    local_shape = list(param.shape)
+                else:
+                    # Non-contiguous (e.g., .t() view): use the contiguous
+                    # storage shape (reversed dims for a simple transpose)
+                    local_shape = list(param.shape)[::-1]
+                full_shape = list(local_shape)
+                if shard_dim >= 0 and shard_dim < len(full_shape):
+                    full_shape[shard_dim] *= effective_tp
+
+            # Debug: log first layer tensors with their shard info
+            if "layers.0." in name:
+                mod_type = type(module).__name__ if module else "None"
+                p_contig = param.is_contiguous() if param is not None else True
+                logger.info(
+                    "MX shard debug: %s -> shard_dim=%d, full=%s, storage=%s, "
+                    "contig=%s, module=%s",
+                    name, shard_dim, full_shape, local_shape,
+                    p_contig, mod_type,
+                )
+
             tensors.append(p2p_pb2.TensorDescriptor(
                 name=name,
                 addr=addr,
                 size=numel * element_size,
                 device_id=self.gpu_id,
+                full_shape=full_shape,
+                shard_dim=shard_dim,
+                effective_tp_size=effective_tp,
+                shard_index=shard_index,
             ))
 
         worker = p2p_pb2.WorkerMetadata(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2067,29 +2067,6 @@ class GGUFModelLoader(BaseModelLoader):
         return model
 
 
-_DTYPE_ELEMENT_SIZES = {
-    "float16": 2, "half": 2,
-    "bfloat16": 2,
-    "float32": 4, "float": 4,
-    "float64": 8, "double": 8,
-    "int8": 1,
-    "int16": 2,
-    "int32": 4,
-    "int64": 8,
-    "uint8": 1,
-    "float8_e4m3fn": 1,
-    "float8_e5m2": 1,
-}
-
-
-def _dtype_to_element_size(dtype_str: str) -> int:
-    """Convert dtype string to element size in bytes."""
-    size = _DTYPE_ELEMENT_SIZES.get(dtype_str)
-    if size is None:
-        raise ValueError(f"Unknown dtype: {dtype_str}")
-    return size
-
-
 class RemoteInstanceModelLoader(BaseModelLoader):
     """Model loader that can load Tensors from remote sglang instance."""
 

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2291,57 +2291,58 @@ class RemoteInstanceModelLoader(BaseModelLoader):
 
         # Wait for seed to be ready via ModelExpress
         mx_client = MxClient(server_url=load_config.model_express_url)
-        logger.info(
-            "ModelExpress: waiting for seed ready (model=%s, worker=%d)...",
-            model_name, tp_rank,
-        )
-        ready, session_id, metadata_hash = mx_client.wait_for_ready(
-            model_name, worker_id=tp_rank,
-        )
-        if not ready:
-            raise RuntimeError(
-                f"ModelExpress: timed out waiting for seed ready "
-                f"(model={model_name}, worker={tp_rank})"
+        try:
+            logger.info(
+                "ModelExpress: waiting for seed ready (model=%s)...",
+                model_name,
             )
-
-        # Get source metadata from ModelExpress
-        response = mx_client.get_metadata(model_name)
-        if not response.found:
-            raise RuntimeError(
-                f"ModelExpress: no metadata found for model={model_name}"
+            ready, session_id, metadata_hash = mx_client.wait_for_ready(
+                model_name, worker_id=tp_rank,
             )
+            if not ready:
+                raise RuntimeError(
+                    f"ModelExpress: timed out waiting for seed ready "
+                    f"(model={model_name}, worker={tp_rank})"
+                )
 
-        # Find the worker matching our tp_rank
-        source_worker = None
-        for w in response.workers:
-            if w.worker_rank == tp_rank:
-                source_worker = w
-                break
-        if source_worker is None:
-            raise RuntimeError(
-                f"ModelExpress: no worker metadata for rank={tp_rank}"
+            response = mx_client.get_metadata(model_name)
+            if not response.found:
+                raise RuntimeError(
+                    f"ModelExpress: no metadata found for model={model_name}"
+                )
+
+            # Find the worker matching our tp_rank
+            source_worker = None
+            for w in response.workers:
+                if w.worker_rank == tp_rank:
+                    source_worker = w
+                    break
+            if source_worker is None:
+                raise RuntimeError(
+                    f"ModelExpress: no worker metadata for rank={tp_rank}"
+                )
+
+            # Extract session_id from oneof backend_metadata
+            backend_field = source_worker.WhichOneof("backend_metadata")
+            if backend_field == "transfer_engine_session_id":
+                seed_session_id = source_worker.transfer_engine_session_id
+            else:
+                raise RuntimeError(
+                    f"ModelExpress: expected transfer_engine_session_id, "
+                    f"got backend_metadata={backend_field}"
+                )
+
+            # Build {name: (addr, size_bytes)} from seed tensor descriptors
+            seed_weight_info = {}
+            for td in source_worker.tensors:
+                seed_weight_info[td.name] = (td.addr, td.size)
+
+            logger.info(
+                "ModelExpress: got %d tensor descriptors from seed (session=%s)",
+                len(seed_weight_info), seed_session_id,
             )
-
-        # Extract session_id from oneof backend_metadata
-        backend_field = source_worker.WhichOneof("backend_metadata")
-        if backend_field == "transfer_engine_session_id":
-            seed_session_id = source_worker.transfer_engine_session_id
-        else:
-            raise RuntimeError(
-                f"ModelExpress: expected transfer_engine_session_id, "
-                f"got backend_metadata={backend_field}"
-            )
-
-        # Convert tensor descriptors to {name: (addr, size_bytes)} format
-        # Use raw byte sizes -- RDMA is a memcpy, dtype matching is not required
-        seed_weight_info = {}
-        for td in source_worker.tensors:
-            seed_weight_info[td.name] = (td.addr, td.size)
-
-        logger.info(
-            "ModelExpress: got %d tensor descriptors from seed (session=%s)",
-            len(seed_weight_info), seed_session_id,
-        )
+        finally:
+            mx_client.close()
 
         # Transfer weights via TransferEngine RDMA
         seed_ptr_list = []
@@ -2384,7 +2385,6 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             model.post_load_weights()
 
         logger.info("ModelExpress: weight transfer complete for tp_rank=%d", tp_rank)
-        mx_client.close()
 
 
 class RemoteModelLoader(BaseModelLoader):

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2067,6 +2067,29 @@ class GGUFModelLoader(BaseModelLoader):
         return model
 
 
+_DTYPE_ELEMENT_SIZES = {
+    "float16": 2, "half": 2,
+    "bfloat16": 2,
+    "float32": 4, "float": 4,
+    "float64": 8, "double": 8,
+    "int8": 1,
+    "int16": 2,
+    "int32": 4,
+    "int64": 8,
+    "uint8": 1,
+    "float8_e4m3fn": 1,
+    "float8_e5m2": 1,
+}
+
+
+def _dtype_to_element_size(dtype_str: str) -> int:
+    """Convert dtype string to element size in bytes."""
+    size = _DTYPE_ELEMENT_SIZES.get(dtype_str)
+    if size is None:
+        raise ValueError(f"Unknown dtype: {dtype_str}")
+    return size
+
+
 class RemoteInstanceModelLoader(BaseModelLoader):
     """Model loader that can load Tensors from remote sglang instance."""
 
@@ -2148,6 +2171,13 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                 raise RuntimeError(
                     "Failed to load weights from remote instance via transfer engine."
                 )
+        elif (
+            load_config.remote_instance_weight_loader_backend
+            == RemoteInstanceWeightLoaderBackend.MODEL_EXPRESS
+        ):
+            self.load_model_from_model_express(
+                model, load_config, device_config,
+            )
         else:
             raise ValueError("Invalid remote instance weight loader backend.")
 
@@ -2260,6 +2290,124 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             model.post_load_weights()
 
         return True
+
+    def load_model_from_model_express(
+        self, model, load_config: LoadConfig, device_config: DeviceConfig,
+    ):
+        """Load weights via ModelExpress coordination + TransferEngine RDMA."""
+        from modelexpress.client import MxClient
+
+        transfer_engine = load_config.remote_instance_weight_loader_transfer_engine
+        if transfer_engine is None:
+            raise RuntimeError(
+                "TransferEngine is not initialized for model_express backend."
+            )
+        tp_rank = load_config.tp_rank
+        model_name = load_config.model_express_model_name
+
+        logger.info(
+            "ModelExpress: registering memory regions for tp_rank=%d...", tp_rank
+        )
+        self.remote_instance_transfer_engine_weight_info = register_memory_region(
+            model, transfer_engine
+        )
+
+        # Wait for seed to be ready via ModelExpress
+        mx_client = MxClient(server_url=load_config.model_express_url)
+        logger.info(
+            "ModelExpress: waiting for seed ready (model=%s, worker=%d)...",
+            model_name, tp_rank,
+        )
+        ready, session_id, metadata_hash = mx_client.wait_for_ready(
+            model_name, worker_id=tp_rank,
+        )
+        if not ready:
+            raise RuntimeError(
+                f"ModelExpress: timed out waiting for seed ready "
+                f"(model={model_name}, worker={tp_rank})"
+            )
+
+        # Get source metadata from ModelExpress
+        response = mx_client.get_metadata(model_name)
+        if not response.found:
+            raise RuntimeError(
+                f"ModelExpress: no metadata found for model={model_name}"
+            )
+
+        # Find the worker matching our tp_rank
+        source_worker = None
+        for w in response.workers:
+            if w.worker_rank == tp_rank:
+                source_worker = w
+                break
+        if source_worker is None:
+            raise RuntimeError(
+                f"ModelExpress: no worker metadata for rank={tp_rank}"
+            )
+
+        # Extract session_id from oneof backend_metadata
+        backend_field = source_worker.WhichOneof("backend_metadata")
+        if backend_field == "transfer_engine_session_id":
+            seed_session_id = source_worker.transfer_engine_session_id
+        else:
+            raise RuntimeError(
+                f"ModelExpress: expected transfer_engine_session_id, "
+                f"got backend_metadata={backend_field}"
+            )
+
+        # Convert tensor descriptors to {name: (addr, size_bytes)} format
+        # Use raw byte sizes -- RDMA is a memcpy, dtype matching is not required
+        seed_weight_info = {}
+        for td in source_worker.tensors:
+            seed_weight_info[td.name] = (td.addr, td.size)
+
+        logger.info(
+            "ModelExpress: got %d tensor descriptors from seed (session=%s)",
+            len(seed_weight_info), seed_session_id,
+        )
+
+        # Transfer weights via TransferEngine RDMA
+        seed_ptr_list = []
+        client_ptr_list = []
+        client_len_list = []
+        for name, tensor in model.named_parameters():
+            weight_info = seed_weight_info.get(name, None)
+            if weight_info is None:
+                raise RuntimeError(
+                    f"ModelExpress: cannot find weight info for {name} "
+                    f"in seed metadata"
+                )
+            seed_ptr, seed_size = weight_info
+            local_size = tensor.numel() * tensor.element_size()
+            if seed_size != local_size:
+                raise RuntimeError(
+                    f"ModelExpress: size mismatch for {name}: "
+                    f"seed={seed_size} bytes, local={local_size} bytes"
+                )
+            seed_ptr_list.append(seed_ptr)
+            client_ptr_list.append(tensor.data_ptr())
+            client_len_list.append(local_size)
+
+        logger.info(
+            "ModelExpress: starting RDMA transfer of %d tensors...",
+            len(seed_ptr_list),
+        )
+        ret = transfer_engine.batch_transfer_sync_read(
+            seed_session_id,
+            client_ptr_list,
+            seed_ptr_list,
+            client_len_list,
+        )
+        if ret < 0:
+            raise RuntimeError(
+                f"ModelExpress: batch_transfer_sync_read failed, error={ret}"
+            )
+
+        if hasattr(model, "post_load_weights"):
+            model.post_load_weights()
+
+        logger.info("ModelExpress: weight transfer complete for tp_rank=%d", tp_rank)
+        mx_client.close()
 
 
 class RemoteModelLoader(BaseModelLoader):

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2427,7 +2427,10 @@ def _compute_transfer_plan(model, source_index, tp_rank, tp_size):
         src_eff_tp = td0.effective_tp_size
 
         # Case 2: Replicated tensor (norms, biases, scales, etc.)
-        if shard_dim == -1 or src_eff_tp <= 1:
+        # Note: src_eff_tp <= 1 alone does NOT mean replicated. Source TP=1
+        # has unsharded weights, but if target TP > 1 and shard_dim >= 0,
+        # we still need the overlap algorithm to extract the correct slice.
+        if shard_dim == -1:
             src_rank = min(src_tensors.keys())
             src_td = src_tensors[src_rank]
             if src_td.size != local_size:

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2153,7 +2153,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             == RemoteInstanceWeightLoaderBackend.MODEL_EXPRESS
         ):
             self.load_model_from_model_express(
-                model, load_config, device_config,
+                model, load_config, device_config, model_config,
             )
         else:
             raise ValueError("Invalid remote instance weight loader backend.")
@@ -2270,8 +2270,15 @@ class RemoteInstanceModelLoader(BaseModelLoader):
 
     def load_model_from_model_express(
         self, model, load_config: LoadConfig, device_config: DeviceConfig,
+        model_config=None,
     ):
-        """Load weights via ModelExpress coordination + TransferEngine RDMA."""
+        """Load weights via ModelExpress coordination + TransferEngine RDMA.
+
+        Supports mixed tensor-parallelism: source TP != target TP.
+        All tensors are transferred via RDMA (NVLink intra-node or IB).
+        """
+        from collections import defaultdict
+
         from modelexpress.client import MxClient
 
         transfer_engine = load_config.remote_instance_weight_loader_transfer_engine
@@ -2280,6 +2287,7 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                 "TransferEngine is not initialized for model_express backend."
             )
         tp_rank = load_config.tp_rank
+        tp_size = get_tensor_model_parallel_world_size()
         model_name = load_config.model_express_model_name
 
         logger.info(
@@ -2289,102 +2297,391 @@ class RemoteInstanceModelLoader(BaseModelLoader):
             model, transfer_engine
         )
 
-        # Wait for seed to be ready via ModelExpress
+        # Wait for seed rank 0 to be ready, then fetch all workers
         mx_client = MxClient(server_url=load_config.model_express_url)
         try:
             logger.info(
                 "ModelExpress: waiting for seed ready (model=%s)...",
                 model_name,
             )
-            ready, session_id, metadata_hash = mx_client.wait_for_ready(
-                model_name, worker_id=tp_rank,
-            )
+            ready, _, _ = mx_client.wait_for_ready(model_name, worker_id=0)
             if not ready:
                 raise RuntimeError(
                     f"ModelExpress: timed out waiting for seed ready "
-                    f"(model={model_name}, worker={tp_rank})"
+                    f"(model={model_name})"
                 )
 
+            # Get ALL source workers
             response = mx_client.get_metadata(model_name)
-            if not response.found:
+            if not response.found or len(response.workers) == 0:
                 raise RuntimeError(
                     f"ModelExpress: no metadata found for model={model_name}"
                 )
 
-            # Find the worker matching our tp_rank
-            source_worker = None
-            for w in response.workers:
-                if w.worker_rank == tp_rank:
-                    source_worker = w
-                    break
-            if source_worker is None:
-                raise RuntimeError(
-                    f"ModelExpress: no worker metadata for rank={tp_rank}"
-                )
-
-            # Extract session_id from oneof backend_metadata
-            backend_field = source_worker.WhichOneof("backend_metadata")
-            if backend_field == "transfer_engine_session_id":
-                seed_session_id = source_worker.transfer_engine_session_id
-            else:
-                raise RuntimeError(
-                    f"ModelExpress: expected transfer_engine_session_id, "
-                    f"got backend_metadata={backend_field}"
-                )
-
-            # Build {name: (addr, size_bytes)} from seed tensor descriptors
-            seed_weight_info = {}
-            for td in source_worker.tensors:
-                seed_weight_info[td.name] = (td.addr, td.size)
-
             logger.info(
-                "ModelExpress: got %d tensor descriptors from seed (session=%s)",
-                len(seed_weight_info), seed_session_id,
+                "ModelExpress: got %d source workers", len(response.workers)
             )
+
+            # Build source index: {tensor_name: {src_rank: TensorDescriptor}}
+            source_index = defaultdict(dict)
+            rank_to_session = {}
+            for w in response.workers:
+                backend_field = w.WhichOneof("backend_metadata")
+                if backend_field == "transfer_engine_session_id":
+                    rank_to_session[w.worker_rank] = w.transfer_engine_session_id
+                for td in w.tensors:
+                    source_index[td.name][w.worker_rank] = td
         finally:
             mx_client.close()
 
-        # Transfer weights via TransferEngine RDMA
-        seed_ptr_list = []
-        client_ptr_list = []
-        client_len_list = []
-        for name, tensor in model.named_parameters():
-            weight_info = seed_weight_info.get(name, None)
-            if weight_info is None:
-                raise RuntimeError(
-                    f"ModelExpress: cannot find weight info for {name} "
-                    f"in seed metadata"
-                )
-            seed_ptr, seed_size = weight_info
-            local_size = tensor.numel() * tensor.element_size()
-            if seed_size != local_size:
-                raise RuntimeError(
-                    f"ModelExpress: size mismatch for {name}: "
-                    f"seed={seed_size} bytes, local={local_size} bytes"
-                )
-            seed_ptr_list.append(seed_ptr)
-            client_ptr_list.append(tensor.data_ptr())
-            client_len_list.append(local_size)
+        ops, dim1_fixups = _compute_transfer_plan(
+            model, source_index, tp_rank, tp_size
+        )
 
         logger.info(
-            "ModelExpress: starting RDMA transfer of %d tensors...",
-            len(seed_ptr_list),
+            "ModelExpress: transfer plan: %d RDMA ops, %d dim1 fixups",
+            len(ops), len(dim1_fixups),
         )
-        ret = transfer_engine.batch_transfer_sync_read(
-            seed_session_id,
-            client_ptr_list,
-            seed_ptr_list,
-            client_len_list,
-        )
-        if ret < 0:
-            raise RuntimeError(
-                f"ModelExpress: batch_transfer_sync_read failed, error={ret}"
-            )
 
+        # Execute RDMA
+        _execute_transfer_plan(transfer_engine, ops, rank_to_session)
+
+        # For params sharded on inner dimension, apply GPU-side column slicing
+        _apply_dim1_fixups(dim1_fixups)
+
+        # Fix weight_scale: fill all elements with max(scale) so that
+        # requantize_with_max_scale() becomes an identity operation.
+        # The seed's weights are already requantized with the global max scale,
+        # so setting all weight_scale elements to max makes requant a no-op.
+        for module_name, module in model.named_modules():
+            weight_scale = getattr(module, "weight_scale", None)
+            if weight_scale is not None and isinstance(weight_scale, torch.nn.Parameter):
+                if weight_scale.numel() > 1:
+                    max_val = weight_scale.data.max()
+                    weight_scale.data.fill_(max_val)
+
+        # Run process_weights_after_loading on each quantized module.
+        # This handles: transpose FP8 weights, requantize with max scale
+        # (identity since all weight_scale elements are max),
+        # and convert scales to per-channel format.
+        for module_name, module in model.named_modules():
+            quant_method = getattr(module, "quant_method", None)
+            if quant_method is not None:
+                quant_method.process_weights_after_loading(module)
+        # Also call model-level post_load_weights if it exists (e.g., DeepSeek)
         if hasattr(model, "post_load_weights"):
             model.post_load_weights()
 
         logger.info("ModelExpress: weight transfer complete for tp_rank=%d", tp_rank)
+
+
+def _compute_transfer_plan(model, source_index, tp_rank, tp_size):
+    """Compute RDMA transfer ops for mixed tensor-parallelism.
+
+    For each local parameter, determines which byte ranges to read from which
+    source ranks. Returns (ops, dim1_fixups) where:
+      - ops: list of (src_rank, src_addr, src_offset, dst_addr, dst_offset, length, param_name)
+      - dim1_fixups: list of dicts for params sharded on dim 1 (inner dimension)
+        that need post-transfer GPU-side column slicing.
+
+    Four cases:
+    1. Legacy (no shard metadata): 1:1 rank match
+    2. Replicated (shard_dim == -1): read from any one source rank
+    3. Dim-0 sharded: byte-range overlap algorithm (contiguous row slicing)
+    4. Dim-1 sharded: transfer full source shard + GPU-side column slice
+    """
+    param_to_module = {}
+    for module_name, module in model.named_modules():
+        for param_name, _ in module.named_parameters(recurse=False):
+            full_name = f"{module_name}.{param_name}" if module_name else param_name
+            param_to_module[full_name] = module
+
+    ops = []
+    dim1_fixups = []
+
+    for name, param in model.named_parameters():
+        if name not in source_index:
+            raise RuntimeError(f"ModelExpress: {name} not found in source metadata")
+
+        src_tensors = source_index[name]
+        td0 = next(iter(src_tensors.values()))
+        local_size = param.numel() * param.element_size()
+        dst_addr = param.data_ptr()
+
+        # Case 1: Legacy (old source that didn't publish shard metadata)
+        if td0.effective_tp_size == 0:
+            if tp_rank not in src_tensors:
+                raise RuntimeError(
+                    f"ModelExpress: no source rank {tp_rank} for {name} (legacy mode)"
+                )
+            src_td = src_tensors[tp_rank]
+            if src_td.size != local_size:
+                raise RuntimeError(
+                    f"ModelExpress: size mismatch for {name}: "
+                    f"seed={src_td.size}, local={local_size}"
+                )
+            ops.append((tp_rank, src_td.addr, 0, dst_addr, 0, local_size, name))
+            continue
+
+        shard_dim = td0.shard_dim
+        src_eff_tp = td0.effective_tp_size
+
+        # Case 2: Replicated tensor (norms, biases, scales, etc.)
+        if shard_dim == -1 or src_eff_tp <= 1:
+            src_rank = min(src_tensors.keys())
+            src_td = src_tensors[src_rank]
+            if src_td.size != local_size:
+                new_data = torch.empty(
+                    src_td.size // param.element_size(),
+                    dtype=param.dtype,
+                    device=param.device,
+                )
+                param.data = new_data
+                dst_addr = new_data.data_ptr()
+                local_size = src_td.size
+                logger.info(
+                    "ModelExpress: reallocated %s to %d bytes (was %d)",
+                    name, src_td.size, param.numel() * param.element_size(),
+                )
+            ops.append((src_rank, src_td.addr, 0, dst_addr, 0, local_size, name))
+            continue
+
+        module = param_to_module.get(name)
+        tgt_eff_tp = getattr(module, "tp_size", tp_size) if module else tp_size
+        tgt_shard_index = getattr(module, "tp_rank", tp_rank) if module else tp_rank
+
+        full_dim = td0.full_shape[shard_dim]
+        src_shard = full_dim // src_eff_tp
+        tgt_shard = full_dim // tgt_eff_tp
+
+        # Bytes per unit along the shard dimension
+        stride = td0.size // src_shard if src_shard > 0 else 0
+
+        # Case 4: Inner-dimension sharding (shard_dim >= 1).
+        # Byte-range overlap only works on the outermost dimension (dim 0)
+        # because row-major storage stores inner dims contiguously per row.
+        # For dim-1 sharding: transfer full source shard to a temp buffer,
+        # then do a GPU-side column slice after all RDMA transfers complete.
+        if shard_dim >= 1 and len(td0.full_shape) >= 2:
+            non_shard_dim = td0.full_shape[0]  # rows (not sharded)
+            src_cols = src_shard  # columns per source rank
+            tgt_cols = tgt_shard  # columns target needs
+
+            tgt_global_start = tgt_shard_index * tgt_cols
+            tgt_global_end = tgt_global_start + tgt_cols
+
+            for src_rank in sorted(src_tensors.keys()):
+                src_td = src_tensors[src_rank]
+                src_global_start = src_td.shard_index * src_cols
+                src_global_end = src_global_start + src_cols
+
+                ov_start = max(tgt_global_start, src_global_start)
+                ov_end = min(tgt_global_end, src_global_end)
+
+                if ov_start < ov_end:
+                    # Allocate temp buffer for full source shard
+                    temp = torch.empty(
+                        src_td.size, dtype=torch.uint8, device=param.device,
+                    )
+                    ops.append((
+                        src_rank, src_td.addr, 0,
+                        temp.data_ptr(), 0, src_td.size, name,
+                    ))
+                    dim1_fixups.append({
+                        "param": param,
+                        "name": name,
+                        "temp": temp,
+                        "src_shape": [non_shard_dim, src_cols],
+                        "src_col_start": ov_start - src_global_start,
+                        "src_col_end": ov_end - src_global_start,
+                        "dst_col_start": ov_start - tgt_global_start,
+                        "dst_shape": [non_shard_dim, tgt_cols],
+                        "dtype": param.dtype,
+                        "elem_size": param.element_size(),
+                    })
+            continue
+
+        # Case 3: Outer-dimension sharding (shard_dim == 0).
+        # Byte-range overlap works directly on contiguous row ranges.
+        expected_size = tgt_shard * stride
+        if local_size != expected_size:
+            new_data = torch.empty(
+                expected_size // param.element_size(),
+                dtype=param.dtype,
+                device=param.device,
+            )
+            param.data = new_data
+            dst_addr = new_data.data_ptr()
+            local_size = expected_size
+            logger.info(
+                "ModelExpress: reallocated sharded %s to %d bytes (was %d)",
+                name, expected_size, param.numel() * param.element_size(),
+            )
+
+        # Merged column-parallel layers (QKV, gate_up) pack multiple
+        # sub-tensors along dim 0. Each sub-tensor must be overlapped
+        # independently because the physical layout is [sub0_local,
+        # sub1_local, ...] not a contiguous slice of the full dim.
+        output_sizes = getattr(module, "output_sizes", None) if module else None
+        if output_sizes is not None:
+            src_sub_offset = 0
+            dst_sub_offset = 0
+            for sub_full in output_sizes:
+                sub_src_shard = sub_full // src_eff_tp
+                sub_tgt_shard = sub_full // tgt_eff_tp
+
+                sub_tgt_start = tgt_shard_index * sub_tgt_shard
+                sub_tgt_end = sub_tgt_start + sub_tgt_shard
+
+                for src_rank in sorted(src_tensors.keys()):
+                    src_td = src_tensors[src_rank]
+                    sub_src_start = src_td.shard_index * sub_src_shard
+                    sub_src_end = sub_src_start + sub_src_shard
+
+                    ov_start = max(sub_tgt_start, sub_src_start)
+                    ov_end = min(sub_tgt_end, sub_src_end)
+
+                    if ov_start < ov_end:
+                        src_byte_off = (
+                            src_sub_offset + (ov_start - sub_src_start)
+                        ) * stride
+                        dst_byte_off = (
+                            dst_sub_offset + (ov_start - sub_tgt_start)
+                        ) * stride
+                        length = (ov_end - ov_start) * stride
+
+                        ops.append((
+                            src_rank, src_td.addr, src_byte_off,
+                            dst_addr, dst_byte_off, length, name,
+                        ))
+
+                src_sub_offset += sub_src_shard
+                dst_sub_offset += sub_tgt_shard
+        else:
+            # Simple (non-merged) dim-0 overlap
+            tgt_start = tgt_shard_index * tgt_shard
+            tgt_end = tgt_start + tgt_shard
+
+            for src_rank in sorted(src_tensors.keys()):
+                src_td = src_tensors[src_rank]
+                src_start = src_td.shard_index * src_shard
+                src_end = src_start + src_shard
+
+                ov_start = max(tgt_start, src_start)
+                ov_end = min(tgt_end, src_end)
+
+                if ov_start < ov_end:
+                    src_byte_off = (ov_start - src_start) * stride
+                    dst_byte_off = (ov_start - tgt_start) * stride
+                    length = (ov_end - ov_start) * stride
+
+                    ops.append((
+                        src_rank, src_td.addr, src_byte_off,
+                        dst_addr, dst_byte_off, length, name,
+                    ))
+
+    return ops, dim1_fixups
+
+
+def _apply_dim1_fixups(fixups):
+    """Apply GPU-side column slicing for params sharded on the inner dimension.
+
+    For shard_dim >= 1, RDMA transfers full source shards into temp buffers.
+    This function slices out the needed column ranges and copies them into
+    the target param storage.
+    """
+    if not fixups:
+        return
+
+    # Group fixups by param name to handle multi-source concatenation
+    from collections import defaultdict
+
+    by_param = defaultdict(list)
+    for f in fixups:
+        by_param[f["name"]].append(f)
+
+    for name, param_fixups in by_param.items():
+        param = param_fixups[0]["param"]
+        dst_shape = param_fixups[0]["dst_shape"]
+        elem_size = param_fixups[0]["elem_size"]
+        dtype = param_fixups[0]["dtype"]
+        rows = dst_shape[0]
+        tgt_cols = dst_shape[1]
+
+        # Ensure target param has the correct size
+        expected_elems = rows * tgt_cols
+        if param.numel() != expected_elems:
+            new_data = torch.empty(
+                expected_elems, dtype=dtype, device=param.device,
+            )
+            param.data = new_data
+
+        dst = param.data.reshape(rows, tgt_cols)
+
+        for f in param_fixups:
+            src_shape = f["src_shape"]
+            src_cols = src_shape[1]
+            num_src_bytes = src_shape[0] * src_cols * elem_size
+
+            src_tensor = f["temp"][:num_src_bytes].view(dtype).reshape(
+                src_shape[0], src_cols
+            )
+            sliced = src_tensor[:, f["src_col_start"] : f["src_col_end"]]
+            ncols = f["src_col_end"] - f["src_col_start"]
+            dst_start = f["dst_col_start"]
+            dst[:, dst_start : dst_start + ncols] = sliced
+
+    logger.info(
+        "ModelExpress: applied %d dim-1 fixups for %d params",
+        len(fixups),
+        len(by_param),
+    )
+
+
+def _execute_transfer_plan(transfer_engine, ops, rank_to_session):
+    """Execute RDMA transfer ops grouped by source rank.
+
+    Only receives large ops (>= 1MB). Small ops are loaded from disk.
+    """
+    from collections import defaultdict
+
+    if not ops:
+        return
+
+    by_rank = defaultdict(list)
+    for op in ops:
+        by_rank[op[0]].append(op)
+
+    total_bytes = sum(op[5] for op in ops)
+    logger.info(
+        "ModelExpress: RDMA %d ops, %.2f GB across %d source ranks",
+        len(ops), total_bytes / 1e9, len(by_rank),
+    )
+
+    for src_rank in sorted(by_rank.keys()):
+        rank_ops = by_rank[src_rank]
+        session_id = rank_to_session.get(src_rank)
+        if session_id is None:
+            raise RuntimeError(
+                f"ModelExpress: no TransferEngine session for source rank {src_rank}"
+            )
+
+        rank_bytes = sum(op[5] for op in rank_ops)
+        logger.info(
+            "ModelExpress: rank %d: %d ops (%.2f GB) session=%s",
+            src_rank, len(rank_ops), rank_bytes / 1e9, session_id,
+        )
+
+        src_ptrs = [op[1] + op[2] for op in rank_ops]
+        dst_ptrs = [op[3] + op[4] for op in rank_ops]
+        lengths = [op[5] for op in rank_ops]
+        ret = transfer_engine.batch_transfer_sync_read(
+            session_id, dst_ptrs, src_ptrs, lengths,
+        )
+        if ret < 0:
+            raise RuntimeError(
+                f"ModelExpress: batch transfer from rank {src_rank} failed, error={ret}"
+            )
 
 
 class RemoteModelLoader(BaseModelLoader):
@@ -2848,6 +3145,11 @@ def get_model_loader(
     if load_config.load_format == LoadFormat.DUMMY:
         return DummyModelLoader(load_config)
 
+    # Remote instance loading takes priority -- weights arrive pre-quantized
+    # via RDMA, so no quantization-specific loader is needed.
+    if load_config.load_format == LoadFormat.REMOTE_INSTANCE:
+        return RemoteInstanceModelLoader(load_config)
+
     if model_config and (
         (hasattr(model_config, "modelopt_quant") and model_config.modelopt_quant)
         or model_config.quantization in ["modelopt_fp8", "modelopt_fp4", "modelopt"]
@@ -2909,9 +3211,6 @@ def get_model_loader(
 
     if load_config.load_format == LoadFormat.REMOTE:
         return RemoteModelLoader(load_config)
-
-    if load_config.load_format == LoadFormat.REMOTE_INSTANCE:
-        return RemoteInstanceModelLoader(load_config)
 
     if load_config.load_format == LoadFormat.PRIVATE:
         import importlib

--- a/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
+++ b/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
@@ -122,10 +122,10 @@ def parse_remote_instance_transfer_engine_info_from_scheduler_infos(scheduler_in
 
 
 def register_memory_region(model, transfer_engine):
-    if importlib.util.find_spec("torch") is None:
-        return register_memory_region_v1(model, transfer_engine)
-    else:
-        return register_memory_region_v2(model, transfer_engine)
+    # Always use v1 (per-param registration) for correctness.
+    # v2's block-merging approach has issues with small tensors
+    # that are sub-allocated within CUDA blocks.
+    return register_memory_region_v1(model, transfer_engine)
 
 
 def register_memory_region_v1(model, transfer_engine):
@@ -156,17 +156,50 @@ def register_memory_region_v2(model, transfer_engine):
 
     weight_mr_dict = {}
     weight_addr_set = set()
+    weight_ranges = []
     for name, weight in model.named_parameters():
-        weight_mr_dict[name] = (
-            weight.data_ptr(),
-            weight.numel(),
-            weight.element_size(),
-        )
-        weight_addr_set.add(weight.data_ptr())
+        ptr = weight.data_ptr()
+        nbytes = weight.numel() * weight.element_size()
+        weight_mr_dict[name] = (ptr, weight.numel(), weight.element_size())
+        weight_addr_set.add(ptr)
+        weight_ranges.append((ptr, ptr + nbytes))
 
     import torch
 
     memory_snapshot = torch.cuda.memory.memory_snapshot()
+
+    # Collect all active_allocated blocks with their addresses
+    all_blocks = []
+    for segment in memory_snapshot:
+        for block in segment.get("blocks", []):
+            address = block.get("address", -1)
+            size = block.get("size", -1)
+            state = block.get("state", "")
+            if address >= 0 and size > 0 and state == "active_allocated":
+                all_blocks.append((address, size))
+
+    # Build set of block addresses that contain at least one weight.
+    # First try exact match (fast), then check range containment.
+    blocks_with_weights = set()
+    for addr, sz in all_blocks:
+        if addr in weight_addr_set:
+            blocks_with_weights.add(addr)
+
+    # For weights whose data_ptr doesn't match any block start,
+    # find the enclosing block via range check.
+    unmatched = [
+        (w_start, w_end) for w_start, w_end in weight_ranges
+        if w_start not in weight_addr_set or w_start not in blocks_with_weights
+    ]
+    if unmatched:
+        # Also check all weights that matched addr_set but might not be in blocks
+        # (shouldn't happen, but be safe)
+        for w_start, w_end in weight_ranges:
+            for b_addr, b_sz in all_blocks:
+                if b_addr <= w_start < b_addr + b_sz:
+                    blocks_with_weights.add(b_addr)
+                    break
+
     weight_blocks_for_reg_mr = []
     # Blocks in each segment have continuous physical addresses,
     # so they can be merged for memory registration.
@@ -179,23 +212,40 @@ def register_memory_region_v2(model, transfer_engine):
             state = block.get("state", "")
             if address < 0 or size < 0 or state == "":
                 continue
-            # Only register active allocated memory blocks that hold weights.
-            if state == "active_allocated":
-                if address in weight_addr_set:
-                    if current_weight_block is None:
-                        current_weight_block = (address, size)
-                    elif current_weight_block[0] + current_weight_block[1] == address:
-                        current_weight_block = (
-                            current_weight_block[0],
-                            current_weight_block[1] + size,
-                        )
-                    else:
-                        weight_blocks_for_reg_mr.append(current_weight_block)
-                        current_weight_block = (address, size)
+            if state == "active_allocated" and address in blocks_with_weights:
+                if current_weight_block is None:
+                    current_weight_block = (address, size)
+                elif current_weight_block[0] + current_weight_block[1] == address:
+                    current_weight_block = (
+                        current_weight_block[0],
+                        current_weight_block[1] + size,
+                    )
+                else:
+                    weight_blocks_for_reg_mr.append(current_weight_block)
+                    current_weight_block = (address, size)
         if current_weight_block is not None:
             weight_blocks_for_reg_mr.append(current_weight_block)
 
+    # Verify all weights are covered by a registered block
+    uncovered = []
+    for name, (ptr, numel, elem_size) in weight_mr_dict.items():
+        nbytes = numel * elem_size
+        covered = False
+        for b_addr, b_sz in weight_blocks_for_reg_mr:
+            if b_addr <= ptr and ptr + nbytes <= b_addr + b_sz:
+                covered = True
+                break
+        if not covered:
+            uncovered.append((name, ptr, nbytes))
+    if uncovered:
+        logger.warning(
+            "register_memory_region_v2: %d weights NOT covered by any block: %s",
+            len(uncovered),
+            [(n, hex(a), s) for n, a, s in uncovered[:5]],
+        )
+
     # Register merged memory blocks that hold weights.
+    total_reg_bytes = 0
     for weight_block in weight_blocks_for_reg_mr:
         address, size = weight_block
         ret = transfer_engine.register_memory(address, size)
@@ -203,7 +253,16 @@ def register_memory_region_v2(model, transfer_engine):
             raise RuntimeError(
                 f"register memory failed for weight block at address {address} with size {size}, error: {ret}"
             )
+        total_reg_bytes += size
 
     end_tic = time.time()
-    logger.debug(f"Register memory region v2 time: {(end_tic - start_tic):.4f}s")
+    logger.info(
+        "register_memory_region_v2: registered %d blocks (%d MB), "
+        "%d weights, %d uncovered, took %.2fs",
+        len(weight_blocks_for_reg_mr),
+        total_reg_bytes // (1024 * 1024),
+        len(weight_mr_dict),
+        len(uncovered),
+        end_tic - start_tic,
+    )
     return weight_mr_dict

--- a/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
+++ b/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 class RemoteInstanceWeightLoaderBackend(str, enum.Enum):
     NCCL = "nccl"
     TRANSFER_ENGINE = "transfer_engine"
+    MODEL_EXPRESS = "model_express"
 
 
 def trigger_init_weights_send_group_for_remote_instance_request(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -687,9 +687,7 @@ class ServerArgs:
     remote_instance_weight_loader_send_weights_group_ports: Optional[List[int]] = None
     remote_instance_weight_loader_backend: Literal["transfer_engine", "nccl", "model_express"] = "nccl"
     remote_instance_weight_loader_start_seed_via_transfer_engine: bool = False
-    model_express_url: Optional[str] = None
-    model_express_model_name: Optional[str] = None
-    model_express_source: bool = False
+    model_express_config: Optional[str] = None
 
     # For PD-Multiplexing
     enable_pdmux: bool = False
@@ -2720,10 +2718,10 @@ class ServerArgs:
 
         if self.load_format == "remote_instance":
             if self.remote_instance_weight_loader_backend == "model_express":
-                # ModelExpress backend: requires --model-express-url, not seed IP/port
+                # ModelExpress backend: requires url in --model-express-config
                 if self.model_express_url is None:
                     logger.warning(
-                        "Fallback load_format to 'auto' due to missing --model-express-url."
+                        "Fallback load_format to 'auto' due to missing 'url' in --model-express-config."
                     )
                     self.load_format = "auto"
                 elif not self.validate_transfer_engine():
@@ -5239,21 +5237,10 @@ class ServerArgs:
             help="Start seed server via transfer engine backend for remote instance weight loader.",
         )
         parser.add_argument(
-            "--model-express-url",
+            "--model-express-config",
             type=str,
-            default=ServerArgs.model_express_url,
-            help="The URL of the ModelExpress gRPC server (host:port).",
-        )
-        parser.add_argument(
-            "--model-express-model-name",
-            type=str,
-            default=ServerArgs.model_express_model_name,
-            help="The model name to use for ModelExpress metadata coordination.",
-        )
-        parser.add_argument(
-            "--model-express-source",
-            action="store_true",
-            help="Run as a ModelExpress seed source: publish transfer metadata to the ModelExpress server after loading weights.",
+            default=ServerArgs.model_express_config,
+            help='JSON config for ModelExpress P2P weight loading. Keys: "url" (required, gRPC host:port), "model_name" (optional, defaults to --model-path), "source" (optional bool, true for seed mode). Example: \'{"url": "localhost:8001", "model_name": "my-model", "source": true}\'',
         )
 
         # For PD-Multiplexing
@@ -5818,6 +5805,32 @@ class ServerArgs:
             return False
         else:
             return True
+
+    @property
+    def _parsed_model_express_config(self) -> dict:
+        cache = getattr(self, "_mx_config_cache", None)
+        if cache is not None:
+            return cache
+        if self.model_express_config is None:
+            result = {}
+        elif isinstance(self.model_express_config, str):
+            result = json.loads(self.model_express_config)
+        else:
+            result = self.model_express_config
+        object.__setattr__(self, "_mx_config_cache", result)
+        return result
+
+    @property
+    def model_express_url(self) -> Optional[str]:
+        return self._parsed_model_express_config.get("url")
+
+    @property
+    def model_express_model_name(self) -> Optional[str]:
+        return self._parsed_model_express_config.get("model_name")
+
+    @property
+    def model_express_source(self) -> bool:
+        return self._parsed_model_express_config.get("source", False)
 
     def remote_instance_weight_loader_use_transfer_engine(self):
         # Use TransferEngine as seed backend.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -685,8 +685,11 @@ class ServerArgs:
     remote_instance_weight_loader_seed_instance_ip: Optional[str] = None
     remote_instance_weight_loader_seed_instance_service_port: Optional[int] = None
     remote_instance_weight_loader_send_weights_group_ports: Optional[List[int]] = None
-    remote_instance_weight_loader_backend: Literal["transfer_engine", "nccl"] = "nccl"
+    remote_instance_weight_loader_backend: Literal["transfer_engine", "nccl", "model_express"] = "nccl"
     remote_instance_weight_loader_start_seed_via_transfer_engine: bool = False
+    model_express_url: Optional[str] = None
+    model_express_model_name: Optional[str] = None
+    model_express_source: bool = False
 
     # For PD-Multiplexing
     enable_pdmux: bool = False
@@ -2716,7 +2719,19 @@ class ServerArgs:
             self.custom_weight_loader = []
 
         if self.load_format == "remote_instance":
-            if (
+            if self.remote_instance_weight_loader_backend == "model_express":
+                # ModelExpress backend: requires --model-express-url, not seed IP/port
+                if self.model_express_url is None:
+                    logger.warning(
+                        "Fallback load_format to 'auto' due to missing --model-express-url."
+                    )
+                    self.load_format = "auto"
+                elif not self.validate_transfer_engine():
+                    logger.warning(
+                        "Fallback load_format to 'auto' due to 'transfer_engine' (required by model_express) not being supported."
+                    )
+                    self.load_format = "auto"
+            elif (
                 self.remote_instance_weight_loader_seed_instance_ip is None
                 or self.remote_instance_weight_loader_seed_instance_service_port is None
             ):
@@ -5214,14 +5229,31 @@ class ServerArgs:
         parser.add_argument(
             "--remote-instance-weight-loader-backend",
             type=str,
-            choices=["transfer_engine", "nccl"],
+            choices=["transfer_engine", "nccl", "model_express"],
             default=ServerArgs.remote_instance_weight_loader_backend,
-            help="The backend for loading weights from remote instance. Can be 'transfer_engine' or 'nccl'. Default is 'nccl'.",
+            help="The backend for loading weights from remote instance. Can be 'transfer_engine', 'nccl', or 'model_express'. Default is 'nccl'.",
         )
         parser.add_argument(
             "--remote-instance-weight-loader-start-seed-via-transfer-engine",
             action="store_true",
             help="Start seed server via transfer engine backend for remote instance weight loader.",
+        )
+        parser.add_argument(
+            "--model-express-url",
+            type=str,
+            default=ServerArgs.model_express_url,
+            help="The URL of the ModelExpress gRPC server (host:port).",
+        )
+        parser.add_argument(
+            "--model-express-model-name",
+            type=str,
+            default=ServerArgs.model_express_model_name,
+            help="The model name to use for ModelExpress metadata coordination.",
+        )
+        parser.add_argument(
+            "--model-express-source",
+            action="store_true",
+            help="Run as a ModelExpress seed source: publish transfer metadata to the ModelExpress server after loading weights.",
         )
 
         # For PD-Multiplexing
@@ -5770,7 +5802,11 @@ class ServerArgs:
         )
 
     def validate_transfer_engine(self):
-        if importlib.util.find_spec("mooncake.engine") is None:
+        try:
+            mooncake_available = importlib.util.find_spec("mooncake.engine") is not None
+        except (ModuleNotFoundError, ValueError):
+            mooncake_available = False
+        if not mooncake_available:
             logger.warning(
                 "Failed to import mooncake.engine. Does not support using TransferEngine as remote instance weight loader backend."
             )
@@ -5787,10 +5823,14 @@ class ServerArgs:
         # Use TransferEngine as seed backend.
         if self.remote_instance_weight_loader_start_seed_via_transfer_engine:
             return True
+        # ModelExpress source mode also needs TransferEngine init.
+        if self.model_express_source:
+            return True
         # Use TransferEngine as client backend.
         elif (
             self.load_format == "remote_instance"
-            and self.remote_instance_weight_loader_backend == "transfer_engine"
+            and self.remote_instance_weight_loader_backend
+            in ("transfer_engine", "model_express")
         ):
             return True
         else:


### PR DESCRIPTION
## Summary
- Mixed TP support: seed TP != target TP (e.g., TP2 seed -> TP4 target, or TP4 -> TP2)
- Shard metadata published from seed (full_shape, shard_dim, effective_tp_size, shard_index)
- Transfer plan computes byte-range overlaps for dim-0 sharded params, GPU-side column slicing for dim-1
- Removes small-tensor disk fallback -- all tensors now transfer via RDMA/NVLink (mooncake IPC offset bug fixed upstream)

### Bug fixes in this revision
1. **FP8 shard_dim for RowParallelLinear**: FP8 quant sets `output_dim=0` and `input_dim=1` on all weights. For RowParallelLinear the actual shard dim is `input_dim`, not `output_dim`. Fixed by checking module type before selecting shard_dim.
2. **`src_eff_tp <= 1` replicated short-circuit**: When source is TP=1, all tensors were treated as replicated. Fixed to only check `shard_dim == -1`.

## Depends on
- modelexpress: ai-dynamo/modelexpress#157 + ai-dynamo/modelexpress (idhanani/mx-mixed-tp-v1)
- mooncake: IPC offset fix in `IntraNodeNvlinkTransport::registerLocalMemory()` (upstream pending)

## Test plan

### Llama-3.3-70B-Instruct-FP8

| Direction | Seed | Target | RDMA Ops | Dim1 Fixups | Load Time | Disk Baseline |
|-----------|------|--------|----------|-------------|-----------|---------------|
| Same TP | TP=2 | TP=2 | 1763 | 0 | 1.24s | 13.6s |
| Scale-up | TP=2 | TP=4 | 1763 | 160 | 1.42-1.89s | 13.6s |
| Scale-down | TP=4 | TP=2 | 2725 | 320 | 1.65-1.83s | 8.5s |

- [x] Same TP (TP2->TP2) -- 10.95x speedup, identical outputs
- [x] Scale-up (TP2->TP4) -- coherent output verified
- [x] Scale-down (TP4->TP2) -- coherent output verified, matches disk-loaded TP2

### Qwen3-0.6B (BF16)
- [x] Scale-down (TP2->TP1) -- output matches disk-loaded TP1 exactly