### PR TITLE
[AMD] Fix AMD CI - stage-b-small-1-gpu-amd (partition 7)

### DIFF
--- a/test/registered/models/test_reward_models.py
+++ b/test/registered/models/test_reward_models.py
@@ -25,7 +25,7 @@ from sglang.test.test_utils import CustomTestCase
 
 
 register_cuda_ci(est_time=103, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=132, suite="stage-b-test-small-1-gpu-amd")
+register_amd_ci(est_time=132, suite="stage-b-test-small-1-gpu-amd-nondeterministic")
 
 MODELS = [
     ("LxzGordon/URM-LLaMa-3.1-8B", 1, 4e-2),


### PR DESCRIPTION
## Motivation

`stage-b-test-small-1-gpu-amd` partition 7 has been intermittently failing with random `ModuleNotFoundError` (e.g., `transformers.pytorch_utils`, `sglang`, etc.). The failing module varies between runs, and failures always occur in tests that run **after** `test_reward_models.py`.

### Debugging findings

1. **Not a dependency issue**: Debug checks confirmed `transformers==4.57.1` is correctly installed and `pytorch_utils` imports fine immediately after dependency installation.
2. **Not resource exhaustion**: Inter-test cleanup showed no orphan processes, plenty of free RAM (961 GiB), 0% GPU memory usage, and 17% disk usage — yet the next test still failed.
3. **Isolated to partition 7**: No other partition exhibits this behavior. The common factor is `test_reward_models.py`, which is the **only test** in the suite that uses `SRTRunner(Engine)` (in-process GPU engine initialization) rather than `popen_launch_server` (external server subprocess).
4. **Confirmed by removal**: After moving `test_reward_models.py` out of the partition, the flaky import errors disappeared completely.

### Root cause (not yet fully understood)

`test_reward_models.py` loads 3 reward models sequentially using `HFRunner` (multiprocessing) and `SRTRunner` (in-process `Engine`). After the test subprocess exits, something it leaves behind causes subsequent test subprocesses' server launches to fail with `ModuleNotFoundError`. The exact mechanism is still unclear, it is not orphan processes, GPU memory leaks, shared memory, or Python environment corruption (all verified via automated checks). It may be related to:
- Editable install (`pip install -e`) + Docker overlay FS interaction
- ROCm driver/KFD state not fully resetting between subprocesses
- `.pyc` bytecode cache race conditions during concurrent imports

Further investigation is needed to root-cause and allow `test_reward_models.py` to safely coexist with other tests in the same partition.

- [x] Verified `stage-b-test-small-1-gpu-amd` partition 7 passes without `test_reward_models`
- [x] Verified `test_reward_models` still runs (in `nondeterministic` suite)
- [ ] Long-term: root-cause the interaction between `SRTRunner(Engine)` and subsequent test subprocesses


## Modifications

- Move `test_reward_models.py` from `stage-b-test-small-1-gpu-amd` to `stage-b-test-small-1-gpu-amd-nondeterministic` to fix flaky import errors in AMD CI partition 7.

## Accuracy Tests

<img width="466" height="515" alt="image" src="https://github.com/user-attachments/assets/0703e292-df7a-4b7a-b134-61c50f186437" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
