### PR TITLE
[Perf] Enable nextn=2 in deep_gemm.fp8_paged_mqa_logits for target_verify

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -391,14 +391,25 @@ class Indexer(MultiPlatformOp):
         # Reuse pre-computed schedule metadata if available (from init_forward_metadata),
         # otherwise fall back to computing it here.
         schedule_metadata = getattr(metadata, "paged_mqa_schedule_metadata", None)
+
+        # Determine if nextn=2 optimization can be used (CUDA target_verify only)
+        use_nextn2 = (
+            _is_cuda
+            and forward_batch.forward_mode.is_target_verify()
+            and forward_batch.attn_backend.speculative_num_draft_tokens % 2 == 0
+            and forward_batch.attn_backend.speculative_num_draft_tokens >= 2
+        )
+
         if _is_cuda:
             if schedule_metadata is None:
+                seqlens_for_metadata = (
+                    seqlens_32.reshape(-1, 2) if use_nextn2 else seqlens_32
+                )
                 schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
-                    seqlens_32, blocksize, self.sm_count
+                    seqlens_for_metadata, blocksize, self.sm_count
                 )
 
         assert len(q_fp8.shape) == 3
-        q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
         assert len(kv_cache_fp8.shape) == 2
         block_kv = 1 if _is_hip else 64
         num_heads_kv = 1
@@ -420,6 +431,7 @@ class Indexer(MultiPlatformOp):
         if _is_hip:
             from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
 
+            q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
             batch_size, next_n, heads, _ = q_fp8.shape
             logits = torch.full(
                 (batch_size * next_n, max_seq_len),
@@ -441,7 +453,23 @@ class Indexer(MultiPlatformOp):
                 TotalCuCount=256,
                 WavePerEU=5,
             )
+        elif use_nextn2:
+            # nextn=2: pair consecutive draft tokens for better kernel efficiency
+            q_fp8_input = q_fp8[:q_offset].reshape(-1, 2, *q_fp8.shape[1:])
+            seqlens_input = seqlens_32.reshape(-1, 2)
+            block_tables_input = block_tables[::2]
+            logits = deep_gemm.fp8_paged_mqa_logits(
+                q_fp8_input,
+                kv_cache_fp8,
+                weights[:q_offset],
+                seqlens_input,
+                block_tables_input,
+                schedule_metadata,
+                max_seq_len,
+                clean_logits=False,
+            )
         else:
+            q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
             logits = deep_gemm.fp8_paged_mqa_logits(
                 q_fp8[:q_offset],
                 kv_cache_fp8,

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -619,6 +619,13 @@ class NativeSparseAttnBackend(
                     )
                     else cache_seqlens_int32
                 )
+                # Use 2D seqlens for nextn=2 optimization in target_verify
+                if (
+                    forward_batch.forward_mode.is_target_verify()
+                    and self.speculative_num_draft_tokens % 2 == 0
+                    and self.speculative_num_draft_tokens >= 2
+                ):
+                    seqlens_32 = seqlens_32.reshape(-1, 2)
                 paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                     seqlens_32, 64, deep_gemm.get_num_sms()
                 )
@@ -901,6 +908,13 @@ class NativeSparseAttnBackend(
                     )
                     else cache_seqlens_int32
                 )
+                # Use 2D seqlens for nextn=2 optimization in target_verify
+                if (
+                    forward_mode.is_target_verify()
+                    and self.speculative_num_draft_tokens % 2 == 0
+                    and self.speculative_num_draft_tokens >= 2
+                ):
+                    seqlens_32 = seqlens_32.reshape(-1, 2)
                 paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                     seqlens_32, 64, deep_gemm.get_num_sms()
                 )
@@ -1050,6 +1064,13 @@ class NativeSparseAttnBackend(
                     )
                     else metadata.cache_seqlens_int32
                 )
+                # Use 2D seqlens for nextn=2 optimization in target_verify
+                if (
+                    forward_mode.is_target_verify()
+                    and self.speculative_num_draft_tokens % 2 == 0
+                    and self.speculative_num_draft_tokens >= 2
+                ):
+                    seqlens_32 = seqlens_32.reshape(-1, 2)
                 new_schedule = deep_gemm.get_paged_mqa_logits_metadata(
                     seqlens_32, 64, deep_gemm.get_num_sms()
                 )


### PR DESCRIPTION
## Motivation

DeepGEMM's `fp8_paged_mqa_logits` kernel natively supports `next_n=2` (confirmed via [test_attention.py](https://github.com/deepseek-ai/DeepGEMM/blob/main/tests/test_attention.py)), which processes 2 query positions per KV cache page set more efficiently than the current approach of always using `next_n=1` with draft tokens flattened into the batch dimension.

Currently in target_verify mode, draft tokens are expanded into the batch dimension:
- `q_fp8`: `[bs*num_draft, 1, heads, dim]`
- `seqlens`: `[bs*num_draft]` (1D)
- `block_tables`: `[bs*num_draft, max_pages]` (repeated via `repeat_interleave`)

With `nextn=2`, we pair consecutive draft tokens:
- `q_fp8`: `[bs*num_draft//2, 2, heads, dim]`
- `seqlens`: `[bs*num_draft//2, 2]` (2D)
- `block_tables`: `[bs*num_draft//2, max_pages]` (de-duplicated via `[::2]`)

The output logits shape `[bs*num_draft, max_seq_len]` and ordering are identical, so `topk_transform` and all downstream code require **no changes**.

## Changes

### `nsa_indexer.py` (`_get_topk_paged`)
- Add `use_nextn2` flag: enabled when CUDA + target_verify + even `speculative_num_draft_tokens`
- New `elif use_nextn2` branch that reshapes q, seqlens, and block_tables for the kernel
- Fallback to `nextn=1` for odd draft token counts, HIP, and non-target-verify modes

### `nsa_backend.py` (3 locations)
- Precompute `paged_mqa_schedule_metadata` with 2D seqlens when `nextn=2` applies
- Covers: `init_forward_metadata`, cuda graph metadata init, and cuda graph metadata update

### Generalization for `num_draft_tokens > 2`

| num_draft | nextn | Effective batch | Notes |
|-----------|-------|-----------------|-------|
| 2 | 2 | bs | Primary optimization target |
| 4 | 2 | bs×2 | Pairs: (d0,d1), (d2,d3) per request |
| 6 | 2 | bs×3 | Same pairing strategy |
| 3, 5 (odd) | 1 | bs×N | Falls back to current approach |

## Test plan

- [ ] Verify correctness with `speculative_num_draft_tokens=2` (primary case)
- [ ] Verify correctness with `speculative_num_draft_tokens=4` (even, >2)
- [ ] Verify `speculative_num_draft_tokens=3` falls back to `nextn=1` correctly
- [ ] Verify decode mode is unaffected
- [ ] Run existing NSA + MTP tests for regression
