### PR TITLE
[diffusion] Add /server_info and /model_info endpoints for gateway discovery

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -25,6 +25,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.version import __version__
 
 if TYPE_CHECKING:
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
@@ -93,6 +94,63 @@ async def get_models(request: Request):
         response["pipeline_class"] = model_info.pipeline_cls.__name__
 
     return response
+
+
+@health_router.get("/server_info")
+async def server_info_endpoint(request: Request):
+    """Get server information.
+
+    Returns fields compatible with the LLM engine's /server_info so that
+    the model gateway can discover diffusion workers.
+    """
+    server_args: ServerArgs = request.app.state.server_args
+
+    return {
+        "model_path": server_args.model_path,
+        "served_model_name": server_args.model_id or server_args.model_path,
+        "tp_size": server_args.tp_size,
+        "dp_size": server_args.dp_size,
+        "version": __version__,
+    }
+
+
+@health_router.get("/model_info")
+async def model_info_endpoint(request: Request):
+    """Get model information.
+
+    Returns fields compatible with the LLM engine's /model_info so that
+    the model gateway can detect capabilities for diffusion workers.
+    """
+    from sglang.multimodal_gen.registry import get_model_info
+
+    server_args: ServerArgs = request.app.state.server_args
+    task_type = server_args.pipeline_config.task_type
+
+    try:
+        registry_info = get_model_info(
+            server_args.model_path,
+            backend=server_args.backend,
+            model_id=server_args.model_id,
+        )
+    except Exception:
+        logger.warning("Failed to resolve model info from registry", exc_info=True)
+        registry_info = None
+
+    return {
+        # Fields consumed by the model gateway for worker discovery
+        "model_path": server_args.model_path,
+        "is_generation": True,
+        "model_type": "diffusion",
+        "architectures": (
+            [registry_info.pipeline_cls.__name__] if registry_info else None
+        ),
+        # Fields matching the LLM engine's /model_info shape
+        "has_image_understanding": task_type.accepts_image_input(),
+        "has_audio_understanding": False,
+        # Diffusion-specific fields
+        "task_type": task_type.name,
+        "is_image_gen": task_type.is_image_gen(),
+    }
 
 
 @health_router.get("/health_generate")


### PR DESCRIPTION
## Summary

The diffusion engine was missing `/server_info` and `/model_info` endpoints, preventing the model gateway from discovering and classifying diffusion workers. The LLM engine (`srt`) already exposes both endpoints, and the gateway queries them during worker discovery (`fetch_sglang_http_metadata`).

This PR adds both endpoints to the diffusion engine's `health_router` (no URL prefix) so the gateway can:
- Discover diffusion workers via `/server_info` (get `served_model_name`, `tp_size`, `dp_size`)
- Detect model capabilities via `/model_info` (get `is_generation`, `model_type: "diffusion"`, `architectures`, `task_type`)

### `/server_info` returns:
| Field | Source |
|-------|--------|
| `model_path` | `server_args.model_path` |
| `served_model_name` | `server_args.model_id` or `model_path` |
| `tp_size` | `server_args.tp_size` |
| `dp_size` | `server_args.dp_size` |
| `version` | `sglang.__version__` |

### `/model_info` returns:
| Field | Value | Purpose |
|-------|-------|---------|
| `model_path` | from server_args | Gateway label |
| `is_generation` | `True` | Classify as generation model |
| `model_type` | `"diffusion"` | Distinguish from LLM model types |
| `architectures` | pipeline class name (e.g., `["WanPipeline"]`) | Gateway label |
| `has_image_understanding` | `task_type.accepts_image_input()` | True for I2V, I2I, TI2I, TI2V, I2M |
| `has_audio_understanding` | `False` | No audio diffusion models yet |
| `task_type` | e.g., `"T2V"`, `"I2V"`, `"T2I"` | Diffusion-specific |
| `is_image_gen` | `task_type.is_image_gen()` | True for T2I, I2I, TI2I |

## Test plan

- [ ] Start a diffusion server and verify `curl localhost:30000/server_info` returns correct JSON
- [ ] Verify `curl localhost:30000/model_info` returns correct JSON with `model_type: "diffusion"`
- [ ] Verify the model gateway can discover a diffusion worker with these new endpoints
- [ ] Verify the existing `/v1/model_info` endpoint in `common_api.py` still works (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)