### PR TITLE
Fix CUDA stream synchronization in sampler logprobs extraction

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -649,12 +649,10 @@ def get_token_ids_logprobs_batch_optimized(
     batch_size = len(token_ids_logprobs)
     device = logprobs.device
 
-    # Step 1: Calculate lengths for each request, treating None as empty list
-    # Example: [[1, 3], [2], [0, 2, 4]] -> token_lengths = tensor([2, 1, 3])
-    token_lengths = torch.tensor(
-        [len(token_ids or []) for token_ids in token_ids_logprobs], device=device
-    )
-    total_tokens = int(token_lengths.sum().item())  # 2 + 1 + 3 = 6
+    # Step 1: Calculate lengths and flatten token IDs on CPU first
+    # Example: [[1, 3], [2], [0, 2, 4]] -> lengths = [2, 1, 3], flat_ids = [1, 3, 2, 0, 2, 4]
+    lengths = [len(token_ids or []) for token_ids in token_ids_logprobs]
+    total_tokens = sum(lengths)
 
     # Handle edge case where no tokens are requested
     if total_tokens == 0:
@@ -662,21 +660,25 @@ def get_token_ids_logprobs_batch_optimized(
             [] for _ in token_ids_logprobs
         ]
 
-    # Step 2: Build flattened indices using torch operations
+    flat_token_ids = [
+        token_id
+        for token_ids in token_ids_logprobs
+        for token_id in (token_ids or [])
+    ]
+
+    # Step 2: Create tensors on CPU then transfer to GPU with non_blocking=True
+    # This avoids cudaStreamSynchronize during tensor creation on GPU
+    col_indices = torch.tensor(flat_token_ids, dtype=torch.long).to(
+        device, non_blocking=True
+    )
+
+    # Build row indices on CPU then transfer to avoid cudaStreamSynchronize
+    # (repeat_interleave with GPU tensor causes sync to compute output size,
+    # see https://github.com/pytorch/pytorch/issues/108968)
     # Example: row_indices = [0, 0, 1, 2, 2, 2] (batch indices repeated by their lengths)
     row_indices = torch.repeat_interleave(
-        torch.arange(batch_size, device=device), token_lengths
-    )
-    # Example: col_indices = [1, 3, 2, 0, 2, 4] (flattened token IDs from all requests)
-    col_indices = torch.tensor(
-        [
-            token_id
-            for token_ids in token_ids_logprobs
-            for token_id in (token_ids or [])
-        ],
-        device=device,
-        dtype=torch.long,
-    )
+        torch.arange(batch_size), torch.tensor(lengths, dtype=torch.long)
+    ).to(device, non_blocking=True)
 
     # Step 3: Single vectorized gather operation
     # Example: logprobs[row_indices, col_indices] -> [-2.1, -3.0, -2.2, -2.0, -1.4, -1.6]
@@ -685,7 +687,7 @@ def get_token_ids_logprobs_batch_optimized(
     # Step 4: Split results back per request using torch operations
     # Example: split tensor [6] into chunks of sizes [2, 1, 3] -> [tensor(2), tensor(1), tensor(3)]
     split_logprobs = torch.split_with_sizes(
-        gathered_logprobs, token_lengths.tolist(), dim=0
+        gathered_logprobs, lengths, dim=0
     )
 
     # Step 5: Format output to match expected return structure


### PR DESCRIPTION
## Motivation

  get_token_ids_logprobs_batch_optimized was creating tensors directly on GPU and calling torch.repeat_interleave with a GPU tensor, both of which force a cudaStreamSynchronize — a known PyTorch issue
  (https://github.com/pytorch/pytorch/issues/108968). This stalls the GPU, preventing it from executing kernels concurrently during the sampler phase.

## Modifications

  - Compute lengths and flatten token IDs as Python lists on CPU
  - Create tensors on CPU, then transfer to GPU with non_blocking=True
  - This eliminates the implicit device sync and allows the GPU to continue executing kernels without stalling

##  Accuracy Tests

  No model output changes — this is a performance fix only.

##  Benchmarking and Profiling

  Profiling confirms the cudaStreamSynchronize call is removed after this change.



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
