### PR TITLE
[AMD] align triton version with vllm docker version to optimize fused_moe_triton for Kimi K2.5

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -157,9 +157,9 @@ def get_model_config(
 def get_rocm_configs_compute_bound() -> List[Dict[str, int]]:
     configs: List[BenchmarkConfig] = []
     waves_per_eu_range = 0
-    for num_stages in [2]:
-        for block_m in [32, 64, 128, 256]:
-            for block_k in [32, 64, 128, 256]:
+    for num_stages in [1, 2]:
+        for block_m in [16, 32, 64, 128, 256]:
+            for block_k in [16, 32, 64, 128, 256]:
                 for block_n in [16, 32, 64, 128, 256]:
                     for num_warps in [1, 2, 4, 8]:
                         for group_size in [1, 4, 8, 16, 32]:
@@ -238,6 +238,7 @@ def get_config_filename(
     use_int4_w4a16: bool,
     per_channel_quant: bool,
     block_shape: List[int],
+    down_moe: bool = False,
 ) -> str:
     dtype_str = get_config_dtype_str(
         dtype,
@@ -250,8 +251,6 @@ def get_config_filename(
     # NOTE(woosuk): The current naming convention uses w2.shape[2], which
     # is the intermediate size after silu_and_mul.
     N = shard_intermediate_size // 2
-    if use_int4_w4a16:
-        N = N // 2
 
     filename = get_config_file_name(
         num_experts,
@@ -259,6 +258,7 @@ def get_config_filename(
         dtype_str,
         block_shape,
         per_channel_quant,
+        down_moe,
     )
 
     return filename

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
@@ -241,7 +241,7 @@ class BenchmarkWorker:
         self.seed = seed
         # Get the device ID to allocate tensors and kernels
         # on the respective GPU.
-        self.device_id = int(ray.get_gpu_ids()[0])
+        self.device_id = 0
         set_global_server_args_for_scheduler(server_args)
 
     def benchmark(
@@ -271,8 +271,6 @@ class BenchmarkWorker:
         block_n = block_shape[0] if block_shape else 0
         block_k = block_shape[1] if block_shape else 0
         N = shard_intermediate_size // 2
-        if use_int4_w4a16:
-            N = N // 2
         op_config = get_moe_configs(
             num_experts,
             N,
@@ -370,6 +368,9 @@ def main(args: argparse.Namespace):
     model_config = get_model_config(
         args.model, args.tp_size, args.ep_size, args.disable_shared_experts_fusion
     )
+
+    print(f"{args=}")
+    print(f"{model_config=}")
 
     E = model_config["num_experts"]
     topk = model_config["topk"]

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py
@@ -23,12 +23,8 @@ from common_utils import (
 from ray.experimental.tqdm_ray import tqdm
 
 from sglang.srt.layers.moe.fused_moe_triton.fused_moe import (
-    get_config_dtype_str,
     invoke_fused_moe_kernel,
     moe_align_block_size,
-)
-from sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_config import (
-    get_config_file_name,
 )
 from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
@@ -37,6 +33,7 @@ from sglang.srt.server_args import (
     set_global_server_args_for_scheduler,
 )
 from sglang.srt.utils import is_hip
+from sglang.srt.utils.hf_transformers_utils import get_config
 
 _is_hip = is_hip()
 
@@ -47,6 +44,19 @@ class MoeInputs:
     sorted_token_ids: torch.Tensor
     expert_ids: torch.Tensor
     num_tokens_post_padded: torch.Tensor
+
+
+@dataclasses.dataclass
+class MoeLayerNums:
+    num_layers: int = 61
+    dense_layers: int = 3
+
+    @property
+    def moe_layers(self) -> int:
+        return self.num_layers - self.dense_layers
+
+
+_moe_layer_nums: MoeLayerNums = None
 
 
 class KernelWrapper:
@@ -116,10 +126,34 @@ class KernelWrapper:
         return time_cost
 
 
-def load_topk_ids(topk_ids_dir, i: int):
+def set_moe_layer_nums(model_name):
+    config = get_config(model_name, trust_remote_code=True)
+
+    # Replace config with text_config for encoder-decoder models after getting block_shape and architecture
+    if hasattr(config, "text_config"):
+        config = config.get_text_config()
+
     num_layers = 61
     dense_layers = 3
+
+    if hasattr(config, "num_hidden_layers"):
+        num_layers = config.num_hidden_layers
+    if hasattr(config, "first_k_dense_replace"):
+        dense_layers = config.first_k_dense_replace
+
+    global _moe_layer_nums
+    _moe_layer_nums = MoeLayerNums(num_layers=num_layers, dense_layers=dense_layers)
+    print(f"{_moe_layer_nums=}")
+
+
+def load_topk_ids(topk_ids_dir, i: int):
+    assert (
+        _moe_layer_nums is not None
+    ), "Call set_moe_layer_nums() before load_topk_ids()"
+    num_layers = _moe_layer_nums.num_layers
+    dense_layers = _moe_layer_nums.dense_layers
     moe_layers = num_layers - dense_layers
+
     return torch.load(
         f"{topk_ids_dir}/topk_ids_layer{i % moe_layers + dense_layers}_idx{i // moe_layers}.pt"
     )
@@ -374,15 +408,30 @@ def benchmark_config(
 
     use_cuda_graph = True if not ncu_enable else False
 
+    enable_tma = True
+    # fused_moe_kernel_gptq_awq kernel currently don't support tma
+    if (
+        (use_int8_w8a16 or use_int4_w4a16)
+        and block_shape is not None
+        and block_shape[1] > 0
+    ):
+        enable_tma = False
+
+    # hip currently don't support tma
+    if is_hip:
+        enable_tma = False
+
     kernel0, kernel1 = get_kernel_wrapper(False, inner_iter, use_cuda_graph)
-    kernel_tma0, kernel_tma1 = get_kernel_wrapper(True, inner_iter, use_cuda_graph)
+    if enable_tma:
+        kernel_tma0, kernel_tma1 = get_kernel_wrapper(True, inner_iter, use_cuda_graph)
 
     # JIT compilation & warmup
     if not ncu_enable:
         kernel0.forward_cost()
         kernel1.forward_cost()
-        kernel_tma0.forward_cost()
-        kernel_tma1.forward_cost()
+        if enable_tma:
+            kernel_tma0.forward_cost()
+            kernel_tma1.forward_cost()
 
     ts0 = []
     ts1 = []
@@ -393,14 +442,19 @@ def benchmark_config(
         prepare(i, inner_iter)
         ts0.append(kernel0.forward_cost())
         ts1.append(kernel1.forward_cost())
-        ts_tma0.append(kernel_tma0.forward_cost())
-        ts_tma1.append(kernel_tma1.forward_cost())
+        if enable_tma:
+            ts_tma0.append(kernel_tma0.forward_cost())
+            ts_tma1.append(kernel_tma1.forward_cost())
     torch.cuda.synchronize()
 
     avg = sum(ts0) / (num_iters) * 1000  # us
     avg1 = sum(ts1) / (num_iters) * 1000  # us
-    avg_tma = sum(ts_tma0) / (num_iters) * 1000  # us
-    avg1_tma = sum(ts_tma1) / (num_iters) * 1000  # us
+    if enable_tma:
+        avg_tma = sum(ts_tma0) / (num_iters) * 1000  # us
+        avg1_tma = sum(ts_tma1) / (num_iters) * 1000  # us
+    else:
+        avg_tma = float("inf")
+        avg1_tma = float("inf")
 
     return avg, avg_tma, avg1, avg1_tma
 
@@ -632,22 +686,19 @@ def save_configs_sep(
     block_shape: List[int],
     down_moe: bool = False,
 ) -> None:
-    dtype_str = get_config_dtype_str(
-        dtype,
-        use_int8_w8a16=use_int8_w8a16,
-        use_fp8_w8a8=use_fp8_w8a8,
-        use_int8_w8a8=use_int8_w8a8,
-        use_int4_w4a16=use_int4_w4a16,
-    )
-
-    # NOTE(woosuk): The current naming convention uses w2.shape[2], which
-    # is the intermediate size after silu_and_mul.
-    filename = get_config_file_name(
+    filename = get_config_filename(
         num_experts,
-        shard_intermediate_size // 2,
-        dtype_str,
+        shard_intermediate_size,
+        hidden_size,
+        topk,
+        dtype,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        False,
         block_shape,
-        down_moe=down_moe,
+        down_moe,
     )
 
     print(f"Writing best config to {filename}...")
@@ -658,6 +709,8 @@ def save_configs_sep(
 
 def main(args: argparse.Namespace):
     print(args)
+
+    set_moe_layer_nums(args.model)
 
     server_args = ServerArgs(
         model_path=args.model, tp_size=args.tp_size, ep_size=args.ep_size
@@ -878,7 +931,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dtype",
         type=str,
-        choices=["auto", "fp8_w8a8", "int8_w8a16", "int8_w8a8", "int8_w4a16"],
+        choices=["auto", "fp8_w8a8", "int8_w8a16", "int8_w8a8", "int4_w4a16"],
         default="auto",
     )
     parser.add_argument("--seed", type=int, default=0)

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -23,7 +23,7 @@ ARG GPU_ARCH=gfx950
 # Base image 942 with rocm700 and args
 FROM $BASE_IMAGE_942 AS gfx942
 ENV BUILD_VLLM="0"
-ENV BUILD_TRITON="0"
+ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
@@ -43,7 +43,7 @@ ENV AITER_COMMIT="v0.1.10.post3"
 # Base image 950 and args
 FROM $BASE_IMAGE_950 AS gfx950
 ENV BUILD_VLLM="0"
-ENV BUILD_TRITON="0"
+ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
@@ -75,8 +75,10 @@ ARG SGL_BRANCH=${SGL_DEFAULT}
 # Version override for setuptools_scm (used in nightly builds)
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 
-ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
-ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
+# triton version align with vllm docker file https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile.rocm_base
+# See https://github.com/ROCm/triton-internal/issues/1542, otherwise moe and gemm kernels will cause VGPR spills
+ARG TRITON_REPO="https://github.com/ROCm/triton.git"
+ARG TRITON_COMMIT="57c693b6"
 
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 
@@ -467,7 +469,7 @@ txt = meta.read_text(encoding="utf-8")
 # Example: replace one exact requirement form.
 # Adjust the string to match what you actually see.
 pat = r"^Requires-Dist:\s*triton==3.5.1[^\s]*;"
-txt2, n = re.subn(pat, r"triton>=3.5.1;", txt, flags=re.MULTILINE)
+txt2, n = re.subn(pat, r"triton>=3.4.0;", txt, flags=re.MULTILINE)
 if txt2 == txt:
     raise SystemExit("Did not find expected Requires-Dist line to replace in METADATA")
 meta.write_text(txt2, encoding="utf-8")

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350X,dtype=int4_w4a16.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350X,dtype=int4_w4a16.json
@@ -1,51 +1,78 @@
 {
     "1": {
-        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 16,
         "BLOCK_SIZE_K": 32,
         "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "2": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 4,
         "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "4": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 4,
         "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "8": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "16": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "24": {
-        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
         "GROUP_SIZE_M": 4,
@@ -53,74 +80,47 @@
         "num_stages": 2,
         "waves_per_eu": 0
     },
-    "32": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
-        "waves_per_eu": 0
-    },
-    "48": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
-        "waves_per_eu": 0
-    },
-    "64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
-        "num_stages": 2,
-        "waves_per_eu": 0
-    },
     "96": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 1,
         "waves_per_eu": 0
     },
     "128": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
         "waves_per_eu": 0
     },
     "256": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "512": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 16,
         "num_warps": 2,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "1024": {
         "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 8,
         "num_warps": 2,
         "num_stages": 2,
         "waves_per_eu": 0
@@ -129,8 +129,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     },
@@ -138,8 +138,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     },
@@ -147,8 +147,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     },
@@ -156,8 +156,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     }

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350X,dtype=int4_w4a16_down.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350X,dtype=int4_w4a16_down.json
@@ -1,0 +1,182 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    }
+}

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350_OAM,dtype=int4_w4a16.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350_OAM,dtype=int4_w4a16.json
@@ -1,51 +1,78 @@
 {
     "1": {
-        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 16,
         "BLOCK_SIZE_K": 32,
         "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "2": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 4,
         "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "4": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 4,
         "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "8": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "16": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "24": {
-        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
         "GROUP_SIZE_M": 4,
@@ -53,74 +80,47 @@
         "num_stages": 2,
         "waves_per_eu": 0
     },
-    "32": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
-        "waves_per_eu": 0
-    },
-    "48": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
-        "waves_per_eu": 0
-    },
-    "64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
-        "num_stages": 2,
-        "waves_per_eu": 0
-    },
     "96": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 1,
         "waves_per_eu": 0
     },
     "128": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 8,
-        "num_warps": 2,
-        "num_stages": 2,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
         "waves_per_eu": 0
     },
     "256": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "512": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 16,
         "num_warps": 2,
         "num_stages": 2,
         "waves_per_eu": 0
     },
     "1024": {
         "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 8,
         "num_warps": 2,
         "num_stages": 2,
         "waves_per_eu": 0
@@ -129,8 +129,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 1,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     },
@@ -138,8 +138,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     },
@@ -147,8 +147,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     },
@@ -156,8 +156,8 @@
         "BLOCK_SIZE_M": 128,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 32,
-        "GROUP_SIZE_M": 4,
-        "num_warps": 2,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0
     }

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350_OAM,dtype=int4_w4a16_down.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI350_OAM,dtype=int4_w4a16_down.json
@@ -1,0 +1,182 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    }
+}

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355X,dtype=int4_w4a16.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355X,dtype=int4_w4a16.json
@@ -1,0 +1,164 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    }
+}

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355X,dtype=int4_w4a16_down.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355X,dtype=int4_w4a16_down.json
@@ -1,0 +1,182 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    }
+}

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355_OAM,dtype=int4_w4a16.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355_OAM,dtype=int4_w4a16.json
@@ -1,0 +1,164 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0
+    }
+}

--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355_OAM,dtype=int4_w4a16_down.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=384,N=256,device_name=AMD_Instinct_MI355_OAM,dtype=int4_w4a16_down.json
@@ -1,0 +1,182 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 1,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 0,
+        "USE_TMA": false
+    }
+}

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_config.py
@@ -221,6 +221,8 @@ def try_get_optimal_moe_config(
     else:
         # First try to load optimal config from the file
         E, _, N = w2_shape
+        if dtype == "int4_w4a16":  # int4 is packed
+            N = N * 2
         block_n = block_shape[0] if block_shape else 0
         block_k = block_shape[1] if block_shape else 0
         configs = get_moe_configs(


### PR DESCRIPTION
## Motivation

https://github.com/sgl-project/sglang/pull/19228 this PR fused_moe_triton performance is much slower than https://github.com/vllm-project/vllm/pull/35093, cause Kimi K2.5 sglang performance is much slower than vllm, the key reason is sglang triton version is not same with vllm triton version.

similar problems is tracked in https://github.com/ROCm/triton-internal/issues/1542

[moe_triton_debug.zip](https://github.com/user-attachments/files/25789350/moe_triton_debug.zip)

problem can be reproduced by 
```
unzip moe_triton_debug.zip
cd moe_triton_debug.zip
bash run_sglang.sh
```

performance result:
```
sglang docker triton(3.4.0): 2.124 ms
pip install triton==3.4.0:  2.376 ms
pip install triton==3.5.0: 2.610 ms
pip install triton==3.6.0: 1.287 ms
 
vllm docker triton(https://github.com/ROCm/triton.git 的57c693b6) : 0.705 ms
```

## Modifications

1. change triton version to `https://github.com/ROCm/triton.git + commit 57c693b6` to align with https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile.rocm_base, set `BUILD_TRITON` default to `1`
2. fix `get_moe_configs` when 'use_int4_w4a16', because weight int4 is packed to uint8, so N=w2.shape(2) * 2
3. autotune with new triton use `python benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton_sep.py --model /dev/shm/models/Kimi-K2.5 --tp 8 --dtype int4_w4a16 --tune --disable-shared-experts-fusion --topk-ids-dir kimi_moe/`
4. after https://github.com/sgl-project/sglang/pull/19440, device_name should not be empty

## Accuracy Tests

```
python3 benchmark/gsm8k/bench_sglang.py --host http://127.0.0.1 --port 30000 --num-questions 1319 --parallel 1319 --num-shots 8
100%|███████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:23<00:00, 15.81it/s]
Accuracy: 0.938
Invalid: 0.000
Latency: 83.414 s
Output throughput: 1611.258 token/s
```

## Benchmarking and Profiling
### Profiling Data before opt:
#### Prefill
<img width="1955" height="376" alt="image" src="https://github.com/user-attachments/assets/bacdf46e-6d1c-4c30-a73a-2d10f7bd6895" />

first moe: 2.881ms

second moe: 1.461ms

#### Decode
<img width="2052" height="435" alt="image" src="https://github.com/user-attachments/assets/ef7d5c3a-6464-4b3d-a10e-ccc8b8bfddf5" />

first moe: 276us

second moe: 82us

### Profiling Data after opt:
#### Prefill
<img width="1348" height="331" alt="image" src="https://github.com/user-attachments/assets/b386d32d-4cee-47f5-b393-ffac1fec8720" />

first moe: 2.881 -> 1.497ms

second moe: 1.461 -> 0.847ms

#### Decode
<img width="1421" height="424" alt="image" src="https://github.com/user-attachments/assets/a16d24ed-e594-45d8-85c5-26d159877bf4" />

first moe: 276 -> 143us

second moe: 82 -> 33us

## Benchmarking 

`original` mean performance before https://github.com/sgl-project/sglang/pull/19228
`optimized` mean performance after https://github.com/sgl-project/sglang/pull/19228
`opt_newl` mean performance after this PR

## ISL1024_OSL1024

| Config           |   Concurrency |   Prompts |   Interactivity (tok/s/user) |   Token Tput/GPU (tok/s) |   Mean E2E Latency (ms) |   Median TTFT (s) |   Median TPOT (s) |
|:-----------------|--------------:|----------:|-----------------------------:|-------------------------:|------------------------:|------------------:|------------------:|
| sglang_opt_new   |             4 |        20 |                       33.829 |                   32.874 |               31139.730 |             0.206 |             0.030 |
| sglang_optimized |             4 |        20 |                       25.523 |                   25.301 |               40449.090 |             0.309 |             0.039 |
| sglang_original  |             4 |        20 |                       22.868 |                   22.570 |               45358.570 |             0.600 |             0.044 |
| sglang_opt_new   |             8 |        40 |                       31.008 |                   61.405 |               33343.570 |             0.321 |             0.032 |
| sglang_optimized |             8 |        40 |                       22.336 |                   44.226 |               46296.260 |             0.482 |             0.045 |
| sglang_original  |             8 |        40 |                       15.511 |                   30.574 |               66956.150 |             0.952 |             0.064 |
| sglang_opt_new   |            16 |        80 |                       27.894 |                  109.831 |               37284.300 |             0.592 |             0.036 |
| sglang_optimized |            16 |        80 |                       16.472 |                   65.086 |               62918.010 |             0.883 |             0.061 |
| sglang_original  |            16 |        80 |                       10.433 |                   41.039 |               99786.730 |             1.883 |             0.096 |
| sglang_opt_new   |            32 |       160 |                       21.891 |                  171.831 |               47662.640 |             1.096 |             0.046 |
| sglang_optimized |            32 |       160 |                       11.416 |                   90.060 |               90941.760 |             1.592 |             0.088 |
| sglang_original  |            32 |       160 |                        7.058 |                   55.154 |              148499.110 |             3.569 |             0.142 |
| sglang_opt_new   |            64 |       320 |                       15.686 |                  246.065 |               66564.880 |             1.721 |             0.064 |
| sglang_optimized |            64 |       320 |                        8.408 |                  132.102 |              123995.910 |             2.270 |             0.119 |
| sglang_original  |            64 |       320 |                        4.992 |                   78.185 |              209508.260 |             4.925 |             0.200 |

### SGLang Improvement vs Original

| Config           |   Concurrency |   Interactivity Improvement (%) |   TTFT Improvement (%) |   TPOT Improvement (%) |
|:-----------------|--------------:|--------------------------------:|-----------------------:|-----------------------:|
| sglang_original  |             4 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |             4 |                           11.61 |                  48.48 |                  10.40 |
| sglang_opt_new   |             4 |                           47.94 |                  65.63 |                  32.40 |
| sglang_original  |             8 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |             8 |                           44.00 |                  49.43 |                  30.56 |
| sglang_opt_new   |             8 |                           99.91 |                  66.32 |                  49.98 |
| sglang_original  |            16 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            16 |                           57.88 |                  53.11 |                  36.66 |
| sglang_opt_new   |            16 |                          167.36 |                  68.54 |                  62.60 |
| sglang_original  |            32 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            32 |                           61.75 |                  55.38 |                  38.17 |
| sglang_opt_new   |            32 |                          210.18 |                  69.29 |                  67.76 |
| sglang_original  |            64 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            64 |                           68.43 |                  53.90 |                  40.63 |
| sglang_opt_new   |            64 |                          214.21 |                  65.06 |                  68.17 |

## ISL8192_OSL1024

| Config           |   Concurrency |   Prompts |   Interactivity (tok/s/user) |   Token Tput/GPU (tok/s) |   Mean E2E Latency (ms) |   Median TTFT (s) |   Median TPOT (s) |
|:-----------------|--------------:|----------:|-----------------------------:|-------------------------:|------------------------:|------------------:|------------------:|
| sglang_opt_new   |             4 |        20 |                       27.894 |                  122.552 |               37591.470 |             1.004 |             0.036 |
| sglang_optimized |             4 |        20 |                       22.517 |                   98.336 |               46848.980 |             1.566 |             0.044 |
| sglang_original  |             4 |        20 |                       20.450 |                   85.785 |               53703.830 |             3.502 |             0.049 |
| sglang_opt_new   |             8 |        40 |                       25.530 |                  221.050 |               41682.380 |             1.713 |             0.039 |
| sglang_optimized |             8 |        40 |                       19.550 |                  168.094 |               54814.720 |             2.515 |             0.051 |
| sglang_original  |             8 |        40 |                       14.015 |                  117.459 |               78445.360 |             5.536 |             0.071 |
| sglang_opt_new   |            16 |        80 |                       22.904 |                  388.176 |               47472.790 |             2.853 |             0.044 |
| sglang_optimized |            16 |        80 |                       14.624 |                  249.623 |               73823.920 |             4.085 |             0.068 |
| sglang_original  |            16 |        80 |                        9.574 |                  159.159 |              115786.790 |             9.207 |             0.104 |
| sglang_opt_new   |            32 |       160 |                       16.667 |                  555.236 |               66378.620 |             5.065 |             0.060 |
| sglang_optimized |            32 |       160 |                        9.796 |                  331.344 |              111232.920 |             7.163 |             0.102 |
| sglang_original  |            32 |       160 |                        6.286 |                  206.472 |              178509.640 |            16.262 |             0.159 |
| sglang_opt_new   |            64 |       320 |                       11.072 |                  724.859 |              101690.700 |             9.273 |             0.090 |
| sglang_optimized |            64 |       320 |                        6.798 |                  451.192 |              163372.640 |            13.026 |             0.147 |
| sglang_original  |            64 |       320 |                        4.244 |                  272.335 |              270677.000 |            29.269 |             0.236 |

### SGLang Improvement vs Original

| Config           |   Concurrency |   Interactivity Improvement (%) |   TTFT Improvement (%) |   TPOT Improvement (%) |
|:-----------------|--------------:|--------------------------------:|-----------------------:|-----------------------:|
| sglang_original  |             4 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |             4 |                           10.11 |                  55.26 |                   9.18 |
| sglang_opt_new   |             4 |                           36.40 |                  71.34 |                  26.69 |
| sglang_original  |             8 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |             8 |                           39.49 |                  54.58 |                  28.31 |
| sglang_opt_new   |             8 |                           82.15 |                  69.05 |                  45.10 |
| sglang_original  |            16 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            16 |                           52.75 |                  55.63 |                  34.53 |
| sglang_opt_new   |            16 |                          139.23 |                  69.01 |                  58.20 |
| sglang_original  |            32 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            32 |                           55.85 |                  55.96 |                  35.84 |
| sglang_opt_new   |            32 |                          165.15 |                  68.86 |                  62.29 |
| sglang_original  |            64 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            64 |                           60.18 |                  55.50 |                  37.57 |
| sglang_opt_new   |            64 |                          160.88 |                  68.32 |                  61.67 |

## ISL1024_OSL8192

| Config           |   Concurrency |   Prompts |   Interactivity (tok/s/user) |   Token Tput/GPU (tok/s) |   Mean E2E Latency (ms) |   Median TTFT (s) |   Median TPOT (s) |
|:-----------------|--------------:|----------:|-----------------------------:|-------------------------:|------------------------:|------------------:|------------------:|
| sglang_opt_new   |             4 |        20 |                       30.760 |                   17.280 |              266657.230 |             0.210 |             0.033 |
| sglang_optimized |             4 |        20 |                       24.195 |                   13.602 |              338758.250 |             0.308 |             0.041 |
| sglang_original  |             4 |        20 |                       21.612 |                   12.194 |              377872.410 |             0.598 |             0.046 |
| sglang_opt_new   |             8 |        40 |                       28.369 |                   31.861 |              289241.750 |             0.336 |             0.035 |
| sglang_optimized |             8 |        40 |                       21.026 |                   23.599 |              390508.700 |             0.489 |             0.048 |
| sglang_original  |             8 |        40 |                       14.950 |                   16.801 |              548518.190 |             1.025 |             0.067 |
| sglang_opt_new   |            16 |        80 |                       25.648 |                   57.549 |              320272.990 |             0.636 |             0.039 |
| sglang_optimized |            16 |        80 |                       15.790 |                   35.432 |              520177.600 |             0.878 |             0.063 |
| sglang_original  |            16 |        80 |                       10.275 |                   23.014 |              800882.410 |             1.873 |             0.097 |
| sglang_opt_new   |            32 |       160 |                       19.608 |                   87.919 |              419281.810 |             0.995 |             0.051 |
| sglang_optimized |            32 |       160 |                       10.841 |                   48.663 |              757531.390 |             1.586 |             0.092 |
| sglang_original  |            32 |       160 |                        6.928 |                   30.961 |             1190638.980 |             3.562 |             0.144 |
| sglang_opt_new   |            64 |       320 |                       14.083 |                  125.748 |              586299.480 |             1.627 |             0.071 |
| sglang_optimized |            64 |       320 |                        7.916 |                   71.094 |             1037015.790 |             2.121 |             0.126 |
| sglang_original  |            64 |       320 |                        4.908 |                   44.065 |             1673097.970 |             4.939 |             0.204 |

### SGLang Improvement vs Original

| Config           |   Concurrency |   Interactivity Improvement (%) |   TTFT Improvement (%) |   TPOT Improvement (%) |
|:-----------------|--------------:|--------------------------------:|-----------------------:|-----------------------:|
| sglang_original  |             4 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |             4 |                           11.95 |                  48.53 |                  10.68 |
| sglang_opt_new   |             4 |                           42.33 |                  64.88 |                  29.74 |
| sglang_original  |             8 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |             8 |                           40.64 |                  52.32 |                  28.90 |
| sglang_opt_new   |             8 |                           89.76 |                  67.17 |                  47.30 |
| sglang_original  |            16 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            16 |                           53.67 |                  53.12 |                  34.93 |
| sglang_opt_new   |            16 |                          149.60 |                  66.03 |                  59.94 |
| sglang_original  |            32 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            32 |                           56.48 |                  55.48 |                  36.10 |
| sglang_opt_new   |            32 |                          183.02 |                  72.06 |                  64.67 |
| sglang_original  |            64 |                            0.00 |                   0.00 |                   0.00 |
| sglang_optimized |            64 |                           61.28 |                  57.06 |                  38.00 |
| sglang_opt_new   |            64 |                          186.93 |                  67.06 |                  65.15 |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
