### PR TITLE
[VLM] Replace conv3d proj with linear for GLM4V

### DIFF
--- a/python/sglang/srt/models/glm4v.py
+++ b/python/sglang/srt/models/glm4v.py
@@ -211,16 +211,26 @@ class Glm4vVisionPatchEmbed(nn.Module):
             bias=True,
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.view(
-            -1,
-            self.in_channels,
-            self.temporal_patch_size,
-            self.patch_size,
-            self.patch_size,
+        k = self.in_channels * self.temporal_patch_size * self.patch_size**2
+        self.linear = nn.Linear(
+            in_features=k,
+            out_features=self.hidden_size,
+            bias=True,
+            dtype=self.proj.weight.dtype,
         )
-        x = self.proj(x).view(-1, self.hidden_size)
-        return x
+
+    def copy_conv3d_weight_to_linear(self):
+        # Call this after weight loading
+        with torch.no_grad():
+            self.linear.weight.copy_(self.proj.weight.view(self.hidden_size, -1))
+            self.linear.bias.copy_(self.proj.bias)
+        del self.proj
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # After copy_conv3d_weight_to_linear(), self.linear exists and
+        # self.proj has been deleted.  Input x is already 2-D:
+        #   (num_patches, C * T * P * P)
+        return self.linear(x)
 
 
 class Glm4vPatchMerger(nn.Module):
@@ -446,10 +456,16 @@ class Glm4vVisionModel(nn.Module):
 
     @property
     def dtype(self) -> torch.dtype:
+        # After Conv3d to Linear conversion, self.proj is deleted and
+        # self.linear takes its place.
+        if hasattr(self.patch_embed, "linear"):
+            return self.patch_embed.linear.weight.dtype
         return self.patch_embed.proj.weight.dtype
 
     @property
     def device(self) -> torch.device:
+        if hasattr(self.patch_embed, "linear"):
+            return self.patch_embed.linear.weight.device
         return self.patch_embed.proj.weight.device
 
     def rot_pos_emb(
@@ -799,6 +815,7 @@ class Glm4vForConditionalGeneration(nn.Module):
                         self.config, name, loaded_weight
                     )
                 weight_loader(param, loaded_weight)
+        self.visual.patch_embed.copy_conv3d_weight_to_linear()
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/test/registered/vlm/test_patch_embed_perf.py
+++ b/test/registered/vlm/test_patch_embed_perf.py
@@ -1,0 +1,166 @@
+import os
+import statistics
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang.srt.models.glm4v import Glm4vVisionPatchEmbed
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, suite="stage-b-test-large-1-gpu")
+
+PATCH_SIZE = 14
+TEMPORAL_PATCH_SIZE = 2
+IN_CHANNELS = 3
+HIDDEN_SIZE = 1536
+FLAT_DIM = IN_CHANNELS * TEMPORAL_PATCH_SIZE * PATCH_SIZE * PATCH_SIZE
+
+
+class ReferenceConv3dPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        patch_size=PATCH_SIZE,
+        temporal_patch_size=TEMPORAL_PATCH_SIZE,
+        in_channels=IN_CHANNELS,
+        hidden_size=HIDDEN_SIZE,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.in_channels = in_channels
+        self.hidden_size = hidden_size
+
+        kernel_size = (temporal_patch_size, patch_size, patch_size)
+        self.proj = nn.Conv3d(
+            in_channels,
+            hidden_size,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.view(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        x = self.proj(x).view(-1, self.hidden_size)
+        return x
+
+
+def _build_modules(device: str, dtype: torch.dtype):
+    conv_mod = ReferenceConv3dPatchEmbed().to(device=device, dtype=dtype).eval()
+    linear_mod = (
+        Glm4vVisionPatchEmbed(
+            patch_size=PATCH_SIZE,
+            temporal_patch_size=TEMPORAL_PATCH_SIZE,
+            in_channels=IN_CHANNELS,
+            hidden_size=HIDDEN_SIZE,
+        )
+        .to(device=device, dtype=dtype)
+        .eval()
+    )
+
+    with torch.no_grad():
+        linear_mod.proj.weight.copy_(conv_mod.proj.weight)
+        linear_mod.proj.bias.copy_(conv_mod.proj.bias)
+
+        linear_mod.copy_conv3d_weight_to_linear()
+
+    return conv_mod, linear_mod
+
+
+def _benchmark_cuda_module(
+    module: nn.Module,
+    x: torch.Tensor,
+    warmup: int = 50,
+    inner_iters: int = 200,
+    repeats: int = 10,
+) -> float:
+    assert x.is_cuda
+    module.eval()
+
+    with torch.inference_mode():
+        for _ in range(warmup):
+            module(x)
+        torch.cuda.synchronize()
+
+        samples = []
+        for _ in range(repeats):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+
+            start.record()
+            for _ in range(inner_iters):
+                module(x)
+            end.record()
+
+            torch.cuda.synchronize()
+            samples.append(start.elapsed_time(end) / inner_iters)
+
+    return statistics.median(samples)
+
+
+def test_patch_embed_linear_matches_conv3d():
+    torch.manual_seed(0)
+
+    device = "cpu"
+    dtype = torch.float32
+
+    conv_mod, linear_mod = _build_modules(device=device, dtype=dtype)
+
+    x = torch.randn(512, FLAT_DIM, device=device, dtype=dtype)
+
+    with torch.inference_mode():
+        y_conv = conv_mod(x)
+        y_linear = linear_mod(x)
+
+    torch.testing.assert_close(
+        y_conv,
+        y_linear,
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required for perf benchmark"
+)
+def test_patch_embed_linear_conv3d():
+    torch.manual_seed(0)
+    torch.backends.cudnn.benchmark = True
+
+    device = "cuda"
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+    conv_mod, linear_mod = _build_modules(device=device, dtype=dtype)
+
+    num_patches = int(os.getenv("GLM4V_NUM_PATCHES", "4096"))
+    warmup = int(os.getenv("GLM4V_WARMUP", "50"))
+    inner_iters = int(os.getenv("GLM4V_INNER_ITERS", "200"))
+    repeats = int(os.getenv("GLM4V_REPEATS", "10"))
+
+    x = torch.randn(num_patches, FLAT_DIM, device=device, dtype=dtype).contiguous()
+
+    conv_ms = _benchmark_cuda_module(
+        conv_mod, x, warmup=warmup, inner_iters=inner_iters, repeats=repeats
+    )
+    linear_ms = _benchmark_cuda_module(
+        linear_mod, x, warmup=warmup, inner_iters=inner_iters, repeats=repeats
+    )
+
+    speedup = conv_ms / linear_ms
+    print(
+        f"\n[patch_embed perf] conv3d={conv_ms:.4f} ms | "
+        f"linear={linear_ms:.4f} ms | speedup={speedup:.3f}x"
+    )
+
+    min_speedup = float(os.getenv("GLM4V_MIN_SPEEDUP", "1.00"))
+    assert speedup >= min_speedup, (
+        f"Expected speedup >= {min_speedup:.3f}x, but got {speedup:.3f}x "
+        f"(conv3d={conv_ms:.4f} ms, linear={linear_ms:.4f} ms)"
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Inspired by https://github.com/sgl-project/sglang/pull/19788 with some optimizations:

lmms_evals no drops.


Main and PR are the same score:
```
➜  python git:(main) ✗ python -m sglang.launch_server --model-path zai-org/GLM-4.5V --mm-attention-backend fa3 --port 30000 --tp-size 4
```

```
2026-03-06 14:40:15 | INFO     | __main__:cli_evaluate:476 - Verbosity set to INFO
2026-03-06 14:40:18 | INFO     | __main__:cli_evaluate_single:565 - Evaluation tracker args: {}
2026-03-06 14:40:18 | INFO     | __main__:cli_evaluate_single:649 - Selected Tasks: ['mmmu_val']
2026-03-06 14:40:18 | INFO     | lmms_eval.evaluator:simple_evaluate:170 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2026-03-06 14:40:19 | INFO     | lmms_eval.evaluator:evaluate:515 - Running on rank 0 (local rank 0)
2026-03-06 14:40:19 | INFO     | lmms_eval.api.task:build_all_requests:428 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 14021.62it/s]
2026-03-06 14:40:19 | INFO     | lmms_eval.evaluator:evaluate:609 - Running generate_until requests
Model Responding:  98%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊    | 880/900 [02:50<00:03,  5.77it/s]2026-03-06 14:43:10 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:136 - Metric summary - Total elapsed time: 4206.687s, Total gen tokens: 114995, Avg speed: 27.3 tokens/s
Model Responding: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [02:50<00:00,  5.27it/s]
Postprocessing: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 8781.68it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.50833}, 'Art': {'num': 30, 'acc': 0.63333}, 'Art_Theory': {'num': 30, 'acc': 0.5}, 'Design': {'num': 30, 'acc': 0.6}, 'Music': {'num': 30, 'acc': 0.3}, 'Overall-Business': {'num': 150, 'acc': 0.29333}, 'Accounting': {'num': 30, 'acc': 0.36667}, 'Economics': {'num': 30, 'acc': 0.36667}, 'Finance': {'num': 30, 'acc': 0.16667}, 'Manage': {'num': 30, 'acc': 0.3}, 'Marketing': {'num': 30, 'acc': 0.26667}, 'Overall-Science': {'num': 150, 'acc': 0.24}, 'Biology': {'num': 30, 'acc': 0.3}, 'Chemistry': {'num': 30, 'acc': 0.16667}, 'Geography': {'num': 30, 'acc': 0.33333}, 'Math': {'num': 30, 'acc': 0.23333}, 'Physics': {'num': 30, 'acc': 0.16667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.38667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.6}, 'Clinical_Medicine': {'num': 30, 'acc': 0.36667}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.13333}, 'Pharmacy': {'num': 30, 'acc': 0.36667}, 'Public_Health': {'num': 30, 'acc': 0.46667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.325}, 'History': {'num': 30, 'acc': 0.33333}, 'Literature': {'num': 30, 'acc': 0.46667}, 'Sociology': {'num': 30, 'acc': 0.26667}, 'Psychology': {'num': 30, 'acc': 0.23333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.29048}, 'Agriculture': {'num': 30, 'acc': 0.3}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.2}, 'Computer_Science': {'num': 30, 'acc': 0.36667}, 'Electronics': {'num': 30, 'acc': 0.2}, 'Energy_and_Power': {'num': 30, 'acc': 0.46667}, 'Materials': {'num': 30, 'acc': 0.23333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.26667}, 'Overall': {'num': 900, 'acc': 0.33222}}
fatal: not a git repository (or any of the parent directories): .git
2026-03-06 14:43:10 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:238 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=zai-org/GLM-4.5V), gen_kwargs: (), limit: None, offset: 0, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.3322|±  |N/A   |
```


More performance test will be done soon.

Server:
```
python -m sglang.launch_server --model-path zai-org/GLM-4.1V-9B-Thinking --mm-attention-backend fa3 --port 30000
```
Client:
```
➜  bench_script bash test_image.sh
{"id":"3139aaab39334c4ba7d79dedbb06c3ad","object":"chat.completion","created":1772799452,"model":"nvidia/Eagle2.5-8B","choices":[{"index":0,"message":{"role":"assistant","content":"<think>用户现在需要描述图上的内容。首先看画面主体：一个人戴着灰色针织帽，穿牛仔外套，双手举着佳能相机（Canon相机）拍照，背景是户外开阔地，光线柔和，可能是傍晚或清晨，背景有模糊的自然景观（树木、开阔地）。要分解元素：人物装扮（帽子、外套）、动作（拍照）、相机品牌、环境氛围等。\n\n所以组织语言：图中展示了一位戴着灰色针织帽、穿着牛仔外套的人，正双手举着佳能相机进行拍摄。背景是一片开阔的户外场景，光线柔和，远处有模糊的树木和开阔地，整体氛围给人一种自然、宁静的感觉，仿佛是在户外的自然环境中记录美好瞬间。需要确认细节：相机是佳能（能看到Canon字样），人物的动作是举着相机拍照，穿着牛仔外套和针织帽，背景是户外开阔地，光线偏暖，可能是黄昏或清晨时分。\n\n总结描述：图中是一位戴着灰色针织帽、身穿牛仔外套的人，正双手握着佳能相机进行拍摄，背景是开阔的户外自然场景（有树木和开阔地），整体画面呈现出一种在户外记录瞬间的氛围，光线柔和，给人宁静自然的感觉。</think><answer>图中展示了一位戴着灰色针织帽、穿着牛仔外套的人，正双手举着佳能相机进行拍摄。背景是一片开阔的户外场景，远处有模糊的树木与开阔地，光线柔和，整体氛围给人一种自然、宁静的感觉，仿佛是在户外的自然环境中记录美好瞬间。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151348}],"usage":{"prompt_tokens":1028,"total_tokens":1341,"completion_tokens":313,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real	0m2.314s
user	0m0.002s
sys	0m0.002s
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
