### PR TITLE
[Bug] Fix missing TTFT histogram for single-batch requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1611,6 +1611,12 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 }
 
             state.finished = recv_obj.finished_reasons[i] is not None
+
+            # Collect metrics BEFORE the safety net sets first_token_time,
+            # so that TTFT is recorded even for single-batch requests.
+            if self.enable_metrics and state.obj.log_metrics:
+                self.collect_metrics(state, recv_obj, i)
+
             if state.finished:
                 # Ensure first_token_time is set before computing decode_throughput.
                 # Without this, requests that finish on their first output batch
@@ -1651,9 +1657,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             state.out_list.append(out_dict)
             state.event.set()
 
-            # Log metrics and dump
-            if self.enable_metrics and state.obj.log_metrics:
-                self.collect_metrics(state, recv_obj, i)
             if self.dump_requests_folder and state.finished and state.obj.log_metrics:
                 self.dump_requests(state, out_dict)
             if self.crash_dump_folder and state.finished and state.obj.log_metrics:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -134,6 +134,7 @@ class ReqState:
     obj: Union[GenerateReqInput, EmbeddingReqInput]
     time_stats: APIServerReqTimeStats
     last_completion_tokens: int = 1
+    ttft_observed: bool = False
 
     # For streaming output
     last_output_offset: int = 0
@@ -1611,12 +1612,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 }
 
             state.finished = recv_obj.finished_reasons[i] is not None
-
-            # Collect metrics BEFORE the safety net sets first_token_time,
-            # so that TTFT is recorded even for single-batch requests.
-            if self.enable_metrics and state.obj.log_metrics:
-                self.collect_metrics(state, recv_obj, i)
-
             if state.finished:
                 # Ensure first_token_time is set before computing decode_throughput.
                 # Without this, requests that finish on their first output batch
@@ -1657,6 +1652,9 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             state.out_list.append(out_dict)
             state.event.set()
 
+            # Log metrics and dump
+            if self.enable_metrics and state.obj.log_metrics:
+                self.collect_metrics(state, recv_obj, i)
             if self.dump_requests_folder and state.finished and state.obj.log_metrics:
                 self.dump_requests(state, out_dict)
             if self.crash_dump_folder and state.finished and state.obj.log_metrics:
@@ -1930,10 +1928,12 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             if priority is not None:
                 labels["priority"] = str(priority)
         if (
-            state.time_stats.first_token_time == 0.0
+            not state.ttft_observed
             and self.disaggregation_mode != DisaggregationMode.PREFILL
         ):
-            state.time_stats.set_first_token_time()
+            if state.time_stats.first_token_time == 0.0:
+                state.time_stats.set_first_token_time()
+            state.ttft_observed = True
             state.last_completion_tokens = completion_tokens
             self.metrics_collector.observe_time_to_first_token(
                 labels, state.time_stats.get_first_token_latency()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1612,12 +1612,13 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 }
 
             state.finished = recv_obj.finished_reasons[i] is not None
+
+            # Set first_token_time on the first output batch.
+            # This is the single write point for first_token_time.
+            if state.time_stats.first_token_time == 0.0:
+                state.time_stats.set_first_token_time()
+
             if state.finished:
-                # Ensure first_token_time is set before computing decode_throughput.
-                # Without this, requests that finish on their first output batch
-                # would have first_token_time=0.0, producing bogus throughput.
-                if state.time_stats.first_token_time == 0.0:
-                    state.time_stats.set_first_token_time()
                 state.time_stats.trace_ctx.trace_set_root_attrs(
                     self.convert_to_span_attrs(state, recv_obj, i)
                 )
@@ -1931,8 +1932,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             not state.ttft_observed
             and self.disaggregation_mode != DisaggregationMode.PREFILL
         ):
-            if state.time_stats.first_token_time == 0.0:
-                state.time_stats.set_first_token_time()
             state.ttft_observed = True
             state.last_completion_tokens = completion_tokens
             self.metrics_collector.observe_time_to_first_token(

--- a/test/registered/metrics/test_priority_metrics.py
+++ b/test/registered/metrics/test_priority_metrics.py
@@ -19,7 +19,6 @@ from sglang.test.test_utils import (
 register_cuda_ci(
     est_time=60,
     suite="stage-b-test-small-1-gpu",
-    disabled="Flaky: no TTFT histogram samples. See https://github.com/sgl-project/sglang/actions/runs/22787468608/job/66118130037",
 )
 register_amd_ci(est_time=60, suite="stage-b-test-small-1-gpu-amd")
 


### PR DESCRIPTION
## Summary
- Decouple TTFT histogram observation from `first_token_time` timestamp by adding `ttft_observed` flag to `ReqState`
- Move `set_first_token_time()` to a single unconditional write point on first output batch, outside the `finished` block
- `collect_metrics()` becomes read-only w.r.t. `first_token_time` — no ordering dependency with the throughput guard
- Re-enable `test_priority_metrics` CI (fixes flaky failure from #19984)

## Background

#19984 added a safety net `set_first_token_time()` inside the `finished` block to fix bogus decode throughput. This ran before `collect_metrics()`, which used `first_token_time == 0.0` as a "first token?" check — causing TTFT histogram to be silently skipped for single-batch requests.

**Before #19984** — TTFT histogram worked, but decode throughput was bogus:
```
1. state.finished = ...
2. if state.finished:
     set_finished_time()
     convert_to_output_meta_info(...)       ← reads first_token_time (still 0.0) ✗
3. state.event.set()
4. collect_metrics()                        ← sets first_token_time + records TTFT ✓
```

**After #19984** — decode throughput fixed, but TTFT histogram regressed:
```
1. state.finished = ...
2. if state.finished:
     if first_token_time == 0.0:
       set_first_token_time()               ← safety net: fixed throughput ✓
     convert_to_output_meta_info(...)       ← reads correct first_token_time ✓
3. state.event.set()
4. collect_metrics()                        ← first_token_time already set
                                               → == 0.0 check fails → skips TTFT ✗
```

## Fix

Decouple the two concerns so correctness doesn't depend on execution order:

```
1. state.finished = ...
2. if first_token_time == 0.0:
     set_first_token_time()                 ← single write point (unconditional) ✓
3. if state.finished:
     convert_to_output_meta_info(...)       ← reads correct first_token_time ✓
4. state.event.set()
5. collect_metrics()                        ← uses ttft_observed flag, not first_token_time
                                               → records TTFT exactly once ✓
```

- `first_token_time` has exactly one write point in `handle_batch_output`
- `collect_metrics()` uses `state.ttft_observed` flag instead of `first_token_time == 0.0`
- Two concerns (timestamp bookkeeping vs histogram observation) are fully decoupled