### PR TITLE
[diffusion] attention: add AITER Sage attention backend

### DIFF
--- a/docs/diffusion/performance/attention_backends.md
+++ b/docs/diffusion/performance/attention_backends.md
@@ -30,6 +30,7 @@ For SGLang-native pipelines, the CLI accepts the lowercase names of `AttentionBa
 | `video_sparse_attn` | `VIDEO_SPARSE_ATTN` | Requires `vsa`. Configure `sparsity` via `--attention-backend-config`. |
 | `vmoba_attn` | `VMOBA_ATTN` | Requires `kernel.attn.vmoba_attn.vmoba`. Configure via `--attention-backend-config`. |
 | `aiter` | `AITER` | Requires `aiter`. |
+| `aiter_sage` | `AITER_SAGE` | Requires `aiter`. |
 | `sparse_video_gen_2_attn` | `SPARSE_VIDEO_GEN_2_ATTN` | Requires `svg`. See installation instructions at https://github.com/svg-project/Sparse-VideoGen. |
 
 ## Selection priority
@@ -93,7 +94,8 @@ Some backends require additional configuration. You can pass these parameters vi
 | `sage_attn_3` | ✅ | ❌ | ❌ | ❌ | CUDA-only (optional dependency). |
 | `video_sparse_attn` | ✅ | ❌ | ❌ | ❌ | CUDA-only. Requires `vsa`. Configure `sparsity` via `--attention-backend-config`. |
 | `vmoba_attn` | ✅ | ❌ | ❌ | ❌ | CUDA-only. Requires `kernel.attn.vmoba_attn.vmoba`. Configure via `--attention-backend-config`. |
-| `aiter` | ✅ | ❌ | ❌ | ❌ | Requires `aiter`. |
+| `aiter` | ❌ | ✅ | ❌ | ❌ | Requires `aiter`. |
+| `aiter_sage` | ❌ | ✅ | ❌ | ❌ | Requires `aiter`. |
 | `sparse_video_gen_2_attn` | ✅ | ❌ | ❌ | ❌ | CUDA-only. Requires `svg`. |
 
 ## Usage

--- a/python/sglang/multimodal_gen/configs/models/adapter/base.py
+++ b/python/sglang/multimodal_gen/configs/models/adapter/base.py
@@ -22,6 +22,7 @@ class AdapterArchConfig(ArchConfig):
             AttentionBackendEnum.SAGE_ATTN,
             AttentionBackendEnum.FA,
             AttentionBackendEnum.AITER,
+            AttentionBackendEnum.AITER_SAGE,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,
             AttentionBackendEnum.VMOBA_ATTN,

--- a/python/sglang/multimodal_gen/configs/models/dits/base.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/base.py
@@ -29,6 +29,7 @@ class DiTArchConfig(ArchConfig):
             AttentionBackendEnum.SAGE_ATTN,
             AttentionBackendEnum.FA,
             AttentionBackendEnum.AITER,
+            AttentionBackendEnum.AITER_SAGE,
             AttentionBackendEnum.TORCH_SDPA,
             AttentionBackendEnum.VIDEO_SPARSE_ATTN,
             AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter_sage.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter_sage.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import aiter
+
 import torch
-import functools
 
 from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
     AttentionBackend,
@@ -30,7 +29,9 @@ class AITERSageBackend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls() -> type["AttentionMetadataBuilder"]:
-        raise NotImplementedError("AITER Sage backend does not have a metadata builder.")
+        raise NotImplementedError(
+            "AITER Sage backend does not have a metadata builder."
+        )
 
 
 class AITERSageImpl(AttentionImpl):
@@ -49,9 +50,12 @@ class AITERSageImpl(AttentionImpl):
 
         try:
             from aiter.ops.triton.attention.fav3_sage import fav3_sage_wrapper_func
+
             self.aiter_sage_attn_fn = fav3_sage_wrapper_func
         except ImportError:
-            raise ImportError("AITER Sage attention is not available, please update AITER version.")
+            raise ImportError(
+                "AITER Sage attention is not available, please update AITER version."
+            )
 
     def forward(
         self,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter_sage.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter_sage.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import aiter
+import torch
+import functools
+
+from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+)
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+
+
+class AITERSageBackend(AttentionBackend):
+
+    @staticmethod
+    def get_enum() -> AttentionBackendEnum:
+        return AttentionBackendEnum.AITER_SAGE
+
+    @staticmethod
+    def get_impl_cls() -> type["AITERSageImpl"]:
+        return AITERSageImpl
+
+    @staticmethod
+    def get_metadata_cls() -> type["AttentionMetadata"]:
+        # AITER Sage backend does not require special metadata.
+        return AttentionMetadata
+
+    @staticmethod
+    def get_builder_cls() -> type["AttentionMetadataBuilder"]:
+        raise NotImplementedError("AITER Sage backend does not have a metadata builder.")
+
+
+class AITERSageImpl(AttentionImpl):
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        softmax_scale: float,
+        causal: bool = False,
+        num_kv_heads: int | None = None,
+        prefix: str = "",
+        dropout_p: float = 0.0,
+        **extra_impl_args,
+    ) -> None:
+
+        try:
+            from aiter.ops.triton.attention.fav3_sage import fav3_sage_wrapper_func
+            self.aiter_sage_attn_fn = fav3_sage_wrapper_func
+        except ImportError:
+            raise ImportError("AITER Sage attention is not available, please update AITER version.")
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata | None = None,
+    ) -> torch.Tensor:
+        """
+        Performs attention using aiter sage backend.
+
+        Args:
+            query: Query tensor of shape [batch_size, seq_len, head_num, head_dim]
+            key: Key tensor of shape [batch_size, seq_len, head_num, head_dim]
+            value: Value tensor of shape [batch_size, seq_len, head_num, head_dim]
+            attn_metadata: Metadata for the attention operation (unused).
+
+        Returns:
+            Output tensor of shape [batch_size, seq_len, head_num, head_dim]
+        """
+
+        output = self.aiter_sage_attn_fn(query, key, value)
+        return output

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -576,6 +576,7 @@ class QwenImageCrossAttention(nn.Module):
             supported_attention_backends={
                 AttentionBackendEnum.FA,
                 AttentionBackendEnum.AITER,
+                AttentionBackendEnum.AITER_SAGE,
                 AttentionBackendEnum.TORCH_SDPA,
                 AttentionBackendEnum.SAGE_ATTN,
                 AttentionBackendEnum.SAGE_ATTN_3,

--- a/python/sglang/multimodal_gen/runtime/platforms/interface.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/interface.py
@@ -34,6 +34,7 @@ class AttentionBackendEnum(enum.Enum):
     SPARSE_VIDEO_GEN_2_ATTN = enum.auto()
     VMOBA_ATTN = enum.auto()
     AITER = enum.auto()
+    AITER_SAGE = enum.auto()
     SLA_ATTN = enum.auto()
     SAGE_SLA_ATTN = enum.auto()
     NO_ATTENTION = enum.auto()

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -115,6 +115,16 @@ class RocmPlatform(Platform):
             logger.info("Using AITer backend on ROCm.")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter.AITerBackend"
 
+        elif selected_backend == AttentionBackendEnum.AITER_SAGE:
+            if dtype in (torch.float16, torch.bfloat16):
+                logger.info("Using AITER Sage backend on ROCm.")
+                return "sglang.multimodal_gen.runtime.layers.attention.backends.aiter_sage.AITERSageBackend"
+            else:
+                logger.warning(
+                    "AITER Sage backend only supports bf16/fp16 inputs but got dtype=%s.",
+                    dtype,
+                )
+
         elif selected_backend in (
             AttentionBackendEnum.SLIDING_TILE_ATTN,
             AttentionBackendEnum.SAGE_ATTN,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Sage attention is supported for NV GPUs, but the support for AMD Sage attention is missing. This PR adds the support for it.

## Modifications

- Adds a new backend type `AITER_SAGE`
- Adds it as a supported attention backend where sage is typically supported

## Accuracy Tests

## Benchmarking and Profiling

### Performance Comparison Report

#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 276887.31 ms | 241404.22 ms | **-35483.09 ms (-12.8%)** | ✅ |
| **Throughput** | 0.00 req/s | 0.00 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 5.10 | 4.61 | -0.50 | -9.7% | ⚪️ |
| TextEncodingStage | 1461.92 | 1460.04 | -1.88 | -0.1% | ⚪️ |
| ImageEncodingStage | 861.02 | 914.68 | +53.66 | +6.2% | ⚪️ |
| ImageVAEEncodingStage | 4040.19 | 3997.95 | -42.24 | -1.0% | ⚪️ |
| LatentPreparationStage | 0.17 | 0.13 | -0.05 | -26.3% | ⚪️ |
| TimestepPreparationStage | 0.35 | 0.31 | -0.05 | -13.0% | ⚪️ |
| DenoisingStage | 266231.67 | 230743.97 | -35487.70 | -13.3% | 🟢 |
| DecodingStage | 4282.54 | 4278.92 | -3.63 | -0.1% | ⚪️ |


### Output videos

AITER:
https://github.com/user-attachments/assets/62ae8e96-85e0-4b3f-b1dc-c15c708b4738


AITER SAGE:
https://github.com/user-attachments/assets/43f64ee6-dba4-45a5-9bca-8302bcfaff22




## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
