### PR TITLE
[WIP] Structural tag for tool choice required

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -342,10 +342,14 @@ class OpenAIServingChat(OpenAIServingBase):
                 tool_call_constraint = parser.get_structure_constraint(
                     request.tool_choice
                 )
-            # Handle JSON schema constraint directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
+            elif request.tool_choice == "required" or isinstance(
                 request.tool_choice, ToolChoice
             ):
+                # Only use JSON schema constraint as fallback when no
+                # tool_call_parser is configured.  When a parser is available,
+                # get_structure_constraint already handles tool_choice and the
+                # native parser produces better multi-tool-call results than
+                # grammar-constrained JSON arrays.
                 json_schema = get_json_schema_constraint(
                     request.tools, request.tool_choice
                 )
@@ -1096,22 +1100,27 @@ class OpenAIServingChat(OpenAIServingBase):
     ) -> ToolCallProcessingResult:
         """Process tool calls in the response"""
 
-        # Handle required or named tool choice
-        if tool_choice == "required" or (
+        # For required tool choice, force finish_reason to tool_calls
+        force_tool_calls = tool_choice == "required" or (
             isinstance(tool_choice, ToolChoice) and tool_choice.type == "function"
-        ):
-            # Set finish reason to tool_calls since we're processing tool calls
+        )
+
+        # When output was constrained by JSON schema, parse as a JSON array.
+        # This applies to named ToolChoice (always constrained) or "required"
+        # without a native tool_call_parser.
+        json_schema_constrained = isinstance(tool_choice, ToolChoice) or (
+            tool_choice == "required" and not self.tool_call_parser
+        )
+        if json_schema_constrained:
             if finish_reason["type"] == "stop":
                 finish_reason["type"] = "tool_calls"
                 finish_reason["matched"] = None
             try:
-                # For required tool choice, we expect a JSON array of tool calls
                 tool_call_data = orjson.loads(text)
                 tool_calls = []
                 for i, tool in enumerate(tool_call_data):
-                    # Create a ToolCallItem from the JSON data
                     call_info = ToolCallItem(
-                        tool_index=i,  # Use the loop index as tool_index
+                        tool_index=i,
                         name=tool["name"],
                         parameters=json.dumps(tool["parameters"], ensure_ascii=False),
                     )
@@ -1135,7 +1144,8 @@ class OpenAIServingChat(OpenAIServingBase):
                 logger.error(f"Tool call parsing error: {e}")
                 return ToolCallProcessingResult(None, text, finish_reason)
 
-        # Use parser since output is not constrained by JSON schema
+        # Use the native format parser (handles both "auto" and "required"
+        # when a tool_call_parser is configured).
         parser = FunctionCallParser(tools, self.tool_call_parser)
         if parser.has_tool_call(text):
             if finish_reason["type"] == "stop":
@@ -1157,11 +1167,18 @@ class OpenAIServingChat(OpenAIServingBase):
                             ),
                         )
                     )
+                if force_tool_calls and finish_reason["type"] == "stop":
+                    finish_reason["type"] = "tool_calls"
+                    finish_reason["matched"] = None
                 return ToolCallProcessingResult(tool_calls, text, finish_reason)
             except Exception as e:
                 logger.error(f"Tool call parsing error: {e}")
-                # Return error but don't fail the whole request
                 return ToolCallProcessingResult(None, text, finish_reason)
+
+        if force_tool_calls:
+            if finish_reason["type"] == "stop":
+                finish_reason["type"] = "tool_calls"
+                finish_reason["matched"] = None
 
         return ToolCallProcessingResult(None, text, finish_reason)
 
@@ -1259,10 +1276,13 @@ class OpenAIServingChat(OpenAIServingBase):
     ):
         """Process tool calls in streaming response"""
         if index not in parser_dict:
-            # Use JSON detector directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
-                request.tool_choice, ToolChoice
-            ):
+            # Use JsonArrayParser only when the output was constrained by a
+            # JSON schema (named ToolChoice, or "required" without a native
+            # tool_call_parser).  Otherwise use the native format parser.
+            use_json_parser = isinstance(request.tool_choice, ToolChoice) or (
+                request.tool_choice == "required" and not self.tool_call_parser
+            )
+            if use_json_parser:
                 parser_dict[index] = JsonArrayParser()
             else:
                 parser_dict[index] = FunctionCallParser(

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -1,6 +1,9 @@
 import logging
 from typing import Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
+from xgrammar import StructuralTag
+from xgrammar.structural_tag import JSONSchemaFormat, TagFormat, TriggeredTagsFormat
+
 from sglang.srt.entrypoints.openai.protocol import (
     LegacyStructuralTagResponseFormat,
     StructuresResponseFormat,
@@ -183,6 +186,51 @@ class FunctionCallParser:
             triggers=list(tool_trigger_set),
         )
 
+    def _build_structural_tag_for_required(self) -> Optional[object]:
+        """Build a StructuralTag with at_least_one=True for tool_choice="required".
+
+        Uses xgrammar's TriggeredTagsFormat so the grammar enforces at least one
+        tool call while keeping the model in its native output format (e.g. Qwen's
+        <tool_call> blocks).
+        """
+        get_structure_info = self.detector.structure_info()
+        tags: List[TagFormat] = []
+        trigger_set: Set[str] = set()
+
+        for tool in self.tools:
+            function = tool.function
+            name = function.name
+            assert name is not None
+            info = get_structure_info(name)
+
+            is_strict = (
+                function.strict or self.tool_strict_level >= ToolStrictLevel.PARAMETER
+            )
+            schema = function.parameters if is_strict else {}
+
+            tags.append(
+                TagFormat(
+                    type="tag",
+                    begin=info.begin,
+                    content=JSONSchemaFormat(
+                        type="json_schema", json_schema=schema or {}
+                    ),
+                    end=info.end,
+                )
+            )
+            trigger_set.add(info.trigger)
+
+        return StructuralTag(
+            type="structural_tag",
+            format=TriggeredTagsFormat(
+                type="triggered_tags",
+                triggers=list(trigger_set),
+                tags=tags,
+                at_least_one=True,
+                stop_after_first=False,
+            ),
+        )
+
     def get_structure_constraint(
         self, tool_choice: Union[ToolChoice, Literal["auto", "required"]]
     ) -> Optional[ToolCallConstraint]:
@@ -209,6 +257,11 @@ class FunctionCallParser:
         ):
             tag = self.get_structure_tag()
             return ("structural_tag", tag)
-        elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+        elif tool_choice == "required":
+            if self.detector.supports_structural_tag():
+                return ("structural_tag", self._build_structural_tag_for_required())
+            json_schema = get_json_schema_constraint(self.tools, tool_choice)
+            return ("json_schema", json_schema)
+        elif isinstance(tool_choice, ToolChoice):
             json_schema = get_json_schema_constraint(self.tools, tool_choice)
             return ("json_schema", json_schema)

--- a/test/registered/function_call/test_function_call_parser.py
+++ b/test/registered/function_call/test_function_call_parser.py
@@ -3724,5 +3724,65 @@ function call<|role_sep|>
         self.assertEqual(params["city"], "Rome")
 
 
+class TestStructuralTagForRequired(unittest.TestCase):
+    """Test that get_structure_constraint returns a structural_tag for tool_choice='required'."""
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_current_weather",
+                    description="Get the current weather in a given location",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "The city name",
+                            },
+                            "state": {
+                                "type": "string",
+                                "description": "Two-letter state abbreviation",
+                            },
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city", "state", "unit"],
+                    },
+                ),
+            ),
+        ]
+
+    def test_required_returns_structural_tag_for_qwen25(self):
+        """tool_choice='required' should return a structural_tag constraint
+        (not None and not json_schema) when the detector supports structural tags."""
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+        parser = FunctionCallParser(self.tools, "qwen25")
+        constraint = parser.get_structure_constraint("required")
+        self.assertIsNotNone(constraint)
+        constraint_type, constraint_value = constraint
+        self.assertEqual(constraint_type, "structural_tag")
+
+        dumped = constraint_value.model_dump()
+        fmt = dumped["format"]
+        self.assertEqual(fmt["type"], "triggered_tags")
+        self.assertTrue(fmt["at_least_one"])
+        self.assertFalse(fmt["stop_after_first"])
+        self.assertIn("<tool_call>", fmt["triggers"])
+        self.assertGreaterEqual(len(fmt["tags"]), 1)
+
+    def test_auto_no_strict_returns_none(self):
+        """tool_choice='auto' without strict tools should return None (no constraint)."""
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+        parser = FunctionCallParser(self.tools, "qwen25")
+        constraint = parser.get_structure_constraint("auto")
+        self.assertIsNone(constraint)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Use native structural tag grammar for tool_choice="required" instead of JSON array schema. Empirically observe that when using JSON array schema, which is not native to Qwen model, the model is more motivated to output only one tool when it could have call more tools (bare minimum condition to satisfy tool_choice="required")

## Modifications

<!-- Detail the changes made in this pull request. -->

- Use native structural tag grammar for tool_choice="required" instead of JSON array schema
- The old code applied a JSON array schema (minItems: 1) for tool_choice="required", forcing the model into a format it wasn't trained on. The model would close the array after 1 element since ] is valid after satisfying minItems.
- Use xgrammar's TriggeredTagsFormat(at_least_one=True) to constrain generation in the model's native format (e.g. <tool_call> blocks), enforcing "at least one tool call" while allowing multiple.
- Fix serving_chat.py to not overwrite the parser's constraint with JSON schema (if -> elif), and route tool_choice="required" through the native parser when one is configured.
- Falls back to JSON schema for detectors without structural tag support.

## Accuracy Tests
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

[TODO] Verify with benchmarks to see if model accuracy drop because of this grammar fix

## Benchmarking and Profiling

Should not affect speed/performance
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
