### PR TITLE
[AMD] feat: true on policy for triton backend

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1075,6 +1075,14 @@ class TritonAttnBackend(AttentionBackend):
                     layer.v_scale,
                 )
 
+        # In deterministic mode, use the unified 1-stage kernel so that decode
+        # and extend share the same sequential reduction order, enabling bit-wise
+        # alignment of log_probs between rollout (decode) and training (extend).
+        if self.enable_deterministic:
+            return self._forward_decode_unified(
+                q, o, layer, forward_batch, logits_soft_cap, sinks
+            )
+
         if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
             kv_indptr = self.forward_metadata.window_kv_indptr
             kv_indices = self.forward_metadata.window_kv_indices
@@ -1105,6 +1113,83 @@ class TritonAttnBackend(AttentionBackend):
             v_descale,
             logit_cap=logits_soft_cap,
             sinks=sinks,
+            xai_temperature_len=layer.xai_temperature_len,
+        )
+        return o
+
+    def _forward_decode_unified(
+        self,
+        q: torch.Tensor,
+        o: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        logits_soft_cap: float,
+        sinks: Optional[torch.Tensor],
+    ):
+        """
+        Decode attention using the unified 1-stage kernel for bit-wise alignment
+        with the extend (training) path.
+
+        During decode, each sequence contributes exactly 1 query token. We treat
+        this as a degenerate extend call where:
+          - qo_indptr = [0, 1, 2, ..., bs]  (one Q token per sequence)
+          - kv_indptr / kv_indices already built by init_forward_metadata for decode
+          - prefix_lens = full KV length per sequence (all KV slots are "prefix";
+            the current token was written to the cache before this call)
+          - max_len_extend = 1
+
+        This ensures the same sequential reduction order as the unified kernel
+        used in extend and in the training forward pass, achieving bit-wise
+        identical attention outputs and therefore identical log_probs.
+        """
+        bs = forward_batch.batch_size
+
+        # One Q token per sequence.
+        qo_indptr = torch.arange(bs + 1, dtype=torch.int32, device=self.device)
+
+        # Reuse the kv_indptr / kv_indices already prepared for decode.
+        # These already include the token that was just written to the KV cache.
+        if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
+            kv_indptr = self.forward_metadata.window_kv_indptr
+            kv_indices = self.forward_metadata.window_kv_indices
+            sliding_window_size = layer.sliding_window_size
+            window_kv_lens = kv_indptr[1 : bs + 1] - kv_indptr[:bs]
+            window_start_pos = forward_batch.seq_lens[:bs] - window_kv_lens - 1
+        else:
+            kv_indptr = self.forward_metadata.kv_indptr
+            kv_indices = self.forward_metadata.kv_indices
+            sliding_window_size = -1
+            window_start_pos = None
+
+        if layer.k_scale is not None and layer.v_scale is not None:
+            k_descale = layer.k_scale_float
+            v_descale = layer.v_scale_float
+        else:
+            k_descale = 1.0
+            v_descale = 1.0
+
+        # All KV slots are prefix (no new extend tokens beyond the one already
+        # written to cache). prefix_lens equals the per-sequence KV length.
+        prefix_lens = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
+
+        self.extend_attention_fwd_unified(
+            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+            o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+            k_descale,
+            v_descale,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            prefix_lens,
+            max_len_extend=1,
+            sm_scale=layer.scaling,
+            logit_cap=logits_soft_cap,
+            is_causal=True,
+            sliding_window_size=sliding_window_size,
+            sinks=sinks,
+            window_start_pos=window_start_pos,
             xai_temperature_len=layer.xai_temperature_len,
         )
         return o

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -118,8 +118,6 @@ class RMSNorm(MultiPlatformOp):
         )
         if _use_aiter:
             self._forward_method = self.forward_aiter
-        if get_global_server_args().rl_on_policy_target is not None:
-            self._forward_method = self.forward_native
 
     def forward_cuda(
         self,
@@ -175,6 +173,17 @@ class RMSNorm(MultiPlatformOp):
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if is_batch_invariant_mode_enabled():
+            if (
+                residual is not None
+                or get_global_server_args().rl_on_policy_target is not None
+            ):
+                return self.forward_native(x, residual, post_residual_addition)
+            return rms_norm_batch_invariant(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+            )
         if residual is not None:
             residual_out = torch.empty_like(x)
             output = torch.empty_like(x)
@@ -200,6 +209,18 @@ class RMSNorm(MultiPlatformOp):
         # Fallback to native implementation if vllm is not available
         if not _has_vllm_rms_norm:
             return self.forward_native(x, residual, post_residual_addition)
+
+        if is_batch_invariant_mode_enabled():
+            if (
+                residual is not None
+                or get_global_server_args().rl_on_policy_target is not None
+            ):
+                return self.forward_native(x, residual, post_residual_addition)
+            return rms_norm_batch_invariant(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+            )
 
         if not x.is_contiguous():
             # NOTE: Remove this if aiter kernel supports discontinuous input

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -100,6 +100,10 @@ class RMSNorm(MultiPlatformOp):
     ) -> None:
         super().__init__()
         self.has_weight = has_weight
+        # When rl_on_policy_target is set, match HF's RMSNorm behavior:
+        # cast x to orig_dtype BEFORE multiplying with weight (like HF does).
+        if get_global_server_args().rl_on_policy_target is not None and not cast_x_before_out_mul:
+            cast_x_before_out_mul = True
         self.cast_x_before_out_mul = cast_x_before_out_mul
         self.fp32_residual = fp32_residual
         self.override_orig_dtype = override_orig_dtype
@@ -114,6 +118,8 @@ class RMSNorm(MultiPlatformOp):
         )
         if _use_aiter:
             self._forward_method = self.forward_aiter
+        if get_global_server_args().rl_on_policy_target is not None:
+            self._forward_method = self.forward_native
 
     def forward_cuda(
         self,
@@ -220,15 +226,29 @@ class RMSNorm(MultiPlatformOp):
         if not x.is_contiguous():
             x = x.contiguous()
         orig_dtype = self.override_orig_dtype or x.dtype
-        x = x.to(torch.float32)
         if residual is not None:
-            x = x + residual.to(torch.float32)
-            if post_residual_addition is not None:
-                x = x + post_residual_addition.to(torch.float32)
-            if self.fp32_residual:
+            if (
+                not self.fp32_residual
+                and get_global_server_args().rl_on_policy_target is not None
+            ):
+                # Match HF's behavior: add residual in orig_dtype (bf16) BEFORE
+                # upcasting to fp32 for norm. HF adds residual + attn_out in
+                # bf16, then passes to layernorm. SGLang's default upcasts both
+                # to fp32 before adding, which is more precise but produces
+                # different results from the training side.
+                x = x.to(orig_dtype) + residual.to(orig_dtype)
                 residual = x.clone()
+                x = x.to(torch.float32)
             else:
-                residual = x.to(orig_dtype)
+                x = x.to(torch.float32) + residual.to(torch.float32)
+                if post_residual_addition is not None:
+                    x = x + post_residual_addition.to(torch.float32)
+                if self.fp32_residual:
+                    residual = x.clone()
+                else:
+                    residual = x.to(orig_dtype)
+        else:
+            x = x.to(torch.float32)
 
         hidden_size = x.shape[-1]
         if hidden_size != self.hidden_size:
@@ -252,7 +272,12 @@ class RMSNorm(MultiPlatformOp):
         x = x * torch.rsqrt(variance + self.variance_epsilon)
 
         if self.cast_x_before_out_mul:
-            x = self.weight * x.to(orig_dtype)
+            if get_global_server_args().rl_on_policy_target is not None:
+                # Match HF: cast weight to orig_dtype too (weight may be fp32
+                # if caller set weight_dtype=torch.float32, but HF uses bf16).
+                x = self.weight.to(orig_dtype) * x.to(orig_dtype)
+            else:
+                x = self.weight * x.to(orig_dtype)
         else:
             x = (x * self.weight).to(orig_dtype)
 

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -92,9 +92,8 @@ class RotaryEmbedding(MultiPlatformOp):
 
         if get_global_server_args().rl_on_policy_target is not None:
             self._forward_method = self.forward_native
-            self._apply_rotary_emb_wrapped = torch.compile(dynamic=True)(
-                apply_rotary_emb
-            )
+            # NOTE: Do NOT torch.compile _apply_rotary_emb_wrapped — it can
+            # change numerical behavior and cause misalignment with HF's RoPE.
         self.position_cos, self.position_sin = None, None
 
     def _compute_inv_freq(self, base: Union[int, float]) -> torch.Tensor:
@@ -115,19 +114,31 @@ class RotaryEmbedding(MultiPlatformOp):
                 / self.rotary_dim
             )
         )
-        if get_global_server_args().rl_on_policy_target is not None:
-            inv_freq = inv_freq.cuda()
         return inv_freq
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         """Compute the cos and sin cache."""
         inv_freq = self._compute_inv_freq(self.base)
-        t = torch.arange(self.max_position_embeddings, dtype=torch.float)
-
-        freqs = torch.einsum("i,j -> ij", t, inv_freq)
-        cos = freqs.cos()
-        sin = freqs.sin()
-        cache = torch.cat((cos, sin), dim=-1)
+        if get_global_server_args().rl_on_policy_target is not None:
+            # Compute entirely on CPU to match HF's numerical behavior exactly.
+            # GPU float32 ops can produce slightly different results from CPU,
+            # causing bf16 rounding differences after cast.
+            t = torch.arange(
+                self.max_position_embeddings, dtype=torch.float, device="cpu"
+            )
+            inv_freq_cpu = inv_freq.cpu() if inv_freq.is_cuda else inv_freq
+            freqs = torch.einsum("i,j -> ij", t, inv_freq_cpu)
+            cos = freqs.cos()
+            sin = freqs.sin()
+            cache = torch.cat((cos, sin), dim=-1)
+            if torch.cuda.is_available():
+                cache = cache.to(torch.device("cuda"))
+        else:
+            t = torch.arange(self.max_position_embeddings, dtype=torch.float)
+            freqs = torch.einsum("i,j -> ij", t, inv_freq)
+            cos = freqs.cos()
+            sin = freqs.sin()
+            cache = torch.cat((cos, sin), dim=-1)
         return cache
 
     def _ensure_cos_sin_cache_length(self, needed_max_pos: int):

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -123,10 +123,10 @@ class Sampler(nn.Module):
             # In RL on-policy mode, we use log_softmax to compute logprobs to match the trainer.
             logprobs_via_logsoftmax_kernel = None
             if self.rl_on_policy_target is not None:
-                # TODO: use more inplace ops to save memory
-                logits_div_temperature = (
-                    logits.bfloat16().div(sampling_info.temperatures).bfloat16()
-                )
+                # Use fp32 log_softmax to match training-side computation exactly.
+                # The training side computes log_softmax in fp32; previous bf16
+                # casts here introduced a systematic ~5e-4 drift in logprob_abs_diff.
+                logits_div_temperature = logits.div(sampling_info.temperatures)
                 logprobs_via_logsoftmax_kernel = torch.log_softmax(
                     logits_div_temperature, dim=-1
                 )

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -20,6 +20,7 @@ import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.distributed import (
@@ -92,9 +93,18 @@ class Qwen2MLP(nn.Module):
 
     def forward(self, x):
         if get_global_server_args().rl_on_policy_target is not None:
-            x = x.bfloat16()
-
-        gate_up, _ = self.gate_up_proj(x)
+            # Split into separate gate and up matmuls to match HF's MLP which
+            # does gate_proj(x) and up_proj(x) separately. A single merged
+            # matmul produces different floating-point results due to different
+            # accumulation order, causing logprob drift in on-policy training.
+            intermediate_size = self.gate_up_proj.output_size // 2
+            gate_weight = self.gate_up_proj.weight[:intermediate_size]
+            up_weight = self.gate_up_proj.weight[intermediate_size:]
+            gate = F.linear(x, gate_weight)
+            up = F.linear(x, up_weight)
+            gate_up = torch.cat([gate, up], dim=-1)
+        else:
+            gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
@@ -280,11 +290,6 @@ class Qwen2Model(nn.Module):
                 quant_config=quant_config,
                 use_attn_tp_group=is_dp_attention_enabled(),
                 prefix=add_prefix("embed_tokens", prefix),
-                params_dtype=(
-                    torch.float32
-                    if get_global_server_args().rl_on_policy_target is not None
-                    else None
-                ),
             )
         else:
             self.embed_tokens = PPMissingLayer()
@@ -305,18 +310,22 @@ class Qwen2Model(nn.Module):
             prefix=add_prefix("layers", prefix),
         )
         if self.pp_group.is_last_rank:
-            norm_kwargs = (
-                dict(
+            # For non-triton on-policy backends, preserve fp32 final norm.
+            _server_args = get_global_server_args()
+            if (
+                _server_args.rl_on_policy_target is not None
+                and _server_args.attention_backend != "triton"
+            ):
+                _norm_kwargs = dict(
                     weight_dtype=torch.float32,
                     cast_x_before_out_mul=True,
                     override_orig_dtype=torch.float32,
                     fp32_residual=True,
                 )
-                if get_global_server_args().rl_on_policy_target is not None
-                else {}
-            )
+            else:
+                _norm_kwargs = {}
             self.norm = RMSNorm(
-                config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+                config.hidden_size, eps=config.rms_norm_eps, **_norm_kwargs
             )
         else:
             self.norm = PPMissingLayer(return_tuple=True)

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -88,16 +88,18 @@ class Qwen3Attention(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.tp_rank = get_tensor_model_parallel_rank()
 
-        norm_kwargs = (
-            dict(
-                weight_dtype=torch.float32,
-                cast_x_before_out_mul=True,
-            )
-            if get_global_server_args().rl_on_policy_target is not None
-            else {}
-        )
-        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
-        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
+        # For non-triton on-policy backends, keep fp32 qk norms for precision.
+        # For triton on-policy, RMSNorm.__init__ auto-enables cast_x_before_out_mul.
+        _server_args = get_global_server_args()
+        if (
+            _server_args.rl_on_policy_target is not None
+            and _server_args.attention_backend != "triton"
+        ):
+            _qk_norm_kwargs = dict(weight_dtype=torch.float32, cast_x_before_out_mul=True)
+        else:
+            _qk_norm_kwargs = {}
+        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **_qk_norm_kwargs)
+        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **_qk_norm_kwargs)
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size,
@@ -178,7 +180,12 @@ class Qwen3Attention(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        if get_global_server_args().rl_on_policy_target is not None:
+        _server_args = get_global_server_args()
+        # Non-triton on-policy path: ensure bf16 dtype before attention.
+        if (
+            _server_args.rl_on_policy_target is not None
+            and _server_args.attention_backend != "triton"
+        ):
             hidden_states = hidden_states.bfloat16()
 
         if (
@@ -196,7 +203,11 @@ class Qwen3Attention(nn.Module):
                 forward_batch=forward_batch,
             )
 
-        if get_global_server_args().rl_on_policy_target is not None:
+        # Non-triton on-policy path: ensure q/k are bf16 for attention kernel.
+        if (
+            _server_args.rl_on_policy_target is not None
+            and _server_args.attention_backend != "triton"
+        ):
             q = q.to(torch.bfloat16)
             k = k.to(torch.bfloat16)
 
@@ -243,21 +254,27 @@ class Qwen3DecoderLayer(nn.Module):
             prefix=add_prefix("mlp", prefix),
         )
 
-        norm_kwargs = (
-            dict(
+        # For non-triton on-policy backends, preserve fp32 residual path.
+        # For triton on-policy, RMSNorm.__init__ auto-enables cast_x_before_out_mul
+        # and uses forward_native; residual is added in bf16 to match HF.
+        _server_args = get_global_server_args()
+        if (
+            _server_args.rl_on_policy_target is not None
+            and _server_args.attention_backend != "triton"
+        ):
+            _ln_kwargs = dict(
                 weight_dtype=torch.float32,
                 cast_x_before_out_mul=True,
                 override_orig_dtype=torch.float32,
                 fp32_residual=True,
             )
-            if get_global_server_args().rl_on_policy_target is not None
-            else {}
-        )
+        else:
+            _ln_kwargs = {}
         self.input_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+            config.hidden_size, eps=config.rms_norm_eps, **_ln_kwargs
         )
         self.post_attention_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
+            config.hidden_size, eps=config.rms_norm_eps, **_ln_kwargs
         )
 
         self.layer_scatter_modes = LayerScatterModes.init_new(


### PR DESCRIPTION
## Motivation

Support true on-policy RL for text models on AMD GPU with triton attention backend. 

For bit-wise identical log-probs between sglang rollout (decode) and FSDP training (extend), the inference and training must execute exactly the same numerical operations.

## Modifications

When `get_global_server_args().rl_on_policy_target is not None` and using triton attention backend on AMD:

1. **triton_backend.py**: In deterministic mode, route decode through `_forward_decode_unified()` which uses the same 1-stage `extend_attention_fwd_unified` kernel as the extend path — ensures bit-wise identical attention computation between decode and extend.

2. **rotary_embedding/base.py**: 
   - Disable `torch.compile` on `_apply_rotary_emb_wrapped` (compiled version produces different numerics)
   - Fix device mismatch bug: `_compute_inv_freq` was moving `inv_freq` to CUDA, but `_compute_cos_sin_cache` still built `t` on CPU. Added separate CPU path for `rl_on_policy_target` to match HF's RoPE numerics exactly.

3. **layernorm.py**: 
   - Auto-set `cast_x_before_out_mul=True` to match HF RMSNorm (cast x to orig_dtype *before* multiplying with weight)
   - Use bf16 residual addition (not fp32) in `forward_native` to match HF behavior
   - In `forward_aiter` / `forward_hip`: when `is_batch_invariant_mode_enabled()` and `rl_on_policy_target is not None`, fall back to `forward_native`

4. **sampler.py**: Use fp32 `log_softmax` instead of bf16 to match training-side log-prob computation.

5. **qwen2.py / qwen3.py**: Split fused gate/up matmul into separate `F.linear` calls to match HF accumulation order; gate additional norm/dtype kwargs on `attention_backend != "triton"` to preserve original non-triton paths.

## Accuracy Tests

Verified using [`run_simple_amd_triton.py`](https://github.com/JessicaJiang-123/miles/blob/amd-top-final-version/examples/true_on_policy/run_simple_amd_triton.py) from the [miles](https://github.com/radixark/miles) RL training framework, on Qwen3-0.6B (single AMD GPU, triton attention backend, `rl_on_policy_target=fsdp`):

train_rollout_logprob_abs_diff: 0.0

<img width="420" alt="logprob_diff" src="https://github.com/user-attachments/assets/6869c203-b602-4733-9bb2-8f275cdef97d" />

## Checklist
- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://docs.sglang.ai/developer_guide/contribution_guide.html#pr-merge-process).

## Collaborators
@XinyuJiangCMU
@JessicaJiang-123