### PR TITLE
[JIT] Inject target architecture flag into JIT compilation

### DIFF
--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -94,6 +94,10 @@ namespace device {
 #if !defined(USE_ROCM)
 #if defined(__CUDA_ARCH__)
 #define SGL_TARGET_CUDA_ARCH __CUDA_ARCH__
+#if defined(SGL_CUDA_ARCH)
+static_assert(__CUDA_ARCH__ == SGL_CUDA_ARCH,
+              "SGL_CUDA_ARCH mismatch: injected arch flag does not match device target");
+#endif
 #elif defined(SGL_CUDA_ARCH)
 #define SGL_TARGET_CUDA_ARCH SGL_CUDA_ARCH
 #endif

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -96,8 +96,8 @@ namespace device {
 #error "SGL_CUDA_ARCH is not defined. JIT compilation must inject -DSGL_CUDA_ARCH via load_jit()."
 #endif
 #if defined(__CUDA_ARCH__)
-static_assert(__CUDA_ARCH__ == SGL_CUDA_ARCH,
-              "SGL_CUDA_ARCH mismatch: injected arch flag does not match device target");
+static_assert(
+    __CUDA_ARCH__ == SGL_CUDA_ARCH, "SGL_CUDA_ARCH mismatch: injected arch flag does not match device target");
 #endif
 #define SGL_ARCH_HOPPER_OR_GREATER (SGL_CUDA_ARCH >= 900)
 #define SGL_ARCH_BLACKWELL_OR_GREATER ((SGL_CUDA_ARCH >= 1000) && (CUDA_VERSION >= 12090))

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -88,6 +88,25 @@ namespace device {
 /// \brief Macro: forced-inline device function qualifier.
 #define SGL_DEVICE __forceinline__ __device__
 
+// Architecture detection: SGL_CUDA_ARCH is injected by load_jit() and is
+// available in both host and device compilation passes, whereas __CUDA_ARCH__
+// is only defined by nvcc during the device pass.
+#if !defined(USE_ROCM)
+#if defined(__CUDA_ARCH__)
+#define SGL_TARGET_CUDA_ARCH __CUDA_ARCH__
+#elif defined(SGL_CUDA_ARCH)
+#define SGL_TARGET_CUDA_ARCH SGL_CUDA_ARCH
+#endif
+#endif
+
+#ifdef SGL_TARGET_CUDA_ARCH
+#define SGL_ARCH_HOPPER_OR_GREATER (SGL_TARGET_CUDA_ARCH >= 900)
+#define SGL_ARCH_BLACKWELL_OR_GREATER ((SGL_TARGET_CUDA_ARCH >= 1000) && (CUDA_VERSION >= 12090))
+#else
+#define SGL_ARCH_HOPPER_OR_GREATER 0
+#define SGL_ARCH_BLACKWELL_OR_GREATER 0
+#endif
+
 /// \brief Number of threads per warp (always 32 on NVIDIA/AMD GPUs).
 inline constexpr auto kWarpThreads = 32u;
 /// \brief Full warp active mask (all 32 lanes).
@@ -102,7 +121,7 @@ inline constexpr auto kFullMask = 0xffffffffu;
  */
 template <bool kUsePDL>
 SGL_DEVICE void PDLWaitPrimary() {
-#if !defined(USE_ROCM) && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+#if SGL_ARCH_HOPPER_OR_GREATER
   if constexpr (kUsePDL) {
     asm volatile("griddepcontrol.wait;" ::: "memory");
   }
@@ -117,7 +136,7 @@ SGL_DEVICE void PDLWaitPrimary() {
  */
 template <bool kUsePDL>
 SGL_DEVICE void PDLTriggerSecondary() {
-#if !defined(USE_ROCM) && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+#if SGL_ARCH_HOPPER_OR_GREATER
   if constexpr (kUsePDL) {
     asm volatile("griddepcontrol.launch_dependents;" :::);
   }

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -92,21 +92,16 @@ namespace device {
 // available in both host and device compilation passes, whereas __CUDA_ARCH__
 // is only defined by nvcc during the device pass.
 #if !defined(USE_ROCM)
+#if !defined(SGL_CUDA_ARCH)
+#error "SGL_CUDA_ARCH is not defined. JIT compilation must inject -DSGL_CUDA_ARCH via load_jit()."
+#endif
 #if defined(__CUDA_ARCH__)
-#define SGL_TARGET_CUDA_ARCH __CUDA_ARCH__
-#if defined(SGL_CUDA_ARCH)
 static_assert(__CUDA_ARCH__ == SGL_CUDA_ARCH,
               "SGL_CUDA_ARCH mismatch: injected arch flag does not match device target");
 #endif
-#elif defined(SGL_CUDA_ARCH)
-#define SGL_TARGET_CUDA_ARCH SGL_CUDA_ARCH
-#endif
-#endif
-
-#ifdef SGL_TARGET_CUDA_ARCH
-#define SGL_ARCH_HOPPER_OR_GREATER (SGL_TARGET_CUDA_ARCH >= 900)
-#define SGL_ARCH_BLACKWELL_OR_GREATER ((SGL_TARGET_CUDA_ARCH >= 1000) && (CUDA_VERSION >= 12090))
-#else
+#define SGL_ARCH_HOPPER_OR_GREATER (SGL_CUDA_ARCH >= 900)
+#define SGL_ARCH_BLACKWELL_OR_GREATER ((SGL_CUDA_ARCH >= 1000) && (CUDA_VERSION >= 12090))
+#else  // USE_ROCM
 #define SGL_ARCH_HOPPER_OR_GREATER 0
 #define SGL_ARCH_BLACKWELL_OR_GREATER 0
 #endif

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -172,7 +172,9 @@ def load_jit(
         selected_cuda_cflags = DEFAULT_HIP_CFLAGS
         extra_cuda_cflags = ["-DUSE_ROCM"] + extra_cuda_cflags
     else:
-        extra_cuda_cflags = [f"-DSGL_CUDA_ARCH={_get_cuda_arch_value()}"] + extra_cuda_cflags
+        extra_cuda_cflags = [
+            f"-DSGL_CUDA_ARCH={_get_cuda_arch_value()}"
+        ] + extra_cuda_cflags
     if not env_existed:
         os.environ[env_key] = _get_cuda_arch_list()
     try:

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -171,6 +171,8 @@ def load_jit(
     if is_hip_runtime():
         selected_cuda_cflags = DEFAULT_HIP_CFLAGS
         extra_cuda_cflags = ["-DUSE_ROCM"] + extra_cuda_cflags
+    else:
+        extra_cuda_cflags = [f"-DSGL_CUDA_ARCH={_get_cuda_arch_value()}"] + extra_cuda_cflags
     if not env_existed:
         os.environ[env_key] = _get_cuda_arch_list()
     try:
@@ -196,6 +198,14 @@ def is_arch_support_pdl() -> bool:
 
     device = torch.cuda.current_device()
     return torch.cuda.get_device_capability(device)[0] >= 9
+
+
+@cache_once
+def _get_cuda_arch_value() -> int:
+    """Get CUDA arch value for -DSGL_CUDA_ARCH (e.g. 900 for SM 9.0)."""
+    device = torch.cuda.current_device()
+    major, minor = torch.cuda.get_device_capability(device)
+    return major * 100 + minor * 10
 
 
 @cache_once


### PR DESCRIPTION
## Motivation

Follow-up from #19794 (comment by @DarkSharpness): `__CUDA_ARCH__` is only available in the device pass, so arch macros can't be used for host-side dispatch. This PR injects `-DSGL_CUDA_ARCH=<value>` via `load_jit()` so that arch-dependent macros work in both host and device passes.

## Modifications

- **`utils.py`**: Inject `-DSGL_CUDA_ARCH={major*100+minor*10}` into JIT cuda cflags based on `torch.cuda.get_device_capability()`.
- **`utils.cuh`**: Add `SGL_TARGET_CUDA_ARCH` (prefers `__CUDA_ARCH__` in device pass, falls back to `SGL_CUDA_ARCH` in host pass). Define `SGL_ARCH_HOPPER_OR_GREATER` and `SGL_ARCH_BLACKWELL_OR_GREATER`. Refactor PDL guards to use them.

## Accuracy Tests

Compile-time only change. No kernel logic modified.

## Benchmarking and Profiling

No performance impact. 

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
