### PR TITLE
Introduce EncoderCacheManager for VLM encoder output caching (#16957)

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -22,7 +22,11 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputs,
 )
-from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalStaticCache
+from sglang.srt.mem_cache.multimodal_cache import (
+    EmbeddingResult,
+    EncoderCacheManager,
+    MultiModalStaticCache,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.multimodal.evs import EVSEmbeddingResult
 from sglang.srt.server_args import get_global_server_args
@@ -373,11 +377,46 @@ class MultiModalityDataPaddingPatternMultimodalTokens(MultiModalityDataPaddingPa
 
 
 embedding_cache: Optional[MultiModalStaticCache] = None
+encoder_cache_manager: Optional[EncoderCacheManager] = None
 
 
 def init_mm_embedding_cache(max_size: int = 0):
     global embedding_cache
     embedding_cache = MultiModalStaticCache(max_size)
+
+
+def init_encoder_cache_manager(
+    max_size_bytes: int,
+    max_entry_count: Optional[int] = None,
+    max_encoder_tokens: Optional[int] = None,
+) -> EncoderCacheManager:
+    """Initialize the global encoder cache manager.
+
+    Called by the scheduler during startup.  The encoder cache manager
+    provides reference-counted, scheduler-driven caching of encoder outputs
+    (vision features / multimodal embeddings) so that repeated encoder
+    computations for the same input can be skipped.
+
+    Args:
+        max_size_bytes: Maximum total bytes for cached encoder outputs.
+        max_entry_count: Optional cap on the number of cached entries.
+        max_encoder_tokens: Optional cap on total encoder output tokens.
+
+    Returns:
+        The initialized ``EncoderCacheManager`` instance.
+    """
+    global encoder_cache_manager
+    encoder_cache_manager = EncoderCacheManager(
+        max_size_bytes=max_size_bytes,
+        max_entry_count=max_entry_count,
+        max_encoder_tokens=max_encoder_tokens,
+    )
+    return encoder_cache_manager
+
+
+def get_encoder_cache_manager() -> Optional[EncoderCacheManager]:
+    """Return the global encoder cache manager, or ``None`` if not initialized."""
+    return encoder_cache_manager
 
 
 def get_embedding_chunk(
@@ -572,7 +611,18 @@ def _get_chunked_prefill_embedding(
             continue
         item_hashes = [item.hash for item in embedding_items_per_req]
         embedding_items_hash = MultiModalStaticCache.combine_hashes(item_hashes)
-        embedding_per_req = embedding_cache.get(item_hashes)
+
+        # Try encoder cache manager first (ref-counted, scheduler-driven)
+        _ecm = encoder_cache_manager
+        ecm_tensor = None
+        if _ecm is not None and embedding_items_hash is not None:
+            ecm_tensor = _ecm.acquire(embedding_items_hash)
+
+        if ecm_tensor is not None:
+            embedding_per_req = EmbeddingResult(embedding=ecm_tensor)
+        else:
+            embedding_per_req = embedding_cache.get(item_hashes)
+
         if embedding_per_req is None:
             embedding = data_embedding_func(embedding_items_per_req)
             embedding_per_req = (
@@ -587,6 +637,15 @@ def _get_chunked_prefill_embedding(
                     "`SGLANG_VLM_CACHE_SIZE_MB` environment variable or reducing the input "
                     "embedding size."
                 )
+            # Also store in encoder cache manager for ref-counted management
+            if (
+                _ecm is not None
+                and embedding_items_hash is not None
+                and isinstance(embedding_per_req, EmbeddingResult)
+            ):
+                num_tokens = embedding_per_req.embedding.shape[0]
+                _ecm.put(embedding_items_hash, embedding_per_req.embedding, num_tokens)
+                _ecm.acquire(embedding_items_hash)
 
         extend_prefix_len = prefix_length[i]
         extend_seq_len = extend_length[i] if i < len(extend_length) else 0
@@ -781,7 +840,17 @@ def _get_chunked_prefill_embedding_for_chunked_items(
         item_hashes = [item.hash for item in embedding_items_per_chunk]
         embedding_items_hash = MultiModalStaticCache.combine_hashes(item_hashes)
 
-        embedding_per_chunk = embedding_cache.get(embedding_items_hash)
+        # Try encoder cache manager first (ref-counted, scheduler-driven)
+        _ecm = encoder_cache_manager
+        ecm_tensor = None
+        if _ecm is not None and embedding_items_hash is not None:
+            ecm_tensor = _ecm.acquire(embedding_items_hash)
+
+        if ecm_tensor is not None:
+            embedding_per_chunk = ecm_tensor
+        else:
+            embedding_per_chunk = embedding_cache.get(embedding_items_hash)
+
         if embedding_per_chunk is None:
             # ViT forward for items related with per chunk
             embedding_per_chunk = data_embedding_func(embedding_items_per_chunk)
@@ -793,6 +862,15 @@ def _get_chunked_prefill_embedding_for_chunked_items(
                     "Consider increasing `SGLANG_VLM_CACHE_SIZE_MB` or reducing "
                     "video frame count / resolution for a single request."
                 )
+            # Also store in encoder cache manager for ref-counted management
+            if _ecm is not None and embedding_items_hash is not None:
+                num_tokens = embedding_per_chunk.shape[0]
+                _ecm.put(
+                    embedding_items_hash,
+                    embedding_for_cache,
+                    num_tokens,
+                )
+                _ecm.acquire(embedding_items_hash)
         else:
             target_device = embedding_items_per_req[0].feature.device
             if embedding_per_chunk.device != target_device:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -136,7 +136,11 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
 )
-from sglang.srt.managers.mm_utils import init_mm_embedding_cache, unwrap_shm_features
+from sglang.srt.managers.mm_utils import (
+    init_encoder_cache_manager,
+    init_mm_embedding_cache,
+    unwrap_shm_features,
+)
 from sglang.srt.managers.overlap_utils import FutureMap
 from sglang.srt.managers.prefill_delayer import (
     PrefillDelayer,
@@ -782,6 +786,13 @@ class Scheduler(
 
         embedding_cache_size = envs.SGLANG_VLM_CACHE_SIZE_MB.get()
         init_mm_embedding_cache(embedding_cache_size * 1024 * 1024)
+
+        # Initialize encoder cache manager for scheduler-driven, ref-counted
+        # caching of encoder outputs (vision features / multimodal embeddings).
+        encoder_cache_size = envs.SGLANG_VLM_CACHE_SIZE_MB.get()
+        self.encoder_cache_manager = init_encoder_cache_manager(
+            max_size_bytes=encoder_cache_size * 1024 * 1024,
+        )
 
     def init_running_status(self):
         self.waiting_queue: List[Req] = []
@@ -1603,6 +1614,13 @@ class Scheduler(
             # For session requests, keep mm_inputs for the next request
             if req.session:
                 continue
+
+            # Release encoder cache references for finished requests
+            if self.encoder_cache_manager is not None:
+                for item in mm_inputs.mm_items:
+                    if item.hash is not None:
+                        self.encoder_cache_manager.release(item.hash)
+
             # For non-session requests, clear features and mm_inputs
             for item in mm_inputs.mm_items:
                 item.feature = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -141,6 +141,7 @@ from sglang.srt.managers.mm_utils import (
     init_mm_embedding_cache,
     unwrap_shm_features,
 )
+from sglang.srt.mem_cache.multimodal_cache import MultiModalStaticCache
 from sglang.srt.managers.overlap_utils import FutureMap
 from sglang.srt.managers.prefill_delayer import (
     PrefillDelayer,
@@ -1617,9 +1618,12 @@ class Scheduler(
 
             # Release encoder cache references for finished requests
             if self.encoder_cache_manager is not None:
-                for item in mm_inputs.mm_items:
-                    if item.hash is not None:
-                        self.encoder_cache_manager.release(item.hash)
+                item_hashes = [
+                    item.hash for item in mm_inputs.mm_items if item.hash is not None
+                ]
+                combined = MultiModalStaticCache.combine_hashes(item_hashes)
+                if combined is not None:
+                    self.encoder_cache_manager.release(combined)
 
             # For non-session requests, clear features and mm_inputs
             for item in mm_inputs.mm_items:

--- a/python/sglang/srt/mem_cache/multimodal_cache.py
+++ b/python/sglang/srt/mem_cache/multimodal_cache.py
@@ -1,11 +1,17 @@
 import abc
+import logging
+import threading
+import time
 from collections import OrderedDict
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict, List, Optional, Set, Tuple
 
 import torch
 
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+
+logger = logging.getLogger(__name__)
 
 
 class MultimodalCache(abc.ABC):
@@ -141,3 +147,591 @@ class MultiModalStaticCache(MultimodalCache):
 
     def available_size(self):
         return self.__len__()
+
+
+# ---------------------------------------------------------------------------
+# EncoderCacheManager: scheduler-driven, ref-counted encoder output cache
+# ---------------------------------------------------------------------------
+
+
+class CacheEntryState(Enum):
+    """Lifecycle states for a cache entry."""
+
+    ACTIVE = auto()  # In use by at least one request
+    FREEABLE = auto()  # No active references, eligible for eviction
+    FREED = auto()  # Evicted, memory released
+
+
+@dataclass
+class EncoderCacheEntry:
+    """A single cached encoder output with reference tracking.
+
+    Attributes:
+        mm_hash: The hash key identifying this multimodal input.
+        data: The cached tensor (encoder feature or embedding).
+        num_tokens: Number of encoder output tokens this entry represents.
+        ref_count: Number of active requests using this entry.
+        state: Current lifecycle state.
+        last_access_time: Monotonic timestamp of last access (for LRU).
+        creation_time: Monotonic timestamp of creation.
+        data_size_bytes: Size of the cached tensor in bytes.
+    """
+
+    mm_hash: int
+    data: torch.Tensor
+    num_tokens: int
+    ref_count: int = 0
+    state: CacheEntryState = CacheEntryState.ACTIVE
+    last_access_time: float = field(default_factory=time.monotonic)
+    creation_time: float = field(default_factory=time.monotonic)
+    data_size_bytes: int = 0
+
+    def __post_init__(self):
+        if self.data is not None:
+            self.data_size_bytes = _get_tensor_size(self.data)
+
+
+class EncoderCacheManager:
+    """Scheduler-driven cache manager for encoder outputs (vision features and
+    multimodal embeddings).
+
+    Unlike the passive LRU ``MultiModalStaticCache``, this manager is
+    **actively driven by the scheduler** with reference counting and a
+    three-state lifecycle (ACTIVE -> FREEABLE -> FREED).
+
+    Design contract (from issue #16957):
+      Decisions on allocation and eviction are made during the scheduling
+      phase.  The actual physical release is completed by the worker at an
+      appropriate time.
+
+    Key capabilities:
+      - **Reference counting**: entries are not evicted while any request
+        holds a reference.
+      - **Recyclable queue**: entries move ACTIVE -> FREEABLE when ref_count
+        drops to zero, and can be promoted back to ACTIVE on a cache hit.
+      - **Budget computation**: ``compute_budget`` reports how many encoder
+        tokens can still be admitted given the current memory usage.
+      - **Two-tier caching**: supports separate namespaces for raw encoder
+        features (``mm_feature``) and projected embeddings (``mm_embedding``).
+      - **Thread safety**: all public methods are protected by a lock so
+        the manager can be shared between the scheduler and workers.
+
+    Parameters:
+        max_size_bytes: Maximum total size in bytes for cached tensors.
+        max_entry_count: Optional cap on the number of entries.
+        max_encoder_tokens: Optional cap on total encoder tokens across all
+            cached entries.
+    """
+
+    def __init__(
+        self,
+        max_size_bytes: int,
+        max_entry_count: Optional[int] = None,
+        max_encoder_tokens: Optional[int] = None,
+    ):
+        self._max_size_bytes = max_size_bytes
+        self._max_entry_count = max_entry_count
+        self._max_encoder_tokens = max_encoder_tokens
+        self._lock = threading.Lock()
+
+        # Primary cache: mm_hash -> EncoderCacheEntry
+        self._cache: OrderedDict[int, EncoderCacheEntry] = OrderedDict()
+
+        # Tracking sets for lifecycle management
+        self._active_hashes: Set[int] = set()
+        self._freeable_hashes: Set[int] = set()
+
+        # Accounting
+        self._current_size_bytes: int = 0
+        self._current_encoder_tokens: int = 0
+        self._hit_count: int = 0
+        self._miss_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API – cache operations
+    # ------------------------------------------------------------------
+
+    def get(self, mm_hash: int) -> Optional[torch.Tensor]:
+        """Look up a cached encoder output by hash.
+
+        If found, the entry is touched (moved to end of LRU order) and
+        returned.  This does **not** increment the reference count -- use
+        ``acquire`` for that.
+
+        Returns:
+            The cached tensor, or ``None`` on a miss.
+        """
+        with self._lock:
+            entry = self._cache.get(mm_hash)
+            if entry is None or entry.state == CacheEntryState.FREED:
+                self._miss_count += 1
+                return None
+            self._hit_count += 1
+            entry.last_access_time = time.monotonic()
+            self._cache.move_to_end(mm_hash)
+            return entry.data
+
+    def get_by_combined_hash(
+        self, mm_hashes: List[int]
+    ) -> Optional[torch.Tensor]:
+        """Look up using a combined hash derived from a list of item hashes.
+
+        Mirrors the ``MultiModalStaticCache.combine_hashes`` convention so
+        callers can use either individual or combined keys.
+        """
+        combined = MultimodalCache.combine_hashes(mm_hashes)
+        if combined is None:
+            return None
+        return self.get(combined)
+
+    def put(
+        self,
+        mm_hash: int,
+        data: torch.Tensor,
+        num_tokens: int = 0,
+    ) -> bool:
+        """Insert or update an encoder output in the cache.
+
+        If the hash already exists, the entry is refreshed (data replaced,
+        access time updated) without changing the reference count.
+
+        If insertion requires eviction and there is not enough freeable
+        space, the call returns ``False``.
+
+        Args:
+            mm_hash: Hash key for the multimodal input.
+            data: Encoder output tensor to cache.
+            num_tokens: Number of encoder output tokens this entry covers.
+
+        Returns:
+            ``True`` if the entry was successfully cached.
+        """
+        with self._lock:
+            return self._put_locked(mm_hash, data, num_tokens)
+
+    def has(self, mm_hash: int) -> bool:
+        """Check whether a hash is present and not freed."""
+        with self._lock:
+            entry = self._cache.get(mm_hash)
+            return entry is not None and entry.state != CacheEntryState.FREED
+
+    def acquire(self, mm_hash: int) -> Optional[torch.Tensor]:
+        """Acquire a reference to a cached entry.
+
+        Increments the reference count and ensures the entry is in ACTIVE
+        state (promoting from FREEABLE if necessary).  This should be called
+        by the **scheduler** when a request begins using a cached encoder
+        output.
+
+        Returns:
+            The cached tensor, or ``None`` if the hash is not in the cache.
+        """
+        with self._lock:
+            entry = self._cache.get(mm_hash)
+            if entry is None or entry.state == CacheEntryState.FREED:
+                return None
+            entry.ref_count += 1
+            entry.last_access_time = time.monotonic()
+            if entry.state == CacheEntryState.FREEABLE:
+                self._freeable_hashes.discard(mm_hash)
+                entry.state = CacheEntryState.ACTIVE
+                self._active_hashes.add(mm_hash)
+            self._cache.move_to_end(mm_hash)
+            return entry.data
+
+    def release(self, mm_hash: int) -> bool:
+        """Release a reference to a cached entry.
+
+        Decrements the reference count.  When the count reaches zero the
+        entry transitions to FREEABLE and becomes eligible for eviction.
+
+        This should be called by the **scheduler** when a request that was
+        using this encoder output finishes or is preempted.
+
+        Returns:
+            ``True`` if the release was successful.
+        """
+        with self._lock:
+            entry = self._cache.get(mm_hash)
+            if entry is None or entry.state == CacheEntryState.FREED:
+                return False
+            entry.ref_count = max(0, entry.ref_count - 1)
+            if entry.ref_count == 0 and entry.state == CacheEntryState.ACTIVE:
+                entry.state = CacheEntryState.FREEABLE
+                self._active_hashes.discard(mm_hash)
+                self._freeable_hashes.add(mm_hash)
+            return True
+
+    def evict(self, mm_hash: int) -> bool:
+        """Explicitly evict a single entry.
+
+        Only FREEABLE entries (ref_count == 0) can be evicted.
+
+        Returns:
+            ``True`` if the entry was evicted.
+        """
+        with self._lock:
+            return self._evict_entry_locked(mm_hash)
+
+    def evict_freeable(self, target_bytes: int = 0) -> int:
+        """Evict FREEABLE entries in LRU order until at least
+        ``target_bytes`` of memory has been reclaimed (or all freeable
+        entries have been evicted).
+
+        Args:
+            target_bytes: Minimum number of bytes to free.  Pass 0 to evict
+                all freeable entries.
+
+        Returns:
+            Total bytes actually freed.
+        """
+        with self._lock:
+            return self._evict_freeable_locked(target_bytes)
+
+    def clear(self) -> None:
+        """Remove all entries regardless of state."""
+        with self._lock:
+            self._cache.clear()
+            self._active_hashes.clear()
+            self._freeable_hashes.clear()
+            self._current_size_bytes = 0
+            self._current_encoder_tokens = 0
+
+    # ------------------------------------------------------------------
+    # Public API – budget and introspection
+    # ------------------------------------------------------------------
+
+    def compute_budget(self) -> "EncoderBudget":
+        """Compute how many more encoder tokens and bytes the cache can
+        accept before eviction is required.
+
+        Returns an ``EncoderBudget`` with the remaining capacity.
+        """
+        with self._lock:
+            remaining_bytes = max(0, self._max_size_bytes - self._current_size_bytes)
+            if self._max_encoder_tokens is not None:
+                remaining_tokens = max(
+                    0, self._max_encoder_tokens - self._current_encoder_tokens
+                )
+            else:
+                remaining_tokens = None
+
+            freeable_bytes = sum(
+                self._cache[h].data_size_bytes
+                for h in self._freeable_hashes
+                if h in self._cache
+            )
+            freeable_tokens = sum(
+                self._cache[h].num_tokens
+                for h in self._freeable_hashes
+                if h in self._cache
+            )
+
+            if self._max_entry_count is not None:
+                remaining_entries = max(
+                    0, self._max_entry_count - len(self._cache)
+                )
+            else:
+                remaining_entries = None
+
+            return EncoderBudget(
+                remaining_bytes=remaining_bytes,
+                remaining_tokens=remaining_tokens,
+                remaining_entries=remaining_entries,
+                freeable_bytes=freeable_bytes,
+                freeable_tokens=freeable_tokens,
+                total_bytes=self._max_size_bytes,
+                used_bytes=self._current_size_bytes,
+                total_tokens=self._max_encoder_tokens,
+                used_tokens=self._current_encoder_tokens,
+            )
+
+    @property
+    def current_size_bytes(self) -> int:
+        return self._current_size_bytes
+
+    @property
+    def num_entries(self) -> int:
+        return len(self._cache)
+
+    @property
+    def num_active(self) -> int:
+        return len(self._active_hashes)
+
+    @property
+    def num_freeable(self) -> int:
+        return len(self._freeable_hashes)
+
+    @property
+    def hit_rate(self) -> float:
+        total = self._hit_count + self._miss_count
+        return self._hit_count / total if total > 0 else 0.0
+
+    def get_stats(self) -> Dict[str, int]:
+        """Return a snapshot of cache statistics."""
+        with self._lock:
+            return {
+                "num_entries": len(self._cache),
+                "num_active": len(self._active_hashes),
+                "num_freeable": len(self._freeable_hashes),
+                "current_size_bytes": self._current_size_bytes,
+                "current_encoder_tokens": self._current_encoder_tokens,
+                "hit_count": self._hit_count,
+                "miss_count": self._miss_count,
+            }
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def __contains__(self, mm_hash: int) -> bool:
+        return self.has(mm_hash)
+
+    # ------------------------------------------------------------------
+    # Internal helpers (must be called with self._lock held)
+    # ------------------------------------------------------------------
+
+    def _put_locked(
+        self,
+        mm_hash: int,
+        data: torch.Tensor,
+        num_tokens: int,
+    ) -> bool:
+        data_size = _get_tensor_size(data)
+
+        # Update existing entry
+        existing = self._cache.get(mm_hash)
+        if existing is not None and existing.state != CacheEntryState.FREED:
+            old_size = existing.data_size_bytes
+            old_tokens = existing.num_tokens
+            existing.data = data
+            existing.num_tokens = num_tokens
+            existing.data_size_bytes = data_size
+            existing.last_access_time = time.monotonic()
+            self._current_size_bytes += data_size - old_size
+            self._current_encoder_tokens += num_tokens - old_tokens
+            self._cache.move_to_end(mm_hash)
+            return True
+
+        # Evict freeable entries if needed to make room
+        needed = data_size - max(0, self._max_size_bytes - self._current_size_bytes)
+        if needed > 0:
+            freed = self._evict_freeable_locked(needed)
+            if self._current_size_bytes + data_size > self._max_size_bytes:
+                # Still not enough space after evicting everything freeable
+                return False
+
+        # Check entry count limit
+        if (
+            self._max_entry_count is not None
+            and len(self._cache) >= self._max_entry_count
+        ):
+            # Try to evict one freeable entry
+            if not self._freeable_hashes:
+                return False
+            oldest = self._get_lru_freeable_locked()
+            if oldest is not None:
+                self._evict_entry_locked(oldest)
+            else:
+                return False
+
+        # Check token budget
+        if (
+            self._max_encoder_tokens is not None
+            and self._current_encoder_tokens + num_tokens > self._max_encoder_tokens
+        ):
+            # Try freeing until we have room
+            tokens_needed = (
+                self._current_encoder_tokens
+                + num_tokens
+                - self._max_encoder_tokens
+            )
+            self._evict_freeable_by_tokens_locked(tokens_needed)
+            if self._current_encoder_tokens + num_tokens > self._max_encoder_tokens:
+                return False
+
+        # Insert new entry
+        entry = EncoderCacheEntry(
+            mm_hash=mm_hash,
+            data=data,
+            num_tokens=num_tokens,
+            ref_count=0,
+            state=CacheEntryState.FREEABLE,
+        )
+        self._cache[mm_hash] = entry
+        self._freeable_hashes.add(mm_hash)
+        self._current_size_bytes += data_size
+        self._current_encoder_tokens += num_tokens
+        return True
+
+    def _evict_entry_locked(self, mm_hash: int) -> bool:
+        entry = self._cache.get(mm_hash)
+        if entry is None:
+            return False
+        if entry.state == CacheEntryState.ACTIVE:
+            # Cannot evict an entry with active references
+            return False
+        if entry.state == CacheEntryState.FREED:
+            return False
+        # Perform eviction
+        self._current_size_bytes -= entry.data_size_bytes
+        self._current_encoder_tokens -= entry.num_tokens
+        self._freeable_hashes.discard(mm_hash)
+        self._active_hashes.discard(mm_hash)
+        del self._cache[mm_hash]
+        return True
+
+    def _evict_freeable_locked(self, target_bytes: int) -> int:
+        """Evict LRU freeable entries until target_bytes freed or none left."""
+        freed = 0
+        # Collect freeable in LRU order (iteration order of OrderedDict)
+        to_evict = []
+        for h, entry in self._cache.items():
+            if entry.state == CacheEntryState.FREEABLE:
+                to_evict.append(h)
+                freed += entry.data_size_bytes
+                if target_bytes > 0 and freed >= target_bytes:
+                    break
+
+        actual_freed = 0
+        for h in to_evict:
+            entry = self._cache.get(h)
+            if entry is not None:
+                actual_freed += entry.data_size_bytes
+                self._current_size_bytes -= entry.data_size_bytes
+                self._current_encoder_tokens -= entry.num_tokens
+                self._freeable_hashes.discard(h)
+                del self._cache[h]
+        return actual_freed
+
+    def _evict_freeable_by_tokens_locked(self, target_tokens: int) -> int:
+        """Evict LRU freeable entries until target_tokens freed."""
+        freed_tokens = 0
+        to_evict = []
+        for h, entry in self._cache.items():
+            if entry.state == CacheEntryState.FREEABLE:
+                to_evict.append(h)
+                freed_tokens += entry.num_tokens
+                if freed_tokens >= target_tokens:
+                    break
+
+        actual_freed = 0
+        for h in to_evict:
+            entry = self._cache.get(h)
+            if entry is not None:
+                actual_freed += entry.num_tokens
+                self._current_size_bytes -= entry.data_size_bytes
+                self._current_encoder_tokens -= entry.num_tokens
+                self._freeable_hashes.discard(h)
+                del self._cache[h]
+        return actual_freed
+
+    def _get_lru_freeable_locked(self) -> Optional[int]:
+        """Return the hash of the least recently used freeable entry."""
+        for h, entry in self._cache.items():
+            if entry.state == CacheEntryState.FREEABLE:
+                return h
+        return None
+
+
+@dataclass
+class EncoderBudget:
+    """Snapshot of remaining encoder cache capacity.
+
+    Returned by ``EncoderCacheManager.compute_budget()`` so the scheduler
+    can decide whether to admit new encoder work.
+    """
+
+    remaining_bytes: int
+    remaining_tokens: Optional[int]
+    remaining_entries: Optional[int]
+    freeable_bytes: int
+    freeable_tokens: int
+    total_bytes: int
+    used_bytes: int
+    total_tokens: Optional[int]
+    used_tokens: int
+
+    @property
+    def available_bytes(self) -> int:
+        """Total bytes that could be used (remaining + freeable)."""
+        return self.remaining_bytes + self.freeable_bytes
+
+    @property
+    def available_tokens(self) -> Optional[int]:
+        """Total tokens that could be used (remaining + freeable)."""
+        if self.remaining_tokens is None:
+            return None
+        return self.remaining_tokens + self.freeable_tokens
+
+    def can_admit(self, size_bytes: int, num_tokens: int = 0) -> bool:
+        """Check if a new entry of the given size could be admitted
+        (possibly after evicting freeable entries)."""
+        if self.available_bytes < size_bytes:
+            return False
+        if self.remaining_tokens is not None:
+            avail_tokens = self.available_tokens
+            if avail_tokens is not None and avail_tokens < num_tokens:
+                return False
+        return True
+
+
+class EncoderCacheType(Enum):
+    """Namespace keys for the two-tier encoder cache."""
+
+    FEATURE = "mm_feature"
+    EMBEDDING = "mm_embedding"
+
+
+class MultiTierEncoderCacheManager:
+    """Convenience wrapper that manages separate ``EncoderCacheManager``
+    instances for raw encoder features and projected embeddings.
+
+    This allows the scheduler to cache ViT outputs (features) separately
+    from the final projected embeddings, enabling partial re-use: for
+    example, if only the projection layer changes across requests, the
+    raw features can still be reused.
+
+    Parameters:
+        feature_cache_bytes: Max bytes for the feature cache.
+        embedding_cache_bytes: Max bytes for the embedding cache.
+        max_encoder_tokens: Optional global token cap applied to each tier.
+    """
+
+    def __init__(
+        self,
+        feature_cache_bytes: int,
+        embedding_cache_bytes: int,
+        max_encoder_tokens: Optional[int] = None,
+    ):
+        self._caches: Dict[EncoderCacheType, EncoderCacheManager] = {
+            EncoderCacheType.FEATURE: EncoderCacheManager(
+                max_size_bytes=feature_cache_bytes,
+                max_encoder_tokens=max_encoder_tokens,
+            ),
+            EncoderCacheType.EMBEDDING: EncoderCacheManager(
+                max_size_bytes=embedding_cache_bytes,
+                max_encoder_tokens=max_encoder_tokens,
+            ),
+        }
+
+    def get_cache(self, tier: EncoderCacheType) -> EncoderCacheManager:
+        """Return the cache for a specific tier."""
+        return self._caches[tier]
+
+    @property
+    def feature_cache(self) -> EncoderCacheManager:
+        return self._caches[EncoderCacheType.FEATURE]
+
+    @property
+    def embedding_cache(self) -> EncoderCacheManager:
+        return self._caches[EncoderCacheType.EMBEDDING]
+
+    def clear(self) -> None:
+        for cache in self._caches.values():
+            cache.clear()
+
+    def get_stats(self) -> Dict[str, Dict[str, int]]:
+        return {
+            tier.value: cache.get_stats()
+            for tier, cache in self._caches.items()
+        }

--- a/test/registered/radix_cache/test_encoder_cache_manager.py
+++ b/test/registered/radix_cache/test_encoder_cache_manager.py
@@ -1,0 +1,561 @@
+"""
+Unit tests for the EncoderCacheManager implementation.
+
+This module tests the scheduler-driven, ref-counted encoder output cache
+introduced in issue #16957.
+
+Test Coverage:
+- Basic put/get/has operations
+- Reference counting (acquire/release)
+- LRU eviction of freeable entries
+- Protection of active (referenced) entries from eviction
+- Budget computation
+- Entry lifecycle: ACTIVE -> FREEABLE -> evicted
+- Size and token limit enforcement
+- Multi-tier cache wrapper
+- Thread safety basics
+- Cache statistics
+
+Usage:
+    python test_encoder_cache_manager.py
+    python -m pytest test_encoder_cache_manager.py -v
+"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+# CPU-based unit test, runs quickly on any runner
+register_cuda_ci(est_time=5, suite="stage-b-test-small-1-gpu")
+
+import threading
+import time
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.multimodal_cache import (
+    CacheEntryState,
+    EncoderBudget,
+    EncoderCacheEntry,
+    EncoderCacheManager,
+    EncoderCacheType,
+    MultiTierEncoderCacheManager,
+)
+
+
+def _make_tensor(num_tokens: int, hidden_dim: int = 64) -> torch.Tensor:
+    """Create a dummy encoder output tensor."""
+    return torch.randn(num_tokens, hidden_dim)
+
+
+def _tensor_bytes(t: torch.Tensor) -> int:
+    return t.element_size() * t.numel()
+
+
+class TestEncoderCacheEntry(unittest.TestCase):
+    """Test cases for EncoderCacheEntry dataclass."""
+
+    def test_post_init_computes_size(self):
+        t = _make_tensor(10)
+        entry = EncoderCacheEntry(mm_hash=42, data=t, num_tokens=10)
+        self.assertEqual(entry.data_size_bytes, _tensor_bytes(t))
+
+    def test_default_state_is_active(self):
+        entry = EncoderCacheEntry(mm_hash=1, data=_make_tensor(5), num_tokens=5)
+        self.assertEqual(entry.state, CacheEntryState.ACTIVE)
+        self.assertEqual(entry.ref_count, 0)
+
+
+class TestEncoderCacheManager(unittest.TestCase):
+    """Test cases for the core EncoderCacheManager."""
+
+    def _make_cache(self, max_bytes=10_000_000, **kwargs):
+        return EncoderCacheManager(max_size_bytes=max_bytes, **kwargs)
+
+    # ----- Basic operations -----
+
+    def test_put_and_get(self):
+        cache = self._make_cache()
+        t = _make_tensor(10)
+        self.assertTrue(cache.put(1, t, num_tokens=10))
+        result = cache.get(1)
+        self.assertIsNotNone(result)
+        self.assertTrue(torch.equal(result, t))
+
+    def test_get_miss(self):
+        cache = self._make_cache()
+        self.assertIsNone(cache.get(999))
+
+    def test_has(self):
+        cache = self._make_cache()
+        self.assertFalse(cache.has(1))
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        self.assertTrue(cache.has(1))
+
+    def test_contains_operator(self):
+        cache = self._make_cache()
+        cache.put(42, _make_tensor(3), num_tokens=3)
+        self.assertIn(42, cache)
+        self.assertNotIn(99, cache)
+
+    def test_len(self):
+        cache = self._make_cache()
+        self.assertEqual(len(cache), 0)
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.put(2, _make_tensor(5), num_tokens=5)
+        self.assertEqual(len(cache), 2)
+
+    def test_clear(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.put(2, _make_tensor(5), num_tokens=5)
+        cache.clear()
+        self.assertEqual(len(cache), 0)
+        self.assertFalse(cache.has(1))
+        self.assertEqual(cache.current_size_bytes, 0)
+
+    # ----- Reference counting -----
+
+    def test_acquire_increments_refcount(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        result = cache.acquire(1)
+        self.assertIsNotNone(result)
+        self.assertEqual(cache.num_active, 1)
+        self.assertEqual(cache.num_freeable, 0)
+
+    def test_acquire_miss_returns_none(self):
+        cache = self._make_cache()
+        self.assertIsNone(cache.acquire(999))
+
+    def test_release_decrements_refcount(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.acquire(1)
+        self.assertEqual(cache.num_active, 1)
+        cache.release(1)
+        self.assertEqual(cache.num_active, 0)
+        self.assertEqual(cache.num_freeable, 1)
+
+    def test_multiple_acquires_and_releases(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.acquire(1)
+        cache.acquire(1)
+        self.assertEqual(cache.num_active, 1)
+        # Release once - still active (ref_count=1)
+        cache.release(1)
+        self.assertEqual(cache.num_active, 1)
+        # Release again - now freeable (ref_count=0)
+        cache.release(1)
+        self.assertEqual(cache.num_active, 0)
+        self.assertEqual(cache.num_freeable, 1)
+
+    def test_acquire_promotes_from_freeable(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        # Entry starts as FREEABLE (ref_count=0 after put)
+        self.assertEqual(cache.num_freeable, 1)
+        # Acquire promotes to ACTIVE
+        cache.acquire(1)
+        self.assertEqual(cache.num_active, 1)
+        self.assertEqual(cache.num_freeable, 0)
+
+    # ----- Eviction -----
+
+    def test_evict_freeable_entry(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        # Entry is freeable (no references)
+        self.assertTrue(cache.evict(1))
+        self.assertFalse(cache.has(1))
+
+    def test_cannot_evict_active_entry(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.acquire(1)
+        # Cannot evict while referenced
+        self.assertFalse(cache.evict(1))
+        self.assertTrue(cache.has(1))
+
+    def test_lru_eviction_on_put(self):
+        """When cache is full, freeable entries are evicted in LRU order."""
+        t1 = _make_tensor(10)
+        t2 = _make_tensor(10)
+        size = _tensor_bytes(t1)
+        # Cache can hold exactly one entry
+        cache = self._make_cache(max_bytes=size)
+        cache.put(1, t1, num_tokens=10)
+        self.assertTrue(cache.has(1))
+        # Inserting second entry should evict first
+        cache.put(2, t2, num_tokens=10)
+        self.assertFalse(cache.has(1))
+        self.assertTrue(cache.has(2))
+
+    def test_active_entries_not_evicted_on_put(self):
+        """Active (referenced) entries survive eviction pressure."""
+        t1 = _make_tensor(10)
+        t2 = _make_tensor(10)
+        size = _tensor_bytes(t1)
+        cache = self._make_cache(max_bytes=size)
+        cache.put(1, t1, num_tokens=10)
+        cache.acquire(1)  # Protect entry 1
+        # Cannot insert t2 because entry 1 is active and can't be evicted
+        self.assertFalse(cache.put(2, t2, num_tokens=10))
+        self.assertTrue(cache.has(1))
+        self.assertFalse(cache.has(2))
+
+    def test_evict_freeable_reclaims_space(self):
+        cache = self._make_cache()
+        t1 = _make_tensor(100)
+        cache.put(1, t1, num_tokens=100)
+        size_before = cache.current_size_bytes
+        freed = cache.evict_freeable(target_bytes=0)
+        self.assertEqual(freed, size_before)
+        self.assertEqual(cache.current_size_bytes, 0)
+
+    def test_evict_freeable_with_target(self):
+        cache = self._make_cache()
+        t1 = _make_tensor(10)
+        t2 = _make_tensor(10)
+        cache.put(1, t1, num_tokens=10)
+        cache.put(2, t2, num_tokens=10)
+        # Evict just enough to free one entry
+        freed = cache.evict_freeable(target_bytes=_tensor_bytes(t1))
+        self.assertGreaterEqual(freed, _tensor_bytes(t1))
+        # At least one entry should remain
+        self.assertLessEqual(len(cache), 2)
+
+    # ----- Size limits -----
+
+    def test_max_entry_count(self):
+        cache = self._make_cache(max_entry_count=2)
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.put(2, _make_tensor(5), num_tokens=5)
+        # Third entry evicts the oldest freeable
+        self.assertTrue(cache.put(3, _make_tensor(5), num_tokens=5))
+        self.assertEqual(len(cache), 2)
+        # Entry 1 (oldest) should have been evicted
+        self.assertFalse(cache.has(1))
+
+    def test_max_encoder_tokens(self):
+        cache = self._make_cache(max_encoder_tokens=20)
+        cache.put(1, _make_tensor(10), num_tokens=10)
+        cache.put(2, _make_tensor(10), num_tokens=10)
+        # Cache is at 20 tokens, adding more should evict
+        self.assertTrue(cache.put(3, _make_tensor(5), num_tokens=5))
+        # Total should not exceed 20 after eviction
+        budget = cache.compute_budget()
+        self.assertLessEqual(budget.used_tokens, 20)
+
+    def test_put_fails_when_single_entry_exceeds_max(self):
+        t = _make_tensor(100)
+        size = _tensor_bytes(t)
+        # Max size is smaller than a single entry
+        cache = self._make_cache(max_bytes=size - 1)
+        self.assertFalse(cache.put(1, t, num_tokens=100))
+
+    # ----- Update existing entry -----
+
+    def test_put_updates_existing(self):
+        cache = self._make_cache()
+        t1 = _make_tensor(10, hidden_dim=32)
+        t2 = _make_tensor(10, hidden_dim=64)
+        cache.put(1, t1, num_tokens=10)
+        size1 = cache.current_size_bytes
+        cache.put(1, t2, num_tokens=10)
+        self.assertEqual(len(cache), 1)
+        result = cache.get(1)
+        self.assertTrue(torch.equal(result, t2))
+        # Size should reflect new tensor
+        self.assertEqual(cache.current_size_bytes, _tensor_bytes(t2))
+
+    # ----- Budget computation -----
+
+    def test_compute_budget_empty(self):
+        cache = self._make_cache(max_bytes=1000, max_encoder_tokens=50)
+        budget = cache.compute_budget()
+        self.assertEqual(budget.remaining_bytes, 1000)
+        self.assertEqual(budget.remaining_tokens, 50)
+        self.assertEqual(budget.freeable_bytes, 0)
+        self.assertEqual(budget.freeable_tokens, 0)
+        self.assertTrue(budget.can_admit(500, 25))
+
+    def test_compute_budget_after_inserts(self):
+        cache = self._make_cache(max_bytes=100_000, max_encoder_tokens=100)
+        t = _make_tensor(30)
+        cache.put(1, t, num_tokens=30)
+        budget = cache.compute_budget()
+        self.assertEqual(budget.used_tokens, 30)
+        self.assertEqual(budget.used_bytes, _tensor_bytes(t))
+        self.assertEqual(budget.remaining_tokens, 70)
+        self.assertEqual(budget.freeable_tokens, 30)  # entry is freeable
+        self.assertTrue(budget.can_admit(_tensor_bytes(t), 30))
+
+    def test_budget_can_admit_with_freeable(self):
+        t = _make_tensor(10)
+        size = _tensor_bytes(t)
+        cache = self._make_cache(max_bytes=size)
+        cache.put(1, t, num_tokens=10)
+        budget = cache.compute_budget()
+        # Remaining is 0, but freeable covers it
+        self.assertEqual(budget.remaining_bytes, 0)
+        self.assertEqual(budget.available_bytes, size)
+        self.assertTrue(budget.can_admit(size, 10))
+
+    def test_budget_cannot_admit_when_active_fills_cache(self):
+        t = _make_tensor(10)
+        size = _tensor_bytes(t)
+        cache = self._make_cache(max_bytes=size)
+        cache.put(1, t, num_tokens=10)
+        cache.acquire(1)  # Make it active
+        budget = cache.compute_budget()
+        # Nothing freeable
+        self.assertEqual(budget.freeable_bytes, 0)
+        self.assertFalse(budget.can_admit(size, 10))
+
+    # ----- Statistics -----
+
+    def test_hit_rate(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.get(1)  # hit
+        cache.get(2)  # miss
+        self.assertAlmostEqual(cache.hit_rate, 0.5)
+
+    def test_get_stats(self):
+        cache = self._make_cache()
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.acquire(1)
+        stats = cache.get_stats()
+        self.assertEqual(stats["num_entries"], 1)
+        self.assertEqual(stats["num_active"], 1)
+        self.assertEqual(stats["num_freeable"], 0)
+
+    # ----- Combined hash lookup -----
+
+    def test_get_by_combined_hash(self):
+        cache = self._make_cache()
+        from sglang.srt.mem_cache.multimodal_cache import MultimodalCache
+
+        combined = MultimodalCache.combine_hashes([10, 20, 30])
+        t = _make_tensor(15)
+        cache.put(combined, t, num_tokens=15)
+        result = cache.get_by_combined_hash([10, 20, 30])
+        self.assertIsNotNone(result)
+        self.assertTrue(torch.equal(result, t))
+
+    def test_get_by_combined_hash_empty_list(self):
+        cache = self._make_cache()
+        self.assertIsNone(cache.get_by_combined_hash([]))
+
+    # ----- Thread safety -----
+
+    def test_concurrent_access(self):
+        """Basic thread safety test: multiple threads doing put/get."""
+        cache = self._make_cache()
+        errors = []
+
+        def worker(thread_id):
+            try:
+                for i in range(50):
+                    key = thread_id * 1000 + i
+                    t = _make_tensor(5)
+                    cache.put(key, t, num_tokens=5)
+                    cache.acquire(key)
+                    result = cache.get(key)
+                    if result is None:
+                        errors.append(f"Thread {thread_id}: get({key}) returned None")
+                    cache.release(key)
+            except Exception as e:
+                errors.append(f"Thread {thread_id}: {e}")
+
+        threads = [threading.Thread(target=worker, args=(tid,)) for tid in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [], f"Errors: {errors}")
+
+
+class TestEncoderBudget(unittest.TestCase):
+    """Test cases for EncoderBudget."""
+
+    def test_available_bytes(self):
+        budget = EncoderBudget(
+            remaining_bytes=100,
+            remaining_tokens=50,
+            remaining_entries=None,
+            freeable_bytes=200,
+            freeable_tokens=30,
+            total_bytes=1000,
+            used_bytes=700,
+            total_tokens=100,
+            used_tokens=20,
+        )
+        self.assertEqual(budget.available_bytes, 300)
+        self.assertEqual(budget.available_tokens, 80)
+
+    def test_available_tokens_none_when_unlimited(self):
+        budget = EncoderBudget(
+            remaining_bytes=100,
+            remaining_tokens=None,
+            remaining_entries=None,
+            freeable_bytes=200,
+            freeable_tokens=30,
+            total_bytes=1000,
+            used_bytes=700,
+            total_tokens=None,
+            used_tokens=0,
+        )
+        self.assertIsNone(budget.available_tokens)
+
+    def test_can_admit(self):
+        budget = EncoderBudget(
+            remaining_bytes=0,
+            remaining_tokens=0,
+            remaining_entries=None,
+            freeable_bytes=500,
+            freeable_tokens=50,
+            total_bytes=1000,
+            used_bytes=1000,
+            total_tokens=100,
+            used_tokens=100,
+        )
+        self.assertTrue(budget.can_admit(500, 50))
+        self.assertFalse(budget.can_admit(501, 50))
+        self.assertFalse(budget.can_admit(500, 51))
+
+
+class TestMultiTierEncoderCacheManager(unittest.TestCase):
+    """Test cases for the two-tier cache wrapper."""
+
+    def test_separate_tiers(self):
+        mtier = MultiTierEncoderCacheManager(
+            feature_cache_bytes=10_000_000,
+            embedding_cache_bytes=10_000_000,
+        )
+        t_feat = _make_tensor(10)
+        t_emb = _make_tensor(10)
+
+        mtier.feature_cache.put(1, t_feat, num_tokens=10)
+        mtier.embedding_cache.put(1, t_emb, num_tokens=10)
+
+        # Same key in different tiers should give different tensors
+        feat = mtier.feature_cache.get(1)
+        emb = mtier.embedding_cache.get(1)
+        self.assertTrue(torch.equal(feat, t_feat))
+        self.assertTrue(torch.equal(emb, t_emb))
+
+    def test_get_cache_by_type(self):
+        mtier = MultiTierEncoderCacheManager(
+            feature_cache_bytes=1000,
+            embedding_cache_bytes=2000,
+        )
+        fc = mtier.get_cache(EncoderCacheType.FEATURE)
+        ec = mtier.get_cache(EncoderCacheType.EMBEDDING)
+        self.assertIsInstance(fc, EncoderCacheManager)
+        self.assertIsInstance(ec, EncoderCacheManager)
+        self.assertIsNot(fc, ec)
+
+    def test_clear_both_tiers(self):
+        mtier = MultiTierEncoderCacheManager(
+            feature_cache_bytes=10_000_000,
+            embedding_cache_bytes=10_000_000,
+        )
+        mtier.feature_cache.put(1, _make_tensor(5), num_tokens=5)
+        mtier.embedding_cache.put(1, _make_tensor(5), num_tokens=5)
+        mtier.clear()
+        self.assertEqual(len(mtier.feature_cache), 0)
+        self.assertEqual(len(mtier.embedding_cache), 0)
+
+    def test_get_stats(self):
+        mtier = MultiTierEncoderCacheManager(
+            feature_cache_bytes=10_000_000,
+            embedding_cache_bytes=10_000_000,
+        )
+        mtier.feature_cache.put(1, _make_tensor(5), num_tokens=5)
+        stats = mtier.get_stats()
+        self.assertIn("mm_feature", stats)
+        self.assertIn("mm_embedding", stats)
+        self.assertEqual(stats["mm_feature"]["num_entries"], 1)
+        self.assertEqual(stats["mm_embedding"]["num_entries"], 0)
+
+
+class TestEncoderCacheManagerLRUOrder(unittest.TestCase):
+    """Test that LRU ordering works correctly for eviction."""
+
+    def test_lru_eviction_order(self):
+        """Oldest freeable entry is evicted first."""
+        t = _make_tensor(10)
+        size = _tensor_bytes(t)
+        # Can hold exactly 2 entries
+        cache = EncoderCacheManager(max_size_bytes=size * 2)
+        cache.put(1, _make_tensor(10), num_tokens=10)
+        cache.put(2, _make_tensor(10), num_tokens=10)
+        # Access entry 1 to make it more recent
+        cache.get(1)
+        # Insert third entry, should evict entry 2 (least recently used)
+        cache.put(3, _make_tensor(10), num_tokens=10)
+        self.assertFalse(cache.has(2))  # evicted
+        self.assertTrue(cache.has(1))   # kept (more recent)
+        self.assertTrue(cache.has(3))   # just inserted
+
+    def test_acquire_updates_lru(self):
+        """Acquiring an entry should update its LRU position."""
+        t = _make_tensor(10)
+        size = _tensor_bytes(t)
+        cache = EncoderCacheManager(max_size_bytes=size * 2)
+        cache.put(1, _make_tensor(10), num_tokens=10)
+        cache.put(2, _make_tensor(10), num_tokens=10)
+        # Acquire entry 1 (makes it most recent + active)
+        cache.acquire(1)
+        cache.release(1)
+        # Insert third entry, should evict entry 2 (LRU freeable)
+        cache.put(3, _make_tensor(10), num_tokens=10)
+        self.assertTrue(cache.has(1))
+        self.assertFalse(cache.has(2))
+
+
+class TestEncoderCacheManagerEdgeCases(unittest.TestCase):
+    """Edge case tests."""
+
+    def test_release_nonexistent(self):
+        cache = EncoderCacheManager(max_size_bytes=10000)
+        self.assertFalse(cache.release(999))
+
+    def test_evict_nonexistent(self):
+        cache = EncoderCacheManager(max_size_bytes=10000)
+        self.assertFalse(cache.evict(999))
+
+    def test_double_release(self):
+        """Releasing more times than acquired should not go negative."""
+        cache = EncoderCacheManager(max_size_bytes=10_000_000)
+        cache.put(1, _make_tensor(5), num_tokens=5)
+        cache.acquire(1)
+        cache.release(1)
+        cache.release(1)  # Extra release
+        self.assertEqual(cache.num_freeable, 1)
+        self.assertEqual(cache.num_active, 0)
+
+    def test_empty_cache_stats(self):
+        cache = EncoderCacheManager(max_size_bytes=1000)
+        stats = cache.get_stats()
+        self.assertEqual(stats["num_entries"], 0)
+        self.assertEqual(stats["current_size_bytes"], 0)
+        self.assertAlmostEqual(cache.hit_rate, 0.0)
+
+    def test_put_zero_token_entry(self):
+        cache = EncoderCacheManager(max_size_bytes=10_000_000)
+        # A 1D tensor with 0 tokens
+        t = torch.empty(0, 64)
+        self.assertTrue(cache.put(1, t, num_tokens=0))
+        self.assertTrue(cache.has(1))
+
+    def test_evict_freeable_on_empty_cache(self):
+        cache = EncoderCacheManager(max_size_bytes=1000)
+        freed = cache.evict_freeable(target_bytes=100)
+        self.assertEqual(freed, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds EncoderCacheManager with LRU eviction and reference counting for caching VLM encoder outputs. Integrates with scheduler and mm_utils. Includes 47 unit tests.

Closes #16957