### PR TITLE
[Diffusion] Make QwenImageLayered resolution configurable

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -436,6 +436,13 @@ class PipelineConfig:
             default=PipelineConfig.flow_shift,
             help="Flow shift parameter",
         )
+        parser.add_argument(
+            f"--{prefix_with_dot}resolution",
+            type=int,
+            dest=f"{prefix_with_dot.replace('-', '_')}resolution",
+            default=None,
+            help="Override the selected pipeline config's resolution setting. Only applies to pipelines that define a resolution field.",
+        )
 
         # DiT configuration
         parser.add_argument(

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -500,7 +500,7 @@ class QwenImageEditPlus_2511_PipelineConfig(QwenImageEditPlusPipelineConfig):
 
 @dataclass
 class QwenImageLayeredPipelineConfig(QwenImageEditPipelineConfig):
-    resolution: int = 640  # TODO: allow user to set resolution
+    resolution: int = 640
     vae_precision: str = "bf16"
 
     def _prepare_edit_cond_kwargs(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/qwen_image_layered.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/qwen_image_layered.py
@@ -422,7 +422,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         image = load_image(batch.image_path[0])
         image = image.convert("RGBA")
         image_size = image.size
-        resolution = 640  # TODO: support user-specified resolution
+        resolution = server_args.pipeline_config.resolution
         calculated_width, calculated_height = calculate_dimensions(
             resolution * resolution, image_size[0] / image_size[1]
         )

--- a/python/sglang/multimodal_gen/test/unit/test_server_args_unit.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args_unit.py
@@ -1,8 +1,11 @@
 import os
+import sys
 import unittest
+from unittest.mock import patch
 
 from sglang.multimodal_gen.registry import _get_config_info
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.utils import FlexibleArgumentParser
 
 
 class TestServerArgsPathExpansion(unittest.TestCase):
@@ -44,6 +47,27 @@ class TestModelIdResolution(unittest.TestCase):
         # with an unresolvable path, expect RuntimeError from the detector step
         with self.assertRaises((RuntimeError, Exception)):
             _get_config_info("/data/no-such-model", model_id="NonExistentModelXYZ")
+
+
+class TestPipelineResolutionCliOverride(unittest.TestCase):
+    def setUp(self):
+        _get_config_info.cache_clear()
+
+    def test_resolution_flag_overrides_qwen_image_layered_pipeline_config(self):
+        parser = FlexibleArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        argv = [
+            "--model-path",
+            "Qwen/Qwen-Image-Layered",
+            "--resolution",
+            "768",
+        ]
+
+        with patch.object(sys, "argv", ["sglang"] + argv):
+            args, unknown_args = parser.parse_known_args(argv)
+            server_args = ServerArgs.from_cli_args(args, unknown_args)
+
+        self.assertEqual(server_args.pipeline_config.resolution, 768)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`QwenImageLayeredBeforeDenoisingStage` hardcodes `resolution = 640` instead of reading from the pipeline config.

```python
# qwen_image_layered.py L425
resolution = 640  # TODO: support user-specified resolution

# qwen_image.py L503
resolution: int = 640  # TODO: allow user to set resolution
```

## Modifications

Use `server_args.pipeline_config.resolution` in `QwenImageLayeredBeforeDenoisingStage.forward()` instead of hardcoded `640`. Remove resolved TODO comments.

Default behavior unchanged (still 640). Users can now configure resolution via `QwenImageLayeredPipelineConfig`.

## Accuracy Tests

Existing `qwen_image_layered_i2i` CI test covers this code path.

No model output changes, default resolution value remains 640.

## Benchmarking and Profiling

N/A, no performance impact (config field read vs integer literal).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).