### PR TITLE
Add KV cache usage Prometheus metric (#5979)

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -92,6 +92,7 @@ class SchedulerStats:
     cache_hit_rate: float = 0.0
 
     max_total_num_tokens: int = 0
+    gpu_cache_usage_perc: float = 0.0
 
     # Speculative decoding
     spec_accept_length: float = 0.0
@@ -267,6 +268,14 @@ class SchedulerMetricsCollector:
         self.max_total_num_tokens = Gauge(
             name="sglang:max_total_num_tokens",
             documentation="Maximum total number of tokens in the KV cache pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        # KV cache usage percentage (vLLM-compatible metric name)
+        self.gpu_cache_usage_perc = Gauge(
+            name="sglang:gpu_cache_usage_perc",
+            documentation="GPU KV cache usage percentage (0.0 to 1.0).",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -948,6 +957,7 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
+        self._log_gauge(self.gpu_cache_usage_perc, stats.gpu_cache_usage_perc)
 
         # Speculative decoding
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -286,6 +286,7 @@ class SchedulerMetricsMixin:
             self.stats.num_running_reqs_offline_batch = 0
             self.stats.num_used_tokens = num_used
             self.stats.token_usage = token_usage
+            self.stats.gpu_cache_usage_perc = token_usage
             self.stats.full_token_usage = full_token_usage
             if self.is_hybrid_swa:
                 self.stats.swa_token_usage = swa_token_usage
@@ -466,6 +467,7 @@ class SchedulerMetricsMixin:
             self.stats.num_used_tokens = num_used
             # maximum usage of all pools
             self.stats.token_usage = token_usage
+            self.stats.gpu_cache_usage_perc = token_usage
             # usage of full attention
             self.stats.full_token_usage = full_token_usage
             if self.is_hybrid_swa:

--- a/test/registered/metrics/test_metrics.py
+++ b/test/registered/metrics/test_metrics.py
@@ -140,6 +140,7 @@ class TestEnableMetrics(CustomTestCase):
             "sglang:num_queue_reqs",
             "sglang:num_grammar_queue_reqs",
             "sglang:cache_hit_rate",
+            "sglang:gpu_cache_usage_perc",
             "sglang:spec_accept_length",
             "sglang:prompt_tokens_total",
             "sglang:generation_tokens_total",


### PR DESCRIPTION
## Summary
- Adds `sglang:gpu_cache_usage_perc` Prometheus Gauge exposing KV cache usage ratio (0.0–1.0), mirroring vLLM's `vllm:gpu_cache_usage_perc` for compatibility
- Updates on every prefill and decode stats interval via `SchedulerMetricsMixin`
- Adds the metric to the existing metrics test

Closes #5979