### PR TITLE
[AMD] Fix nightly GLM-5: NSA indexer tensor aliasing on ROCm during CUDA graph capture

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -313,6 +313,13 @@ class Indexer(MultiPlatformOp):
 
         q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
 
+        # On ROCm, CUDA graph capture rejects in-place writes to aliased
+        # tensors (q_rope / k_rope are torch.split views of query / key).
+        # Cloning breaks the alias so the write-back succeeds.
+        if _is_hip:
+            q_rope = q_rope.clone()
+            k_rope = k_rope.clone()
+
         query[..., : self.rope_head_dim] = q_rope
         key[..., : self.rope_head_dim] = k_rope
 
@@ -352,6 +359,8 @@ class Indexer(MultiPlatformOp):
         )
 
         _, k_rope = self.rotary_emb(positions, k_rope, k_rope)
+        if _is_hip:
+            k_rope = k_rope.clone()
         key[..., : self.rope_head_dim] = k_rope
         key = rotate_activation(key)
 


### PR DESCRIPTION
## Motivation

PR #19263 removed the `forward_native` override for rotary embeddings in DeepSeek V3.2 (`self.rotary_emb.forward = self.rotary_emb.forward_native`). Previously, `forward_native` returned **new tensors** via `torch.cat()`. After removal, on HIP the dispatch path became `forward_hip` → `forward_cuda` → `apply_rope_with_cos_sin_cache_inplace`, which modifies tensors **in-place** and returns the same view objects.

In `_get_q_k_bf16` (nsa_indexer.py), `torch.split` creates `q_rope` / `k_rope` as views of `query` / `key`. After `rotary_emb` now returns those same views (in-place), the write-back `query[..., :rope_dim] = q_rope` is a self-aliased in-place operation that ROCm rejects during CUDA graph capture:

```
RuntimeError: unsupported operation: some elements of the input tensor
and the written-to tensor refer to a single memory location.
Please clone() the tensor before performing the operation.
```

**Bisect evidence:**
- [Run #580](https://github.com/sgl-project/sglang/actions/runs/22648816293/job/65643197394) (commit `441045a`, Mar 4, **before** #19263) → GLM-5 **passed**
- [Run #600](https://github.com/sgl-project/sglang/actions/runs/22695771394) (commit `a710b7d`, Mar 5, **after** #19263) → GLM-5 **failed**

Affected nightly jobs (both ROCm 7.0 and 7.2, both MI300X and MI35x):

| Nightly Run | Failing Jobs |
|-------------|-------------|
| [ROCm 7.2 #169](https://github.com/sgl-project/sglang/actions/runs/22700080128) | `nightly-8-gpu-glm5-rocm720`, `nightly-8-gpu-mi35x-glm5-rocm720` |
| [ROCm 7.0 #600](https://github.com/sgl-project/sglang/actions/runs/22695771394) | `nightly-8-gpu-glm5`, `nightly-8-gpu-mi35x-glm5` |

## Modifications

**`python/sglang/srt/layers/attention/nsa/nsa_indexer.py`**: Clone the rotary embedding outputs on HIP before writing them back into `query` / `key`. This breaks the `torch.split` view alias so the in-place assignment succeeds during CUDA graph capture. Gated behind `if _is_hip:` so CUDA performance is unaffected.

## Accuracy Tests

Verify by re-running any affected nightly job via `workflow_dispatch`:

- `job_filter = nightly-8-gpu-glm5-rocm720` (ROCm 7.2)
- `job_filter = nightly-8-gpu-mi35x-glm5-rocm720` (ROCm 7.2)
- `job_filter = nightly-8-gpu-glm5` (ROCm 7.0)
- `job_filter = nightly-8-gpu-mi35x-glm5` (ROCm 7.0)

No accuracy impact — the fix only ensures correct tensor semantics during graph capture.

**Verification runs** (triggered on this branch, commit `60bd7fd`):

| Run | Platform | Status |
|-----|----------|--------|
| [ROCm 7.0](https://github.com/sgl-project/sglang/actions/runs/22740732107) | MI300X + MI35x | in progress |
| [ROCm 7.2](https://github.com/sgl-project/sglang/actions/runs/22743766645) | MI300X + MI35x | in progress |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] N/A: No new unit tests needed (bugfix restoring previous behavior).
- [x] N/A: No documentation changes needed.
- [x] N/A: No speed impact on CUDA (`.clone()` is HIP-only).
