### PR TITLE
[env] Add SGLANG_SORT_WEIGHT_FILES env var for sequential I/O optimization

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -39,6 +39,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.srt.environ import envs
 
 logger = init_logger(__name__)
 
@@ -125,6 +126,9 @@ class TextEncoderLoader(ComponentLoader):
             raise RuntimeError(
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
+
+        if envs.SGLANG_SORT_WEIGHT_FILES.get():
+            hf_weights_files.sort()
 
         return hf_folder, hf_weights_files, use_safetensors
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -161,6 +161,7 @@ class Envs:
 
     # Model & File Download
     SGLANG_USE_MODELSCOPE = EnvBool(False)
+    SGLANG_SORT_WEIGHT_FILES = EnvBool(False)
     SGLANG_DISABLED_MODEL_ARCHS = EnvTuple(tuple())
 
     # Logging Options

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -469,6 +469,9 @@ class DefaultModelLoader(BaseModelLoader):
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
 
+        if envs.SGLANG_SORT_WEIGHT_FILES.get():
+            hf_weights_files.sort()
+
         return hf_folder, hf_weights_files, use_safetensors
 
     def _get_weights_iterator(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When loading large sharded models, the order in which weight files are accessed can impact I/O performance. `glob.glob()` returns files in an order determined by the underlying file system (typically inode order on ext4), which may not be sequential. On inference-engine-aware file systems with sequential prefetch, non-sequential access leads to suboptimal prefetch behavior and increased I/O latency.

This PR adds a lightweight environment variable `SGLANG_SORT_WEIGHT_FILES` that sorts weight files alphabetically before loading, ensuring a deterministic and sequential access pattern.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- **`python/sglang/srt/environ.py`**: Add `SGLANG_SORT_WEIGHT_FILES = EnvBool(False)` to the `Envs` class.
- **`python/sglang/srt/model_loader/loader.py`**: Sort `hf_weights_files` in `DefaultModelLoader._prepare_weights()` when the env var is set. Applies to all weight formats (safetensors, bin, pt).
- **`python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py`**: Sort `hf_weights_files` in `TextEncoderLoader._prepare_weights()` using the same env var, replacing the previous `self._server_args` approach with a cleaner direct env var read.

Key design points:
- **Zero invasion**: Guarded by a runtime switch (`default=False`). When disabled by default, no code path is touched.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

No accuracy impact. The change only affects the *order* of file loading, not the content. Each tensor is loaded by name from the state dict, so the final model weights are identical regardless of file order.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

| Metric | Without Sort (avg) | With Sort (avg) |
|---|---|---|
| Weight-load phase | 1244 s | 1230 s |
| Tensor deserialization | 704 s | 666 s |
| Startup overhead | 107 s | 107 s |
| **Total end-to-end** | **2055 s** | **2003 s** |

**Key observations:**
- On inference-engine-aware file systems with sequential prefetch optimizations, the improvement is expected to be significantly larger.
- This switch-controlled feature serves as a prerequisite for follow-up I/O optimizations (e.g., concurrent prefetch).

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
