### PR TITLE
[Core] Add input_embeds_bytes for faster embedding input

### DIFF
--- a/docs/basic_usage/sampling_params.md
+++ b/docs/basic_usage/sampling_params.md
@@ -12,6 +12,8 @@ The `/generate` endpoint accepts the following parameters in JSON format. For de
 | text                       | `Optional[Union[List[str], str]] = None`                                     | The input prompt. Can be a single prompt or a batch of prompts.                                                                                                 |
 | input_ids                  | `Optional[Union[List[List[int]], List[int]]] = None`                         | The token IDs for text; one can specify either text or input_ids.                                                                                               |
 | input_embeds               | `Optional[Union[List[List[List[float]]], List[List[float]]]] = None`         | The embeddings for input_ids; one can specify either text, input_ids, or input_embeds.                                                                          |
+| input_embeds_bytes         | `Optional[Union[List[Base64Bytes], Base64Bytes]] = None`                     | Alternative to input_embeds: base64-encoded raw float32 bytes (row-major). Requires `input_embeds_shape`. Smaller on the wire and faster to decode than the JSON float list. See [example](#input_embeds_bytes). |
+| input_embeds_shape         | `Optional[Union[List[List[int]], List[int]]] = None`                         | Shape `[seq_len, d_model]` for `input_embeds_bytes`.                                                                                                            |
 | image_data                 | `Optional[Union[List[List[ImageDataItem]], List[ImageDataItem], ImageDataItem]] = None` | The image input. Supports three formats: (1) **Raw images**: PIL Image, file path, URL, or base64 string; (2) **Processor output**: Dict with `format: "processor_output"` containing HuggingFace processor outputs; (3) **Precomputed embeddings**: Dict with `format: "precomputed_embedding"` and `feature` containing pre-calculated visual embeddings. Can be a single image, list of images, or list of lists of images. See [Multimodal Input Formats](#multimodal-input-formats) for details. |
 | audio_data                 | `Optional[Union[List[AudioDataItem], AudioDataItem]] = None`                 | The audio input. Can be a file name, URL, or base64 encoded string.                                                                                             |
 | sampling_params            | `Optional[Union[List[Dict], Dict]] = None`                                   | The sampling parameters as described in the sections below.                                                                                                     |
@@ -116,6 +118,26 @@ print(response.json())
 ```
 
 Detailed example in [send request](./send_request.ipynb).
+
+### input_embeds_bytes
+
+Send pre-computed embeddings as base64-encoded raw float32 bytes (smaller and faster than the JSON float list). Requires `--disable-radix-cache`. This bypasses the tokenizer; only enable for trusted clients.
+
+```python
+import base64, requests, torch
+
+# embeds: torch.Tensor of shape (seq_len, d_model)
+arr = embeds.to(torch.float32).contiguous().cpu().numpy()
+response = requests.post(
+    "http://localhost:30000/generate",
+    json={
+        "input_embeds_bytes": base64.b64encode(arr.tobytes()).decode(),
+        "input_embeds_shape": list(arr.shape),
+        "sampling_params": {"max_new_tokens": 32},
+    },
+)
+print(response.json())
+```
 
 ### Streaming
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -26,6 +26,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import torch
+from pydantic import Base64Bytes
 
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import BaseFinishReason
@@ -127,6 +128,13 @@ class GenerateReqInput(BaseReq):
     input_ids: Optional[Union[List[List[int]], List[int]]] = None
     # The embeddings for input_ids; one can specify either text or input_ids or input_embeds.
     input_embeds: Optional[Union[List[List[List[float]]], List[List[float]]]] = None
+    # Alternative to input_embeds: base64-encoded raw float32 bytes of shape
+    # (seq_len, d_model), row-major. Requires input_embeds_shape. Faster and
+    # smaller on the wire than the JSON float list. WARNING: input_embeds (in
+    # either encoding) bypasses the tokenizer; enable only for trusted clients.
+    input_embeds_bytes: Optional[Union[List[Base64Bytes], Base64Bytes]] = None
+    # Shape for input_embeds_bytes: [seq_len, d_model] (or list thereof for batch).
+    input_embeds_shape: Optional[Union[List[List[int]], List[int]]] = None
     # The image input. It can be an image instance, file name, URL, or base64 encoded string.
     # Can be formatted as:
     # - Single image for a single request
@@ -278,15 +286,23 @@ class GenerateReqInput(BaseReq):
 
     def _validate_inputs(self):
         """Validate that the input configuration is valid."""
-        if (
-            self.text is None and self.input_ids is None and self.input_embeds is None
-        ) or (
-            self.text is not None
-            and self.input_ids is not None
-            and self.input_embeds is not None
-        ):
+        provided = sum(
+            x is not None
+            for x in (
+                self.text,
+                self.input_ids,
+                self.input_embeds,
+                self.input_embeds_bytes,
+            )
+        )
+        if provided != 1:
             raise ValueError(
-                "Either text, input_ids or input_embeds should be provided."
+                "Exactly one of text, input_ids, input_embeds or "
+                "input_embeds_bytes should be provided."
+            )
+        if (self.input_embeds_bytes is None) != (self.input_embeds_shape is None):
+            raise ValueError(
+                "input_embeds_bytes and input_embeds_shape must be provided together."
             )
 
     def _determine_batch_size(self):
@@ -309,6 +325,15 @@ class GenerateReqInput(BaseReq):
                 self.is_single = False
                 self.batch_size = len(self.input_ids)
             self.input_embeds = None
+        elif self.input_embeds_bytes is not None:
+            if isinstance(self.input_embeds_bytes, list):
+                if len(self.input_embeds_bytes) == 0:
+                    raise ValueError("input_embeds_bytes cannot be empty.")
+                self.is_single = False
+                self.batch_size = len(self.input_embeds_bytes)
+            else:
+                self.is_single = True
+                self.batch_size = 1
         else:
             if isinstance(self.input_embeds[0][0], float):
                 self.is_single = True
@@ -342,6 +367,9 @@ class GenerateReqInput(BaseReq):
                 self.input_ids = [self.input_ids]
             if self.input_embeds is not None:
                 self.input_embeds = [self.input_embeds]
+            if self.input_embeds_bytes is not None:
+                self.input_embeds_bytes = [self.input_embeds_bytes]
+                self.input_embeds_shape = [self.input_embeds_shape]
 
     def _normalize_single_inputs(self):
         """Normalize inputs for a single example."""
@@ -397,6 +425,9 @@ class GenerateReqInput(BaseReq):
             if not isinstance(self.input_embeds, list):
                 raise ValueError("input_embeds should be a list for batch processing.")
             self.input_embeds = self.input_embeds * self.parallel_sample_num
+        elif self.input_embeds_bytes is not None:
+            self.input_embeds_bytes = self.input_embeds_bytes * self.parallel_sample_num
+            self.input_embeds_shape = self.input_embeds_shape * self.parallel_sample_num
 
     def _normalize_lora_paths(self, num):
         """Normalize LoRA paths for batch processing."""
@@ -594,6 +625,16 @@ class GenerateReqInput(BaseReq):
             input_ids=self.input_ids[i] if self.input_ids is not None else None,
             input_embeds=(
                 self.input_embeds[i] if self.input_embeds is not None else None
+            ),
+            input_embeds_bytes=(
+                self.input_embeds_bytes[i]
+                if self.input_embeds_bytes is not None
+                else None
+            ),
+            input_embeds_shape=(
+                self.input_embeds_shape[i]
+                if self.input_embeds_shape is not None
+                else None
             ),
             image_data=self.image_data[i],
             video_data=self.video_data[i],

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -684,8 +684,8 @@ class TokenizedGenerateReqInput(BaseReq):
     # The start location in the prompt for returning routed experts.
     routed_experts_start_len: int = 0
 
-    # The input embeds
-    input_embeds: Optional[Union[List[List[List[float]]], List[List[float]]]] = None
+    # The input embeds (np.ndarray after tokenizer_manager conversion)
+    input_embeds: Optional[Any] = None
 
     # Session info for continual prompting
     session_params: Optional[SessionParams] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -499,7 +499,7 @@ class Req(ReqDllmMixin):
         stream: bool = False,
         origin_input_ids_unpadded: Optional[Tuple[int]] = None,
         lora_id: Optional[str] = None,
-        input_embeds: Optional[List[List[float]]] = None,
+        input_embeds: Optional[np.ndarray] = None,
         token_type_ids: List[int] = None,
         session: Optional[Session] = None,
         custom_logit_processor: Optional[str] = None,
@@ -1513,8 +1513,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
             # If input_embeds are available, store them
             if req.input_embeds is not None:
-                # If req.input_embeds is already a list, append its content directly
-                input_embeds.extend(req.input_embeds)  # Use extend to avoid nesting
+                # Collect per-request arrays; concatenate once at the end
+                input_embeds.append(req.input_embeds)
 
             multimodal_inputs.append(req.multimodal_inputs)
 
@@ -1616,9 +1616,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.orig_seq_lens = orig_seq_lens_tensor
         self.out_cache_loc = out_cache_loc
         self.input_embeds = (
-            torch.tensor(input_embeds, pin_memory=_pin).to(
-                self.device, non_blocking=True
-            )
+            torch.tensor(
+                np.concatenate([np.asarray(e, dtype=np.float32) for e in input_embeds]),
+                pin_memory=_pin,
+            ).to(self.device, non_blocking=True)
             if input_embeds
             else None
         )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -665,6 +665,33 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             input_ids, token_type_ids, input_format, original_batch_size
         )
 
+    def _decode_input_embeds_bytes(self, data: bytes, shape: List[int]) -> np.ndarray:
+        """Decode raw float32 bytes into a (seq_len, d_model) ndarray."""
+        if not (isinstance(shape, list) and len(shape) == 2):
+            raise ValueError(
+                f"input_embeds_shape must be [seq_len, d_model], got {shape!r}"
+            )
+        seq_len, d_model = shape
+        max_len = self.max_req_input_len or self.context_len
+        if seq_len <= 0 or seq_len > max_len:
+            raise ValueError(
+                f"input_embeds_shape seq_len {seq_len} must be in (0, {max_len}]"
+            )
+        if d_model != self.model_config.hidden_size:
+            raise ValueError(
+                f"input_embeds_shape d_model {d_model} does not match "
+                f"model hidden_size {self.model_config.hidden_size}"
+            )
+        expected = seq_len * d_model * 4
+        if len(data) != expected:
+            raise ValueError(
+                f"input_embeds_bytes length {len(data)} does not match shape "
+                f"{shape} (expected {expected} bytes for float32)"
+            )
+        # copy: frombuffer yields a read-only view; downstream torch ops
+        # on a read-only array are undefined behavior
+        return np.frombuffer(data, dtype=np.float32).reshape(seq_len, d_model).copy()
+
     async def _tokenize_one_request(
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
@@ -677,15 +704,21 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         is_cross_encoder_request = (
             isinstance(obj, EmbeddingReqInput) and obj.is_cross_encoder_request
         )
-        if obj.input_embeds is not None:
+        input_embeds_bytes = getattr(obj, "input_embeds_bytes", None)
+        if obj.input_embeds is not None or input_embeds_bytes is not None:
             if not self.server_args.disable_radix_cache:
                 raise ValueError(
                     "input_embeds is provided while disable_radix_cache is False. "
                     "Please add `--disable-radix-cache` when you launch the server "
                     "if you want to use input_embeds as inputs."
                 )
-            # ndarray: faster pickle IPC + tensor construction downstream
-            input_embeds = np.asarray(obj.input_embeds, dtype=np.float32)
+            if input_embeds_bytes is not None:
+                input_embeds = self._decode_input_embeds_bytes(
+                    input_embeds_bytes, obj.input_embeds_shape
+                )
+            else:
+                # ndarray: faster pickle IPC + tensor construction downstream
+                input_embeds = np.asarray(obj.input_embeds, dtype=np.float32)
             input_ids = obj.input_ids
         elif obj.input_ids is not None:
             input_ids = obj.input_ids
@@ -1062,7 +1095,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 raise ValueError(
                     "Batch tokenization is not needed for pre-tokenized input_ids. Do not set `enable_tokenizer_batch_encode`."
                 )
-            if obj[i].input_embeds is not None:
+            if (
+                obj[i].input_embeds is not None
+                or getattr(obj[i], "input_embeds_bytes", None) is not None
+            ):
                 raise ValueError(
                     "Batch tokenization is not needed for input_embeds. Do not set `enable_tokenizer_batch_encode`."
                 )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -32,6 +32,7 @@ from http import HTTPStatus
 from typing import Any, Awaitable, Dict, List, Optional, Tuple, Union
 
 import fastapi
+import numpy as np
 import uvloop
 import zmq
 import zmq.asyncio
@@ -683,7 +684,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                     "Please add `--disable-radix-cache` when you launch the server "
                     "if you want to use input_embeds as inputs."
                 )
-            input_embeds = obj.input_embeds
+            # ndarray: faster pickle IPC + tensor construction downstream
+            input_embeds = np.asarray(obj.input_embeds, dtype=np.float32)
             input_ids = obj.input_ids
         elif obj.input_ids is not None:
             input_ids = obj.input_ids
@@ -932,7 +934,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         input_text: str,
         input_ids: List[int],
-        input_embeds: Optional[Union[List[float], None]] = None,
+        input_embeds: Optional[np.ndarray] = None,
         mm_inputs: Optional[Dict] = None,
         token_type_ids: Optional[List[int]] = None,
     ) -> Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput]:

--- a/test/registered/core/test_input_embeddings.py
+++ b/test/registered/core/test_input_embeddings.py
@@ -1,9 +1,9 @@
+import base64
 import json
-import os
-import tempfile
 import unittest
 
 import requests
+import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from sglang.srt.utils import kill_process_tree
@@ -42,7 +42,7 @@ class TestInputEmbeds(CustomTestCase):
         """Generate input embeddings for a given text."""
         input_ids = self.tokenizer(text, return_tensors="pt")["input_ids"]
         embeddings = self.ref_model.get_input_embeddings()(input_ids)
-        return embeddings.squeeze().tolist()  # Convert tensor to a list for API use
+        return embeddings.squeeze()  # CPU float tensor, shape (seq_len, d_model)
 
     def send_request(self, payload):
         """Send a POST request to the /generate endpoint and return the response."""
@@ -51,20 +51,6 @@ class TestInputEmbeds(CustomTestCase):
             json=payload,
             timeout=30,  # Set a reasonable timeout for the API request
         )
-        if response.status_code == 200:
-            return response.json()
-        return {
-            "error": f"Request failed with status {response.status_code}: {response.text}"
-        }
-
-    def send_file_request(self, file_path):
-        """Send a POST request to the /generate_from_file endpoint with a file."""
-        with open(file_path, "rb") as f:
-            response = requests.post(
-                self.base_url + "/generate_from_file",
-                files={"file": f},
-                timeout=30,  # Set a reasonable timeout for the API request
-            )
         if response.status_code == 200:
             return response.json()
         return {
@@ -90,13 +76,35 @@ class TestInputEmbeds(CustomTestCase):
             embeddings = self.generate_input_embeddings(text)
             payload = {
                 "model": self.model,
-                "input_embeds": embeddings,
+                "input_embeds": embeddings.tolist(),
                 "sampling_params": {"temperature": 0, "max_new_tokens": 50},
             }
             response = self.send_request(payload)
             print(
                 f"Embeddings Input (for text '{text}'):\nResponse: {json.dumps(response, indent=2)}\n{'-' * 80}"
             )
+
+    def test_embedding_bytes_response(self):
+        """Test input_embeds_bytes (raw float32) matches input_embeds output."""
+        for text in self.texts:
+            embeddings = self.generate_input_embeddings(text)
+            arr = embeddings.detach().to(torch.float32).contiguous().cpu().numpy()
+            sampling = {"temperature": 0, "max_new_tokens": 50}
+
+            list_resp = self.send_request(
+                {"input_embeds": arr.tolist(), "sampling_params": sampling}
+            )
+            bytes_resp = self.send_request(
+                {
+                    "input_embeds_bytes": base64.b64encode(arr.tobytes()).decode(),
+                    "input_embeds_shape": list(arr.shape),
+                    "sampling_params": sampling,
+                }
+            )
+
+            self.assertNotIn("error", list_resp, list_resp)
+            self.assertNotIn("error", bytes_resp, bytes_resp)
+            self.assertEqual(list_resp["text"], bytes_resp["text"])
 
     def test_compare_text_vs_embedding(self):
         """Test and compare responses for text-based and embedding-based inputs."""
@@ -111,7 +119,7 @@ class TestInputEmbeds(CustomTestCase):
             embeddings = self.generate_input_embeddings(text)
             embed_payload = {
                 "model": self.model,
-                "input_embeds": embeddings,
+                "input_embeds": embeddings.tolist(),
                 "sampling_params": {"temperature": 0, "max_new_tokens": 50},
             }
             # Get responses
@@ -126,25 +134,6 @@ class TestInputEmbeds(CustomTestCase):
             )
             # This is flaky, so we skip this temporarily
             # self.assertEqual(text_response["text"], embed_response["text"])
-
-    def test_generate_from_file(self):
-        """Test the /generate_from_file endpoint using tokenized embeddings."""
-        for text in self.texts:
-            embeddings = self.generate_input_embeddings(text)
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".json", delete=False
-            ) as tmp_file:
-                json.dump(embeddings, tmp_file)
-                tmp_file_path = tmp_file.name
-
-            try:
-                response = self.send_file_request(tmp_file_path)
-                print(
-                    f"Text Input: {text}\nResponse from /generate_from_file: {json.dumps(response, indent=2)}\n{'-' * 80}"
-                )
-            finally:
-                # Ensure the temporary file is deleted
-                os.remove(tmp_file_path)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/registered/core/test_io_struct.py
+++ b/test/registered/core/test_io_struct.py
@@ -316,6 +316,38 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertFalse(req.is_single)
         self.assertEqual(req.batch_size, 2)
 
+    def test_input_embeds_bytes_normalization(self):
+        """Test normalization of input_embeds_bytes."""
+        # Single: raw bytes with shape
+        req = GenerateReqInput(
+            input_embeds_bytes=b"\x00" * 8, input_embeds_shape=[1, 2]
+        )
+        req.normalize_batch_and_arguments()
+        self.assertTrue(req.is_single)
+        self.assertEqual(req.batch_size, 1)
+
+        # Batch: list of bytes with list of shapes
+        req = GenerateReqInput(
+            input_embeds_bytes=[b"\x00" * 8, b"\x00" * 16],
+            input_embeds_shape=[[1, 2], [2, 2]],
+        )
+        req.normalize_batch_and_arguments()
+        self.assertFalse(req.is_single)
+        self.assertEqual(req.batch_size, 2)
+        self.assertEqual(req[0].input_embeds_bytes, b"\x00" * 8)
+        self.assertEqual(req[0].input_embeds_shape, [1, 2])
+        self.assertEqual(req[1].input_embeds_shape, [2, 2])
+
+        # bytes without shape should fail
+        with self.assertRaises(ValueError):
+            GenerateReqInput(
+                input_embeds_bytes=b"\x00" * 8
+            ).normalize_batch_and_arguments()
+
+        # shape without bytes should fail
+        with self.assertRaises(ValueError):
+            GenerateReqInput(input_embeds_shape=[1, 2]).normalize_batch_and_arguments()
+
     def test_input_embeds_with_parallel_sampling(self):
         """Test input_embeds normalization with parallel sampling (n > 1)."""
         # Test single input_embeds with parallel sampling
@@ -547,17 +579,23 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
     def test_error_cases(self):
         """Test various error cases."""
-        # Test when neither text, input_ids, nor input_embeds is provided
+        # No input provided
         with self.assertRaises(ValueError):
-            req = GenerateReqInput()
-            req.normalize_batch_and_arguments()
+            GenerateReqInput().normalize_batch_and_arguments()
 
-        # Test when all of text, input_ids, and input_embeds are provided
-        with self.assertRaises(ValueError):
-            req = GenerateReqInput(
-                text="Hello", input_ids=[1, 2, 3], input_embeds=[[0.1, 0.2]]
-            )
-            req.normalize_batch_and_arguments()
+        # More than one input type provided
+        for kwargs in (
+            {"text": "Hello", "input_ids": [1, 2, 3]},
+            {"text": "Hello", "input_embeds": [[0.1, 0.2]]},
+            {
+                "input_ids": [1],
+                "input_embeds_bytes": b"x",
+                "input_embeds_shape": [1, 1],
+            },
+            {"text": "Hi", "input_ids": [1], "input_embeds": [[0.1]]},
+        ):
+            with self.assertRaises(ValueError):
+                GenerateReqInput(**kwargs).normalize_batch_and_arguments()
 
     def test_multiple_input_formats(self):
         """Test different combinations of input formats."""


### PR DESCRIPTION
**Builds on #20205** — the first commit in this PR's diff is from that branch; only the second commit is new.

## Motivation

The `input_embeds` JSON float list path is slow for large embeddings: for a 7B model (`d_model=3584`) with a 125-token prompt, the ~9.2MB JSON body takes ~100ms for `json.loads` alone (see #20206 for the other ~220ms from pydantic Union resolution).

This adds an alternative encoding: base64-encoded raw float32 bytes with an explicit shape field.

## Modifications

New fields on `GenerateReqInput`:
- `input_embeds_bytes: Optional[Union[List[Base64Bytes], Base64Bytes]]` — base64-encoded raw float32 bytes, row-major
- `input_embeds_shape: Optional[Union[List[List[int]], List[int]]]` — `[seq_len, d_model]` (or list thereof for batch)

Server decodes via `np.frombuffer(data, dtype=np.float32).reshape(shape)` — validation enforces `len(bytes) == seq_len * d_model * 4` so allocation is exactly `len(bytes)` with no amplification. `seq_len` is bounded by `max_req_input_len` and `d_model` must match the model's `hidden_size`.

The JSON float list path remains supported; this is additive.

**Behavior change**: `_validate_inputs` now requires exactly one of (`text`, `input_ids`, `input_embeds`, `input_embeds_bytes`). Previously some combinations (e.g. `text` + `input_ids`) were silently accepted; these are now rejected.

**Also removes** the dead `test_generate_from_file` (the `/generate_from_file` endpoint was removed in #17442).

**Security**: `input_embeds` (in either encoding) bypasses the tokenizer and should only be enabled for trusted clients (see the warning in the field comment). This matches vLLM's `--enable-prompt-embeds` posture.

## Client encoding example

```python
import base64, requests, torch

arr = embeds.to(torch.float32).contiguous().cpu().numpy()
response = requests.post(
    "http://localhost:30000/generate",
    json={
        "input_embeds_bytes": base64.b64encode(arr.tobytes()).decode(),
        "input_embeds_shape": list(arr.shape),
        "sampling_params": {"max_new_tokens": 32},
    },
)
```

## Accuracy Tests

`test_embedding_bytes_response` asserts generation output matches the `input_embeds` JSON-list path at `temperature=0`.

## Benchmarking and Profiling

| | `input_embeds` (JSON list) | `input_embeds_bytes` |
|---|---|---|
| wire size | ~9.2 MB | ~2.4 MB |
| server decode | ~100ms (`json.loads`) | ~2ms (`np.frombuffer`) |

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests — `test_io_struct.py::test_input_embeds_bytes_normalization`, `test_input_embeddings.py::test_embedding_bytes_response`
- [x] Update documentation — `docs/basic_usage/sampling_params.md` with fields + code example