### PR TITLE
[Fix] avoid false mamba leak for cow_mamba slots in waiting queue

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -143,9 +143,16 @@ class SchedulerRuntimeCheckerMixin:
             mamba_evictable_size,
         ) = self._get_mamba_token_info()
         session_held = self._session_held_tokens()
+        waiting_held_mamba_slots = set()
+        for req in getattr(self, "waiting_queue", []):
+            if req.req_pool_idx is None and req.mamba_pool_idx is not None:
+                idx = req.mamba_pool_idx
+                waiting_held_mamba_slots.add(
+                    int(idx.item()) if hasattr(idx, "item") else int(idx)
+                )
         memory_leak = (
             full_num_used != self.tree_cache.full_protected_size() + session_held
-            or mamba_num_used != self.tree_cache.mamba_protected_size()
+            or mamba_num_used != self.tree_cache.mamba_protected_size() + len(waiting_held_mamba_slots)
         )
         if memory_leak:
             free_full_pages = set(
@@ -165,9 +172,9 @@ class SchedulerRuntimeCheckerMixin:
             cached_mamba_pages = set(
                 self.tree_cache.all_mamba_values_flatten().tolist()
             )
-            expected_mamba_pages = set(range(self.req_to_token_pool.mamba_pool.size))
+            expected_mamba_pages = set(range(1, self.req_to_token_pool.mamba_pool.size + 1))
             leaked_mamba_pages = (
-                expected_mamba_pages - free_mamba_pages - cached_mamba_pages
+                expected_mamba_pages - free_mamba_pages - cached_mamba_pages - waiting_held_mamba_slots
             )
             token_msg = (
                 f"{full_available_size=}, {full_evictable_size=}, {self.token_to_kv_pool_allocator.size=}, {self.tree_cache.full_protected_size()=}\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
**Start command**
```
python3 -m sglang.launch_server --model-path /data/models/Qwen3.5-35B-A3B-FP8 --context-length 262144 --host 0.0.0.0 --port 8000 --tensor-parallel-size 2  --reasoning-parser qwen3 --tool-call-parser qwen3_coder --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --mamba-scheduler-strategy extra_buffer
```
**ERROR**
```
Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3161, in run_scheduler_process
    scheduler.event_loop_normal()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1124, in event_loop_normal
    self.self_check_during_idle()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py", line 384, in self_check_during_idle
    self.check_memory()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py", line 296, in check_memory
    raise_error_or_warn(
  File "/sgl-workspace/sglang/python/sglang/srt/utils/common.py", line 4082, in raise_error_or_warn
    raise ValueError(message)
ValueError: token_to_kv_pool_allocator memory leak detected! full_available_size=161331, full_evictable_size=261888, self.token_to_kv_pool_allocator.size=423219, self.tree_cache.full_protected_size()=0
mamba_available_size=117, mamba_evictable_size=3, self.req_to_token_pool.mamba_pool.size=121, self.tree_cache.mamba_protected_size()=0, leaked_full_pages=None, leaked_mamba_pages={10}
```
## Modifications

**Cause of the problem:**
(1) There are two requests decoding in running-req, both with long output tokens.
(2) The **full token usage** reaches 1, triggering the eviction of one request and cleaning up its **full KV cache** and **Mamba KV cache**.
(3) The evicted request is re-added to the **waiting_queue**, but it hits the prefix cache and a mamba slot is allocated during the execution of **_match_post_processor**.
(4) Throughout this process, **batch_is_full** remains true due to **NO_TOKEN**, so this request can never be added to the **can_run_list**.
(5) Wait until the first request completes execution.
(6) In the next scheduler loop, **get_next_batch_to_run** -> **get_new_batch_prefill**, but batch_is_full is still true, thus the request in the **waiting_queue** cannot be selected, and there are no remaining requests in the **running_batch** at this point.
(7) The scheduler then enters an idle state and invokes **self.self_check_during_idle()**.
(8) The pre-allocated mamba slot from the earlier cache hit is neither in the free_slot pool nor managed by radixcache, leading to a false positive judgment of memory leak.

**Root cause:**
The memory leak check in the **_check_mamba_memory** function fails to account for the pre-allocated mamba slots of cache-hit requests in the waiting_queue.

**solution**
fix **_check_mamba_memory**

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.