### PR TITLE
[AMD] [diffusion] feat: enable AITer GroupNorm for VAE decode on ROCm

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -22,10 +22,41 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
+from sglang.multimodal_gen.runtime.utils.common import get_bool_env_var
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 logger = init_logger(__name__)
+
+_is_hip = current_platform.is_hip()
+_use_aiter_vae = get_bool_env_var("SGLANG_USE_AITER_VAE") and _is_hip
+
+
+def _replace_groupnorm_with_aiter(module: torch.nn.Module) -> int:
+    """Recursively replace nn.GroupNorm with AITer GroupNorm in a module tree.
+
+    Returns the number of replaced modules.
+    """
+    from aiter.ops.groupnorm import GroupNorm as AiterGroupNorm
+
+    count = 0
+    for name, child in module.named_children():
+        if isinstance(child, torch.nn.GroupNorm) and child.affine:
+            aiter_gn = AiterGroupNorm(
+                num_groups=child.num_groups,
+                num_channels=child.num_channels,
+                eps=child.eps,
+                affine=True,
+                device=child.weight.device,
+                dtype=child.weight.dtype,
+            )
+            aiter_gn.weight = child.weight
+            aiter_gn.bias = child.bias
+            setattr(module, name, aiter_gn)
+            count += 1
+        else:
+            count += _replace_groupnorm_with_aiter(child)
+    return count
 
 
 def _ensure_tensor_decode_output(decode_output):
@@ -60,6 +91,7 @@ class DecodingStage(PipelineStage):
         super().__init__()
         self.vae: ParallelTiledVAE = vae
         self.pipeline = weakref.ref(pipeline) if pipeline else None
+        self._aiter_gn_applied = False
 
     @property
     def parallelism_type(self) -> StageParallelismType:
@@ -154,6 +186,25 @@ class DecodingStage(PipelineStage):
         image = (image / 2 + 0.5).clamp(0, 1)
         return image
 
+    def _apply_aiter_groupnorm(self):
+        """Replace nn.GroupNorm with AITer GroupNorm (called once after VAE load)."""
+        if self._aiter_gn_applied:
+            return
+        self._aiter_gn_applied = True
+        try:
+            count = _replace_groupnorm_with_aiter(self.vae)
+            if count > 0:
+                logger.info(
+                    "Replaced %d nn.GroupNorm modules with AITer GroupNorm in VAE",
+                    count,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to apply AITer GroupNorm to VAE. "
+                "Model may be in an inconsistent state.",
+                exc_info=True,
+            )
+
     def load_model(self):
         # load vae if not already loaded (used for memory constrained devices)
         pipeline = self.pipeline() if self.pipeline else None
@@ -165,6 +216,8 @@ class DecodingStage(PipelineStage):
             if pipeline:
                 pipeline.add_module("vae", self.vae)
             self.server_args.model_loaded["vae"] = True
+        if _use_aiter_vae:
+            self._apply_aiter_groupnorm()
 
     def offload_model(self):
         # Offload models if needed

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -29,7 +29,7 @@ from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 logger = init_logger(__name__)
 
 _is_hip = current_platform.is_hip()
-_use_aiter_vae = get_bool_env_var("SGLANG_USE_AITER_VAE") and _is_hip
+_use_aiter_vae = get_bool_env_var("SGLANG_USE_ROCM_VAE") and _is_hip
 
 
 def _replace_groupnorm_with_aiter(module: torch.nn.Module) -> int:


### PR DESCRIPTION
## Summary
Replace `nn.GroupNorm` with aiter's CK  GroupNorm in VAE decode stage on ROCm, controlled by `SGLANG_USE_ROCM_VAE=1` (off by default).

## Motivation
Profiling Z-Image-Turbo VAE decode on MI300X/MI35X shows PyTorch's native `RowwiseMomentsCUDAKernel` is poorly optimized for AMD GPUs, 1.57ms per call vs AITer's 0.13ms (12x faster).

## Results (Z-Image-Turbo, 1024×1024, MI300X)
max_concurrency=8, num_prompts=64


| Metric | Baseline | AITer GroupNorm | Change |
|--------|----------|-----------------|--------|
| GroupNorm kernel time | 51.4ms | 6.0ms | **-88%** |
| VAE decode total | ~205ms | ~162ms | **-21%** |
| End-to-end throughput | 0.745 | 0.770 | **+3~5%** |

## Modifications
- `decoding.py`: recursively swap `nn.GroupNorm` → `aiter.GroupNorm` after VAE load
- Zero-copy weight sharing; safe fallback on error

### Design note
GroupNorm lives in diffusers' `Decoder` / `ResnetBlock2D` / `UNetMidBlock2D`, not in SGLang code.
We use runtime module replacement (`named_children` + `setattr`) rather than patching diffusers directly so that:
- The change is opt-in (`SGLANG_USE_ROCM_VAE=1`) and has no effect on non-ROCm platforms
- Diffusers upgrades won't break or overwrite the optimization
- Only the VAE decode stage is affected; other pipelines remain untouched

## Accuracy Tests

```
export SGLANG_USE_ROCM_VAE=1
sglang generate --model-path=Tongyi-MAI/Z-Image-Turbo --log-level=info --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' --width=1024 --height=1024 --num-inference-steps=9 --guidance-scale=0.0 --seed=42 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false
```

<img width="1028" height="857" alt="image" src="https://github.com/user-attachments/assets/0689ae86-cf86-4a52-885f-1a5bd759e1a4" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
