### PR TITLE
Add external kvcache offloading connector support

### DIFF
--- a/docs/advanced_features/kv_connector.md
+++ b/docs/advanced_features/kv_connector.md
@@ -1,0 +1,88 @@
+# KV Connector Guide
+
+Implement `BaseKVConnector` (`sglang/srt/mem_cache/kv_connector.py`) to integrate an external KV cache offloading framework into SGLang.
+
+## Architecture
+
+```
+Scheduler
+    │
+    v
+ExtendedRadixCache  ───>  RadixCache (manage GPU KV pool)
+    │
+    v
+BaseKVConnector (your impl)  ───>  External Storage (CPU/SSD/remote)
+```
+
+`ExtendedRadixCache` wraps `RadixCache` via composition. It intercepts
+`match_prefix`, `cache_finished_req` etc. to coordinate with the connector.
+GPU memory allocation and radix tree operations are handled by the inner
+`RadixCache`; the connector only manages external storage and async transfers.
+
+## How It Works
+
+Each scheduler iteration:
+
+1. **Poll completions** — `check_completed_store_tasks()` / `check_completed_load_tasks()`
+   release GPU radix tree node locks so GPU nodes become evictable, otherwise tree nodes stay locked and GPU memory leaks.
+2. **Match prefix** — `get_new_hit_length()`: query external storage for tokens
+   beyond the GPU radix cache hit.
+3. **Prepare load** — `init_load_back`: pre-allocate GPU slots, create locked
+   TreeNode, enqueue `LoadOperation`.
+4. **Dispatch load** — `start_load_kv()`: async transfer from external storage into pre-allocated GPU slots.
+5. **Request completes** — `start_store_kv()`: async transfer of new KV data to external storage; node locked until done.
+
+## Constructor
+
+```python
+class BaseKVConnector(ABC):
+    def __init__(self, params, server_args, tp_group, tp_rank, kvcache):
+```
+
+| Parameter     | Key Contents                                                       |
+|---------------|--------------------------------------------------------------------|
+| `params`      | `page_size`, `token_to_kv_pool_allocator`                          |
+| `server_args` | Model path, `tp_size`, dtype, `kv_connector_extra_config`          |
+| `tp_group`    | `torch.distributed` process group (`None` if tp=1)                 |
+| `tp_rank`     | 0-based TP rank                                                    |
+| `kvcache`     | `k_buffer` / `v_buffer`: list of per-layer GPU tensors `[num_slots, num_kv_heads, head_dim]` |
+
+## Methods to Implement
+
+### Abstract (required)
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `get_new_hit_length` | `(token_ids, token_mask, update_state_for_load, rid) -> int` | Query external storage for cached tokens. `token_mask[i]=True` for positions not on GPU. When `update_state_for_load=True`, reserve state keyed by `rid` for the upcoming load. |
+| `release_load_state` | `(rid) -> None` | Release state reserved by `get_new_hit_length` (called when GPU alloc fails). |
+| `start_load_kv` | `(task_id, load_ops: List[LoadOperation]) -> None` | Begin async KV cache transfer from storage to GPU. Each `LoadOperation` has `rid`, `device_indices` (pre-allocated GPU slots), and `node` (opaque). |
+| `check_completed_load_tasks` | `() -> List[int]` | Non-blocking poll. Return completed load `task_id`s. |
+| `start_store_kv` | `(task_id, token_ids, kv_indices: Tensor) -> None` | Begin async KV cache transfer from GPU to storage. `kv_indices[i]` is the GPU pool slot for `token_ids[i]`. |
+| `check_completed_store_tasks` | `() -> List[int]` | Non-blocking poll. Return completed store `task_id`s. |
+
+### Optional (default no-ops)
+
+| Method | Purpose |
+|--------|---------|
+| `prefetch(rid, token_ids)` | Pre-stage data from slow to fast tier before scheduling. |
+| `check_prefetch_completed(rid) -> bool` | Gate scheduling (default `True`). |
+| `cancel_prefetch(rid)` | Cancel prefetch on request abort. |
+| `layer_done_counter` (property) | Layer-wise sync counter for overlapped load+compute. |
+| `reset()` | Clear all state on cache flush. |
+| `shutdown()` | Cleanup resources. |
+
+## Example
+
+Reference implementation: `FlexKVConnector` (`sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py`).
+
+## Launch
+
+```bash
+# Full module path
+python -m sglang.launch_server --model ... \
+    --kv-connector-cls my_package.my_module.MyConnector
+
+# Built-in alias
+python -m sglang.launch_server --model ... \
+    --kv-connector-cls flexkv
+```

--- a/docs/advanced_features/kv_connector.md
+++ b/docs/advanced_features/kv_connector.md
@@ -65,7 +65,8 @@ class BaseKVConnector(ABC):
 | Method | Purpose |
 |--------|---------|
 | `prefetch(rid, token_ids)` | Pre-stage data from slow to fast tier before scheduling. |
-| `check_prefetch_completed(rid) -> bool` | Gate scheduling (default `True`). |
+| `check_prefetch_progress(rid) -> bool` | Gate scheduling (default `True`). |
+| `pop_prefetch_loaded_tokens(rid) -> int` | Pop and return the number of tokens loaded from storage for a request. Returns 0 if no prefetch was done or was revoked. This should be called after check_prefetch_progress() returns True. |
 | `cancel_prefetch(rid)` | Cancel prefetch on request abort. |
 | `layer_done_counter` (property) | Layer-wise sync counter for overlapped load+compute. |
 | `reset()` | Clear all state on cache flush. |

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -989,6 +989,7 @@ class Req(ReqDllmMixin):
                 MatchPrefixParams(
                     key=RadixKey(token_ids=token_ids, extra_key=self.extra_key),
                     req=self,
+                    update_connector_state=True,
                     cow_mamba=cow_mamba,
                 )
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -850,7 +850,14 @@ class Scheduler(
                 )
                 from sglang.srt.mem_cache.kv_connector import BaseKVConnector
 
-                module_path, class_name = server_args.kv_connector_cls.rsplit(".", 1)
+                # module_path, class_name = server_args.kv_connector_cls.rsplit(".", 1)
+                _KV_CONNECTOR_ALIASES = {
+                    "flexkv": "sglang.srt.mem_cache.storage.flexkv.flexkv_connector.FlexKVConnector",
+                }
+                connector_cls_path = _KV_CONNECTOR_ALIASES.get(
+                    server_args.kv_connector_cls, server_args.kv_connector_cls
+                )
+                module_path, class_name = connector_cls_path.rsplit(".", 1)
                 module = importlib.import_module(module_path)
                 connector_cls = getattr(module, class_name)
                 if not issubclass(connector_cls, BaseKVConnector):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -862,7 +862,7 @@ class Scheduler(
                     server_args=server_args,
                     tp_group=self.tp_group,
                     tp_rank=self.tp_rank,
-                    kvcache=params.token_to_kv_pool_allocator.get_kvcache()
+                    kvcache=params.token_to_kv_pool_allocator.get_kvcache(),
                 )
                 self.tree_cache = ExtendedRadixCache(
                     params=params,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -364,6 +364,7 @@ class Scheduler(
         self.page_size = server_args.page_size
         self.enable_hierarchical_cache = server_args.enable_hierarchical_cache
         self.enable_hicache_storage = server_args.hicache_storage_backend is not None
+        self.enable_kv_connector = server_args.kv_connector_cls is not None
         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
         self.enable_hisparse = server_args.enable_hisparse
         self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
@@ -868,6 +869,10 @@ class Scheduler(
                     params=params,
                     connector=connector,
                 )
+                if self.tree_cache.layer_done_counter is not None:
+                    self.tp_worker.register_hicache_layer_transfer_counter(
+                        self.tree_cache.layer_done_counter
+                    )
             elif server_args.enable_lmcache:
                 from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import (
                     LMCRadixCache,
@@ -2094,7 +2099,7 @@ class Scheduler(
                 direction * recv_req.priority < direction * candidate_req.priority
             )
             if abort_existing_req:
-                if self.enable_hicache_storage:
+                if self.enable_hicache_storage or self.enable_kv_connector:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(candidate_req.rid)
                 elif self.enable_hierarchical_cache:
@@ -2126,7 +2131,7 @@ class Scheduler(
         for req in self.waiting_queue:
             entry_time = req.time_stats.wait_queue_entry_time
             if 0 < entry_time < deadline:
-                if self.enable_hicache_storage:
+                if self.enable_hicache_storage or self.enable_kv_connector:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
                 self.send_to_tokenizer.send_output(
@@ -2598,7 +2603,7 @@ class Scheduler(
             chunked_req=self.chunked_req,
         )
         self.max_prefill_bs = max(self.max_prefill_bs, len(can_run_list))
-        if self.enable_hierarchical_cache:
+        if self.enable_hierarchical_cache or self.enable_kv_connector:
             # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
             new_batch.hicache_consumer_index = (
                 self.tree_cache.ready_to_load_host_cache()
@@ -3284,7 +3289,7 @@ class Scheduler(
             # This only works for requests that have not started anything.
             # We still need to send something back to TokenizerManager to clean up the state.
             req = self.waiting_queue.pop(i)
-            if self.enable_hicache_storage:
+            if self.enable_hicache_storage or self.enable_kv_connector:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
             self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2535,7 +2535,7 @@ class Scheduler(
                 ):
                     break
 
-            if self.enable_hicache_storage:
+            if self.enable_hicache_storage or self.enable_kv_connector:
                 prefetch_done = self.tree_cache.check_prefetch_progress(req.rid)
                 if not prefetch_done:
                     # skip staging requests that are ongoing prefetch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2362,6 +2362,7 @@ class Scheduler(
                 self.running_batch = self.update_running_batch(self.running_batch)
                 ret = self.running_batch if not self.running_batch.is_empty() else None
             else:
+                self.running_batch.batch_is_full = False
                 ret = None
 
         # Handle DP attention and log stats

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -862,6 +862,7 @@ class Scheduler(
                     server_args=server_args,
                     tp_group=self.tp_group,
                     tp_rank=self.tp_rank,
+                    kvcache=params.token_to_kv_pool_allocator.get_kvcache()
                 )
                 self.tree_cache = ExtendedRadixCache(
                     params=params,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2432,8 +2432,8 @@ class Scheduler(
             for req in ready_grammar_requests:
                 self._add_request_to_queue(req)
 
-        if self.enable_hierarchical_cache:
-            self.tree_cache.check_hicache_events()
+        if self.enable_hierarchical_cache or self.enable_kv_connector:
+            self.tree_cache.check_kv_events()
 
         if self.enable_priority_preemption:
             # Reset batch_is_full to try preemption with a prefill adder.
@@ -2657,7 +2657,7 @@ class Scheduler(
 
         # Eagerly release lock_ref on completed write-through nodes so they
         # become evictable, improving batch scheduling headroom.
-        if self.enable_hierarchical_cache:
+        if self.enable_hierarchical_cache or self.enable_kv_connector:
             self.tree_cache.flush_write_through_acks()
 
         # Check if decode out of memory

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -841,6 +841,32 @@ class Scheduler(
                 from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 
                 self.tree_cache = MambaRadixCache(params)
+            elif server_args.kv_connector_cls is not None:
+                import importlib
+
+                from sglang.srt.mem_cache.extended_radix_cache import (
+                    ExtendedRadixCache,
+                )
+                from sglang.srt.mem_cache.kv_connector import BaseKVConnector
+
+                module_path, class_name = server_args.kv_connector_cls.rsplit(".", 1)
+                module = importlib.import_module(module_path)
+                connector_cls = getattr(module, class_name)
+                if not issubclass(connector_cls, BaseKVConnector):
+                    raise TypeError(
+                        f"Connector class {class_name} must inherit from "
+                        "sglang.srt.mem_cache.kv_connector.BaseKVConnector"
+                    )
+                connector = connector_cls(
+                    params=params,
+                    server_args=server_args,
+                    tp_group=self.tp_group,
+                    tp_rank=self.tp_rank,
+                )
+                self.tree_cache = ExtendedRadixCache(
+                    params=params,
+                    connector=connector,
+                )
             elif server_args.enable_lmcache:
                 from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import (
                     LMCRadixCache,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2030,6 +2030,8 @@ class Scheduler(
                     last_hash,
                     prefix_keys,
                 )
+        elif self.enable_kv_connector:
+            self.tree_cache.prefetch(req)
 
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.NULL:

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -41,6 +41,8 @@ class MatchPrefixParams:
     # Mamba specific
     cow_mamba: bool = False
     req: Optional[Req] = None
+    # KVConnector specific
+    update_connector_state: bool = False
 
 
 @dataclasses.dataclass
@@ -247,7 +249,7 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
         """
         pass
 
-    def check_hicache_events(self) -> Any:
+    def check_kv_events(self) -> Any:
         """
         Check HiCache related activities to update radix tree and synchronize across TP workers if needed
         """

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -9,7 +9,6 @@ from typing import (
     NamedTuple,
     Optional,
     Protocol,
-    Tuple,
     runtime_checkable,
 )
 

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExtendedRadixCache(BasePrefixCache):
-    """RadixCache decorator with external KV storage connector.
-    """
+    """RadixCache decorator with external KV storage connector."""
+
     def __init__(
         self,
         params: CacheInitParams,
@@ -112,7 +112,7 @@ class ExtendedRadixCache(BasePrefixCache):
             return device_match_result
 
         token_mask = torch.zeros(len(key), dtype=torch.bool)
-        token_mask[device_indices.numel():] = True
+        token_mask[device_indices.numel() :] = True
 
         new_hit_length = self._connector.get_new_hit_length(
             token_ids=key.token_ids,
@@ -138,7 +138,9 @@ class ExtendedRadixCache(BasePrefixCache):
 
         host_hit_length = req.host_hit_length
 
-        if host_hit_length <= 0 or (mem_quota is not None and host_hit_length > mem_quota):
+        if host_hit_length <= 0 or (
+            mem_quota is not None and host_hit_length > mem_quota
+        ):
             self._connector.cancel_load_task(req.rid)
             return
 
@@ -169,7 +171,9 @@ class ExtendedRadixCache(BasePrefixCache):
         new_node.key = key
         new_node.value = device_indices
         new_node.parent = last_node
-        last_node.children[self._inner_radixtree.get_child_key_fn(new_node.key)] = new_node
+        last_node.children[self._inner_radixtree.get_child_key_fn(new_node.key)] = (
+            new_node
+        )
         self._inner_radixtree.evictable_size_ += len(device_indices)
         self._inner_radixtree._record_store_event(new_node)
 

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import torch
 
@@ -9,6 +9,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     EvictParams,
     EvictResult,
+    InitLoadBackParams,
     MatchPrefixParams,
     MatchResult,
 )
@@ -130,19 +131,20 @@ class ExtendedRadixCache(BasePrefixCache):
 
     def init_load_back(
         self,
-        req: Req,
-        mem_quota: Optional[int] = None,
-    ) -> None:
+        params: InitLoadBackParams,
+    ) -> Tuple[torch.Tensor, Any]:
         if self._connector is None:
-            return
+            return torch.tensor([], dtype=torch.int32, device="cuda"), params.last_host_node
 
-        host_hit_length = req.host_hit_length
+        req = params.req
+        mem_quota = params.mem_quota
+        host_hit_length = params.host_hit_length
 
         if host_hit_length <= 0 or (
             mem_quota is not None and host_hit_length > mem_quota
         ):
             self._connector.release_load_state(req.rid)
-            return
+            return torch.tensor([], dtype=torch.int32, device="cuda"), params.last_host_node
 
         device_indices = self._inner_radixtree.token_to_kv_pool_allocator.alloc(
             host_hit_length
@@ -187,8 +189,7 @@ class ExtendedRadixCache(BasePrefixCache):
             )
         )
 
-        req.prefix_indices = torch.cat([req.prefix_indices, device_indices])
-        req.last_node = new_node
+        return device_indices, new_node
 
     def ready_to_load_host_cache(self) -> int:
         if self._connector is None or not self._load_queue:

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -141,7 +141,7 @@ class ExtendedRadixCache(BasePrefixCache):
         if host_hit_length <= 0 or (
             mem_quota is not None and host_hit_length > mem_quota
         ):
-            self._connector.cancel_load_task(req.rid)
+            self._connector.release_load_state(req.rid)
             return
 
         device_indices = self._inner_radixtree.token_to_kv_pool_allocator.alloc(
@@ -157,7 +157,7 @@ class ExtendedRadixCache(BasePrefixCache):
                 "Failed to allocate %d GPU slots for external load",
                 host_hit_length,
             )
-            self._connector.cancel_load_task(req.rid)
+            self._connector.release_load_state(req.rid)
             return
 
         gpu_cached_len = len(req.prefix_indices)

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -30,8 +30,6 @@ class ExtendedRadixCache(BasePrefixCache):
         params: CacheInitParams,
         connector: Optional[BaseKVConnector] = None,
     ):
-        assert not params.disable, "ExtendedRadixCache requires radix cache enabled"
-        
         self._inner_radixtree = RadixCache(params)
         self._connector = connector
 

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -279,8 +279,8 @@ class ExtendedRadixCache(BasePrefixCache):
     def inc_lock_ref(self, node):
         return self._inner_radixtree.inc_lock_ref(node)
 
-    def dec_lock_ref(self, node, swa_uuid_for_lock=None):
-        return self._inner_radixtree.dec_lock_ref(node, swa_uuid_for_lock)
+    def dec_lock_ref(self, node):
+        return self._inner_radixtree.dec_lock_ref(node)
 
     def cache_unfinished_req(self, req: Req, **kwargs):
         return self._inner_radixtree.cache_unfinished_req(req, **kwargs)

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -221,7 +221,7 @@ class ExtendedRadixCache(BasePrefixCache):
         self._load_task_id_counter += 1
 
         self._inner_radixtree.inc_lock_ref(req.last_node)
-        
+
         self._connector.start_store_kv(
             task_id=task_id,
             token_ids=token_ids,
@@ -232,6 +232,11 @@ class ExtendedRadixCache(BasePrefixCache):
 
     def evict(self, params: EvictParams) -> EvictResult:
         return self._inner_radixtree.evict(params)
+
+    def flush_write_through_acks(self) -> None:
+        if self._connector is None:
+            return
+        self._check_store_completion()
 
     def check_kv_events(self):
         if self._connector is None:

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    EvictParams,
+    EvictResult,
+    MatchPrefixParams,
+    MatchResult,
+)
+from sglang.srt.mem_cache.kv_connector import BaseKVConnector, LoadOperation
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+
+logger = logging.getLogger(__name__)
+
+
+class ExtendedRadixCache(BasePrefixCache):
+    """RadixCache decorator with external KV storage connector.
+    """
+    def __init__(
+        self,
+        params: CacheInitParams,
+        connector: Optional[BaseKVConnector] = None,
+    ):
+        assert not params.disable, "ExtendedRadixCache requires radix cache enabled"
+        
+        self._inner_radixtree = RadixCache(params)
+        self._connector = connector
+
+        self._load_task_id_counter = 0
+        self._load_queue: List[LoadOperation] = []
+        self._ongoing_load_tasks: Dict[int, List[TreeNode]] = {}
+        self._ongoing_store_tasks: Dict[int, TreeNode] = {}
+
+    # -- Forward PrefixCacheTrait properties to inner cache --
+
+    @property
+    def req_to_token_pool(self):
+        return self._inner_radixtree.req_to_token_pool
+
+    @req_to_token_pool.setter
+    def req_to_token_pool(self, value):
+        self._inner_radixtree.req_to_token_pool = value
+
+    @property
+    def token_to_kv_pool_allocator(self):
+        return self._inner_radixtree.token_to_kv_pool_allocator
+
+    @token_to_kv_pool_allocator.setter
+    def token_to_kv_pool_allocator(self, value):
+        self._inner_radixtree.token_to_kv_pool_allocator = value
+
+    @property
+    def page_size(self):
+        return self._inner_radixtree.page_size
+
+    @page_size.setter
+    def page_size(self, value):
+        self._inner_radixtree.page_size = value
+
+    @property
+    def disable(self):
+        return self._inner_radixtree.disable
+
+    @property
+    def device(self):
+        return self._inner_radixtree.device
+
+    @property
+    def metrics_collector(self):
+        return self._inner_radixtree.metrics_collector
+
+    @metrics_collector.setter
+    def metrics_collector(self, value):
+        self._inner_radixtree.metrics_collector = value
+
+    @property
+    def layer_done_counter(self):
+        if self._connector is None:
+            return None
+        return self._connector.layer_done_counter
+
+    # -- Core methods with connector logic --
+
+    def reset(self):
+        self._ongoing_store_tasks.clear()
+        self._ongoing_load_tasks.clear()
+        self._load_queue.clear()
+
+        if self._connector is not None:
+            self._connector.reset()
+
+        self._inner_radixtree.reset()
+
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
+        device_match_result = self._inner_radixtree.match_prefix(params)
+        if self._connector is None:
+            return device_match_result
+
+        key = params.key
+        device_indices: torch.Tensor = device_match_result.device_indices
+        last_device_node = device_match_result.last_device_node
+
+        uncached_len = len(key) - device_indices.numel()
+        if uncached_len <= 0:
+            return device_match_result
+
+        token_mask = torch.zeros(len(key), dtype=torch.bool)
+        token_mask[device_indices.numel():] = True
+
+        new_hit_length = self._connector.get_new_hit_length(
+            token_ids=key.token_ids,
+            token_mask=token_mask,
+            update_state_for_load=params.update_connector_state,
+            rid=params.req.rid if params.req is not None else None,
+        )
+
+        return MatchResult(
+            device_indices=device_indices,
+            last_device_node=last_device_node,
+            last_host_node=last_device_node,
+            host_hit_length=new_hit_length,
+        )
+
+    def init_load_back(
+        self,
+        req: Req,
+        mem_quota: Optional[int] = None,
+    ) -> None:
+        if self._connector is None:
+            return
+
+        host_hit_length = req.host_hit_length
+
+        if host_hit_length <= 0 or (mem_quota is not None and host_hit_length > mem_quota):
+            self._connector.cancel_load_task(req.rid)
+            return
+
+        device_indices = self._inner_radixtree.token_to_kv_pool_allocator.alloc(
+            host_hit_length
+        )
+        if device_indices is None:
+            self.evict(EvictParams(num_tokens=host_hit_length))
+            device_indices = self._inner_radixtree.token_to_kv_pool_allocator.alloc(
+                host_hit_length
+            )
+        if device_indices is None:
+            logger.warning(
+                "Failed to allocate %d GPU slots for external load",
+                host_hit_length,
+            )
+            self._connector.cancel_load_task(req.rid)
+            return
+
+        gpu_cached_len = len(req.prefix_indices)
+        key = RadixKey(
+            token_ids=req.fill_ids[gpu_cached_len : gpu_cached_len + host_hit_length],
+            extra_key=req.extra_key,
+        )
+
+        last_node = req.last_node
+        new_node = TreeNode()
+        new_node.key = key
+        new_node.value = device_indices
+        new_node.parent = last_node
+        last_node.children[self._inner_radixtree.get_child_key_fn(new_node.key)] = new_node
+        self._inner_radixtree.evictable_size_ += len(device_indices)
+        self._inner_radixtree._record_store_event(new_node)
+
+        self._inner_radixtree.inc_lock_ref(new_node)
+
+        self._load_queue.append(
+            LoadOperation(
+                rid=req.rid,
+                device_indices=device_indices,
+                node=new_node,
+            )
+        )
+
+        req.prefix_indices = torch.cat([req.prefix_indices, device_indices])
+        req.last_node = new_node
+
+    def ready_to_load_host_cache(self) -> int:
+        if self._connector is None or not self._load_queue:
+            return -1
+
+        task_id = self._load_task_id_counter
+        self._load_task_id_counter += 1
+
+        self._connector.start_load_kv(task_id, self._load_queue)
+
+        nodes = [op.node for op in self._load_queue]
+        self._ongoing_load_tasks[task_id] = nodes
+
+        self._load_queue.clear()
+        return task_id
+
+    def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):
+        self._inner_radixtree.cache_finished_req(req, is_insert=is_insert, **kwargs)
+
+        if self._connector is None or not is_insert:
+            return
+
+        req_id = req.req_pool_idx
+        token_ids = (req.origin_input_ids + req.output_ids)[:-1]
+        kv_indices = self._inner_radixtree.req_to_token_pool.req_to_token[
+            req_id, : len(token_ids)
+        ]
+
+        task_id = self._load_task_id_counter
+        self._load_task_id_counter += 1
+
+        self._connector.start_store_kv(
+            task_id=task_id,
+            token_ids=token_ids,
+            kv_indices=kv_indices,
+        )
+
+        self._inner_radixtree.inc_lock_ref(req.last_node)
+        self._ongoing_store_tasks[task_id] = req.last_node
+
+    def evict(self, params: EvictParams) -> EvictResult:
+        return self._inner_radixtree.evict(params)
+
+    def check_kv_events(self):
+        if self._connector is None:
+            return
+        self._check_store_completion()
+        self._check_load_completion()
+
+    def prefetch(self, req: Req) -> None:
+        if self._connector is None:
+            return
+        token_ids = (req.origin_input_ids + req.output_ids)[:-1]
+        self._connector.prefetch(req.rid, token_ids)
+
+    def can_be_scheduled(self, req: Req) -> bool:
+        if self._connector is None:
+            return True
+        return self._connector.check_prefetch_completed(req.rid)
+
+    def release_aborted_request(self, req: Req) -> None:
+        if self._connector is None:
+            return
+        self._connector.cancel_prefetch(req.rid)
+
+    # -- Private helpers --
+
+    def _check_store_completion(self) -> None:
+        completed_ids = self._connector.check_completed_store_tasks()
+        for task_id in completed_ids:
+            node = self._ongoing_store_tasks.pop(task_id, None)
+            if node is not None:
+                self._inner_radixtree.dec_lock_ref(node)
+
+    def _check_load_completion(self) -> None:
+        completed_ids = self._connector.check_completed_load_tasks()
+        for task_id in completed_ids:
+            nodes = self._ongoing_load_tasks.pop(task_id, None)
+            if nodes is not None:
+                for node in nodes:
+                    self._inner_radixtree.dec_lock_ref(node)
+
+    # -- Pass-through methods --
+
+    def insert(self, key, value=None, **kwargs):
+        return self._inner_radixtree.insert(key, value=value, **kwargs)
+
+    def inc_lock_ref(self, node):
+        return self._inner_radixtree.inc_lock_ref(node)
+
+    def dec_lock_ref(self, node, swa_uuid_for_lock=None):
+        return self._inner_radixtree.dec_lock_ref(node, swa_uuid_for_lock)
+
+    def cache_unfinished_req(self, req: Req, **kwargs):
+        return self._inner_radixtree.cache_unfinished_req(req, **kwargs)
+
+    def evictable_size(self):
+        return self._inner_radixtree.evictable_size()
+
+    def protected_size(self):
+        return self._inner_radixtree.protected_size()
+
+    def total_size(self):
+        return self._inner_radixtree.total_size()
+
+    def pretty_print(self):
+        return self._inner_radixtree.pretty_print()
+
+    def all_values_flatten(self):
+        return self._inner_radixtree.all_values_flatten()
+
+    def take_events(self):
+        return self._inner_radixtree.take_events()
+
+    def __getattr__(self, name):
+        return getattr(self._inner_radixtree, name)

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -250,15 +250,20 @@ class ExtendedRadixCache(BasePrefixCache):
         token_ids = (req.origin_input_ids + req.output_ids)[:-1]
         self._connector.prefetch(req.rid, token_ids)
 
-    def can_be_scheduled(self, req: Req) -> bool:
+    def check_prefetch_progress(self, req_id: str) -> bool:
         if self._connector is None:
             return True
-        return self._connector.check_prefetch_completed(req.rid)
+        return self._connector.check_prefetch_progress(req_id)
 
-    def release_aborted_request(self, req: Req) -> None:
+    def pop_prefetch_loaded_tokens(self, req_id: str) -> int:
+        if self._connector is None:
+            return 0
+        return self._connector.pop_prefetch_loaded_tokens(req_id)
+
+    def release_aborted_request(self, req_id: str) -> None:
         if self._connector is None:
             return
-        self._connector.cancel_prefetch(req.rid)
+        self._connector.cancel_prefetch(req_id)
 
     # -- Private helpers --
 

--- a/python/sglang/srt/mem_cache/extended_radix_cache.py
+++ b/python/sglang/srt/mem_cache/extended_radix_cache.py
@@ -220,13 +220,14 @@ class ExtendedRadixCache(BasePrefixCache):
         task_id = self._load_task_id_counter
         self._load_task_id_counter += 1
 
+        self._inner_radixtree.inc_lock_ref(req.last_node)
+        
         self._connector.start_store_kv(
             task_id=task_id,
             token_ids=token_ids,
             kv_indices=kv_indices,
         )
 
-        self._inner_radixtree.inc_lock_ref(req.last_node)
         self._ongoing_store_tasks[task_id] = req.last_node
 
     def evict(self, params: EvictParams) -> EvictResult:

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -508,7 +508,7 @@ class HiMambaRadixCache(MambaRadixCache):
     def flush_write_through_acks(self) -> None:
         self.writing_check()
 
-    def check_hicache_events(self):
+    def check_kv_events(self):
         self.writing_check()
         self.loading_check()
 

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -46,6 +46,7 @@ from sglang.srt.mem_cache.utils import convert_to_bigram_key
 from sglang.srt.observability.metrics_collector import StorageMetricsCollector
 
 if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
     from sglang.srt.server_args import ServerArgs
 
@@ -986,7 +987,7 @@ class HiRadixCache(RadixCache):
     def flush_write_through_acks(self) -> None:
         self.writing_check()
 
-    def check_hicache_events(self):
+    def check_kv_events(self):
         self.writing_check()
         self.loading_check()
         if self.enable_storage:

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -967,15 +967,14 @@ class HiRadixCache(RadixCache):
                 logger.debug(
                     f"loading back {len(loading_values)} tokens for node {last_node.id}"
                 )
-                return loading_values, last_node
+                req.prefix_indices = torch.cat([req.prefix_indices, loading_values])
+                req.last_node = last_node
+                return
 
             while last_node.evicted:
                 last_node = last_node.parent
-
-        return (
-            torch.empty((0,), dtype=torch.int64, device=self.device),
-            last_node,
-        )
+            
+            req.last_node = last_node
 
     def ready_to_load_host_cache(self) -> int:
         """

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -967,14 +967,15 @@ class HiRadixCache(RadixCache):
                 logger.debug(
                     f"loading back {len(loading_values)} tokens for node {last_node.id}"
                 )
-                req.prefix_indices = torch.cat([req.prefix_indices, loading_values])
-                req.last_node = last_node
-                return
+                return loading_values, last_node
 
             while last_node.evicted:
                 last_node = last_node.parent
             
-            req.last_node = last_node
+        return (
+            torch.empty((0,), dtype=torch.int64, device=self.device),
+            last_node,
+        )
 
     def ready_to_load_host_cache(self) -> int:
         """

--- a/python/sglang/srt/mem_cache/kv_connector.py
+++ b/python/sglang/srt/mem_cache/kv_connector.py
@@ -19,11 +19,13 @@ class BaseKVConnector(ABC):
         server_args: Any = None,
         tp_group: Any = None,
         tp_rank: int = 0,
+        kvcache: Any = None,
     ):
         self.params = params
         self.server_args = server_args
         self.tp_group = tp_group
         self.tp_rank = tp_rank
+        self.kvcache = kvcache
 
     @abstractmethod
     def get_new_hit_length(

--- a/python/sglang/srt/mem_cache/kv_connector.py
+++ b/python/sglang/srt/mem_cache/kv_connector.py
@@ -49,8 +49,8 @@ class BaseKVConnector(ABC):
         ...
 
     @abstractmethod
-    def cancel_load_task(self, rid: str) -> None:
-        """Cancel a locked load, releasing state acquired by get_new_hit_length.
+    def release_load_state(self, rid: str) -> None:
+        """Release the load state acquired by get_new_hit_length.
 
         Args:
             rid: Request id previously passed to get_new_hit_length.

--- a/python/sglang/srt/mem_cache/kv_connector.py
+++ b/python/sglang/srt/mem_cache/kv_connector.py
@@ -13,13 +13,15 @@ class LoadOperation(NamedTuple):
 
 
 class BaseKVConnector(ABC):
-    def __init__(self, tp_group: Any = None, tp_rank: int = 0):
-        """Initialize connector with tensor-parallel context.
-
-        Args:
-            tp_group: Tensor-parallel process group.
-            tp_rank: Rank within the tp group.
-        """
+    def __init__(
+        self,
+        params: Any = None,
+        server_args: Any = None,
+        tp_group: Any = None,
+        tp_rank: int = 0,
+    ):
+        self.params = params
+        self.server_args = server_args
         self.tp_group = tp_group
         self.tp_rank = tp_rank
 

--- a/python/sglang/srt/mem_cache/kv_connector.py
+++ b/python/sglang/srt/mem_cache/kv_connector.py
@@ -114,7 +114,7 @@ class BaseKVConnector(ABC):
         """
         pass
 
-    def check_prefetch_completed(self, rid: str) -> bool:
+    def check_prefetch_progress(self, rid: str) -> bool:
         """Return True if the prefetch for *rid* has completed.
 
         Args:
@@ -123,6 +123,19 @@ class BaseKVConnector(ABC):
             True if complete or no prefetch was needed.
         """
         return True
+
+    def pop_prefetch_loaded_tokens(self, rid: str) -> int:
+        """
+        Pop and return the number of tokens loaded from storage for a request.
+        Returns 0 if no prefetch was done or was revoked.
+        This should be called after check_prefetch_progress() returns True.
+
+        Args:
+            rid: Request id previously passed to prefetch.
+        Returns:
+            Number of tokens loaded from storage.
+        """
+        return 0
 
     def cancel_prefetch(self, rid: str) -> None:
         """Cancel an in-progress or pending prefetch for *rid*.

--- a/python/sglang/srt/mem_cache/kv_connector.py
+++ b/python/sglang/srt/mem_cache/kv_connector.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List, NamedTuple, Optional
+
+import torch
+
+
+class LoadOperation(NamedTuple):
+    rid: str
+    device_indices: torch.Tensor
+    node: Any
+
+
+class BaseKVConnector(ABC):
+    def __init__(self, tp_group: Any = None, tp_rank: int = 0):
+        """Initialize connector with tensor-parallel context.
+
+        Args:
+            tp_group: Tensor-parallel process group.
+            tp_rank: Rank within the tp group.
+        """
+        self.tp_group = tp_group
+        self.tp_rank = tp_rank
+
+    @abstractmethod
+    def get_new_hit_length(
+        self,
+        token_ids: List[int],
+        token_mask: torch.Tensor,
+        update_state_for_load: bool = False,
+        rid: Optional[str] = None,
+    ) -> int:
+        """Return number of externally cached tokens beyond the device hit.
+
+        Args:
+            token_ids: Full token id sequence.
+            token_mask: Boolean mask; True for positions to match.
+            update_state_for_load: Lock internal state until the load is
+                started or cancelled via *rid*.
+            rid: Request id for tracking the subsequent load task.
+        Returns:
+            Number of new matched tokens.
+        """
+        ...
+
+    @abstractmethod
+    def cancel_load_task(self, rid: str) -> None:
+        """Cancel a locked load, releasing state acquired by get_new_hit_length.
+
+        Args:
+            rid: Request id previously passed to get_new_hit_length.
+        """
+        ...
+
+    @abstractmethod
+    def start_load_kv(
+        self,
+        task_id: int,
+        load_ops: List[LoadOperation],
+    ) -> None:
+        """Start a batch of external-to-GPU load operations.
+
+        Args:
+            task_id: Caller-assigned id for completion tracking.
+            load_ops: Pending load operations to execute.
+        """
+        ...
+
+    @abstractmethod
+    def check_completed_load_tasks(self) -> List[int]:
+        """Return task_ids of completed load tasks.
+
+        Returns:
+            List of completed load task_ids.
+        """
+        ...
+
+    @abstractmethod
+    def start_store_kv(
+        self,
+        task_id: int,
+        token_ids: List[int],
+        kv_indices: torch.Tensor,
+    ) -> None:
+        """Asynchronously store KV cache to external storage.
+
+        Args:
+            task_id: Caller-assigned id for completion tracking.
+            token_ids: Token id sequence to store.
+            kv_indices: Corresponding GPU KV pool indices.
+        """
+        ...
+
+    @abstractmethod
+    def check_completed_store_tasks(self) -> List[int]:
+        """Return task_ids of completed store tasks.
+
+        Returns:
+            List of completed store task_ids.
+        """
+        ...
+
+    def prefetch(self, rid: str, token_ids: List[int]) -> None:
+        """Start prefetching KV cache from external storage.
+
+        Args:
+            rid: Request id.
+            token_ids: Token id sequence to prefetch.
+        """
+        pass
+
+    def check_prefetch_completed(self, rid: str) -> bool:
+        """Return True if the prefetch for *rid* has completed.
+
+        Args:
+            rid: Request id previously passed to prefetch.
+        Returns:
+            True if complete or no prefetch was needed.
+        """
+        return True
+
+    def cancel_prefetch(self, rid: str) -> None:
+        """Cancel an in-progress or pending prefetch for *rid*.
+
+        Args:
+            rid: Request id previously passed to prefetch.
+        """
+        pass
+
+    @property
+    def layer_done_counter(self) -> Any:
+        """Return the layer-wise transfer counter, or None."""
+        return None
+
+    def register_layer_transfer_counter(self, kvcache: Any) -> None:
+        """Register the layer transfer counter with the KV cache pool.
+
+        Args:
+            kvcache: KV cache pool instance.
+        """
+        pass
+
+    def reset(self) -> None:
+        """Reset connector state (called on cache reset)."""
+        pass
+
+    def shutdown(self) -> None:
+        """Cleanup resources."""
+        pass

--- a/python/sglang/srt/mem_cache/session_aware_cache.py
+++ b/python/sglang/srt/mem_cache/session_aware_cache.py
@@ -331,8 +331,8 @@ class SessionAwareCache(BasePrefixCache):
     def flush_write_through_acks(self) -> None:
         return self.inner.flush_write_through_acks()
 
-    def check_hicache_events(self):
-        return self.inner.check_hicache_events()
+    def check_kv_events(self):
+        return self.inner.check_kv_events()
 
     def take_events(self):
         return self.inner.take_events()

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -1,0 +1,602 @@
+import ctypes
+import logging
+import os
+import socket
+import struct
+import time
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.mem_cache.kv_connector import BaseKVConnector, LoadOperation
+from sglang.srt.utils import broadcast_pyobj
+
+try:
+    from flexkv.common.request import KVResponseStatus
+    from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+    from flexkv.integration.config import FlexKVConfig
+    from flexkv.kvmanager import KVManager
+    from flexkv.server.client import KVTPClient
+except ImportError as e:
+    raise RuntimeError("FlexKV is not installed. Please install it.") from e
+
+logger = logging.getLogger(__name__)
+
+
+# ---- libc / eventfd ----
+libc = ctypes.CDLL("libc.so.6", use_errno=True)
+
+libc.eventfd.argtypes = [ctypes.c_uint, ctypes.c_int]
+libc.eventfd.restype = ctypes.c_int
+
+libc.read.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+libc.read.restype = ctypes.c_ssize_t
+
+libc.write.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+libc.write.restype = ctypes.c_ssize_t
+
+EFD_SEMAPHORE = 0x1
+EFD_NONBLOCK = 0x800
+
+
+def eventfd(initval=0, flags=0):
+    fd = libc.eventfd(ctypes.c_uint(initval), ctypes.c_int(flags))
+    if fd == -1:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return fd
+
+
+def eventfd_write(fd, val):
+    v = ctypes.c_uint64(val)
+    buf = ctypes.byref(v)
+    n = libc.write(fd, buf, ctypes.sizeof(v))
+    if n != ctypes.sizeof(v):
+        err = ctypes.get_errno()
+        raise OSError(err, f"eventfd write failed: {os.strerror(err)}")
+
+
+def eventfd_read(fd):
+    """Blocking read from eventfd."""
+    v = ctypes.c_uint64()
+    buf = ctypes.byref(v)
+    n = libc.read(fd, buf, ctypes.sizeof(v))
+    if n != ctypes.sizeof(v):
+        err = ctypes.get_errno()
+        if err == 11:  # EAGAIN
+            return 0
+        raise OSError(err, f"eventfd read failed: {os.strerror(err)}")
+    return v.value
+
+
+def send_fds(sock: socket.socket, fds: list, extra_data: bytes = b"x"):
+    """Send multiple fds + extra_data via Unix domain socket."""
+    fds_packed = struct.pack(f"{len(fds)}i", *fds)
+    ancdata = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds_packed)]
+    sock.sendmsg([extra_data], ancdata)
+
+
+def recv_fds(sock: socket.socket, num_fds: int):
+    """Receive multiple fds + extra_data via Unix domain socket."""
+    data_buf = bytearray(256)
+    anc_buf_size = socket.CMSG_SPACE(num_fds * struct.calcsize("i"))
+
+    nbytes, ancdata, flags, addr = sock.recvmsg_into(
+        [data_buf], anc_buf_size, anc_buf_size
+    )
+    data = bytes(data_buf[:nbytes])
+
+    fds = []
+    for level, ctype, cdata in ancdata:
+        if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
+            num_received = len(cdata) // struct.calcsize("i")
+            fds = list(
+                struct.unpack(
+                    f"{num_received}i", cdata[: num_received * struct.calcsize("i")]
+                )
+            )
+            break
+    if not fds:
+        raise RuntimeError("did not receive fds via SCM_RIGHTS")
+    return fds, data
+
+
+# ---- CUDA Runtime (via ctypes) ----
+def load_cudart():
+    candidates = [
+        "libcudart.so",
+        "libcudart.so.12",
+        "libcudart.so.11.0",
+        "/usr/local/cuda/lib64/libcudart.so",
+    ]
+    for lib in candidates:
+        try:
+            return ctypes.CDLL(lib)
+        except OSError:
+            continue
+    return None
+
+
+cudart = load_cudart()
+
+if cudart:
+    cudart.cudaLaunchHostFunc.argtypes = [
+        ctypes.c_void_p,
+        ctypes.CFUNCTYPE(None, ctypes.c_void_p),
+        ctypes.c_void_p,
+    ]
+    cudart.cudaLaunchHostFunc.restype = ctypes.c_int
+
+
+# ---- Layer-wise transfer components ----
+
+
+class FlexKVLayerLoadingEvent:
+    def __init__(self, num_layers: int):
+        self._num_layers = num_layers
+        self.load_event_fds: List[int] = [
+            eventfd(0, EFD_SEMAPHORE) for _ in range(num_layers)
+        ]
+        self._finished = True
+        self._last_layer_wait_count = 0
+        self.wait_remaining: List[int] = [2] * num_layers
+
+    def reset_for_new_transfer(self):
+        self._finished = False
+        self._last_layer_wait_count = 0
+        self.wait_remaining = [2] * self._num_layers
+
+    def wait(self, layer_index: int):
+        assert 0 <= layer_index < self._num_layers
+        eventfd_read(self.load_event_fds[layer_index])
+        if layer_index == self._num_layers - 1:
+            self._last_layer_wait_count += 1
+            if self._last_layer_wait_count >= 2:
+                self._finished = True
+
+    def close(self):
+        for fd in self.load_event_fds:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+        self.load_event_fds.clear()
+
+    def __del__(self):
+        self.close()
+
+
+class FlexKVLayerDoneCounter:
+    """Triple-buffered layer-wise transfer counter using eventfds.
+
+    Provides the same ``set_consumer`` / ``wait_until`` interface expected by
+    the KV cache memory pool so that the attention backend can synchronize
+    per-layer with an in-flight host->device transfer.
+
+    Because ``ExtendedRadixCache`` assigns monotonically increasing *task_ids*
+    while this counter cycles through a fixed number of producer slots, a
+    ``_task_to_producer`` mapping translates between the two id spaces.
+    """
+
+    def __init__(self, num_layers: int):
+        self.num_layers = num_layers
+        self.num_counters = 3
+        self.events: List[FlexKVLayerLoadingEvent] = [
+            FlexKVLayerLoadingEvent(num_layers) for _ in range(self.num_counters)
+        ]
+        self.producer_index = -1
+        self.consumer_index = -1
+        self._task_to_producer: Dict[int, int] = {}
+
+    def register_task(self, task_id: int, producer_id: int):
+        self._task_to_producer[task_id] = producer_id
+
+    def update_producer(self) -> int:
+        self.producer_index = (self.producer_index + 1) % self.num_counters
+        assert self.events[
+            self.producer_index
+        ]._finished, "Producer event should be finished before reuse"
+        return self.producer_index
+
+    def set_consumer(self, index: int):
+        if index < 0:
+            self.consumer_index = -1
+            return
+        producer_id = self._task_to_producer.pop(index, None)
+        if producer_id is not None:
+            self.consumer_index = producer_id
+        else:
+            self.consumer_index = index
+
+    def wait_until(self, threshold: int):
+        if self.consumer_index < 0:
+            return
+        event = self.events[self.consumer_index]
+        if event.wait_remaining[threshold] <= 0:
+            return
+        event.wait_remaining[threshold] -= 1
+        event.wait(threshold)
+
+    def reset(self):
+        self.producer_index = -1
+        self.consumer_index = -1
+        self._task_to_producer.clear()
+
+    def __del__(self):
+        for event in self.events:
+            event.close()
+        self.events.clear()
+
+
+# ---- FlexKV Connector ----
+
+
+class FlexKVConnector(BaseKVConnector):
+    """KV cache connector backed by FlexKV's distributed cache system.
+
+    Implements ``BaseKVConnector`` so it can be used with
+    ``ExtendedRadixCache`` via ``--kv-connector-cls``.
+    """
+
+    def __init__(
+        self,
+        params: Any = None,
+        server_args: Any = None,
+        tp_group: Any = None,
+        tp_rank: int = 0,
+        kvcache: Any = None,
+    ):
+        super().__init__(params, server_args, tp_group, tp_rank, kvcache)
+
+        model_config = ModelConfig.from_server_args(server_args)
+
+        self.flexkv_config = FlexKVConfig.from_env()
+        self.flexkv_config.post_init_from_sglang_config(
+            sglang_config=model_config,
+            tp_size=server_args.tp_size,
+            page_size=params.page_size,
+        )
+
+        self.tp_size = server_args.tp_size
+        self.rank = tp_rank
+
+        k_pool = getattr(kvcache, "k_buffer", None)
+        v_pool = getattr(kvcache, "v_buffer", None)
+
+        if self.rank == 0:
+            self.kv_manager = KVManager(
+                model_config=self.flexkv_config.model_config,
+                cache_config=self.flexkv_config.cache_config,
+                server_recv_port=self.flexkv_config.server_recv_port,
+            )
+            self.kv_manager.start()
+
+        self.tp_client = KVTPClient(self.flexkv_config.gpu_register_port, 0, self.rank)
+        self._register_to_server(k_pool, v_pool)
+
+        self.num_layers = model_config.num_hidden_layers if model_config else 0
+        self.enable_layerwise_transfer = bool(
+            int(os.getenv("FLEXKV_ENABLE_LAYERWISE_TRANSFER", "1"))
+        )
+        self.layerwise_eventfd_socket = os.getenv(
+            "FLEXKV_LAYERWISE_EVENTFD_SOCKET", "/tmp/flexkv_layerwise_eventfd.sock"
+        )
+        self._layer_done_counter: Optional[FlexKVLayerDoneCounter] = None
+        self._worker_connected = False
+
+        self._init_layer_transfer_components()
+
+        if self._layer_done_counter is not None and kvcache is not None:
+            kvcache.register_layer_transfer_counter(self._layer_done_counter)
+
+        # rid -> flexkv_task_id (pending loads awaiting start_load_kv)
+        self._pending_loads: Dict[str, int] = {}
+        # ext_task_id -> producer_id (layerwise loads in flight)
+        self._ongoing_loads: Dict[int, int] = {}
+        # ext_task_ids whose load has completed
+        self._completed_loads: List[int] = []
+        # ext_task_id -> flexkv_task_id (stores in flight, rank 0 only)
+        self._ongoing_stores: Dict[int, int] = {}
+        # ext_task_ids whose store has completed or was skipped (rank 0 only)
+        self._completed_stores: List[int] = []
+
+        if self.rank == 0:
+            while not self.kv_manager.is_ready():
+                time.sleep(3)
+                logger.info("[FlexKV] Waiting for FlexKV to be ready...")
+            logger.info("[FlexKV] FlexKV is ready")
+
+        logger.info(
+            "[FlexKV] Connector initialized for rank %d, layerwise_transfer=%s",
+            self.rank,
+            self.enable_layerwise_transfer,
+        )
+
+    # ---- BaseKVConnector abstract methods ----
+
+    def get_new_hit_length(
+        self,
+        token_ids: List[int],
+        token_mask: torch.Tensor,
+        update_state_for_load: bool = False,
+        rid: Optional[str] = None,
+    ) -> int:
+        hit_length = 0
+        flexkv_task_id = -1
+
+        if self.rank == 0:
+            token_ids_np = np.array(token_ids, dtype=np.int64)
+            flexkv_task_id, matched_mask = self.kv_manager.get_match(
+                token_ids=token_ids_np,
+                token_mask=token_mask,
+            )
+            hit_length = int(matched_mask.sum()) if matched_mask is not None else 0
+            if not update_state_for_load and flexkv_task_id >= 0:
+                self.kv_manager.cancel_tasks([flexkv_task_id])
+
+        if self.tp_group is not None and self.tp_size > 1:
+            data = broadcast_pyobj(
+                [{"hit_length": hit_length, "task_id": flexkv_task_id}],
+                self.rank,
+                self.tp_group,
+                src=0,
+            )[0]
+            hit_length = data["hit_length"]
+            flexkv_task_id = data["task_id"]
+
+        if update_state_for_load and rid is not None and hit_length > 0:
+            self._pending_loads[rid] = flexkv_task_id
+
+        return hit_length
+
+    def release_load_state(self, rid: str) -> None:
+        self._pending_loads.pop(rid, None)
+
+    def start_load_kv(
+        self,
+        task_id: int,
+        load_ops: List[LoadOperation],
+    ) -> None:
+        flexkv_task_ids: List[int] = []
+        slot_mappings: List[torch.Tensor] = []
+
+        for op in load_ops:
+            fk_tid = self._pending_loads.pop(op.rid, -1)
+            if fk_tid < 0:
+                continue
+            flexkv_task_ids.append(fk_tid)
+            indices = op.device_indices
+            slot_mappings.append(indices.cpu() if indices.is_cuda else indices)
+
+        if not flexkv_task_ids:
+            self._completed_loads.append(task_id)
+            return
+
+        if self.enable_layerwise_transfer and self._layer_done_counter is not None:
+            producer_id = self._layer_done_counter.update_producer()
+            self._layer_done_counter.events[producer_id].reset_for_new_transfer()
+            self._layer_done_counter.register_task(task_id, producer_id)
+
+            if self.rank == 0:
+                self.kv_manager.launch(
+                    task_ids=flexkv_task_ids,
+                    slot_mappings=slot_mappings,
+                    as_batch=True,
+                    layerwise_transfer=True,
+                    counter_id=producer_id,
+                )
+
+            self._ongoing_loads[task_id] = producer_id
+        else:
+            if self.rank == 0:
+                self.kv_manager.launch(
+                    task_ids=flexkv_task_ids,
+                    slot_mappings=slot_mappings,
+                    as_batch=True,
+                    layerwise_transfer=False,
+                )
+                response = self.kv_manager.wait(flexkv_task_ids, timeout=30.0)
+                if not all(
+                    tid in response and response[tid].status == KVResponseStatus.SUCCESS
+                    for tid in flexkv_task_ids
+                ):
+                    logger.warning(
+                        "[FlexKV] Some tasks failed in non-layerwise transfer"
+                    )
+
+            if self.tp_group is not None and self.tp_size > 1:
+                torch.distributed.barrier(self.tp_group)
+
+            self._completed_loads.append(task_id)
+
+    def check_completed_load_tasks(self) -> List[int]:
+        for ext_tid, producer_id in list(self._ongoing_loads.items()):
+            if self._layer_done_counter.events[producer_id]._finished:
+                self._completed_loads.append(ext_tid)
+                del self._ongoing_loads[ext_tid]
+
+        result = list(self._completed_loads)
+        self._completed_loads.clear()
+        return result
+
+    def start_store_kv(
+        self,
+        task_id: int,
+        token_ids: List[int],
+        kv_indices: torch.Tensor,
+    ) -> None:
+        if self.rank != 0:
+            return
+
+        try:
+            token_ids_np = np.array(token_ids, dtype=np.int64)
+            fk_task_id, unmatched_mask = self.kv_manager.put_match(
+                token_ids=token_ids_np, token_mask=None
+            )
+
+            if unmatched_mask.sum() > 0:
+                filtered = kv_indices[unmatched_mask]
+                slot_mapping = filtered.cpu() if filtered.is_cuda else filtered
+                self.kv_manager.launch(
+                    task_ids=[fk_task_id], slot_mappings=[slot_mapping]
+                )
+                self._ongoing_stores[task_id] = fk_task_id
+            else:
+                self._completed_stores.append(task_id)
+        except Exception as e:
+            logger.error("[FlexKV] start_store_kv failed: %s", e)
+            self._completed_stores.append(task_id)
+
+    def check_completed_store_tasks(self) -> List[int]:
+        completed_ext_ids = list(self._completed_stores)
+        self._completed_stores.clear()
+
+        if self.rank == 0 and self._ongoing_stores:
+            fk_to_ext = {v: k for k, v in self._ongoing_stores.items()}
+            completed_dict = self.kv_manager.try_wait(task_ids=list(fk_to_ext.keys()))
+            for fk_tid in completed_dict:
+                ext_tid = fk_to_ext[fk_tid]
+                completed_ext_ids.append(ext_tid)
+                del self._ongoing_stores[ext_tid]
+
+        if self.tp_group is not None and self.tp_size > 1:
+            completed_ext_ids = broadcast_pyobj(
+                [completed_ext_ids] if self.rank == 0 else [None],
+                self.rank,
+                self.tp_group,
+                src=0,
+            )[0]
+
+        return completed_ext_ids
+
+    # ---- Optional overrides ----
+
+    def cancel_prefetch(self, rid: str) -> None:
+        self._pending_loads.pop(rid, None)
+
+    @property
+    def layer_done_counter(self) -> Any:
+        return self._layer_done_counter
+
+    def register_layer_transfer_counter(self, kvcache: Any) -> None:
+        if self._layer_done_counter is not None:
+            kvcache.register_layer_transfer_counter(self._layer_done_counter)
+
+    def reset(self) -> None:
+        self._pending_loads.clear()
+        self._ongoing_loads.clear()
+        self._completed_loads.clear()
+
+        if self.rank == 0:
+            for fk_tid in list(self._ongoing_stores.values()):
+                if fk_tid >= 0:
+                    self._wait_flexkv_task(fk_tid)
+        self._ongoing_stores.clear()
+        self._completed_stores.clear()
+
+        if self._layer_done_counter is not None:
+            self._layer_done_counter.reset()
+
+    def shutdown(self) -> None:
+        if self.rank == 0:
+            self.kv_manager.shutdown()
+
+    # ---- Private helpers ----
+
+    def _wait_flexkv_task(self, fk_task_id: int, timeout: float = 20.0) -> bool:
+        if fk_task_id < 0 or self.rank != 0:
+            return True
+        try:
+            response = self.kv_manager.wait([fk_task_id], timeout=timeout)
+            return (
+                fk_task_id in response
+                and response[fk_task_id].status == KVResponseStatus.SUCCESS
+            )
+        except Exception as e:
+            logger.error("[FlexKV] wait task failed: %s", e)
+            return False
+
+    def _register_to_server(
+        self,
+        k_caches: List[torch.Tensor],
+        v_caches: List[torch.Tensor],
+    ) -> None:
+        assert len(k_caches) == len(v_caches)
+        assert (
+            k_caches[0].ndim == 3
+        ), f"Expected 3D tensor, got shape={k_caches[0].shape}"
+
+        num_layer = len(k_caches)
+        num_blocks, num_kv_heads, head_size = k_caches[0].shape
+
+        gpu_layout = KVCacheLayout(
+            type=KVCacheLayoutType.LAYERFIRST,
+            num_layer=num_layer,
+            num_block=num_blocks,
+            tokens_per_block=1,
+            num_head=num_kv_heads,
+            head_size=head_size,
+            is_mla=False,
+        )
+        self.tp_client.register_to_server(k_caches + v_caches, gpu_layout)
+        logger.info("[FlexKV] Registered KV caches to server")
+
+    def _init_layer_transfer_components(self):
+        if not self.enable_layerwise_transfer:
+            self._layer_done_counter = None
+            self._worker_connected = False
+            logger.info("[FlexKV] Rank %d: Layerwise transfer disabled", self.rank)
+            return
+
+        self._layer_done_counter = FlexKVLayerDoneCounter(self.num_layers)
+        self._send_eventfds_to_worker()
+        logger.info("[FlexKV] Rank %d: Initialized layerwise transfer", self.rank)
+
+    def _send_eventfds_to_worker(
+        self, max_retries: int = 180, retry_interval: float = 1.0
+    ):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        for attempt in range(max_retries):
+            try:
+                sock.connect(self.layerwise_eventfd_socket)
+                logger.info("[FlexKV] Rank %d: Connected to worker socket", self.rank)
+                break
+            except (FileNotFoundError, ConnectionRefusedError):
+                if attempt == max_retries - 1:
+                    sock.close()
+                    raise RuntimeError(
+                        f"[FlexKV] Rank {self.rank}: Failed to connect "
+                        f"after {max_retries} attempts"
+                    )
+                if attempt % 10 == 0:
+                    logger.info(
+                        "[FlexKV] Rank %d: Worker not ready, retrying...",
+                        self.rank,
+                    )
+                time.sleep(retry_interval)
+
+        try:
+            num_counters = self._layer_done_counter.num_counters
+            metadata = struct.pack(
+                "iiii", self.rank, self.tp_size, self.num_layers, num_counters
+            )
+            sock.sendall(metadata)
+
+            for counter_id in range(num_counters):
+                fds = self._layer_done_counter.events[counter_id].load_event_fds
+                send_fds(sock, fds, struct.pack("i", counter_id))
+
+            self._worker_connected = True
+            logger.info(
+                "[FlexKV] Rank %d: Sent %d sets of eventfds",
+                self.rank,
+                num_counters,
+            )
+        except Exception as e:
+            sock.close()
+            raise RuntimeError(
+                f"[FlexKV] Rank {self.rank}: Failed to send eventfds: {e}"
+            )

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -333,8 +333,8 @@ class FlexKVConnector(BaseKVConnector):
                 token_mask=token_mask,
             )
             hit_length = int(matched_mask.sum()) if matched_mask is not None else 0
-            if not update_state_for_load and flexkv_task_id >= 0:
-                self.kv_manager.cancel_tasks([flexkv_task_id])
+            if not update_state_for_load:
+                self.kv_manager.cancel([flexkv_task_id])
 
         if self.tp_group is not None and self.tp_size > 1:
             data = broadcast_pyobj(
@@ -348,7 +348,6 @@ class FlexKVConnector(BaseKVConnector):
 
         if update_state_for_load and rid is not None and hit_length > 0:
             self._pending_loads[rid] = flexkv_task_id
-
         return hit_length
 
     def release_load_state(self, rid: str) -> None:

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -301,6 +301,8 @@ class FlexKVConnector(BaseKVConnector):
         self._ongoing_stores: Dict[int, int] = {}
         # ext_task_ids whose store has completed or was skipped (rank 0 only)
         self._completed_stores: List[int] = []
+        # flexkv task ids for periodic drain to prevent pipe deadlock
+        self._load_fkv_tids: List[int] = []
 
         if self.rank == 0:
             while not self.kv_manager.is_ready():
@@ -387,6 +389,8 @@ class FlexKVConnector(BaseKVConnector):
                     counter_id=producer_id,
                 )
 
+            if self.rank == 0:
+                self._load_fkv_tids.extend(flexkv_task_ids)
             self._ongoing_loads[task_id] = producer_id
         else:
             if self.rank == 0:
@@ -411,6 +415,10 @@ class FlexKVConnector(BaseKVConnector):
             self._completed_loads.append(task_id)
 
     def check_completed_load_tasks(self) -> List[int]:
+        if self.rank == 0 and len(self._load_fkv_tids) >= 100:
+            self.kv_manager.try_wait(task_ids=self._load_fkv_tids)
+            self._load_fkv_tids.clear()
+
         for ext_tid, producer_id in list(self._ongoing_loads.items()):
             if self._layer_done_counter.events[producer_id]._finished:
                 self._completed_loads.append(ext_tid)
@@ -487,6 +495,7 @@ class FlexKVConnector(BaseKVConnector):
         self._pending_loads.clear()
         self._ongoing_loads.clear()
         self._completed_loads.clear()
+        self._load_fkv_tids.clear()
 
         if self.rank == 0:
             for fk_tid in list(self._ongoing_stores.values()):

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -284,6 +284,10 @@ class FlexKVConnector(BaseKVConnector):
         self.layerwise_eventfd_socket = os.getenv(
             "FLEXKV_LAYERWISE_EVENTFD_SOCKET", "/tmp/flexkv_layerwise_eventfd.sock"
         )
+        self.layerwise_eventfd_connect_max_retries = max(
+            360,
+            int(os.getenv("FLEXKV_LAYERWISE_EVENTFD_CONNECT_MAX_RETRIES", "0")),
+        )
         self._layer_done_counter: Optional[FlexKVLayerDoneCounter] = None
         self._worker_connected = False
 
@@ -564,9 +568,10 @@ class FlexKVConnector(BaseKVConnector):
         logger.info("[FlexKV] Rank %d: Initialized layerwise transfer", self.rank)
 
     def _send_eventfds_to_worker(
-        self, max_retries: int = 180, retry_interval: float = 1.0
+        self, retry_interval: float = 1.0
     ):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        max_retries =self.layerwise_eventfd_connect_max_retries
 
         for attempt in range(max_retries):
             try:

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -310,6 +310,14 @@ class FlexKVConnector(BaseKVConnector):
         self._completed_stores: List[int] = []
         # flexkv task ids for periodic drain to prevent pipe deadlock
         self._load_fkv_tids: List[int] = []
+        # rid -> flexkv_task_id (prefetch in flight)
+        self._ongoing_prefetches: Dict[str, int] = {}
+        cache_cfg = self.flexkv_config.cache_config
+        self._prefetch_enabled = bool(
+            cache_cfg.enable_ssd
+            or cache_cfg.enable_remote
+            or cache_cfg.enable_kv_sharing
+        )
 
         if self.rank == 0:
             while not self.kv_manager.is_ready():
@@ -318,9 +326,10 @@ class FlexKVConnector(BaseKVConnector):
             logger.info("[FlexKV] FlexKV is ready")
 
         logger.info(
-            "[FlexKV] Connector initialized for rank %d, layerwise_transfer=%s",
+            "[FlexKV] Connector initialized for rank %d, layerwise_transfer=%s, prefetch_enabled=%s",
             self.rank,
             self.enable_layerwise_transfer,
+            self._prefetch_enabled,
         )
 
     # ---- BaseKVConnector abstract methods ----
@@ -489,8 +498,73 @@ class FlexKVConnector(BaseKVConnector):
 
     # ---- Optional overrides ----
 
+    def prefetch(self, rid: str, token_ids: List[int]) -> None:
+        if not self._prefetch_enabled:
+            return
+        if not rid:
+            return
+
+        prefetch_task_id = -1
+        if self.rank == 0:
+            token_ids_np = np.array(token_ids, dtype=np.int64)
+            prefetch_task_id = self.kv_manager.prefetch_async(token_ids=token_ids_np)
+
+        if self.tp_cpu_group is not None and self.tp_size > 1:
+            prefetch_task_id = broadcast_pyobj(
+                [{"task_id": prefetch_task_id}],
+                self.rank,
+                self.tp_cpu_group,
+                src=0,
+            )[0]["task_id"]
+
+        if prefetch_task_id >= 0:
+            self._ongoing_prefetches[rid] = prefetch_task_id
+
+    def check_prefetch_progress(self, rid: str) -> bool:
+        if not self._prefetch_enabled:
+            return True
+
+        prefetch_task_id = self._ongoing_prefetches.get(rid, -1)
+        if prefetch_task_id < 0:
+            return True
+
+        is_completed = False
+        if self.rank == 0:
+            completed = self.kv_manager.try_wait(task_ids=[prefetch_task_id])
+            if prefetch_task_id in completed:
+                status = completed[prefetch_task_id].status
+                if status != KVResponseStatus.SUCCESS:
+                    logger.warning(
+                        "[FlexKV] prefetch task %d for rid=%s finished with status=%s",
+                        prefetch_task_id,
+                        rid,
+                        status,
+                    )
+                is_completed = True
+
+        if self.tp_cpu_group is not None and self.tp_size > 1:
+            data = broadcast_pyobj(
+                [{"is_completed": is_completed}],
+                self.rank,
+                self.tp_cpu_group,
+                src=0,
+            )[0]
+            is_completed = data["is_completed"]
+
+        if is_completed:
+            self._ongoing_prefetches.pop(rid, None)
+        return is_completed
+
+    def pop_prefetch_loaded_tokens(self, rid: str) -> int:
+        # TODO: Implement this
+        return 0
+
     def cancel_prefetch(self, rid: str) -> None:
         self._pending_loads.pop(rid, None)
+        prefetch_task_id = self._ongoing_prefetches.pop(rid, -1)
+        if self.rank == 0 and prefetch_task_id >= 0:
+            # Flexkv not support cancel prefetch task yet
+            pass
 
     @property
     def layer_done_counter(self) -> Any:
@@ -502,6 +576,7 @@ class FlexKVConnector(BaseKVConnector):
 
     def reset(self) -> None:
         self._pending_loads.clear()
+        self._ongoing_prefetches.clear()
         self._ongoing_loads.clear()
         self._completed_loads.clear()
         self._load_fkv_tids.clear()

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -261,6 +261,7 @@ class FlexKVConnector(BaseKVConnector):
 
         self.tp_size = server_args.tp_size
         self.rank = tp_rank
+        self.tp_cpu_group = getattr(tp_group, "cpu_group", tp_group) if tp_group is not None else None
 
         self.k_pool = getattr(kvcache, "k_buffer", None)
         self.v_pool = getattr(kvcache, "v_buffer", None)
@@ -338,11 +339,11 @@ class FlexKVConnector(BaseKVConnector):
             if not update_state_for_load:
                 self.kv_manager.cancel([flexkv_task_id])
 
-        if self.tp_group is not None and self.tp_size > 1:
+        if self.tp_cpu_group is not None and self.tp_size > 1:
             data = broadcast_pyobj(
                 [{"hit_length": hit_length, "task_id": flexkv_task_id}],
                 self.rank,
-                self.tp_group,
+                self.tp_cpu_group,
                 src=0,
             )[0]
             hit_length = data["hit_length"]
@@ -409,8 +410,8 @@ class FlexKVConnector(BaseKVConnector):
                         "[FlexKV] Some tasks failed in non-layerwise transfer"
                     )
 
-            if self.tp_group is not None and self.tp_size > 1:
-                torch.distributed.barrier(self.tp_group)
+            if self.tp_cpu_group is not None and self.tp_size > 1:
+                torch.distributed.barrier(self.tp_cpu_group)
 
             self._completed_loads.append(task_id)
 
@@ -468,11 +469,11 @@ class FlexKVConnector(BaseKVConnector):
                 completed_ext_ids.append(ext_tid)
                 del self._ongoing_stores[ext_tid]
 
-        if self.tp_group is not None and self.tp_size > 1:
+        if self.tp_cpu_group is not None and self.tp_size > 1:
             completed_ext_ids = broadcast_pyobj(
                 [completed_ext_ids] if self.rank == 0 else [None],
                 self.rank,
-                self.tp_group,
+                self.tp_cpu_group,
                 src=0,
             )[0]
 

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -349,6 +349,7 @@ class FlexKVConnector(BaseKVConnector):
             flexkv_task_id, matched_mask = self.kv_manager.get_match(
                 token_ids=token_ids_np,
                 token_mask=token_mask,
+                cpu_only=True,
             )
             hit_length = int(matched_mask.sum()) if matched_mask is not None else 0
             if not update_state_for_load:

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -262,8 +262,8 @@ class FlexKVConnector(BaseKVConnector):
         self.tp_size = server_args.tp_size
         self.rank = tp_rank
 
-        k_pool = getattr(kvcache, "k_buffer", None)
-        v_pool = getattr(kvcache, "v_buffer", None)
+        self.k_pool = getattr(kvcache, "k_buffer", None)
+        self.v_pool = getattr(kvcache, "v_buffer", None)
 
         if self.rank == 0:
             self.kv_manager = KVManager(
@@ -274,7 +274,7 @@ class FlexKVConnector(BaseKVConnector):
             self.kv_manager.start()
 
         self.tp_client = KVTPClient(self.flexkv_config.gpu_register_port, 0, self.rank)
-        self._register_to_server(k_pool, v_pool)
+        self._register_to_server(self.k_pool, self.v_pool)
 
         self.num_layers = model_config.num_hidden_layers if model_config else 0
         self.enable_layerwise_transfer = bool(
@@ -363,10 +363,10 @@ class FlexKVConnector(BaseKVConnector):
         slot_mappings: List[torch.Tensor] = []
 
         for op in load_ops:
-            fk_tid = self._pending_loads.pop(op.rid, -1)
-            if fk_tid < 0:
+            fkv_tid = self._pending_loads.pop(op.rid, -1)
+            if fkv_tid < 0:
                 continue
-            flexkv_task_ids.append(fk_tid)
+            flexkv_task_ids.append(fkv_tid)
             indices = op.device_indices
             slot_mappings.append(indices.cpu() if indices.is_cuda else indices)
 
@@ -432,7 +432,7 @@ class FlexKVConnector(BaseKVConnector):
 
         try:
             token_ids_np = np.array(token_ids, dtype=np.int64)
-            fk_task_id, unmatched_mask = self.kv_manager.put_match(
+            fkv_task_id, unmatched_mask = self.kv_manager.put_match(
                 token_ids=token_ids_np, token_mask=None
             )
 
@@ -440,9 +440,9 @@ class FlexKVConnector(BaseKVConnector):
                 filtered = kv_indices[unmatched_mask]
                 slot_mapping = filtered.cpu() if filtered.is_cuda else filtered
                 self.kv_manager.launch(
-                    task_ids=[fk_task_id], slot_mappings=[slot_mapping]
+                    task_ids=[fkv_task_id], slot_mappings=[slot_mapping]
                 )
-                self._ongoing_stores[task_id] = fk_task_id
+                self._ongoing_stores[task_id] = fkv_task_id
             else:
                 self._completed_stores.append(task_id)
         except Exception as e:

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_connector.py
@@ -261,7 +261,9 @@ class FlexKVConnector(BaseKVConnector):
 
         self.tp_size = server_args.tp_size
         self.rank = tp_rank
-        self.tp_cpu_group = getattr(tp_group, "cpu_group", tp_group) if tp_group is not None else None
+        self.tp_cpu_group = (
+            getattr(tp_group, "cpu_group", tp_group) if tp_group is not None else None
+        )
 
         self.k_pool = getattr(kvcache, "k_buffer", None)
         self.v_pool = getattr(kvcache, "v_buffer", None)
@@ -421,7 +423,9 @@ class FlexKVConnector(BaseKVConnector):
 
     def check_completed_load_tasks(self) -> List[int]:
         if self.rank == 0 and len(self._load_fkv_tids) >= 100:
-            self.kv_manager.try_wait(task_ids=self._load_fkv_tids)
+            self.kv_manager.try_wait(
+                task_ids=self._load_fkv_tids
+            )  # flush the load tasks
             self._load_fkv_tids.clear()
 
         for ext_tid, producer_id in list(self._ongoing_loads.items()):
@@ -567,11 +571,9 @@ class FlexKVConnector(BaseKVConnector):
         self._send_eventfds_to_worker()
         logger.info("[FlexKV] Rank %d: Initialized layerwise transfer", self.rank)
 
-    def _send_eventfds_to_worker(
-        self, retry_interval: float = 1.0
-    ):
+    def _send_eventfds_to_worker(self, retry_interval: float = 1.0):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        max_retries =self.layerwise_eventfd_connect_max_retries
+        max_retries = self.layerwise_eventfd_connect_max_retries
 
         for attempt in range(max_retries):
             try:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -576,6 +576,10 @@ class ServerArgs:
     enable_hisparse: bool = False
     hisparse_config: Optional[str] = None
 
+    # KVConnector
+    kv_connector_cls: Optional[str] = None
+    kv_connector_extra_config: Optional[str] = None
+
     # LMCache
     enable_lmcache: bool = False
 
@@ -3606,6 +3610,18 @@ class ServerArgs:
                 "and cannot be used at the same time. Please use only one of them."
             )
 
+        if self.kv_connector_cls is not None:
+            if self.disable_radix_cache:
+                raise ValueError(
+                    "The arguments kv-connector-cls and disable-radix-cache are mutually exclusive "
+                    "because ExtendedRadixCache requires radix cache enabled."
+                )
+            if self.enable_hierarchical_cache:
+                raise ValueError(
+                    "The arguments kv-connector-cls and enable-hierarchical-cache are mutually exclusive. "
+                    "Please use only one of them."
+                )
+
         if self.disaggregation_decode_enable_offload_kvcache:
             if self.disaggregation_mode != "decode":
                 raise ValueError(
@@ -3768,6 +3784,11 @@ class ServerArgs:
                     "LMCache is disabled because of using diffusion LLM inference"
                 )
                 self.enable_lmcache = False
+            if self.kv_connector_cls is not None:
+                logger.warning(
+                    "KVConnector is disabled because of using diffusion LLM inference"
+                )
+                self.kv_connector_cls = None
 
         if not self.pp_size > 1:
             logger.warning(
@@ -5438,6 +5459,23 @@ class ServerArgs:
             default=ServerArgs.hisparse_config,
             help="A dictionary in JSON string format for hierarchical sparse attention configuration. "
             'Example: \'{"top_k": 2048, "device_buffer_size": 4096}\'',
+        )
+
+        # KVConnector
+        parser.add_argument(
+            "--kv-connector-cls",
+            type=str,
+            default=ServerArgs.kv_connector_cls,
+            help="The full Python class path for the external KV connector "
+            "(e.g., 'my_module.MyConnector'). The class must inherit from "
+            "sglang.srt.mem_cache.kv_connector.BaseKVConnector.",
+        )
+        parser.add_argument(
+            "--kv-connector-extra-config",
+            type=str,
+            default=ServerArgs.kv_connector_extra_config,
+            help="A dictionary in JSON string format containing extra configuration "
+            "for the external KV connector.",
         )
 
         # LMCache


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR introduces support for an external kvcache connector into the SGLang runtime for kvcache offloading.
## Modifications

<!-- Detail the changes made in this pull request. -->
* Added a new `ExtendedRadixCache` class that decorates the existing `RadixCache` to support an external KV storage connector, handling asynchronous load/store operations, prefetching, and integration with the request scheduling system. (`python/sglang/srt/mem_cache/extended_radix_cache.py`)
* Introduced the `BaseKVConnector` abstract class, defining the interface for external KV storage connectors, including methods for matching, loading, storing, prefetching, and tracking completion of cache operations. (`python/sglang/srt/mem_cache/kv_connector.py`)
* Added new server arguments `kv_connector_cls` and `kv_connector_extra_config` for specifying and configuring the external KV connector. (`python/sglang/srt/server_args.py`)

with @jianyingzhu , @linhu-nv and  @wenpengw-nv

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #24276842962](https://github.com/sgl-project/sglang/actions/runs/24276842962)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->