### PR TITLE
[Feature] Add --default-custom-logit-processor server argument

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """A scheduler that manages a tensor parallel GPU worker."""
 
+import json
 import faulthandler
 import logging
 import os
@@ -1538,6 +1539,15 @@ class Scheduler(
                 # Use default bootstrap port
                 recv_req.bootstrap_port = self.server_args.disaggregation_bootstrap_port
 
+            # Inject default custom_params if not provided by client
+            if (
+                recv_req.sampling_params.custom_params is None
+                and self.server_args.default_custom_params is not None
+            ):
+                recv_req.sampling_params.custom_params = json.loads(
+                    self.server_args.default_custom_params
+                )
+
             req = Req(
                 recv_req.rid,
                 recv_req.input_text,
@@ -1549,7 +1559,14 @@ class Scheduler(
                 stream=recv_req.stream,
                 lora_id=recv_req.lora_id,
                 input_embeds=recv_req.input_embeds,
-                custom_logit_processor=recv_req.custom_logit_processor,
+                custom_logit_processor=(
+                    recv_req.custom_logit_processor
+                    or getattr(
+                        self.server_args,
+                        "_default_custom_logit_processor_str",
+                        None,
+                    )
+                ),
                 require_reasoning=recv_req.require_reasoning,
                 return_hidden_states=recv_req.return_hidden_states,
                 return_routed_experts=recv_req.return_routed_experts,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -13,7 +13,7 @@
 # ==============================================================================
 """A scheduler that manages a tensor parallel GPU worker."""
 
-import json
+import copy
 import faulthandler
 import logging
 import os
@@ -1542,10 +1542,11 @@ class Scheduler(
             # Inject default custom_params if not provided by client
             if (
                 recv_req.sampling_params.custom_params is None
-                and self.server_args.default_custom_params is not None
+                and getattr(self.server_args, "_parsed_default_custom_params", None)
+                is not None
             ):
-                recv_req.sampling_params.custom_params = json.loads(
-                    self.server_args.default_custom_params
+                recv_req.sampling_params.custom_params = copy.deepcopy(
+                    self.server_args._parsed_default_custom_params
                 )
 
             req = Req(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3157,6 +3157,16 @@ class ServerArgs:
 
     def _handle_default_custom_logit_processor(self):
         """Validate and prepare the default custom logit processor if specified."""
+        self._parsed_default_custom_params = None
+
+        if (
+            self.default_custom_params is not None
+            and self.default_custom_logit_processor is None
+        ):
+            raise ValueError(
+                "--default-custom-params requires --default-custom-logit-processor."
+            )
+
         if self.default_custom_logit_processor is not None:
             # Automatically enable custom logit processor
             self.enable_custom_logit_processor = True
@@ -3164,12 +3174,26 @@ class ServerArgs:
             # Ensure default_custom_params is at least '{}' so that
             # schedule_batch.py injects __req__ into custom_params
             if self.default_custom_params is None:
-                self.default_custom_params = '{}'
+                self.default_custom_params = "{}"
+
+            if isinstance(self.default_custom_params, str):
+                self._parsed_default_custom_params = json.loads(
+                    self.default_custom_params
+                )
+            elif isinstance(self.default_custom_params, dict):
+                self._parsed_default_custom_params = self.default_custom_params
+            else:
+                raise ValueError(
+                    "--default-custom-params must be a JSON object string or dict."
+                )
+
+            if not isinstance(self._parsed_default_custom_params, dict):
+                raise ValueError(
+                    "--default-custom-params must decode to a JSON object."
+                )
 
             # Import and validate the class from the provided import path
-            module_path, class_name = self.default_custom_logit_processor.rsplit(
-                ".", 1
-            )
+            module_path, class_name = self.default_custom_logit_processor.rsplit(".", 1)
             module = importlib.import_module(module_path)
             cls = getattr(module, class_name)
 
@@ -3186,7 +3210,6 @@ class ServerArgs:
 
             # Serialize to dill string for downstream pipeline use
             self._default_custom_logit_processor_str = cls.to_str()
-
 
     def _handle_debug_utils(self):
         if is_in_ci() and self.soft_watchdog_timeout is None:
@@ -5127,16 +5150,16 @@ class ServerArgs:
             type=str,
             default=None,
             help="Python import path to a CustomLogitProcessor subclass "
-                 "(e.g., 'mypackage.MyProcessor'). Applied to ALL requests "
-                 "that don't provide their own custom_logit_processor. "
-                 "Automatically enables --enable-custom-logit-processor.",
+            "(e.g., 'mypackage.MyProcessor'). Applied to ALL requests "
+            "that don't provide their own custom_logit_processor. "
+            "Automatically enables --enable-custom-logit-processor.",
         )
         parser.add_argument(
             "--default-custom-params",
             type=str,
             default=None,
             help="JSON string of default custom_params for the default custom logit processor. "
-                 "Applied to requests that don't provide their own custom_params.",
+            "Applied to requests that don't provide their own custom_params.",
         )
         parser.add_argument(
             "--flashinfer-mla-disable-ragged",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -639,6 +639,8 @@ class ServerArgs:
     enable_draft_weights_cpu_backup: bool = False
     allow_auto_truncate: bool = False
     enable_custom_logit_processor: bool = False
+    default_custom_logit_processor: Optional[str] = None
+    default_custom_params: Optional[str] = None
     flashinfer_mla_disable_ragged: bool = False
     disable_shared_experts_fusion: bool = False
     disable_chunked_prefix_cache: bool = False
@@ -817,6 +819,9 @@ class ServerArgs:
 
         # Handle debug utilities.
         self._handle_debug_utils()
+
+        # Handle default custom logit processor.
+        self._handle_default_custom_logit_processor()
 
         # Handle any other necessary validations.
         self._handle_other_validations()
@@ -3150,6 +3155,34 @@ class ServerArgs:
                     self.preferred_sampling_params
                 )
 
+    def _handle_default_custom_logit_processor(self):
+        """Validate and prepare the default custom logit processor if specified."""
+        if self.default_custom_logit_processor is not None:
+            # Automatically enable custom logit processor
+            self.enable_custom_logit_processor = True
+
+            # Import and validate the class from the provided import path
+            module_path, class_name = self.default_custom_logit_processor.rsplit(
+                ".", 1
+            )
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+
+            # Verify it is a CustomLogitProcessor subclass
+            from sglang.srt.sampling.custom_logit_processor import (
+                CustomLogitProcessor,
+            )
+
+            if not (isinstance(cls, type) and issubclass(cls, CustomLogitProcessor)):
+                raise ValueError(
+                    f"--default-custom-logit-processor must point to a "
+                    f"CustomLogitProcessor subclass, got {cls}"
+                )
+
+            # Serialize to dill string for downstream pipeline use
+            self._default_custom_logit_processor_str = cls.to_str()
+
+
     def _handle_debug_utils(self):
         if is_in_ci() and self.soft_watchdog_timeout is None:
             logger.info("Set soft_watchdog_timeout since in CI")
@@ -5083,6 +5116,22 @@ class ServerArgs:
             "--enable-custom-logit-processor",
             action="store_true",
             help="Enable users to pass custom logit processors to the server (disabled by default for security)",
+        )
+        parser.add_argument(
+            "--default-custom-logit-processor",
+            type=str,
+            default=None,
+            help="Python import path to a CustomLogitProcessor subclass "
+                 "(e.g., 'mypackage.MyProcessor'). Applied to ALL requests "
+                 "that don't provide their own custom_logit_processor. "
+                 "Automatically enables --enable-custom-logit-processor.",
+        )
+        parser.add_argument(
+            "--default-custom-params",
+            type=str,
+            default=None,
+            help="JSON string of default custom_params for the default custom logit processor. "
+                 "Applied to requests that don't provide their own custom_params.",
         )
         parser.add_argument(
             "--flashinfer-mla-disable-ragged",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3161,6 +3161,11 @@ class ServerArgs:
             # Automatically enable custom logit processor
             self.enable_custom_logit_processor = True
 
+            # Ensure default_custom_params is at least '{}' so that
+            # schedule_batch.py injects __req__ into custom_params
+            if self.default_custom_params is None:
+                self.default_custom_params = '{}'
+
             # Import and validate the class from the provided import path
             module_path, class_name = self.default_custom_logit_processor.rsplit(
                 ".", 1


### PR DESCRIPTION
## Motivation

Currently, custom logit processors can only be applied per-request by having the client serialize a `CustomLogitProcessor` subclass via dill and include it in the request payload. This requires:

1. Every client to know about and implement the processor serialization
2. The `--enable-custom-logit-processor` flag to be manually set
3. No way to enforce a server-wide processing policy (e.g., banning specific tokens for all requests)

This PR adds a `--default-custom-logit-processor` server argument that allows specifying a `CustomLogitProcessor` subclass at server startup via Python import path. The processor is automatically applied to **all requests** that don't provide their own, enabling server-level logit processing policies without any client-side changes.

## Modifications

**`python/sglang/srt/server_args.py`**

- Added `default_custom_logit_processor: Optional[str]` and `default_custom_params: Optional[str]` fields to `ServerArgs`
- Registered `--default-custom-logit-processor` (Python import path) and `--default-custom-params` (JSON string) CLI arguments
- Added `_handle_default_custom_logit_processor()` validation method called during `__post_init__`:
  - Auto-enables `enable_custom_logit_processor = True`
  - Dynamically imports and validates the class is a `CustomLogitProcessor` subclass
  - Serializes to dill string (`cls.to_str()`) for downstream pipeline compatibility

**`python/sglang/srt/managers/scheduler.py`**

- Added `import json` for parsing `--default-custom-params`
- Injects `default_custom_params` into `recv_req.sampling_params.custom_params` when client doesn't provide one (before `Req` creation)
- Falls back to `server_args._default_custom_logit_processor_str` when client doesn't provide `custom_logit_processor` (inside `Req` constructor call)

**No changes** to `tokenizer_manager.py`, `sampling_batch_info.py`, `sampler.py`, or `custom_logit_processor.py` — the default value is injected at the scheduler level and flows through the existing pipeline unchanged.

### Usage

```bash
python -m sglang.launch_server \
  --model Qwen/Qwen3.5-122B-A10B \
  --default-custom-logit-processor sglang.srt.sampling.custom_logit_processor.DisallowedTokensLogitsProcessor 
```

**Priority**: client-specified processor > server default > none.

## Accuracy Tests

This change does not modify model forward computation or kernel code. The logit processor pipeline itself is unchanged — only the injection point (scheduler) is modified to support server-level defaults. Existing tests (`test_custom_logit_processor`) should pass without modification.

## Benchmarking and Profiling

No performance impact expected. The only added overhead is:
- One-time at startup: `importlib.import_module()` + `cls.to_str()` (dill serialization)
- Per-request: one `or` fallback check and optionally one `json.loads()` call for `default_custom_params`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).