### PR TITLE
[diffusion] reduce LayerwiseOffloadManager reserved GPU memory 

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -81,7 +81,7 @@ class LayerwiseOffloadManager:
         except Exception:
             return None
 
-    def _get_placeholder(self, dtype: torch.dtype) -> torch.Tensor:
+    def _get_shared_empty_tensor(self, dtype: torch.dtype) -> torch.Tensor:
         placeholder = self._offload_placeholders.get(dtype)
         if placeholder is None:
             placeholder = torch.empty((1,), device=self.device, dtype=dtype)
@@ -134,7 +134,7 @@ class LayerwiseOffloadManager:
                         "shape": weight.shape,
                     }
 
-                    weight.data = self._get_placeholder(dtype)
+                    weight.data = self._get_shared_empty_tensor(dtype)
 
                     current_offset += numel
 
@@ -226,7 +226,7 @@ class LayerwiseOffloadManager:
         for name, meta in self._weight_metadata.get(layer_idx, {}).items():
             target = self.get_target_with_name(name)
             # Wraparound prefetch will reload the layer when it is needed again
-            target.data = self._get_placeholder(meta["dtype"])
+            target.data = self._get_shared_empty_tensor(meta["dtype"])
 
         self._gpu_layers.discard(layer_idx)
 

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -81,6 +81,7 @@ class LayerwiseOffloadManager:
         except Exception:
             return None
 
+    @torch.compiler.disable
     def _get_placeholder(self, dtype: torch.dtype) -> torch.Tensor:
         placeholder = self._offload_placeholders.get(dtype)
         if placeholder is None:

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -81,7 +81,6 @@ class LayerwiseOffloadManager:
         except Exception:
             return None
 
-    @torch.compiler.disable
     def _get_placeholder(self, dtype: torch.dtype) -> torch.Tensor:
         placeholder = self._offload_placeholders.get(dtype)
         if placeholder is None:

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -66,6 +66,7 @@ class LayerwiseOffloadManager:
 
         self._named_parameters: Dict[str, torch.nn.Parameter] = {}
         self._named_buffers: Dict[str, torch.Tensor] = {}
+        self._offload_placeholders: Dict[torch.dtype, torch.Tensor] = {}
         # Store forward hooks for removal
         self._forward_hooks: List[Any] = []
 
@@ -79,6 +80,13 @@ class LayerwiseOffloadManager:
             return int(m.group(2))
         except Exception:
             return None
+
+    def _get_placeholder(self, dtype: torch.dtype) -> torch.Tensor:
+        placeholder = self._offload_placeholders.get(dtype)
+        if placeholder is None:
+            placeholder = torch.empty((1,), device=self.device, dtype=dtype)
+            self._offload_placeholders[dtype] = placeholder
+        return placeholder
 
     @torch.compiler.disable
     def _initialize(self) -> None:
@@ -126,7 +134,7 @@ class LayerwiseOffloadManager:
                         "shape": weight.shape,
                     }
 
-                    weight.data = torch.empty((1,), device=self.device, dtype=dtype)
+                    weight.data = self._get_placeholder(dtype)
 
                     current_offset += numel
 
@@ -212,15 +220,13 @@ class LayerwiseOffloadManager:
         # clear prefetch event, since it's useless and needs to be reset
         self._prefetch_events.pop(layer_idx, None)
 
-        if layer_idx <= 0:
-            return
-
         if layer_idx not in self._gpu_layers:
             return
 
         for name, meta in self._weight_metadata.get(layer_idx, {}).items():
             target = self.get_target_with_name(name)
-            target.data = torch.empty((1,), device=self.device, dtype=meta["dtype"])
+            # Wraparound prefetch will reload the layer when it is needed again
+            target.data = self._get_placeholder(meta["dtype"])
 
         self._gpu_layers.discard(layer_idx)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->This PR reduces GPU memory residency in LayerWiseOffloadManager.

## Modifications

<!-- Detail the changes made in this pull request. -->
  - Release layer 0 after use instead of keeping it resident
  - Reuse shared per-dtype placeholder tensors for offloaded weights/buffers
  - Keep wraparound prefetch responsible for reloading layers when needed

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Command used for testing: `sglang generate --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers --log-level info --prompt "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window." --negative-prompt ' ' --720p --num-inference-steps 40 --num-frames 81 --guidance-scale 5.0 --seed 42 --save-output --num-gpus 4 --ulysses-degree 4 --dit-layerwise-offload true --dit-cpu-offload false --vae-cpu-offload false --text-encoder-cpu-offload true --warmup --enable-torch-compile true --perf-dump-path after.json`

  - Peak reserved memory: 71504.0 MB -> 70154.0 MB (-1350 MB)
  - Peak allocated memory: 10681.71 MB -> 9341.48 MB (-1340.23 MB)
  - E2E latency: 214361.84 ms -> 214324.18 ms (neutral)
  
Before PR:

https://github.com/user-attachments/assets/eaa1ce1d-9d96-4e55-91c4-dfc2028d01b5

After PR:


https://github.com/user-attachments/assets/4476bb69-e6dc-494d-8ca6-5b3938194cb0

Performance Test (not affected):

#### 1. High-level Summary
| Metric | Baseline | New | Diff | 
| :--- | :--- | :--- | :--- | 
| **E2E Latency** | 214361.84 ms | 214324.18 ms | **-37.66 ms (-0.0%)** | 
| **Throughput** | 0.00 req/s | 0.00 req/s | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) |
| :--- | :--- | :--- | :--- | :--- | 
| InputValidationStage | 0.04 | 0.04 | +0.00 | +9.3% |
| TextEncodingStage | 684.15 | 682.48 | -1.67 | -0.2% |
| LatentPreparationStage | 0.15 | 0.15 | -0.00 | -2.3% | 
| TimestepPreparationStage | 0.40 | 0.32 | -0.09 | -21.2% |
| DenoisingStage | 210343.43 | 210300.11 | -43.32 | -0.0% | 
| DecodingStage | 3329.43 | 3336.94 | +7.51 | +0.2% | 

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
