### PR TITLE
[VLM] Replace decord with torchcodec for video decoding

### DIFF
--- a/examples/runtime/multimodal/llava_onevision_server.py
+++ b/examples/runtime/multimodal/llava_onevision_server.py
@@ -16,7 +16,7 @@ import openai
 import pybase64
 import requests
 from PIL import Image
-from torchcodec.decoders import VideoDecoder
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 # pip install httpx==0.23.3
 # pip install torchcodec
@@ -200,14 +200,13 @@ def video_speed_test(client, video_path):
 
 def prepare_video_messages(video_path):
     max_frames_num = 32
-    decoder = VideoDecoder(video_path, dimension_order="NHWC")
+    decoder = VideoDecoderWrapper(video_path)
     total_frame_num = len(decoder)
     uniform_sampled_frames = np.linspace(
         0, total_frame_num - 1, max_frames_num, dtype=int
     )
     frame_idx = uniform_sampled_frames.tolist()
-    frames_batch = decoder.get_frames_at(frame_idx)
-    frames = frames_batch.data.numpy()
+    frames = decoder.get_frames_at(frame_idx)
 
     base64_frames = []
     for frame in frames:

--- a/examples/runtime/multimodal/llava_onevision_server.py
+++ b/examples/runtime/multimodal/llava_onevision_server.py
@@ -16,6 +16,7 @@ import openai
 import pybase64
 import requests
 from PIL import Image
+
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 # pip install httpx==0.23.3

--- a/examples/runtime/multimodal/llava_onevision_server.py
+++ b/examples/runtime/multimodal/llava_onevision_server.py
@@ -15,11 +15,11 @@ import numpy as np
 import openai
 import pybase64
 import requests
-from decord import VideoReader, cpu
 from PIL import Image
+from torchcodec.decoders import VideoDecoder
 
 # pip install httpx==0.23.3
-# pip install decord
+# pip install torchcodec
 # pip install protobuf==3.20.0
 
 
@@ -200,13 +200,14 @@ def video_speed_test(client, video_path):
 
 def prepare_video_messages(video_path):
     max_frames_num = 32
-    vr = VideoReader(video_path, ctx=cpu(0))
-    total_frame_num = len(vr)
+    decoder = VideoDecoder(video_path, dimension_order="NHWC")
+    total_frame_num = len(decoder)
     uniform_sampled_frames = np.linspace(
         0, total_frame_num - 1, max_frames_num, dtype=int
     )
     frame_idx = uniform_sampled_frames.tolist()
-    frames = vr.get_batch(frame_idx).asnumpy()
+    frames_batch = decoder.get_frames_at(frame_idx)
+    frames = frames_batch.data.numpy()
 
     base64_frames = []
     for frame in frames:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -67,7 +67,8 @@ dependencies = [
   "torch==2.9.1",
   "torchao==0.9.0",
   "torchaudio==2.9.1",
-  "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
+  "torchcodec==0.10.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
+  "av ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "torchvision",
   "tqdm",
   "transformers==4.57.1",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "cuda-python==12.9",
-  "decord2",
   "datasets",
   "einops",
   "fastapi",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
   "torch==2.9.1",
   "torchao==0.9.0",
   "torchaudio==2.9.1",
-  "torchcodec==0.10.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
+  "torchcodec==0.9.1 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec 0.9.1 for torch 2.9.x. Not available on Linux ARM.
   "av ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "torchvision",
   "tqdm",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "build",
   "compressed-tensors",
   "cuda-python==12.9",
+  "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "datasets",
   "einops",
   "fastapi",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -23,7 +23,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "datasets",
-  "decord; platform_machine == 'x86_64'",
   "einops",
   "fastapi",
   "gguf",

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -22,7 +22,6 @@ dependencies = [
   "av",
   "build",
   "compressed-tensors",
-  "decord2",
   "datasets",
   "einops",
   "fastapi",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -24,7 +24,6 @@ runtime_common = [
   "av",
   "build",
   "compressed-tensors",
-  "decord2",
   "datasets",
   "einops",
   "fastapi",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -28,7 +28,6 @@ dependencies = [
   "build",
   "compressed-tensors",
   "datasets",
-  "decord",
   "einops",
   "fastapi",
   "gguf",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 dependencies = [
   "torch==2.9.0",
-  "torchcodec==0.10.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
+  "torchcodec==0.9.1 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. torch==2.9.0 on XPU uses 0.9.1
   "av ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "torchaudio==2.9.0",
   "torchvision",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 dependencies = [
   "torch==2.9.0",
-  "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
+  "torchcodec==0.10.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
   "av ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "torchaudio==2.9.0",
   "torchvision",

--- a/python/sglang/check_env.py
+++ b/python/sglang/check_env.py
@@ -50,7 +50,7 @@ PACKAGE_LIST = [
     "tiktoken",
     "anthropic",
     "litellm",
-    "decord2",
+    "torchcodec",
 ]
 
 

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -385,8 +385,7 @@ class BaseMultimodalProcessor(ABC):
         """
         estimate the total frame count from all visual input
         """
-        # Lazy import because decord is not available on some arm platforms.
-        from decord import VideoReader, cpu
+        from torchcodec.decoders import VideoDecoder
 
         # Before processing inputs
         if not image_data or len(image_data) == 0:
@@ -396,8 +395,8 @@ class BaseMultimodalProcessor(ABC):
             if isinstance(image, str) and image.startswith("video:"):
                 path = image[len("video:") :]
                 # Estimate frames for the video
-                vr = VideoReader(path, ctx=cpu(0))
-                num_frames = len(vr)
+                decoder = VideoDecoder(path, dimension_order="NHWC")
+                num_frames = len(decoder)
             else:
                 # For images, each contributes one frame
                 num_frames = 1

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -385,7 +385,7 @@ class BaseMultimodalProcessor(ABC):
         """
         estimate the total frame count from all visual input
         """
-        from torchcodec.decoders import VideoDecoder
+        from sglang.srt.utils.common import _HAS_TORCHCODEC
 
         # Before processing inputs
         if not image_data or len(image_data) == 0:
@@ -394,9 +394,16 @@ class BaseMultimodalProcessor(ABC):
         for image in image_data:
             if isinstance(image, str) and image.startswith("video:"):
                 path = image[len("video:") :]
-                # Estimate frames for the video
-                decoder = VideoDecoder(path, dimension_order="NHWC")
-                num_frames = len(decoder)
+                if _HAS_TORCHCODEC:
+                    from torchcodec.decoders import VideoDecoder
+
+                    decoder = VideoDecoder(path, dimension_order="NHWC")
+                    num_frames = len(decoder)
+                else:
+                    from decord import VideoReader, cpu
+
+                    vr = VideoReader(path, ctx=cpu(0))
+                    num_frames = len(vr)
             else:
                 # For images, each contributes one frame
                 num_frames = 1

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -385,7 +385,7 @@ class BaseMultimodalProcessor(ABC):
         """
         estimate the total frame count from all visual input
         """
-        from sglang.srt.utils.common import _HAS_TORCHCODEC
+        from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
         # Before processing inputs
         if not image_data or len(image_data) == 0:
@@ -394,16 +394,8 @@ class BaseMultimodalProcessor(ABC):
         for image in image_data:
             if isinstance(image, str) and image.startswith("video:"):
                 path = image[len("video:") :]
-                if _HAS_TORCHCODEC:
-                    from torchcodec.decoders import VideoDecoder
-
-                    decoder = VideoDecoder(path, dimension_order="NHWC")
-                    num_frames = len(decoder)
-                else:
-                    from decord import VideoReader, cpu
-
-                    vr = VideoReader(path, ctx=cpu(0))
-                    num_frames = len(vr)
+                decoder = VideoDecoderWrapper(path)
+                num_frames = len(decoder)
             else:
                 # For images, each contributes one frame
                 num_frames = 1

--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -6,7 +6,7 @@ from typing import List
 
 import numpy as np
 import torch
-from decord import VideoReader, cpu, gpu
+from torchcodec.decoders import VideoDecoder
 from PIL import Image
 
 from sglang.srt.managers.schedule_batch import (
@@ -205,14 +205,8 @@ class InternVLProcessor(BaseMultimodalProcessor):
         return torch.stack(tiles).to(torch.bfloat16)
 
     @staticmethod
-    def _open_video_reader(path: str) -> VideoReader:
-        try:
-            return VideoReader(path, ctx=gpu(0), num_threads=1)
-        except (RuntimeError, OSError) as e:
-            logger.warning(
-                "[internvl] VideoReader gpu decode failed (%s), fallback CPU", e
-            )
-            return VideoReader(path, ctx=cpu(0), num_threads=1)
+    def _open_video_reader(path: str) -> VideoDecoder:
+        return VideoDecoder(path, dimension_order="NHWC")
 
     def _ensure_placeholders_before_assistant(
         self, prompt: str, placeholder: str, want: int
@@ -490,7 +484,7 @@ class InternVLProcessor(BaseMultimodalProcessor):
             for video in base_output.videos:
                 vr = (
                     video
-                    if isinstance(video, VideoReader)
+                    if isinstance(video, VideoDecoder)
                     else self._open_video_reader(str(video))
                 )
                 max_frame = len(vr) - 1
@@ -503,12 +497,9 @@ class InternVLProcessor(BaseMultimodalProcessor):
                 per_video_tiles = []
                 per_video_patch_cnt = []
                 for fi in frame_indices:
+                    # VideoDecoder returns NHWC tensor for single frame
                     frame = vr[int(fi)]
-                    img_np = (
-                        frame.asnumpy()
-                        if hasattr(frame, "asnumpy")
-                        else np.array(frame)
-                    )
+                    img_np = frame.numpy()
                     frame_t = (
                         torch.from_numpy(img_np).permute(2, 0, 1).cuda().float() / 255.0
                     )

--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -8,13 +8,6 @@ import numpy as np
 import torch
 from PIL import Image
 
-try:
-    from torchcodec.decoders import VideoDecoder
-
-    _HAS_TORCHCODEC = True
-except ImportError:
-    _HAS_TORCHCODEC = False
-
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -26,6 +19,7 @@ from sglang.srt.multimodal.processors.base_processor import (
     BaseMultiModalProcessorOutput,
     MultimodalSpecialTokens,
 )
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -212,17 +206,7 @@ class InternVLProcessor(BaseMultimodalProcessor):
 
     @staticmethod
     def _open_video_reader(path: str):
-        if _HAS_TORCHCODEC:
-            return VideoDecoder(path, dimension_order="NHWC")
-        from decord import VideoReader, cpu, gpu
-
-        try:
-            return VideoReader(path, ctx=gpu(0), num_threads=1)
-        except (RuntimeError, OSError) as e:
-            logger.warning(
-                "[internvl] VideoReader gpu decode failed (%s), fallback CPU", e
-            )
-            return VideoReader(path, ctx=cpu(0), num_threads=1)
+        return VideoDecoderWrapper(path)
 
     def _ensure_placeholders_before_assistant(
         self, prompt: str, placeholder: str, want: int
@@ -498,9 +482,7 @@ class InternVLProcessor(BaseMultimodalProcessor):
 
         if base_output.videos and num_frames > 0 and self.video_token_id is not None:
             for video in base_output.videos:
-                is_video_obj = (_HAS_TORCHCODEC and isinstance(video, VideoDecoder)) or (
-                    not _HAS_TORCHCODEC and hasattr(video, "get_avg_fps")
-                )
+                is_video_obj = isinstance(video, VideoDecoderWrapper)
                 vr = video if is_video_obj else self._open_video_reader(str(video))
                 max_frame = len(vr) - 1
                 frame_indices = (
@@ -512,12 +494,7 @@ class InternVLProcessor(BaseMultimodalProcessor):
                 per_video_tiles = []
                 per_video_patch_cnt = []
                 for fi in frame_indices:
-                    frame = vr[int(fi)]
-                    img_np = (
-                        frame.numpy()
-                        if hasattr(frame, "numpy")
-                        else np.array(frame)
-                    )
+                    img_np = vr[int(fi)]
                     frame_t = (
                         torch.from_numpy(img_np).permute(2, 0, 1).cuda().float() / 255.0
                     )

--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -6,8 +6,14 @@ from typing import List
 
 import numpy as np
 import torch
-from torchcodec.decoders import VideoDecoder
 from PIL import Image
+
+try:
+    from torchcodec.decoders import VideoDecoder
+
+    _HAS_TORCHCODEC = True
+except ImportError:
+    _HAS_TORCHCODEC = False
 
 from sglang.srt.managers.schedule_batch import (
     Modality,
@@ -205,8 +211,18 @@ class InternVLProcessor(BaseMultimodalProcessor):
         return torch.stack(tiles).to(torch.bfloat16)
 
     @staticmethod
-    def _open_video_reader(path: str) -> VideoDecoder:
-        return VideoDecoder(path, dimension_order="NHWC")
+    def _open_video_reader(path: str):
+        if _HAS_TORCHCODEC:
+            return VideoDecoder(path, dimension_order="NHWC")
+        from decord import VideoReader, cpu, gpu
+
+        try:
+            return VideoReader(path, ctx=gpu(0), num_threads=1)
+        except (RuntimeError, OSError) as e:
+            logger.warning(
+                "[internvl] VideoReader gpu decode failed (%s), fallback CPU", e
+            )
+            return VideoReader(path, ctx=cpu(0), num_threads=1)
 
     def _ensure_placeholders_before_assistant(
         self, prompt: str, placeholder: str, want: int
@@ -482,11 +498,10 @@ class InternVLProcessor(BaseMultimodalProcessor):
 
         if base_output.videos and num_frames > 0 and self.video_token_id is not None:
             for video in base_output.videos:
-                vr = (
-                    video
-                    if isinstance(video, VideoDecoder)
-                    else self._open_video_reader(str(video))
+                is_video_obj = (_HAS_TORCHCODEC and isinstance(video, VideoDecoder)) or (
+                    not _HAS_TORCHCODEC and hasattr(video, "get_avg_fps")
                 )
+                vr = video if is_video_obj else self._open_video_reader(str(video))
                 max_frame = len(vr) - 1
                 frame_indices = (
                     [0]
@@ -497,9 +512,12 @@ class InternVLProcessor(BaseMultimodalProcessor):
                 per_video_tiles = []
                 per_video_patch_cnt = []
                 for fi in frame_indices:
-                    # VideoDecoder returns NHWC tensor for single frame
                     frame = vr[int(fi)]
-                    img_np = frame.numpy()
+                    img_np = (
+                        frame.numpy()
+                        if hasattr(frame, "numpy")
+                        else np.array(frame)
+                    )
                     frame_t = (
                         torch.from_numpy(img_np).permute(2, 0, 1).cuda().float() / 255.0
                     )

--- a/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
+++ b/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from math import sqrt
-from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -27,14 +26,7 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 from sglang.srt.utils.common import sample_video_frames
-
-from sglang.srt.utils.common import _HAS_TORCHCODEC
-
-if TYPE_CHECKING:
-    if _HAS_TORCHCODEC:
-        from torchcodec.decoders import VideoDecoder
-    else:
-        from decord import VideoReader as VideoDecoder
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 DEFAULT_NUM_TILES = 12
 NUM_VIDEO_TILES = 1
@@ -108,13 +100,8 @@ class NanoNemotronVLImageProcessor(BaseMultimodalProcessor):
         frames = sample_video_frames(
             video, desired_fps=DESIRED_FPS, max_frames=MAX_FRAMES
         )
-        if _HAS_TORCHCODEC and hasattr(video, "metadata"):
-            frames_batch = video.get_frames_at(frames)
-            video_array = frames_batch.data.numpy()  # NHWC uint8
-            avg_fps = video.metadata.average_fps
-        else:
-            video_array = video.get_batch(frames).asnumpy()
-            avg_fps = video.get_avg_fps()
+        video_array = video.get_frames_at(frames)
+        avg_fps = video.avg_fps
         if avg_fps > 0:
             frame_duration_ms = int(1000 / avg_fps)
         else:

--- a/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
+++ b/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
@@ -29,7 +29,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.utils.common import sample_video_frames
 
 if TYPE_CHECKING:
-    from decord import VideoReader
+    from torchcodec.decoders import VideoDecoder
 
 DEFAULT_NUM_TILES = 12
 NUM_VIDEO_TILES = 1
@@ -99,13 +99,14 @@ class NanoNemotronVLImageProcessor(BaseMultimodalProcessor):
         return f"Frame {frame_index + 1} sampled at {timestamp:.2f} seconds: {self.PLACEHOLDER}{self.IMG_CONTEXT_TOKEN * num_tokens}{self.IMG_END_TOKEN}"
 
     @staticmethod
-    def parse_video(video: "VideoReader") -> tuple[np.ndarray, list[float]]:
+    def parse_video(video: "VideoDecoder") -> tuple[np.ndarray, list[float]]:
         frames = sample_video_frames(
             video, desired_fps=DESIRED_FPS, max_frames=MAX_FRAMES
         )
-        video_array = video.get_batch(frames).asnumpy()
+        frames_batch = video.get_frames_at(frames)
+        video_array = frames_batch.data.numpy()  # NHWC uint8
         # doing the `1000 /` and then `/ 1000` is to match vllm's timestamping *exactly*, for reference.
-        frame_duration_ms = int(1000 / video.get_avg_fps())
+        frame_duration_ms = int(1000 / video.metadata.average_fps)
         timestamps = [i * frame_duration_ms / 1000.0 for i in frames]
         return video_array, timestamps
 

--- a/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
+++ b/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
@@ -26,7 +26,6 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 from sglang.srt.utils.common import sample_video_frames
-from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 DEFAULT_NUM_TILES = 12
 NUM_VIDEO_TILES = 1

--- a/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
+++ b/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
@@ -28,8 +28,13 @@ from sglang.srt.multimodal.processors.base_processor import (
 )
 from sglang.srt.utils.common import sample_video_frames
 
+from sglang.srt.utils.common import _HAS_TORCHCODEC
+
 if TYPE_CHECKING:
-    from torchcodec.decoders import VideoDecoder
+    if _HAS_TORCHCODEC:
+        from torchcodec.decoders import VideoDecoder
+    else:
+        from decord import VideoReader as VideoDecoder
 
 DEFAULT_NUM_TILES = 12
 NUM_VIDEO_TILES = 1
@@ -99,14 +104,17 @@ class NanoNemotronVLImageProcessor(BaseMultimodalProcessor):
         return f"Frame {frame_index + 1} sampled at {timestamp:.2f} seconds: {self.PLACEHOLDER}{self.IMG_CONTEXT_TOKEN * num_tokens}{self.IMG_END_TOKEN}"
 
     @staticmethod
-    def parse_video(video: "VideoDecoder") -> tuple[np.ndarray, list[float]]:
+    def parse_video(video) -> tuple[np.ndarray, list[float]]:
         frames = sample_video_frames(
             video, desired_fps=DESIRED_FPS, max_frames=MAX_FRAMES
         )
-        frames_batch = video.get_frames_at(frames)
-        video_array = frames_batch.data.numpy()  # NHWC uint8
-        # doing the `1000 /` and then `/ 1000` is to match vllm's timestamping *exactly*, for reference.
-        frame_duration_ms = int(1000 / video.metadata.average_fps)
+        if _HAS_TORCHCODEC and hasattr(video, "metadata"):
+            frames_batch = video.get_frames_at(frames)
+            video_array = frames_batch.data.numpy()  # NHWC uint8
+            frame_duration_ms = int(1000 / video.metadata.average_fps)
+        else:
+            video_array = video.get_batch(frames).asnumpy()
+            frame_duration_ms = int(1000 / video.get_avg_fps())
         timestamps = [i * frame_duration_ms / 1000.0 for i in frames]
         return video_array, timestamps
 

--- a/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
+++ b/python/sglang/srt/multimodal/processors/nano_nemotron_vl.py
@@ -111,10 +111,14 @@ class NanoNemotronVLImageProcessor(BaseMultimodalProcessor):
         if _HAS_TORCHCODEC and hasattr(video, "metadata"):
             frames_batch = video.get_frames_at(frames)
             video_array = frames_batch.data.numpy()  # NHWC uint8
-            frame_duration_ms = int(1000 / video.metadata.average_fps)
+            avg_fps = video.metadata.average_fps
         else:
             video_array = video.get_batch(frames).asnumpy()
-            frame_duration_ms = int(1000 / video.get_avg_fps())
+            avg_fps = video.get_avg_fps()
+        if avg_fps > 0:
+            frame_duration_ms = int(1000 / avg_fps)
+        else:
+            frame_duration_ms = 0
         timestamps = [i * frame_duration_ms / 1000.0 for i in frames]
         return video_array, timestamps
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -171,24 +171,23 @@ async def preprocess_video(
 
     if _HAS_TORCHCODEC:
         total_frames, video_fps = len(vr), vr.metadata.average_fps
-        nframes = smart_nframes(
-            video_config, total_frames=total_frames, video_fps=video_fps
-        )
-        idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
-        idx = np.unique(idx)
-        frames_batch = vr.get_frames_at(idx.tolist())
-        video = frames_batch.data.pin_memory()
-        video = video.permute(0, 3, 1, 2)  # NHWC -> TCHW
     else:
         total_frames, video_fps = len(vr), vr.get_avg_fps()
-        nframes = smart_nframes(
-            video_config, total_frames=total_frames, video_fps=video_fps
-        )
-        idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
-        idx = np.unique(idx)
+
+    nframes = smart_nframes(
+        video_config, total_frames=total_frames, video_fps=video_fps
+    )
+    idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
+    idx = np.unique(idx)
+
+    if _HAS_TORCHCODEC:
+        frames_batch = vr.get_frames_at(idx.tolist())
+        video = frames_batch.data.pin_memory()
+    else:
         video_np = vr.get_batch(idx).asnumpy()
         video = torch.from_numpy(video_np).pin_memory()
-        video = video.permute(0, 3, 1, 2)  # NHWC -> TCHW
+
+    video = video.permute(0, 3, 1, 2)  # NHWC -> TCHW
 
     nframes, _, height, width = video.shape
     min_pixels = video_config.get("min_pixels", VIDEO_MIN_PIXELS)

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -7,7 +7,7 @@ from typing import List, Union
 import numpy as np
 import torch
 import torchvision
-from decord import VideoReader
+from torchcodec.decoders import VideoDecoder
 from PIL import Image
 from torchvision.transforms import InterpolationMode
 
@@ -156,18 +156,19 @@ async def preprocess_video(
     video_config: dict = {},
 ) -> torch.Tensor:
     # preprocessed video
-    if not isinstance(vr, VideoReader):
+    if not isinstance(vr, VideoDecoder):
         return vr
     entry_time = time.perf_counter()
 
-    total_frames, video_fps = len(vr), vr.get_avg_fps()
+    total_frames, video_fps = len(vr), vr.metadata.average_fps
     nframes = smart_nframes(
         video_config, total_frames=total_frames, video_fps=video_fps
     )
     idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
     idx = np.unique(idx)
-    video_np = vr.get_batch(idx).asnumpy()
-    video = torch.from_numpy(video_np).pin_memory()
+    frames_batch = vr.get_frames_at(idx.tolist())
+    # frames_batch.data is NHWC (uint8), convert to TCHW
+    video = frames_batch.data.pin_memory()
     video = video.permute(0, 3, 1, 2)  # Convert to TCHW format
 
     nframes, _, height, width = video.shape

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -9,12 +9,6 @@ import torch
 import torchvision
 from PIL import Image
 
-try:
-    from torchcodec.decoders import VideoDecoder
-
-    _HAS_TORCHCODEC = True
-except ImportError:
-    _HAS_TORCHCODEC = False
 from torchvision.transforms import InterpolationMode
 
 from sglang.srt.environ import envs
@@ -35,6 +29,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 
 IMAGE_FACTOR = 28
@@ -162,17 +157,12 @@ async def preprocess_video(
     video_config: dict = {},
 ) -> torch.Tensor:
     # preprocessed video
-    is_video_obj = (_HAS_TORCHCODEC and isinstance(vr, VideoDecoder)) or (
-        not _HAS_TORCHCODEC and hasattr(vr, "get_avg_fps")
-    )
+    is_video_obj = isinstance(vr, VideoDecoderWrapper)
     if not is_video_obj:
         return vr
     entry_time = time.perf_counter()
 
-    if _HAS_TORCHCODEC:
-        total_frames, video_fps = len(vr), vr.metadata.average_fps
-    else:
-        total_frames, video_fps = len(vr), vr.get_avg_fps()
+    total_frames, video_fps = len(vr), vr.avg_fps
 
     nframes = smart_nframes(
         video_config, total_frames=total_frames, video_fps=video_fps
@@ -180,12 +170,7 @@ async def preprocess_video(
     idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
     idx = np.unique(idx)
 
-    if _HAS_TORCHCODEC:
-        frames_batch = vr.get_frames_at(idx.tolist())
-        video = frames_batch.data.pin_memory()
-    else:
-        video_np = vr.get_batch(idx).asnumpy()
-        video = torch.from_numpy(video_np).pin_memory()
+    video = vr.get_frames_as_tensor(idx.tolist())
 
     video = video.permute(0, 3, 1, 2)  # NHWC -> TCHW
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -8,7 +8,6 @@ import numpy as np
 import torch
 import torchvision
 from PIL import Image
-
 from torchvision.transforms import InterpolationMode
 
 from sglang.srt.environ import envs

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -7,8 +7,14 @@ from typing import List, Union
 import numpy as np
 import torch
 import torchvision
-from torchcodec.decoders import VideoDecoder
 from PIL import Image
+
+try:
+    from torchcodec.decoders import VideoDecoder
+
+    _HAS_TORCHCODEC = True
+except ImportError:
+    _HAS_TORCHCODEC = False
 from torchvision.transforms import InterpolationMode
 
 from sglang.srt.environ import envs
@@ -156,20 +162,33 @@ async def preprocess_video(
     video_config: dict = {},
 ) -> torch.Tensor:
     # preprocessed video
-    if not isinstance(vr, VideoDecoder):
+    is_video_obj = (_HAS_TORCHCODEC and isinstance(vr, VideoDecoder)) or (
+        not _HAS_TORCHCODEC and hasattr(vr, "get_avg_fps")
+    )
+    if not is_video_obj:
         return vr
     entry_time = time.perf_counter()
 
-    total_frames, video_fps = len(vr), vr.metadata.average_fps
-    nframes = smart_nframes(
-        video_config, total_frames=total_frames, video_fps=video_fps
-    )
-    idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
-    idx = np.unique(idx)
-    frames_batch = vr.get_frames_at(idx.tolist())
-    # frames_batch.data is NHWC (uint8), convert to TCHW
-    video = frames_batch.data.pin_memory()
-    video = video.permute(0, 3, 1, 2)  # Convert to TCHW format
+    if _HAS_TORCHCODEC:
+        total_frames, video_fps = len(vr), vr.metadata.average_fps
+        nframes = smart_nframes(
+            video_config, total_frames=total_frames, video_fps=video_fps
+        )
+        idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
+        idx = np.unique(idx)
+        frames_batch = vr.get_frames_at(idx.tolist())
+        video = frames_batch.data.pin_memory()
+        video = video.permute(0, 3, 1, 2)  # NHWC -> TCHW
+    else:
+        total_frames, video_fps = len(vr), vr.get_avg_fps()
+        nframes = smart_nframes(
+            video_config, total_frames=total_frames, video_fps=video_fps
+        )
+        idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
+        idx = np.unique(idx)
+        video_np = vr.get_batch(idx).asnumpy()
+        video = torch.from_numpy(video_np).pin_memory()
+        video = video.permute(0, 3, 1, 2)  # NHWC -> TCHW
 
     nframes, _, height, width = video.shape
     min_pixels = video_config.get("min_pixels", VIDEO_MIN_PIXELS)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -94,7 +94,6 @@ from typing_extensions import Literal
 
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
-
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 if TYPE_CHECKING:
@@ -993,9 +992,7 @@ def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
     return VideoDecoderWrapper(source, device=device)
 
 
-def sample_video_frames(
-    video, *, desired_fps: int, max_frames: int
-) -> list[int]:
+def sample_video_frames(video, *, desired_fps: int, max_frames: int) -> list[int]:
     total_frames = len(video)
     assert total_frames > 0, "Video must have at least one frame"
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -95,9 +95,14 @@ from typing_extensions import Literal
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 
-if TYPE_CHECKING:
+try:
     from torchcodec.decoders import VideoDecoder
 
+    _HAS_TORCHCODEC = True
+except ImportError:
+    _HAS_TORCHCODEC = False
+
+if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -951,8 +956,69 @@ def get_image_bytes(image_file: Union[str, bytes]):
         raise NotImplementedError(f"Invalid image: {image_file}")
 
 
+def _load_video_decord(video_file: Union[str, bytes], use_gpu: bool = True):
+    """Fallback video loader using decord (for platforms without torchcodec)."""
+    from decord import VideoReader, cpu, gpu
+
+    try:
+        from decord.bridge import decord_bridge
+
+        ctx = gpu(0)
+        _ = decord_bridge.get_ctx_device(ctx)
+    except Exception:
+        ctx = cpu(0)
+
+    tmp_file = None
+    vr = None
+    try:
+        if isinstance(video_file, bytes):
+            tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+            tmp_file.write(video_file)
+            tmp_file.close()
+            vr = VideoReader(tmp_file.name, ctx=ctx)
+        elif isinstance(video_file, str):
+            if video_file.startswith(("http://", "https://")):
+                timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
+                response = requests.get(video_file, stream=True, timeout=timeout)
+                response.raise_for_status()
+                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+                for chunk in response.iter_content(chunk_size=8192):
+                    tmp_file.write(chunk)
+                tmp_file.close()
+                vr = VideoReader(tmp_file.name, ctx=ctx)
+            elif video_file.startswith("data:"):
+                _, encoded = video_file.split(",", 1)
+                video_bytes = pybase64.b64decode(encoded, validate=True)
+                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+                tmp_file.write(video_bytes)
+                tmp_file.close()
+                vr = VideoReader(tmp_file.name, ctx=ctx)
+            elif video_file.startswith("file://"):
+                video_file = unquote(urlparse(video_file).path)
+                vr = VideoReader(video_file, ctx=ctx)
+            elif os.path.isfile(unquote(urlparse(video_file).path)):
+                vr = VideoReader(video_file, ctx=ctx)
+            else:
+                video_bytes = pybase64.b64decode(video_file, validate=True)
+                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+                tmp_file.write(video_bytes)
+                tmp_file.close()
+                vr = VideoReader(tmp_file.name, ctx=ctx)
+        elif isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
+            vr = video_file
+        else:
+            raise ValueError(f"Unsupported video input type: {type(video_file)}")
+
+        return vr
+
+    finally:
+        if tmp_file and os.path.exists(tmp_file.name):
+            os.unlink(tmp_file.name)
+
+
 def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
-    from torchcodec.decoders import VideoDecoder
+    if not _HAS_TORCHCODEC:
+        return _load_video_decord(video_file, use_gpu)
 
     tmp_file = None
     decoder = None
@@ -994,12 +1060,15 @@ def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
 
 
 def sample_video_frames(
-    video: "VideoDecoder", *, desired_fps: int, max_frames: int
+    video, *, desired_fps: int, max_frames: int
 ) -> list[int]:
     total_frames = len(video)
     assert total_frames > 0, "Video must have at least one frame"
 
-    avg_fps = video.metadata.average_fps
+    if _HAS_TORCHCODEC and hasattr(video, "metadata"):
+        avg_fps = video.metadata.average_fps
+    else:
+        avg_fps = video.get_avg_fps()
     duration = total_frames / avg_fps
     fps = min(desired_fps, avg_fps)
 
@@ -1013,8 +1082,6 @@ def sample_video_frames(
 
 
 def encode_video(video_path, frame_count_limit=None):
-    from torchcodec.decoders import VideoDecoder
-
     if not os.path.exists(video_path):
         logger.error(f"Video {video_path} does not exist")
         return []
@@ -1027,14 +1094,25 @@ def encode_video(video_path, frame_count_limit=None):
         idxs = [int(i * gap + gap / 2) for i in range(n)]
         return [l[i] for i in idxs]
 
-    decoder = VideoDecoder(video_path, dimension_order="NHWC")
-    sample_fps = round(decoder.metadata.average_fps / 1)  # FPS
-    frame_indices = [i for i in range(0, len(decoder), sample_fps)]
-    if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
-        frame_indices = uniform_sample(frame_indices, frame_count_limit)
+    if _HAS_TORCHCODEC:
+        decoder = VideoDecoder(video_path, dimension_order="NHWC")
+        sample_fps = round(decoder.metadata.average_fps / 1)  # FPS
+        frame_indices = [i for i in range(0, len(decoder), sample_fps)]
+        if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
+            frame_indices = uniform_sample(frame_indices, frame_count_limit)
+        frames_batch = decoder.get_frames_at(frame_indices)
+        frames = [Image.fromarray(f.numpy().astype("uint8")) for f in frames_batch.data]
+    else:
+        from decord import VideoReader, cpu
 
-    frames_batch = decoder.get_frames_at(frame_indices)
-    frames = [Image.fromarray(f.numpy().astype("uint8")) for f in frames_batch.data]
+        vr = VideoReader(video_path, ctx=cpu(0))
+        sample_fps = round(vr.get_avg_fps() / 1)  # FPS
+        frame_indices = [i for i in range(0, len(vr), sample_fps)]
+        if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
+            frame_indices = uniform_sample(frame_indices, frame_count_limit)
+        frames = vr.get_batch(frame_indices).asnumpy()
+        frames = [Image.fromarray(v.astype("uint8")) for v in frames]
+
     return frames
 
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -95,12 +95,7 @@ from typing_extensions import Literal
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 
-try:
-    from torchcodec.decoders import VideoDecoder
-
-    _HAS_TORCHCODEC = True
-except ImportError:
-    _HAS_TORCHCODEC = False
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -999,25 +994,7 @@ def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
         raise ValueError(f"Unsupported video input type: {type(video_file)}")
 
     try:
-        if _HAS_TORCHCODEC:
-            return VideoDecoder(source, dimension_order="NHWC")
-        else:
-            from decord import VideoReader, cpu, gpu
-
-            try:
-                from decord.bridge import decord_bridge
-
-                ctx = gpu(0)
-                _ = decord_bridge.get_ctx_device(ctx)
-            except Exception:
-                ctx = cpu(0)
-
-            if isinstance(source, bytes):
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                tmp_file.write(source)
-                tmp_file.close()
-                source = tmp_file.name
-            return VideoReader(source, ctx=ctx)
+        return VideoDecoderWrapper(source)
     finally:
         if tmp_file and os.path.exists(tmp_file.name):
             os.unlink(tmp_file.name)
@@ -1029,10 +1006,7 @@ def sample_video_frames(
     total_frames = len(video)
     assert total_frames > 0, "Video must have at least one frame"
 
-    if _HAS_TORCHCODEC and hasattr(video, "metadata"):
-        avg_fps = video.metadata.average_fps
-    else:
-        avg_fps = video.get_avg_fps()
+    avg_fps = video.avg_fps
     duration = total_frames / avg_fps if avg_fps > 0 else 0
     fps = min(desired_fps, avg_fps)
 
@@ -1058,16 +1032,9 @@ def encode_video(video_path, frame_count_limit=None):
         idxs = [int(i * gap + gap / 2) for i in range(n)]
         return [l[i] for i in idxs]
 
-    if _HAS_TORCHCODEC:
-        decoder = VideoDecoder(video_path, dimension_order="NHWC")
-        avg_fps = decoder.metadata.average_fps
-        total_frames = len(decoder)
-    else:
-        from decord import VideoReader, cpu
-
-        decoder = VideoReader(video_path, ctx=cpu(0))
-        avg_fps = decoder.get_avg_fps()
-        total_frames = len(decoder)
+    decoder = VideoDecoderWrapper(video_path)
+    avg_fps = decoder.avg_fps
+    total_frames = len(decoder)
 
     sample_fps = round(avg_fps / 1)
     if sample_fps == 0:
@@ -1079,12 +1046,8 @@ def encode_video(video_path, frame_count_limit=None):
     if not frame_indices:
         return []
 
-    if _HAS_TORCHCODEC:
-        frames_batch = decoder.get_frames_at(frame_indices)
-        frames = [Image.fromarray(f.numpy().astype("uint8")) for f in frames_batch.data]
-    else:
-        frames_data = decoder.get_batch(frame_indices).asnumpy()
-        frames = [Image.fromarray(v.astype("uint8")) for v in frames_data]
+    frames_data = decoder.get_frames_at(frame_indices)
+    frames = [Image.fromarray(v.astype("uint8")) for v in frames_data]
 
     return frames
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -956,104 +956,68 @@ def get_image_bytes(image_file: Union[str, bytes]):
         raise NotImplementedError(f"Invalid image: {image_file}")
 
 
-def _load_video_decord(video_file: Union[str, bytes], use_gpu: bool = True):
-    """Fallback video loader using decord (for platforms without torchcodec)."""
-    from decord import VideoReader, cpu, gpu
+def _normalize_video_input(
+    video_file: Union[str, bytes],
+) -> tuple[Union[str, bytes, None], "tempfile.NamedTemporaryFile | None"]:
+    """Normalize video input (URL, base64, file://, etc.) to a file path or bytes.
 
-    try:
-        from decord.bridge import decord_bridge
-
-        ctx = gpu(0)
-        _ = decord_bridge.get_ctx_device(ctx)
-    except Exception:
-        ctx = cpu(0)
-
+    Returns (source, tmp_file) where source is a file path or bytes suitable for
+    a decoder, and tmp_file is a temp file that the caller must clean up.
+    """
     tmp_file = None
-    vr = None
-    try:
-        if isinstance(video_file, bytes):
+    if isinstance(video_file, bytes):
+        return video_file, None
+    elif isinstance(video_file, str):
+        if video_file.startswith(("http://", "https://")):
+            timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
+            response = requests.get(video_file, stream=True, timeout=timeout)
+            response.raise_for_status()
             tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-            tmp_file.write(video_file)
+            for chunk in response.iter_content(chunk_size=8192):
+                tmp_file.write(chunk)
             tmp_file.close()
-            vr = VideoReader(tmp_file.name, ctx=ctx)
-        elif isinstance(video_file, str):
-            if video_file.startswith(("http://", "https://")):
-                timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
-                response = requests.get(video_file, stream=True, timeout=timeout)
-                response.raise_for_status()
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                for chunk in response.iter_content(chunk_size=8192):
-                    tmp_file.write(chunk)
-                tmp_file.close()
-                vr = VideoReader(tmp_file.name, ctx=ctx)
-            elif video_file.startswith("data:"):
-                _, encoded = video_file.split(",", 1)
-                video_bytes = pybase64.b64decode(encoded, validate=True)
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                tmp_file.write(video_bytes)
-                tmp_file.close()
-                vr = VideoReader(tmp_file.name, ctx=ctx)
-            elif video_file.startswith("file://"):
-                video_file = unquote(urlparse(video_file).path)
-                vr = VideoReader(video_file, ctx=ctx)
-            elif os.path.isfile(unquote(urlparse(video_file).path)):
-                vr = VideoReader(video_file, ctx=ctx)
-            else:
-                video_bytes = pybase64.b64decode(video_file, validate=True)
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                tmp_file.write(video_bytes)
-                tmp_file.close()
-                vr = VideoReader(tmp_file.name, ctx=ctx)
-        elif isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
-            vr = video_file
+            return tmp_file.name, tmp_file
+        elif video_file.startswith("data:"):
+            _, encoded = video_file.split(",", 1)
+            return pybase64.b64decode(encoded, validate=True), None
+        elif video_file.startswith("file://"):
+            return unquote(urlparse(video_file).path), None
+        elif os.path.isfile(unquote(urlparse(video_file).path)):
+            return video_file, None
         else:
-            raise ValueError(f"Unsupported video input type: {type(video_file)}")
-
-        return vr
-
-    finally:
-        if tmp_file and os.path.exists(tmp_file.name):
-            os.unlink(tmp_file.name)
+            return pybase64.b64decode(video_file, validate=True), None
+    else:
+        return None, None
 
 
 def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
-    if not _HAS_TORCHCODEC:
-        return _load_video_decord(video_file, use_gpu)
+    if isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
+        return video_file
 
-    tmp_file = None
-    decoder = None
+    source, tmp_file = _normalize_video_input(video_file)
+    if source is None:
+        raise ValueError(f"Unsupported video input type: {type(video_file)}")
+
     try:
-        if isinstance(video_file, bytes):
-            decoder = VideoDecoder(video_file, dimension_order="NHWC")
-        elif isinstance(video_file, str):
-            if video_file.startswith(("http://", "https://")):
-                timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
-                response = requests.get(video_file, stream=True, timeout=timeout)
-                response.raise_for_status()
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                for chunk in response.iter_content(chunk_size=8192):
-                    tmp_file.write(chunk)
-                tmp_file.close()
-                decoder = VideoDecoder(tmp_file.name, dimension_order="NHWC")
-            elif video_file.startswith("data:"):
-                _, encoded = video_file.split(",", 1)
-                video_bytes = pybase64.b64decode(encoded, validate=True)
-                decoder = VideoDecoder(video_bytes, dimension_order="NHWC")
-            elif video_file.startswith("file://"):
-                video_file = unquote(urlparse(video_file).path)
-                decoder = VideoDecoder(video_file, dimension_order="NHWC")
-            elif os.path.isfile(unquote(urlparse(video_file).path)):
-                decoder = VideoDecoder(video_file, dimension_order="NHWC")
-            else:
-                video_bytes = pybase64.b64decode(video_file, validate=True)
-                decoder = VideoDecoder(video_bytes, dimension_order="NHWC")
-        elif isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
-            decoder = video_file
+        if _HAS_TORCHCODEC:
+            return VideoDecoder(source, dimension_order="NHWC")
         else:
-            raise ValueError(f"Unsupported video input type: {type(video_file)}")
+            from decord import VideoReader, cpu, gpu
 
-        return decoder
+            try:
+                from decord.bridge import decord_bridge
 
+                ctx = gpu(0)
+                _ = decord_bridge.get_ctx_device(ctx)
+            except Exception:
+                ctx = cpu(0)
+
+            if isinstance(source, bytes):
+                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+                tmp_file.write(source)
+                tmp_file.close()
+                source = tmp_file.name
+            return VideoReader(source, ctx=ctx)
     finally:
         if tmp_file and os.path.exists(tmp_file.name):
             os.unlink(tmp_file.name)
@@ -1069,7 +1033,7 @@ def sample_video_frames(
         avg_fps = video.metadata.average_fps
     else:
         avg_fps = video.get_avg_fps()
-    duration = total_frames / avg_fps
+    duration = total_frames / avg_fps if avg_fps > 0 else 0
     fps = min(desired_fps, avg_fps)
 
     num_frames = math.floor(duration * fps)
@@ -1096,22 +1060,31 @@ def encode_video(video_path, frame_count_limit=None):
 
     if _HAS_TORCHCODEC:
         decoder = VideoDecoder(video_path, dimension_order="NHWC")
-        sample_fps = round(decoder.metadata.average_fps / 1)  # FPS
-        frame_indices = [i for i in range(0, len(decoder), sample_fps)]
-        if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
-            frame_indices = uniform_sample(frame_indices, frame_count_limit)
-        frames_batch = decoder.get_frames_at(frame_indices)
-        frames = [Image.fromarray(f.numpy().astype("uint8")) for f in frames_batch.data]
+        avg_fps = decoder.metadata.average_fps
+        total_frames = len(decoder)
     else:
         from decord import VideoReader, cpu
 
-        vr = VideoReader(video_path, ctx=cpu(0))
-        sample_fps = round(vr.get_avg_fps() / 1)  # FPS
-        frame_indices = [i for i in range(0, len(vr), sample_fps)]
-        if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
-            frame_indices = uniform_sample(frame_indices, frame_count_limit)
-        frames = vr.get_batch(frame_indices).asnumpy()
-        frames = [Image.fromarray(v.astype("uint8")) for v in frames]
+        decoder = VideoReader(video_path, ctx=cpu(0))
+        avg_fps = decoder.get_avg_fps()
+        total_frames = len(decoder)
+
+    sample_fps = round(avg_fps / 1)
+    if sample_fps == 0:
+        sample_fps = 1
+    frame_indices = [i for i in range(0, total_frames, sample_fps)]
+    if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
+        frame_indices = uniform_sample(frame_indices, frame_count_limit)
+
+    if not frame_indices:
+        return []
+
+    if _HAS_TORCHCODEC:
+        frames_batch = decoder.get_frames_at(frame_indices)
+        frames = [Image.fromarray(f.numpy().astype("uint8")) for f in frames_batch.data]
+    else:
+        frames_data = decoder.get_batch(frame_indices).asnumpy()
+        frames = [Image.fromarray(v.astype("uint8")) for v in frames_data]
 
     return frames
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -96,8 +96,7 @@ from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 
 if TYPE_CHECKING:
-    # Apparently importing this here is necessary to avoid a segfault, see comment in load_video below
-    from decord import VideoReader
+    from torchcodec.decoders import VideoDecoder
 
     from sglang.srt.server_args import ServerArgs
 
@@ -953,25 +952,13 @@ def get_image_bytes(image_file: Union[str, bytes]):
 
 
 def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
-    # We import decord here to avoid a strange Segmentation fault (core dumped) issue.
-    from decord import VideoReader, cpu, gpu
-
-    try:
-        from decord.bridge import decord_bridge
-
-        ctx = gpu(0)
-        _ = decord_bridge.get_ctx_device(ctx)
-    except Exception:
-        ctx = cpu(0)
+    from torchcodec.decoders import VideoDecoder
 
     tmp_file = None
-    vr = None
+    decoder = None
     try:
         if isinstance(video_file, bytes):
-            tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-            tmp_file.write(video_file)
-            tmp_file.close()
-            vr = VideoReader(tmp_file.name, ctx=ctx)
+            decoder = VideoDecoder(video_file, dimension_order="NHWC")
         elif isinstance(video_file, str):
             if video_file.startswith(("http://", "https://")):
                 timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
@@ -981,32 +968,25 @@ def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
                 for chunk in response.iter_content(chunk_size=8192):
                     tmp_file.write(chunk)
                 tmp_file.close()
-                vr = VideoReader(tmp_file.name, ctx=ctx)
+                decoder = VideoDecoder(tmp_file.name, dimension_order="NHWC")
             elif video_file.startswith("data:"):
                 _, encoded = video_file.split(",", 1)
                 video_bytes = pybase64.b64decode(encoded, validate=True)
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                tmp_file.write(video_bytes)
-                tmp_file.close()
-                vr = VideoReader(tmp_file.name, ctx=ctx)
+                decoder = VideoDecoder(video_bytes, dimension_order="NHWC")
             elif video_file.startswith("file://"):
                 video_file = unquote(urlparse(video_file).path)
-                vr = VideoReader(video_file, ctx=ctx)
-            # `urlparse` supports file:// paths, and so does VideoReader
+                decoder = VideoDecoder(video_file, dimension_order="NHWC")
             elif os.path.isfile(unquote(urlparse(video_file).path)):
-                vr = VideoReader(video_file, ctx=ctx)
+                decoder = VideoDecoder(video_file, dimension_order="NHWC")
             else:
                 video_bytes = pybase64.b64decode(video_file, validate=True)
-                tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                tmp_file.write(video_bytes)
-                tmp_file.close()
-                vr = VideoReader(tmp_file.name, ctx=ctx)
+                decoder = VideoDecoder(video_bytes, dimension_order="NHWC")
         elif isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
-            vr = video_file
+            decoder = video_file
         else:
             raise ValueError(f"Unsupported video input type: {type(video_file)}")
 
-        return vr
+        return decoder
 
     finally:
         if tmp_file and os.path.exists(tmp_file.name):
@@ -1014,13 +994,14 @@ def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
 
 
 def sample_video_frames(
-    video: "VideoReader", *, desired_fps: int, max_frames: int
+    video: "VideoDecoder", *, desired_fps: int, max_frames: int
 ) -> list[int]:
     total_frames = len(video)
     assert total_frames > 0, "Video must have at least one frame"
 
-    duration = total_frames / video.get_avg_fps()
-    fps = min(desired_fps, video.get_avg_fps())
+    avg_fps = video.metadata.average_fps
+    duration = total_frames / avg_fps
+    fps = min(desired_fps, avg_fps)
 
     num_frames = math.floor(duration * fps)
     num_frames = min(max_frames, num_frames, total_frames)
@@ -1032,8 +1013,7 @@ def sample_video_frames(
 
 
 def encode_video(video_path, frame_count_limit=None):
-    # Lazy import because decord is not available on some arm platforms.
-    from decord import VideoReader, cpu
+    from torchcodec.decoders import VideoDecoder
 
     if not os.path.exists(video_path):
         logger.error(f"Video {video_path} does not exist")
@@ -1047,14 +1027,14 @@ def encode_video(video_path, frame_count_limit=None):
         idxs = [int(i * gap + gap / 2) for i in range(n)]
         return [l[i] for i in idxs]
 
-    vr = VideoReader(video_path, ctx=cpu(0))
-    sample_fps = round(vr.get_avg_fps() / 1)  # FPS
-    frame_indices = [i for i in range(0, len(vr), sample_fps)]
+    decoder = VideoDecoder(video_path, dimension_order="NHWC")
+    sample_fps = round(decoder.metadata.average_fps / 1)  # FPS
+    frame_indices = [i for i in range(0, len(decoder), sample_fps)]
     if frame_count_limit is not None and len(frame_indices) > frame_count_limit:
         frame_indices = uniform_sample(frame_indices, frame_count_limit)
 
-    frames = vr.get_batch(frame_indices).asnumpy()
-    frames = [Image.fromarray(v.astype("uint8")) for v in frames]
+    frames_batch = decoder.get_frames_at(frame_indices)
+    frames = [Image.fromarray(f.numpy().astype("uint8")) for f in frames_batch.data]
     return frames
 
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -953,51 +953,44 @@ def get_image_bytes(image_file: Union[str, bytes]):
 
 def _normalize_video_input(
     video_file: Union[str, bytes],
-) -> tuple[Union[str, bytes, None], "tempfile.NamedTemporaryFile | None"]:
+) -> Union[str, bytes, None]:
     """Normalize video input (URL, base64, file://, etc.) to a file path or bytes.
 
-    Returns (source, tmp_file) where source is a file path or bytes suitable for
-    a decoder, and tmp_file is a temp file that the caller must clean up.
+    Returns a file path or bytes suitable for a decoder, or None on failure.
+    URLs and base64 are returned as bytes (no temp files needed since both
+    torchcodec and VideoDecoderWrapper accept bytes natively).
     """
-    tmp_file = None
     if isinstance(video_file, bytes):
-        return video_file, None
+        return video_file
     elif isinstance(video_file, str):
         if video_file.startswith(("http://", "https://")):
             timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
             response = requests.get(video_file, stream=True, timeout=timeout)
             response.raise_for_status()
-            tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-            for chunk in response.iter_content(chunk_size=8192):
-                tmp_file.write(chunk)
-            tmp_file.close()
-            return tmp_file.name, tmp_file
+            return response.content
         elif video_file.startswith("data:"):
             _, encoded = video_file.split(",", 1)
-            return pybase64.b64decode(encoded, validate=True), None
+            return pybase64.b64decode(encoded, validate=True)
         elif video_file.startswith("file://"):
-            return unquote(urlparse(video_file).path), None
+            return unquote(urlparse(video_file).path)
         elif os.path.isfile(unquote(urlparse(video_file).path)):
-            return video_file, None
+            return video_file
         else:
-            return pybase64.b64decode(video_file, validate=True), None
+            return pybase64.b64decode(video_file, validate=True)
     else:
-        return None, None
+        return None
 
 
 def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
     if isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
         return video_file
 
-    source, tmp_file = _normalize_video_input(video_file)
+    source = _normalize_video_input(video_file)
     if source is None:
         raise ValueError(f"Unsupported video input type: {type(video_file)}")
 
-    try:
-        return VideoDecoderWrapper(source)
-    finally:
-        if tmp_file and os.path.exists(tmp_file.name):
-            os.unlink(tmp_file.name)
+    device = "cuda" if use_gpu else "cpu"
+    return VideoDecoderWrapper(source, device=device)
 
 
 def sample_video_frames(

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -1,0 +1,80 @@
+"""Unified video decoder: torchcodec preferred, decord as fallback."""
+
+import numpy as np
+
+try:
+    from torchcodec.decoders import VideoDecoder
+
+    _BACKEND = "torchcodec"
+except ImportError:
+    _BACKEND = "decord"
+
+
+class VideoDecoderWrapper:
+    """Unified video decoder that uses torchcodec when available, decord as fallback.
+
+    All frames are returned in NHWC uint8 numpy format for consistency.
+    """
+
+    def __init__(self, source):
+        """source: file path (str) or video bytes."""
+        if _BACKEND == "torchcodec":
+            self._decoder = VideoDecoder(source, dimension_order="NHWC")
+        else:
+            from decord import VideoReader, cpu
+
+            if isinstance(source, bytes):
+                import os
+                import tempfile
+
+                self._tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+                self._tmp.write(source)
+                self._tmp.close()
+                self._decoder = VideoReader(self._tmp.name, ctx=cpu(0))
+            else:
+                self._tmp = None
+                self._decoder = VideoReader(source, ctx=cpu(0))
+
+    def __len__(self):
+        return len(self._decoder)
+
+    def __getitem__(self, idx):
+        """Return single frame as numpy NHWC uint8."""
+        if _BACKEND == "torchcodec":
+            return self._decoder[idx].numpy()
+        else:
+            frame = self._decoder[idx]
+            return frame.asnumpy() if hasattr(frame, "asnumpy") else np.array(frame)
+
+    @property
+    def avg_fps(self) -> float:
+        if _BACKEND == "torchcodec":
+            return self._decoder.metadata.average_fps
+        else:
+            return self._decoder.get_avg_fps()
+
+    def get_frames_at(self, indices: list) -> np.ndarray:
+        """Return frames at given indices as numpy array with shape (N, H, W, C)."""
+        if _BACKEND == "torchcodec":
+            batch = self._decoder.get_frames_at(indices)
+            return batch.data.numpy()
+        else:
+            return self._decoder.get_batch(indices).asnumpy()
+
+    def get_frames_as_tensor(self, indices: list):
+        """Return frames at given indices as a torch tensor (NHWC, uint8, pinned memory)."""
+        import torch
+
+        if _BACKEND == "torchcodec":
+            batch = self._decoder.get_frames_at(indices)
+            return batch.data.pin_memory()
+        else:
+            arr = self._decoder.get_batch(indices).asnumpy()
+            return torch.from_numpy(arr).pin_memory()
+
+    def __del__(self):
+        if _BACKEND == "decord" and hasattr(self, "_tmp") and self._tmp is not None:
+            import os
+
+            if os.path.exists(self._tmp.name):
+                os.unlink(self._tmp.name)

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -1,6 +1,10 @@
 """Unified video decoder: torchcodec preferred, decord as fallback."""
 
+import logging
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 try:
     from torchcodec.decoders import VideoDecoder
@@ -10,16 +14,32 @@ except ImportError:
     _BACKEND = "decord"
 
 
+def _try_cuda_backend() -> bool:
+    """Try to enable torchcodec CUDA backend. Returns True on success."""
+    try:
+        from torchcodec.decoders import set_cuda_backend
+
+        set_cuda_backend("beta")
+        return True
+    except Exception:
+        return False
+
+
 class VideoDecoderWrapper:
     """Unified video decoder that uses torchcodec when available, decord as fallback.
 
     All frames are returned in NHWC uint8 numpy format for consistency.
     """
 
-    def __init__(self, source):
-        """source: file path (str) or video bytes."""
+    def __init__(self, source, device: str = "cpu"):
+        """source: file path (str) or video bytes.
+        device: "cpu" or "cuda". GPU decoding only supported with torchcodec.
+        """
         if _BACKEND == "torchcodec":
-            self._decoder = VideoDecoder(source, dimension_order="NHWC")
+            kwargs = {"dimension_order": "NHWC"}
+            if device == "cuda" and _try_cuda_backend():
+                kwargs["device"] = "cuda"
+            self._decoder = VideoDecoder(source, **kwargs)
         else:
             from decord import VideoReader, cpu
 

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -47,7 +47,17 @@ class VideoDecoderWrapper:
             kwargs = {"dimension_order": "NHWC"}
             if device == "cuda" and _try_cuda_backend():
                 kwargs["device"] = "cuda"
-            self._decoder = VideoDecoder(source, **kwargs)
+            try:
+                self._decoder = VideoDecoder(source, **kwargs)
+            except RuntimeError:
+                if "device" in kwargs:
+                    logger.warning(
+                        "CUDA video decoding failed, falling back to CPU."
+                    )
+                    kwargs.pop("device")
+                    self._decoder = VideoDecoder(source, **kwargs)
+                else:
+                    raise
         else:
             from decord import VideoReader, cpu
 

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -51,9 +51,7 @@ class VideoDecoderWrapper:
                 self._decoder = VideoDecoder(source, **kwargs)
             except RuntimeError:
                 if "device" in kwargs:
-                    logger.warning(
-                        "CUDA video decoding failed, falling back to CPU."
-                    )
+                    logger.warning("CUDA video decoding failed, falling back to CPU.")
                     kwargs.pop("device")
                     self._decoder = VideoDecoder(source, **kwargs)
                 else:

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -44,7 +44,6 @@ class VideoDecoderWrapper:
             from decord import VideoReader, cpu
 
             if isinstance(source, bytes):
-                import os
                 import tempfile
 
                 self._tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -10,7 +10,7 @@ try:
     from torchcodec.decoders import VideoDecoder
 
     _BACKEND = "torchcodec"
-except ImportError:
+except (ImportError, RuntimeError):
     _BACKEND = "decord"
 
 

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -14,15 +14,22 @@ except ImportError:
     _BACKEND = "decord"
 
 
+_cuda_backend_enabled: bool | None = None
+
+
 def _try_cuda_backend() -> bool:
-    """Try to enable torchcodec CUDA backend. Returns True on success."""
+    """Try to enable torchcodec CUDA backend. Caches result after first call."""
+    global _cuda_backend_enabled
+    if _cuda_backend_enabled is not None:
+        return _cuda_backend_enabled
     try:
         from torchcodec.decoders import set_cuda_backend
 
         set_cuda_backend("beta")
-        return True
+        _cuda_backend_enabled = True
     except Exception:
-        return False
+        _cuda_backend_enabled = False
+    return _cuda_backend_enabled
 
 
 class VideoDecoderWrapper:
@@ -35,6 +42,7 @@ class VideoDecoderWrapper:
         """source: file path (str) or video bytes.
         device: "cpu" or "cuda". GPU decoding only supported with torchcodec.
         """
+        self._tmp_path = None
         if _BACKEND == "torchcodec":
             kwargs = {"dimension_order": "NHWC"}
             if device == "cuda" and _try_cuda_backend():
@@ -44,14 +52,17 @@ class VideoDecoderWrapper:
             from decord import VideoReader, cpu
 
             if isinstance(source, bytes):
+                import os
                 import tempfile
 
-                self._tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-                self._tmp.write(source)
-                self._tmp.close()
-                self._decoder = VideoReader(self._tmp.name, ctx=cpu(0))
+                fd, tmp_path = tempfile.mkstemp(suffix=".mp4")
+                try:
+                    os.write(fd, source)
+                finally:
+                    os.close(fd)
+                self._tmp_path = tmp_path
+                self._decoder = VideoReader(tmp_path, ctx=cpu(0))
             else:
-                self._tmp = None
                 self._decoder = VideoReader(source, ctx=cpu(0))
 
     def __len__(self):
@@ -91,9 +102,20 @@ class VideoDecoderWrapper:
             arr = self._decoder.get_batch(indices).asnumpy()
             return torch.from_numpy(arr).pin_memory()
 
-    def __del__(self):
-        if _BACKEND == "decord" and hasattr(self, "_tmp") and self._tmp is not None:
+    def close(self):
+        """Explicitly clean up temporary files."""
+        if self._tmp_path is not None:
             import os
 
-            if os.path.exists(self._tmp.name):
-                os.unlink(self._tmp.name)
+            if os.path.exists(self._tmp_path):
+                os.unlink(self._tmp_path)
+            self._tmp_path = None
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/python/sglang/test/vlm_utils.py
+++ b/python/sglang/test/vlm_utils.py
@@ -378,17 +378,16 @@ class ImageOpenAITestMixin(TestOpenAIMLLMServerBase):
         # the memory consumed by the Vision Attention varies a lot, e.g. blocked qkv vs full-sequence sdpa
         # the size of the video embeds differs from the `modality` argument when preprocessed
 
-        from torchcodec.decoders import VideoDecoder
+        from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
         max_frames_num = 10
-        decoder = VideoDecoder(video_path, dimension_order="NHWC")
+        decoder = VideoDecoderWrapper(video_path)
         total_frame_num = len(decoder)
         uniform_sampled_frames = np.linspace(
             0, total_frame_num - 1, max_frames_num, dtype=int
         )
         frame_idx = uniform_sampled_frames.tolist()
-        frames_batch = decoder.get_frames_at(frame_idx)
-        frames = frames_batch.data.numpy()
+        frames = decoder.get_frames_at(frame_idx)
 
         base64_frames = []
         for frame in frames:

--- a/python/sglang/test/vlm_utils.py
+++ b/python/sglang/test/vlm_utils.py
@@ -378,20 +378,17 @@ class ImageOpenAITestMixin(TestOpenAIMLLMServerBase):
         # the memory consumed by the Vision Attention varies a lot, e.g. blocked qkv vs full-sequence sdpa
         # the size of the video embeds differs from the `modality` argument when preprocessed
 
-        # We import decord here to avoid a strange Segmentation fault (core dumped) issue.
-        # The following import order will cause Segmentation fault.
-        # import decord
-        # from transformers import AutoTokenizer
-        from decord import VideoReader, cpu
+        from torchcodec.decoders import VideoDecoder
 
         max_frames_num = 10
-        vr = VideoReader(video_path, ctx=cpu(0))
-        total_frame_num = len(vr)
+        decoder = VideoDecoder(video_path, dimension_order="NHWC")
+        total_frame_num = len(decoder)
         uniform_sampled_frames = np.linspace(
             0, total_frame_num - 1, max_frames_num, dtype=int
         )
         frame_idx = uniform_sampled_frames.tolist()
-        frames = vr.get_batch(frame_idx).asnumpy()
+        frames_batch = decoder.get_frames_at(frame_idx)
+        frames = frames_batch.data.numpy()
 
         base64_frames = []
         for frame in frames:

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -28,10 +28,10 @@ echo "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-}"
 # The NVIDIA driver packages may have broken dependencies that are unrelated to these packages
 # Run apt-get update first to refresh package index (stale index causes 404 on security.ubuntu.com)
 apt-get update || true
-apt-get install -y --no-install-recommends python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils || {
+apt-get install -y --no-install-recommends python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev || {
     echo "Warning: apt-get install failed, checking if required packages are available..."
     # Verify the packages we need are actually installed
-    for pkg in python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils; do
+    for pkg in python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils ffmpeg; do
         if ! dpkg -l "$pkg" 2>/dev/null | grep -q "^ii"; then
             echo "ERROR: Required package $pkg is not installed and apt-get failed"
             exit 1

--- a/test/registered/vlm/test_video_utils.py
+++ b/test/registered/vlm/test_video_utils.py
@@ -16,7 +16,8 @@ class DummyVideo:
     def __len__(self):
         return self._frames
 
-    def get_avg_fps(self):
+    @property
+    def avg_fps(self):
         return self._fps
 
 

--- a/test/registered/vlm/test_vision_chunked_prefill.py
+++ b/test/registered/vlm/test_vision_chunked_prefill.py
@@ -40,19 +40,16 @@ logger = logging.getLogger(__name__)
 class TestVisionChunkedPrefill(CustomTestCase):
 
     def prepare_video_messages(self, video_path, max_frames_num=8):
-        # We import decord here to avoid a strange Segmentation fault (core dumped) issue.
-        # The following import order will cause Segmentation fault.
-        # import decord
-        # from transformers import AutoTokenizer
-        from decord import VideoReader, cpu
+        from torchcodec.decoders import VideoDecoder
 
-        vr = VideoReader(video_path, ctx=cpu(0))
-        total_frame_num = len(vr)
+        decoder = VideoDecoder(video_path, dimension_order="NHWC")
+        total_frame_num = len(decoder)
         uniform_sampled_frames = np.linspace(
             0, total_frame_num - 1, max_frames_num, dtype=int
         )
         frame_idx = uniform_sampled_frames.tolist()
-        frames = vr.get_batch(frame_idx).asnumpy()
+        frames_batch = decoder.get_frames_at(frame_idx)
+        frames = frames_batch.data.numpy()
 
         base64_frames = []
         for frame in frames:

--- a/test/registered/vlm/test_vision_chunked_prefill.py
+++ b/test/registered/vlm/test_vision_chunked_prefill.py
@@ -40,16 +40,15 @@ logger = logging.getLogger(__name__)
 class TestVisionChunkedPrefill(CustomTestCase):
 
     def prepare_video_messages(self, video_path, max_frames_num=8):
-        from torchcodec.decoders import VideoDecoder
+        from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
-        decoder = VideoDecoder(video_path, dimension_order="NHWC")
+        decoder = VideoDecoderWrapper(video_path)
         total_frame_num = len(decoder)
         uniform_sampled_frames = np.linspace(
             0, total_frame_num - 1, max_frames_num, dtype=int
         )
         frame_idx = uniform_sampled_frames.tolist()
-        frames_batch = decoder.get_frames_at(frame_idx)
-        frames = frames_batch.data.numpy()
+        frames = decoder.get_frames_at(frame_idx)
 
         base64_frames = []
         for frame in frames:


### PR DESCRIPTION
## Summary
Replace unmaintained `decord` with PyTorch-official `torchcodec` for video decoding.

### Why
- decord is unmaintained (3+ years), causes segfaults, hangs, and is unpicklable
- torchcodec is actively maintained, supports GPU decoding, and was already a dependency (but unused)

### What
- **New `VideoDecoderWrapper`** (`python/sglang/srt/utils/video_decoder.py`): unified adapter that abstracts torchcodec vs decord behind one interface. No `_HAS_TORCHCODEC` checks scattered in consumer code.
- **GPU video decoding**: supports `device="cuda"` via torchcodec's beta CUDA backend with cached initialization
- **ARM fallback**: graceful fallback to decord on Linux ARM where torchcodec has no prebuilt wheels. Context manager support for reliable temp file cleanup.
- **Simplified input handling**: URLs and base64 inputs resolved to bytes directly (torchcodec accepts bytes natively), avoiding unnecessary temp files

### Files changed
- New: `video_decoder.py` (VideoDecoderWrapper)
- `common.py`: `load_video()`, `encode_video()`, `sample_video_frames()`
- Processors: `internvl.py`, `qwen_vl.py`, `base_processor.py`, `nano_nemotron_vl.py`
- Tests and examples updated
- `pyproject*.toml`: `torchcodec` bumped to 0.9.1, `decord2` conditional for ARM only

Refs: #3885

Co-authored-by: BakerBunker <17872844+BakerBunker@users.noreply.github.com>

## Test plan
- [x] Test video loading with torchcodec on x86_64
- [x] Test GPU video decoding (device="cuda")
- [x] Verify fallback works when torchcodec is unavailable (ARM)
- [x] Run VLM tests (chunked prefill, InternVL, Qwen-VL)