### PR TITLE
fix: set first_token_time before computing decode_throughput for single-batch completions

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1612,6 +1612,11 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
             state.finished = recv_obj.finished_reasons[i] is not None
             if state.finished:
+                # Ensure first_token_time is set before computing decode_throughput.
+                # Without this, requests that finish on their first output batch
+                # would have first_token_time=0.0, producing bogus throughput.
+                if state.time_stats.first_token_time == 0.0:
+                    state.time_stats.set_first_token_time()
                 state.time_stats.trace_ctx.trace_set_root_attrs(
                     self.convert_to_span_attrs(state, recv_obj, i)
                 )


### PR DESCRIPTION
## Summary

- Fix bogus `decode_throughput` values (e.g. `3.9e-05` tokens/sec) when a request finishes on its very first output batch
- Ensure `set_first_token_time()` is called before `convert_to_output_meta_info()` computes `decode_throughput`

## Motivation

When a request generates all tokens and finishes in a single output batch (e.g. short response with speculative decoding + high cache hit rate), `first_token_time` was still `0.0` when `decode_throughput` was calculated. This caused:

```
decode_latency = finished_time - 0.0  # raw perf_counter since boot (~741k seconds)
decode_throughput = 29 / 741578 ≈ 3.9e-05  # should be ~31 tokens/sec
```

The bug occurs because `set_first_token_time()` is only called inside `collect_metrics()`, which runs **after** `convert_to_output_meta_info()`. For most requests this is fine since they produce multiple output batches, but single-batch completions hit this race.

The gRPC path (`grpc_request_manager.py`) already handles this correctly by setting `first_token_time` unconditionally before checking `finished`.

## Test plan

- [ ] Verify with short-output requests using speculative decoding that `decode_throughput` values are reasonable
- [ ] Verify normal multi-batch requests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)