### PR TITLE
Replace soundfile+torchaudio with torchcodec AudioDecoder in load_audio

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -90,6 +90,7 @@ from torch import nn
 from torch.library import Library
 from torch.profiler import ProfilerActivity, profile, record_function
 from torch.utils._contextlib import _DecoratorContextManager
+from torchcodec.decoders import AudioDecoder
 from typing_extensions import Literal
 
 from sglang.srt.environ import envs
@@ -845,59 +846,41 @@ def decode_video_base64(video_base64):
 def load_audio(
     audio_file: str, sr: Optional[int] = None, mono: bool = True
 ) -> np.ndarray:
-    # Use soundfile here, since librosa use it under the hood,
-    # and librosa will not support audio loading in the future
-    import soundfile as sf
-    import torch
-    import torchaudio
-
     if sr is None:
         sr = 16000
 
-    # Load audio data
+    # Normalize input to a source that AudioDecoder accepts
+    # (str path/URL, bytes, or file-like object)
     if isinstance(audio_file, bytes):
-        audio, original_sr = sf.read(BytesIO(audio_file))
-    elif audio_file.startswith("data:"):
-        audio_file = audio_file.split(",")[1]
-        audio, original_sr = sf.read(
-            BytesIO(pybase64.b64decode(audio_file, validate=True))
-        )
-    elif audio_file.startswith("http://") or audio_file.startswith("https://"):
+        source = audio_file
+    elif isinstance(audio_file, str) and audio_file.startswith("data:"):
+        source = pybase64.b64decode(audio_file.split(",")[1], validate=True)
+    elif isinstance(audio_file, str) and (
+        audio_file.startswith("http://") or audio_file.startswith("https://")
+    ):
         timeout = int(os.getenv("REQUEST_TIMEOUT", "5"))
         response = requests.get(audio_file, stream=True, timeout=timeout)
-        audio_file = BytesIO(response.content)
+        source = response.content
         response.close()
-        audio, original_sr = sf.read(audio_file)
-    elif audio_file.startswith("file://"):
-        audio_file = unquote(urlparse(audio_file).path)
-        audio, original_sr = sf.read(audio_file)
+    elif isinstance(audio_file, str) and audio_file.startswith("file://"):
+        source = unquote(urlparse(audio_file).path)
     elif isinstance(audio_file, str):
-        audio, original_sr = sf.read(audio_file)
+        source = audio_file
     else:
         raise ValueError(f"Invalid audio format: {audio_file}")
 
-    # Convert to mono first (before resampling) to reduce computation
-    if mono and len(audio.shape) > 1:
-        audio = np.mean(audio, axis=1)
-
-    # Resample audio if the original sample rate is different from the desired sample rate
-    if original_sr != sr:
-        audio_tensor = torch.from_numpy(audio).float()
-        if audio_tensor.dim() == 1:
-            audio_tensor = audio_tensor.unsqueeze(0)
-        else:
-            audio_tensor = audio_tensor.T  # (time, channel) -> (channel, time)
-
-        audio_tensor = torchaudio.functional.resample(
-            audio_tensor, orig_freq=original_sr, new_freq=sr
-        )
-
-        if audio_tensor.shape[0] == 1:
-            audio = audio_tensor.squeeze(0).numpy()
-        else:
-            audio = audio_tensor.T.numpy()  # (channel, time) -> (time, channel)
-
-    return audio
+    # AudioDecoder handles decoding, resampling, and channel conversion in one step
+    decoder = AudioDecoder(
+        source,
+        sample_rate=sr,
+        num_channels=1 if mono else None,
+    )
+    samples = decoder.get_all_samples()
+    # AudioDecoder returns (channels, time); squeeze mono to 1-D,
+    # transpose multi-channel to (time, channels) for backward compat
+    if mono:
+        return samples.data.squeeze(0).numpy()
+    return samples.data.T.numpy()
 
 
 @dataclass

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -92,6 +92,13 @@ from torch.profiler import ProfilerActivity, profile, record_function
 from torch.utils._contextlib import _DecoratorContextManager
 from typing_extensions import Literal
 
+try:
+    from torchcodec.decoders import AudioDecoder
+
+    _HAS_TORCHCODEC_AUDIO = True
+except (ImportError, RuntimeError):
+    _HAS_TORCHCODEC_AUDIO = False
+
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
@@ -845,13 +852,6 @@ def decode_video_base64(video_base64):
 def load_audio(
     audio_file: str, sr: Optional[int] = None, mono: bool = True
 ) -> np.ndarray:
-    try:
-        from torchcodec.decoders import AudioDecoder
-
-        _HAS_TORCHCODEC = True
-    except (ImportError, RuntimeError):
-        _HAS_TORCHCODEC = False
-
     if sr is None:
         sr = 16000
 
@@ -874,7 +874,7 @@ def load_audio(
     else:
         raise ValueError(f"Invalid audio format: {audio_file}")
 
-    if _HAS_TORCHCODEC:
+    if _HAS_TORCHCODEC_AUDIO:
         decoder = AudioDecoder(
             source,
             sample_rate=sr,

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -859,9 +859,9 @@ def load_audio(
         audio_file.startswith("http://") or audio_file.startswith("https://")
     ):
         timeout = int(os.getenv("REQUEST_TIMEOUT", "5"))
-        response = requests.get(audio_file, stream=True, timeout=timeout)
-        source = response.content
-        response.close()
+        with requests.get(audio_file, timeout=timeout) as response:
+            response.raise_for_status()
+            source = response.content
     elif isinstance(audio_file, str) and audio_file.startswith("file://"):
         source = unquote(urlparse(audio_file).path)
     elif isinstance(audio_file, str):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -845,13 +845,17 @@ def decode_video_base64(video_base64):
 def load_audio(
     audio_file: str, sr: Optional[int] = None, mono: bool = True
 ) -> np.ndarray:
-    from torchcodec.decoders import AudioDecoder
+    try:
+        from torchcodec.decoders import AudioDecoder
+
+        _HAS_TORCHCODEC = True
+    except (ImportError, RuntimeError):
+        _HAS_TORCHCODEC = False
 
     if sr is None:
         sr = 16000
 
-    # Normalize input to a source that AudioDecoder accepts
-    # (str path/URL, bytes, or file-like object)
+    # Normalize input: resolve URL / base64 / file:// to bytes or path
     if isinstance(audio_file, bytes):
         source = audio_file
     elif isinstance(audio_file, str) and audio_file.startswith("data:"):
@@ -870,18 +874,45 @@ def load_audio(
     else:
         raise ValueError(f"Invalid audio format: {audio_file}")
 
-    # AudioDecoder handles decoding, resampling, and channel conversion in one step
-    decoder = AudioDecoder(
-        source,
-        sample_rate=sr,
-        num_channels=1 if mono else None,
-    )
-    samples = decoder.get_all_samples()
-    # AudioDecoder returns (channels, time); squeeze mono to 1-D,
-    # transpose multi-channel to (time, channels) for backward compat
-    if mono:
-        return samples.data.squeeze(0).numpy()
-    return samples.data.T.numpy()
+    if _HAS_TORCHCODEC:
+        decoder = AudioDecoder(
+            source,
+            sample_rate=sr,
+            num_channels=1 if mono else None,
+        )
+        samples = decoder.get_all_samples()
+        if mono:
+            return samples.data.squeeze(0).numpy()
+        return samples.data.T.numpy()
+
+    # Fallback: soundfile + torchaudio (ARM / no FFmpeg)
+    import soundfile as sf
+    import torch
+    import torchaudio
+
+    if isinstance(source, bytes):
+        audio, original_sr = sf.read(BytesIO(source))
+    else:
+        audio, original_sr = sf.read(source)
+
+    if mono and len(audio.shape) > 1:
+        audio = np.mean(audio, axis=1)
+
+    if original_sr != sr:
+        audio_tensor = torch.from_numpy(audio).float()
+        if audio_tensor.dim() == 1:
+            audio_tensor = audio_tensor.unsqueeze(0)
+        else:
+            audio_tensor = audio_tensor.T
+        audio_tensor = torchaudio.functional.resample(
+            audio_tensor, orig_freq=original_sr, new_freq=sr
+        )
+        if audio_tensor.shape[0] == 1:
+            audio = audio_tensor.squeeze(0).numpy()
+        else:
+            audio = audio_tensor.T.numpy()
+
+    return audio
 
 
 @dataclass

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -90,7 +90,6 @@ from torch import nn
 from torch.library import Library
 from torch.profiler import ProfilerActivity, profile, record_function
 from torch.utils._contextlib import _DecoratorContextManager
-from torchcodec.decoders import AudioDecoder
 from typing_extensions import Literal
 
 from sglang.srt.environ import envs
@@ -846,6 +845,8 @@ def decode_video_base64(video_base64):
 def load_audio(
     audio_file: str, sr: Optional[int] = None, mono: bool = True
 ) -> np.ndarray:
+    from torchcodec.decoders import AudioDecoder
+
     if sr is None:
         sr = 16000
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -92,16 +92,9 @@ from torch.profiler import ProfilerActivity, profile, record_function
 from torch.utils._contextlib import _DecoratorContextManager
 from typing_extensions import Literal
 
-try:
-    from torchcodec.decoders import AudioDecoder
-
-    _HAS_TORCHCODEC_AUDIO = True
-except (ImportError, RuntimeError):
-    _HAS_TORCHCODEC_AUDIO = False
-
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
-from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+from sglang.srt.utils.video_decoder import _BACKEND, VideoDecoderWrapper
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -874,7 +867,9 @@ def load_audio(
     else:
         raise ValueError(f"Invalid audio format: {audio_file}")
 
-    if _HAS_TORCHCODEC_AUDIO:
+    if _BACKEND == "torchcodec":
+        from torchcodec.decoders import AudioDecoder
+
         decoder = AudioDecoder(
             source,
             sample_rate=sr,


### PR DESCRIPTION
## Motivation

Follow-up to #20055 (video decoding migration to torchcodec). This PR migrates `load_audio()` from soundfile + torchaudio to torchcodec's `AudioDecoder`, unifying all media decoding under torchcodec.

## Changes

Replace `soundfile.read()` + `torchaudio.functional.resample()` with `torchcodec.decoders.AudioDecoder`, which handles decoding, resampling, and channel conversion in a single step. Falls back to soundfile + torchaudio on ARM / no-FFmpeg environments, reusing `video_decoder._BACKEND` flag for unified detection.

**Before:** soundfile loads raw audio → numpy mono conversion → torchaudio polyphase resample  
**After:** `AudioDecoder(source, sample_rate=sr, num_channels=1)` → done

- All input formats preserved: bytes, base64, HTTP URL, `file://`, local path
- Output shape backward-compatible: mono → `(time,)`, stereo → `(time, channels)`
- ARM fallback to soundfile + torchaudio via shared `_BACKEND` flag from `video_decoder.py`

## Test plan

- [x] Short audio (<1min, mono & stereo, various sample rates)
- [x] Long stereo audio (2hr, 44.1kHz→16kHz) — 3.09s
- [x] Base64 and bytes input
- [x] `file://` URL input
- [x] Multi-channel stereo preservation (`mono=False`)
- [x] Qwen2-Audio-7B-Instruct server: speech recognition (Trump WEF) ✅
- [x] Qwen2-Audio-7B-Instruct server: ambient audio (bird song) ✅
- [ ] CI: all existing audio-related tests pass