### PR TITLE
Fix spec NaN/OOB detection: skip during CUDA graph capture, sync check otherwise

### DIFF
--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -706,22 +706,27 @@ def draft_tp_context(tp_group: GroupCoordinator):
 
 
 def maybe_detect_nan(tensor: torch.Tensor, msg: str = ""):
-    """Async NaN check — no GPU-CPU sync, error surfaces at next sync point."""
+    """NaN check — skips during CUDA graph capture, sync check otherwise."""
     if not envs.SGLANG_SPEC_NAN_DETECTION.get():
         return
-    torch._assert_async(~torch.any(torch.isnan(tensor)), f"NaN detected! {msg}")
+    if torch.cuda.is_current_stream_capturing():
+        return
+    if torch.any(torch.isnan(tensor)).item():
+        raise RuntimeError(f"NaN detected! {msg}")
 
 
 def maybe_detect_oob(indices: torch.Tensor, low: int, high: int, msg: str):
-    """Async OOB check — no GPU-CPU sync, error surfaces at next sync point."""
+    """OOB check — skips during CUDA graph capture, sync check otherwise."""
     if not envs.SGLANG_SPEC_OOB_DETECTION.get():
+        return
+    if torch.cuda.is_current_stream_capturing():
         return
     if indices.numel() == 0:
         return
-    torch._assert_async(
-        (indices.min() >= low) & (indices.max() < high),
-        f"OOB indices not in [{low}, {high}): {msg}",
-    )
+    min_val = indices.min().item()
+    max_val = indices.max().item()
+    if min_val < low or max_val >= high:
+        raise RuntimeError(f"OOB indices not in [{low}, {high}): {msg}")
 
 
 # Disable torch.compile for this function because it will be

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -706,13 +706,19 @@ def draft_tp_context(tp_group: GroupCoordinator):
 
 
 def maybe_detect_nan(tensor: torch.Tensor, msg: str = ""):
-    """NaN check — skips during CUDA graph capture, sync check otherwise."""
+    """NaN check — skips during CUDA graph capture, replaces NaN otherwise.
+
+    Uses warn-and-replace instead of crash because NaN in draft model logits
+    (e.g. from upstream flashinfer CUTLASS FP4 GEMM bugs) doesn't affect
+    correctness — bad draft tokens get rejected by the verifier.
+    """
     if not envs.SGLANG_SPEC_NAN_DETECTION.get():
         return
     if torch.cuda.is_current_stream_capturing():
         return
     if torch.any(torch.isnan(tensor)).item():
-        raise RuntimeError(f"NaN detected! {msg}")
+        logger.warning("NaN detected in speculative decoding! %s", msg)
+        tensor.nan_to_num_()
 
 
 def maybe_detect_oob(indices: torch.Tensor, low: int, high: int, msg: str):

--- a/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py
@@ -70,6 +70,10 @@ class TestEagleDPAttnServerLarge(CustomTestCase):
             "4",
             "--kv-cache-dtype",
             "fp8_e4m3",
+            # Workaround: flashinfer CUTLASS FP4 GEMM has PDL race condition on
+            # Blackwell (flashinfer#2708), use cuDNN backend until fixed upstream
+            "--fp4-gemm-backend",
+            "flashinfer_cudnn",
             "--model-loader-extra-config",
             '{"enable_multithread_load": true,"num_threads": 64}',
         ]

--- a/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py
@@ -70,10 +70,6 @@ class TestEagleDPAttnServerLarge(CustomTestCase):
             "4",
             "--kv-cache-dtype",
             "fp8_e4m3",
-            # Workaround: flashinfer CUTLASS FP4 GEMM has PDL race condition on
-            # Blackwell (flashinfer#2708), use cuDNN backend until fixed upstream
-            "--fp4-gemm-backend",
-            "flashinfer_cudnn",
             "--model-loader-extra-config",
             '{"enable_multithread_load": true,"num_threads": 64}',
         ]


### PR DESCRIPTION
## Summary
- Handle NaN gracefully in speculative decoding: warn + replace instead of crash
- Fix `maybe_detect_nan` / `maybe_detect_oob` to skip during CUDA graph capture

**Problem**: The B200 nightly EAGLE DP attention test crashes due to NaN in draft model logits, caused by upstream flashinfer CUTLASS FP4 GEMM PDL race condition ([flashinfer#2708](https://github.com/flashinfer-ai/flashinfer/issues/2708)). PR #19899 added NaN detection using `torch._assert_async` which causes unrecoverable CUDA abort on NaN.

**Fix**: Change `maybe_detect_nan` to **warn + replace** (like the sampler's `--enable-nan-detection`):
- Log a warning when NaN is detected (keeps intentional detection for debugging)
- Replace NaN values in-place with `nan_to_num_()` (safe defaults)
- Skip during CUDA graph capture (`.item()` is illegal during capture)
- NaN in draft logits doesn't affect correctness — bad draft tokens get rejected by the verifier

**Why not cuDNN workaround?** `--fp4-gemm-backend flashinfer_cudnn` propagates to the draft model but the NaN still occurs in the EAGLE draft path, suggesting additional NaN sources beyond the FP4 GEMM kernel.

Related: #20043, [flashinfer#2708](https://github.com/flashinfer-ai/flashinfer/issues/2708), [flashinfer#2716](https://github.com/flashinfer-ai/flashinfer/pull/2716)

## Test plan
- [ ] B200 nightly EAGLE DP attention test passes (NaN is logged but handled gracefully)
- [x] Detection skips during CUDA graph capture
- [x] NaN detection still active (warnings logged for debugging)