### PR TITLE
[Bug Fix] Return HTTP 400 for streaming requests with validation errors (#19996)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -596,7 +596,7 @@ class OpenAIServingChat(OpenAIServingBase):
         raw_request: Request,
     ) -> StreamingResponse:
         """Handle streaming chat completion request"""
-        await self.tokenizer_manager.validate_request(adapted_request, raw_request)
+        await self.tokenizer_manager.validate_request_for_streaming(adapted_request)
         return StreamingResponse(
             self._generate_chat_stream(adapted_request, request, raw_request),
             media_type="text/event-stream",

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -596,6 +596,7 @@ class OpenAIServingChat(OpenAIServingBase):
         raw_request: Request,
     ) -> StreamingResponse:
         """Handle streaming chat completion request"""
+        await self.tokenizer_manager.validate_request(adapted_request, raw_request)
         return StreamingResponse(
             self._generate_chat_stream(adapted_request, request, raw_request),
             media_type="text/event-stream",

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -177,6 +177,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         raw_request: Request,
     ) -> StreamingResponse:
         """Handle streaming completion request"""
+        await self.tokenizer_manager.validate_request_for_streaming(adapted_request)
         return StreamingResponse(
             self._generate_completion_stream(adapted_request, request, raw_request),
             media_type="text/event-stream",

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -526,11 +526,27 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 async for response in self._handle_batch_request(obj, request):
                     yield response
 
-    async def validate_request(
+    async def validate_request_for_streaming(
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
-        request: Optional[fastapi.Request] = None,
     ) -> None:
+        """Validate request for streaming without creating state or acquiring LoRA references.
+
+        This method is designed to be called before streaming starts, so that validation
+        errors can be returned with proper HTTP status codes (e.g., 400) instead of being
+        sent through SSE after the stream has started.
+
+        Unlike generate_request, this method:
+        - Does NOT create rid_to_state (avoids KeyError)
+        - Does NOT acquire LoRA references (avoids reference leak)
+        - Does NOT send requests to scheduler
+
+        Args:
+            obj: The request object to validate
+
+        Raises:
+            ValueError: If validation fails (e.g., context length exceeded)
+        """
         self.auto_create_handle_loop()
 
         obj.normalize_batch_and_arguments()
@@ -552,12 +568,138 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             await self.is_pause_cond.wait_for(lambda: not self.is_pause)
 
         async with self.model_update_lock.reader_lock:
-            await self._validate_and_resolve_lora(obj)
+            if obj.lora_path:
+                if not self.server_args.enable_lora:
+                    first_adapter = (
+                        obj.lora_path
+                        if isinstance(obj.lora_path, str)
+                        else next((a for a in obj.lora_path if a), None)
+                    )
+                    raise ValueError(
+                        f"LoRA adapter '{first_adapter}' was requested, but LoRA is not enabled. "
+                        "Please launch the server with --enable-lora flag and preload adapters "
+                        "using --lora-paths or /load_lora_adapter endpoint."
+                    )
 
             if obj.is_single:
-                await self._tokenize_one_request(obj)
+                await self._tokenize_and_validate_only(obj)
             else:
-                await self._batch_tokenize_and_process(obj)
+                await self._batch_tokenize_and_validate_only(obj)
+
+    async def _tokenize_and_validate_only(
+        self,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+    ) -> None:
+        """Tokenize and validate request without creating tokenized object or state.
+
+        This method performs tokenization and validation but does NOT:
+        - Create rid_to_state entry
+        - Create TokenizedGenerateReqInput/TokenizedEmbeddingReqInput
+        - Acquire LoRA references
+
+        Args:
+            obj: The request object to validate
+
+        Raises:
+            ValueError: If validation fails
+        """
+        input_text = obj.text
+        token_type_ids = None
+        is_cross_encoder_request = (
+            isinstance(obj, EmbeddingReqInput) and obj.is_cross_encoder_request
+        )
+
+        if obj.input_embeds is not None:
+            if not self.server_args.disable_radix_cache:
+                raise ValueError(
+                    "input_embeds is provided while disable_radix_cache is False. "
+                    "Please add `--disable-radix-cache` when you launch the server "
+                    "if you want to use input_embeds as inputs."
+                )
+            input_ids = obj.input_ids
+        elif obj.input_ids is not None:
+            input_ids = obj.input_ids
+        else:
+            if self.tokenizer is None:
+                raise ValueError(
+                    "The engine initialized with skip_tokenizer_init=True cannot "
+                    "accept text prompts. Please provide input_ids or re-initialize "
+                    "the engine with skip_tokenizer_init=False."
+                )
+
+            if not input_text and self.mm_processor and obj.contains_mm_input():
+                input_ids = []
+            else:
+                input_ids, token_type_ids = await self._tokenize_texts(
+                    input_text, is_cross_encoder_request
+                )
+
+        if self.mm_processor and obj.contains_mm_input():
+            if obj.image_data is not None and not isinstance(obj.image_data, list):
+                obj.image_data = [obj.image_data]
+            if obj.video_data is not None and not isinstance(obj.video_data, list):
+                obj.video_data = [obj.video_data]
+            if obj.audio_data is not None and not isinstance(obj.audio_data, list):
+                obj.audio_data = [obj.audio_data]
+            self._validate_mm_limits(obj)
+
+            mm_inputs = None
+
+            if (
+                not self.server_args.language_only
+                or self.server_args.encoder_transfer_backend
+                in ["zmq_to_tokenizer", "mooncake"]
+            ):
+                if self.server_args.language_only:
+                    mm_inputs = await self.mm_receiver.recv_mm_data(
+                        img_data=obj.image_data,
+                        mm_processor=self.mm_processor,
+                        prompt=(input_text or input_ids),
+                        need_wait_for_image=obj.need_wait_for_image,
+                    )
+                if mm_inputs is None:
+                    mm_inputs: Dict = await self.mm_data_processor.process(
+                        image_data=obj.image_data,
+                        audio_data=obj.audio_data,
+                        input_text_or_ids=(input_text or input_ids),
+                        request_obj=obj,
+                        max_req_input_len=self.max_req_input_len,
+                    )
+            elif (
+                self.server_args.language_only
+                and self.server_args.encoder_transfer_backend == "zmq_to_scheduler"
+                and not obj.need_wait_for_image
+            ):
+                mm_inputs: Dict = await self.mm_data_processor.process(
+                    image_data=obj.image_data,
+                    audio_data=obj.audio_data,
+                    input_text_or_ids=(input_text or input_ids),
+                    request_obj=obj,
+                    max_req_input_len=self.max_req_input_len,
+                )
+
+            if mm_inputs and "input_ids" in mm_inputs:
+                input_ids = mm_inputs["input_ids"]
+        else:
+            mm_inputs = None
+
+        self._validate_one_request(obj, input_ids)
+
+    async def _batch_tokenize_and_validate_only(
+        self,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+    ) -> None:
+        """Batch tokenize and validate without creating state.
+
+        Args:
+            obj: The batch request object to validate
+
+        Raises:
+            ValueError: If validation fails for any request in the batch
+        """
+        batch_size = obj.batch_size
+        for i in range(batch_size):
+            await self._tokenize_and_validate_only(obj[i])
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -526,6 +526,39 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 async for response in self._handle_batch_request(obj, request):
                     yield response
 
+    async def validate_request(
+        self,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+        request: Optional[fastapi.Request] = None,
+    ) -> None:
+        self.auto_create_handle_loop()
+
+        obj.normalize_batch_and_arguments()
+        self._set_default_priority(obj)
+        self._validate_rid(obj)
+
+        if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:
+            dp_size = self.server_args.dp_size
+            if dp_size <= 1 and obj.routed_dp_rank == 0:
+                logger.warning(
+                    f"routed_dp_rank={obj.routed_dp_rank} is ignored because dp_size={dp_size}"
+                )
+            elif obj.routed_dp_rank < 0 or obj.routed_dp_rank >= dp_size:
+                raise ValueError(
+                    f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
+                )
+
+        async with self.is_pause_cond:
+            await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+
+        async with self.model_update_lock.reader_lock:
+            await self._validate_and_resolve_lora(obj)
+
+            if obj.is_single:
+                await self._tokenize_one_request(obj)
+            else:
+                await self._batch_tokenize_and_process(obj)
+
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool
     ) -> InputFormat:


### PR DESCRIPTION
For oversized prompts (input tokens exceed context length), SGLang OpenAI-compatible /v1/chat/completions behaves inconsistently between streaming and non-streaming:
- stream=true : Returns HTTP 200 with an error payload (error.code=400)
- stream=false : Returns HTTP 400

This is inconsistent with vLLM which returns HTTP 400 for both cases.
Added a validate_request method to TokenizerManager that performs request validation without sending the request to the scheduler. This method is called in _handle_streaming_request before returning the StreamingResponse, ensuring validation errors return HTTP 400 instead of HTTP 200.
Fixes #19996 