### PR TITLE
[AMD] Add Claude skills for AMD CI workflows

### DIFF
--- a/.claude/skills/amd/enable-amd-model/SKILL.md
+++ b/.claude/skills/amd/enable-amd-model/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: enable-amd-model
+description: End-to-end workflow for enabling a new model on AMD GPUs in SGLang. Covers HuggingFace architecture research, AMD backend selection (aiter/triton/wave/NSA with auto-selection logic), accuracy test file creation for MI30x and MI35x, CI workflow YAML updates, and documentation. Use when enabling a model on AMD, adding a model to AMD CI, or when the user mentions AMD model enablement.
+---
+
+# Enable a Model on AMD GPUs
+
+End-to-end workflow: architecture research, test files (MI30x + MI35x), CI YAML (2 workflow files x 3 edit locations each), documentation, and local validation.
+
+## Step 1: Architecture Research
+
+Fetch the model's HuggingFace config and SGLang model implementation.
+
+```bash
+curl -s https://huggingface.co/{MODEL_PATH}/raw/main/config.json | python3 -m json.tool
+```
+
+Key fields to extract:
+
+| Field | What it tells you |
+|---|---|
+| `architectures` | Maps to `python/sglang/srt/models/` via `ModelRegistry` |
+| `num_hidden_layers` | Total layer count |
+| `num_attention_heads` / `num_key_value_heads` | GQA ratio |
+| `kv_lora_rank` or `q_lora_rank` | MLA architecture indicator |
+| `num_experts` / `num_experts_per_tok` | MoE configuration |
+| `quantization_config` | FP8/INT4/MXFP4 format |
+
+### Determine AttentionArch
+
+SGLang has two attention architectures (defined in `python/sglang/srt/configs/model_config.py`):
+
+| AttentionArch | Models | Detection |
+|---|---|---|
+| **MLA** | DeepSeek-V2/V3/V3.2, Kimi-K2/K2.5, MiniCPM3, GLM-MoE-DSA, MistralLarge3, Pixtral, BailingMoe, SarvamMLA | Has `kv_lora_rank` in config, or architecture class in MLA list in `model_config.py` |
+| **MHA** | Everything else (Llama, Mistral, Mixtral, Qwen, MiniMax, GLM-5, Grok, etc.) | Default |
+
+Read the model source in `python/sglang/srt/models/` and `python/sglang/srt/configs/model_config.py` to confirm.
+
+## Step 2: Backend Selection
+
+### Auto-selection (preferred)
+
+SGLang **auto-selects** the attention backend when `--attention-backend` is not set. On AMD (`is_hip()` is true), the logic in `server_args.py::_get_default_attn_backend()` is:
+
+| AttentionArch | Auto-selected backend | Condition |
+|---|---|---|
+| MHA | `aiter` | Default on HIP |
+| MLA | `aiter` | When `num_kv_heads / tp_size` is 16 or 128 |
+| MLA | `triton` | When head count is not 16 or 128 |
+| NSA models (GLM-5) | `nsa` with `tilelang` prefill+decode | Auto-detected on HIP |
+
+**In most cases, just set `SGLANG_USE_AITER=1` and let auto-selection work.** Only override `--attention-backend` when you need a specific backend.
+
+### AMD-compatible backends
+
+From `ATTENTION_BACKEND_CHOICES` in `server_args.py`:
+
+| Backend | AMD support | When to use |
+|---|---|---|
+| `aiter` | AMD-specific | Default for most MHA and MLA models |
+| `triton` | Cross-platform | Fallback when aiter doesn't support head count; also used for some base models |
+| `wave` | AMD-specific | Wave kernel backend (experimental) |
+| `nsa` | Yes (with tilelang) | For NSA models (GLM-5 style); prefill/decode default to `tilelang` on HIP |
+| `torch_native` | Cross-platform | Generic fallback |
+| `flex_attention` | Cross-platform | Torch flex attention |
+
+NSA sub-backends (`NSA_CHOICES`): `tilelang` (default on HIP), `aiter`, `flashmla_sparse`, `flashmla_kv`, `flashmla_auto`, `fa3`, `trtllm`.
+
+### Special cases
+
+- **Llama4**: auto-selects `aiter` on HIP
+- **Diffusion models**: forces `triton` on HIP
+- **Mixed prefill/decode**: use `--prefill-attention-backend` and `--decode-attention-backend` to override separately (e.g., Kimi-K2.5 uses `aiter` prefill + `triton` decode)
+- **NSA models**: use `--nsa-prefill-backend tilelang --nsa-decode-backend tilelang` (or let auto-selection handle it)
+
+### Common server args by model type
+
+| Model characteristic | Additional args |
+|---|---|
+| MoE with many experts | `--ep-size 8` |
+| Large models (>100B) | `--mem-fraction-static 0.85 --watchdog-timeout 1200` |
+| MLA models | `--chunked-prefill-size 131072` |
+| Models needing trust | `--trust-remote-code` |
+| Fast loading | `--model-loader-extra-config '{"enable_multithread_load": true}'` |
+
+## Step 3: Create Test Files
+
+Create **two** test files — one for MI30x, one for MI35x. See the `write-amd-nightly-test` skill for detailed templates and patterns.
+
+### File locations
+
+- MI30x: `test/registered/amd/accuracy/mi30x/test_{model}_eval_amd.py`
+- MI35x: `test/registered/amd/accuracy/mi35x/test_{model}_eval_mi35x.py`
+
+### Key MI30x vs MI35x differences
+
+| | MI30x | MI35x |
+|---|---|---|
+| HF cache | (system default) | `os.environ.setdefault("HF_HOME", "/data2/models/huggingface")` and `os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")` |
+| `est_time` | 3600 | 5400 |
+| Suite name prefix | `nightly-amd-accuracy-8-gpu-` | `nightly-amd-8-gpu-mi35x-` or `nightly-amd-accuracy-8-gpu-mi35x-` |
+| Class name suffix | `EvalAMD` | `EvalMI35x` |
+| Summary header | `(MI325)` | `(MI35x)` |
+| `timeout` in ModelConfig | 3600 | 5400 |
+
+## Step 4: Update CI Workflow YAML
+
+Edit **both** workflow files. Each requires changes in **three** places.
+
+### Runners
+
+| Platform | GPUs | Runner label |
+|---|---|---|
+| MI30x (MI300X/MI325X) | 1 | `linux-mi325-1gpu-sglang` |
+| MI30x | 2 | `linux-mi325-2gpu-sglang` |
+| MI30x | 8 | `linux-mi325-8gpu-sglang` |
+| MI35x (MI355X) | 1 | `linux-mi35x-gpu-1` |
+| MI35x | 8 | `linux-mi35x-gpu-8` |
+| MI35x (disagg/RDMA) | 8 | `linux-mi35x-gpu-8.fabric` |
+
+### File 1: `.github/workflows/nightly-test-amd.yml`
+
+**Place 1** — Add to `job_select` options list:
+```yaml
+          - nightly-8-gpu-{model}           # MI30x
+          - nightly-8-gpu-mi35x-{model}     # MI35x
+```
+
+**Place 2** — Add job definition block (MI30x template):
+```yaml
+  nightly-8-gpu-{model}:
+    if: >-
+      (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request')
+      && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all'
+      || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-{model},'))
+    runs-on: linux-mi325-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+      - name: Accuracy Test (8-GPU {MODEL_DISPLAY})
+        timeout-minutes: 120
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite {SUITE_NAME} --nightly --timeout-per-file 3600 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+```
+
+MI35x variant: `runs-on: linux-mi35x-gpu-8`, job name prefix `nightly-8-gpu-mi35x-{model}`.
+
+**Place 3** — Add to `check-all-jobs.needs` list:
+```yaml
+      - nightly-8-gpu-{model}
+      - nightly-8-gpu-mi35x-{model}
+```
+
+### File 2: `.github/workflows/nightly-test-amd-rocm720.yml`
+
+Same three places, but:
+- Job names get `-rocm720` suffix
+- Docker setup adds `--rocm-version rocm720`
+- Install step adds `--skip-test-time-deps`
+- Suite name stays the same (test file is shared)
+
+## Step 5: Update Documentation
+
+If the model has a docs page under `docs/basic_usage/`, add an AMD GPU deployment section. If the model is new, add it to `docs/supported_models/text_generation/generative_models.md`.
+
+## Step 6: Local Validation
+
+```bash
+docker exec -it {CONTAINER} bash
+cd /sglang-checkout && pip install -e "python[all]"
+
+SGLANG_USE_AITER=1 python3 -m sglang.launch_server \
+    --model {MODEL_PATH} --tp 8 {OTHER_ARGS} &
+
+python3 test/registered/amd/accuracy/mi30x/test_{model}_eval_amd.py
+```
+
+Verify: accuracy meets threshold, no HIP errors, server launches within timeout.
+
+## Checklist
+
+- [ ] HuggingFace config analyzed (AttentionArch: MLA or MHA)
+- [ ] Backend verified (auto-selection or explicit override)
+- [ ] MI30x test file created in `test/registered/amd/accuracy/mi30x/`
+- [ ] MI35x test file created in `test/registered/amd/accuracy/mi35x/`
+- [ ] `nightly-test-amd.yml` updated (3 places: options, job block, needs)
+- [ ] `nightly-test-amd-rocm720.yml` updated (3 places: options, job block, needs)
+- [ ] Documentation updated (if applicable)
+- [ ] Local validation passed on AMD hardware
+
+## References
+
+- `python/sglang/srt/server_args.py` — `ATTENTION_BACKEND_CHOICES`, `_get_default_attn_backend()`, auto-selection logic
+- `python/sglang/srt/configs/model_config.py` — `AttentionArch` enum (MLA, MHA)
+- `python/sglang/srt/layers/attention/attention_registry.py` — backend name → class mapping
+- `test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py` — standalone MHA test
+- `test/registered/amd/accuracy/mi30x/test_deepseek_v32_eval_amd.py` — standalone MLA test
+- `test/registered/amd/accuracy/mi30x/test_kimi_k25_eval_amd.py` — shared evaluator test
+- `test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py` — NSA backend test
+- `.github/workflows/nightly-test-amd.yml` — CI workflow (ROCm default)
+- `.github/workflows/nightly-test-amd-rocm720.yml` — CI workflow (ROCm 7.2)

--- a/.claude/skills/amd/write-amd-nightly-test/SKILL.md
+++ b/.claude/skills/amd/write-amd-nightly-test/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: write-amd-nightly-test
+description: Write AMD nightly accuracy and performance tests for MI30x and MI35x platforms. Covers GSM8K completion benchmarks, MMMU VLM evaluations, performance benchmarks with NightlyBenchmarkRunner, CI suite registration with register_amd_ci, and cross-platform test variants. Use when creating AMD test files, adding models to AMD nightly CI, or writing accuracy/performance tests for AMD GPUs.
+---
+
+# Write AMD Nightly Test
+
+Guide for writing nightly CI tests that run on AMD MI30x (MI300X/MI325X) and MI35x (MI355X) hardware.
+
+## Test Types and Templates
+
+| Type | Evaluation | Template file |
+|---|---|---|
+| Text accuracy (GSM8K standalone) | Inline 5-shot completion benchmark | `test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py` |
+| Text accuracy (shared evaluator) | `sglang.test.few_shot_gsm8k.run_eval` | `test/registered/amd/accuracy/mi30x/test_kimi_k25_eval_amd.py` |
+| Text accuracy (LMEvalMixin) | `LMEvalMixin` + `CustomTestCase` | `test/registered/amd/accuracy/mi30x/test_qwen35_eval_amd.py` |
+| VLM accuracy (MMMU) | `run_eval` with `eval_name="mmmu"` | `test/registered/amd/accuracy/mi30x/test_vlms_mmmu_eval_amd.py` |
+| Performance | `NightlyBenchmarkRunner` | `test/registered/amd/perf/mi30x/test_deepseek_v32_basic_perf_amd.py` |
+| Diffusion | Custom server + generation | `test/registered/amd/test_wan2_2_i2v_a14b.py` |
+
+## CI Registration
+
+Every test file **must** call `register_amd_ci` at module level:
+
+```python
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(
+    est_time=3600,
+    suite="nightly-amd-accuracy-8-gpu-{model}",
+    nightly=True,
+)
+```
+
+The `suite` name must match the CI workflow YAML job that invokes `run_suite.py --suite {suite}`.
+
+### Suite naming (from actual codebase)
+
+Suite names are **not strictly uniform** — follow the naming style closest to existing tests of the same type:
+
+| Pattern | Examples |
+|---|---|
+| `nightly-amd-accuracy-8-gpu-{model}` | `nightly-amd-accuracy-8-gpu-minimax-m25`, `nightly-amd-accuracy-8-gpu-glm5` |
+| `nightly-amd-8-gpu-{feature}` | `nightly-amd-8-gpu-grok`, `nightly-amd-8-gpu-deepseek-v3-kv-fp8` |
+| `nightly-amd-8-gpu-mi35x-{model}` | `nightly-amd-8-gpu-mi35x-glm5`, `nightly-amd-8-gpu-mi35x-minimax-m25` |
+| `nightly-amd-accuracy-8-gpu-mi35x-{model}` | `nightly-amd-accuracy-8-gpu-mi35x-qwen35`, `nightly-amd-accuracy-8-gpu-mi35x-kimi-k25` |
+| `nightly-perf-8-gpu-{model}` | `nightly-perf-8-gpu-deepseek-v32-basic`, `nightly-perf-8-gpu-grok2` |
+| `nightly-perf-8-gpu-mi35x-{model}` | `nightly-perf-8-gpu-mi35x-deepseek-v32-basic` |
+| `nightly-8-gpu-{model}` | `nightly-8-gpu-qwen3-235b` |
+| `nightly-amd` | Shared 2-GPU GSM8K accuracy suite |
+| `nightly-amd-accuracy-2-gpu-vlm` | VLM MMMU 2-GPU suite |
+| `stage-b-test-small-1-gpu-amd` | Per-PR unit tests on AMD |
+| `stage-c-test-large-8-gpu-amd` | Per-PR 8-GPU tests on AMD |
+
+### Runners
+
+| Platform | GPUs | Runner label |
+|---|---|---|
+| MI30x | 1 | `linux-mi325-1gpu-sglang` |
+| MI30x | 2 | `linux-mi325-2gpu-sglang` |
+| MI30x | 8 | `linux-mi325-8gpu-sglang` |
+| MI35x | 1 | `linux-mi35x-gpu-1` |
+| MI35x | 8 | `linux-mi35x-gpu-8` |
+| MI35x (disagg) | 8 | `linux-mi35x-gpu-8.fabric` |
+
+## Text Accuracy Test Patterns
+
+### Pattern A: Standalone GSM8K (inline benchmark, `unittest.TestCase`)
+
+For models needing custom server args or per-model iteration. Most accuracy tests use this pattern.
+
+Key structure from `test_minimax_m25_eval_amd.py`:
+
+```python
+from sglang.test.ci.ci_register import register_amd_ci
+register_amd_ci(est_time=3600, suite="nightly-amd-accuracy-8-gpu-{model}", nightly=True)
+
+@dataclass
+class ModelConfig:
+    model_path: str
+    tp_size: int = 8
+    accuracy_threshold: float = 0.50
+    other_args: Optional[List[str]] = None
+    env_vars: Optional[dict] = None
+    timeout: Optional[int] = None
+    variant: Optional[str] = None
+
+MODELS = [
+    ModelConfig(
+        model_path="{ORG}/{MODEL}",
+        tp_size=8,
+        accuracy_threshold=0.93,
+        timeout=3600,
+        variant="TP8",
+        other_args=["--attention-backend", "aiter", ...],
+        env_vars={"SGLANG_USE_AITER": "1"},
+    ),
+]
+
+class TestModelEvalAMD(unittest.TestCase):
+    def test_accuracy(self):
+        for config in self.models:
+            process = popen_launch_server(config.model_path, ...)
+            try:
+                acc, invalid, latency = run_gsm8k_benchmark(...)
+            finally:
+                kill_process_tree(process.pid)
+```
+
+### Pattern B: Shared evaluator (`CustomTestCase` + `few_shot_gsm8k`)
+
+For simpler models with a long-lived server. Used by Kimi-K2.5, Kimi-K2, DeepSeek-V3.2 variants.
+
+```python
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import CustomTestCase
+
+class TestModelEvalAMD(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.process = popen_launch_server(MODEL_PATH, cls.base_url, ...)
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_accuracy(self):
+        args = SimpleNamespace(num_shots=8, num_questions=1319, parallel=1319, ...)
+        metrics = run_eval_few_shot_gsm8k(args)
+        self.assertGreaterEqual(metrics["accuracy"], THRESHOLD)
+```
+
+### Pattern C: LMEvalMixin (`CustomTestCase` + mixin)
+
+For models that use the `lm-eval` harness. Used by Qwen3.5.
+
+```python
+from sglang.test.test_utils import CustomTestCase, LMEvalMixin
+
+class TestModelEvalAMD(LMEvalMixin, CustomTestCase):
+    ...
+```
+
+## Backend Args by Architecture
+
+### MHA models (standard attention)
+
+```python
+other_args=[
+    "--attention-backend", "aiter",  # or omit to use auto-selection
+    "--trust-remote-code",
+    "--mem-fraction-static", "0.85",
+],
+env_vars={"SGLANG_USE_AITER": "1"},
+```
+
+### MLA models (DeepSeek-style)
+
+```python
+other_args=[
+    "--attention-backend", "aiter",  # auto-selects when head_num is 16 or 128
+    "--chunked-prefill-size", "131072",
+    "--trust-remote-code",
+    "--mem-fraction-static", "0.85",
+    "--model-loader-extra-config", '{"enable_multithread_load": true}',
+    "--watchdog-timeout", "1200",
+],
+env_vars={"SGLANG_USE_AITER": "1"},
+```
+
+### MoE models
+
+Add `--ep-size 8` for models with many experts (e.g., MiniMax-M2.5 with 256 experts).
+
+### NSA models (GLM-5 style)
+
+```python
+other_args=[
+    "--trust-remote-code",
+    "--nsa-prefill-backend", "tilelang",  # default on HIP, can omit
+    "--nsa-decode-backend", "tilelang",   # default on HIP, can omit
+    "--chunked-prefill-size", "131072",
+    "--mem-fraction-static", "0.80",
+    "--model-loader-extra-config", '{"enable_multithread_load": true}',
+    "--watchdog-timeout", "1200",
+],
+env_vars={"SGLANG_USE_AITER": "1"},
+```
+
+### Mixed prefill/decode (Kimi-K2.5)
+
+```python
+other_args=[
+    "--decode-attention-backend", "triton",
+    "--prefill-attention-backend", "aiter",
+],
+env_vars={"SGLANG_USE_AITER": "1", "SGLANG_ROCM_FUSED_DECODE_MLA": "0"},
+```
+
+## VLM Accuracy Test Pattern
+
+VLM tests use MMMU evaluation instead of GSM8K:
+
+```python
+args = SimpleNamespace(
+    base_url=self.base_url,
+    model=model_path,
+    eval_name="mmmu",
+    num_examples=100,
+    num_threads=64,
+    max_tokens=30,
+)
+metrics = run_eval(args)
+```
+
+VLM tests typically:
+- Use TP=1 or TP=2 (smaller models)
+- Support retries (up to 3 attempts)
+- Track startup/eval/total times in summaries
+- Exclude known-failing models via `AMD_FAILING_VLM_MODELS` list
+
+## Performance Test Pattern
+
+Performance tests use `NightlyBenchmarkRunner`:
+
+```python
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+
+runner = NightlyBenchmarkRunner(model_path, variant_config, ...)
+runner.run_benchmark_for_model(batch_sizes=[1, 32], input_lens=[...], output_lens=[...])
+```
+
+## MI30x vs MI35x Differences
+
+When creating a MI35x variant, apply these changes:
+
+```python
+# Add at TOP of MI35x file (before other imports)
+import os
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
+```
+
+| Aspect | MI30x | MI35x |
+|---|---|---|
+| Suite name | `nightly-amd-accuracy-8-gpu-{model}` | `nightly-amd-8-gpu-mi35x-{model}` |
+| `est_time` | 3600 | 5400 |
+| Class name | `Test{Model}EvalAMD` | `Test{Model}EvalMI35x` |
+| `timeout` | 3600 | 5400 |
+
+## GitHub Step Summary
+
+```python
+from sglang.test.test_utils import is_in_ci, write_github_step_summary
+
+if is_in_ci():
+    summary = "### {Model} ({Platform})\n\n"
+    summary += "| Model | TP | Accuracy | Threshold | Status |\n"
+    summary += "| ----- | -- | -------- | --------- | ------ |\n"
+    summary += f"| {path} | {tp} | {acc:.3f} | {threshold} | {status} |\n"
+    write_github_step_summary(summary)
+```
+
+## Accuracy Thresholds
+
+Always measure on real AMD hardware first. Set threshold ~2-3% below measured accuracy.
+
+## Checklist
+
+- [ ] Test class inherits from `unittest.TestCase` or `CustomTestCase`
+- [ ] `register_amd_ci(...)` called at module level
+- [ ] Suite name matches CI workflow YAML job
+- [ ] `SGLANG_USE_AITER=1` set in env vars
+- [ ] Server killed in teardown via `kill_process_tree`
+- [ ] GitHub step summary generated
+- [ ] Has `if __name__ == "__main__": unittest.main()`
+- [ ] MI35x variant created with HF cache env, adjusted est_time/timeout, updated suite name
+- [ ] Accuracy threshold validated on real hardware
+
+## References
+
+- `.claude/skills/write-sglang-test/SKILL.md` — general SGLang test writing guide
+- `.claude/skills/amd/enable-amd-model/SKILL.md` — full enablement workflow including CI YAML
+- `python/sglang/srt/server_args.py` — `ATTENTION_BACKEND_CHOICES`, `NSA_CHOICES`, auto-selection
+- `python/sglang/test/few_shot_gsm8k.py` — shared GSM8K evaluator
+- `python/sglang/test/test_utils.py` — `CustomTestCase`, `LMEvalMixin`, `popen_launch_server`
+- `python/sglang/test/nightly_utils.py` — `NightlyBenchmarkRunner` for perf tests
+- `test/registered/amd/accuracy/mi30x/test_minimax_m25_eval_amd.py` — standalone MHA template
+- `test/registered/amd/accuracy/mi30x/test_deepseek_v32_eval_amd.py` — standalone MLA template
+- `test/registered/amd/accuracy/mi30x/test_kimi_k25_eval_amd.py` — shared evaluator template
+- `test/registered/amd/accuracy/mi30x/test_glm5_eval_amd.py` — NSA backend template
+- `test/registered/amd/accuracy/mi30x/test_qwen35_eval_amd.py` — LMEvalMixin template
+- `test/registered/amd/accuracy/mi30x/test_vlms_mmmu_eval_amd.py` — VLM template
+- `test/registered/amd/perf/mi30x/test_deepseek_v32_basic_perf_amd.py` — perf template


### PR DESCRIPTION
## Motivation

AMD model enablement and CI debugging workflows follow repeatable patterns that have been applied to 15+ models (MiniMax-M2.5, GLM-5, Kimi-K2.5, DeepSeek-V3.2, Qwen-3.5, etc.). Formalizing them as Claude Code skills lets AI agents execute these workflows consistently without rediscovering patterns each time.

## Modifications

Add two Claude Code skills under `.claude/skills/amd/`, complementing the existing upstream skills (`add-jit-kernel`, `add-sgl-kernel`, `sglang-bisect-ci-regression`, `write-sglang-test`):

| Skill | Lines | What it does |
|---|---|---|
| `enable-amd-model` | 219 | End-to-end: HF architecture research, AMD backend auto-selection (aiter/triton/wave/NSA with head-count logic from `_get_default_attn_backend`), accuracy test files for MI30x + MI35x, CI YAML updates (2 files x 3 edit locations), docs, local validation |
| `write-amd-nightly-test` | 294 | Guide for all AMD test patterns: standalone GSM8K, shared `few_shot_gsm8k` evaluator, `LMEvalMixin`, VLM MMMU, `NightlyBenchmarkRunner` perf tests. Covers `register_amd_ci` suites, all 6 runner labels, MI30x/MI35x variants, and backend args by architecture (MHA/MLA/MoE/NSA/mixed prefill-decode) |

### Key details verified against codebase

- **Backends**: Full `ATTENTION_BACKEND_CHOICES` list from `server_args.py`; auto-selection logic for MHA (`aiter` on HIP), MLA (depends on `num_kv_heads / tp_size` being 16 or 128), NSA (`tilelang` default on HIP)
- **Runner labels**: All 6 labels from workflow YAML (`linux-mi325-{1,2,8}gpu-sglang`, `linux-mi35x-gpu-{1,8}`, `linux-mi35x-gpu-8.fabric`)
- **AttentionArch**: Only `MLA` and `MHA` exist (from `model_config.py`); NSA is a backend, not an architecture
- **Suite names**: Documented actual naming patterns from 50+ `register_amd_ci()` calls across the codebase
- **Test patterns**: All 6 types (standalone GSM8K, shared evaluator, LMEvalMixin, VLM MMMU, NightlyBenchmarkRunner, diffusion) with reference template files

### Files

```
.claude/skills/amd/enable-amd-model/SKILL.md        # NEW (219 lines)
.claude/skills/amd/write-amd-nightly-test/SKILL.md   # NEW (294 lines)
```

## Checklist

- [x] All backend choices verified against `server_args.py` (`ATTENTION_BACKEND_CHOICES`, `NSA_CHOICES`)
- [x] Runner labels verified against workflow YAML files
- [x] Suite names verified against `register_amd_ci()` calls in test files
- [x] Test patterns verified against actual test file templates
- [x] Both skills under 500 lines (219 + 294 = 513 total)
- [x] Follows existing `.claude/skills/` SKILL.md format