### PR TITLE
[NPU] Add force dynamic qunat for modelslimW8A8Int8

### DIFF
--- a/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_w8a8_int8.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.parameter import (
     PerTensorScaleParameter,
 )
 from sglang.srt.layers.quantization.modelslim.schemes import ModelSlimLinearScheme
+from sglang.srt.utils import get_bool_env_var
 
 
 class ModelSlimW8A8Int8(ModelSlimLinearScheme):
@@ -28,7 +29,8 @@ class ModelSlimW8A8Int8(ModelSlimLinearScheme):
         self.is_dynamic = (
             self.quant_config.get(prefix + ".weight", "") == "W8A8_DYNAMIC"
         )
-        if self.is_dynamic:
+        self.force_dynamic_quant = get_bool_env_var("FORCE_DYNAMIC_QUANT", "false")
+        if self.is_dynamic or self.force_dynamic_quant:
             self.kernel = NPUW8A8Int8DynamicLinearMethod()
         else:
             self.kernel = NPUW8A8Int8LinearMethod()

--- a/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_w8a8_int8.py
@@ -29,7 +29,7 @@ class ModelSlimW8A8Int8(ModelSlimLinearScheme):
         self.is_dynamic = (
             self.quant_config.get(prefix + ".weight", "") == "W8A8_DYNAMIC"
         )
-        self.force_dynamic_quant = get_bool_env_var("FORCE_DYNAMIC_QUANT", "false")
+        self.force_dynamic_quant = get_bool_env_var("SGLANG_ASCEND_W8A8_LINEAR_FORCE_DYNAMIC_QUANT", "false")
         if self.is_dynamic or self.force_dynamic_quant:
             self.kernel = NPUW8A8Int8DynamicLinearMethod()
         else:


### PR DESCRIPTION
## Motivation

Currently, for Ascend NPU's ModelSlim quantization, some W8A8 weight support both dynamic quant and static quant.  Whether the W8A8INT8 linear scheme uses dynamic quantization is determined by the description of each weight in the quant_model_description.json. Specifically, if the weight is described as "W8A8_DYNAMIC", dynamic quantization is used; otherwise, the default is static quantization with "W8A8". However, in some cases, we need to enable dynamic quantization even when the model weight supports static quantization. For example, static quantization may lead to a drop in the speculative inference acceptance rate for long sequences in Eagle3. In such cases, dynamic quantization should be used to maintain performance.

## Modifications

- Introduced an environment variable, SGLANG_ASCEND_W8A8_LINEAR_FORCE_DYNAMIC_QUANT, which is disabled by default. If this environment variable is enabled, dynamic quantization will be forced for the ModelSlim W8A8Int8, using the NPUW8A8Int8DynamicLinearMethod as the kernel. This will occur even if self.is_dynamic = (self.quant_config.get(prefix + ".weight", "") == "W8A8_DYNAMIC") evaluates to False.

- To prevent weight loading errors, the create_weights method will still create the parameters related to static quantization (even though these parameters won't be used when dynamic quantization is enabled).

## Accuracy Tests

## Benchmarking and Profiling
Compared using Qwen3-14B W8A8 (https://modelscope.cn/models/aleoyang/Qwen3-14B-w8a8-MindIE/)
and eagle3 weight is https://huggingface.co/AngelSlim/Qwen3-14B_eagle3/tree/main.

### Not use SGLANG_ASCEND_W8A8_LINEAR_FORCE_DYNAMIC_QUANT:
<img width="398" height="106" alt="image" src="https://github.com/user-attachments/assets/3f8e9226-8228-49dc-9fba-98f6d6bf11d4" />

### Use SGLANG_ASCEND_W8A8_LINEAR_FORCE_DYNAMIC_QUANT:
<img width="409" height="124" alt="image" src="https://github.com/user-attachments/assets/baabd97f-13a5-4c87-9724-68203d7e683c" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
