### PR TITLE
Add --enable-thinking/--disable-thinking server flags (#5948)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -99,6 +99,7 @@ class OpenAIServingChat(OpenAIServingBase):
         self.template_manager = template_manager
         self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+        self.enable_thinking = self.tokenizer_manager.server_args.enable_thinking
 
         # Get default sampling parameters from model's generation config
         self.default_sampling_params = (
@@ -238,11 +239,42 @@ class OpenAIServingChat(OpenAIServingBase):
 
         return None
 
+    def _get_thinking_template_key(self) -> Optional[str]:
+        """Return the chat_template_kwargs key that controls thinking for the
+        current reasoning_parser, or ``None`` when the parser is unknown /
+        does not support toggling."""
+        if self.reasoning_parser in ("qwen3", "glm45", "nemotron_3", "interns1"):
+            return "enable_thinking"
+        if self.reasoning_parser in ("deepseek-v3", "kimi_k2"):
+            return "thinking"
+        return None
+
+    def _apply_thinking_default(self, request: ChatCompletionRequest) -> None:
+        """Inject the server-level ``--enable-thinking`` / ``--disable-thinking``
+        default into the request's ``chat_template_kwargs`` when the request
+        does not already carry an explicit per-request override."""
+        if self.enable_thinking is None:
+            return  # server did not set a default
+
+        key = self._get_thinking_template_key()
+        if key is None:
+            return  # reasoning parser doesn't support toggling
+
+        ctk = request.chat_template_kwargs
+        if ctk is not None and key in ctk:
+            return  # per-request value takes precedence
+
+        if ctk is None:
+            ctk = {}
+        ctk[key] = self.enable_thinking
+        request.chat_template_kwargs = ctk
+
     def _convert_to_internal_request(
         self,
         request: ChatCompletionRequest,
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, ChatCompletionRequest]:
+        """Convert OpenAI chat completion request to internal format"""
         reasoning_effort = (
             request.chat_template_kwargs.pop("reasoning_effort", None)
             if request.chat_template_kwargs
@@ -251,7 +283,8 @@ class OpenAIServingChat(OpenAIServingBase):
         if reasoning_effort is not None:
             request.reasoning_effort = reasoning_effort
 
-        """Convert OpenAI chat completion request to internal format"""
+        # Apply server-level thinking default before template rendering
+        self._apply_thinking_default(request)
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
 
         # Process messages and apply chat template

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -424,6 +424,7 @@ class ServerArgs:
     file_storage_path: str = "sglang_storage"
     enable_cache_report: bool = False
     reasoning_parser: Optional[str] = None
+    enable_thinking: Optional[bool] = None
     tool_call_parser: Optional[str] = None
     tool_server: Optional[str] = None
     sampling_defaults: str = "model"
@@ -3150,6 +3151,14 @@ class ServerArgs:
                     self.preferred_sampling_params
                 )
 
+        # Validate enable_thinking flag
+        if self.enable_thinking is not None and self.reasoning_parser is None:
+            logger.warning(
+                "--enable-thinking/--disable-thinking has no effect without "
+                "--reasoning-parser. Please specify a reasoning parser "
+                "(e.g., --reasoning-parser qwen3)."
+            )
+
     def _handle_debug_utils(self):
         if is_in_ci() and self.soft_watchdog_timeout is None:
             logger.info("Set soft_watchdog_timeout since in CI")
@@ -3999,6 +4008,24 @@ class ServerArgs:
             choices=list(ReasoningParser.DetectorMap.keys()),
             default=ServerArgs.reasoning_parser,
             help=f"Specify the parser for reasoning models, supported parsers are: {list(ReasoningParser.DetectorMap.keys())}.",
+        )
+        thinking_group = parser.add_mutually_exclusive_group()
+        thinking_group.add_argument(
+            "--enable-thinking",
+            action="store_true",
+            default=None,
+            dest="enable_thinking",
+            help="Enable thinking/reasoning mode by default for all requests. "
+            "Models like Qwen3 will generate <think>...</think> reasoning content. "
+            "Per-request chat_template_kwargs can override this default.",
+        )
+        thinking_group.add_argument(
+            "--disable-thinking",
+            action="store_false",
+            dest="enable_thinking",
+            help="Disable thinking/reasoning mode by default for all requests. "
+            "Models like Qwen3 will skip reasoning and respond directly. "
+            "Per-request chat_template_kwargs can override this default.",
         )
         tool_call_parser_choices = list(FunctionCallParser.ToolCallParserEnum.keys())
         parser.add_argument(


### PR DESCRIPTION
Adds mutually exclusive `--enable-thinking`/`--disable-thinking` CLI flags. Per-request override still works.

Closes #5948