### PR TITLE
Fix ModelOpt offline detection: check HF cache for hf_quant_config.json

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2837,6 +2837,15 @@ def has_hf_quant_config(model_path: str) -> bool:
     """
     if os.path.exists(os.path.join(model_path, "hf_quant_config.json")):
         return True
+    # Check the local HF cache (works in offline mode)
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        cached = try_to_load_from_cache(model_path, "hf_quant_config.json")
+        if cached is not None and isinstance(cached, str):
+            return True
+    except Exception:
+        pass
     try:
         from huggingface_hub import HfApi
 


### PR DESCRIPTION
## Summary
- Fix `nvidia/DeepSeek-V3-0324-FP4` offline loading failure: `RuntimeError: size mismatch for weight: [7168, 9216] vs [7168, 18432]`
- Root cause: `_is_already_quantized()` returns False in offline mode (`HF_HUB_OFFLINE=1`) because `has_hf_quant_config()` can't check remote repos or the local HF cache — only checks `os.path.exists(model_path/...)` (fails for remote model IDs) and `hf_api.file_exists()` (fails offline)
- This causes the ModelOpt loader to take the wrong path (`_standard_quantization_workflow` instead of pre-quantized loading), creating a base model with standard dimensions that don't match FP4-packed weights
- Fix adds `try_to_load_from_cache()` check before the API call, which finds cached files in offline mode

**CI failure example**: https://github.com/sgl-project/sglang/actions/runs/22731094707/job/65941983434

**Note**: The B200 CI test also has a separate issue — `TestDeepseekV3FP4CutlassMoE` crashes during inference with "Piecewise CUDA Graph failed with error: Unsupported method call" → CUDA coredump → timeout. This is unrelated to the offline loading fix.

## Test plan
- [x] Verified on B200 runner: `try_to_load_from_cache` finds `hf_quant_config.json` in the local HF cache even with `HF_HUB_OFFLINE=1`
- [x] Verified `_is_already_quantized()` would return True in offline mode with this fix
- [x] Fallback to `hf_api.file_exists()` preserved for non-cached models
- [ ] CI: `test_deepseek_v3_fp4_4gpu` — offline loading should succeed (no more shape mismatch), but CutlassMoE CUDA crash is a separate issue