### PR TITLE
[Docs] Add Copy option in Document

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,7 +45,7 @@ markdown:
 	mkdir -p "$(BUILDDIR)/html/markdown"; \
 	\
 	# 1) Copy .md and .rst files as-is; additionally convert .rst -> .md \
-	find $(SOURCEDIR) -path "*/_build/*" -prune -o \( -name "*.md" -o -name "*.rst" \) -print0 | \
+	find $(SOURCEDIR) -path "*/_build/*" -prune -o -path "*/_ext" -prune -o \( -name "*.md" -o -name "*.rst" \) -print0 | \
 		parallel -0 -j3 --halt soon,fail=1 ' \
 		SRC="{}"; \
 		REL_DIR=$$(dirname "$$SRC"); \
@@ -60,7 +60,7 @@ markdown:
 		' || exit 1; \
 	\
 	# 2) Convert .ipynb -> .md \
-	find $(SOURCEDIR) -path "*/_build/*" -prune -o -name "*.ipynb" -print0 | \
+	find $(SOURCEDIR) -path "*/_build/*" -prune -o -path "*/_ext" -prune -o -name "*.ipynb" -print0 | \
 		parallel -0 -j3 --halt soon,fail=1 ' \
 		NB_SRC="{}"; \
 		REL_DIR=$$(dirname "$$NB_SRC"); \

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,3 +122,9 @@ make markdown   # export markdown artifacts into _build/html/markdown
 ```
 
 Then, the compiled results are forced pushed to [sgl-project.io](https://github.com/sgl-project/sgl-project.github.io) for rendering. In other words, sgl-project.io is push-only. All the changes of SGLang docs should be made directly in SGLang main repo, then push to the sgl-project.io.
+
+### Custom Extensions (`_ext/`)
+
+The `docs/_ext/` directory contains Sphinx extensions used only for documentation:
+
+* **sphinx_copy_page_source**: Adds a "Copy" option in the download dropdown (next to .md and .pdf). Clicking it copies the current page's Markdown source to the clipboard. Requires `make markdown` for the fallback URL to work.

--- a/docs/_ext/sphinx_copy_page_source/__init__.py
+++ b/docs/_ext/sphinx_copy_page_source/__init__.py
@@ -1,0 +1,17 @@
+"""
+Sphinx extension to add a "Copy" button that copies the current page's
+Markdown source to clipboard. Works alongside sphinx_book_theme's download
+button (.md open in new tab, PDF).
+"""
+
+import os
+
+__version__ = "0.1.0"
+
+
+def setup(app):
+    ext_dir = os.path.dirname(__file__)
+    app.config.html_static_path.append(ext_dir)
+    app.add_js_file("copy_page_source.js")
+    app.add_css_file("copy_page_source.css")
+    return {"version": __version__, "parallel_read_safe": True}

--- a/docs/_ext/sphinx_copy_page_source/copy_page_source.css
+++ b/docs/_ext/sphinx_copy_page_source/copy_page_source.css
@@ -1,0 +1,4 @@
+/* Copy option in download dropdown */
+.copy-page-source-btn.copy-page-source-done {
+  opacity: 0.8;
+}

--- a/docs/_ext/sphinx_copy_page_source/copy_page_source.js
+++ b/docs/_ext/sphinx_copy_page_source/copy_page_source.js
@@ -1,0 +1,87 @@
+/**
+ * Add "Copy" option inside the download dropdown (.md, .pdf, Copy).
+ * Copies the current page's Markdown source to clipboard.
+ */
+(function () {
+  function getMarkdownUrl() {
+    var dropdown = document.querySelector(".dropdown-download-buttons");
+    if (dropdown) {
+      var mdLink = dropdown.querySelector('a[href*=".md"]');
+      if (mdLink) {
+        var href = mdLink.getAttribute("href");
+        if (href) {
+          try {
+            var full = new URL(href, window.location.origin).href;
+            if (new URL(full).origin === window.location.origin) return full;
+          } catch (e) {}
+        }
+      }
+    }
+    var pathname = window.location.pathname.replace(/\/$/, "/index.html");
+    if (!/\.html?$/.test(pathname)) pathname += ".html";
+    var mdPath = pathname.replace(/\.html?$/, ".md").replace(/^\//, "");
+    return window.location.origin + "/markdown/" + mdPath;
+  }
+
+  function copyMarkdownToClipboard(btn) {
+    var url = getMarkdownUrl();
+    if (btn) btn.disabled = true;
+
+    fetch(url, { credentials: "same-origin" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("Markdown not found: " + url);
+        return r.text();
+      })
+      .then(function (text) {
+        return navigator.clipboard.writeText(text);
+      })
+      .then(function () {
+        if (btn) {
+          var textSpan = btn.querySelector(".btn__text-container");
+          if (textSpan) textSpan.textContent = "Copied";
+          btn.classList.add("copy-page-source-done");
+          setTimeout(function () {
+            if (textSpan) textSpan.textContent = "Copy";
+            btn.disabled = false;
+            btn.classList.remove("copy-page-source-done");
+          }, 2000);
+        }
+      })
+      .catch(function (err) {
+        if (btn) btn.disabled = false;
+        console.warn("Copy page source failed:", err);
+        alert("Could not copy Markdown. Try opening the .md link and copying manually.");
+      });
+  }
+
+  function injectCopyOption() {
+    var menu = document.querySelector(".dropdown-download-buttons .dropdown-menu");
+    if (!menu || document.getElementById("copy-page-source-dropdown-item")) return;
+
+    var li = document.createElement("li");
+    li.id = "copy-page-source-dropdown-item";
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-sm btn-download-source-button dropdown-item copy-page-source-btn";
+    btn.title = "Copy this page's Markdown source to clipboard";
+    btn.setAttribute("aria-label", "Copy Markdown to clipboard");
+    btn.innerHTML =
+      '<span class="btn__icon-container"><i class="fas fa-copy"></i></span>' +
+      '<span class="btn__text-container">Copy</span>';
+    btn.addEventListener("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      copyMarkdownToClipboard(btn);
+    });
+    li.appendChild(btn);
+    menu.appendChild(li);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", injectCopyOption);
+  } else {
+    injectCopyOption();
+  }
+  setTimeout(injectCopyOption, 500);
+  setTimeout(injectCopyOption, 1500);
+})();

--- a/docs/_ext/sphinx_copy_page_source/copy_page_source.js
+++ b/docs/_ext/sphinx_copy_page_source/copy_page_source.js
@@ -3,8 +3,15 @@
  * Copies the current page's Markdown source to clipboard.
  */
 (function () {
+  var DROPDOWN_SELECTOR = ".dropdown-download-buttons";
+  var DROPDOWN_MENU_SELECTOR = DROPDOWN_SELECTOR + " .dropdown-menu";
+  var COPY_ITEM_ID = "copy-page-source-dropdown-item";
+  var COPY_BTN_CLASS = "copy-page-source-btn";
+  var COPY_DONE_CLASS = "copy-page-source-done";
+  var FEEDBACK_DURATION_MS = 2000;
+
   function getMarkdownUrl() {
-    var dropdown = document.querySelector(".dropdown-download-buttons");
+    var dropdown = document.querySelector(DROPDOWN_SELECTOR);
     if (dropdown) {
       var mdLink = dropdown.querySelector('a[href*=".md"]');
       if (mdLink) {
@@ -13,7 +20,9 @@
           try {
             var full = new URL(href, window.location.origin).href;
             if (new URL(full).origin === window.location.origin) return full;
-          } catch (e) {}
+          } catch (e) {
+            console.warn("Failed to parse URL:", href, e);
+          }
         }
       }
     }
@@ -39,12 +48,12 @@
         if (btn) {
           var textSpan = btn.querySelector(".btn__text-container");
           if (textSpan) textSpan.textContent = "Copied";
-          btn.classList.add("copy-page-source-done");
+          btn.classList.add(COPY_DONE_CLASS);
           setTimeout(function () {
             if (textSpan) textSpan.textContent = "Copy";
             btn.disabled = false;
-            btn.classList.remove("copy-page-source-done");
-          }, 2000);
+            btn.classList.remove(COPY_DONE_CLASS);
+          }, FEEDBACK_DURATION_MS);
         }
       })
       .catch(function (err) {
@@ -54,15 +63,14 @@
       });
   }
 
-  function injectCopyOption() {
-    var menu = document.querySelector(".dropdown-download-buttons .dropdown-menu");
-    if (!menu || document.getElementById("copy-page-source-dropdown-item")) return;
+  function injectCopyOption(menu) {
+    if (!menu || document.getElementById(COPY_ITEM_ID)) return;
 
     var li = document.createElement("li");
-    li.id = "copy-page-source-dropdown-item";
+    li.id = COPY_ITEM_ID;
     var btn = document.createElement("button");
     btn.type = "button";
-    btn.className = "btn btn-sm btn-download-source-button dropdown-item copy-page-source-btn";
+    btn.className = "btn btn-sm btn-download-source-button dropdown-item " + COPY_BTN_CLASS;
     btn.title = "Copy this page's Markdown source to clipboard";
     btn.setAttribute("aria-label", "Copy Markdown to clipboard");
     btn.innerHTML =
@@ -77,11 +85,32 @@
     menu.appendChild(li);
   }
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", injectCopyOption);
-  } else {
-    injectCopyOption();
+  function tryInject() {
+    var menu = document.querySelector(DROPDOWN_MENU_SELECTOR);
+    if (menu) {
+      injectCopyOption(menu);
+      return true;
+    }
+    return false;
   }
-  setTimeout(injectCopyOption, 500);
-  setTimeout(injectCopyOption, 1500);
+
+  function observeAndInject() {
+    if (tryInject()) return;
+    var body = document.body;
+    if (!body) return;
+    var observer = new MutationObserver(function (mutations, obs) {
+      if (tryInject()) obs.disconnect();
+    });
+    observer.observe(body, { childList: true, subtree: true });
+  }
+
+  function init() {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", observeAndInject);
+    } else {
+      observeAndInject();
+    }
+  }
+
+  init();
 })();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@ import sys
 from datetime import datetime
 
 sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "_ext")))
 
 version_file = "../python/sglang/version.py"
 with open(version_file, "r") as f:
@@ -26,6 +27,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "myst_parser",
     "sphinx_copybutton",
+    "sphinx_copy_page_source",
     "sphinxcontrib.mermaid",
     "nbsphinx",
     "sphinx.ext.mathjax",
@@ -95,7 +97,7 @@ master_doc = "index"
 
 language = "en"
 
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "_ext", "Thumbs.db", ".DS_Store"]
 
 pygments_style = "sphinx"
 


### PR DESCRIPTION
# docs: add Copy option in download dropdown via sphinx_copy_page_source extension

Closes #20152

## Checklist

- [x] If this is not a feature request but a general question, please start a discussion at https://github.com/sgl-project/sglang/discussions. Otherwise, it will be closed.
- [x] Please use English. Otherwise, it will be closed.

## Motivation

The documentation download button currently offers ".md" (opens in new tab) and ".pdf" options. As raised in [#20152](https://github.com/sgl-project/sglang/issues/20152), users requested the ability to **directly copy** the Markdown source to clipboard instead of opening it in a new tab and manually copying.

This PR adds a "Copy" option inside the download dropdown that copies the current page's Markdown source to the clipboard with a single click.

## Modifications

- **Add `sphinx_copy_page_source` extension** in `docs/_ext/`:
  - `__init__.py`: Sphinx extension setup, registers JS and CSS
  - `copy_page_source.js`: Injects "Copy" option into the download dropdown; fetches `.md` content and copies to clipboard via `navigator.clipboard.writeText()`
  - `copy_page_source.css`: Styles for the Copy option
- **Update `docs/conf.py`**: Add `_ext` to `sys.path`, add extension to `extensions`, add `_ext` to `exclude_patterns`
- **Update `docs/Makefile`**: Exclude `_ext` from `make markdown` find commands
- **Update `docs/README.md`**: Document the `_ext/` directory and `sphinx_copy_page_source` extension

## Related resources

- Issue: [#20152](https://github.com/sgl-project/sglang/issues/20152) – "This button will open it in the new tab as the .md source. But is it possible to have it directly copy"

## Accuracy Tests

N/A – Documentation-only change.

## Benchmarking and Profiling

<img width="867" height="635" alt="image" src="https://github.com/user-attachments/assets/3eeb20eb-5afb-4517-906d-a47f7ac90bda" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
