### PR TITLE
[Qwen3.5] Fix MoE double allreduce with `--enable-flashinfer-allreduce-fusion`

### DIFF
--- a/test/registered/8-gpu-models/test_qwen35.py
+++ b/test/registered/8-gpu-models/test_qwen35.py
@@ -29,6 +29,7 @@ class TestQwen35(unittest.TestCase):
             "--reasoning-parser=qwen3",
             "--tool-call-parser=qwen3_coder",
             "--mem-fraction-static=0.8",
+            "--enable-flashinfer-allreduce-fusion",
         ]
         mtp_args = [
             "--speculative-algorithm=EAGLE",

--- a/test/registered/8-gpu-models/test_qwen35_bf16.py
+++ b/test/registered/8-gpu-models/test_qwen35_bf16.py
@@ -1,5 +1,3 @@
-import shutil
-import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -7,88 +5,31 @@ import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_cuda_ci
 
 # This eval harness applies the chat_template, which is critical for qwen3.5
 # to get good accuracy on gsm8k
-from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
-    ModelLaunchSettings,
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=1400, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=1000, suite="stage-c-test-8-gpu-h200")
 
-QWEN35_FP4_MODEL = "nvidia/Qwen3.5-397B-A17B-NVFP4"
-QWEN35_27B_MODEL = "Qwen/Qwen3.5-27B"
-ACC_THRESHOLDS = {QWEN35_FP4_MODEL: {"gsm8k": 0.95}, QWEN35_27B_MODEL: {"gsm8k": 0.8}}
+QWEN35_MODEL = "Qwen/Qwen3.5-397B-A17B"
 
-
-class TestQwen35FP4(unittest.TestCase):
-    def test_gsm8k(self):
-        base_args = [
-            "--tp-size",
-            "4",
-            "--chunked-prefill-size",
-            "2048",
-            "--mamba-scheduler-strategy",
-            "extra_buffer",
-            "--mamba-track-interval",
-            "128",
-            "--mamba-ssm-dtype",
-            "bfloat16",
-            "--max-running-requests",
-            "128",
-            "--reasoning-parser",
-            "qwen3",
-            "--attention-backend",
-            "trtllm_mha",
-            "--quantization",
-            "modelopt_fp4",
-            "--enable-flashinfer-allreduce-fusion",
-            "--model-loader-extra-config",
-            '{"enable_multithread_load": true,"num_threads": 6}',
-        ]
-
-        variants = [
-            ModelLaunchSettings(
-                QWEN35_FP4_MODEL,
-                extra_args=base_args,
-                variant="Triton",
-            ),
-            ModelLaunchSettings(
-                QWEN35_FP4_MODEL,
-                extra_args=base_args + ["--linear-attn-decode-backend", "flashinfer"],
-                variant="FlashInfer",
-            ),
-        ]
-
-        run_combined_tests(
-            models=variants,
-            test_name="Qwen3.5-397B-A17B-NVFP4",
-            accuracy_params=AccuracyTestParams(
-                dataset="gsm8k",
-                baseline_accuracy=ACC_THRESHOLDS[QWEN35_FP4_MODEL]["gsm8k"],
-                num_examples=200,
-                num_threads=128,
-                max_tokens=16000,
-                thinking_mode="qwen3",
-                temperature=0.6,
-                top_p=0.95,
-                top_k=20,
-            ),
-        )
+ACC_THRESHOLDS = {
+    QWEN35_MODEL: {"gsm8k": 0.95},
+}
 
 
-class TestQwen35FP4MTP(CustomTestCase):
+class TestQwen35BF16(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = QWEN35_FP4_MODEL
+        cls.model = QWEN35_MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
             cls.model,
@@ -96,7 +37,7 @@ class TestQwen35FP4MTP(CustomTestCase):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--tp-size",
-                "4",
+                "8",
                 "--chunked-prefill-size",
                 "2048",
                 "--mamba-scheduler-strategy",
@@ -109,10 +50,61 @@ class TestQwen35FP4MTP(CustomTestCase):
                 "128",
                 "--reasoning-parser",
                 "qwen3",
-                "--attention-backend",
-                "trtllm_mha",
-                "--quantization",
-                "modelopt_fp4",
+                "--enable-flashinfer-allreduce-fusion",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true,"num_threads": 64}',
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            model=self.model,
+            eval_name="gsm8k",
+            num_shots=5,
+            num_examples=200,
+            max_tokens=16000,
+            num_threads=128,
+            repeat=1,
+            temperature=0.6,
+            top_p=0.95,
+            top_k=20,
+            base_url=self.base_url,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreaterEqual(metrics["score"], ACC_THRESHOLDS[self.model]["gsm8k"])
+
+
+class TestQwen35BF16MTP(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN35_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "8",
+                "--chunked-prefill-size",
+                "2048",
+                "--mamba-scheduler-strategy",
+                "extra_buffer",
+                "--mamba-track-interval",
+                "128",
+                "--mamba-ssm-dtype",
+                "bfloat16",
+                "--max-running-requests",
+                "128",
+                "--reasoning-parser",
+                "qwen3",
                 "--enable-flashinfer-allreduce-fusion",
                 "--speculative-algorithm",
                 "NEXTN",
@@ -125,7 +117,7 @@ class TestQwen35FP4MTP(CustomTestCase):
                 "--mem-fraction-static",
                 "0.8",
                 "--model-loader-extra-config",
-                '{"enable_multithread_load": true,"num_threads": 6}',
+                '{"enable_multithread_load": true,"num_threads": 64}',
             ],
         )
 
@@ -161,10 +153,10 @@ class TestQwen35FP4MTP(CustomTestCase):
         self.assertGreater(avg_spec_accept_length, 3.3)
 
 
-class TestQwen35FP4MTPV2(CustomTestCase):
+class TestQwen35BF16MTPV2(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = QWEN35_FP4_MODEL
+        cls.model = QWEN35_MODEL
         cls.base_url = DEFAULT_URL_FOR_TEST
         envs.SGLANG_ENABLE_SPEC_V2.set(True)
         cls.process = popen_launch_server(
@@ -173,7 +165,7 @@ class TestQwen35FP4MTPV2(CustomTestCase):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--tp-size",
-                "4",
+                "8",
                 "--chunked-prefill-size",
                 "2048",
                 "--mamba-scheduler-strategy",
@@ -186,10 +178,6 @@ class TestQwen35FP4MTPV2(CustomTestCase):
                 "128",
                 "--reasoning-parser",
                 "qwen3",
-                "--attention-backend",
-                "trtllm_mha",
-                "--quantization",
-                "modelopt_fp4",
                 "--enable-flashinfer-allreduce-fusion",
                 "--speculative-algorithm",
                 "NEXTN",
@@ -202,7 +190,7 @@ class TestQwen35FP4MTPV2(CustomTestCase):
                 "--mem-fraction-static",
                 "0.8",
                 "--model-loader-extra-config",
-                '{"enable_multithread_load": true,"num_threads": 6}',
+                '{"enable_multithread_load": true,"num_threads": 64}',
             ],
         )
 
@@ -237,80 +225,6 @@ class TestQwen35FP4MTPV2(CustomTestCase):
         ]
         print(f"{avg_spec_accept_length=}")
         self.assertGreater(avg_spec_accept_length, 3.3)
-
-
-class TestQwen35WithHiCache(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = QWEN35_27B_MODEL
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.storage_dir = tempfile.mkdtemp(prefix="qwen35-hicache-")
-        env = {
-            "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.storage_dir,
-        }
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            env=env,
-            other_args=[
-                "--tp-size",
-                "4",
-                "--chunked-prefill-size",
-                "2048",
-                "--mamba-scheduler-strategy",
-                "extra_buffer",
-                "--mamba-track-interval",
-                "128",
-                "--mamba-ssm-dtype",
-                "bfloat16",
-                "--max-running-requests",
-                "128",
-                "--reasoning-parser",
-                "qwen3",
-                "--enable-flashinfer-allreduce-fusion",
-                "--model-loader-extra-config",
-                '{"enable_multithread_load": true,"num_threads": 11}',
-                "--hicache-mem-layout",
-                "page_first_direct",
-                "--enable-hierarchical-cache",
-                "--hicache-ratio",
-                "2",
-                "--hicache-size",
-                "0",
-                "--hicache-write-policy",
-                "write_through",
-                "--hicache-storage-backend",
-                "file",
-                "--hicache-storage-prefetch-policy",
-                "wait_complete",
-            ],
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-        shutil.rmtree(cls.storage_dir, ignore_errors=True)
-
-    def test_gsm8k(self):
-        args = SimpleNamespace(
-            model=self.model,
-            eval_name="gsm8k",
-            num_shots=5,
-            num_examples=200,
-            max_tokens=16000,
-            num_threads=128,
-            repeat=1,
-            temperature=0.6,
-            top_p=0.95,
-            top_k=20,
-            base_url=self.base_url,
-            host="http://127.0.0.1",
-            port=int(self.base_url.split(":")[-1]),
-        )
-        metrics = run_eval(args)
-        print(f"{metrics=}")
-        self.assertGreaterEqual(metrics["score"], ACC_THRESHOLDS[self.model]["gsm8k"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix #20050.

This was a tricky one to track down. The root cause was a double allreduce introduced in #19070. That PR added MLP allreduce fusion for dense Qwen3.5, but it also ended up applying the fusion path to MoE layers. MoE already performs its own TP allreduce when `use_reduce_scatter` is false, so the next layer would allreduce the same tensor again. That effectively scales the MoE output by `tp_size`, which leads to gibberish at higher TP sizes, especially TP4 and TP8. The fix is to skip allreduce fusion for MoE layers.

This only happens when `--enable-flashinfer-allreduce-fusion` is enabled, and it is not specific to NVFP4. CI has not been catching this because the existing Qwen3.5 tests do not use `--enable-flashinfer-allreduce-fusion`.

## Test Plan

Manually tested but forgot to record output, so CI by adding `--enable-flashinfer-allreduce-fusion` to all Qwen3.5 CI tests. Also added a new Qwen3.5 BF16 CI test, can remove if too heavy.