### PR TITLE
[Diffusion] Add fp8 dtype support for encoder loaders

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -492,7 +492,7 @@ class PipelineConfig:
             type=str,
             dest=f"{prefix_with_dot.replace('-', '_')}text_encoder_precisions",
             default=PipelineConfig.DEFAULT_TEXT_ENCODER_PRECISIONS,
-            choices=["fp32", "fp16", "bf16"],
+            choices=["fp32", "fp16", "bf16", "fp8"],
             help="Precision for each text encoder",
         )
 
@@ -502,7 +502,7 @@ class PipelineConfig:
             type=str,
             dest=f"{prefix_with_dot.replace('-', '_')}image_encoder_precision",
             default=PipelineConfig.image_encoder_precision,
-            choices=["fp32", "fp16", "bf16"],
+            choices=["fp32", "fp16", "bf16", "fp8"],
             help="Precision for image encoder",
         )
 

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
@@ -47,6 +47,7 @@ class ImageEncoderLoader(TextEncoderLoader):
         encoder_config.update_model_arch(model_config)
 
         # Always start with local device; load_model will adjust for offload if needed
+        # TODO(will): add support for other dtypes
         return self.load_model(
             component_model_path,
             encoder_config,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
@@ -47,7 +47,6 @@ class ImageEncoderLoader(TextEncoderLoader):
         encoder_config.update_model_arch(model_config)
 
         # Always start with local device; load_model will adjust for offload if needed
-        # TODO(will): add support for other dtypes
         return self.load_model(
             component_model_path,
             encoder_config,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -38,7 +38,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     get_diffusers_component_config,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.utils import PRECISION_TO_TYPE, _DEFAULT_DTYPE_COMPATIBLE
 from sglang.srt.environ import envs
 
 logger = init_logger(__name__)
@@ -198,7 +198,6 @@ class TextEncoderLoader(ComponentLoader):
             encoder_config = server_args.pipeline_config.text_encoder_configs[1]
             encoder_config.update_model_arch(model_config)
             encoder_dtype = server_args.pipeline_config.text_encoder_precisions[1]
-        # TODO(will): add support for other dtypes
         return self.load_model(
             component_model_path,
             encoder_config,
@@ -224,7 +223,11 @@ class TextEncoderLoader(ComponentLoader):
         else:
             model_device = local_torch_device
 
-        with set_default_torch_dtype(PRECISION_TO_TYPE[dtype]):
+        target_dtype = PRECISION_TO_TYPE[dtype]
+        # fp8 can't be used as default dtype; init in bf16, then cast after loading
+        init_dtype = target_dtype if target_dtype in _DEFAULT_DTYPE_COMPATIBLE else torch.bfloat16
+
+        with set_default_torch_dtype(init_dtype):
             with model_device, skip_init_modules():
                 architectures = getattr(model_config, "architectures", [])
                 model_cls, _ = ModelRegistry.resolve_model_cls(architectures)
@@ -242,6 +245,17 @@ class TextEncoderLoader(ComponentLoader):
             loaded_weights = model.load_weights(
                 self._get_all_weights(model, model_path, to_cpu=should_offload)
             )
+
+            # Cast to target dtype if init dtype was different (e.g. fp8).
+            # Convert per-parameter/buffer in-place to avoid holding both
+            # full bf16 and fp8 copies in memory at the same time.
+            if target_dtype != init_dtype:
+                for p in model.parameters():
+                    if p.is_floating_point():
+                        p.data = p.data.to(target_dtype)
+                for b in model.buffers():
+                    if b.is_floating_point():
+                        b.data = b.data.to(target_dtype)
 
             # Explicitly move model to target device after loading weights
             if not should_offload:

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -198,6 +198,7 @@ class TextEncoderLoader(ComponentLoader):
             encoder_config = server_args.pipeline_config.text_encoder_configs[1]
             encoder_config.update_model_arch(model_config)
             encoder_dtype = server_args.pipeline_config.text_encoder_precisions[1]
+        # TODO(will): add support for other dtypes
         return self.load_model(
             component_model_path,
             encoder_config,

--- a/python/sglang/multimodal_gen/utils.py
+++ b/python/sglang/multimodal_gen/utils.py
@@ -58,7 +58,11 @@ PRECISION_TO_TYPE = {
     "fp32": torch.float32,
     "fp16": torch.float16,
     "bf16": torch.bfloat16,
+    "fp8": torch.float8_e4m3fn,
 }
+
+# dtypes that can be passed to torch.set_default_dtype
+_DEFAULT_DTYPE_COMPATIBLE = {torch.float32, torch.float64, torch.float16, torch.bfloat16}
 
 STR_BACKEND_ENV_VAR: str = "SGLANG_DIFFUSION_ATTENTION_BACKEND"
 STR_ATTN_CONFIG_ENV_VAR: str = "SGLANG_DIFFUSION_ATTENTION_CONFIG"


### PR DESCRIPTION
# [Diffusion] Add fp8 dtype support for encoder loaders

## Motivation

`TextEncoderLoader` and `ImageEncoderLoader` have a TODO requesting support for additional precision types beyond fp32/fp16/bf16. This PR adds fp8 (`float8_e4m3fn`) support for loading pre-quantized fp8 checkpoints.

## Modifications

- Add `fp8` -> `torch.float8_e4m3fn` to `PRECISION_TO_TYPE` in `utils.py`
- Add `_DEFAULT_DTYPE_COMPATIBLE` set to guard against passing unsupported dtypes to `torch.set_default_dtype`
- Handle fp8 in `TextEncoderLoader.load_model`: fp8 doesn't work with `torch.set_default_dtype`, so we init in bf16 and cast in-place after loading
- Add `fp8` to CLI choices for `--text-encoder-precisions` and `--image-encoder-precision` in `base.py`

and this is a naive dtype cast for pre-quantized fp8 checkpoints. It does not perform online quantization with scale factors.

## Accuracy Tests

N/A -- fp8 is opt-in via CLI flags and defaults are unchanged.

## Benchmarking and Profiling

N/A -- no inference speed impact expected.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
