### PR TITLE
Include cache details in continuous usage chunks

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -722,9 +722,11 @@ class OpenAIServingChat(OpenAIServingBase):
                             request.stream_options
                             and request.stream_options.continuous_usage_stats
                         ):
-                            chunk.usage = UsageProcessor.calculate_token_usage(
+                            chunk.usage = UsageProcessor.calculate_continuous_usage(
                                 prompt_tokens=prompt_tokens.get(index, 0),
                                 completion_tokens=completion_tokens.get(index, 0),
+                                cached_tokens=cached_tokens.get(index, 0),
+                                enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
                             )
 
                         yield f"data: {chunk.model_dump_json()}\n\n"
@@ -777,9 +779,11 @@ class OpenAIServingChat(OpenAIServingBase):
                             request.stream_options
                             and request.stream_options.continuous_usage_stats
                         ):
-                            chunk.usage = UsageProcessor.calculate_token_usage(
+                            chunk.usage = UsageProcessor.calculate_continuous_usage(
                                 prompt_tokens=prompt_tokens.get(index, 0),
                                 completion_tokens=completion_tokens.get(index, 0),
+                                cached_tokens=cached_tokens.get(index, 0),
+                                enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
                             )
 
                         yield f"data: {chunk.model_dump_json()}\n\n"
@@ -1297,9 +1301,12 @@ class OpenAIServingChat(OpenAIServingBase):
             if request.stream_options and request.stream_options.continuous_usage_stats:
                 prompt_tokens = content["meta_info"].get("prompt_tokens", 0)
                 completion_tokens = content["meta_info"].get("completion_tokens", 0)
-                chunk.usage = UsageProcessor.calculate_token_usage(
+                cached_tokens = content["meta_info"].get("cached_tokens", 0)
+                chunk.usage = UsageProcessor.calculate_continuous_usage(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
+                    cached_tokens=cached_tokens,
+                    enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
                 )
 
             yield f"data: {chunk.model_dump_json()}\n\n"
@@ -1347,9 +1354,12 @@ class OpenAIServingChat(OpenAIServingBase):
             if request.stream_options and request.stream_options.continuous_usage_stats:
                 prompt_tokens = content["meta_info"].get("prompt_tokens", 0)
                 completion_tokens = content["meta_info"].get("completion_tokens", 0)
-                chunk.usage = UsageProcessor.calculate_token_usage(
+                cached_tokens = content["meta_info"].get("cached_tokens", 0)
+                chunk.usage = UsageProcessor.calculate_continuous_usage(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
+                    cached_tokens=cached_tokens,
+                    enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
                 )
 
             yield f"data: {chunk.model_dump_json()}\n\n"

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -311,9 +311,11 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     request.stream_options
                     and request.stream_options.continuous_usage_stats
                 ):
-                    chunk.usage = UsageProcessor.calculate_token_usage(
+                    chunk.usage = UsageProcessor.calculate_continuous_usage(
                         prompt_tokens=prompt_tokens.get(index, 0),
                         completion_tokens=completion_tokens.get(index, 0),
+                        cached_tokens=content["meta_info"].get("cached_tokens", 0),
+                        enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
                     )
 
                 yield f"data: {chunk.model_dump_json()}\n\n"

--- a/python/sglang/srt/entrypoints/openai/usage_processor.py
+++ b/python/sglang/srt/entrypoints/openai/usage_processor.py
@@ -72,6 +72,24 @@ class UsageProcessor:
         )
 
     @staticmethod
+    def calculate_continuous_usage(
+        prompt_tokens: int,
+        completion_tokens: int,
+        cached_tokens: int = 0,
+        enable_cache_report: bool = False,
+    ) -> UsageInfo:
+        cached_details = (
+            UsageProcessor._details_if_cached(cached_tokens)
+            if enable_cache_report
+            else None
+        )
+        return UsageProcessor.calculate_token_usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_details,
+        )
+
+    @staticmethod
     def calculate_token_usage(
         prompt_tokens: int,
         completion_tokens: int,

--- a/test/manual/openai_server/features/test_continuous_usage_stats.py
+++ b/test/manual/openai_server/features/test_continuous_usage_stats.py
@@ -17,7 +17,12 @@ class TestContinuousUsageStats(CustomTestCase):
     def setUpClass(cls):
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(cls.model, cls.base_url, timeout=300)
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=300,
+            other_args=["--enable-cache-report"],
+        )
         cls.client = openai.Client(api_key="EMPTY", base_url=f"{cls.base_url}/v1")
         cls.aclient = openai.AsyncClient(api_key="EMPTY", base_url=f"{cls.base_url}/v1")
 
@@ -96,6 +101,54 @@ class TestContinuousUsageStats(CustomTestCase):
 
         assert len(usage_chunks) == 1
         assert len(usage_chunks[0].choices) == 0
+
+    def test_continuous_usage_stats_include_cache_details_when_enabled(self):
+        messages = [
+            {
+                "role": "user",
+                "content": "Summarize how attention works in one short paragraph.",
+            }
+        ]
+
+        prime = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            max_tokens=24,
+            temperature=0,
+        )
+        assert prime.usage.prompt_tokens > 0
+
+        stream = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            stream=True,
+            max_tokens=24,
+            temperature=0,
+            stream_options={"include_usage": True, "continuous_usage_stats": True},
+        )
+
+        saw_usage = False
+        saw_content = False
+        saw_cache_details = False
+        saw_positive_cached_tokens = False
+
+        for chunk in stream:
+            has_content = len(chunk.choices) > 0 and chunk.choices[0].delta.content
+            if has_content:
+                saw_content = True
+            if not chunk.usage:
+                continue
+            saw_usage = True
+            if chunk.usage.prompt_tokens_details is None:
+                continue
+            saw_cache_details = True
+            if chunk.usage.prompt_tokens_details.cached_tokens > 0:
+                saw_positive_cached_tokens = True
+
+        assert saw_content
+        assert saw_usage
+        assert saw_cache_details
+        assert saw_positive_cached_tokens
 
     def test_async_runner(self):
         asyncio.run(self.test_continuous_usage_stats_async())


### PR DESCRIPTION
## Motivation

When `stream_options.continuous_usage_stats=true`, streamed OpenAI-compatible chat/completion chunks include token totals, but they currently drop `usage.prompt_tokens_details.cached_tokens` even when `--enable-cache-report` is enabled.

This creates an inconsistency with non-streaming responses and with the final `include_usage` chunk at the end of a stream. In practice, clients that stop reading before the final usage-only chunk can observe prompt/completion token counts but miss the cache split entirely.

## Modifications

  - Added `UsageProcessor.calculate_continuous_usage(...)` to build per-chunk usage payloads with optional cached-token details.
  - Updated streaming `chat.completions` continuous usage paths to include cached token details when cache reporting is enabled.
  - Updated streaming `completions` continuous usage paths to do the same, so both OpenAI-compatible streaming endpoints stay consistent.
  - Added a regression test in `test/manual/openai_server/features/test_continuous_usage_stats.py` that:
    - launches the server with `--enable-cache-report`
    - primes the cache with a first request
    - sends a second streaming `chat.completions` request with `include_usage=true` and `continuous_usage_stats=true`
    - asserts that streamed usage chunks expose `prompt_tokens_details.cached_tokens`

  ## Accuracy Tests

  Not applicable. This change only affects usage metadata returned by the OpenAI-compatible API and does not change model outputs or decoding behavior.

  ## Benchmarking and Profiling

  Not applicable. This change only adds cached-token details to streamed usage metadata and is not expected to affect inference speed.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/
  contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-
  and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-
  documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/
  contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/
  contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

  ## Review Process

  1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/
  MAINTAINER.md#pull-request-merge-process).
  2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
  3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
     - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
  4. After green CI and required approvals, ask Merge Oncalls to merge.