### PR TITLE
[AMD] Support AMD True on-policy Using Triton Backend

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1021,6 +1021,14 @@ class TritonAttnBackend(AttentionBackend):
                 layer, forward_batch.out_cache_loc, k, v
             )
 
+        # In deterministic mode, use the unified 1-stage kernel so that decode
+        # and extend share the same sequential reduction order, enabling bit-wise
+        # alignment of log_probs between rollout (decode) and training (extend).
+        if self.enable_deterministic:
+            return self._forward_decode_unified(
+                q, o, layer, forward_batch, logits_soft_cap, sinks
+            )
+
         if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
             kv_indptr = self.forward_metadata.window_kv_indptr
             kv_indices = self.forward_metadata.window_kv_indices
@@ -1041,6 +1049,67 @@ class TritonAttnBackend(AttentionBackend):
             self.max_kv_splits,
             layer.scaling,
             logit_cap=logits_soft_cap,
+            sinks=sinks,
+            xai_temperature_len=layer.xai_temperature_len,
+        )
+        return o
+
+    def _forward_decode_unified(
+        self,
+        q: torch.Tensor,
+        o: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        logits_soft_cap: float,
+        sinks: Optional[torch.Tensor],
+    ):
+        """
+        Decode attention using the unified 1-stage kernel for bit-wise alignment
+        with the extend (training) path.
+
+        During decode, each sequence contributes exactly 1 query token. We treat
+        this as a degenerate extend call where:
+          - qo_indptr = [0, 1, 2, ..., bs]  (one Q token per sequence)
+          - kv_indptr / kv_indices already built by init_forward_metadata for decode
+          - prefix_lens = full KV length per sequence (all KV slots are "prefix";
+            the current token was written to the cache before this call)
+          - max_len_extend = 1
+
+        This ensures the same sequential reduction order as _fwd_kernel_unified
+        used in extend and in the FSDP training forward pass, achieving bit-wise
+        identical attention outputs and therefore identical log_probs.
+        """
+        bs = forward_batch.batch_size
+
+        # One Q token per sequence.
+        qo_indptr = torch.arange(bs + 1, dtype=torch.int32, device=self.device)
+
+        # Reuse the kv_indptr / kv_indices already prepared for decode.
+        # These already include the token that was just written to the KV cache.
+        if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
+            kv_indptr = self.forward_metadata.window_kv_indptr
+            kv_indices = self.forward_metadata.window_kv_indices
+        else:
+            kv_indptr = self.forward_metadata.kv_indptr
+            kv_indices = self.forward_metadata.kv_indices
+
+        # All KV slots are prefix (no new extend tokens beyond the one already
+        # written to cache).  prefix_lens equals the per-sequence KV length.
+        prefix_lens = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
+
+        self.extend_attention_fwd_unified(
+            q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+            o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            prefix_lens,
+            max_len_extend=1,
+            sm_scale=layer.scaling,
+            logit_cap=logits_soft_cap,
+            is_causal=True,
             sinks=sinks,
             xai_temperature_len=layer.xai_temperature_len,
         )

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -166,6 +166,17 @@ class RMSNorm(MultiPlatformOp):
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if is_batch_invariant_mode_enabled():
+            if (
+                residual is not None
+                or get_global_server_args().rl_on_policy_target == "fsdp"
+            ):
+                return self.forward_native(x, residual, post_residual_addition)
+            return rms_norm_batch_invariant(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+            )
         if residual is not None:
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
@@ -191,6 +202,17 @@ class RMSNorm(MultiPlatformOp):
         # Fallback to native implementation if vllm is not available
         if not _has_vllm_rms_norm:
             return self.forward_native(x, residual, post_residual_addition)
+        if is_batch_invariant_mode_enabled():
+            if (
+                residual is not None
+                or get_global_server_args().rl_on_policy_target == "fsdp"
+            ):
+                return self.forward_native(x, residual, post_residual_addition)
+            return rms_norm_batch_invariant(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+            )
 
         if not x.is_contiguous():
             # NOTE: Remove this if aiter kernel supports discontinuous input


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Support true on-policy RL for text models on AMD GPU with triton attention backend.

For bit-wise identical log-probs between sglang rollout (decode) and FSDP training (extend), the inference and training must execute exactly the same numerical operations.

## Modifications

<!-- Detail the changes made in this pull request. -->
When `get_global_server_args().rl_on_policy_target is not None` and using triton attention backend on AMD:

1. **triton_backend.py**: In deterministic mode, route decode through `_forward_decode_unified()` which uses the same 1-stage `extend_attention_fwd_unified` kernel as the extend path.
2. **layernorm.py**: In `forward_aiter` / `forward_hip`: when `is_batch_invariant_mode_enabled()` and `rl_on_policy_target is not None`, fall back to `forward_native`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified using [`run_simple_amd_triton.py`](https://github.com/JessicaJiang-123/miles/blob/amd-top-final-version/examples/true_on_policy/run_simple_amd_triton.py) from the [miles](https://github.com/radixark/miles) RL training framework, on Qwen3-0.6B (single AMD GPU, triton attention backend, `rl_on_policy_target=fsdp`):

train_rollout_logprob_abs_diff: 0.0
mismatch_k3_kl: 0.0

<img width="797" height="311" alt="top-wandb-fv-new" src="https://github.com/user-attachments/assets/6f359608-531f-4f8c-8f1f-0c146ad040c5" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.

## Collaborators
@XinyuJiangCMU
@JessicaJiang-123