### PR TITLE
[Core] Skip pydantic validation for input_embeds

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -26,6 +26,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import torch
+from pydantic import SkipValidation
 
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import BaseFinishReason
@@ -126,7 +127,10 @@ class GenerateReqInput(BaseReq):
     # The token ids for text; one can specify either text or input_ids
     input_ids: Optional[Union[List[List[int]], List[int]]] = None
     # The embeddings for input_ids; one can specify either text or input_ids or input_embeds.
-    input_embeds: Optional[Union[List[List[List[float]]], List[List[float]]]] = None
+    # SkipValidation: pydantic Union resolution is O(n) in float count (~200ms for large payloads).
+    input_embeds: SkipValidation[
+        Optional[Union[List[List[List[float]]], List[List[float]]]]
+    ] = None
     # The image input. It can be an image instance, file name, URL, or base64 encoded string.
     # Can be formatted as:
     # - Single image for a single request
@@ -310,12 +314,18 @@ class GenerateReqInput(BaseReq):
                 self.batch_size = len(self.input_ids)
             self.input_embeds = None
         else:
-            if isinstance(self.input_embeds[0][0], float):
-                self.is_single = True
-                self.batch_size = 1
-            else:
+            try:
+                first = self.input_embeds[0][0]
+            except (TypeError, IndexError, KeyError) as e:
+                raise ValueError(
+                    "input_embeds must be list[list[float]] or list[list[list[float]]] for batch"
+                ) from e
+            if isinstance(first, list):
                 self.is_single = False
                 self.batch_size = len(self.input_embeds)
+            else:
+                self.is_single = True
+                self.batch_size = 1
 
     def _handle_parallel_sampling(self):
         """Handle parallel sampling parameters and adjust batch size if needed."""


### PR DESCRIPTION
## Motivation

FastAPI's body auto-parsing runs pydantic validation on `GenerateReqInput`. For `input_embeds`, the `Union[List[List[List[float]]], List[List[float]]]` annotation triggers pydantic's Union resolver, which walks every element trying to match each variant. For a 7B model (`d_model=3584`) with a 125-token prompt (~448K floats), this takes **200+ms of synchronous work on the asyncio event loop** per request, capping server concurrency at ~2.

## Modifications

Wrap the `input_embeds` annotation with `SkipValidation`. The OpenAPI schema is unchanged (`SkipValidation` preserves the type for `/docs`); other fields are still validated.

The `_determine_batch_size` check is changed from `isinstance(first, float)` to `isinstance(first, list)` since pydantic no longer coerces ints to floats, and bare indexing errors are caught and re-raised as `ValueError` (existing `/generate` handler catches `ValueError` → HTTP 400). This also fixes a latent bug: integer `input_embeds` (e.g. `[[1,2],[3,4]]`) were previously misclassified as batch requests.

**Note**: This PR works best combined with #20205 — that PR adds `np.asarray` in `tokenizer_manager` which catches malformed `input_embeds` with a clear `ValueError` before IPC. Standalone, malformed data that passes the shallow check here would fail later at `torch.tensor` in the scheduler.

## Accuracy Tests

N/A — HTTP parsing layer only, does not affect model forward.

## Benchmarking and Profiling

Measured (FastAPI TestClient, 448K floats, ~9MB body):
- `/generate` body parse: **~320ms → ~100ms**

The remaining ~100ms is stdlib `json.loads`; see `input_embeds_bytes` (follow-up PR) for a faster encoding.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [ ] Add unit tests — existing `test_io_struct.py::test_input_embeds_normalization` covers the path
- [x] Update documentation as needed — N/A (OpenAPI schema unchanged)