### PR TITLE
Add MlxAttnBackend for macOS

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
+++ b/python/sglang/jit_kernel/diffusion/triton/mps_fallback.py
@@ -16,6 +16,7 @@ import torch
 from torch import Tensor
 
 from sglang.srt.environ import envs
+from sglang.srt.utils.tensor_bridge import mlx_to_torch, torch_to_mlx
 
 # MLX acceleration – opt-in via SGLANG_USE_MLX=1
 _MLX_AVAILABLE = False
@@ -27,38 +28,6 @@ except ImportError:
     pass
 
 _USE_MLX = envs.SGLANG_USE_MLX.get() and _MLX_AVAILABLE
-
-# Dtype mapping for torch <-> MLX tensor bridge
-_TORCH_TO_MLX_DTYPE = (
-    {
-        torch.float32: mx.float32,
-        torch.float16: mx.float16,
-        torch.bfloat16: mx.bfloat16,
-    }
-    if _MLX_AVAILABLE
-    else {}
-)
-
-_MLX_TO_TORCH_DTYPE = {v: k for k, v in _TORCH_TO_MLX_DTYPE.items()}
-
-
-def _torch_to_mlx(tensor: torch.Tensor) -> "mx.array":
-    """Convert a PyTorch tensor to an MLX array (via numpy on CPU)."""
-    t = tensor.cpu().detach()
-    if t.dtype == torch.bfloat16:
-        return mx.array(t.float().numpy(), dtype=mx.bfloat16)
-    return mx.array(t.numpy())
-
-
-def _mlx_to_torch(array: "mx.array", device: torch.device) -> torch.Tensor:
-    """Convert an MLX array to a PyTorch tensor (zero-copy via memoryview)."""
-    torch_dtype = _MLX_TO_TORCH_DTYPE.get(array.dtype, torch.float32)
-    array = mx.contiguous(array)
-    mx.eval(array)
-    tensor = torch.frombuffer(memoryview(array), dtype=torch_dtype).reshape(array.shape)
-    if device.type == "mps":
-        tensor = tensor.to(device)
-    return tensor
 
 
 def fuse_scale_shift_kernel_native(
@@ -231,17 +200,17 @@ if _USE_MLX:
         """MLX-accelerated norm_infer (layer norm / rms norm inference)."""
         device = x.device
         orig_dtype = x.dtype
-        x_mx = _torch_to_mlx(x)
+        x_mx = torch_to_mlx(x)
         if is_rms_norm:
             w_mx = (
-                _torch_to_mlx(weight) if weight is not None else mx.ones(x_mx.shape[-1])
+                torch_to_mlx(weight) if weight is not None else mx.ones(x_mx.shape[-1])
             )
             result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)
         else:
-            w_mx = _torch_to_mlx(weight) if weight is not None else None
-            b_mx = _torch_to_mlx(bias) if bias is not None else None
+            w_mx = torch_to_mlx(weight) if weight is not None else None
+            b_mx = torch_to_mlx(bias) if bias is not None else None
             result_mx = mx.fast.layer_norm(x_mx, w_mx, b_mx, eps)
-        result = _mlx_to_torch(result_mx, device).to(orig_dtype)
+        result = mlx_to_torch(result_mx, device).to(orig_dtype)
         if out is not None:
             out.copy_(result)
             return out
@@ -254,10 +223,10 @@ if _USE_MLX:
         shape = x.shape
         device = x.device
         orig_dtype = x.dtype
-        x_mx = _torch_to_mlx(x.reshape(-1, x.shape[-1]))
-        w_mx = _torch_to_mlx(w)
+        x_mx = torch_to_mlx(x.reshape(-1, x.shape[-1]))
+        w_mx = torch_to_mlx(w)
         result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)
-        return _mlx_to_torch(result_mx, device).to(orig_dtype).view(shape)
+        return mlx_to_torch(result_mx, device).to(orig_dtype).view(shape)
 
     def rms_norm_fn_native(  # noqa: F811
         x,
@@ -295,10 +264,10 @@ if _USE_MLX:
             w = weight.float() + 1.0
         else:
             w = weight
-        x_mx = _torch_to_mlx(x_flat)
-        w_mx = _torch_to_mlx(w) if w is not None else mx.ones(x_mx.shape[-1])
+        x_mx = torch_to_mlx(x_flat)
+        w_mx = torch_to_mlx(w) if w is not None else mx.ones(x_mx.shape[-1])
         result_mx = mx.fast.rms_norm(x_mx, w_mx, eps)
-        x_hat = _mlx_to_torch(result_mx, device)
+        x_hat = mlx_to_torch(result_mx, device)
         if bias is not None:
             x_hat = x_hat + bias.to(x_hat.device, x_hat.dtype)
         final_dtype = out_dtype if out_dtype is not None else orig_dtype

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -309,6 +309,7 @@ class Envs:
 
     # MPS (Apple Silicon)
     SGLANG_USE_MLX = EnvBool(False)
+    SGLANG_USE_MLX_ATTENTION = EnvBool(False)
 
     # NPU
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -109,6 +109,13 @@ def create_torch_native_backend(runner):
     return TorchNativeAttnBackend(runner)
 
 
+@register_attention_backend("mlx")
+def create_mlx_backend(runner):
+    from sglang.srt.layers.attention.mlx_backend import MlxAttnBackend
+
+    return MlxAttnBackend(runner)
+
+
 @register_attention_backend("flex_attention")
 def create_flex_attention_backend(runner):
     from sglang.srt.layers.attention.torch_flex_backend import TorchFlexAttnBackend

--- a/python/sglang/srt/layers/attention/mlx_backend.py
+++ b/python/sglang/srt/layers/attention/mlx_backend.py
@@ -1,0 +1,235 @@
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.utils.tensor_bridge import mlx_to_torch, sync_torch, torch_to_mlx
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class MlxAttnBackend(AttentionBackend):
+    def __init__(self, model_runner: "ModelRunner"):
+        super().__init__()
+        self.device = model_runner.device
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        pass
+
+    def _run_mlx_sdpa_forward_extend(
+        self,
+        query: torch.Tensor,
+        output: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        extend_prefix_lens: torch.Tensor,
+        extend_seq_lens: torch.Tensor,
+        scaling=None,
+        causal=False,
+    ):
+        assert seq_lens.shape[0] == extend_prefix_lens.shape[0]
+        assert seq_lens.shape[0] == extend_seq_lens.shape[0]
+
+        sync_torch()
+
+        start_q, start_kv = 0, 0
+        for seq_idx in range(seq_lens.shape[0]):
+            extend_seq_len_q = extend_seq_lens[seq_idx].item()
+            prefill_seq_len_q = extend_prefix_lens[seq_idx].item()
+            seq_len_kv = seq_lens[seq_idx].item()
+
+            end_q = start_q + extend_seq_len_q
+            end_kv = start_kv + seq_len_kv
+
+            per_req_query = query[start_q:end_q, :, :]
+            per_req_query_redudant = torch.empty(
+                (seq_len_kv, per_req_query.shape[1], per_req_query.shape[2]),
+                dtype=per_req_query.dtype,
+                device=per_req_query.device,
+            )
+            per_req_query_redudant[prefill_seq_len_q:, :, :] = per_req_query
+
+            req_pool_idx = req_pool_indices[seq_idx].item()
+            per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
+            per_req_key = k_cache[per_req_tokens]
+            per_req_value = v_cache[per_req_tokens]
+
+            if not (per_req_query.dtype == per_req_key.dtype == per_req_value.dtype):
+                per_req_key = per_req_key.to(per_req_query.dtype)
+                per_req_value = per_req_value.to(per_req_query.dtype)
+
+            mq = mx.expand_dims(torch_to_mlx(per_req_query_redudant), 0).transpose(
+                0, 2, 1, 3
+            )  # [1, n_heads, seq_len, head_dim]
+            mk = mx.expand_dims(torch_to_mlx(per_req_key), 0).transpose(
+                0, 2, 1, 3
+            )  # [1, n_heads, seq_len, head_dim]
+            mv = mx.expand_dims(torch_to_mlx(per_req_value), 0).transpose(
+                0, 2, 1, 3
+            )  # [1, n_heads, seq_len, head_dim]
+
+            mask = "causal" if causal else None
+
+            mo = mx.fast.scaled_dot_product_attention(
+                mq, mk, mv, scale=scaling if scaling is not None else 1.0, mask=mask
+            )
+
+            to = mlx_to_torch(
+                mo.transpose(0, 2, 1, 3).squeeze(0), output.device
+            )  # [seq_len, n_heads, head_dim]
+            output[start_q:end_q, :, :] = to[prefill_seq_len_q:, :, :]
+
+            start_q, start_kv = end_q, end_kv
+
+        sync_torch()
+
+        return output
+
+    def _run_mlx_sdpa_forward_decode(
+        self,
+        query: torch.Tensor,
+        output: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        scaling=None,
+    ):
+        sync_torch()
+
+        start_q, start_kv = 0, 0
+        for seq_idx in range(seq_lens.shape[0]):
+            seq_len_q = 1
+            seq_len_kv = seq_lens[seq_idx].item()
+            end_q = start_q + seq_len_q
+            end_kv = start_kv + seq_len_kv
+
+            per_req_query = query[start_q:end_q, :, :]
+
+            req_pool_idx = req_pool_indices[seq_idx].item()
+            per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
+            per_req_key = k_cache[per_req_tokens]
+            per_req_value = v_cache[per_req_tokens]
+
+            if not (per_req_query.dtype == per_req_key.dtype == per_req_value.dtype):
+                per_req_key = per_req_key.to(per_req_query.dtype)
+                per_req_value = per_req_value.to(per_req_query.dtype)
+
+            mq = mx.expand_dims(torch_to_mlx(per_req_query), 0).transpose(
+                0, 2, 1, 3
+            )  # [1, n_heads, 1, head_dim]
+            mk = mx.expand_dims(torch_to_mlx(per_req_key), 0).transpose(
+                0, 2, 1, 3
+            )  # [1, n_heads, seq_len_kv, head_dim]
+            mv = mx.expand_dims(torch_to_mlx(per_req_value), 0).transpose(0, 2, 1, 3)
+
+            mo = mx.fast.scaled_dot_product_attention(
+                mq, mk, mv, scale=scaling if scaling is not None else 1.0, mask=None
+            )
+
+            to = mlx_to_torch(
+                mo.transpose(0, 2, 1, 3).squeeze(0), output.device
+            )  # [1, n_heads, head_dim]
+            output[start_q:end_q, :, :] = to
+
+            start_q, start_kv = end_q, end_kv
+
+        sync_torch()
+
+        return output
+
+    def forward_extend(
+        self,
+        q,
+        k,
+        v,
+        layer: "RadixAttention",
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        if layer.qk_head_dim != layer.v_head_dim:
+            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+        else:
+            o = torch.empty_like(q)
+
+        if layer.is_cross_attention:
+            cache_loc = forward_batch.encoder_out_cache_loc
+        else:
+            cache_loc = forward_batch.out_cache_loc
+
+        if save_kv_cache:
+            forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+
+        q_ = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        o_ = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+
+        causal = True
+        if layer.is_cross_attention or layer.attn_type == AttentionType.ENCODER_ONLY:
+            causal = False
+
+        self._run_mlx_sdpa_forward_extend(
+            q_,
+            o_,
+            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+            forward_batch.req_to_token_pool.req_to_token,
+            forward_batch.req_pool_indices,
+            forward_batch.seq_lens,
+            forward_batch.extend_prefix_lens,
+            forward_batch.extend_seq_lens,
+            scaling=layer.scaling,
+            causal=causal,
+        )
+        return o
+
+    def forward_decode(
+        self,
+        q,
+        k,
+        v,
+        layer: "RadixAttention",
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        q = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
+
+        if layer.qk_head_dim != layer.v_head_dim:
+            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+        else:
+            o = torch.empty_like(q)
+
+        if layer.is_cross_attention:
+            cache_loc = forward_batch.encoder_out_cache_loc
+        else:
+            cache_loc = forward_batch.out_cache_loc
+
+        if save_kv_cache:
+            forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+
+        q_ = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        o_ = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+
+        self._run_mlx_sdpa_forward_decode(
+            q_,
+            o_,
+            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+            forward_batch.req_to_token_pool.req_to_token,
+            forward_batch.req_pool_indices,
+            forward_batch.seq_lens,
+            scaling=layer.scaling,
+        )
+
+        return o
+
+    def support_triton(self):
+        return False

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -129,10 +129,8 @@ def get_last_loc(
     req_pool_indices_tensor: torch.Tensor,
     prefix_lens_tensor: torch.Tensor,
 ) -> torch.Tensor:
-    if (
-        get_global_server_args().attention_backend != "ascend"
-        and get_global_server_args().attention_backend != "torch_native"
-    ):
+    backend = get_global_server_args().attention_backend
+    if backend not in ["ascend", "torch_native", "mlx"]:
         impl = get_last_loc_triton
     else:
         impl = get_last_loc_torch

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2101,6 +2101,13 @@ class ServerArgs:
             elif is_hip():
                 return "aiter"
             elif is_mps():
+                if envs.SGLANG_USE_MLX_ATTENTION.get():
+                    try:
+                        import mlx.core  # noqa
+
+                        return "mlx"
+                    except ImportError:
+                        pass
                 return "torch_native"
             else:
                 return "flashinfer" if is_flashinfer_available() else "triton"
@@ -2118,6 +2125,13 @@ class ServerArgs:
                 else:
                     return "triton"
             elif is_mps():
+                if envs.SGLANG_USE_MLX_ATTENTION.get():
+                    try:
+                        import mlx.core  # noqa
+
+                        return "mlx"
+                    except ImportError:
+                        pass
                 return "torch_native"
             else:
                 return "triton"
@@ -2145,6 +2159,12 @@ class ServerArgs:
         if self.attention_backend == "torch_native":
             logger.warning(
                 "Cuda graph is disabled because of using torch native attention backend"
+            )
+            self.disable_cuda_graph = True
+
+        if self.attention_backend == "mlx":
+            logger.warning(
+                "Cuda graph is disabled because of using MLX attention backend"
             )
             self.disable_cuda_graph = True
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -378,7 +378,7 @@ def get_float_env_var(name: str, default: float = 0.0) -> float:
 
 
 def support_triton(backend: str) -> bool:
-    return backend not in ["torch_native", "intel_amx"]
+    return backend not in ["torch_native", "intel_amx", "mlx"]
 
 
 _ENABLE_TORCH_INFERENCE_MODE = get_bool_env_var(

--- a/python/sglang/srt/utils/tensor_bridge.py
+++ b/python/sglang/srt/utils/tensor_bridge.py
@@ -1,0 +1,141 @@
+# Copied and adapted from: https://github.com/vllm-project/vllm-metal
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+try:
+    import mlx.core as mx
+except ImportError:  # pragma: no cover - exercised on non-MLX setups
+    mx = None
+
+logger = logging.getLogger(__name__)
+
+# MPS has a 4GB (2^32 bytes) limit for MPSTemporaryNDArray allocations.
+# Metal may allocate multiple temporary buffers internally, so we use a
+# conservative threshold of 1GB to avoid hitting the limit.
+# See: https://github.com/anthropics/vllm-metal/issues/43
+_MPS_SAFE_SIZE_BYTES = 1 << 30  # 1GB
+
+MLX_AVAILABLE = mx is not None
+
+MLX_TO_TORCH_DTYPE = (
+    {
+        mx.float32: torch.float32,
+        mx.float16: torch.float16,
+        mx.bfloat16: torch.bfloat16,
+        mx.int32: torch.int32,
+        mx.int64: torch.int64,
+        mx.int16: torch.int16,
+        mx.int8: torch.int8,
+        mx.uint8: torch.uint8,
+        mx.bool_: torch.bool,
+    }
+    if MLX_AVAILABLE
+    else {}
+)
+
+TORCH_TO_MLX_DTYPE = {v: k for k, v in MLX_TO_TORCH_DTYPE.items()}
+
+
+def _require_mlx() -> Any:
+    if mx is None:
+        raise ImportError("mlx is required for sglang.srt.utils.tensor_bridge")
+    return mx
+
+
+def get_torch_device() -> torch.device:
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def _get_tensor_size_bytes(array) -> int:
+    return array.size * array.dtype.size
+
+
+def _is_safe_for_mps(array) -> bool:
+    return _get_tensor_size_bytes(array) < _MPS_SAFE_SIZE_BYTES
+
+
+def torch_to_mlx(tensor: torch.Tensor):
+    mx_mod = _require_mlx()
+
+    if tensor.device.type == "mps":
+        tensor = tensor.cpu()
+
+    tensor = tensor.detach()
+
+    # Note: numpy does not support bfloat16.
+    if tensor.dtype == torch.bfloat16:
+        return mx_mod.array(tensor.float().numpy(), dtype=mx_mod.bfloat16)
+
+    return mx_mod.array(tensor.numpy())
+
+
+def mlx_to_torch(
+    array,
+    device: torch.device | str | None = None,
+    already_contiguous: bool = False,
+) -> torch.Tensor:
+    mx_mod = _require_mlx()
+
+    if device is None:
+        device = get_torch_device()
+    elif isinstance(device, str):
+        device = torch.device(device)
+
+    torch_dtype = MLX_TO_TORCH_DTYPE.get(array.dtype)
+    if torch_dtype is None:
+        raise ValueError(f"Unsupported MLX dtype: {array.dtype}")
+
+    if not already_contiguous:
+        array = mx_mod.contiguous(array)
+
+    mx_mod.eval(array)
+    tensor = torch.frombuffer(memoryview(array), dtype=torch_dtype).reshape(array.shape)
+
+    if device.type == "mps":
+        if _is_safe_for_mps(array):
+            tensor = tensor.to(device)
+        else:
+            logger.debug(
+                "Tensor too large for MPS (%d bytes > %d limit), keeping on CPU",
+                _get_tensor_size_bytes(array),
+                _MPS_SAFE_SIZE_BYTES,
+            )
+    elif device.type != "cpu":
+        tensor = tensor.to(device)
+
+    return tensor
+
+
+def sync_mlx() -> None:
+    mx_mod = _require_mlx()
+
+    try:
+        mx_mod.synchronize()
+    except (AttributeError, TypeError):
+        mx_mod.eval(mx_mod.array(0, dtype=mx_mod.int32))
+
+
+def sync_torch() -> None:
+    if torch.backends.mps.is_available():
+        torch.mps.synchronize()
+
+
+__all__ = [
+    "MLX_AVAILABLE",
+    "MLX_TO_TORCH_DTYPE",
+    "TORCH_TO_MLX_DTYPE",
+    "_MPS_SAFE_SIZE_BYTES",
+    "_get_tensor_size_bytes",
+    "_is_safe_for_mps",
+    "get_torch_device",
+    "mlx_to_torch",
+    "sync_mlx",
+    "sync_torch",
+    "torch_to_mlx",
+]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR adds an `MlxAttnBackend` for macOS using `mx.fast.scaled_dot_product_attention`.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
The following tests were run on an M1 MacBook Pro

### SDPA

Device | Backend | SDPA Latency (100 runs)
-- | -- | -- 
MPS | torch_native | 0.046s
CPU | mlx | 0.011s
CPU | torch_native | 0.141s

### E2E

With `SGLANG_USE_MLX_ATTENTION=0` (default):

```bash
> uv run python -m sglang.bench_one_batch --model-path /Users/yexiaodong/.cache/modelscope/hub/models/Qwen/Qwen3-0.6B --trust-remote-code --disable-radix-cache --disable-cuda-graph --tp-size 1 --batch-size 1 --input-len 60 --output-len 100 --port 43440
W0311 10:39:37.161000 29488 sglang-diffusion/lib/python3.11/site-packages/torch/distributed/elastic/multiprocessing/redirects.py:29] NOTE: Redirects are currently not supported in Windows or MacOs.
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/attention/fla/utils.py:212: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")
[2026-03-11 10:39:39] INFO server_args.py:2154: Attention backend not specified. Use torch_native backend by default.
[2026-03-11 10:39:39] WARNING server_args.py:2160: Cuda graph is disabled because of using torch native attention backend
[2026-03-11 10:39:39] WARNING common.py:1221: Fail to set RLIMIT_STACK: current limit exceeds maximum limit
[2026-03-11 10:39:39 TP0] Init torch distributed begin.
[2026-03-11 10:39:39 TP0] Init torch distributed ends. elapsed=0.05 s, mem usage=0.00 GB
[2026-03-11 10:39:39 TP0] Ignore import error when loading sglang.srt.models.bailing_moe_linear: No module named 'vllm'
[2026-03-11 10:39:39 TP0] Ignore import error when loading sglang.srt.models.bailing_moe_nextn: No module named 'vllm'
[2026-03-11 10:39:39 TP0] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-03-11 10:39:39 TP0] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-03-11 10:39:39 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/sglang-diffusion/lib/python3.11/site-packages/transformers/__init__.py)
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/attention/fla/utils.py:212: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[2026-03-11 10:39:39 TP0] Load weight begin. avail mem=3.55 GB
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
[2026-03-11 10:39:40 TP0] Parameter lm_head.weight not found in params_dict
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.81s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.81s/it]

[2026-03-11 10:39:41 TP0] Load weight end. elapsed=2.07 s, type=Qwen3ForCausalLM, avail mem=2.22 GB, mem usage=1.32 GB.
[2026-03-11 10:39:41 TP0] Using KV cache dtype: torch.bfloat16
[2026-03-11 10:39:42 TP0] KV Cache is allocated. #tokens: 20033, K size: 1.07 GB, V size: 1.07 GB
[2026-03-11 10:39:42 TP0] Memory pool end. avail mem=1.78 GB
[2026-03-11 10:39:42 TP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
max_total_num_tokens=20033
Warmup ...
Prefill. latency: 0.46183 s, throughput:    129.92 token/s
Decode 0. Batch size: 1, latency: 1.48535 s, throughput:      0.67 token/s
Decode 1. Batch size: 1, latency: 0.10879 s, throughput:      9.19 token/s
Decode 2. Batch size: 1, latency: 0.11965 s, throughput:      8.36 token/s
Decode 3. Batch size: 1, latency: 0.19780 s, throughput:      5.06 token/s
Decode 4. Batch size: 1, latency: 0.12490 s, throughput:      8.01 token/s
Decode.  median latency: 0.13355 s, median throughput:      7.49 token/s
Total. latency:  6.230 s, throughput:     14.77 token/s
Benchmark ...
Prefill. latency: 0.23880 s, throughput:    251.26 token/s
Decode 0. Batch size: 1, latency: 0.11311 s, throughput:      8.84 token/s
Decode 1. Batch size: 1, latency: 0.13725 s, throughput:      7.29 token/s
Decode 2. Batch size: 1, latency: 0.11654 s, throughput:      8.58 token/s
Decode 3. Batch size: 1, latency: 0.11223 s, throughput:      8.91 token/s
Decode 4. Batch size: 1, latency: 0.11668 s, throughput:      8.57 token/s
Decode.  median latency: 0.14338 s, median throughput:      6.97 token/s
Total. latency: 14.447 s, throughput:     11.08 token/s
```

With `SGLANG_USE_MLX_ATTENTION=1`:

```bash
> export SGLANG_USE_MLX_ATTENTION=1
> uv run python -m sglang.bench_one_batch --model-path /Users/yexiaodong/.cache/modelscope/hub/models/Qwen/Qwen3-0.6B --trust-remote-code --disable-radix-cache --disable-cuda-graph --tp-size 1 --batch-size 1 --input-len 60 --output-len 100 --port 43440
W0311 10:42:13.546000 30323 sglang-diffusion/lib/python3.11/site-packages/torch/distributed/elastic/multiprocessing/redirects.py:29] NOTE: Redirects are currently not supported in Windows or MacOs.
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/attention/fla/utils.py:212: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/quantization/awq.py:87: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/quantization/gguf.py:48: UserWarning: Only CUDA and MUSA support GGUF quantization currently.
  warnings.warn(f"Only CUDA and MUSA support GGUF quantization currently.")
[2026-03-11 10:42:15] INFO server_args.py:2154: Attention backend not specified. Use mlx backend by default.
[2026-03-11 10:42:15] WARNING server_args.py:2166: Cuda graph is disabled because of using MLX attention backend
[2026-03-11 10:42:15] WARNING common.py:1221: Fail to set RLIMIT_STACK: current limit exceeds maximum limit
[2026-03-11 10:42:15 TP0] Init torch distributed begin.
[2026-03-11 10:42:15 TP0] Init torch distributed ends. elapsed=0.07 s, mem usage=0.01 GB
[2026-03-11 10:42:15 TP0] Ignore import error when loading sglang.srt.models.bailing_moe_linear: No module named 'vllm'
[2026-03-11 10:42:15 TP0] Ignore import error when loading sglang.srt.models.bailing_moe_nextn: No module named 'vllm'
[2026-03-11 10:42:15 TP0] Ignore import error when loading sglang.srt.models.glm_ocr: No module named 'transformers.models.glm_ocr'
[2026-03-11 10:42:15 TP0] Ignore import error when loading sglang.srt.models.glm_ocr_nextn: No module named 'transformers.models.glm_ocr'
[2026-03-11 10:42:15 TP0] Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/sglang-diffusion/lib/python3.11/site-packages/transformers/__init__.py)
/Users/yexiaodong/go/src/github.com/yeahdongcn/sglang/python/sglang/srt/layers/attention/fla/utils.py:212: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[2026-03-11 10:42:15 TP0] Load weight begin. avail mem=5.26 GB
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
[2026-03-11 10:42:15 TP0] Parameter lm_head.weight not found in params_dict
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.87s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.88s/it]

[2026-03-11 10:42:17 TP0] Load weight end. elapsed=2.05 s, type=Qwen3ForCausalLM, avail mem=2.66 GB, mem usage=2.60 GB.
[2026-03-11 10:42:17 TP0] Using KV cache dtype: torch.bfloat16
[2026-03-11 10:42:18 TP0] KV Cache is allocated. #tokens: 20948, K size: 1.12 GB, V size: 1.12 GB
[2026-03-11 10:42:18 TP0] Memory pool end. avail mem=1.83 GB
[2026-03-11 10:42:18 TP0] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
max_total_num_tokens=20948
Warmup ...
Prefill. latency: 0.35949 s, throughput:    166.90 token/s
Decode 0. Batch size: 1, latency: 0.75724 s, throughput:      1.32 token/s
Decode 1. Batch size: 1, latency: 0.15707 s, throughput:      6.37 token/s
Decode 2. Batch size: 1, latency: 0.14944 s, throughput:      6.69 token/s
Decode 3. Batch size: 1, latency: 0.14776 s, throughput:      6.77 token/s
Decode 4. Batch size: 1, latency: 0.15017 s, throughput:      6.66 token/s
Decode.  median latency: 0.16092 s, median throughput:      6.21 token/s
Total. latency:  6.301 s, throughput:     14.60 token/s
Benchmark ...
Prefill. latency: 0.27506 s, throughput:    218.14 token/s
Decode 0. Batch size: 1, latency: 0.15287 s, throughput:      6.54 token/s
Decode 1. Batch size: 1, latency: 0.16120 s, throughput:      6.20 token/s
Decode 2. Batch size: 1, latency: 0.15242 s, throughput:      6.56 token/s
Decode 3. Batch size: 1, latency: 0.15380 s, throughput:      6.50 token/s
Decode 4. Batch size: 1, latency: 0.16570 s, throughput:      6.04 token/s
Decode.  median latency: 0.18469 s, median throughput:      5.41 token/s
Total. latency: 19.160 s, throughput:      8.35 token/s
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
