### PR TITLE
[Bugfix] Skip _mamba_verify_update for idle batch

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -795,6 +795,11 @@ class EAGLEWorker(TpModelWorker):
         spec_info: EagleVerifyInput,
         seq_lens_pre_verify: torch.Tensor,
     ):
+        # Under DP attention, some ranks can be IDLE during target verify and never
+        # initialize mamba forward metadata for this step.
+        if batch.forward_mode.is_idle():
+            return
+
         accepted_length = (
             torch.tensor(
                 res.accept_length_per_req_cpu,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Currently, when cuda graph is disabled and the forward_batch is `IDLE`, the `forward_batch_generation` will enter `ModelRuneer.forward_idle` and it will not init attention metadata, which is used in `_mamba_verify_update`. With will trigger an `AttributeError: 'NoneType' object has no attribute 'mamba_cache_indices'`

To reproduce
```
python3 -m sglang.launch_server \
    --model-path Qwen/Qwen3.5-122B-A10B-FP8 \
    --disable-cuda-graph \
    --mem-fraction-static 0.8 \
    --tp-size 2 \
    --ep 2 \
    --dp 2 \
    --enable-dp-attention \
    --speculative-algorithm NEXTN \
    --speculative-eagle-topk 1 \
    --speculative-num-steps 3 \
    --speculative-num-draft-tokens 4 \
    --mamba-scheduler-strategy extra_buffer \
    --ep-num-redundant-experts 16
```
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
