### PR TITLE
[Core] Unify `max_num_reqs` `dp_size` division for pool sizing

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -684,15 +684,10 @@ class ModelRunnerKVCacheMixin:
         if max_num_reqs is not None:
             max_num_reqs = max_num_reqs // self.dp_size
         else:
-            max_num_reqs = min(
-                max(
-                    int(
-                        self.max_total_num_tokens / self.model_config.context_len * 512
-                    ),
-                    2048,
-                ),
-                4096,
+            estimated = int(
+                self.max_total_num_tokens / self.model_config.context_len * 512
             )
+            max_num_reqs = max(min(estimated, 4096), 2048)
 
         if self.mambaish_config is not None:
             ratio = self._calculate_mamba_ratio()

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -676,11 +676,14 @@ class ModelRunnerKVCacheMixin:
                 )
 
     def init_memory_pool(self: ModelRunner, pre_model_load_memory: int):
-        max_num_reqs = self.server_args.max_running_requests
         max_total_tokens = self.server_args.max_total_tokens
         self.max_total_num_tokens = self.profile_max_num_token(pre_model_load_memory)
 
-        if max_num_reqs is None:
+        # Resolve max_num_reqs (per dp worker)
+        max_num_reqs = self.server_args.max_running_requests
+        if max_num_reqs is not None:
+            max_num_reqs = max_num_reqs // self.dp_size
+        else:
             max_num_reqs = min(
                 max(
                     int(
@@ -698,15 +701,6 @@ class ModelRunnerKVCacheMixin:
             max_num_reqs = min(
                 max_num_reqs, self.server_args.max_mamba_cache_size // ratio
             )
-
-            # for dp attention, we need control the max_num_reqs for speculative decoding mamba space
-            if (
-                not self.spec_algorithm.is_none()
-                and self.server_args.enable_dp_attention
-            ):
-                max_num_reqs = min(
-                    max_num_reqs, self.server_args.max_running_requests // self.dp_size
-                )
 
         if max_total_tokens is not None:
             if max_total_tokens > self.max_total_num_tokens:


### PR DESCRIPTION
## Summary

When `--enable-dp-attention` is on, `max_running_requests` is a global value (across all dp workers). Each worker's pool should be sized with `max_running_requests // dp_size`.

**Before**: only mamba + speculative decoding did `// dp_size` (added in #16138 as a targeted fix for mamba intermediate state memory reservation). Non-mamba models with dp attention used the global value, over-allocating `req_to_token_pool`.

**After**: `// dp_size` is applied uniformly for all models when `max_running_requests` is explicitly set. The mamba-specific `// dp_size` block is removed since the generic path now covers it.

## Details

- `self.dp_size` is `dp_size if enable_dp_attention else 1`, so non-dp scenarios get `// 1` (no-op)
- Auto-computed `max_num_reqs` (when `max_running_requests is None`) derives from `max_total_num_tokens` which is already per-worker — no division needed
- `max_mamba_cache_size` is already divided by `dp_size` in `handle_max_mamba_cache`, so the `min()` comparison remains correct (both sides are per-worker values)
- The runtime limit in `model_runner.py:606-613` also does `// dp_size`, keeping consistency between pool sizing and runtime cap

## Context

The original mamba-only `// dp_size` was introduced in #16138 (`[Bugfix] fix some memory computation bugs for qwen3next with mtp`), specifically to match the per-worker intermediate state memory reservation for speculative decoding. This PR generalizes that fix to all model types.