### PR TITLE
[Disagg] Skip health check enqueue when PD disagg queues have backlog

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1413,14 +1413,34 @@ class Scheduler(
         self.session_controller.maybe_reap(now)
         for recv_req in recv_reqs:
             # If it is a health check generation request and there are running requests, ignore it.
-            if is_health_check_generate_req(recv_req) and (
-                self.chunked_req is not None
-                or self.dllm_manager.any_staging_reqs()
-                or not self.running_batch.is_empty()
-                or len(self.offload_tags) > 0
-            ):
-                self.return_health_check_ct += 1
-                continue
+            if is_health_check_generate_req(recv_req):
+                # Check if there are requests being processed
+                has_running_requests = (
+                    self.chunked_req is not None
+                    or self.dllm_manager.any_staging_reqs()
+                    or not self.running_batch.is_empty()
+                    or len(self.offload_tags) > 0
+                )
+                
+                # In PD disaggregation mode, also check if health check would be blocked
+                # in special queues (bootstrap/prealloc) due to external factors
+                will_block_in_pd_queue = False
+                if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                    # If bootstrap queue has backlog, health check will also be blocked there
+                    will_block_in_pd_queue = (
+                        len(self.disagg_prefill_bootstrap_queue.queue) > 0
+                        or len(self.disagg_prefill_inflight_queue) > 0
+                    )
+                elif self.disaggregation_mode == DisaggregationMode.DECODE:
+                    # If prealloc/transfer queue has backlog, health check will also be blocked there
+                    will_block_in_pd_queue = (
+                        len(self.disagg_decode_prealloc_queue.queue) > 0
+                        or len(self.disagg_decode_transfer_queue.queue) > 0
+                    )
+                
+                if has_running_requests or will_block_in_pd_queue:
+                    self.return_health_check_ct += 1
+                    continue
 
             output = self._request_dispatcher(recv_req)
             if output is not None:


### PR DESCRIPTION
- Check `disagg_prefill_bootstrap_queue` / `disagg_prefill_inflight_queue` backlog on prefill node
- Check `disagg_decode_prealloc_queue` / `disagg_decode_transfer_queue` backlog on decode node
- Reuse existing `return_health_check_ct` fast-path to defer health check signal to next batch completion