### PR TITLE
fix(grpc): add server-side keepalive options to prevent GOAWAY

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -1020,6 +1020,12 @@ async def serve_grpc(
         options=[
             ("grpc.max_send_message_length", 1024 * 1024 * 256),
             ("grpc.max_receive_message_length", 1024 * 1024 * 256),
+            # Allow client HTTP/2 keepalive pings every 10s+.
+            # Without this, the gRPC C-core default (300s minimum) causes
+            # GOAWAY when clients send pings more frequently during long
+            # requests (e.g. prefill) where no DATA frames flow.
+            ("grpc.http2.min_recv_ping_interval_without_data_ms", 10000),
+            ("grpc.keepalive_permit_without_calls", True),
         ],
     )
 


### PR DESCRIPTION
## Summary

The gRPC server uses C-core defaults which enforce a 300s minimum ping interval (`grpc.http2.min_recv_ping_interval_without_data_ms`). Clients sending keepalive pings more frequently (e.g. every 30s) receive GOAWAY after 2 violations during long requests where no DATA frames flow (e.g. during prefill).

## Fix

Add two server options:
- `grpc.http2.min_recv_ping_interval_without_data_ms = 10000` — accept client pings every 10s+
- `grpc.keepalive_permit_without_calls = True` — allow pings on idle connections