### PR TITLE
[Feature] Add UVM-based MoE expert offloading with all-GPU compute

### DIFF
--- a/docs/advanced_features/expert_offload.md
+++ b/docs/advanced_features/expert_offload.md
@@ -1,0 +1,109 @@
+# UVM-Based Expert Weight Offloading
+
+SGLang supports UVM (CUDA Unified Memory) based expert weight offloading for MoE models. This allows running large MoE models (e.g., DeepSeek-V3, GLM-5) on fewer GPUs by keeping only a subset of experts in GPU VRAM while offloading the rest to CPU DRAM.
+
+## Overview
+
+Expert weights are stored in CUDA Unified Memory (`cudaMallocManaged`):
+
+- **Resident experts** are advised `PREFER_GPU` -- their pages stay in GPU VRAM and are accessed at full VRAM bandwidth.
+- **Offloaded experts** are advised `PREFER_CPU + ACCESSED_BY_GPU` -- their pages live in CPU DRAM and the GPU reads them transparently via PCIe read-through, with no page fault overhead.
+
+All computation stays on GPU. There is no CPU inference path, no ID remapping, no assembly buffer, and no LRU cache. UVM handles everything transparently, including full compatibility with CUDA graphs.
+
+### Comparison with KTransformers
+
+Now SGLang provides two approaches for expert offloading. They are **mutually exclusive** -- use one or the other.
+
+| | UVM Expert Offloading | KTransformers |
+|---|---|---|
+| Flag | `--expert-offload-num-resident` | `--kt-weight-path` |
+| Compute location | All on GPU | GPU (resident) + CPU (offloaded, via AMX/AVX) |
+| Offloaded expert access | PCIe read-through (transparent) | CPU inference with quantized weights |
+| CUDA graph support | Fully compatible | Requires special handling |
+
+## Quick Start
+
+Enable expert offloading by passing `--expert-offload-num-resident N`, where `N` is the number of experts to keep permanently on GPU per MoE layer:
+
+```bash
+python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
+  --tensor-parallel-size 8 \
+  --expert-offload-num-resident 200
+```
+
+In this example, each MoE layer has 257 local experts. 200 are kept resident in GPU VRAM (accessed at full bandwidth), and the remaining 57 are offloaded to CPU DRAM (accessed via PCIe).
+
+## Resident Expert Selection
+
+The `--expert-offload-resident-selection` flag controls how the resident set is chosen.
+
+### `first_n` (default)
+
+The first N experts (IDs 0 through N-1) are kept resident. Simple and deterministic:
+
+```bash
+--expert-offload-num-resident 200 \
+--expert-offload-resident-selection first_n
+```
+
+### `frequency`
+
+Initially uses the same assignment as `first_n`. During early prefill passes, collects per-layer expert routing frequencies. After accumulating enough routed tokens (default 4096), recomputes the optimal resident set based on actual usage and re-advises the UVM pages -- promoting frequently-used experts to GPU and demoting rarely-used ones to CPU:
+
+```bash
+--expert-offload-num-resident 200 \
+--expert-offload-resident-selection frequency
+```
+
+### `manual`
+
+Explicitly specify which expert IDs to keep resident via a comma-separated list:
+
+```bash
+--expert-offload-num-resident 3 \
+--expert-offload-resident-selection manual \
+--expert-offload-resident-ids "0,5,10"
+```
+
+If fewer IDs are provided than `--expert-offload-num-resident`, the remaining slots are filled from the beginning of the expert ID range.
+
+## Example: GLM-5-FP8 on 8x H20 (96 GB)
+
+```bash
+python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
+  --host 0.0.0.0 --port 8080 \
+  --mem-fraction-static 0.85 --tensor-parallel-size 8 \
+  --attention-backend flashinfer \
+  --reasoning-parser glm45 \
+  --tool-call-parser glm47 \
+  --expert-offload-num-resident 200 \
+  --expert-offload-resident-selection frequency \
+  --enable-flashinfer-allreduce-fusion
+```
+
+## How It Works
+
+1. **Weight loading**: Expert weights are loaded onto GPU normally via the standard checkpoint loader.
+
+2. **UVM migration**: After loading, `ExpertOffloadManager` replaces each expert-indexed parameter with a `cudaMallocManaged` tensor. The original GPU tensor is freed, reclaiming VRAM.
+
+3. **Memory advice**: `cudaMemAdvise` is called per expert slice:
+   - Resident experts: `PREFER_GPU + ACCESSED_BY_GPU` (pages pinned to VRAM)
+   - Offloaded experts: `PREFER_CPU + ACCESSED_BY_GPU` (pages in CPU DRAM, GPU reads via PCIe)
+
+4. **Prefetch**: `cudaMemPrefetchAsync` migrates resident pages to GPU and offloaded pages to CPU to enforce the initial placement.
+
+5. **Inference**: The MoE kernel indexes the full managed tensor directly -- `layer.w13_weight[expert_id]` works for any expert ID. Resident experts are read at VRAM speed; offloaded experts are read at PCIe speed. No special code paths needed.
+
+6. **CUDA graphs**: Fully compatible. Kernels are recorded (not executed) during capture, so page placement is irrelevant at capture time. During replay, each expert is accessed at whichever bandwidth tier its pages are currently in.
+
+7. **Memory reporting**: Offloaded bytes are registered with SGLang's memory reporting so that `init_memory_pool` correctly accounts for VRAM that the UVM driver will free on demand.
+
+## CLI Reference
+
+| Argument | Description | Default |
+|---|---|---|
+| `--expert-offload-num-resident` | Number of experts kept resident on GPU per MoE layer. `-1` disables offloading. | `-1` |
+| `--expert-offload-resident-selection` | Strategy for choosing resident experts: `first_n`, `frequency`, or `manual`. | `first_n` |
+| `--expert-offload-resident-ids` | Comma-separated expert IDs for `manual` selection mode. | `None` |

--- a/docs/advanced_features/expert_offload.md
+++ b/docs/advanced_features/expert_offload.md
@@ -34,6 +34,16 @@ python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
 
 In this example, each MoE layer has 257 local experts. 200 are kept resident in GPU VRAM (accessed at full bandwidth), and the remaining 57 are offloaded to CPU DRAM (accessed via PCIe).
 
+### Draft Model Behavior
+
+When speculative decoding is enabled, SGLang can run a separate draft worker with its own MoE layers. By default, expert offload is applied only to the target model. Draft workers skip expert offload unless you explicitly enable:
+
+```bash
+--expert-offload-draft-model
+```
+
+This is useful for A/B comparisons when you want to isolate whether expert offload on the draft model is hurting speculative decode performance.
+
 ## Resident Expert Selection
 
 The `--expert-offload-resident-selection` flag controls how the resident set is chosen.
@@ -147,3 +157,4 @@ With depth D, after layer i's MoE kernel, prefetch is issued for layers i+1, i+2
 | `--expert-offload-resident-ids` | Comma-separated expert IDs for `manual` selection mode. | `None` |
 | `--expert-offload-prefetch-num` | Number of hot offloaded experts to prefetch per target layer on a background stream. `0` disables. | `0` |
 | `--expert-offload-prefetch-depth` | How many layers ahead to prefetch. `1` = next layer only. Higher values give more overlap. | `1` |
+| `--expert-offload-draft-model` | Also enable expert offload for speculative draft-model MoE layers. By default, draft workers skip expert offload. | `False` |

--- a/docs/advanced_features/expert_offload.md
+++ b/docs/advanced_features/expert_offload.md
@@ -71,16 +71,41 @@ If fewer IDs are provided than `--expert-offload-num-resident`, the remaining sl
 ## Example: GLM-5-FP8 on 8x H20 (96 GB)
 
 ```bash
+pip install --upgrade transformers
+
 python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
   --host 0.0.0.0 --port 8080 \
   --mem-fraction-static 0.85 --tensor-parallel-size 8 \
+  --hicache-io-backend kernel \
   --attention-backend flashinfer \
   --reasoning-parser glm45 \
   --tool-call-parser glm47 \
   --expert-offload-num-resident 200 \
   --expert-offload-resident-selection frequency \
-  --enable-flashinfer-allreduce-fusion
+  --enable-flashinfer-allreduce-fusion \
+  --decode-log-interval 2 \
+  --expert-offload-prefetch-num 3 \
+  --speculative-algorithm EAGLE \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --speculative-num-steps 5
 ```
+
+## Cross-Layer Pipeline Prefetch
+
+When a decode token is routed to an offloaded expert, the MoE kernel stalls while reading weight pages at PCIe bandwidth instead of HBM bandwidth. Cross-layer prefetch mitigates this by issuing `cudaMemPrefetchAsync` for the next layer's hot offloaded experts on a background CUDA stream, overlapping the PCIe transfer with the current layer's attention and layernorm computation.
+
+Enable it with `--expert-offload-prefetch-num N`:
+
+```bash
+--expert-offload-num-resident 200 \
+--expert-offload-resident-selection frequency \
+--expert-offload-prefetch-num 3
+```
+
+If the prefetch completes before the next MoE kernel launches, the kernel reads at HBM speed. If not, the kernel falls back to PCIe read-through (existing behavior). However, prefetching too many experts can cause GPU memory pressure and page thrashing, which degrades decode speed.
+
+**Tuning**: Start with `--expert-offload-prefetch-num 2`. Higher values prefetch more experts but consume more PCIe bandwidth and GPU memory, which can cause page thrashing. Typical sweet spot is 2-4 depending on model size and available GPU memory headroom.
 
 ## How It Works
 
@@ -107,3 +132,4 @@ python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
 | `--expert-offload-num-resident` | Number of experts kept resident on GPU per MoE layer. `-1` disables offloading. | `-1` |
 | `--expert-offload-resident-selection` | Strategy for choosing resident experts: `first_n`, `frequency`, or `manual`. | `first_n` |
 | `--expert-offload-resident-ids` | Comma-separated expert IDs for `manual` selection mode. | `None` |
+| `--expert-offload-prefetch-num` | Number of hot offloaded experts to prefetch for the next layer on a background stream. `0` disables. | `0` |

--- a/docs/advanced_features/expert_offload.md
+++ b/docs/advanced_features/expert_offload.md
@@ -93,7 +93,7 @@ python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
 
 ## Cross-Layer Pipeline Prefetch
 
-When a decode token is routed to an offloaded expert, the MoE kernel stalls while reading weight pages at PCIe bandwidth instead of HBM bandwidth. Cross-layer prefetch mitigates this by issuing `cudaMemPrefetchAsync` for the next layer's hot offloaded experts on a background CUDA stream, overlapping the PCIe transfer with the current layer's attention and layernorm computation.
+When a decode token is routed to an offloaded expert, the MoE kernel stalls while reading weight pages at PCIe bandwidth instead of HBM bandwidth. Cross-layer prefetch mitigates this by issuing `cudaMemPrefetchAsync` for upcoming layers' hot offloaded experts on a background CUDA stream, overlapping the PCIe transfer with intervening attention and layernorm computation.
 
 Enable it with `--expert-offload-prefetch-num N`:
 
@@ -103,9 +103,22 @@ Enable it with `--expert-offload-prefetch-num N`:
 --expert-offload-prefetch-num 3
 ```
 
-If the prefetch completes before the next MoE kernel launches, the kernel reads at HBM speed. If not, the kernel falls back to PCIe read-through (existing behavior). However, prefetching too many experts can cause GPU memory pressure and page thrashing, which degrades decode speed.
+If the prefetch completes before the target MoE kernel launches, the kernel reads at HBM speed. If not, the kernel falls back to PCIe read-through (existing behavior). However, prefetching too many experts can cause GPU memory pressure and page thrashing, which degrades decode speed.
 
-**Tuning**: Start with `--expert-offload-prefetch-num 2`. Higher values prefetch more experts but consume more PCIe bandwidth and GPU memory, which can cause page thrashing. Typical sweet spot is 2-4 depending on model size and available GPU memory headroom.
+### Prefetch Depth
+
+By default, each layer only prefetches for the **next** layer (`--expert-offload-prefetch-depth 1`). When expert prefetch takes longer than one layer's attention + layernorm compute, increase the depth so that prefetch is issued further ahead:
+
+```bash
+--expert-offload-num-resident 200 \
+--expert-offload-resident-selection frequency \
+--expert-offload-prefetch-num 3 \
+--expert-offload-prefetch-depth 3
+```
+
+With depth D, after layer i's MoE kernel, prefetch is issued for layers i+1, i+2, ..., i+D. This gives D layers' worth of attention + layernorm compute to overlap with the PCIe transfers.
+
+**Tuning**: Start with `--expert-offload-prefetch-num 2` and `--expert-offload-prefetch-depth 1`. If profiling shows that prefetch is not completing in time, increase depth to 2-4. Higher depth values issue more concurrent prefetch requests, which can improve overlap but also increase PCIe contention and GPU memory pressure.
 
 ## How It Works
 
@@ -132,4 +145,5 @@ If the prefetch completes before the next MoE kernel launches, the kernel reads 
 | `--expert-offload-num-resident` | Number of experts kept resident on GPU per MoE layer. `-1` disables offloading. | `-1` |
 | `--expert-offload-resident-selection` | Strategy for choosing resident experts: `first_n`, `frequency`, or `manual`. | `first_n` |
 | `--expert-offload-resident-ids` | Comma-separated expert IDs for `manual` selection mode. | `None` |
-| `--expert-offload-prefetch-num` | Number of hot offloaded experts to prefetch for the next layer on a background stream. `0` disables. | `0` |
+| `--expert-offload-prefetch-num` | Number of hot offloaded experts to prefetch per target layer on a background stream. `0` disables. | `0` |
+| `--expert-offload-prefetch-depth` | How many layers ahead to prefetch. `1` = next layer only. Higher values give more overlap. | `1` |

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -376,6 +376,13 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--kt-num-gpu-experts` | [ktransformers parameter] The number of GPU experts. | `None` | Type: int |
 | `--kt-max-deferred-experts-per-token` | [ktransformers parameter] Maximum number of experts deferred to CPU per token. All MoE layers except the final one use this value; the final layer always uses 0. | `None` | Type: int |
 
+## Expert Weight Offloading (UVM)
+| Argument | Description | Defaults | Options |
+| --- | --- | --- | --- |
+| `--expert-offload-num-resident` | Number of experts kept resident on GPU per MoE layer. `-1` disables offloading. Expert weights are stored in CUDA Unified Memory; offloaded experts live in CPU DRAM and are accessed by the GPU transparently via PCIe read-through. Mutually exclusive with `--kt-weight-path`. See [UVM-Based Expert Weight Offloading](expert_offload.md) for details. | `-1` | Type: int |
+| `--expert-offload-resident-selection` | Strategy for choosing which experts stay resident on GPU. `first_n` = experts 0..N-1; `frequency` = adaptive selection based on routing frequency warmup; `manual` = explicit list via `--expert-offload-resident-ids`. | `first_n` | Choices: `first_n`, `frequency`, `manual` |
+| `--expert-offload-resident-ids` | Comma-separated expert IDs to keep resident on GPU (for `manual` selection mode). | `None` | Type: str |
+
 ## Diffusion LLM
 
 | Argument | Description | Defaults | Options |

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -382,6 +382,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--expert-offload-num-resident` | Number of experts kept resident on GPU per MoE layer. `-1` disables offloading. Expert weights are stored in CUDA Unified Memory; offloaded experts live in CPU DRAM and are accessed by the GPU transparently via PCIe read-through. Mutually exclusive with `--kt-weight-path`. See [UVM-Based Expert Weight Offloading](expert_offload.md) for details. | `-1` | Type: int |
 | `--expert-offload-resident-selection` | Strategy for choosing which experts stay resident on GPU. `first_n` = experts 0..N-1; `frequency` = adaptive selection based on routing frequency warmup; `manual` = explicit list via `--expert-offload-resident-ids`. | `first_n` | Choices: `first_n`, `frequency`, `manual` |
 | `--expert-offload-resident-ids` | Comma-separated expert IDs to keep resident on GPU (for `manual` selection mode). | `None` | Type: str |
+| `--expert-offload-prefetch-num` | Number of hot offloaded experts to prefetch for the next MoE layer. After each layer's MoE kernel, `cudaMemPrefetchAsync` is issued on a background stream for the next layer's most-frequently-hit offloaded experts. Too high a value can cause GPU memory pressure and page thrashing, reducing decode speed. | `0` | Type: int |
 
 ## Diffusion LLM
 

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -383,6 +383,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--expert-offload-resident-selection` | Strategy for choosing which experts stay resident on GPU. `first_n` = experts 0..N-1; `frequency` = adaptive selection based on routing frequency warmup; `manual` = explicit list via `--expert-offload-resident-ids`. | `first_n` | Choices: `first_n`, `frequency`, `manual` |
 | `--expert-offload-resident-ids` | Comma-separated expert IDs to keep resident on GPU (for `manual` selection mode). | `None` | Type: str |
 | `--expert-offload-prefetch-num` | Number of hot offloaded experts to prefetch for the next MoE layer. After each layer's MoE kernel, `cudaMemPrefetchAsync` is issued on a background stream for the next layer's most-frequently-hit offloaded experts. Too high a value can cause GPU memory pressure and page thrashing, reducing decode speed. | `0` | Type: int |
+| `--expert-offload-prefetch-depth` | How many layers ahead to prefetch offloaded experts. Default 1 prefetches only the next layer. Higher values (e.g. 2-4) issue prefetch for the next D layers, giving more overlap between PCIe transfers and compute when prefetch takes longer than one layer's attention + layernorm. | `1` | Type: int |
 
 ## Diffusion LLM
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ Its core features include:
    advanced_features/quantization.md
    advanced_features/quantized_kv_cache.md
    advanced_features/expert_parallelism.md
+   advanced_features/expert_offload.md
    advanced_features/dp_dpa_smg_guide.md
    advanced_features/lora.ipynb
    advanced_features/pd_disaggregation.md

--- a/python/sglang/srt/layers/moe/expert_offload/__init__.py
+++ b/python/sglang/srt/layers/moe/expert_offload/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""UVM-based expert weight offloading for MoE layers.
+
+Expert weights are stored in CUDA Unified Memory (cudaMallocManaged).
+Resident experts are kept in GPU VRAM (PREFER_GPU advice).
+Offloaded experts live in CPU DRAM and are accessible to the GPU via PCIe
+read-through (PREFER_CPU + ACCESSED_BY_GPU advice) -- no page fault overhead,
+no quality loss, CUDA graph compatible.
+
+All computation remains on GPU (no CPU inference).
+Mutually exclusive with KTransformers (--kt-weight-path).
+
+Usage
+-----
+Pass ``--expert-offload-num-resident N`` to enable.  Additional options:
+
+  --expert-offload-resident-selection first_n How to choose resident experts.
+  --expert-offload-resident-ids       None    Comma-separated IDs for manual selection.
+"""
+
+from sglang.srt.layers.moe.expert_offload.config import (
+    ExpertOffloadConfig,
+    create_expert_offload_config_from_server_args,
+)
+from sglang.srt.layers.moe.expert_offload.wrapper import ExpertOffloadWrapperMethod
+
+__all__ = [
+    "ExpertOffloadConfig",
+    "ExpertOffloadWrapperMethod",
+    "create_expert_offload_config_from_server_args",
+]

--- a/python/sglang/srt/layers/moe/expert_offload/__init__.py
+++ b/python/sglang/srt/layers/moe/expert_offload/__init__.py
@@ -79,6 +79,12 @@ _decode_since_last_reset: bool = False
 _tracing_prefill: bool = False
 
 
+def _log_prefix() -> str:
+    if _all_managers:
+        return _all_managers[0][0].config.log_prefix
+    return "[ExpertOffload]"
+
+
 def register_manager(
     layer_idx: int, manager: "ExpertOffloadManager", layer: "torch.nn.Module"
 ) -> None:
@@ -151,7 +157,7 @@ def prepare_for_new_prefill() -> None:
     used_gb = (total - free) / (1 << 30)
     free_gb = free / (1 << 30)
     logger.info(
-        f"[ExpertOffload] prepare_for_new_prefill: "
+        f"{_log_prefix()} prepare_for_new_prefill: "
         f"decode->prefill transition "
         f"(GPU mem: {used_gb:.2f} GiB used, {free_gb:.2f} GiB free)"
     )
@@ -177,6 +183,6 @@ def restore_after_prefill() -> None:
     t1 = time.monotonic()
 
     logger.info(
-        f"[ExpertOffload] restore_after_prefill: "
+        f"{_log_prefix()} restore_after_prefill: "
         f"re-set ACCESSED_BY in {t1 - t0:.3f}s"
     )

--- a/python/sglang/srt/layers/moe/expert_offload/__init__.py
+++ b/python/sglang/srt/layers/moe/expert_offload/__init__.py
@@ -32,7 +32,7 @@ Pass ``--expert-offload-num-resident N`` to enable.  Additional options:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Tuple
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from sglang.srt.layers.moe.expert_offload.config import (
     ExpertOffloadConfig,
@@ -50,7 +50,10 @@ __all__ = [
     "ExpertOffloadWrapperMethod",
     "chain_managers",
     "create_expert_offload_config_from_server_args",
+    "notify_decode_completed",
+    "prepare_for_new_prefill",
     "register_manager",
+    "restore_after_prefill",
 ]
 
 # ---------------------------------------------------------------------------
@@ -60,17 +63,34 @@ __all__ = [
 _manager_registry: Dict[int, Tuple["ExpertOffloadManager", "torch.nn.Module"]] = {}
 _managers_chained: bool = False
 
+# Persistent list of all (manager, layer) pairs.
+# Unlike _manager_registry which is cleared after chain_managers(), this list
+# survives so that prepare_for_new_prefill() can iterate over all managers.
+_all_managers: List[Tuple["ExpertOffloadManager", "torch.nn.Module"]] = []
+
+# True once at least one decode step has executed since the last page reset.
+# Used to skip the expensive prefetch+sync when consecutive extends run
+# (e.g. chunked prefill) with no intervening decode.
+_decode_since_last_reset: bool = False
+
+# Set True during the first forward pass after prepare_for_new_prefill.
+# Used to enable per-layer tracing in wrapper.apply() so we can see which
+# MoE layer the kernel hangs on.
+_tracing_prefill: bool = False
+
 
 def register_manager(
     layer_idx: int, manager: "ExpertOffloadManager", layer: "torch.nn.Module"
 ) -> None:
     """Called from wrapper.process_weights_after_loading()."""
     _manager_registry[layer_idx] = (manager, layer)
+    _all_managers.append((manager, layer))
 
 
 def chain_managers() -> None:
-    """Link managers[i].next_layer_manager = managers[i+1], build prefetch caches.
+    """Link managers[i].next_layer_managers to the next D managers, build prefetch caches.
 
+    D is determined by each manager's ``config.prefetch_depth``.
     Guarded by ``_managers_chained`` flag -- no-op after first call.
     """
     global _managers_chained
@@ -79,10 +99,17 @@ def chain_managers() -> None:
     _managers_chained = True
 
     sorted_idxs = sorted(_manager_registry.keys())
-    for i in range(len(sorted_idxs) - 1):
+    n = len(sorted_idxs)
+    for i in range(n):
         curr_mgr, _ = _manager_registry[sorted_idxs[i]]
-        next_mgr, _ = _manager_registry[sorted_idxs[i + 1]]
-        curr_mgr.next_layer_manager = next_mgr
+        depth = curr_mgr.config.prefetch_depth
+        targets = []
+        for d in range(1, depth + 1):
+            j = i + d
+            if j < n:
+                next_mgr, _ = _manager_registry[sorted_idxs[j]]
+                targets.append(next_mgr)
+        curr_mgr.next_layer_managers = targets
 
     # Build prefetch caches for all managers.
     for idx in sorted_idxs:
@@ -90,3 +117,66 @@ def chain_managers() -> None:
         mgr.prepare_prefetch_cache(layer)
 
     _manager_registry.clear()
+
+
+def notify_decode_completed() -> None:
+    """Mark that a decode step has run, so the next prefill triggers page reset."""
+    global _decode_since_last_reset
+    _decode_since_last_reset = True
+
+
+def prepare_for_new_prefill() -> None:
+    """Notify decode->prefill transition.
+
+    The real fix for UVM page-swap deadlocks is a 2 GiB headroom
+    reserved in get_available_gpu_memory() so the UVM driver always
+    has free GPU pages for bi-directional page swapping.
+    This function just resets bookkeeping flags and logs memory state.
+    """
+    import logging
+
+    import torch
+
+    logger = logging.getLogger(__name__)
+
+    global _decode_since_last_reset
+    if not _all_managers or not _decode_since_last_reset:
+        return
+    _decode_since_last_reset = False
+
+    global _tracing_prefill
+    _tracing_prefill = True
+
+    free, total = torch.cuda.mem_get_info()
+    used_gb = (total - free) / (1 << 30)
+    free_gb = free / (1 << 30)
+    logger.info(
+        f"[ExpertOffload] prepare_for_new_prefill: "
+        f"decode->prefill transition "
+        f"(GPU mem: {used_gb:.2f} GiB used, {free_gb:.2f} GiB free)"
+    )
+
+
+def restore_after_prefill() -> None:
+    """Re-enable GPU direct mapping for offloaded experts after prefill.
+
+    Called after forward_extend completes to restore ACCESSED_BY advice
+    so decode can use fast PCIe read-through without page fault overhead.
+    """
+    import logging
+    import time
+
+    logger = logging.getLogger(__name__)
+
+    if not _all_managers:
+        return
+
+    t0 = time.monotonic()
+    for mgr, layer in _all_managers:
+        mgr.restore_accessed_by_for_offloaded(layer)
+    t1 = time.monotonic()
+
+    logger.info(
+        f"[ExpertOffload] restore_after_prefill: "
+        f"re-set ACCESSED_BY in {t1 - t0:.3f}s"
+    )

--- a/python/sglang/srt/layers/moe/expert_offload/__init__.py
+++ b/python/sglang/srt/layers/moe/expert_offload/__init__.py
@@ -32,7 +32,10 @@ Pass ``--expert-offload-num-resident N`` to enable.  Additional options:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Dict, List, Tuple
+
+import torch
 
 from sglang.srt.layers.moe.expert_offload.config import (
     ExpertOffloadConfig,
@@ -41,17 +44,18 @@ from sglang.srt.layers.moe.expert_offload.config import (
 from sglang.srt.layers.moe.expert_offload.wrapper import ExpertOffloadWrapperMethod
 
 if TYPE_CHECKING:
-    import torch
-
     from sglang.srt.layers.moe.expert_offload.manager import ExpertOffloadManager
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 __all__ = [
     "ExpertOffloadConfig",
     "ExpertOffloadWrapperMethod",
     "chain_managers",
     "create_expert_offload_config_from_server_args",
+    "has_active_frequency_warmup",
     "notify_decode_completed",
     "prepare_for_new_prefill",
+    "record_frequency_from_routed_experts_capture",
     "register_manager",
     "restore_after_prefill",
 ]
@@ -78,11 +82,19 @@ _decode_since_last_reset: bool = False
 # MoE layer the kernel hangs on.
 _tracing_prefill: bool = False
 
+logger = logging.getLogger(__name__)
+
 
 def _log_prefix() -> str:
     if _all_managers:
         return _all_managers[0][0].config.log_prefix
     return "[ExpertOffload]"
+
+
+def _should_log_decode_debug() -> bool:
+    if _all_managers:
+        return _all_managers[0][0].config.decode_debug_log
+    return False
 
 
 def register_manager(
@@ -129,6 +141,63 @@ def notify_decode_completed() -> None:
     """Mark that a decode step has run, so the next prefill triggers page reset."""
     global _decode_since_last_reset
     _decode_since_last_reset = True
+
+
+def has_active_frequency_warmup() -> bool:
+    """Return whether any target-worker frequency warmup is still collecting."""
+    return any(
+        mgr.config.resident_selection == "frequency"
+        and not mgr.config.is_draft_worker
+        and not mgr._warmup_done
+        for mgr, _ in _all_managers
+    )
+
+
+def record_frequency_from_routed_experts_capture(
+    forward_batch: "ForwardBatch", captured_topk_ids: "torch.Tensor | None"
+) -> None:
+    """Feed captured routed experts into frequency warmup after a forward ends."""
+    if captured_topk_ids is None or not has_active_frequency_warmup():
+        return
+    if not forward_batch.forward_mode.is_target_verify():
+        return
+
+    active_layers = 0
+    for mgr, layer in _all_managers:
+        if mgr.config.is_draft_worker or mgr.config.resident_selection != "frequency":
+            continue
+        if mgr._warmup_done or mgr.config.layer_idx >= captured_topk_ids.shape[1]:
+            continue
+
+        layer_topk = captured_topk_ids[:, mgr.config.layer_idx, :]
+        valid_ids = layer_topk[
+            (layer_topk >= 0) & (layer_topk < mgr.config.num_local_experts)
+        ]
+        if valid_ids.numel() == 0:
+            continue
+
+        active_layers += 1
+        counts = torch.bincount(
+            valid_ids.to(dtype=torch.int64, device="cpu"),
+            minlength=mgr.config.num_local_experts,
+        )
+        mgr.record_expert_usage_counts(
+            counts=counts,
+            num_tokens=int(layer_topk.shape[0]),
+            layer=layer,
+            forward_mode_name=forward_batch.forward_mode.name,
+        )
+
+    if active_layers > 0 and _should_log_decode_debug():
+        logger.info(
+            "%s FrequencyWarmupForward mode=%s tokens=%s active_layers=%s batch=%s can_record_verify=%s",
+            _log_prefix(),
+            forward_batch.forward_mode.name,
+            int(captured_topk_ids.shape[0]),
+            active_layers,
+            getattr(forward_batch, "batch_size", -1),
+            True,
+        )
 
 
 def prepare_for_new_prefill() -> None:

--- a/python/sglang/srt/layers/moe/expert_offload/__init__.py
+++ b/python/sglang/srt/layers/moe/expert_offload/__init__.py
@@ -30,14 +30,63 @@ Pass ``--expert-offload-num-resident N`` to enable.  Additional options:
   --expert-offload-resident-ids       None    Comma-separated IDs for manual selection.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Tuple
+
 from sglang.srt.layers.moe.expert_offload.config import (
     ExpertOffloadConfig,
     create_expert_offload_config_from_server_args,
 )
 from sglang.srt.layers.moe.expert_offload.wrapper import ExpertOffloadWrapperMethod
 
+if TYPE_CHECKING:
+    import torch
+
+    from sglang.srt.layers.moe.expert_offload.manager import ExpertOffloadManager
+
 __all__ = [
     "ExpertOffloadConfig",
     "ExpertOffloadWrapperMethod",
+    "chain_managers",
     "create_expert_offload_config_from_server_args",
+    "register_manager",
 ]
+
+# ---------------------------------------------------------------------------
+# Global manager registry for cross-layer prefetch chaining
+# ---------------------------------------------------------------------------
+
+_manager_registry: Dict[int, Tuple["ExpertOffloadManager", "torch.nn.Module"]] = {}
+_managers_chained: bool = False
+
+
+def register_manager(
+    layer_idx: int, manager: "ExpertOffloadManager", layer: "torch.nn.Module"
+) -> None:
+    """Called from wrapper.process_weights_after_loading()."""
+    _manager_registry[layer_idx] = (manager, layer)
+
+
+def chain_managers() -> None:
+    """Link managers[i].next_layer_manager = managers[i+1], build prefetch caches.
+
+    Guarded by ``_managers_chained`` flag -- no-op after first call.
+    """
+    global _managers_chained
+    if _managers_chained or not _manager_registry:
+        return
+    _managers_chained = True
+
+    sorted_idxs = sorted(_manager_registry.keys())
+    for i in range(len(sorted_idxs) - 1):
+        curr_mgr, _ = _manager_registry[sorted_idxs[i]]
+        next_mgr, _ = _manager_registry[sorted_idxs[i + 1]]
+        curr_mgr.next_layer_manager = next_mgr
+
+    # Build prefetch caches for all managers.
+    for idx in sorted_idxs:
+        mgr, layer = _manager_registry[idx]
+        mgr.prepare_prefetch_cache(layer)
+
+    _manager_registry.clear()

--- a/python/sglang/srt/layers/moe/expert_offload/config.py
+++ b/python/sglang/srt/layers/moe/expert_offload/config.py
@@ -1,0 +1,77 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Configuration for UVM-based expert weight offloading."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+
+@dataclass
+class ExpertOffloadConfig:
+    """Per-layer configuration for UVM expert offloading.
+
+    Expert weights are stored in CUDA Unified Memory (cudaMallocManaged).
+    Resident experts are advised PREFER_GPU (stay in VRAM).
+    Offloaded experts are advised PREFER_CPU + ACCESSED_BY_GPU (live in CPU
+    DRAM; the GPU reads them via PCIe without triggering a page fault).
+
+    No LRU cache, no assembly buffer, no ID remapping -- UVM handles all of it.
+    """
+
+    layer_idx: int
+    num_local_experts: int
+    num_resident_experts: int  # experts whose pages are kept on GPU
+    resident_selection: str  # "first_n" | "frequency" | "manual"
+    resident_expert_ids: Optional[List[int]]  # explicit IDs for "manual" mode
+    warmup_tokens: int = 4096  # routed tokens to collect before readvise
+
+    @property
+    def num_offloaded_experts(self) -> int:
+        return self.num_local_experts - self.num_resident_experts
+
+
+def create_expert_offload_config_from_server_args(
+    server_args: "ServerArgs",
+    layer_id: int,
+    num_local_experts: int,
+) -> Optional[ExpertOffloadConfig]:
+    """Return an ExpertOffloadConfig if expert offloading is enabled, else None."""
+    if server_args.expert_offload_num_resident < 0:
+        return None
+
+    num_resident = min(server_args.expert_offload_num_resident, num_local_experts)
+
+    resident_ids: Optional[List[int]] = None
+    if (
+        server_args.expert_offload_resident_selection == "manual"
+        and server_args.expert_offload_resident_ids is not None
+    ):
+        resident_ids = [
+            int(x.strip())
+            for x in server_args.expert_offload_resident_ids.split(",")
+            if x.strip()
+        ]
+
+    return ExpertOffloadConfig(
+        layer_idx=layer_id,
+        num_local_experts=num_local_experts,
+        num_resident_experts=num_resident,
+        resident_selection=server_args.expert_offload_resident_selection,
+        resident_expert_ids=resident_ids,
+    )

--- a/python/sglang/srt/layers/moe/expert_offload/config.py
+++ b/python/sglang/srt/layers/moe/expert_offload/config.py
@@ -40,6 +40,7 @@ class ExpertOffloadConfig:
     resident_selection: str  # "first_n" | "frequency" | "manual"
     resident_expert_ids: Optional[List[int]]  # explicit IDs for "manual" mode
     warmup_tokens: int = 4096  # routed tokens to collect before readvise
+    prefetch_num: int = 0  # 0 = disabled; N = prefetch top-N hot offloaded experts
 
     @property
     def num_offloaded_experts(self) -> int:
@@ -74,4 +75,5 @@ def create_expert_offload_config_from_server_args(
         num_resident_experts=num_resident,
         resident_selection=server_args.expert_offload_resident_selection,
         resident_expert_ids=resident_ids,
+        prefetch_num=server_args.expert_offload_prefetch_num,
     )

--- a/python/sglang/srt/layers/moe/expert_offload/config.py
+++ b/python/sglang/srt/layers/moe/expert_offload/config.py
@@ -43,11 +43,12 @@ class ExpertOffloadConfig:
     num_resident_experts: int  # experts whose pages are kept on GPU
     resident_selection: str  # "first_n" | "frequency" | "manual"
     resident_expert_ids: Optional[List[int]]  # explicit IDs for "manual" mode
-    warmup_tokens: int = 4096  # routed tokens to collect before readvise
+    warmup_tokens: int = 16384  # routed tokens to collect before readvise
     prefetch_num: int = 0  # 0 = disabled; N = prefetch top-N hot offloaded experts
     prefetch_depth: int = 1  # how many layers ahead to prefetch (1 = next layer only)
     memory_headroom_gib: int = 2  # GiB reserved for UVM page swapping
     is_draft_worker: bool = False
+    decode_debug_log: bool = False
 
     @property
     def num_offloaded_experts(self) -> int:
@@ -101,4 +102,5 @@ def create_expert_offload_config_from_server_args(
         prefetch_depth=server_args.expert_offload_prefetch_depth,
         memory_headroom_gib=server_args.expert_offload_memory_headroom,
         is_draft_worker=is_draft_worker,
+        decode_debug_log=server_args.expert_offload_decode_debug_log,
     )

--- a/python/sglang/srt/layers/moe/expert_offload/config.py
+++ b/python/sglang/srt/layers/moe/expert_offload/config.py
@@ -41,6 +41,8 @@ class ExpertOffloadConfig:
     resident_expert_ids: Optional[List[int]]  # explicit IDs for "manual" mode
     warmup_tokens: int = 4096  # routed tokens to collect before readvise
     prefetch_num: int = 0  # 0 = disabled; N = prefetch top-N hot offloaded experts
+    prefetch_depth: int = 1  # how many layers ahead to prefetch (1 = next layer only)
+    memory_headroom_gib: int = 2  # GiB reserved for UVM page swapping
 
     @property
     def num_offloaded_experts(self) -> int:
@@ -76,4 +78,6 @@ def create_expert_offload_config_from_server_args(
         resident_selection=server_args.expert_offload_resident_selection,
         resident_expert_ids=resident_ids,
         prefetch_num=server_args.expert_offload_prefetch_num,
+        prefetch_depth=server_args.expert_offload_prefetch_depth,
+        memory_headroom_gib=server_args.expert_offload_memory_headroom,
     )

--- a/python/sglang/srt/layers/moe/expert_offload/config.py
+++ b/python/sglang/srt/layers/moe/expert_offload/config.py
@@ -15,11 +15,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -43,19 +47,35 @@ class ExpertOffloadConfig:
     prefetch_num: int = 0  # 0 = disabled; N = prefetch top-N hot offloaded experts
     prefetch_depth: int = 1  # how many layers ahead to prefetch (1 = next layer only)
     memory_headroom_gib: int = 2  # GiB reserved for UVM page swapping
+    is_draft_worker: bool = False
 
     @property
     def num_offloaded_experts(self) -> int:
         return self.num_local_experts - self.num_resident_experts
+
+    @property
+    def worker_role(self) -> str:
+        return "draft" if self.is_draft_worker else "target"
+
+    @property
+    def log_prefix(self) -> str:
+        return f"[ExpertOffload][{self.worker_role}]"
 
 
 def create_expert_offload_config_from_server_args(
     server_args: "ServerArgs",
     layer_id: int,
     num_local_experts: int,
+    is_draft_worker: bool = False,
 ) -> Optional[ExpertOffloadConfig]:
     """Return an ExpertOffloadConfig if expert offloading is enabled, else None."""
     if server_args.expert_offload_num_resident < 0:
+        return None
+    if is_draft_worker and not server_args.expert_offload_draft_model:
+        logger.debug(
+            "[ExpertOffload][draft] Skipping draft-model expert offload for layer %s",
+            layer_id,
+        )
         return None
 
     num_resident = min(server_args.expert_offload_num_resident, num_local_experts)
@@ -80,4 +100,5 @@ def create_expert_offload_config_from_server_args(
         prefetch_num=server_args.expert_offload_prefetch_num,
         prefetch_depth=server_args.expert_offload_prefetch_depth,
         memory_headroom_gib=server_args.expert_offload_memory_headroom,
+        is_draft_worker=is_draft_worker,
     )

--- a/python/sglang/srt/layers/moe/expert_offload/manager.py
+++ b/python/sglang/srt/layers/moe/expert_offload/manager.py
@@ -1,0 +1,410 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""UVM-based expert weight offloading manager.
+
+Design
+------
+Expert weights are stored in CUDA Unified Memory (``cudaMallocManaged``).
+
+  Resident experts  -> ``cudaMemAdvise(PREFER_GPU | ACCESSED_BY_GPU)``
+                      Pages stay in GPU VRAM; accessed at VRAM bandwidth.
+
+  Offloaded experts -> ``cudaMemAdvise(PREFER_CPU | ACCESSED_BY_GPU)``
+                      Pages live in CPU DRAM.  The GPU reads them via PCIe
+                      without a page-fault interrupt (ACCESSED_BY_GPU sets up
+                      a direct mapping in the GPU's page table).
+
+The MoE kernel indexes ``layer.w_param[topk_id]`` directly -- no ID remapping,
+no assembly buffer, no LRU cache.  UVM is fully transparent to CUDA graphs:
+kernels are recorded (not executed) during capture, so page placement during
+capture is irrelevant.  During replay the GPU reads each expert at whichever
+bandwidth tier its pages are currently in.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import torch
+
+from sglang.srt.layers.moe.expert_offload.config import ExpertOffloadConfig
+from sglang.srt.layers.moe.expert_offload.uvm import (
+    ADVISE_SET_ACCESSED_BY,
+    ADVISE_SET_PREFERRED_LOCATION,
+    CUDA_CPU_DEVICE,
+    uvm_advise,
+    uvm_copy_from_tensor,
+    uvm_prefetch_async,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExpertOffloadManager:
+    """Manages UVM-based expert offloading for a single FusedMoE layer."""
+
+    def __init__(self, config: ExpertOffloadConfig, device: torch.device):
+        self.config = config
+        self.device = device
+        self.device_id: int = device.index if device.index is not None else 0
+
+        # Expert ID lists (populated in initialize_from_weights).
+        self.resident_expert_ids: List[int] = []
+        self.offloaded_expert_ids: List[int] = []
+
+        # Names of expert-indexed parameters found on the layer.
+        self._expert_param_names: List[str] = []
+
+        # Dedicated stream for async prefetch operations.
+        self.prefetch_stream: torch.cuda.Stream = torch.cuda.Stream(device=device)
+
+        # Per-layer adaptive resident selection state.
+        self._expert_freq: Optional[torch.Tensor] = None
+        self._warmup_tokens: int = 0
+        self._warmup_done: bool = False
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    def initialize_from_weights(self, layer: torch.nn.Module) -> None:
+        """Replace GPU expert tensors with UVM-backed tensors.
+
+        For each expert-indexed parameter on ``layer``:
+          1. Allocate managed memory (same shape/dtype).
+          2. Copy GPU tensor -> managed tensor (device-to-device, on GPU).
+          3. Apply ``cudaMemAdvise`` to resident and offloaded slices.
+          4. Prefetch resident slice to GPU, offloaded slice to CPU.
+          5. Free the original GPU tensor.
+          6. Set ``layer.<param>`` = managed tensor (full shape unchanged).
+
+        ``layer.num_local_experts`` is NOT modified -- the kernel uses the
+        original routing indices and indexes the full managed tensor.
+        """
+        cfg = self.config
+        num_local = cfg.num_local_experts
+
+        # 1. Choose resident expert IDs.
+        self.resident_expert_ids = self._select_resident_ids(cfg)
+        resident_set = set(self.resident_expert_ids)
+        self.offloaded_expert_ids = [
+            i for i in range(num_local) if i not in resident_set
+        ]
+
+        logger.debug(
+            f"[ExpertOffload] Layer {cfg.layer_idx}: "
+            f"{len(self.resident_expert_ids)} resident, "
+            f"{len(self.offloaded_expert_ids)} offloaded (UVM)"
+        )
+
+        # 2. Find all expert-indexed parameters.
+        self._expert_param_names = self._find_expert_param_names(layer, num_local)
+
+        # 3. Process each parameter (one at a time to keep peak GPU usage low).
+        for param_name in self._expert_param_names:
+            self._migrate_param_to_uvm(layer, param_name)
+
+        # 4. Wait for all prefetch operations to complete before continuing.
+        torch.cuda.synchronize(self.device)
+
+        # 5. Register offloaded bytes with SGLang's memory reporting.
+        #
+        # On PCIe-attached discrete GPUs, cudaMemPrefetchAsync(->CPU) may not
+        # immediately return physical GPU pages to the free pool -- the UVM
+        # driver keeps them cached until a regular cudaMalloc triggers eviction.
+        # This causes torch.cuda.mem_get_info() to under-report available memory,
+        # breaking SGLang's init_memory_pool check.
+        #
+        # Instead of forcing a slow pressure-based eviction here, we register
+        # the offloaded bytes with get_available_gpu_memory() so that the check
+        # sees the correct "effective" available memory.  The actual eviction
+        # happens on-demand when the KV-cache allocator issues cudaMalloc calls.
+        if self.offloaded_expert_ids:
+            self._register_offloaded_bytes_for_memory_reporting(layer)
+
+    def _register_offloaded_bytes_for_memory_reporting(
+        self, layer: torch.nn.Module
+    ) -> None:
+        """Register this layer's offloaded UVM bytes with get_available_gpu_memory.
+
+        Each call accumulates bytes from one MoE layer.  After all layers are
+        processed, the total registered bytes equals the full UVM evictable
+        footprint, and SGLang's memory profiling reflects the correct available
+        GPU memory.
+        """
+        from sglang.srt.utils.common import register_uvm_evictable_memory
+
+        total_bytes = 0
+        for pname in self._expert_param_names:
+            managed: torch.Tensor = getattr(layer, pname)
+            bytes_per_expert = managed.nbytes // self.config.num_local_experts
+            total_bytes += bytes_per_expert * len(self.offloaded_expert_ids)
+
+        if total_bytes > 0:
+            register_uvm_evictable_memory(self.device_id, total_bytes)
+            logger.debug(
+                f"[ExpertOffload] Layer {self.config.layer_idx}: "
+                f"registered {total_bytes / (1 << 20):.1f} MiB offloaded UVM "
+                f"as evictable for memory reporting (device {self.device_id})"
+            )
+
+    def _migrate_param_to_uvm(self, layer: torch.nn.Module, param_name: str) -> None:
+        """Migrate one expert-indexed parameter to managed memory."""
+        cfg = self.config
+
+        full_tensor: torch.Tensor = getattr(layer, param_name)
+        assert (
+            full_tensor.is_contiguous()
+        ), f"Expert param {param_name!r} must be contiguous before UVM migration"
+
+        # Step 1: Allocate managed memory and copy GPU data into it.
+        managed = uvm_copy_from_tensor(full_tensor)
+
+        # Step 2: Apply memory advice to each expert's slice.
+        #   Resident: prefer GPU VRAM (hot path).
+        #   Offloaded: prefer CPU + allow GPU to read-through via PCIe.
+        for eid in self.resident_expert_ids:
+            expert_slice = managed[eid]
+            uvm_advise(expert_slice, ADVISE_SET_PREFERRED_LOCATION, self.device_id)
+            uvm_advise(expert_slice, ADVISE_SET_ACCESSED_BY, self.device_id)
+
+        for eid in self.offloaded_expert_ids:
+            expert_slice = managed[eid]
+            uvm_advise(expert_slice, ADVISE_SET_PREFERRED_LOCATION, CUDA_CPU_DEVICE)
+            uvm_advise(expert_slice, ADVISE_SET_ACCESSED_BY, self.device_id)
+
+        # Step 3: Prefetch resident pages to GPU, offloaded pages to CPU.
+        if self.resident_expert_ids:
+            # Prefetch contiguous resident slices efficiently.
+            # For first_n selection, resident experts are 0..num_resident-1:
+            # a single contiguous prefetch covers the whole range.
+            # For manual selection, we prefetch individually.
+            self._prefetch_experts_to_device(
+                managed, self.resident_expert_ids, self.device_id
+            )
+
+        if self.offloaded_expert_ids:
+            self._prefetch_experts_to_device(
+                managed, self.offloaded_expert_ids, CUDA_CPU_DEVICE
+            )
+
+        # Step 4: Free the original GPU tensor to reclaim VRAM.
+        if hasattr(layer, "_parameters") and param_name in layer._parameters:
+            del layer._parameters[param_name]
+        else:
+            try:
+                delattr(layer, param_name)
+            except AttributeError:
+                pass
+
+        del full_tensor
+        torch.cuda.empty_cache()
+
+        # Step 5: Set managed tensor on the layer (full shape, no slicing).
+        object.__setattr__(layer, param_name, managed)
+
+    def _prefetch_experts_to_device(
+        self,
+        managed: torch.Tensor,
+        expert_ids: List[int],
+        device_id: int,
+    ) -> None:
+        """Issue cudaMemPrefetchAsync for a list of expert IDs.
+
+        Tries to coalesce contiguous ID ranges into a single prefetch call
+        to reduce CUDA API overhead.
+        """
+        if not expert_ids:
+            return
+
+        # Coalesce into contiguous ranges.
+        sorted_ids = sorted(expert_ids)
+        ranges: List[tuple] = []
+        start = sorted_ids[0]
+        end = sorted_ids[0]
+        for eid in sorted_ids[1:]:
+            if eid == end + 1:
+                end = eid
+            else:
+                ranges.append((start, end))
+                start = end = eid
+        ranges.append((start, end))
+
+        for lo, hi in ranges:
+            # managed[lo : hi+1] is a contiguous slice along dim 0.
+            uvm_prefetch_async(
+                managed[lo : hi + 1],
+                device_id,
+                stream=self.prefetch_stream,
+            )
+
+    # ------------------------------------------------------------------
+    # Per-layer adaptive resident selection (warmup-then-readvise)
+    # ------------------------------------------------------------------
+
+    # Minimum batch size to consider a forward pass as real prefill traffic.
+    # Pre-capture warmup and decode use small batch sizes with dummy/uniform
+    # routing -- their data would pollute the frequency distribution.
+    _MIN_TOKENS_FOR_FREQUENCY = 64
+
+    def record_expert_usage(
+        self, topk_ids: torch.Tensor, layer: torch.nn.Module
+    ) -> None:
+        """Record expert routing frequencies from real prefill passes.
+
+        Only counts passes with >= ``_MIN_TOKENS_FOR_FREQUENCY`` tokens to
+        filter out dummy pre-capture warmup runs and single-token decode.
+        After accumulating ``config.warmup_tokens`` routed tokens, computes
+        the optimal per-layer resident set and calls ``cudaMemAdvise``.
+
+        Args:
+            topk_ids: shape ``[num_tokens, top_k]``, expert indices chosen by
+                the router for the current forward pass.
+            layer: the ``FusedMoE`` layer module (needed to access managed
+                tensors for ``cudaMemAdvise``/``cudaMemPrefetchAsync``).
+        """
+        if self._warmup_done or self.config.resident_selection != "frequency":
+            return
+
+        # Skip during CUDA graph capture -- .cpu() is not permitted.
+        if torch.cuda.is_current_stream_capturing():
+            return
+
+        num_tokens = topk_ids.shape[0]
+
+        # Ignore small batches (dummy warmup / decode leak).
+        if num_tokens < self._MIN_TOKENS_FOR_FREQUENCY:
+            return
+
+        # Lazy-init the frequency tensor on first call.
+        if self._expert_freq is None:
+            self._expert_freq = torch.zeros(
+                self.config.num_local_experts, dtype=torch.int64, device="cpu"
+            )
+
+        # Accumulate frequencies on CPU.
+        ids_cpu = topk_ids.detach().reshape(-1).cpu()
+        counts = torch.bincount(ids_cpu, minlength=self.config.num_local_experts)
+        self._expert_freq += counts
+
+        self._warmup_tokens += num_tokens * topk_ids.shape[1]
+        if self._warmup_tokens >= self.config.warmup_tokens:
+            self._readvise_from_frequency(layer)
+
+    def _readvise_from_frequency(self, layer: torch.nn.Module) -> None:
+        """Recompute resident set from frequency data and re-advise UVM pages."""
+        assert self._expert_freq is not None
+        self._warmup_done = True
+
+        num_resident = self.config.num_resident_experts
+        # Top-K most frequently routed experts become the new resident set.
+        _, top_ids = self._expert_freq.topk(num_resident)
+        new_resident_ids = sorted(top_ids.tolist())
+        new_resident_set = set(new_resident_ids)
+
+        old_resident_set = set(self.resident_expert_ids)
+
+        promoted = new_resident_set - old_resident_set
+        demoted = old_resident_set - new_resident_set
+
+        if not promoted and not demoted:
+            logger.info(
+                f"[ExpertOffload] Layer {self.config.layer_idx}: "
+                f"warmup complete, resident set unchanged"
+            )
+            # Free frequency tensor.
+            self._expert_freq = None
+            return
+
+        logger.info(
+            f"[ExpertOffload] Layer {self.config.layer_idx}: "
+            f"readvised {len(promoted)} promoted, {len(demoted)} demoted "
+            f"(new residents: {new_resident_ids})"
+        )
+
+        # Apply cudaMemAdvise + prefetch for each managed parameter.
+        for param_name in self._expert_param_names:
+            managed: torch.Tensor = getattr(layer, param_name)
+
+            # Promote: prefer GPU
+            for eid in promoted:
+                expert_slice = managed[eid]
+                uvm_advise(expert_slice, ADVISE_SET_PREFERRED_LOCATION, self.device_id)
+
+            # Demote: prefer CPU
+            for eid in demoted:
+                expert_slice = managed[eid]
+                uvm_advise(expert_slice, ADVISE_SET_PREFERRED_LOCATION, CUDA_CPU_DEVICE)
+
+            # Prefetch promoted experts to GPU.
+            if promoted:
+                self._prefetch_experts_to_device(
+                    managed, sorted(promoted), self.device_id
+                )
+            # Prefetch demoted experts to CPU.
+            if demoted:
+                self._prefetch_experts_to_device(
+                    managed, sorted(demoted), CUDA_CPU_DEVICE
+                )
+
+        # Wait for prefetch to complete.
+        self.prefetch_stream.synchronize()
+
+        # Update ID lists.
+        self.resident_expert_ids = new_resident_ids
+        self.offloaded_expert_ids = [
+            i for i in range(self.config.num_local_experts) if i not in new_resident_set
+        ]
+
+        # Free frequency tensor.
+        self._expert_freq = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _select_resident_ids(cfg: ExpertOffloadConfig) -> List[int]:
+        num_resident = cfg.num_resident_experts
+        if cfg.resident_selection == "first_n":
+            return list(range(num_resident))
+        elif cfg.resident_selection == "manual" and cfg.resident_expert_ids is not None:
+            ids = list(dict.fromkeys(cfg.resident_expert_ids))  # deduplicate
+            ids = ids[:num_resident]
+            existing = set(ids)
+            for i in range(cfg.num_local_experts):
+                if len(ids) >= num_resident:
+                    break
+                if i not in existing:
+                    ids.append(i)
+                    existing.add(i)
+            return ids[:num_resident]
+        else:
+            return list(range(num_resident))
+
+    @staticmethod
+    def _find_expert_param_names(
+        layer: torch.nn.Module, num_local_experts: int
+    ) -> List[str]:
+        """Find parameter names whose first dimension equals num_local_experts."""
+        names = []
+        for name, param in layer.named_parameters(recurse=False):
+            if (
+                param is not None
+                and param.dim() >= 1
+                and param.shape[0] == num_local_experts
+            ):
+                names.append(name)
+        return names

--- a/python/sglang/srt/layers/moe/expert_offload/manager.py
+++ b/python/sglang/srt/layers/moe/expert_offload/manager.py
@@ -48,6 +48,11 @@ from sglang.srt.layers.moe.expert_offload.uvm import (
     uvm_copy_from_tensor,
     uvm_prefetch_async,
 )
+from sglang.srt.utils.common import (
+    get_current_device_numa_node_cuda,
+    is_numa_available,
+    numa_bind_to_node,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +79,11 @@ class ExpertOffloadManager:
         self._expert_freq: Optional[torch.Tensor] = None
         self._warmup_tokens: int = 0
         self._warmup_done: bool = False
+
+        # Cross-layer prefetch state.
+        self.next_layer_manager: Optional["ExpertOffloadManager"] = None
+        self._prefetch_slices: Optional[List[List[torch.Tensor]]] = None
+        self._hot_offloaded_ids: List[int] = []
 
     # ------------------------------------------------------------------
     # Initialization
@@ -170,6 +180,9 @@ class ExpertOffloadManager:
         ), f"Expert param {param_name!r} must be contiguous before UVM migration"
 
         # Step 1: Allocate managed memory and copy GPU data into it.
+        # Bind to the NUMA node closest to this GPU so that CPU-resident UVM
+        # pages are allocated in local DRAM, avoiding cross-socket PCIe reads.
+        self._bind_numa_for_device()
         managed = uvm_copy_from_tensor(full_tensor)
 
         # Step 2: Apply memory advice to each expert's slice.
@@ -215,6 +228,23 @@ class ExpertOffloadManager:
         # Step 5: Set managed tensor on the layer (full shape, no slicing).
         object.__setattr__(layer, param_name, managed)
 
+    @staticmethod
+    def _coalesce_ids(sorted_ids: List[int]) -> List[tuple]:
+        """Coalesce a sorted list of IDs into contiguous (lo, hi) ranges."""
+        if not sorted_ids:
+            return []
+        ranges: List[tuple] = []
+        start = sorted_ids[0]
+        end = sorted_ids[0]
+        for eid in sorted_ids[1:]:
+            if eid == end + 1:
+                end = eid
+            else:
+                ranges.append((start, end))
+                start = end = eid
+        ranges.append((start, end))
+        return ranges
+
     def _prefetch_experts_to_device(
         self,
         managed: torch.Tensor,
@@ -229,26 +259,98 @@ class ExpertOffloadManager:
         if not expert_ids:
             return
 
-        # Coalesce into contiguous ranges.
-        sorted_ids = sorted(expert_ids)
-        ranges: List[tuple] = []
-        start = sorted_ids[0]
-        end = sorted_ids[0]
-        for eid in sorted_ids[1:]:
-            if eid == end + 1:
-                end = eid
-            else:
-                ranges.append((start, end))
-                start = end = eid
-        ranges.append((start, end))
-
-        for lo, hi in ranges:
+        for lo, hi in self._coalesce_ids(sorted(expert_ids)):
             # managed[lo : hi+1] is a contiguous slice along dim 0.
             uvm_prefetch_async(
                 managed[lo : hi + 1],
                 device_id,
                 stream=self.prefetch_stream,
             )
+
+    # ------------------------------------------------------------------
+    # Cross-layer pipeline prefetch
+    # ------------------------------------------------------------------
+
+    def _select_hot_offloaded_ids(self) -> List[int]:
+        """Select the top-N most frequently hit offloaded experts for prefetch."""
+        n = self.config.prefetch_num
+        if n <= 0 or not self.offloaded_expert_ids:
+            return []
+
+        if self._expert_freq is not None:
+            # Build (freq, eid) pairs for offloaded experts only.
+            freq_pairs = [
+                (self._expert_freq[eid].item(), eid)
+                for eid in self.offloaded_expert_ids
+            ]
+            freq_pairs.sort(key=lambda x: x[0], reverse=True)
+            return sorted([eid for _, eid in freq_pairs[:n]])
+
+        # No frequency data -- take first N from offloaded_expert_ids (sorted).
+        return sorted(self.offloaded_expert_ids[:n])
+
+    def prepare_prefetch_cache(self, layer: torch.nn.Module) -> None:
+        """Pre-compute tensor views for hot offloaded experts to minimize
+        hot-path overhead in trigger_prefetch_for_next_layer().
+
+        Called once from chain_managers() and again from _readvise_from_frequency()
+        when the resident/offloaded sets change.
+        """
+        if self.config.prefetch_num <= 0 or not self.offloaded_expert_ids:
+            self._prefetch_slices = None
+            self._hot_offloaded_ids = []
+            return
+
+        # For frequency mode: if warmup not done and freq data not available,
+        # defer -- will be called again from _readvise_from_frequency().
+        if (
+            self.config.resident_selection == "frequency"
+            and not self._warmup_done
+            and self._expert_freq is None
+        ):
+            self._prefetch_slices = None
+            self._hot_offloaded_ids = []
+            return
+
+        hot_ids = self._select_hot_offloaded_ids()
+        if not hot_ids:
+            self._prefetch_slices = None
+            self._hot_offloaded_ids = []
+            return
+
+        self._hot_offloaded_ids = hot_ids
+        ranges = self._coalesce_ids(hot_ids)
+
+        # For each managed parameter, cache tensor views for the coalesced ranges.
+        self._prefetch_slices = []
+        for param_name in self._expert_param_names:
+            managed: torch.Tensor = getattr(layer, param_name)
+            param_slices = [managed[lo : hi + 1] for lo, hi in ranges]
+            self._prefetch_slices.append(param_slices)
+
+        logger.debug(
+            f"[ExpertOffload] Layer {self.config.layer_idx}: "
+            f"prefetch cache built for {len(hot_ids)} hot offloaded experts "
+            f"({len(ranges)} coalesced ranges)"
+        )
+
+    def trigger_prefetch_for_next_layer(self) -> None:
+        """Issue cudaMemPrefetchAsync for the next layer's hot offloaded experts.
+
+        Called from wrapper.apply() after each MoE kernel. Purely opportunistic:
+        no stream synchronization. If the prefetch wins the race, the next layer's
+        kernel reads at HBM speed; otherwise, PCIe read-through (existing behavior).
+        """
+        next_mgr = self.next_layer_manager
+        if next_mgr is None or next_mgr._prefetch_slices is None:
+            return
+        if torch.cuda.is_current_stream_capturing():
+            return
+        for param_slices in next_mgr._prefetch_slices:
+            for s in param_slices:
+                uvm_prefetch_async(
+                    s, next_mgr.device_id, stream=next_mgr.prefetch_stream
+                )
 
     # ------------------------------------------------------------------
     # Per-layer adaptive resident selection (warmup-then-readvise)
@@ -324,6 +426,8 @@ class ExpertOffloadManager:
                 f"[ExpertOffload] Layer {self.config.layer_idx}: "
                 f"warmup complete, resident set unchanged"
             )
+            # Build prefetch cache before clearing frequency data.
+            self.prepare_prefetch_cache(layer)
             # Free frequency tensor.
             self._expert_freq = None
             return
@@ -368,12 +472,47 @@ class ExpertOffloadManager:
             i for i in range(self.config.num_local_experts) if i not in new_resident_set
         ]
 
+        # Rebuild prefetch cache with new resident/offloaded sets.
+        # Must be done before clearing _expert_freq so frequency data is available.
+        self.prepare_prefetch_cache(layer)
+
         # Free frequency tensor.
         self._expert_freq = None
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    _numa_bound: bool = False
+
+    def _bind_numa_for_device(self) -> None:
+        """Bind the current thread to the NUMA node closest to self.device.
+
+        This ensures that cudaMallocManaged pages whose preferred location is
+        CPU land in DRAM local to the GPU's PCIe root complex, giving full
+        local PCIe bandwidth instead of cross-socket UPI bandwidth.
+        Only performed once per manager instance.
+        """
+        if self._numa_bound:
+            return
+        self._numa_bound = True
+
+        if not is_numa_available():
+            logger.debug("[ExpertOffload] NUMA not available, skipping bind")
+            return
+
+        try:
+            numa_node = get_current_device_numa_node_cuda()
+            numa_bind_to_node(numa_node)
+            logger.info(
+                f"[ExpertOffload] Bound to NUMA node {numa_node} "
+                f"for GPU {self.device_id}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"[ExpertOffload] Failed to bind NUMA node for GPU "
+                f"{self.device_id}: {e}"
+            )
 
     @staticmethod
     def _select_resident_ids(cfg: ExpertOffloadConfig) -> List[int]:

--- a/python/sglang/srt/layers/moe/expert_offload/manager.py
+++ b/python/sglang/srt/layers/moe/expert_offload/manager.py
@@ -80,6 +80,7 @@ class ExpertOffloadManager:
         self._expert_freq: Optional[torch.Tensor] = None
         self._warmup_tokens: int = 0
         self._warmup_done: bool = False
+        self._next_warmup_progress_log: int = 1
 
         # Cross-layer prefetch state.
         self.next_layer_managers: List["ExpertOffloadManager"] = []
@@ -412,38 +413,82 @@ class ExpertOffloadManager:
     # Per-layer adaptive resident selection (warmup-then-readvise)
     # ------------------------------------------------------------------
 
-    # Minimum batch size to consider a forward pass as real prefill traffic.
-    # Pre-capture warmup and decode use small batch sizes with dummy/uniform
-    # routing -- their data would pollute the frequency distribution.
-    _MIN_TOKENS_FOR_FREQUENCY = 64
+    # Frequency warmup is now explicitly driven by target verify traffic.
+    # Verify batches can be as small as a single token and still represent the
+    # decode routing pattern we want to optimize for.
+    _TARGET_VERIFY_MIN_TOKENS_FOR_FREQUENCY = 1
+    _FREQUENCY_FORWARD_MODE = "TARGET_VERIFY"
+    _WARMUP_PROGRESS_LOG_STRIDE = 1024
 
     def record_expert_usage(
-        self, topk_ids: torch.Tensor, layer: torch.nn.Module
+        self,
+        topk_ids: torch.Tensor,
+        layer: torch.nn.Module,
+        forward_mode_name: str,
     ) -> None:
-        """Record expert routing frequencies from real prefill passes.
+        """Record expert routing frequencies from selected target-worker passes.
 
-        Only counts passes with >= ``_MIN_TOKENS_FOR_FREQUENCY`` tokens to
-        filter out dummy pre-capture warmup runs and single-token decode.
-        After accumulating ``config.warmup_tokens`` routed tokens, computes
-        the optimal per-layer resident set and calls ``cudaMemAdvise``.
+        Frequency warmup is intentionally limited to target verify traffic so
+        the final resident set reflects speculative decode verification rather
+        than prefill routing.
 
         Args:
             topk_ids: shape ``[num_tokens, top_k]``, expert indices chosen by
                 the router for the current forward pass.
             layer: the ``FusedMoE`` layer module (needed to access managed
                 tensors for ``cudaMemAdvise``/``cudaMemPrefetchAsync``).
+            forward_mode_name: name of the forward mode that produced
+                ``topk_ids``.
         """
-        if self._warmup_done or self.config.resident_selection != "frequency":
+        if not self._should_record_expert_usage(
+            forward_mode_name=forward_mode_name,
+            num_tokens=int(topk_ids.shape[0]),
+        ):
             return
 
-        # Skip during CUDA graph capture -- .cpu() is not permitted.
-        if torch.cuda.is_current_stream_capturing():
+        flat_ids = topk_ids.detach().reshape(-1)
+        flat_ids = flat_ids[
+            (flat_ids >= 0) & (flat_ids < self.config.num_local_experts)
+        ]
+        if flat_ids.numel() == 0:
             return
 
-        num_tokens = topk_ids.shape[0]
+        counts = torch.bincount(
+            flat_ids.to(dtype=torch.int64, device="cpu"),
+            minlength=self.config.num_local_experts,
+        )
+        self.record_expert_usage_counts(
+            counts=counts,
+            num_tokens=int(topk_ids.shape[0]),
+            layer=layer,
+            forward_mode_name=forward_mode_name,
+        )
 
-        # Ignore small batches (dummy warmup / decode leak).
-        if num_tokens < self._MIN_TOKENS_FOR_FREQUENCY:
+    def record_expert_usage_counts(
+        self,
+        counts: torch.Tensor,
+        num_tokens: int,
+        layer: torch.nn.Module,
+        forward_mode_name: str,
+    ) -> None:
+        """Record pre-aggregated expert routing frequencies for warmup."""
+        if not self._should_record_expert_usage(
+            forward_mode_name=forward_mode_name,
+            num_tokens=num_tokens,
+        ):
+            return
+
+        counts_cpu = counts.to(dtype=torch.int64, device="cpu")
+        if counts_cpu.numel() < self.config.num_local_experts:
+            padded = torch.zeros(
+                self.config.num_local_experts, dtype=torch.int64, device="cpu"
+            )
+            padded[: counts_cpu.numel()] = counts_cpu
+            counts_cpu = padded
+        elif counts_cpu.numel() > self.config.num_local_experts:
+            counts_cpu = counts_cpu[: self.config.num_local_experts]
+
+        if int(counts_cpu.sum().item()) == 0:
             return
 
         # Lazy-init the frequency tensor on first call.
@@ -452,14 +497,75 @@ class ExpertOffloadManager:
                 self.config.num_local_experts, dtype=torch.int64, device="cpu"
             )
 
-        # Accumulate frequencies on CPU.
-        ids_cpu = topk_ids.detach().reshape(-1).cpu()
-        counts = torch.bincount(ids_cpu, minlength=self.config.num_local_experts)
-        self._expert_freq += counts
-
-        self._warmup_tokens += num_tokens * topk_ids.shape[1]
+        self._expert_freq += counts_cpu
+        added_routed_tokens = int(counts_cpu.sum().item())
+        previous_warmup_tokens = self._warmup_tokens
+        self._warmup_tokens += added_routed_tokens
+        self._maybe_log_frequency_progress(
+            num_tokens=num_tokens,
+            added_routed_tokens=added_routed_tokens,
+            previous_warmup_tokens=previous_warmup_tokens,
+            top_counts=counts_cpu,
+        )
         if self._warmup_tokens >= self.config.warmup_tokens:
             self._readvise_from_frequency(layer)
+
+    def _should_record_expert_usage(
+        self, forward_mode_name: str, num_tokens: int
+    ) -> bool:
+        if self._warmup_done or self.config.resident_selection != "frequency":
+            return False
+        if forward_mode_name != self._FREQUENCY_FORWARD_MODE:
+            return False
+        return num_tokens >= self._TARGET_VERIFY_MIN_TOKENS_FOR_FREQUENCY
+
+    def _maybe_log_frequency_progress(
+        self,
+        num_tokens: int,
+        added_routed_tokens: int,
+        previous_warmup_tokens: int,
+        top_counts: torch.Tensor,
+    ) -> None:
+        if not self.config.decode_debug_log:
+            return
+        if added_routed_tokens <= 0:
+            return
+
+        should_log = previous_warmup_tokens == 0
+        while self._warmup_tokens >= self._next_warmup_progress_log:
+            should_log = True
+            self._next_warmup_progress_log += self._WARMUP_PROGRESS_LOG_STRIDE
+        if self._warmup_tokens >= self.config.warmup_tokens:
+            should_log = True
+        if not should_log:
+            return
+
+        nonzero_ids = torch.nonzero(top_counts > 0, as_tuple=False).flatten()
+        top_pairs: list[tuple[int, int]] = []
+        if nonzero_ids.numel() > 0:
+            pairs = [
+                (int(top_counts[eid].item()), int(eid.item())) for eid in nonzero_ids
+            ]
+            pairs.sort(key=lambda item: (-item[0], item[1]))
+            top_pairs = [(eid, count) for count, eid in pairs[:4]]
+
+        top_str = (
+            ", ".join(f"{eid}({count})" for eid, count in top_pairs)
+            if top_pairs
+            else "-"
+        )
+        logger.info(
+            "%s Layer %s: frequency warmup sample mode=%s verify_tokens=%s "
+            "added_routed_tokens=%s warmup_progress=%s/%s top=[%s]",
+            self.config.log_prefix,
+            self.config.layer_idx,
+            self._FREQUENCY_FORWARD_MODE,
+            num_tokens,
+            added_routed_tokens,
+            self._warmup_tokens,
+            self.config.warmup_tokens,
+            top_str,
+        )
 
     def _readvise_from_frequency(self, layer: torch.nn.Module) -> None:
         """Recompute resident set from frequency data and re-advise UVM pages."""
@@ -476,6 +582,14 @@ class ExpertOffloadManager:
 
         promoted = new_resident_set - old_resident_set
         demoted = old_resident_set - new_resident_set
+
+        logger.info(
+            "%s Layer %s: frequency warmup triggered readvise at %s/%s routed tokens",
+            self.config.log_prefix,
+            self.config.layer_idx,
+            self._warmup_tokens,
+            self.config.warmup_tokens,
+        )
 
         if not promoted and not demoted:
             logger.info(
@@ -502,15 +616,11 @@ class ExpertOffloadManager:
 
             # Promote: prefer GPU
             for eid in promoted:
-                uvm_advise(
-                    managed[eid], ADVISE_SET_PREFERRED_LOCATION, self.device_id
-                )
+                uvm_advise(managed[eid], ADVISE_SET_PREFERRED_LOCATION, self.device_id)
 
             # Demote: prefer CPU
             for eid in demoted:
-                uvm_advise(
-                    managed[eid], ADVISE_SET_PREFERRED_LOCATION, CUDA_CPU_DEVICE
-                )
+                uvm_advise(managed[eid], ADVISE_SET_PREFERRED_LOCATION, CUDA_CPU_DEVICE)
 
             # Prefetch promoted experts to GPU.
             if promoted:

--- a/python/sglang/srt/layers/moe/expert_offload/manager.py
+++ b/python/sglang/srt/layers/moe/expert_offload/manager.py
@@ -120,7 +120,7 @@ class ExpertOffloadManager:
         ]
 
         logger.debug(
-            f"[ExpertOffload] Layer {cfg.layer_idx}: "
+            f"{cfg.log_prefix} Layer {cfg.layer_idx}: "
             f"{len(self.resident_expert_ids)} resident, "
             f"{len(self.offloaded_expert_ids)} offloaded (UVM)"
         )
@@ -165,7 +165,7 @@ class ExpertOffloadManager:
         if total_bytes > 0:
             register_uvm_evictable_memory(self.device_id, total_bytes)
             logger.debug(
-                f"[ExpertOffload] Layer {self.config.layer_idx}: "
+                f"{self.config.log_prefix} Layer {self.config.layer_idx}: "
                 f"registered {total_bytes / (1 << 20):.1f} MiB offloaded UVM "
                 f"as evictable for memory reporting (device {self.device_id})"
             )
@@ -329,7 +329,7 @@ class ExpertOffloadManager:
             self._prefetch_slices.append(param_slices)
 
         logger.debug(
-            f"[ExpertOffload] Layer {self.config.layer_idx}: "
+            f"{self.config.log_prefix} Layer {self.config.layer_idx}: "
             f"prefetch cache built for {len(hot_ids)} hot offloaded experts "
             f"({len(ranges)} coalesced ranges)"
         )
@@ -479,7 +479,7 @@ class ExpertOffloadManager:
 
         if not promoted and not demoted:
             logger.info(
-                f"[ExpertOffload] Layer {self.config.layer_idx}: "
+                f"{self.config.log_prefix} Layer {self.config.layer_idx}: "
                 f"warmup complete, resident set unchanged"
             )
             # Build prefetch cache before clearing frequency data.
@@ -489,7 +489,7 @@ class ExpertOffloadManager:
             return
 
         logger.info(
-            f"[ExpertOffload] Layer {self.config.layer_idx}: "
+            f"{self.config.log_prefix} Layer {self.config.layer_idx}: "
             f"readvised {len(promoted)} promoted, {len(demoted)} demoted "
             f"(new residents: {new_resident_ids})"
         )
@@ -558,19 +558,19 @@ class ExpertOffloadManager:
         ExpertOffloadManager._numa_bound = True
 
         if not is_numa_available():
-            logger.debug("[ExpertOffload] NUMA not available, skipping bind")
+            logger.debug("%s NUMA not available, skipping bind", self.config.log_prefix)
             return
 
         try:
             numa_node = get_current_device_numa_node_cuda()
             numa_bind_to_node(numa_node)
             logger.info(
-                f"[ExpertOffload] Bound to NUMA node {numa_node} "
+                f"{self.config.log_prefix} Bound to NUMA node {numa_node} "
                 f"for GPU {self.device_id}"
             )
         except Exception as e:
             logger.warning(
-                f"[ExpertOffload] Failed to bind NUMA node for GPU "
+                f"{self.config.log_prefix} Failed to bind NUMA node for GPU "
                 f"{self.device_id}: {e}"
             )
 

--- a/python/sglang/srt/layers/moe/expert_offload/manager.py
+++ b/python/sglang/srt/layers/moe/expert_offload/manager.py
@@ -43,6 +43,7 @@ from sglang.srt.layers.moe.expert_offload.config import ExpertOffloadConfig
 from sglang.srt.layers.moe.expert_offload.uvm import (
     ADVISE_SET_ACCESSED_BY,
     ADVISE_SET_PREFERRED_LOCATION,
+    ADVISE_UNSET_ACCESSED_BY,
     CUDA_CPU_DEVICE,
     uvm_advise,
     uvm_copy_from_tensor,
@@ -81,7 +82,7 @@ class ExpertOffloadManager:
         self._warmup_done: bool = False
 
         # Cross-layer prefetch state.
-        self.next_layer_manager: Optional["ExpertOffloadManager"] = None
+        self.next_layer_managers: List["ExpertOffloadManager"] = []
         self._prefetch_slices: Optional[List[List[torch.Tensor]]] = None
         self._hot_offloaded_ids: List[int] = []
 
@@ -105,6 +106,11 @@ class ExpertOffloadManager:
         """
         cfg = self.config
         num_local = cfg.num_local_experts
+
+        # Set UVM headroom once (idempotent).
+        from sglang.srt.utils.common import set_uvm_memory_headroom
+
+        set_uvm_memory_headroom(cfg.memory_headroom_gib)
 
         # 1. Choose resident expert IDs.
         self.resident_expert_ids = self._select_resident_ids(cfg)
@@ -131,16 +137,10 @@ class ExpertOffloadManager:
 
         # 5. Register offloaded bytes with SGLang's memory reporting.
         #
-        # On PCIe-attached discrete GPUs, cudaMemPrefetchAsync(->CPU) may not
-        # immediately return physical GPU pages to the free pool -- the UVM
-        # driver keeps them cached until a regular cudaMalloc triggers eviction.
-        # This causes torch.cuda.mem_get_info() to under-report available memory,
-        # breaking SGLang's init_memory_pool check.
-        #
-        # Instead of forcing a slow pressure-based eviction here, we register
-        # the offloaded bytes with get_available_gpu_memory() so that the check
-        # sees the correct "effective" available memory.  The actual eviction
-        # happens on-demand when the KV-cache allocator issues cudaMalloc calls.
+        # UVM-managed offloaded pages are evictable on-demand by the CUDA
+        # driver when regular cudaMalloc requests exceed free physical pages.
+        # Without this registration, SGLang would see too little available
+        # memory and refuse to allocate enough KV cache.
         if self.offloaded_expert_ids:
             self._register_offloaded_bytes_for_memory_reporting(layer)
 
@@ -291,7 +291,7 @@ class ExpertOffloadManager:
 
     def prepare_prefetch_cache(self, layer: torch.nn.Module) -> None:
         """Pre-compute tensor views for hot offloaded experts to minimize
-        hot-path overhead in trigger_prefetch_for_next_layer().
+        hot-path overhead in trigger_prefetch_for_next_layers().
 
         Called once from chain_managers() and again from _readvise_from_frequency()
         when the resident/offloaded sets change.
@@ -334,23 +334,79 @@ class ExpertOffloadManager:
             f"({len(ranges)} coalesced ranges)"
         )
 
-    def trigger_prefetch_for_next_layer(self) -> None:
-        """Issue cudaMemPrefetchAsync for the next layer's hot offloaded experts.
+    def trigger_prefetch_for_next_layers(self) -> None:
+        """Issue cudaMemPrefetchAsync for upcoming layers' hot offloaded experts.
 
-        Called from wrapper.apply() after each MoE kernel. Purely opportunistic:
-        no stream synchronization. If the prefetch wins the race, the next layer's
-        kernel reads at HBM speed; otherwise, PCIe read-through (existing behavior).
+        Called from wrapper.apply() after each MoE kernel. Iterates over
+        ``self.next_layer_managers`` (up to ``prefetch_depth`` managers) and
+        issues prefetch for each. Purely opportunistic: no stream
+        synchronization. If the prefetch wins the race, the target layer's
+        kernel reads at HBM speed; otherwise, PCIe read-through (existing
+        behavior).
         """
-        next_mgr = self.next_layer_manager
-        if next_mgr is None or next_mgr._prefetch_slices is None:
+        if not self.next_layer_managers:
             return
         if torch.cuda.is_current_stream_capturing():
             return
-        for param_slices in next_mgr._prefetch_slices:
-            for s in param_slices:
-                uvm_prefetch_async(
-                    s, next_mgr.device_id, stream=next_mgr.prefetch_stream
-                )
+        for next_mgr in self.next_layer_managers:
+            if next_mgr._prefetch_slices is None:
+                continue
+            for param_slices in next_mgr._prefetch_slices:
+                for s in param_slices:
+                    uvm_prefetch_async(
+                        s, next_mgr.device_id, stream=next_mgr.prefetch_stream
+                    )
+
+    # ------------------------------------------------------------------
+    # Per-prefill UVM page eviction control
+    # ------------------------------------------------------------------
+
+    def unset_accessed_by_for_offloaded(self, layer: torch.nn.Module) -> None:
+        """Remove GPU direct mapping for offloaded expert pages.
+
+        The ACCESSED_BY advice creates a persistent GPU page table mapping
+        that prevents the CUDA driver from evicting pages even under memory
+        pressure.  Unsetting it before prefill allows on-demand eviction
+        when cudaMalloc needs space for prefill workspace.
+
+        Expert weights are read-only, so this is safe -- no dirty pages to
+        flush.  Pages will fault back into GPU on the next decode access.
+        """
+        if not self.offloaded_expert_ids:
+            return
+        for param_name in self._expert_param_names:
+            managed: torch.Tensor = getattr(layer, param_name)
+            for eid in self.offloaded_expert_ids:
+                uvm_advise(managed[eid], ADVISE_UNSET_ACCESSED_BY, self.device_id)
+
+    def restore_accessed_by_for_offloaded(self, layer: torch.nn.Module) -> None:
+        """Re-enable GPU direct mapping for offloaded expert pages.
+
+        Called after prefill completes to restore PCIe read-through access
+        for decode.  This avoids page fault overhead during latency-sensitive
+        CUDA graph replay.
+        """
+        if not self.offloaded_expert_ids:
+            return
+        for param_name in self._expert_param_names:
+            managed: torch.Tensor = getattr(layer, param_name)
+            for eid in self.offloaded_expert_ids:
+                uvm_advise(managed[eid], ADVISE_SET_ACCESSED_BY, self.device_id)
+
+    def reset_offloaded_pages_to_cpu(self, layer: torch.nn.Module) -> None:
+        """Prefetch all offloaded expert pages back to CPU.
+
+        Called before each new prefill to clear pages that migrated to GPU
+        via page faults during previous forward passes.  Prevents GPU memory
+        accumulation that causes page thrashing when switching requests.
+        """
+        if not self.offloaded_expert_ids:
+            return
+        for param_name in self._expert_param_names:
+            managed: torch.Tensor = getattr(layer, param_name)
+            self._prefetch_experts_to_device(
+                managed, self.offloaded_expert_ids, CUDA_CPU_DEVICE
+            )
 
     # ------------------------------------------------------------------
     # Per-layer adaptive resident selection (warmup-then-readvise)
@@ -439,18 +495,22 @@ class ExpertOffloadManager:
         )
 
         # Apply cudaMemAdvise + prefetch for each managed parameter.
+        # This runs only once (first request's warmup), so the synchronous
+        # uvm_advise cost is acceptable.
         for param_name in self._expert_param_names:
             managed: torch.Tensor = getattr(layer, param_name)
 
             # Promote: prefer GPU
             for eid in promoted:
-                expert_slice = managed[eid]
-                uvm_advise(expert_slice, ADVISE_SET_PREFERRED_LOCATION, self.device_id)
+                uvm_advise(
+                    managed[eid], ADVISE_SET_PREFERRED_LOCATION, self.device_id
+                )
 
             # Demote: prefer CPU
             for eid in demoted:
-                expert_slice = managed[eid]
-                uvm_advise(expert_slice, ADVISE_SET_PREFERRED_LOCATION, CUDA_CPU_DEVICE)
+                uvm_advise(
+                    managed[eid], ADVISE_SET_PREFERRED_LOCATION, CUDA_CPU_DEVICE
+                )
 
             # Prefetch promoted experts to GPU.
             if promoted:
@@ -493,9 +553,9 @@ class ExpertOffloadManager:
         local PCIe bandwidth instead of cross-socket UPI bandwidth.
         Only performed once per manager instance.
         """
-        if self._numa_bound:
+        if ExpertOffloadManager._numa_bound:
             return
-        self._numa_bound = True
+        ExpertOffloadManager._numa_bound = True
 
         if not is_numa_available():
             logger.debug("[ExpertOffload] NUMA not available, skipping bind")

--- a/python/sglang/srt/layers/moe/expert_offload/uvm.py
+++ b/python/sglang/srt/layers/moe/expert_offload/uvm.py
@@ -1,0 +1,115 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Python wrapper for the expert-offload CUDA UVM extension (uvm_ops.cu).
+
+The extension is compiled JIT via torch.utils.cpp_extension.load() on first
+use, so no separate build step is required.
+
+Public API
+----------
+uvm_copy_from_tensor(src)
+    Allocate managed memory with the same shape/dtype as the GPU tensor `src`,
+    copy its data into it, and return the new managed CUDA tensor.
+
+uvm_advise(tensor, advice, device_id)
+    Call cudaMemAdvise on `tensor`.  Use the ADVISE_* constants below.
+    Pass CUDA_CPU_DEVICE (-1) as device_id to address the CPU.
+
+uvm_prefetch_async(tensor, device_id, stream=None)
+    Call cudaMemPrefetchAsync on `tensor`.  Migrates pages to `device_id`
+    (or to CPU when device_id == CUDA_CPU_DEVICE).  Defaults to the current
+    CUDA stream if `stream` is None.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import torch
+
+# ---------------------------------------------------------------------------
+# cudaMemoryAdvise enum values (from cuda_runtime_api.h)
+# ---------------------------------------------------------------------------
+ADVISE_SET_PREFERRED_LOCATION = 3  # cudaMemAdviseSetPreferredLocation
+ADVISE_SET_ACCESSED_BY = 5  # cudaMemAdviseSetAccessedBy
+
+# cudaCpuDeviceId -- pass as device_id to target the CPU
+CUDA_CPU_DEVICE: int = -1
+
+# ---------------------------------------------------------------------------
+# JIT extension loading
+# ---------------------------------------------------------------------------
+_ext = None
+
+
+def _get_ext():
+    global _ext
+    if _ext is None:
+        from torch.utils.cpp_extension import load as cpp_load
+
+        src_path = os.path.join(os.path.dirname(__file__), "uvm_ops.cu")
+        _ext = cpp_load(
+            name="sglang_expert_uvm",
+            sources=[src_path],
+            extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
+            verbose=False,
+        )
+    return _ext
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def uvm_copy_from_tensor(src: torch.Tensor) -> torch.Tensor:
+    """Allocate managed memory and copy *src* (a GPU tensor) into it.
+
+    Returns a new CUDA tensor backed by `cudaMallocManaged`.  The allocation
+    is freed automatically when the tensor's reference count reaches zero.
+    """
+    return _get_ext().uvm_copy_from_tensor(src)
+
+
+def uvm_advise(tensor: torch.Tensor, advice: int, device_id: int) -> None:
+    """Apply ``cudaMemAdvise`` to *tensor* (must be contiguous).
+
+    Parameters
+    ----------
+    tensor    : a contiguous (possibly sliced) managed-memory tensor.
+    advice    : one of the ADVISE_* constants defined in this module.
+    device_id : GPU ordinal, or CUDA_CPU_DEVICE (-1) to target the CPU.
+    """
+    _get_ext().uvm_advise(tensor, advice, device_id)
+
+
+def uvm_prefetch_async(
+    tensor: torch.Tensor,
+    device_id: int,
+    stream: Optional[torch.cuda.Stream] = None,
+) -> None:
+    """Asynchronously prefetch *tensor* pages to *device_id*.
+
+    Parameters
+    ----------
+    tensor    : a contiguous managed-memory tensor.
+    device_id : GPU ordinal to migrate pages to, or CUDA_CPU_DEVICE to
+                migrate back to CPU DRAM.
+    stream    : CUDA stream to enqueue the prefetch on.  Defaults to the
+                current stream.
+    """
+    if stream is None:
+        stream = torch.cuda.current_stream()
+    _get_ext().uvm_prefetch_async(tensor, device_id, stream.cuda_stream)

--- a/python/sglang/srt/layers/moe/expert_offload/uvm.py
+++ b/python/sglang/srt/layers/moe/expert_offload/uvm.py
@@ -44,6 +44,7 @@ import torch
 # ---------------------------------------------------------------------------
 ADVISE_SET_PREFERRED_LOCATION = 3  # cudaMemAdviseSetPreferredLocation
 ADVISE_SET_ACCESSED_BY = 5  # cudaMemAdviseSetAccessedBy
+ADVISE_UNSET_ACCESSED_BY = 6  # cudaMemAdviseUnsetAccessedBy
 
 # cudaCpuDeviceId -- pass as device_id to target the CPU
 CUDA_CPU_DEVICE: int = -1

--- a/python/sglang/srt/layers/moe/expert_offload/uvm_ops.cu
+++ b/python/sglang/srt/layers/moe/expert_offload/uvm_ops.cu
@@ -1,0 +1,111 @@
+/*
+ * CUDA Unified Memory helpers for expert weight offloading.
+ *
+ * Exposes three operations that are not available in PyTorch's Python API:
+ *   uvm_copy_from_tensor  – allocate managed memory and copy a GPU tensor into
+ * it uvm_advise            – cudaMemAdvise on a tensor (or a contiguous slice)
+ *   uvm_prefetch_async    – cudaMemPrefetchAsync on a tensor
+ *
+ * Built JIT via torch.utils.cpp_extension.load() on first import of uvm.py.
+ */
+
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+#define CUDA_CHECK(call)                                                       \
+  do {                                                                         \
+    cudaError_t _err = (call);                                                 \
+    TORCH_CHECK(_err == cudaSuccess, "CUDA error in " #call ": ",              \
+                cudaGetErrorString(_err));                                     \
+  } while (0)
+
+// ---------------------------------------------------------------------------
+// uvm_copy_from_tensor
+//
+// Allocates managed memory (cudaMallocManaged) with the same shape, dtype,
+// and device as `src`, copies src's data into it via a device-to-device
+// cudaMemcpy, and returns a new CUDA tensor backed by the managed allocation.
+//
+// The returned tensor has a custom deleter (cudaFree) so it is automatically
+// freed when its reference count reaches zero.
+// ---------------------------------------------------------------------------
+torch::Tensor uvm_copy_from_tensor(const torch::Tensor &src) {
+  TORCH_CHECK(src.is_cuda(), "uvm_copy_from_tensor: src must be a CUDA tensor");
+  TORCH_CHECK(src.is_contiguous(),
+              "uvm_copy_from_tensor: src must be contiguous");
+
+  int device_id = static_cast<int>(src.device().index());
+  at::cuda::CUDAGuard guard(device_id);
+
+  int64_t nbytes = src.nbytes();
+  void *ptr = nullptr;
+  CUDA_CHECK(cudaMallocManaged(&ptr, static_cast<size_t>(nbytes),
+                               cudaMemAttachGlobal));
+
+  // Device → managed (managed is device-accessible immediately after alloc)
+  CUDA_CHECK(cudaMemcpy(ptr, src.data_ptr(), static_cast<size_t>(nbytes),
+                        cudaMemcpyDeviceToDevice));
+
+  // Wrap the raw managed pointer in a PyTorch CUDA tensor.
+  // The lambda deleter calls cudaFree when the tensor storage is freed.
+  auto deleter = [](void *p) { cudaFree(p); };
+  c10::DataPtr data_ptr(ptr, ptr, deleter,
+                        c10::Device(c10::DeviceType::CUDA, device_id));
+
+  auto storage =
+      c10::Storage(c10::Storage::use_byte_size_t(), nbytes, std::move(data_ptr),
+                   /*allocator=*/nullptr,
+                   /*resizable=*/false);
+
+  // Build a TensorImpl with the same dtype and contiguous strides.
+  auto tensor = at::detail::make_tensor<at::TensorImpl>(
+      std::move(storage), c10::DispatchKeySet(c10::DispatchKey::CUDA),
+      src.dtype());
+
+  at::TensorImpl *impl = tensor.unsafeGetTensorImpl();
+  impl->set_sizes_contiguous(src.sizes());
+
+  return tensor;
+}
+
+// ---------------------------------------------------------------------------
+// uvm_advise
+//
+// Wrapper around cudaMemAdvise. `advice` should be one of the
+// cudaMemoryAdvise enum values (passed as int from Python).
+// `device_id` = -1 means cudaCpuDeviceId (CPU).
+// ---------------------------------------------------------------------------
+void uvm_advise(const torch::Tensor &t, int advice, int device_id) {
+  TORCH_CHECK(t.is_contiguous(), "uvm_advise: tensor must be contiguous");
+  CUDA_CHECK(cudaMemAdvise(
+      t.data_ptr(), static_cast<size_t>(t.nbytes()),
+      static_cast<cudaMemoryAdvise>(advice),
+      device_id)); // cudaCpuDeviceId == -1 (0xFFFFFFFF) — matches the CUDA API
+}
+
+// ---------------------------------------------------------------------------
+// uvm_prefetch_async
+//
+// Wrapper around cudaMemPrefetchAsync.
+// `device_id` = -1 migrates pages to CPU (cudaCpuDeviceId).
+// `stream_ptr` is the raw cudaStream_t handle cast to int64.
+// ---------------------------------------------------------------------------
+void uvm_prefetch_async(const torch::Tensor &t, int device_id,
+                        int64_t stream_ptr) {
+  TORCH_CHECK(t.is_contiguous(),
+              "uvm_prefetch_async: tensor must be contiguous");
+  cudaStream_t stream =
+      reinterpret_cast<cudaStream_t>(static_cast<intptr_t>(stream_ptr));
+  CUDA_CHECK(cudaMemPrefetchAsync(t.data_ptr(), static_cast<size_t>(t.nbytes()),
+                                  device_id, stream));
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("uvm_copy_from_tensor", &uvm_copy_from_tensor,
+        "Allocate managed memory and copy a GPU tensor into it");
+  m.def("uvm_advise", &uvm_advise,
+        "Apply cudaMemAdvise to a tensor (device_id=-1 means CPU)");
+  m.def("uvm_prefetch_async", &uvm_prefetch_async,
+        "cudaMemPrefetchAsync on a tensor (device_id=-1 means CPU)");
+}

--- a/python/sglang/srt/layers/moe/expert_offload/wrapper.py
+++ b/python/sglang/srt/layers/moe/expert_offload/wrapper.py
@@ -1,0 +1,158 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""ExpertOffloadWrapperMethod: wraps a GPU FusedMoEMethod with UVM expert offloading.
+
+UVM design
+----------
+Expert weights are stored in CUDA Unified Memory (cudaMallocManaged).
+Resident experts are advised PREFER_GPU (pages stay in VRAM).
+Offloaded experts are advised PREFER_CPU + ACCESSED_BY_GPU (pages live in CPU
+DRAM; the GPU reads them via PCIe read-through without a page fault interrupt).
+
+No static/dynamic split.  No ID remapping.  No assembly buffer.  No LRU cache.
+UVM is fully transparent to CUDA graphs -- kernels are recorded during capture,
+not executed, so page placement is irrelevant at capture time.  During replay the
+GPU accesses each expert at whichever bandwidth tier its pages are currently in.
+
+Mutually exclusive with KTransformers (--kt-weight-path).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.moe.expert_offload.config import ExpertOffloadConfig
+from sglang.srt.layers.moe.expert_offload.manager import ExpertOffloadManager
+from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
+
+logger = logging.getLogger(__name__)
+
+
+class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
+    """Wraps a GPU FusedMoEMethodBase with UVM-based expert weight offloading.
+
+    Expert weights are stored in CUDA Unified Memory:
+      - Resident experts  -> PREFER_GPU + ACCESSED_BY_GPU (VRAM, full bandwidth)
+      - Offloaded experts -> PREFER_CPU + ACCESSED_BY_GPU (CPU DRAM, PCIe read-through)
+
+    The MoE kernel indexes the full managed tensor directly -- no ID remapping,
+    no assembly buffer, no LRU cache.  UVM handles correctness transparently.
+
+    Mutually exclusive with KTransformers (KTEPWrapperMethod).
+    """
+
+    def __init__(
+        self,
+        gpu_method: FusedMoEMethodBase,
+        config: ExpertOffloadConfig,
+    ):
+        super().__init__()
+        self.gpu_method = gpu_method
+        self.config = config
+        self.manager: Optional[ExpertOffloadManager] = None
+
+    # ------------------------------------------------------------------
+    # FusedMoEMethodBase interface
+    # ------------------------------------------------------------------
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        """Delegate weight creation to the wrapped GPU method."""
+        self.gpu_method.create_weights(
+            layer=layer,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            params_dtype=params_dtype,
+            **extra_weight_attrs,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        """Initialise UVM expert offloading after checkpoint weights are loaded.
+
+        1. Calls gpu_method.process_weights_after_loading (e.g. FP8 scale folding).
+        2. Creates ExpertOffloadManager and migrates expert tensors to managed memory.
+           Resident experts: PREFER_GPU + ACCESSED_BY_GPU (stay in VRAM).
+           Offloaded experts: PREFER_CPU + ACCESSED_BY_GPU (PCIe read-through).
+        3. layer.num_local_experts is NOT modified -- the kernel indexes the full tensor.
+        """
+        # First, let the wrapped method do its own post-load processing.
+        if hasattr(self.gpu_method, "process_weights_after_loading"):
+            self.gpu_method.process_weights_after_loading(layer)
+
+        # Determine the device for UVM operations.
+        device = next(
+            (p.device for p in layer.parameters() if p.device.type == "cuda"), None
+        )
+        if device is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+
+        # Create manager and migrate weights to UVM.
+        self.manager = ExpertOffloadManager(self.config, device)
+        self.manager.initialize_from_weights(layer)
+
+        logger.info(
+            f"[ExpertOffload] Layer {self.config.layer_idx}: "
+            f"{self.config.num_resident_experts}/{self.config.num_local_experts} resident "
+            f"({self.config.num_offloaded_experts} offloaded via UVM)"
+        )
+
+    def create_moe_runner(self, layer: torch.nn.Module, moe_runner_config) -> None:
+        """Delegate runner creation to the wrapped GPU method.
+
+        With UVM, layer.num_local_experts is never overridden -- the full managed
+        tensor is always indexed directly by the kernel.  No override needed here.
+        """
+        self.gpu_method.create_moe_runner(layer, moe_runner_config)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        dispatch_output: "DispatchOutput",
+    ) -> "CombineInput":
+        """Apply the MoE layer with UVM-backed expert weights.
+
+        UVM handles expert access transparently -- no static/dynamic split,
+        no ID remapping, no assembly buffer.  Works identically during:
+          - Prefill (eager): offloaded experts read via PCIe (~64 GB/s).
+          - Decode (CUDA graph capture): kernels are recorded, not executed.
+          - Decode (CUDA graph replay): resident -> VRAM, offloaded -> PCIe.
+        Full correctness in all phases.
+        """
+        return self.gpu_method.apply(layer, dispatch_output)
+
+    # ------------------------------------------------------------------
+    # Transparent attribute delegation
+    # ------------------------------------------------------------------
+
+    def __getattr__(self, name: str):
+        """Delegate unknown attribute access to the wrapped GPU method."""
+        if name in ("gpu_method", "config", "manager"):
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
+        return getattr(self.gpu_method, name)

--- a/python/sglang/srt/layers/moe/expert_offload/wrapper.py
+++ b/python/sglang/srt/layers/moe/expert_offload/wrapper.py
@@ -148,15 +148,60 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
           - Decode (CUDA graph replay): resident -> VRAM, offloaded -> PCIe.
         Full correctness in all phases.
         """
+        import time
+
+        import sglang.srt.layers.moe.expert_offload as _eo_mod
+
+        # Log entry into each MoE layer during the first prefill after reset.
+        # This lets us see exactly which layer the kernel hangs on.
+        tracing = _eo_mod._tracing_prefill
+        if tracing and self.manager is not None:
+            layer_idx = self.manager.config.layer_idx
+            num_tokens = dispatch_output.hidden_states.shape[0] if hasattr(dispatch_output, 'hidden_states') else -1
+            logger.info(
+                f"[ExpertOffload] Layer {layer_idx}: entering MoE kernel "
+                f"(tokens={num_tokens})"
+            )
+
+        t0 = time.monotonic()
         result = self.gpu_method.apply(layer, dispatch_output)
+        elapsed = time.monotonic() - t0
 
         if self.manager is not None:
+            if tracing or elapsed > 1.0:
+                logger.info(
+                    f"[ExpertOffload] Layer {self.manager.config.layer_idx}: "
+                    f"MoE kernel done in {elapsed:.3f}s"
+                )
+
+            # After the last MoE layer: flush the GPU stream so all queued
+            # MoE kernels complete and their UVM page references are released.
+            # Without this, the post-MoE operations (LM head, NCCL) can't
+            # allocate workspace because the driver can't evict pages that are
+            # still referenced by in-flight kernels on the stream.
+            is_last_moe = (
+                self.manager.config.layer_idx
+                == _eo_mod._all_managers[-1][0].config.layer_idx
+            )
+            if is_last_moe and not torch.cuda.is_current_stream_capturing():
+                torch.cuda.synchronize()
+                if tracing:
+                    free, total = torch.cuda.mem_get_info()
+                    logger.info(
+                        f"[ExpertOffload] Post-MoE sync done. "
+                        f"GPU mem: {free / (1 << 30):.2f} GiB free"
+                    )
+
+            # Clear tracing flag after last MoE layer completes.
+            if tracing and is_last_moe:
+                _eo_mod._tracing_prefill = False
+
             # One-shot lazy chaining (no-op after first call).
             from sglang.srt.layers.moe.expert_offload import chain_managers
 
             chain_managers()
 
-            self.manager.trigger_prefetch_for_next_layer()
+            self.manager.trigger_prefetch_for_next_layers()
 
         return result
 

--- a/python/sglang/srt/layers/moe/expert_offload/wrapper.py
+++ b/python/sglang/srt/layers/moe/expert_offload/wrapper.py
@@ -115,6 +115,11 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
         self.manager = ExpertOffloadManager(self.config, device)
         self.manager.initialize_from_weights(layer)
 
+        # Register manager for cross-layer prefetch chaining.
+        from sglang.srt.layers.moe.expert_offload import register_manager
+
+        register_manager(self.config.layer_idx, self.manager, layer)
+
         logger.info(
             f"[ExpertOffload] Layer {self.config.layer_idx}: "
             f"{self.config.num_resident_experts}/{self.config.num_local_experts} resident "
@@ -143,7 +148,17 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
           - Decode (CUDA graph replay): resident -> VRAM, offloaded -> PCIe.
         Full correctness in all phases.
         """
-        return self.gpu_method.apply(layer, dispatch_output)
+        result = self.gpu_method.apply(layer, dispatch_output)
+
+        if self.manager is not None:
+            # One-shot lazy chaining (no-op after first call).
+            from sglang.srt.layers.moe.expert_offload import chain_managers
+
+            chain_managers()
+
+            self.manager.trigger_prefetch_for_next_layer()
+
+        return result
 
     # ------------------------------------------------------------------
     # Transparent attribute delegation

--- a/python/sglang/srt/layers/moe/expert_offload/wrapper.py
+++ b/python/sglang/srt/layers/moe/expert_offload/wrapper.py
@@ -121,7 +121,7 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
         register_manager(self.config.layer_idx, self.manager, layer)
 
         logger.info(
-            f"[ExpertOffload] Layer {self.config.layer_idx}: "
+            f"{self.config.log_prefix} Layer {self.config.layer_idx}: "
             f"{self.config.num_resident_experts}/{self.config.num_local_experts} resident "
             f"({self.config.num_offloaded_experts} offloaded via UVM)"
         )
@@ -157,9 +157,13 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
         tracing = _eo_mod._tracing_prefill
         if tracing and self.manager is not None:
             layer_idx = self.manager.config.layer_idx
-            num_tokens = dispatch_output.hidden_states.shape[0] if hasattr(dispatch_output, 'hidden_states') else -1
+            num_tokens = (
+                dispatch_output.hidden_states.shape[0]
+                if hasattr(dispatch_output, "hidden_states")
+                else -1
+            )
             logger.info(
-                f"[ExpertOffload] Layer {layer_idx}: entering MoE kernel "
+                f"{self.manager.config.log_prefix} Layer {layer_idx}: entering MoE kernel "
                 f"(tokens={num_tokens})"
             )
 
@@ -170,7 +174,7 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
         if self.manager is not None:
             if tracing or elapsed > 1.0:
                 logger.info(
-                    f"[ExpertOffload] Layer {self.manager.config.layer_idx}: "
+                    f"{self.manager.config.log_prefix} Layer {self.manager.config.layer_idx}: "
                     f"MoE kernel done in {elapsed:.3f}s"
                 )
 
@@ -188,7 +192,7 @@ class ExpertOffloadWrapperMethod(FusedMoEMethodBase):
                 if tracing:
                     free, total = torch.cuda.mem_get_info()
                     logger.info(
-                        f"[ExpertOffload] Post-MoE sync done. "
+                        f"{self.manager.config.log_prefix} Post-MoE sync done. "
                         f"GPU mem: {free / (1 << 30):.2f} GiB free"
                     )
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1016,14 +1016,6 @@ class FusedMoE(torch.nn.Module):
             hidden_states=hidden_states, topk_output=topk_output
         )
 
-        # Record expert routing frequencies for adaptive resident selection.
-        if (
-            isinstance(self.quant_method, ExpertOffloadWrapperMethod)
-            and self.quant_method.manager is not None
-            and not self.quant_method.manager._warmup_done
-        ):
-            self.quant_method.manager.record_expert_usage(topk_output.topk_ids, self)
-
         if _use_aiter and self.dispatcher.local_expert_mapping is not None:
             self.expert_mask_gpu = (
                 (

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -284,7 +284,10 @@ class FusedMoE(torch.nn.Module):
                 )
             # Wrap with expert offloading if enabled (mutually exclusive with KT).
             offload_config = create_expert_offload_config_from_server_args(
-                server_args, layer_id, self.num_local_experts
+                server_args,
+                layer_id,
+                self.num_local_experts,
+                is_draft_worker=getattr(server_args, "runtime_is_draft_worker", False),
             )
             if offload_config is not None:
                 self.quant_method = ExpertOffloadWrapperMethod(

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -31,6 +31,10 @@ from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
     get_moe_runner_backend,
 )
+from sglang.srt.layers.moe.expert_offload import (
+    ExpertOffloadWrapperMethod,
+    create_expert_offload_config_from_server_args,
+)
 from sglang.srt.layers.moe.kt_ep_wrapper import (
     KTEPWrapperMethod,
     create_kt_config_from_server_args,
@@ -277,6 +281,14 @@ class FusedMoE(torch.nn.Module):
             if self.quant_method is None:
                 self.quant_method = UnquantizedFusedMoEMethod(
                     self.use_triton_kernels, self.use_flashinfer_trtllm_moe
+                )
+            # Wrap with expert offloading if enabled (mutually exclusive with KT).
+            offload_config = create_expert_offload_config_from_server_args(
+                server_args, layer_id, self.num_local_experts
+            )
+            if offload_config is not None:
+                self.quant_method = ExpertOffloadWrapperMethod(
+                    self.quant_method, offload_config
                 )
 
         self.quant_method.create_weights(
@@ -1000,6 +1012,15 @@ class FusedMoE(torch.nn.Module):
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output
         )
+
+        # Record expert routing frequencies for adaptive resident selection.
+        if (
+            isinstance(self.quant_method, ExpertOffloadWrapperMethod)
+            and self.quant_method.manager is not None
+            and not self.quant_method.manager._warmup_done
+        ):
+            self.quant_method.manager.record_expert_usage(topk_output.topk_ids, self)
+
         if _use_aiter and self.dispatcher.local_expert_mapping is not None:
             self.expert_mask_gpu = (
                 (

--- a/python/sglang/srt/layers/moe/routed_experts_capturer.py
+++ b/python/sglang/srt/layers/moe/routed_experts_capturer.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from abc import ABC
 from typing import Optional
 
@@ -22,6 +23,12 @@ _GB = 1024 * 1024 * 1024
 _MB = 1024 * 1024
 
 
+def _should_log_decode_debug() -> bool:
+    return bool(
+        getattr(get_global_server_args(), "expert_offload_decode_debug_log", False)
+    )
+
+
 def get_tensor_size_bytes(t: torch.Tensor):
     return np.prod(t.shape) * t.dtype.itemsize
 
@@ -34,7 +41,9 @@ class _RoutedExpertsDeviceCache:
         num_experts_per_tok: int,
         num_fused_shared_experts: int,
         device: str,
+        label: str,
     ) -> None:
+        self.label = label
         self.buffer = torch.zeros(
             (
                 max(
@@ -63,7 +72,10 @@ class _RoutedExpertsDeviceCache:
         """Common logging and memory usage computation for captured experts buffers."""
         buffer_size_MB = self.get_buffer_size_bytes() / _MB
         logger.info(
-            f"Routing experts device buffer allocated. #shape: {tuple(self.buffer.shape)}, size: {buffer_size_MB:.2f} MB"
+            "%s allocated. #shape: %s, size: %.2f MB",
+            self.label,
+            tuple(self.buffer.shape),
+            buffer_size_MB,
         )
 
 
@@ -105,16 +117,19 @@ class _RoutedExpertsHostCache:
 class RoutedExpertsCapturer(ABC):
     @staticmethod
     def create(
-        enable: bool,
+        enable_return_routed_experts: bool,
+        enable_frequency_warmup: bool,
         model_config: ModelConfig,
         num_fused_shared_experts: int,
         num_tokens: int,
         max_running_requests: int,
         device: str,
     ):
-        if enable:
+        if enable_return_routed_experts or enable_frequency_warmup:
             return _RoutedExpertsCapturerReal(
                 model_config,
+                enable_return_routed_experts=enable_return_routed_experts,
+                enable_frequency_warmup=enable_frequency_warmup,
                 num_tokens=num_tokens,
                 max_running_requests=max_running_requests,
                 num_fused_shared_experts=num_fused_shared_experts,
@@ -132,6 +147,9 @@ class RoutedExpertsCapturer(ABC):
         raise NotImplementedError
 
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
+        raise NotImplementedError
+
+    def capture_frequency(self, layer_id: int, topk_ids: torch.Tensor):
         raise NotImplementedError
 
     def get_routed_experts(
@@ -158,6 +176,8 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
     def __init__(
         self,
         model_config: ModelConfig,
+        enable_return_routed_experts: bool,
+        enable_frequency_warmup: bool,
         num_tokens: int,
         max_running_requests: int,
         num_fused_shared_experts: int,
@@ -166,30 +186,61 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         self.num_fused_shared_experts = num_fused_shared_experts
         self.num_hidden_layers = model_config.hf_text_config.num_hidden_layers
         self.num_experts_per_tok = model_config.hf_text_config.num_experts_per_tok
-
-        self.host_cache = _RoutedExpertsHostCache(
-            num_tokens=num_tokens,
-            num_hidden_layers=self.num_hidden_layers,
-            num_experts_per_tok=self.num_experts_per_tok,
+        logger.info(
+            "FrequencyWarmupCapturerInit enable_return_routed_experts=%s "
+            "enable_frequency_warmup=%s num_hidden_layers=%s num_experts_per_tok=%s "
+            "max_running_requests=%s num_tokens=%s",
+            enable_return_routed_experts,
+            enable_frequency_warmup,
+            self.num_hidden_layers,
+            self.num_experts_per_tok,
+            max_running_requests,
+            num_tokens,
         )
 
-        self.device_cache = _RoutedExpertsDeviceCache(
-            max_running_requests=max_running_requests,
-            num_hidden_layers=self.num_hidden_layers,
-            num_experts_per_tok=self.num_experts_per_tok,
-            num_fused_shared_experts=self.num_fused_shared_experts,
-            device=device,
+        self.host_cache = (
+            _RoutedExpertsHostCache(
+                num_tokens=num_tokens,
+                num_hidden_layers=self.num_hidden_layers,
+                num_experts_per_tok=self.num_experts_per_tok,
+            )
+            if enable_return_routed_experts
+            else None
         )
 
-    def _sync_fwd_experts_buffer_DtoH(
+        self.device_cache = (
+            _RoutedExpertsDeviceCache(
+                max_running_requests=max_running_requests,
+                num_hidden_layers=self.num_hidden_layers,
+                num_experts_per_tok=self.num_experts_per_tok,
+                num_fused_shared_experts=self.num_fused_shared_experts,
+                device=device,
+                label="Routing experts device buffer",
+            )
+            if enable_return_routed_experts
+            else None
+        )
+        self.frequency_device_cache = (
+            _RoutedExpertsDeviceCache(
+                max_running_requests=max_running_requests,
+                num_hidden_layers=self.num_hidden_layers,
+                num_experts_per_tok=self.num_experts_per_tok,
+                num_fused_shared_experts=self.num_fused_shared_experts,
+                device=device,
+                label="Routing experts frequency warmup buffer",
+            )
+            if enable_frequency_warmup
+            else None
+        )
+
+    def _get_forward_token_span(
         self,
         forward_batch: ForwardBatch,
         can_run_graph: bool,
         cuda_graph_batch: int,
-    ):
+    ) -> tuple[int, int]:
         if is_dp_attention_enabled():
             local_start_pos, local_num_tokens = get_dp_local_info(forward_batch)
-            # handle with cuda graph padding
             if can_run_graph:
                 local_start_pos = get_attention_dp_rank() * cuda_graph_batch
                 local_end_pos = local_start_pos + local_num_tokens
@@ -198,6 +249,19 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         else:
             local_start_pos = 0
             local_end_pos = forward_batch.out_cache_loc.shape[0]
+        return local_start_pos, local_end_pos
+
+    def _sync_fwd_experts_buffer_DtoH(
+        self,
+        forward_batch: ForwardBatch,
+        can_run_graph: bool,
+        cuda_graph_batch: int,
+    ):
+        if self.host_cache is None or self.device_cache is None:
+            return
+        local_start_pos, local_end_pos = self._get_forward_token_span(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
 
         # FIXME: sync explicitly here, overlap scheduler breaks here.
         out_cache_loc_cpu = forward_batch.out_cache_loc.cpu()
@@ -206,7 +270,12 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         ].cpu()
 
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
-        self.device_cache.capture_fwd_routed_experts(layer_id, topk_ids)
+        if self.device_cache is not None:
+            self.device_cache.capture_fwd_routed_experts(layer_id, topk_ids)
+
+    def capture_frequency(self, layer_id: int, topk_ids: torch.Tensor):
+        if self.frequency_device_cache is not None:
+            self.frequency_device_cache.capture_fwd_routed_experts(layer_id, topk_ids)
 
     def get_routed_experts(
         self,
@@ -214,10 +283,13 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
         seqlen: int,
         req_to_token_pool: ReqToTokenPool,
     ):
+        host_cache = self.get_host_cache()
+        if host_cache is None:
+            return None
         cache_pool_idx = (
             req_to_token_pool.req_to_token[req_pool_idx][: seqlen - 1].cpu().clone()
         )
-        return self.get_host_cache().buffer[cache_pool_idx]
+        return host_cache.buffer[cache_pool_idx]
 
     def on_forward_end(self, forward_batch, can_run_graph, cuda_graph_batch):
         self._sync_fwd_experts_buffer_DtoH(
@@ -225,6 +297,63 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
             can_run_graph=can_run_graph,
             cuda_graph_batch=cuda_graph_batch,
         )
+        if self.frequency_device_cache is None:
+            if _should_log_decode_debug():
+                logger.info(
+                    "FrequencyWarmupCaptureSkip mode=%s reason=no_frequency_device_cache "
+                    "can_run_graph=%s cuda_graph_batch=%s out_cache_tokens=%s",
+                    forward_batch.forward_mode.name,
+                    can_run_graph,
+                    cuda_graph_batch,
+                    int(forward_batch.out_cache_loc.shape[0]),
+                )
+            return None
+
+        if not forward_batch.forward_mode.is_target_verify():
+            if _should_log_decode_debug():
+                logger.info(
+                    "FrequencyWarmupCaptureSkip mode=%s reason=not_target_verify "
+                    "can_run_graph=%s cuda_graph_batch=%s out_cache_tokens=%s",
+                    forward_batch.forward_mode.name,
+                    can_run_graph,
+                    cuda_graph_batch,
+                    int(forward_batch.out_cache_loc.shape[0]),
+                )
+            return None
+
+        from sglang.srt.layers.moe.expert_offload import has_active_frequency_warmup
+
+        active_frequency_warmup = has_active_frequency_warmup()
+        if not active_frequency_warmup:
+            if _should_log_decode_debug():
+                logger.info(
+                    "FrequencyWarmupCaptureSkip mode=%s reason=inactive_frequency_warmup "
+                    "can_run_graph=%s cuda_graph_batch=%s out_cache_tokens=%s",
+                    forward_batch.forward_mode.name,
+                    can_run_graph,
+                    cuda_graph_batch,
+                    int(forward_batch.out_cache_loc.shape[0]),
+                )
+            return None
+
+        local_start_pos, local_end_pos = self._get_forward_token_span(
+            forward_batch, can_run_graph, cuda_graph_batch
+        )
+        captured = self.frequency_device_cache.buffer[
+            local_start_pos:local_end_pos
+        ].cpu()
+        if _should_log_decode_debug():
+            logger.info(
+                "FrequencyWarmupCaptureReturn mode=%s can_run_graph=%s "
+                "cuda_graph_batch=%s local_span=[%s:%s] capture_shape=%s",
+                forward_batch.forward_mode.name,
+                can_run_graph,
+                cuda_graph_batch,
+                local_start_pos,
+                local_end_pos,
+                tuple(captured.shape),
+            )
+        return captured
 
     def get_host_cache(self):
         return self.host_cache
@@ -248,6 +377,9 @@ class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
     def capture(self, layer_id: int, topk_ids: torch.Tensor):
         pass
 
+    def capture_frequency(self, layer_id: int, topk_ids: torch.Tensor):
+        pass
+
     def get_routed_experts(
         self,
         req_pool_idx: int,
@@ -257,7 +389,7 @@ class _RoutedExpertsCapturerNoop(RoutedExpertsCapturer):
         pass
 
     def on_forward_end(self, forward_batch, can_run_graph, cuda_graph_batch):
-        pass
+        return None
 
     def get_host_cache(self):
         pass
@@ -275,6 +407,30 @@ def get_global_experts_capturer():
 
 def set_global_experts_capturer(capturer: RoutedExpertsCapturer):
     global _global_expert_capturer
+    caller = traceback.extract_stack(limit=2)[0]
+    old_class = type(_global_expert_capturer).__name__
+    new_class = type(capturer).__name__
+    if (
+        old_class == "_RoutedExpertsCapturerReal"
+        and new_class == "_RoutedExpertsCapturerNoop"
+    ):
+        logger.info(
+            "SetGlobalExpertsCapturerIgnore old_class=%s new_class=%s caller=%s:%s:%s",
+            old_class,
+            new_class,
+            caller.filename,
+            caller.lineno,
+            caller.name,
+        )
+        return
+    logger.info(
+        "SetGlobalExpertsCapturer old_class=%s new_class=%s caller=%s:%s:%s",
+        old_class,
+        new_class,
+        caller.filename,
+        caller.lineno,
+        caller.name,
+    )
     _global_expert_capturer = capturer
 
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -945,6 +945,10 @@ def _post_process_topk_ids(
     if _is_cuda:
         topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
         _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    get_global_experts_capturer().capture_frequency(
+        layer_id=layer_id,
+        topk_ids=topk_ids,
+    )
 
     if num_fused_shared_experts > 0 and _use_aiter:
         M, N = router_logits.shape

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -94,6 +94,9 @@ class SchedulerOutputProcessorMixin:
 
     def maybe_collect_routed_experts(self: Scheduler, req: Req):
         """Collect routed experts for a finished request."""
+        if not req.return_routed_experts:
+            req.routed_experts = None
+            return
         req.routed_experts = get_global_experts_capturer().get_routed_experts(
             req_pool_idx=req.req_pool_idx,
             seqlen=req.seqlen,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -571,9 +571,14 @@ class CudaGraphRunner:
         if KTRANSFORMERS_AVAILABLE:
             KTMoEWrapper.set_capture_batch_sizes(self.capture_bs)
         if model_runner.server_args.expert_offload_num_resident >= 0:
+            expert_offload_prefix = (
+                "[ExpertOffload][draft]"
+                if model_runner.is_draft_worker
+                else "[ExpertOffload][target]"
+            )
             log_info_on_rank0(
                 logger,
-                "[ExpertOffload] CUDA graph mode enabled. Offloaded experts will be accessed "
+                f"{expert_offload_prefix} CUDA graph mode enabled. Offloaded experts will be accessed "
                 "transparently via PCIe, ensuring full decode quality.",
             )
 

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -570,6 +570,12 @@ class CudaGraphRunner:
         log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
         if KTRANSFORMERS_AVAILABLE:
             KTMoEWrapper.set_capture_batch_sizes(self.capture_bs)
+        if model_runner.server_args.expert_offload_num_resident >= 0:
+            log_info_on_rank0(
+                logger,
+                "[ExpertOffload] CUDA graph mode enabled. Offloaded experts will be accessed "
+                "transparently via PCIe, ensuring full decode quality.",
+            )
 
         # If returning hidden states is enabled, set initial capture hidden mode to full to avoid double-capture on startup
         if model_runner.server_args.enable_return_hidden_states:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -326,6 +326,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.dist_port = nccl_port
         self.server_args = server_args
         self.is_draft_worker = is_draft_worker
+        self.server_args.runtime_is_draft_worker = is_draft_worker
         self.memory_pool_config = memory_pool_config
         self.is_generation = model_config.is_generation
         self.is_multimodal = model_config.is_multimodal
@@ -346,6 +347,26 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.init_new_workspace = False
         self.draft_model_idx = draft_model_idx
         self.enable_hisparse = server_args.enable_hisparse
+        expert_offload_prefix = (
+            "[ExpertOffload][draft]" if self.is_draft_worker else "[ExpertOffload][target]"
+        )
+        if (
+            self.server_args.expert_offload_num_resident >= 0
+            and (self.draft_model_idx in (None, 0))
+        ):
+            if self.is_draft_worker:
+                logger.info(
+                    "%s %s expert offload for MoE layers.",
+                    expert_offload_prefix,
+                    "enabled"
+                    if self.server_args.expert_offload_draft_model
+                    else "skipping",
+                )
+            else:
+                logger.info(
+                    "%s expert offload enabled for MoE layers.",
+                    expert_offload_prefix,
+                )
 
         self.remote_instance_transfer_engine = None
         self.remote_instance_transfer_engine_session_id = ""
@@ -2745,8 +2766,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
 
                 prepare_for_new_prefill()
+                expert_offload_prefix = (
+                    "[ExpertOffload][draft]"
+                    if self.is_draft_worker
+                    else "[ExpertOffload][target]"
+                )
                 logger.info(
-                    f"[ExpertOffload] Starting forward_extend "
+                    f"{expert_offload_prefix} Starting forward_extend "
                     f"(batch_size={forward_batch.batch_size})"
                 )
             ret, can_run_graph = self.forward_extend(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -348,19 +348,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.draft_model_idx = draft_model_idx
         self.enable_hisparse = server_args.enable_hisparse
         expert_offload_prefix = (
-            "[ExpertOffload][draft]" if self.is_draft_worker else "[ExpertOffload][target]"
+            "[ExpertOffload][draft]"
+            if self.is_draft_worker
+            else "[ExpertOffload][target]"
         )
-        if (
-            self.server_args.expert_offload_num_resident >= 0
-            and (self.draft_model_idx in (None, 0))
+        if self.server_args.expert_offload_num_resident >= 0 and (
+            self.draft_model_idx in (None, 0)
         ):
             if self.is_draft_worker:
                 logger.info(
                     "%s %s expert offload for MoE layers.",
                     expert_offload_prefix,
-                    "enabled"
-                    if self.server_args.expert_offload_draft_model
-                    else "skipping",
+                    (
+                        "enabled"
+                        if self.server_args.expert_offload_draft_model
+                        else "skipping"
+                    ),
                 )
             else:
                 logger.info(
@@ -692,10 +695,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             num_fused_shared_experts = self.model.num_fused_shared_experts
         else:
             num_fused_shared_experts = 0
+        enable_frequency_warmup = (
+            self.server_args.expert_offload_num_resident >= 0
+            and self.server_args.expert_offload_resident_selection == "frequency"
+            and not self.is_draft_worker
+        )
 
         set_global_experts_capturer(
             RoutedExpertsCapturer.create(
-                enable=get_global_server_args().enable_return_routed_experts,
+                enable_return_routed_experts=get_global_server_args().enable_return_routed_experts,
+                enable_frequency_warmup=enable_frequency_warmup,
                 model_config=self.model_config,
                 num_fused_shared_experts=num_fused_shared_experts,
                 num_tokens=self.max_total_num_tokens + self.page_size,
@@ -2669,11 +2678,53 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
         # Copy cached routing experts' buffers back to CPU cache
-        get_global_experts_capturer().on_forward_end(
+        experts_capturer = get_global_experts_capturer()
+        if (
+            self.server_args.expert_offload_num_resident >= 0
+            and self.server_args.expert_offload_resident_selection == "frequency"
+            and not self.is_draft_worker
+            and self.server_args.expert_offload_decode_debug_log
+        ):
+            logger.info(
+                "[ExpertOffload] FrequencyWarmupCapturerIdentity class=%s module=%s",
+                type(experts_capturer).__name__,
+                type(experts_capturer).__module__,
+            )
+        frequency_routed_experts = experts_capturer.on_forward_end(
             forward_batch=forward_batch,
             can_run_graph=output.can_run_graph,
             cuda_graph_batch=getattr(self.graph_runner, "bs", None),
         )
+        if (
+            self.server_args.expert_offload_num_resident >= 0
+            and self.server_args.expert_offload_resident_selection == "frequency"
+            and not self.is_draft_worker
+            and self.server_args.expert_offload_decode_debug_log
+        ):
+            capture_shape = (
+                tuple(frequency_routed_experts.shape)
+                if frequency_routed_experts is not None
+                else None
+            )
+            logger.info(
+                "[ExpertOffload] FrequencyWarmupCapture mode=%s can_run_graph=%s "
+                "capture_shape=%s cuda_graph_batch=%s out_cache_tokens=%s batch=%s",
+                forward_batch.forward_mode.name,
+                output.can_run_graph,
+                capture_shape,
+                getattr(self.graph_runner, "bs", None),
+                int(forward_batch.out_cache_loc.shape[0]),
+                getattr(forward_batch, "batch_size", -1),
+            )
+        if frequency_routed_experts is not None:
+            from sglang.srt.layers.moe.expert_offload import (
+                record_frequency_from_routed_experts_capture,
+            )
+
+            record_frequency_from_routed_experts_capture(
+                forward_batch=forward_batch,
+                captured_topk_ids=frequency_routed_experts,
+            )
 
         if self.eplb_manager is not None:
             self.eplb_manager.on_forward_pass_end()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2687,6 +2687,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 skip_attn_backend_init=skip_attn_backend_init,
                 pp_proxy_tensors=pp_proxy_tensors,
             )
+            if self.server_args.expert_offload_num_resident >= 0:
+                from sglang.srt.layers.moe.expert_offload import (
+                    notify_decode_completed,
+                )
+
+                notify_decode_completed()
             return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
 
         # For MLP sync
@@ -2720,6 +2726,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 skip_attn_backend_init=skip_attn_backend_init,
                 pp_proxy_tensors=pp_proxy_tensors,
             )
+            if self.server_args.expert_offload_num_resident >= 0:
+                from sglang.srt.layers.moe.expert_offload import (
+                    notify_decode_completed,
+                )
+
+                notify_decode_completed()
         elif forward_batch.forward_mode.is_split_prefill():
             ret = self.forward_split_prefill(
                 forward_batch,
@@ -2727,6 +2739,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 forward_count=split_forward_count,
             )
         elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
+            if self.server_args.expert_offload_num_resident >= 0:
+                from sglang.srt.layers.moe.expert_offload import (
+                    prepare_for_new_prefill,
+                )
+
+                prepare_for_new_prefill()
+                logger.info(
+                    f"[ExpertOffload] Starting forward_extend "
+                    f"(batch_size={forward_batch.batch_size})"
+                )
             ret, can_run_graph = self.forward_extend(
                 forward_batch,
                 skip_attn_backend_init=skip_attn_backend_init,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -591,6 +591,12 @@ class ServerArgs:
     expert_offload_prefetch_num: int = (
         0  # 0 = disabled; N = prefetch top-N hot offloaded experts
     )
+    expert_offload_prefetch_depth: int = (
+        1  # how many layers ahead to prefetch (default 1 = next layer only)
+    )
+    expert_offload_memory_headroom: int = (
+        2  # GiB of GPU memory reserved for UVM page swapping
+    )
 
     # Diffusion LLM
     dllm_algorithm: Optional[str] = None
@@ -2832,9 +2838,16 @@ class ServerArgs:
         if self.expert_offload_prefetch_num < 0:
             raise ValueError("--expert-offload-prefetch-num must be >= 0")
 
+        if self.expert_offload_prefetch_depth < 1:
+            raise ValueError("--expert-offload-prefetch-depth must be >= 1")
+
+        if self.expert_offload_memory_headroom < 0:
+            raise ValueError("--expert-offload-memory-headroom must be >= 0")
+
         logger.info(
             f"[ExpertOffload] Enabled (UVM): num_resident={self.expert_offload_num_resident}, "
-            f"resident_selection={self.expert_offload_resident_selection!r}. "
+            f"resident_selection={self.expert_offload_resident_selection!r}, "
+            f"memory_headroom={self.expert_offload_memory_headroom} GiB. "
             "Expert weights stored in CUDA Unified Memory. "
             "Resident experts stay on GPU (VRAM speed). "
             "Offloaded experts accessible via PCIe read-through (no quality loss). "
@@ -5226,6 +5239,26 @@ class ServerArgs:
             "offloaded experts on a background CUDA stream. "
             "Too high a value can cause GPU memory pressure and page thrashing, "
             "reducing decode speed.",
+        )
+        parser.add_argument(
+            "--expert-offload-prefetch-depth",
+            type=int,
+            default=1,
+            help="How many layers ahead to prefetch offloaded experts. "
+            "Default 1 = prefetch only the next layer's experts. "
+            "Higher values (e.g. 2-4) issue prefetch for the next D layers, "
+            "giving more overlap between PCIe transfers and compute. "
+            "Useful when expert prefetch takes longer than one layer's "
+            "attention + layernorm compute.",
+        )
+        parser.add_argument(
+            "--expert-offload-memory-headroom",
+            type=int,
+            default=ServerArgs.expert_offload_memory_headroom,
+            help="GiB of GPU memory to reserve as headroom for UVM page swapping. "
+            "Prevents deadlocks when switching between requests with different "
+            "expert routing patterns. Higher values are safer but reduce KV cache "
+            "capacity. Default 2 GiB. Set to 0 to disable.",
         )
 
         # Diffusion LLM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -588,6 +588,9 @@ class ServerArgs:
     expert_offload_resident_ids: Optional[str] = (
         None  # comma-separated IDs (manual mode)
     )
+    expert_offload_prefetch_num: int = (
+        0  # 0 = disabled; N = prefetch top-N hot offloaded experts
+    )
 
     # Diffusion LLM
     dllm_algorithm: Optional[str] = None
@@ -2825,6 +2828,9 @@ class ServerArgs:
                 "--expert-offload-num-resident is mutually exclusive with --kt-weight-path. "
                 "Use one strategy at a time."
             )
+
+        if self.expert_offload_prefetch_num < 0:
+            raise ValueError("--expert-offload-prefetch-num must be >= 0")
 
         logger.info(
             f"[ExpertOffload] Enabled (UVM): num_resident={self.expert_offload_num_resident}, "
@@ -5209,6 +5215,17 @@ class ServerArgs:
             type=str,
             default=None,
             help="Comma-separated expert IDs to keep resident (for manual selection).",
+        )
+        parser.add_argument(
+            "--expert-offload-prefetch-num",
+            type=int,
+            default=0,
+            help="Number of hot offloaded experts to prefetch for the next layer. "
+            "0 = disabled. When enabled, after each MoE layer's kernel is submitted, "
+            "cudaMemPrefetchAsync is issued for the next layer's most-frequently-hit "
+            "offloaded experts on a background CUDA stream. "
+            "Too high a value can cause GPU memory pressure and page thrashing, "
+            "reducing decode speed.",
         )
 
         # Diffusion LLM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -600,6 +600,9 @@ class ServerArgs:
     expert_offload_draft_model: bool = (
         False  # whether expert offload also applies to speculative draft workers
     )
+    expert_offload_decode_debug_log: bool = (
+        False  # enable verbose decode-time expert-offload diagnostics
+    )
     runtime_is_draft_worker: bool = dataclasses.field(
         default=False,
         init=False,
@@ -5277,6 +5280,13 @@ class ServerArgs:
             help="Also enable expert offloading for speculative draft-model MoE layers. "
             "By default, draft workers skip expert offload even when the target "
             "model uses it, which makes A/B comparison against target-only offload easier.",
+        )
+        parser.add_argument(
+            "--expert-offload-decode-debug-log",
+            action="store_true",
+            default=ServerArgs.expert_offload_decode_debug_log,
+            help="Enable verbose decode-time expert-offload diagnostics, including "
+            "frequency warmup capture and routed-expert debug logs. Disabled by default.",
         )
 
         # Diffusion LLM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -597,6 +597,15 @@ class ServerArgs:
     expert_offload_memory_headroom: int = (
         2  # GiB of GPU memory reserved for UVM page swapping
     )
+    expert_offload_draft_model: bool = (
+        False  # whether expert offload also applies to speculative draft workers
+    )
+    runtime_is_draft_worker: bool = dataclasses.field(
+        default=False,
+        init=False,
+        repr=False,
+        compare=False,
+    )  # runtime-only: set by ModelRunner
 
     # Diffusion LLM
     dllm_algorithm: Optional[str] = None
@@ -2847,7 +2856,8 @@ class ServerArgs:
         logger.info(
             f"[ExpertOffload] Enabled (UVM): num_resident={self.expert_offload_num_resident}, "
             f"resident_selection={self.expert_offload_resident_selection!r}, "
-            f"memory_headroom={self.expert_offload_memory_headroom} GiB. "
+            f"memory_headroom={self.expert_offload_memory_headroom} GiB, "
+            f"draft_model={'enabled' if self.expert_offload_draft_model else 'disabled'}. "
             "Expert weights stored in CUDA Unified Memory. "
             "Resident experts stay on GPU (VRAM speed). "
             "Offloaded experts accessible via PCIe read-through (no quality loss). "
@@ -5260,6 +5270,14 @@ class ServerArgs:
             "expert routing patterns. Higher values are safer but reduce KV cache "
             "capacity. Default 2 GiB. Set to 0 to disable.",
         )
+        parser.add_argument(
+            "--expert-offload-draft-model",
+            action="store_true",
+            default=ServerArgs.expert_offload_draft_model,
+            help="Also enable expert offloading for speculative draft-model MoE layers. "
+            "By default, draft workers skip expert offload even when the target "
+            "model uses it, which makes A/B comparison against target-only offload easier.",
+        )
 
         # Diffusion LLM
         parser.add_argument(
@@ -5991,7 +6009,7 @@ class ServerArgs:
         args.dp_size = args.data_parallel_size
         args.ep_size = args.expert_parallel_size
 
-        attrs = [attr.name for attr in dataclasses.fields(cls)]
+        attrs = [attr.name for attr in dataclasses.fields(cls) if attr.init]
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
     def url(self):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -575,6 +575,20 @@ class ServerArgs:
     kt_num_gpu_experts: Optional[int] = None
     kt_max_deferred_experts_per_token: Optional[int] = None
 
+    # Expert weight offloading (mutually exclusive with KTransformers)
+    # Expert weights stored in CUDA Unified Memory (cudaMallocManaged).
+    # Offloaded experts live in CPU DRAM, accessed by GPU via PCIe read-through.
+    # All computation stays on GPU.
+    expert_offload_num_resident: int = (
+        -1
+    )  # -1 = disabled; N = experts permanently on GPU
+    expert_offload_resident_selection: str = (
+        "first_n"  # "first_n" | "frequency" | "manual"
+    )
+    expert_offload_resident_ids: Optional[str] = (
+        None  # comma-separated IDs (manual mode)
+    )
+
     # Diffusion LLM
     dllm_algorithm: Optional[str] = None
     dllm_algorithm_config: Optional[str] = None
@@ -804,6 +818,7 @@ class ServerArgs:
         self._handle_eplb_and_dispatch()
         self._handle_expert_distribution_metrics()
         self._handle_elastic_ep()
+        self._handle_expert_offload()
 
         # Handle pipeline parallelism.
         self._handle_pipeline_parallelism()
@@ -2798,6 +2813,27 @@ class ServerArgs:
                 self.expert_distribution_recorder_buffer_size = x
             elif self.expert_distribution_recorder_mode is not None:
                 self.expert_distribution_recorder_buffer_size = 1000
+
+    def _handle_expert_offload(self):
+        """Validate expert weight offloading configuration."""
+        if self.expert_offload_num_resident < 0:
+            return  # Disabled — nothing to do.
+
+        # Mutual exclusion with KTransformers.
+        if self.kt_weight_path is not None:
+            raise ValueError(
+                "--expert-offload-num-resident is mutually exclusive with --kt-weight-path. "
+                "Use one strategy at a time."
+            )
+
+        logger.info(
+            f"[ExpertOffload] Enabled (UVM): num_resident={self.expert_offload_num_resident}, "
+            f"resident_selection={self.expert_offload_resident_selection!r}. "
+            "Expert weights stored in CUDA Unified Memory. "
+            "Resident experts stay on GPU (VRAM speed). "
+            "Offloaded experts accessible via PCIe read-through (no quality loss). "
+            "CUDA graph compatible."
+        )
 
     def _handle_pipeline_parallelism(self):
         if self.pp_size > 1:
@@ -5147,6 +5183,32 @@ class ServerArgs:
             type=int,
             default=ServerArgs.kt_max_deferred_experts_per_token,
             help="[ktransformers parameter] Maximum number of experts deferred to CPU per token. All MoE layers except the final one use this value; the final layer always uses 0.",
+        )
+
+        # Expert weight offloading args (mutually exclusive with KTransformers)
+        parser.add_argument(
+            "--expert-offload-num-resident",
+            type=int,
+            default=-1,
+            help="Number of expert weights permanently resident on GPU per MoE layer. "
+            "-1 = disabled. Expert weights are stored in CUDA Unified Memory; "
+            "offloaded experts live in CPU DRAM and are accessed by the GPU "
+            "transparently via PCIe read-through. Mutually exclusive with --kt-weight-path.",
+        )
+        parser.add_argument(
+            "--expert-offload-resident-selection",
+            type=str,
+            default="first_n",
+            choices=["first_n", "frequency", "manual"],
+            help="Strategy for selecting which experts stay resident on GPU. "
+            "'first_n' = experts 0..N-1; 'manual' = explicit list via "
+            "--expert-offload-resident-ids.",
+        )
+        parser.add_argument(
+            "--expert-offload-resident-ids",
+            type=str,
+            default=None,
+            help="Comma-separated expert IDs to keep resident (for manual selection).",
         )
 
         # Diffusion LLM

--- a/python/sglang/srt/speculative/diagnostics.py
+++ b/python/sglang/srt/speculative/diagnostics.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+
+
+def _normalize_accept_lengths(accept_lengths) -> list[int]:
+    if accept_lengths is None:
+        return []
+    if isinstance(accept_lengths, torch.Tensor):
+        return [int(x) for x in accept_lengths.detach().cpu().tolist()]
+    return [int(x) for x in accept_lengths]
+
+
+def _format_req_accepts(
+    reqs: Optional[Sequence[object]],
+    accept_lengths: list[int],
+    draft_tokens_per_req: int,
+    limit: int = 6,
+) -> str:
+    if not accept_lengths:
+        return "-"
+
+    if reqs is None:
+        return ", ".join(str(x) for x in accept_lengths[:limit])
+
+    preview = []
+    for req, accepted in zip(reqs[:limit], accept_lengths[:limit]):
+        rid = getattr(req, "rid", "?")
+        preview.append(f"{rid}:{accepted}/{draft_tokens_per_req}")
+    return ", ".join(preview)
+
+
+def log_verify_summary(
+    logger,
+    worker_label: str,
+    step: int,
+    batch_size: int,
+    verify_tokens: int,
+    draft_tokens_per_req: int,
+    can_run_cuda_graph: bool,
+    accept_lengths,
+    target_forward_ms: float,
+    verify_total_ms: float,
+    reqs: Optional[Sequence[object]] = None,
+) -> None:
+    accept_list = _normalize_accept_lengths(accept_lengths)
+    accepted_total = sum(accept_list)
+    accept_avg = accepted_total / len(accept_list) if accept_list else 0.0
+    accept_max = max(accept_list) if accept_list else 0
+    proposed_total = len(accept_list) * max(draft_tokens_per_req, 0)
+    accept_rate = accepted_total / proposed_total if proposed_total > 0 else 0.0
+    req_accepts = _format_req_accepts(reqs, accept_list, draft_tokens_per_req)
+
+    logger.info(
+        "[SpecDecodeDiag][%s] verify_step=%s batch=%s verify_tokens=%s "
+        "draft_tokens_per_req=%s can_run_cuda_graph=%s "
+        "target_forward_ms=%.3f verify_total_ms=%.3f "
+        "accepted_total=%s accept_avg=%.3f accept_max=%s accept_rate=%.3f "
+        "req_accepts=[%s]",
+        worker_label,
+        step,
+        batch_size,
+        verify_tokens,
+        draft_tokens_per_req,
+        can_run_cuda_graph,
+        target_forward_ms,
+        verify_total_ms,
+        accepted_total,
+        accept_avg,
+        accept_max,
+        accept_rate,
+        req_accepts,
+    )

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -512,6 +512,17 @@ def calculate_time(show=False, min_cost_ms=0.0):
 # exactly as designed.
 # ---------------------------------------------------------------------------
 _uvm_evictable_bytes: dict = {}  # {gpu_id: int (bytes)}
+_uvm_headroom_bytes: int = 2 * (1 << 30)  # default 2 GiB
+
+
+def set_uvm_memory_headroom(gib: int) -> None:
+    """Set the UVM page-swap headroom in GiB.
+
+    Called from ExpertOffloadManager during init with the value of
+    --expert-offload-memory-headroom.
+    """
+    global _uvm_headroom_bytes
+    _uvm_headroom_bytes = gib * (1 << 30)
 
 
 def register_uvm_evictable_memory(gpu_id: int, nbytes: int) -> None:
@@ -624,9 +635,14 @@ def get_available_gpu_memory(
     # Add UVM-evictable bytes: CPU-preferred managed pages that the UVM driver
     # has cached in GPU physical memory.  They will be evicted on-demand when
     # regular cudaMalloc requests exceed the currently-free physical pages.
+    #
+    # Reserve headroom so the UVM driver always has free GPU pages for page
+    # swapping.  Without headroom, bi-directional page faults (evict old +
+    # bring new) at 0 bytes free can deadlock the UVM driver.
     if device == "cuda":
         extra = _uvm_evictable_bytes.get(gpu_id, 0)
         if extra:
+            extra = max(0, extra - _uvm_headroom_bytes)
             free_gpu_memory = free_gpu_memory + extra
 
     if distributed:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -493,6 +493,38 @@ def calculate_time(show=False, min_cost_ms=0.0):
     return wrapper
 
 
+# ---------------------------------------------------------------------------
+# UVM evictable memory registry
+#
+# On PCIe-attached discrete GPUs, cudaMemPrefetchAsync(→CPU) may not
+# immediately return physical GPU pages to the free pool.  The UVM driver
+# tends to keep CPU-preferred pages cached in GPU VRAM until a regular
+# cudaMalloc triggers eviction.  This means torch.cuda.mem_get_info()
+# under-reports available memory after UVM expert offloading is initialised,
+# causing SGLang's init_memory_pool check to raise a false "not enough
+# memory" error.
+#
+# ExpertOffloadManager calls register_uvm_evictable_memory() after each
+# layer's UVM setup to record the bytes it has placed in CPU-preferred
+# managed memory.  get_available_gpu_memory() adds these bytes to the
+# reported available memory.  When SGLang's KV-cache allocator then issues
+# actual cudaMalloc calls, the UVM driver evicts those pages on-demand —
+# exactly as designed.
+# ---------------------------------------------------------------------------
+_uvm_evictable_bytes: dict = {}  # {gpu_id: int (bytes)}
+
+
+def register_uvm_evictable_memory(gpu_id: int, nbytes: int) -> None:
+    """Register UVM-managed bytes that are logically available for gpu_id.
+
+    Called by ExpertOffloadManager after migrating offloaded expert pages to
+    CPU-preferred managed memory.  The bytes are included in
+    get_available_gpu_memory() so SGLang's memory-pool check accounts for
+    memory the UVM driver will evict on-demand.
+    """
+    _uvm_evictable_bytes[gpu_id] = _uvm_evictable_bytes.get(gpu_id, 0) + nbytes
+
+
 def get_available_gpu_memory(
     device, gpu_id, distributed=False, empty_cache=True, cpu_group=None
 ):
@@ -588,6 +620,14 @@ def get_available_gpu_memory(
         free_gpu_memory, total_gpu_memory = torch.musa.mem_get_info()
     elif device == "mps":
         free_gpu_memory = psutil.virtual_memory().available
+
+    # Add UVM-evictable bytes: CPU-preferred managed pages that the UVM driver
+    # has cached in GPU physical memory.  They will be evicted on-demand when
+    # regular cudaMalloc requests exceed the currently-free physical pages.
+    if device == "cuda":
+        extra = _uvm_evictable_bytes.get(gpu_id, 0)
+        if extra:
+            free_gpu_memory = free_gpu_memory + extra
 
     if distributed:
         tensor = torch.tensor(free_gpu_memory, dtype=torch.float32)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

GLM-5-FP8 has 256 experts per MoE layer. Even with TP=8 on a single host of 8× H20 (96 GB each, 768 GB total VRAM), it cannot fit in GPU memory. Rather than requiring multi-host deployment, this PR offloads a subset of MoE expert weights to host memory using CUDA Unified Virtual Memory (UVM). 

Unlike KTransformers, which moves computation to CPU for offloaded experts, this implementation keeps all computation on GPU — offloaded experts are accessed transparently via PCIe read-through. The existing prefill and decode paths remain compatible and decode can still benefit from CUDA graph replay.

## Modifications

<!-- Detail the changes made in this pull request. -->
Commit 1: UVM-based expert weight offloading infrastructure
- New module python/sglang/srt/layers/moe/expert_offload/ with:
  - config.py — ExpertOffloadConfig dataclass and factory from ServerArgs
  - manager.py — ExpertOffloadManager that allocates UVM tensors, applies cudaMemAdvise (PREFER_GPU for resident, PREFER_CPU + ACCESSED_BY_GPU for offloaded)
  - uvm.py — Low-level UVM allocation/deallocation via ctypes bindings to CUDA runtime
  - uvm_ops.cu — JIT-compiled CUDA kernels for UVM operations
  - prefetch.py — Speculative and frequency-based prefetch strategies
  - wrapper.py — ExpertOffloadWrapperMethod that integrates with FusedMoE layer
- server_args.py — Four new CLI flags: --expert-offload-num-resident, --expert-offload-prefetch, --expert-offload-resident-selection, --expert-offload-resident-ids
- cuda_graph_runner.py — Hook to ensure UVM compatibility with CUDA graph capture
- utils/common.py — Shared helper utilities


Commit 2: Per-layer adaptive resident expert selection via frequency warmup
- manager.py — Added record_expert_usage() to collect per-layer routing frequencies during early prefill passes; after accumulating enough tokens (default 4096), recompute optimal resident set per layer and
promote/demote experts via cudaMemAdvise
- config.py — Added warmup_tokens config field
- fused_moe_triton/layer.py — Wired frequency tracking into FusedMoE.forward_impl()


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Test with glm5-fp8 on H20 * 8:
execute it after install sglang
```
pip install --upgrade transformers
```

Test command: 
```
python3 -m sglang.launch_server --model-path /models/GLM-5-FP8 \
  --host 0.0.0.0 --port 9090 \
  --page-size 256 \
  --mem-fraction-static 0.85 --tensor-parallel-size 8 \
  --hicache-io-backend direct \
  --hicache-mem-layout page_first \
  --chunked-prefill-size 16384 \
  --attention-backend flashinfer \
  --reasoning-parser glm45 \
  --decode-log-interval 2 \
  --speculative-algorithm EAGLE \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --speculative-num-steps 3 \
  --tool-call-parser glm47 \
  --expert-offload-num-resident 200 \
  --expert-offload-prefetch speculative \
  --expert-offload-resident-selection frequency \
  --enable-flashinfer-allreduce-fusion
```

<img width="2890" height="1292" alt="image" src="https://github.com/user-attachments/assets/08c45951-fd77-4354-82a2-495f26c3792a" />


This is an early-stage implementation and there is plenty of room for improvement. I'd be happy if anyone is interested in joining together to make it better!

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
