### PR TITLE
[model-gateway] Remove metadata endpoint fallback and align mock workers with real server

### DIFF
--- a/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
@@ -53,48 +53,6 @@ pub struct ModelInfo {
     pub architectures: Option<Vec<String>>,
 }
 
-/// Fallback function to GET JSON from old endpoint (with "get_" prefix) for backward compatibility.
-async fn get_json_fallback(
-    base_url: &str,
-    endpoint: &str,
-    api_key: Option<&str>,
-) -> Result<Value, String> {
-    // FIXME: This fallback logic should be removed together with /get_server_info
-    // and /get_model_info endpoints in http_server.py
-    warn!(
-        concat!(
-            "Endpoint '/{}' returned 404, falling back to '/get_{}' for backward compatibility. ",
-            "The '/get_{}' endpoint is deprecated and will be removed in a future version. ",
-            "Please use '/{}' instead."
-        ),
-        endpoint, endpoint, endpoint, endpoint
-    );
-
-    let old_url = format!("{}/get_{}", base_url, endpoint);
-    let mut req = HTTP_CLIENT.get(&old_url);
-    if let Some(key) = api_key {
-        req = req.bearer_auth(key);
-    }
-
-    let response = req
-        .send()
-        .await
-        .map_err(|e| format!("Failed to connect to {}: {}", old_url, e))?;
-
-    if !response.status().is_success() {
-        return Err(format!(
-            "Server returned status {} from {}",
-            response.status(),
-            old_url
-        ));
-    }
-
-    response
-        .json::<Value>()
-        .await
-        .map_err(|e| format!("Failed to parse response from {}: {}", old_url, e))
-}
-
 /// Get server info from /server_info endpoint.
 pub async fn get_server_info(url: &str, api_key: Option<&str>) -> Result<ServerInfo, String> {
     let base_url = url.trim_end_matches('/');
@@ -109,13 +67,6 @@ pub async fn get_server_info(url: &str, api_key: Option<&str>) -> Result<ServerI
         .send()
         .await
         .map_err(|e| format!("Failed to connect to {}: {}", server_info_url, e))?;
-
-    // If /server_info returns 404, fallback to /get_server_info for backward compatibility
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        let json = get_json_fallback(base_url, "server_info", api_key).await?;
-        return serde_json::from_value(json)
-            .map_err(|e| format!("Failed to parse server info: {}", e));
-    }
 
     if !response.status().is_success() {
         return Err(format!(
@@ -147,13 +98,6 @@ pub async fn get_model_info(url: &str, api_key: Option<&str>) -> Result<ModelInf
         .send()
         .await
         .map_err(|e| format!("Failed to connect to {}: {}", model_info_url, e))?;
-
-    // If /model_info returns 404, fallback to /get_model_info for backward compatibility
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        let json = get_json_fallback(base_url, "model_info", api_key).await?;
-        return serde_json::from_value(json)
-            .map_err(|e| format!("Failed to parse model info: {}", e));
-    }
 
     if !response.status().is_success() {
         return Err(format!(

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -82,6 +82,8 @@ impl MockWorker {
         let app = Router::new()
             .route("/health", get(health_handler))
             .route("/health_generate", get(health_generate_handler))
+            .route("/server_info", get(server_info_handler))
+            .route("/model_info", get(model_info_handler))
             .route("/get_server_info", get(server_info_handler))
             .route("/get_model_info", get(model_info_handler))
             .route("/generate", post(generate_handler))

--- a/sgl-model-gateway/tests/common/tls_mock_worker.rs
+++ b/sgl-model-gateway/tests/common/tls_mock_worker.rs
@@ -101,7 +101,10 @@ impl TlsMockWorker {
         let app = Router::new()
             .route("/health", get(health_handler))
             .route("/health_generate", get(health_generate_handler))
+            .route("/server_info", get(server_info_handler))
+            .route("/model_info", get(model_info_handler))
             .route("/get_server_info", get(server_info_handler))
+            .route("/get_model_info", get(model_info_handler))
             .route("/generate", post(generate_handler))
             .route("/v1/chat/completions", post(chat_completions_handler))
             .with_state(config);
@@ -286,6 +289,29 @@ async fn server_info_handler(State(config): State<Arc<RwLock<TlsMockWorkerConfig
         "host": "127.0.0.1",
         "tls_enabled": true,
         "version": "0.3.0"
+    }))
+    .into_response()
+}
+
+async fn model_info_handler(State(config): State<Arc<RwLock<TlsMockWorkerConfig>>>) -> Response {
+    let config = config.read().await;
+
+    if should_fail(&config).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "Random failure" })),
+        )
+            .into_response();
+    }
+
+    Json(json!({
+        "model_path": "mock-tls-model-path",
+        "tokenizer_path": "mock-tls-tokenizer-path",
+        "is_generation": true,
+        "preferred_sampling_params": {
+            "temperature": 0.7,
+            "top_p": 0.9
+        }
     }))
     .into_response()
 }


### PR DESCRIPTION
## Motivation

`discover_metadata.rs` has fallback logic that tries `/get_server_info` when `/server_info` returns 404. This never actually runs in production because real SGLang servers always respond to both `/server_info` and `/model_info`. The only reason tests passed was that mock workers only exposed the old endpoints, so the fallback kicked in to compensate.

This cleans it up: add the new endpoint paths to mocks so they match real server behavior, then remove the dead fallback code.

## Modifications

- Add `/server_info` and `/model_info` routes to `MockWorker` and `TlsMockWorker` (previously only had `/get_server_info` and `/get_model_info`)
- Add missing `model_info_handler` to `TlsMockWorker`
- Delete `get_json_fallback()` and the 404-fallback blocks in `get_server_info()` / `get_model_info()`

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).