### PR TITLE
Fix avg_request_queue_latency metric not being collected (#6357)

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -90,6 +90,7 @@ class SchedulerStats:
     num_grammar_queue_reqs: int = 0
     num_running_reqs_offline_batch: int = 0
     cache_hit_rate: float = 0.0
+    avg_request_queue_latency: float = 0.0
 
     max_total_num_tokens: int = 0
 
@@ -260,6 +261,12 @@ class SchedulerMetricsCollector:
         self.cache_hit_rate = Gauge(
             name="sglang:cache_hit_rate",
             documentation="The prefix cache hit rate.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.avg_request_queue_latency = Gauge(
+            name="sglang:avg_request_queue_latency",
+            documentation="The average time (in seconds) that requests currently in the waiting queue have been waiting.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -946,6 +953,9 @@ class SchedulerMetricsCollector:
             self.num_running_reqs_offline_batch, stats.num_running_reqs_offline_batch
         )
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self._log_gauge(
+            self.avg_request_queue_latency, stats.avg_request_queue_latency
+        )
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -179,6 +179,23 @@ class SchedulerMetricsMixin:
         self.spec_total_num_accepted_tokens = 0
         self.spec_total_num_forward_ct = 0
 
+    def _compute_avg_queue_latency(self: Scheduler) -> float:
+        """Compute average queue latency (in seconds) for requests currently in the waiting queue."""
+        if not self.waiting_queue:
+            return 0.0
+        now = time.perf_counter()
+        total_wait = sum(
+            now - req.time_stats.wait_queue_entry_time
+            for req in self.waiting_queue
+            if req.time_stats.wait_queue_entry_time > 0.0
+        )
+        count = sum(
+            1
+            for req in self.waiting_queue
+            if req.time_stats.wait_queue_entry_time > 0.0
+        )
+        return total_wait / count if count > 0 else 0.0
+
     def log_prefill_stats(
         self: Scheduler,
         prefill_stats: PrefillStats,
@@ -298,6 +315,7 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.avg_request_queue_latency = self._compute_avg_queue_latency()
 
             self.stats.max_total_num_tokens = self.max_total_num_tokens
 
@@ -479,6 +497,7 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.avg_request_queue_latency = self._compute_avg_queue_latency()
 
             self.stats.max_total_num_tokens = self.max_total_num_tokens
 


### PR DESCRIPTION
Adds `sglang:avg_request_queue_latency` Prometheus Gauge that reports average wait time of requests in the waiting queue. Updates every stats interval.

Closes #6357