### PR TITLE
[model-gateway] Sync real worker load to mesh

### DIFF
--- a/sgl-model-gateway/src/core/worker_registry.rs
+++ b/sgl-model-gateway/src/core/worker_registry.rs
@@ -289,7 +289,7 @@ impl WorkerRegistry {
                 worker.model_id().to_string(),
                 worker.url().to_string(),
                 worker.is_healthy(),
-                0.0, // TODO: Get actual load
+                worker.load() as f64,
             );
         }
 
@@ -413,7 +413,7 @@ impl WorkerRegistry {
                     worker.model_id().to_string(),
                     worker.url().to_string(),
                     is_healthy,
-                    0.0, // TODO: Get actual load
+                    worker.load() as f64,
                 );
             }
         }
@@ -652,6 +652,7 @@ impl WorkerRegistry {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
         let workers_ref = self.workers.clone();
+        let mesh_sync_ref = self.mesh_sync.clone();
 
         let handle = tokio::spawn(async move {
             let mut interval =
@@ -667,17 +668,16 @@ impl WorkerRegistry {
                 }
 
                 // Get all workers from registry
-                let workers: Vec<Arc<dyn Worker>> = workers_ref
+                let workers: Vec<(WorkerId, Arc<dyn Worker>)> = workers_ref
                     .iter()
-                    .map(|entry| entry.value().clone())
+                    .map(|entry| (entry.key().clone(), entry.value().clone()))
                     .collect();
 
-                // Perform health checks in parallel for better performance
-                // This is especially important when there are many workers
+                // Perform health checks in parallel for workers that have health checks enabled
                 let health_futures: Vec<_> = workers
                     .iter()
-                    .filter(|worker| !worker.metadata().health_config.disable_health_check)
-                    .map(|worker| {
+                    .filter(|(_, worker)| !worker.metadata().health_config.disable_health_check)
+                    .map(|(_, worker)| {
                         let worker = worker.clone();
                         async move {
                             let _ = worker.check_health_async().await;
@@ -685,6 +685,19 @@ impl WorkerRegistry {
                     })
                     .collect();
                 futures::future::join_all(health_futures).await;
+
+                // Sync all workers' state to mesh (health + load)
+                if let Some(ref mesh_sync) = *mesh_sync_ref.read().unwrap() {
+                    for (worker_id, worker) in &workers {
+                        mesh_sync.sync_worker_state(
+                            worker_id.as_str().to_string(),
+                            worker.model_id().to_string(),
+                            worker.url().to_string(),
+                            worker.is_healthy(),
+                            worker.load() as f64,
+                        );
+                    }
+                }
             }
         });
 
@@ -831,5 +844,86 @@ mod tests {
         let llama_workers_after = registry.get_by_model("llama-3");
         assert_eq!(llama_workers_after.len(), 1);
         assert_eq!(llama_workers_after[0].url(), "http://worker2:8080");
+    }
+
+    #[test]
+    fn test_register_syncs_real_load_to_mesh() {
+        use smg_mesh::{stores::StateStores, sync::MeshSyncManager};
+
+        let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
+        let mesh_sync = Arc::new(MeshSyncManager::new(stores, "node1".to_string()));
+
+        let registry = WorkerRegistry::new();
+        registry.set_mesh_sync(Some(mesh_sync.clone()));
+
+        let mut labels = HashMap::new();
+        labels.insert("model_id".to_string(), "llama-3".to_string());
+        let worker: Arc<dyn Worker> = Arc::from(Box::new(
+            BasicWorkerBuilder::new("http://worker1:8080")
+                .worker_type(WorkerType::Regular)
+                .labels(labels)
+                .circuit_breaker_config(CircuitBreakerConfig::default())
+                .build(),
+        ) as Box<dyn Worker>);
+
+        // Simulate 3 in-flight requests before registration
+        worker.increment_load();
+        worker.increment_load();
+        worker.increment_load();
+
+        let worker_id = registry.register(worker);
+
+        // Verify mesh received the real load, not hardcoded 0.0
+        let state = mesh_sync
+            .get_worker_state(worker_id.as_str())
+            .expect("worker state should exist in mesh after register");
+        assert_eq!(
+            state.load, 3.0,
+            "mesh sync load should be 3.0 (actual in-flight count), not 0.0"
+        );
+    }
+
+    #[test]
+    fn test_update_worker_health_syncs_real_load_to_mesh() {
+        use smg_mesh::{stores::StateStores, sync::MeshSyncManager};
+
+        let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
+        let mesh_sync = Arc::new(MeshSyncManager::new(stores, "node1".to_string()));
+
+        let registry = WorkerRegistry::new();
+        registry.set_mesh_sync(Some(mesh_sync.clone()));
+
+        let mut labels = HashMap::new();
+        labels.insert("model_id".to_string(), "llama-3".to_string());
+        let worker: Arc<dyn Worker> = Arc::from(Box::new(
+            BasicWorkerBuilder::new("http://worker1:8080")
+                .worker_type(WorkerType::Regular)
+                .labels(labels)
+                .circuit_breaker_config(CircuitBreakerConfig::default())
+                .build(),
+        ) as Box<dyn Worker>);
+
+        // Register with zero load first
+        let worker_id = registry.register(worker.clone());
+        assert_eq!(
+            mesh_sync.get_worker_state(worker_id.as_str()).unwrap().load,
+            0.0
+        );
+
+        // Simulate 5 in-flight requests after registration
+        for _ in 0..5 {
+            worker.increment_load();
+        }
+
+        // update_worker_health should sync the current real load
+        registry.update_worker_health(&worker_id, true);
+
+        let state = mesh_sync
+            .get_worker_state(worker_id.as_str())
+            .expect("worker state should exist in mesh after health update");
+        assert_eq!(
+            state.load, 5.0,
+            "mesh sync load should be 5.0 after health update, not 0.0"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

`WorkerRegistry` still had two mesh sync paths sending `load=0.0` (TODO left from mesh rollout).

In IGW/multi-gateway mode, remote gateways can see health but not real load. This PR replaces the placeholder with actual in-flight load.

## Modifications

- File: `sgl-model-gateway/src/core/worker_registry.rs`
- Replace hardcoded mesh load placeholders with real worker load values.
- Keep worker state in mesh updated during periodic health-check flow.

Tests:

- `test_register_syncs_real_load_to_mesh`
- `test_update_worker_health_syncs_real_load_to_mesh`

Both tests use a real `MeshSyncManager` and assert `get_worker_state(...).load` matches expected non-zero values.

Metric note: this uses `Worker::load()` (in-flight request count). It does not change token-level load collection.

Local verification run:

- `cargo test --lib -- test_register_syncs_real_load test_update_worker_health_syncs`

## Accuracy Tests

N/A. No kernel/model-forward/model-output change.

## Benchmarking and Profiling

N/A for speed benchmarking. This is a correctness fix for mesh state sync.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
	- `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
