### PR TITLE
[Scheduler] Decouple `maybe_send_health_check_signal` from `process_batch_result`

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -980,6 +980,8 @@ class SchedulerDisaggregationDecodeMixin:
             # Update last_batch
             self.last_batch = batch
 
+            self.maybe_send_health_check_signal()
+
     @torch.no_grad()
     def event_loop_overlap_disagg_decode(self: Scheduler):
         self.result_queue = deque()
@@ -1013,6 +1015,8 @@ class SchedulerDisaggregationDecodeMixin:
             # Run sample of the current batch
             # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
             self.launch_batch_sample_if_needed(batch_result)
+
+            self.maybe_send_health_check_signal()
 
             # Update last_batch
             self.last_batch = batch

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1016,10 +1016,10 @@ class SchedulerDisaggregationDecodeMixin:
             # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
             self.launch_batch_sample_if_needed(batch_result)
 
-            self.maybe_send_health_check_signal()
-
             # Update last_batch
             self.last_batch = batch
+
+            self.maybe_send_health_check_signal()
 
     def _run_batch_prebuilt(
         self: Scheduler, batch: ScheduleBatch

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -381,6 +381,8 @@ class SchedulerDisaggregationPrefillMixin:
             # Update last_batch
             self.last_batch = batch
 
+            self.maybe_send_health_check_signal()
+
     @torch.no_grad()
     def event_loop_overlap_disagg_prefill(self: Scheduler) -> None:
         self.result_queue = deque()
@@ -420,6 +422,8 @@ class SchedulerDisaggregationPrefillMixin:
 
             # Update last_batch
             self.last_batch = batch
+
+            self.maybe_send_health_check_signal()
 
     def process_batch_result_disagg_prefill(
         self: Scheduler,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1259,6 +1259,8 @@ class Scheduler(
 
             # Update last_batch
             self.last_batch = batch
+
+            self.maybe_send_health_check_signal()
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
 
@@ -1314,6 +1316,8 @@ class Scheduler(
 
             # Update last_batch
             self.last_batch = batch
+
+            self.maybe_send_health_check_signal()
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
 
@@ -2617,7 +2621,6 @@ class Scheduler(
 
         self.log_batch_result_stats(batch, result)
         self._maybe_clear_mm_inputs(batch)
-        self.maybe_send_health_check_signal()
 
     def maybe_send_health_check_signal(self):
         if self.return_health_check_ct:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -139,6 +139,8 @@ class SchedulerPPMixin:
 
                 self.pp_outputs = next_pp_outputs
 
+            self.maybe_send_health_check_signal()
+
             # When the server is idle, self-check and re-init some states
             if server_is_idle:
                 self.self_check_during_idle()
@@ -313,6 +315,8 @@ class SchedulerPPMixin:
                 consensus_bootstrapped_rids = next_consensus_bootstrapped_rids
 
                 self.running_batch.batch_is_full = False
+
+            self.maybe_send_health_check_signal()
 
             # When the server is idle, self-check and re-init some states
             if server_is_idle and len(self.disagg_prefill_inflight_queue) == 0:
@@ -503,6 +507,8 @@ class SchedulerPPMixin:
             )
             if self.server_args.disaggregation_decode_enable_offload_kvcache:
                 queue_size += len(self.decode_offload_manager.ongoing_offload)
+
+            self.maybe_send_health_check_signal()
 
             if server_is_idle and queue_size == 0:
                 self.self_check_during_idle()

--- a/python/sglang/srt/multiplex/multiplexing_mixin.py
+++ b/python/sglang/srt/multiplex/multiplexing_mixin.py
@@ -219,3 +219,5 @@ class SchedulerMultiplexMixin:
                         self.split_prefill_batch = None
                         wait_prefill_kernel_done = False
                         adjust_stream_group = True
+
+            self.maybe_send_health_check_signal()


### PR DESCRIPTION
## Summary
- Move `maybe_send_health_check_signal()` from `process_batch_result()` to the end of every scheduler event loop iteration
- Covers all 10 event loops: `event_loop_normal`, `event_loop_overlap`, `event_loop_pp`, `event_loop_pp_disagg_prefill`, `event_loop_pp_disagg_decode`, `event_loop_normal_disagg_prefill`, `event_loop_overlap_disagg_prefill`, `event_loop_normal_disagg_decode`, `event_loop_overlap_disagg_decode`, `event_loop_pdmux`

## Background
- `maybe_send_health_check_signal()` was only called inside `process_batch_result()`, which only runs when a batch completes forward
- In PD disaggregation mode, the health check skip logic (`will_block_in_pd_queue`) increments `return_health_check_ct` when `disagg_prefill_inflight_queue` or `disagg_decode_transfer_queue` is non-empty
- When only inflight/transfer queues have pending requests (waiting for KV transfer) and no batch is running, `process_batch_result()` never fires → `HealthCheckOutput` never sent → health check hangs

## Fix
- Call `maybe_send_health_check_signal()` unconditionally at the end of each event loop iteration, so pending health check signals are drained even when the scheduler is idle

## Note on semantics
- The health check skip (`will_block_in_pd_queue`) only triggers when the server is somehow busy (e.g., disagg queues non-empty). It increments `return_health_check_ct` instead of responding immediately.
- If the scheduler loop later reaches `maybe_send_health_check_signal()` and `return_health_check_ct > 0`, it means the event loop is still turning — i.e., the server is alive and responsive, just temporarily unable to serve the health check inline.
- This PR does **not** detect requests stuck inside `run_batch()` (e.g., GPU hang, long prefill blocking the loop). That would require a separate watchdog mechanism outside the event loop.