### PR TITLE
[Qwen-VL] Respect HF processor's default max_pixels for Qwen-VL

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -58,16 +58,15 @@ def configure_processor_max_pixels(processor) -> int:
 
     Priority: env var > HF preprocessor_config > SGLang fallback.
     """
+    ip = getattr(processor, "image_processor", None)
     if envs.SGLANG_IMAGE_MAX_PIXELS.is_set():
         max_pixels = envs.SGLANG_IMAGE_MAX_PIXELS.get()
     else:
-        ip = getattr(processor, "image_processor", None)
         max_pixels = getattr(ip, "max_pixels", None)
         if max_pixels is None:
             max_pixels = IMAGE_MAX_PIXELS_FALLBACK
 
     # Write back so HF internals also use the resolved value.
-    ip = getattr(processor, "image_processor", None)
     if ip is not None:
         ip.max_pixels = max_pixels
     return max_pixels

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -33,7 +33,7 @@ from sglang.utils import logger
 
 IMAGE_FACTOR = 28
 MIN_PIXELS = 4 * 28 * 28
-MAX_PIXELS = envs.SGLANG_IMAGE_MAX_PIXELS.get()
+IMAGE_MAX_PIXELS_FALLBACK = envs.SGLANG_IMAGE_MAX_PIXELS.default
 MAX_RATIO = 200
 RESIZE_RESAMPLE = getattr(Image, envs.SGLANG_RESIZE_RESAMPLE.get(), None)
 if envs.SGLANG_RESIZE_RESAMPLE.is_set() and RESIZE_RESAMPLE is None:
@@ -53,12 +53,32 @@ FPS_MIN_FRAMES = 4
 FPS_MAX_FRAMES = 768
 
 
+def configure_processor_max_pixels(processor) -> int:
+    """Resolve the effective max_pixels and write it back to the HF processor.
+
+    Priority: env var > HF preprocessor_config > SGLang fallback.
+    """
+    if envs.SGLANG_IMAGE_MAX_PIXELS.is_set():
+        max_pixels = envs.SGLANG_IMAGE_MAX_PIXELS.get()
+    else:
+        ip = getattr(processor, "image_processor", None)
+        max_pixels = getattr(ip, "max_pixels", None)
+        if max_pixels is None:
+            max_pixels = IMAGE_MAX_PIXELS_FALLBACK
+
+    # Write back so HF internals also use the resolved value.
+    ip = getattr(processor, "image_processor", None)
+    if ip is not None:
+        ip.max_pixels = max_pixels
+    return max_pixels
+
+
 def smart_resize(
     height: int,
     width: int,
     factor: int = IMAGE_FACTOR,
     min_pixels: int = MIN_PIXELS,
-    max_pixels: int = MAX_PIXELS,
+    max_pixels: int = IMAGE_MAX_PIXELS_FALLBACK,
 ) -> tuple[int, int]:
     """
     Rescales the image so that the following conditions are met:
@@ -247,6 +267,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             hf_config = hf_config.thinker_config
 
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.image_max_pixels = configure_processor_max_pixels(self._processor)
 
         self.IM_START_TOKEN_ID = hf_config.vision_start_token_id
         self.IM_END_TOKEN_ID = hf_config.vision_end_token_id

--- a/python/sglang/test/test_qwen_vl_processor.py
+++ b/python/sglang/test/test_qwen_vl_processor.py
@@ -1,0 +1,43 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.environ import envs
+from sglang.srt.multimodal.processors.qwen_vl import (
+    IMAGE_MAX_PIXELS_FALLBACK,
+    configure_processor_max_pixels,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestQwenVLImageMaxPixels(CustomTestCase):
+    def tearDown(self):
+        envs.SGLANG_IMAGE_MAX_PIXELS.clear()
+
+    def test_uses_processor_default_when_env_not_set(self):
+        processor = SimpleNamespace(image_processor=SimpleNamespace(max_pixels=50176))
+
+        resolved = configure_processor_max_pixels(processor)
+
+        self.assertEqual(resolved, 50176)
+        self.assertEqual(processor.image_processor.max_pixels, 50176)
+
+    def test_env_override_takes_precedence(self):
+        processor = SimpleNamespace(image_processor=SimpleNamespace(max_pixels=50176))
+
+        with envs.SGLANG_IMAGE_MAX_PIXELS.override(123456):
+            resolved = configure_processor_max_pixels(processor)
+
+        self.assertEqual(resolved, 123456)
+        self.assertEqual(processor.image_processor.max_pixels, 123456)
+
+    def test_falls_back_when_processor_has_no_max_pixels(self):
+        processor = SimpleNamespace(image_processor=SimpleNamespace())
+
+        resolved = configure_processor_max_pixels(processor)
+
+        self.assertEqual(resolved, IMAGE_MAX_PIXELS_FALLBACK)
+        self.assertEqual(processor.image_processor.max_pixels, IMAGE_MAX_PIXELS_FALLBACK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fix #20025.

`MAX_PIXELS` in `qwen_vl.py` is evaluated from `envs.SGLANG_IMAGE_MAX_PIXELS.get()` at module load time, ignoring the model's own `max_pixels` config from the HF processor. SGLang's default is much larger than what most Qwen-VL models specify, so images that HF/vLLM would downscale are kept at full resolution, producing more vision tokens and using more memory than expected.

## Modifications

- Ensure max_pixels is properly set at init time with a clear priority: `SGLANG_IMAGE_MAX_PIXELS` env var > HF processor's own `max_pixels` > SGLang built-in fallback. This is done via a new `configure_processor_max_pixels(processor)` called in `QwenVLImageProcessor.__init__`, which also writes the resolved value back to the HF processor so its internal preprocessing stays consistent.
- Add unit tests covering all three priority branches.

## Accuracy Tests

Unit tests added. Default behavior now matches HF transformers / vLLM.

## Benchmarking and Profiling

N/A, init-time config only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
