### PR TITLE
Feat: qwen3.5 logits processor

### DIFF
--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -128,6 +128,14 @@ class Qwen3ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
     NEW_LINE_TOKEN_ID: int = 198
 
 
+class Qwen35ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
+    """A logit processor that controls the length of thinking for Qwen3.5 models."""
+
+    THINKING_START_TOKEN_ID: int = 248068
+    THINKING_END_TOKEN_ID: int = 248069
+    NEW_LINE_TOKEN_ID: int = 198
+
+
 class DeepSeekR1ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
     """A logit processor that controls the length of thinking for DeepSeek-R1 models."""
 


### PR DESCRIPTION
## Summary

- Add `Qwen35ThinkingBudgetLogitProcessor` for Qwen3.5 models
- Qwen3.5 uses different `<think>`/`</think>` token IDs (248068/248069) compared to Qwen3 (151667/151668); using `Qwen3ThinkingBudgetLogitProcessor` on Qwen3.5 silently fails to enforce the thinking budget

## Test

Verified token IDs via `AutoTokenizer` on a Qwen3.5 checkpoint. Confirmed `thinking_budget` enforcement works with the new processor.