### PR TITLE
[Nightly] Replace MiniMax-M2 with MiniMax-M2.5

### DIFF
--- a/test/registered/8-gpu-models/test_minimax_m25.py
+++ b/test/registered/8-gpu-models/test_minimax_m25.py
@@ -9,32 +9,30 @@ from sglang.test.test_utils import ModelLaunchSettings
 # Runs on both H200 and B200 via nightly-8-gpu-common suite
 register_cuda_ci(est_time=1800, suite="nightly-8-gpu-common", nightly=True)
 
-MINIMAX_M2_MODEL_PATH = "MiniMaxAI/MiniMax-M2"
+MINIMAX_M25_MODEL_PATH = "MiniMaxAI/MiniMax-M2.5"
 
 
-class TestMiniMaxM2(unittest.TestCase):
-    """Unified test class for MiniMax-M2 performance and accuracy.
+class TestMiniMaxM25(unittest.TestCase):
+    """Unified test class for MiniMax-M2.5 performance and accuracy.
 
     Single variant with TP=8 + EP=8 configuration.
-    MiniMax-M2 is a 230B MoE model with 10B active params.
     Runs BOTH:
     - Performance test (using NightlyBenchmarkRunner with extra_bench_args)
-    - Accuracy test (using run_eval with mgsm_en)
+    - Accuracy test (using run_eval with gsm8k)
     """
 
-    def test_minimax_m2(self):
-        """Run performance and accuracy for MiniMax-M2."""
+    def test_minimax_m25(self):
+        """Run performance and accuracy for MiniMax-M2.5."""
         base_args = [
-            "--tp=8",
-            "--ep=8",
             "--trust-remote-code",
-            "--model-loader-extra-config",
-            '{"enable_multithread_load": true}',
+            "--ep=8",
+            "--mem-fraction-static=0.85",
+            "--reasoning-parser=minimax-append-think",
         ]
 
         variants = [
             ModelLaunchSettings(
-                MINIMAX_M2_MODEL_PATH,
+                MINIMAX_M25_MODEL_PATH,
                 tp_size=8,
                 extra_args=base_args,
                 variant="TP8+EP8",
@@ -43,10 +41,10 @@ class TestMiniMaxM2(unittest.TestCase):
 
         run_combined_tests(
             models=variants,
-            test_name="MiniMax-M2",
+            test_name="MiniMax-M2.5",
             accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.80),
             performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_minimax_m2",
+                profile_dir="performance_profiles_minimax_m25",
             ),
         )
 


### PR DESCRIPTION
## Summary
- Replace `MiniMaxAI/MiniMax-M2` with `MiniMaxAI/MiniMax-M2.5`
- Add `--reasoning-parser=minimax-append-think` and `--mem-fraction-static=0.85`
- Remove `--model-loader-extra-config` (multithread load)
- GSM8K accuracy baseline remains 0.80

Subsumes the MiniMax M2.5 change from #19218.

## Test plan
- [ ] Verify test is picked up by `nightly-8-gpu-common` suite
- [ ] Confirm MiniMax M2.5 launches and passes accuracy + performance tests