### PR TITLE
[1/2] Feature: Integrate Engram to SGLang

### DIFF
--- a/python/sglang/srt/mem_cache/engram/.gitignore
+++ b/python/sglang/srt/mem_cache/engram/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+build/

--- a/python/sglang/srt/mem_cache/engram/README.md
+++ b/python/sglang/srt/mem_cache/engram/README.md
@@ -134,9 +134,149 @@ Global defaults are defined in `models/engram/engram.py` via the
 | `layer_ids` | `[1, 15]` | Transformer layer indices where Engram is injected |
 | `enable_prefetch` | `True` | Async embedding prefetch on a separate CUDA stream |
 
+## Engram Compute Pipeline
+
+Engram's compute path consists of three stages: **token hashing**, **embedding
+lookup**, and **gated projection**. When prefetch is enabled a fourth
+overlapping stage runs asynchronously on a side CUDA stream.
+
+### Stage 1 — Token compression & n-gram hashing
+
+Before any embedding lookup, raw token IDs are normalised by
+`CompressedTokenizer` (NFKC/NFD normalisation, accent stripping, case folding,
+whitespace collapsing) to collapse semantically equivalent tokens to the same
+compressed ID. This reduces the effective vocabulary and improves hash
+collision quality.
+
+`NgramHashMapping.hash_torch` then computes, for every token position and
+every Engram-injected layer, a set of hash indices using a prime-modulo XOR
+scheme:
+
+```
+mix_n = token[t] * m[0]  XOR  token[t-1] * m[1]  XOR  ...  XOR  token[t-n+1] * m[n-1]
+hash_n_head_j = mix_n  %  prime_j          # prime_j is unique per (layer, ngram, head)
+```
+
+Multipliers `m[k]` are seeded deterministically per layer so each layer
+produces an independent hash space. The output is
+`hash_input_ids: [B, T, num_heads_total]` where
+`num_heads_total = (max_ngram_size - 1) * n_head_per_ngram`.
+
+### Stage 2 — Multi-head embedding lookup
+
+`MultiHeadEmbedding` maps each hash index to a `head_dim`-dimensional vector
+by calling `EngramStore.get_many`. The per-head offsets are added to the raw
+hash indices so that all heads share a single flat embedding table in the
+store. The results are concatenated:
+
+```
+# Tensor shapes with default config (max_ngram_size=3, n_head=8, head_dim=64):
+raw_embeddings : [B, T, 16, 64]   # 16 heads × 64-dim
+embeddings     : [B, T, 1024]     # flattened  (engram_hidden_size)
+```
+
+### Stage 3 — Gated projection & short convolution
+
+The flattened embeddings are projected into the backbone's hidden space and
+combined with the current `hidden_states` via a learned scalar gate:
+
+```
+input_ids [B, T]
+    │
+    ▼
+CompressedTokenizer.compress_torch()       # token-space normalisation
+    │
+    ▼
+NgramHashMapping.hash_torch()              # per-layer prime-modulo XOR hashing
+    │  → hash_input_ids [B, T, num_heads_total]
+    ▼
+MultiHeadEmbedding.forward()               # store.get_many  (CPU DRAM → GPU)
+    │  → raw_embeddings [B, T, num_heads_total, head_dim]
+    │  .flatten(start_dim=-2)
+    │  → embeddings [B, T, engram_hidden_size]
+    ▼
+key_projs_all (Linear)                     # project to [B, T, hc_mult, D]
+    │
+    ├─► parallel_rms_norm (norm1_weight)   # normalise keys
+    │
+hidden_states [B, T, hc_mult, D]
+    │
+    └─► parallel_rms_norm (norm2_weight)   # normalise queries
+    │
+    ▼
+gate = sigmoid( (normed_key · normed_query) / √D )   # scalar gate per head
+    │  shape: [B, T, hc_mult, 1]
+    ▼
+value_proj (Linear)  →  v [B, T, 1, D]
+    │
+    ▼
+value = gate * v                           # gated value
+    │
+    ▼
+output = value + ShortConv(value)          # residual depthwise conv
+    │  shape: [B, T, hc_mult, D]
+    ▼
+added back to hidden_states (hyper-connection residual)
+```
+
+`ShortConv` applies a grouped depthwise 1-D convolution (kernel size 4,
+dilation = `max_ngram_size`) with RMSNorm and SiLU, capturing local sequential
+context on top of the retrieved embeddings.
+
+### Tensor size summary
+
+```
+num_ngram_orders  = max_ngram_size - 1              # e.g. 2  (bigram + trigram)
+num_heads         = n_head_per_ngram                # e.g. 8
+head_dim          = n_embed_per_ngram // num_heads  # e.g. 512 // 8 = 64
+total_heads       = num_ngram_orders * num_heads    # e.g. 16
+engram_hidden_size = num_ngram_orders * n_embed_per_ngram  # e.g. 1024
+```
+
+### Stage 4 — Async prefetch (optional)
+
+When `enable_prefetch=True` (default), Stages 1–2 (hashing + embedding
+lookup) are kicked off on a dedicated side CUDA stream at the very beginning
+of each decode-step forward pass — **before any Transformer layer runs** —
+so that the CPU→GPU embedding transfer overlaps with the entire layer stack:
+
+```
+Qwen2MoelEngram.forward()
+    │
+    ├── embed_tokens(input_ids)                      # (main stream)
+    │
+    ├──[side stream]──► _start_engram_prefetch()     # fired once per forward
+    │                       for each engram layer_id:
+    │                           compress_torch()
+    │                           hash_torch()
+    │                           get_many()  ← CPU DRAM → GPU transfer
+    │                           cuda.Event.record(prefetch_event)
+    │
+    ├── layer 0  (main stream) ◄─── overlaps with side stream above
+    ├── layer 1
+    ├── ...
+    ├── layer N  (Engram-injected)
+    │       └─► Engram.forward()
+    │               └─► _consume_prefetch()
+    │                       main_stream.wait_event(prefetch_event)  # sync
+    │                       return cached embeddings  # Stages 1-2 done
+    │                       → Stage 3: gate + proj + conv
+    ├── ...
+    └── layer M  (next Engram-injected, if any)
+            └─► Engram.forward() → _consume_prefetch() → ...
+```
+
+`_start_engram_prefetch` iterates over all Engram-injected `layer_id`s and
+calls `start_prefetch` on each, so every Engram layer's embeddings are
+prefetched in parallel on the same side stream before the first Transformer
+layer executes. By the time execution reaches an Engram-injected layer, the
+transfer is typically already complete and `_consume_prefetch` only inserts a
+lightweight `wait_event` barrier.
+
+
 ## TODO
 
 - [ ] Support CUDA graph capture with Engram enabled (currently requires `--disable-cuda-graph`)
 - [ ] Production-ready DeepSeek model integration
-- [ ] Custom CUDA kernels for hash mapping and embedding gather
+- [ ] **Custom CUDA kernel for Engram** — replace the current multi-step Python/Triton pipeline with a single fused CUDA kernel covering: token compression, prime-modulo XOR hash computation, multi-head embedding gather (coalesced global-memory reads from CPU-pinned or GPU-resident tables), gate-value computation, and the short depthwise convolution. A fused kernel would eliminate intermediate tensor allocations, reduce kernel-launch overhead, and enable warp-level optimisations for the irregular gather pattern inherent to n-gram hash lookups.
 - [ ] Distributed TP (tensor parallel) support for Engram embeddings across ranks

--- a/python/sglang/srt/mem_cache/engram/README.md
+++ b/python/sglang/srt/mem_cache/engram/README.md
@@ -1,0 +1,142 @@
+# Engram — N-gram Embedding Module for SGLang
+
+Engram is an experimental module that augments Transformer models with
+n-gram hash-based embedding lookups. It runs **alongside** the existing
+KV cache system (HiCache) rather than replacing any backend — the KV cache
+continues to manage paged attention, while Engram independently manages its
+own embedding tables through a dedicated storage layer.
+
+> **Prototype status**: The current implementation is a simulation prototype.
+> We support Qwen2 and Qwen3 model integration as a proof-of-concept
+> (the DeepSeek model variant is not publicly released at this time).
+> The module is used for simulating the Engram architecture and is not yet
+> optimised for production workloads.
+
+## Architecture Overview
+
+Engram is split into two packages with a clear separation of concerns:
+
+```
+sglang/srt/
+├── models/engram/              # Computation side
+│   ├── engram.py               # Core module (hashing, gating, projections)
+│   └── triton_ops/             # Optional Triton kernel implementations
+│       ├── __init__.py
+│       └── engram_triton.py
+│
+└── mem_cache/engram/           # Storage side (this directory)
+    ├── __init__.py             # Package exports
+    ├── engram_store.py         # EngramStore abstract base & EngramStoreConfig
+    ├── engram_store_manager.py # EngramStoreManager + global accessors
+    └── local_engram_store.py   # CPU DRAM-backed store
+
+test/srt/engram/                # Integration tests
+    ├── run_all_tests.py
+    ├── test_import_paths.py
+    ├── test_local_store_manager.py
+    └── test_engram_e2e.py
+```
+
+### Computation side (`models/engram/`)
+
+| Component | Description |
+|---|---|
+| `NgramHashMapping` | Builds n-gram hash keys from token IDs using prime-modulo hashing. Supports both NumPy (offline) and Torch (online) paths. |
+| `MultiHeadEmbedding` | Looks up embeddings from an `EngramStore` given hashed indices. Each n-gram order gets multiple heads with prime-sized tables. |
+| `Engram` | Top-level module that combines hashing, embedding lookup, gating, value projection, and a short depthwise convolution. Supports async prefetch on a separate CUDA stream. |
+| `ShortConv` | Grouped depthwise 1-D convolution with RMSNorm and SiLU activation. |
+| Triton ops | Optional fused kernels for gate-value computation, grouped RMSNorm, and short-conv preprocessing. Activated via `ENGRAM_TRITON=1`. |
+
+### Storage side (`mem_cache/engram/`)
+
+| Component | Description |
+|---|---|
+| `EngramStore` (ABC) | Abstract interface: `put_sharded`, `get_one`, `get_many`, `close`. |
+| `LocalEngramStore` | Default backend — stores embedding tables as CPU tensors (`torch.nn.Embedding`) in process DRAM. No external dependencies. |
+| `EngramStoreManager` | Registry and factory for per-layer `EngramStore` instances. Provides global accessor functions for singleton lifecycle management. |
+
+## Supported Models
+
+| Model | Entry Class | How to Enable |
+|---|---|---|
+| Qwen2 | `Qwen2ForCausalLM` | Requires swapping `Qwen2Model` to `Qwen2MoelEngram` in the model class |
+| Qwen3 | `Qwen3ForCausalLM` | Set environment variable `ENABLE_ENGRAM=1` |
+
+In Qwen3, enabling Engram is controlled by the `ENABLE_ENGRAM` environment
+variable. When set, `Qwen3ForCausalLM` instantiates `Qwen3ModelEngram`
+(which inherits from `Qwen2MoelEngram`) instead of the standard
+`Qwen3Model`.
+
+## Storage Backend
+
+Engram uses a single storage backend: **Local DRAM**.
+
+### Local (default)
+
+Stores all embedding tables as CPU tensors (`torch.nn.Embedding`) in the
+current process's DRAM. No external dependencies; suitable for single-node
+development and testing.
+
+**How it works:**
+
+- `put_sharded(vocab_table)` — validates shape, casts to the configured
+  dtype, and copies the table into an `nn.Embedding` weight buffer.
+- `get_one(index, layer_id, device)` — returns a single embedding vector;
+  returns a zero vector for out-of-range indices.
+- `get_many(indices, layer_id, device)` — batch lookup via `nn.Embedding`,
+  returns a tensor of shape `(*indices.shape, embedding_dim)`.
+- `close()` — no-op (memory is released when the Python object is garbage
+  collected).
+
+**Configuration:**
+
+The backend is selected via `EngramConfig.store_backend` (default `"local"`).
+No environment variables are required.
+
+## Quick Start
+
+### Running integration tests
+
+```bash
+python test/srt/engram/run_all_tests.py
+```
+
+This runs three test suites in sequence:
+
+1. **Import path verification** — checks all modules are importable
+2. **LocalEngramStore + Manager lifecycle** — put/get correctness, global accessor lifecycle
+3. **End-to-end Engram module** — forward pass with `EngramStoreManager`, backward compatibility, multi-layer scenarios
+
+### Launching SGLang with Engram (Qwen3)
+
+> **Note:** CUDA graph capture is not yet supported with Engram. You must
+> pass `--disable-cuda-graph` when launching the server.
+
+```bash
+ENABLE_ENGRAM=1 python -m sglang.launch_server \
+    --model-path Qwen/Qwen3-XXX \
+    --disable-cuda-graph \
+    --port 30000
+```
+
+## Configuration
+
+Global defaults are defined in `models/engram/engram.py` via the
+`EngramConfig` and `BackBoneConfig` dataclasses. Key settings:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `store_backend` | `"local"` | Storage backend (currently only `"local"` is supported) |
+| `engram_vocab_size` | `[1024, 1024]` | Per-ngram-order hash table sizes |
+| `max_ngram_size` | `3` | Maximum n-gram order (bigram + trigram) |
+| `n_embed_per_ngram` | `512` | Total embedding dimension per n-gram |
+| `n_head_per_ngram` | `8` | Number of hash heads per n-gram order |
+| `layer_ids` | `[1, 15]` | Transformer layer indices where Engram is injected |
+| `enable_prefetch` | `True` | Async embedding prefetch on a separate CUDA stream |
+
+## TODO
+
+- [ ] Support CUDA graph capture with Engram enabled (currently requires `--disable-cuda-graph`)
+- [ ] Production-ready DeepSeek model integration
+- [ ] Custom CUDA kernels for hash mapping and embedding gather
+- [ ] Distributed TP (tensor parallel) support for Engram embeddings across ranks

--- a/python/sglang/srt/mem_cache/engram/__init__.py
+++ b/python/sglang/srt/mem_cache/engram/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to SGLang project
+
+"""Engram store backends for HiCache integration.
+
+This package provides the storage-side abstraction for Engram embedding tables.
+The default (and only) backend stores embedding tables in CPU DRAM using
+``torch.nn.Embedding``.
+
+The model-computation side (hash mapping, projections, gating) remains in
+``sglang.srt.models.engram``.  The two sides communicate through the
+:class:`EngramStore` interface defined here.
+
+Engram stores are **not** KV Cache storage backends.  They exist alongside
+whatever KV Cache backend the user configures.
+:class:`EngramStoreManager` handles the lifecycle of per-layer stores and
+can be held by the scheduler or ``HiRadixCache``.
+"""
+
+from .engram_store import EngramStore, EngramStoreConfig
+from .engram_store_manager import (
+    EngramStoreManager,
+    close_global_engram_store_manager,
+    get_global_engram_store_manager,
+    set_global_engram_store_manager,
+)
+
+__all__ = [
+    "EngramStore",
+    "EngramStoreConfig",
+    "EngramStoreManager",
+    "get_global_engram_store_manager",
+    "set_global_engram_store_manager",
+    "close_global_engram_store_manager",
+]

--- a/python/sglang/srt/mem_cache/engram/engram_store.py
+++ b/python/sglang/srt/mem_cache/engram/engram_store.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to SGLang project
+
+"""Abstract interface for Engram embedding storage.
+
+This module defines the storage-only contract that all Engram backends must
+implement.  It is deliberately decoupled from the model-computation side
+(hash mapping, gating, projections) so that different storage technologies
+(e.g. local CPU DRAM) can be plugged in without touching model code.
+
+Key concepts
+------------
+* **vocab_table** – A 2-D ``(total_vocab_size, embedding_dim)`` tensor that
+  holds the full embedding table for one Engram layer.
+* **layer_id** – Each Engram-enabled transformer layer owns an independent
+  embedding table identified by ``layer_id``.
+* **put_sharded / get_many** – The two core operations: bulk-load an
+  embedding table and batch-lookup embeddings by flat indices.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import torch
+
+
+@dataclass
+class EngramStoreConfig:
+    """Backend-agnostic configuration carried through HiCache lifecycle."""
+
+    embedding_dim: int = 64
+    vocab_sizes: List[int] = field(default_factory=list)
+    layer_ids: List[int] = field(default_factory=list)
+    dtype: torch.dtype = torch.float16
+    store_backend: str = "local"
+    extra: Optional[dict] = None
+
+
+class EngramStore(ABC):
+    """Abstract base class for Engram embedding storage backends.
+
+    Every concrete backend must implement at least ``put_sharded``,
+    ``get_one``, ``get_many``, and ``close``.
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        vocab_size: int,
+        layer_id: int,
+        dtype: torch.dtype = torch.float16,
+    ) -> None:
+        self.embedding_dim = int(embedding_dim)
+        self.vocab_size = int(vocab_size)
+        self.layer_id = int(layer_id)
+        self.dtype = dtype
+
+    @abstractmethod
+    def put_sharded(self, vocab_table: torch.Tensor) -> None:
+        """Bulk-load the full embedding table for this layer.
+
+        Parameters
+        ----------
+        vocab_table : torch.Tensor
+            Shape ``(vocab_size, embedding_dim)``, dtype may differ from
+            ``self.dtype`` – implementations should cast internally.
+        """
+
+    @abstractmethod
+    def get_one(self, index: int, layer_id: int, device: torch.device) -> torch.Tensor:
+        """Retrieve a single embedding vector.
+
+        Returns a 1-D tensor of shape ``(embedding_dim,)`` on *device*.
+        Out-of-range indices should return a zero vector.
+        """
+
+    @abstractmethod
+    def get_many(
+        self, indices: torch.Tensor, layer_id: int, device: torch.device
+    ) -> torch.Tensor:
+        """Batch-retrieve embeddings.
+
+        Parameters
+        ----------
+        indices : torch.Tensor
+            Arbitrary-shaped integer tensor of flat vocabulary indices.
+        layer_id : int
+            The transformer layer requesting the lookup.
+        device : torch.device
+            Target device for the returned tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Shape ``(*indices.shape, embedding_dim)`` on *device*.
+        """
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release resources held by this store."""

--- a/python/sglang/srt/mem_cache/engram/engram_store_manager.py
+++ b/python/sglang/srt/mem_cache/engram/engram_store_manager.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to SGLang project
+
+"""Manager for Engram embedding store lifecycle within HiCache.
+
+Engram stores hold embedding parameters (vocab tables) for Engram-enabled
+transformer layers.  They are **not** KV Cache storage backends — they run
+alongside whatever KV Cache backend the user configures.
+
+The manager serves as a **registry + factory**: model-side code
+(``MultiHeadEmbedding``) asks the manager for a store for a given layer,
+and the manager lazily creates it using the configured backend.  This avoids
+the need for model code to know which backend is in use or how to configure
+it.
+
+Lifecycle
+---------
+1. Server/scheduler creates an ``EngramStoreManager`` with the desired
+   backend configuration and sets it as the global instance.
+2. Model init (``Engram`` / ``MultiHeadEmbedding``) calls
+   ``get_global_engram_store_manager().get_or_create_store(...)`` to
+   obtain an ``EngramStore`` for each layer.
+3. During inference, ``MultiHeadEmbedding.forward`` calls
+   ``store.get_many(...)`` as before.
+4. On shutdown, ``manager.close()`` releases all stores.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+import torch
+
+from .engram_store import EngramStore, EngramStoreConfig
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Internal factory
+# ---------------------------------------------------------------------------
+
+
+def _create_engram_store(
+    backend: str,
+    embedding_dim: int,
+    vocab_size: int,
+    layer_id: int,
+    dtype: torch.dtype,
+    cfg: EngramStoreConfig,
+) -> EngramStore:
+    """Instantiate the correct EngramStore backend for one layer."""
+    backend = backend.lower()
+    if backend == "local":
+        from .local_engram_store import LocalEngramStore
+
+        return LocalEngramStore(
+            embedding_dim=embedding_dim,
+            vocab_size=vocab_size,
+            layer_id=layer_id,
+            dtype=dtype,
+            device=torch.device("cpu"),
+        )
+    else:
+        raise ValueError(f"Unknown engram store backend: {backend!r}")
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+
+class EngramStoreManager:
+    """Registry + factory for per-layer EngramStore instances.
+
+    Stores are created lazily via :meth:`get_or_create_store` — the caller
+    (model code) provides the ``vocab_size`` and ``embedding_dim`` that are
+    only known after hash-mapping computation.
+    """
+
+    def __init__(self, config: EngramStoreConfig) -> None:
+        self._config = config
+        self._stores: Dict[int, EngramStore] = {}
+        self._closed = False
+
+        logger.info(
+            "EngramStoreManager created: backend=%s, layer_ids=%s",
+            config.store_backend,
+            config.layer_ids,
+        )
+
+    # -- lazy creation (called from model init) ----------------------------
+
+    def get_or_create_store(
+        self,
+        layer_id: int,
+        vocab_size: int,
+        embedding_dim: int,
+        dtype: torch.dtype = torch.float16,
+    ) -> EngramStore:
+        """Return an existing store or create a new one for *layer_id*.
+
+        This is the primary API for model-side code.  It is called once per
+        layer during ``MultiHeadEmbedding.__init__``.
+        """
+        if layer_id in self._stores:
+            return self._stores[layer_id]
+
+        store = _create_engram_store(
+            backend=self._config.store_backend,
+            embedding_dim=embedding_dim,
+            vocab_size=vocab_size,
+            layer_id=layer_id,
+            dtype=dtype,
+            cfg=self._config,
+        )
+        self._stores[layer_id] = store
+        logger.info(
+            "Created EngramStore for layer %d: backend=%s, "
+            "vocab_size=%d, embedding_dim=%d",
+            layer_id,
+            self._config.store_backend,
+            vocab_size,
+            embedding_dim,
+        )
+        return store
+
+    # -- read-only accessors -----------------------------------------------
+
+    def get_store(self, layer_id: int) -> Optional[EngramStore]:
+        """Return the store for *layer_id*, or ``None`` if not created yet."""
+        return self._stores.get(layer_id)
+
+    def has_layer(self, layer_id: int) -> bool:
+        return layer_id in self._stores
+
+    @property
+    def config(self) -> EngramStoreConfig:
+        return self._config
+
+    @property
+    def layer_ids(self) -> List[int]:
+        return list(self._stores.keys())
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        """Release all stores.  Safe to call multiple times."""
+        if self._closed:
+            return
+        for layer_id, store in self._stores.items():
+            try:
+                store.close()
+            except Exception:
+                logger.exception("Failed to close EngramStore for layer %d", layer_id)
+        self._stores.clear()
+        self._closed = True
+        logger.info("EngramStoreManager closed.")
+
+
+# ---------------------------------------------------------------------------
+# Global singleton accessor
+# ---------------------------------------------------------------------------
+
+_GLOBAL_MANAGER: Optional[EngramStoreManager] = None
+
+
+def set_global_engram_store_manager(manager: EngramStoreManager) -> None:
+    """Set the process-wide EngramStoreManager singleton.
+
+    Called once during server/scheduler initialisation.
+    """
+    global _GLOBAL_MANAGER
+    if _GLOBAL_MANAGER is not None:
+        logger.warning(
+            "Overwriting existing global EngramStoreManager; "
+            "closing the old one first."
+        )
+        _GLOBAL_MANAGER.close()
+    _GLOBAL_MANAGER = manager
+
+
+def get_global_engram_store_manager() -> Optional[EngramStoreManager]:
+    """Return the process-wide EngramStoreManager, or ``None``."""
+    return _GLOBAL_MANAGER
+
+
+def close_global_engram_store_manager() -> None:
+    """Close and clear the global manager."""
+    global _GLOBAL_MANAGER
+    if _GLOBAL_MANAGER is not None:
+        _GLOBAL_MANAGER.close()
+        _GLOBAL_MANAGER = None

--- a/python/sglang/srt/mem_cache/engram/local_engram_store.py
+++ b/python/sglang/srt/mem_cache/engram/local_engram_store.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to SGLang project
+
+"""Local (CPU/GPU memory) Engram embedding store.
+
+This is the simplest backend: it keeps the embedding table in a standard
+``nn.Embedding`` on a configurable device (defaults to CPU).  Suitable for
+single-node development, testing, and small-scale deployments.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.mem_cache.engram.engram_store import EngramStore
+
+
+class LocalEngramStore(EngramStore):
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        vocab_size: int,
+        layer_id: int,
+        dtype: torch.dtype = torch.float16,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__(embedding_dim, vocab_size, layer_id, dtype)
+        self.storage_dtype = torch.float16
+        self.embedding = nn.Embedding(
+            num_embeddings=self.vocab_size,
+            embedding_dim=self.embedding_dim,
+            dtype=self.storage_dtype,
+        )
+        self._device = torch.device("cpu")
+        if device is not None:
+            self._ensure_device(device)
+
+    def _ensure_device(self, device: torch.device) -> None:
+        target = torch.device(device)
+        if target != self._device:
+            self.embedding = self.embedding.to(device=target)
+            self._device = target
+
+    def put_sharded(self, vocab_table: torch.Tensor) -> None:
+        if not isinstance(vocab_table, torch.Tensor):
+            raise TypeError("vocab_table must be a torch.Tensor")
+        if vocab_table.ndim != 2:
+            raise ValueError("vocab_table must be 2D")
+        if (
+            vocab_table.shape[0] != self.vocab_size
+            or vocab_table.shape[1] != self.embedding_dim
+        ):
+            raise ValueError(
+                f"vocab_table shape {tuple(vocab_table.shape)} must match "
+                f"({self.vocab_size}, {self.embedding_dim})"
+            )
+
+        data = vocab_table.detach()
+        if data.dtype != self.storage_dtype:
+            data = data.to(dtype=self.storage_dtype)
+        if data.device != self._device:
+            data = data.to(self._device)
+
+        with torch.no_grad():
+            self.embedding.weight.copy_(data)
+
+    def get_one(self, index: int, layer_id: int, device: torch.device) -> torch.Tensor:
+        if index < 0 or index >= self.vocab_size:
+            return torch.zeros((self.embedding_dim,), dtype=self.dtype, device=device)
+
+        target_device = device or self._device
+        self._ensure_device(target_device)
+
+        idx = torch.tensor([int(index)], dtype=torch.long, device=self._device)
+        out = self.embedding(idx).squeeze(0)
+        if self.dtype != self.storage_dtype:
+            out = out.to(dtype=self.dtype)
+        if device is not None and out.device != device:
+            out = out.to(device=device)
+        return out
+
+    def get_many(
+        self, indices: torch.Tensor, layer_id: int, device: torch.device
+    ) -> torch.Tensor:
+        target_device = device or indices.device
+        self._ensure_device(target_device)
+
+        if indices.numel() == 0:
+            return torch.empty(
+                (*indices.shape, self.embedding_dim),
+                device=target_device,
+                dtype=self.dtype,
+            )
+
+        idx = indices.to(device=self._device, dtype=torch.long)
+        out = self.embedding(idx)
+        if self.dtype != self.storage_dtype:
+            out = out.to(dtype=self.dtype)
+        if device is not None and out.device != device:
+            out = out.to(device=device)
+        return out.view(*indices.shape, self.embedding_dim)
+
+    def close(self) -> None:
+        pass

--- a/python/sglang/srt/models/engram/engram.py
+++ b/python/sglang/srt/models/engram/engram.py
@@ -1,0 +1,699 @@
+"""Engram module — n-gram hash-based conditional memory for LLMs.
+
+This is a prototype implementation demonstrating the core Engram architecture.
+Standard Transformer components (attention, MoE, hyper-connections) are mocked
+to focus on the Engram-specific logic. Production use requires further
+optimisation (custom CUDA kernels, distributed training support, etc.).
+
+Dependencies: torch numpy transformers sympy tokenizers
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from sympy import isprime
+from tokenizers import Regex, normalizers
+from transformers import AutoTokenizer
+
+from sglang.srt.mem_cache.engram.local_engram_store import LocalEngramStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EngramConfig:
+    tokenizer_name_or_path: str = "deepseek-ai/DeepSeek-V3"
+    engram_vocab_size: List[int] = field(default_factory=lambda: [1024, 1024])
+    max_ngram_size: int = 3
+    n_embed_per_ngram: int = 512
+    n_head_per_ngram: int = 8
+    layer_ids: List[int] = field(default_factory=lambda: [1, 15])
+    pad_id: int = 2
+    seed: int = 0
+    kernel_size: int = 4
+    store_backend: str = "local"
+    enable_prefetch: bool = True
+
+
+@dataclass
+class BackBoneConfig:
+    hidden_size: int = 1024
+    hc_mult: int = 4
+    vocab_size: int = 129280
+    num_layers: int = 30
+
+
+engram_cfg = EngramConfig()
+backbone_config = BackBoneConfig()
+
+
+def build_engram_config_from_cli() -> EngramConfig:
+    parser = argparse.ArgumentParser(description="Engram demo config")
+    parser.add_argument(
+        "--store-backend",
+        type=str,
+        default=None,
+        choices=["local"],
+    )
+    parser.add_argument("--engram-vocab-size", type=int, default=None)
+    parser.add_argument("--engram-emb-size", type=int, default=None)
+    parser.add_argument("--engram-head", type=int, default=None)
+    args = parser.parse_args()
+
+    cfg = EngramConfig()
+    if args.store_backend:
+        cfg.store_backend = args.store_backend
+    if args.engram_vocab_size:
+        for i in range(len(cfg.engram_vocab_size)):
+            cfg.engram_vocab_size[i] = args.engram_vocab_size
+    if args.engram_emb_size:
+        cfg.n_embed_per_ngram = args.engram_emb_size
+    if args.engram_head:
+        cfg.n_head_per_ngram = args.engram_head
+    return cfg
+
+
+class CompressedTokenizer:
+    def __init__(
+        self,
+        tokenizer_name_or_path,
+    ):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_name_or_path, trust_remote_code=True
+        )
+
+        SENTINEL = "\uE000"
+        self.normalizer = normalizers.Sequence(
+            [
+                normalizers.NFKC(),
+                normalizers.NFD(),
+                normalizers.StripAccents(),
+                normalizers.Lowercase(),
+                normalizers.Replace(Regex(r"[ \t\r\n]+"), " "),
+                normalizers.Replace(Regex(r"^ $"), SENTINEL),
+                normalizers.Strip(),
+                normalizers.Replace(SENTINEL, " "),
+            ]
+        )
+
+        self.lookup_table, self.num_new_token = self._build_lookup_table()
+        self._lookup_table_torch = {}
+
+    def __len__(self):
+        return self.num_new_token
+
+    def _build_lookup_table(self):
+        old2new = {}
+        key2new = {}
+        new_tokens = []
+
+        vocab_size = len(self.tokenizer)
+        for tid in range(vocab_size):
+            text = self.tokenizer.decode([tid], skip_special_tokens=False)
+
+            if "�" in text:
+                key = self.tokenizer.convert_ids_to_tokens(tid)
+            else:
+                norm = self.normalizer.normalize_str(text)
+                key = norm if norm else text
+
+            nid = key2new.get(key)
+            if nid is None:
+                nid = len(new_tokens)
+                key2new[key] = nid
+                new_tokens.append(key)
+            old2new[tid] = nid
+
+        lookup = np.empty(vocab_size, dtype=np.int64)
+        for tid in range(vocab_size):
+            lookup[tid] = old2new[tid]
+
+        return lookup, len(new_tokens)
+
+    def _compress(self, input_ids):
+        arr = np.asarray(input_ids, dtype=np.int64)
+        pos_mask = arr >= 0
+        out = arr.copy()
+        valid_ids = arr[pos_mask]
+        if valid_ids.size == 0:
+            return out
+        vocab_size = self.lookup_table.shape[0]
+        if valid_ids.max(initial=-1) >= vocab_size:
+            if engram_cfg.pad_id is not None:
+                valid_ids = np.where(
+                    valid_ids < vocab_size, valid_ids, int(engram_cfg.pad_id)
+                )
+            else:
+                valid_ids = np.clip(valid_ids, 0, vocab_size - 1)
+        out[pos_mask] = self.lookup_table[valid_ids]
+        return out
+
+    def _get_lookup_table_torch(self, device: torch.device) -> torch.Tensor:
+        table = self._lookup_table_torch.get(device)
+        if table is None:
+            table = torch.from_numpy(self.lookup_table).to(device=device)
+            self._lookup_table_torch[device] = table
+        return table
+
+    def compress_torch(self, input_ids: torch.Tensor) -> torch.Tensor:
+        arr = input_ids.to(dtype=torch.long)
+        pos_mask = arr >= 0
+        out = arr.clone()
+        if not pos_mask.any():
+            return out
+        lookup_table = self._get_lookup_table_torch(arr.device)
+        valid_ids = arr[pos_mask]
+        vocab_size = lookup_table.shape[0]
+        if valid_ids.max().item() >= vocab_size:
+            if engram_cfg.pad_id is not None:
+                pad_id = int(engram_cfg.pad_id)
+                valid_ids = torch.where(
+                    valid_ids < vocab_size,
+                    valid_ids,
+                    torch.full_like(valid_ids, pad_id),
+                )
+            else:
+                valid_ids = valid_ids.clamp(0, vocab_size - 1)
+        out[pos_mask] = lookup_table[valid_ids]
+        return out
+
+    def __call__(self, input_ids):
+        return self._compress(input_ids)
+
+
+class ShortConv(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        kernel_size: int = 4,
+        dilation: int = 1,
+        norm_eps: float = 1e-5,
+        hc_mult: int = 4,
+        activation: bool = True,
+    ):
+        super().__init__()
+        self.hc_mult = hc_mult
+        self.activation = activation
+        total_channels = hidden_size * hc_mult
+        self.conv = nn.Conv1d(
+            in_channels=total_channels,
+            out_channels=total_channels,
+            kernel_size=kernel_size,
+            groups=total_channels,
+            bias=False,
+            padding=(kernel_size - 1) * dilation,
+            dilation=dilation,
+        )
+
+        self.norm = nn.RMSNorm(total_channels, eps=norm_eps)
+
+        if self.activation:
+            self.act_fn = nn.SiLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Input/Output: (B, T, HC_MULT, D)"""
+        B, T, G, C = x.shape
+        x = x.view(B, T, G * C)
+        x = self.norm(x)
+        x = x.transpose(1, 2)
+        y = self.conv(x)
+        y = y[..., :T]
+        if self.activation:
+            y = self.act_fn(y)
+        y = y.transpose(1, 2).view(B, T, G, C)
+        return y
+
+
+def find_next_prime(start, seen_primes):
+    candidate = start + 1
+    while True:
+        if isprime(candidate) and candidate not in seen_primes:
+            return candidate
+        candidate += 1
+
+
+class NgramHashMapping:
+    def __init__(
+        self,
+        engram_vocab_size,
+        max_ngram_size,
+        n_embed_per_ngram,
+        n_head_per_ngram,
+        layer_ids,
+        tokenizer_name_or_path,
+        pad_id,
+        seed,
+    ):
+        self.vocab_size_per_ngram = engram_vocab_size
+        self.max_ngram_size = max_ngram_size
+        self.n_embed_per_ngram = n_embed_per_ngram
+        self.n_head_per_ngram = n_head_per_ngram
+        self.pad_id = pad_id
+        self.layer_ids = layer_ids
+
+        self.compressed_tokenizer = CompressedTokenizer(
+            tokenizer_name_or_path=tokenizer_name_or_path
+        )
+        self.tokenizer_vocab_size = len(self.compressed_tokenizer)
+        if self.pad_id is not None:
+            self.pad_id = int(self.compressed_tokenizer.lookup_table[self.pad_id])
+
+        max_long = np.iinfo(np.int64).max
+        M_max = int(max_long // self.tokenizer_vocab_size)
+        half_bound = max(1, M_max // 2)
+        PRIME_1 = 10007
+
+        self.layer_multipliers = {}
+
+        for layer_id in self.layer_ids:
+            base_seed = int(seed + PRIME_1 * int(layer_id))
+            g = np.random.default_rng(base_seed)
+            r = g.integers(
+                low=0, high=half_bound, size=(self.max_ngram_size,), dtype=np.int64
+            )
+            multipliers = r * 2 + 1
+            self.layer_multipliers[layer_id] = multipliers
+
+        self.vocab_size_across_layers = self.calculate_vocab_size_across_layers()
+        self._layer_multipliers_torch = {}
+
+    def calculate_vocab_size_across_layers(self):
+        seen_primes = set()
+        vocab_size_across_layers = {}
+
+        for layer_id in self.layer_ids:
+            all_ngram_vocab_sizes = []
+            for ngram in range(2, self.max_ngram_size + 1):
+                current_ngram_heads_sizes = []
+
+                vocab_size = self.vocab_size_per_ngram[ngram - 2]
+                num_head = self.n_head_per_ngram
+                current_prime_search_start = vocab_size - 1
+
+                for _ in range(num_head):
+                    found_prime = find_next_prime(
+                        current_prime_search_start, seen_primes
+                    )
+                    seen_primes.add(found_prime)
+                    current_ngram_heads_sizes.append(found_prime)
+                    current_prime_search_start = found_prime
+
+                all_ngram_vocab_sizes.append(current_ngram_heads_sizes)
+            vocab_size_across_layers[layer_id] = all_ngram_vocab_sizes
+
+        return vocab_size_across_layers
+
+    def _get_ngram_hashes(
+        self,
+        input_ids: np.ndarray,
+        layer_id: int,
+    ) -> np.ndarray:
+        x = np.asarray(input_ids, dtype=np.int64)
+        B, T = x.shape
+
+        multipliers = self.layer_multipliers[layer_id]
+
+        def shift_k(k: int) -> np.ndarray:
+            if k == 0:
+                return x
+            shifted = np.pad(
+                x, ((0, 0), (k, 0)), mode="constant", constant_values=self.pad_id
+            )[:, :T]
+            return shifted
+
+        base_shifts = [shift_k(k) for k in range(self.max_ngram_size)]
+
+        all_hashes = []
+
+        for n in range(2, self.max_ngram_size + 1):
+            n_gram_index = n - 2
+            tokens = base_shifts[:n]
+            mix = tokens[0] * multipliers[0]
+            for k in range(1, n):
+                mix = np.bitwise_xor(mix, tokens[k] * multipliers[k])
+            num_heads_for_this_ngram = self.n_head_per_ngram
+            head_vocab_sizes = self.vocab_size_across_layers[layer_id][n_gram_index]
+
+            for j in range(num_heads_for_this_ngram):
+                mod = int(head_vocab_sizes[j])
+                head_hash = mix % mod
+                all_hashes.append(head_hash.astype(np.int64, copy=False))
+
+        return np.stack(all_hashes, axis=2)
+
+    def _get_layer_multipliers_torch(
+        self, layer_id: int, device: torch.device
+    ) -> torch.Tensor:
+        key = (layer_id, device)
+        multipliers = self._layer_multipliers_torch.get(key)
+        if multipliers is None:
+            multipliers = torch.as_tensor(
+                self.layer_multipliers[layer_id],
+                dtype=torch.long,
+                device=device,
+            )
+            self._layer_multipliers_torch[key] = multipliers
+        return multipliers
+
+    def _get_ngram_hashes_torch(
+        self,
+        input_ids: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        x = input_ids.to(dtype=torch.long)
+        batch_size, seq_len = x.shape
+        multipliers = self._get_layer_multipliers_torch(layer_id, x.device)
+
+        base_shifts = []
+        for k in range(self.max_ngram_size):
+            if k == 0:
+                shifted = x
+            else:
+                shifted = F.pad(x, (k, 0), value=int(self.pad_id))
+                shifted = shifted[:, :seq_len]
+            base_shifts.append(shifted)
+
+        all_hashes = []
+        for n in range(2, self.max_ngram_size + 1):
+            n_gram_index = n - 2
+            tokens = base_shifts[:n]
+            mix = tokens[0] * multipliers[0]
+            for k in range(1, n):
+                mix = torch.bitwise_xor(mix, tokens[k] * multipliers[k])
+            head_vocab_sizes = self.vocab_size_across_layers[layer_id][n_gram_index]
+            for mod in head_vocab_sizes:
+                head_hash = torch.remainder(mix, int(mod))
+                all_hashes.append(head_hash)
+
+        return torch.stack(all_hashes, dim=2)
+
+    def hash(self, input_ids):
+        input_ids = self.compressed_tokenizer(input_ids)
+        hash_ids_for_all_layers = {}
+        for layer_id in self.layer_ids:
+            hash_ids_for_all_layers[layer_id] = self._get_ngram_hashes(
+                input_ids, layer_id=layer_id
+            )
+        return hash_ids_for_all_layers
+
+    def hash_torch(self, input_ids: torch.Tensor, layer_id: int) -> torch.Tensor:
+        input_ids = self.compressed_tokenizer.compress_torch(input_ids)
+        return self._get_ngram_hashes_torch(input_ids, layer_id=layer_id)
+
+
+class MultiHeadEmbedding(nn.Module):
+    def __init__(
+        self,
+        list_of_N: List[int],
+        layer_id: int,
+        D: int,
+        vocab_table: Optional[torch.Tensor] = None,
+        dtype: torch.dtype = torch.float16,
+        store=None,
+    ):
+        super().__init__()
+        self.num_heads = len(list_of_N)
+        self.embedding_dim = D
+        self.layer_id = layer_id
+
+        offsets = [0]
+        for n in list_of_N[:-1]:
+            offsets.append(offsets[-1] + n)
+
+        self.register_buffer("offsets", torch.tensor(offsets, dtype=torch.long))
+
+        total_N = sum(list_of_N)
+
+        if store is not None:
+            self.store = store
+        else:
+            self.store = LocalEngramStore(
+                embedding_dim=D,
+                vocab_size=total_N,
+                layer_id=layer_id,
+                dtype=dtype,
+                device=torch.device("cpu"),
+            )
+        if vocab_table is None:
+            raise ValueError("vocab_table must be provided for put_sharded")
+        self.store.put_sharded(vocab_table)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        offsets = self.offsets.to(device=input_ids.device)
+        shifted_input_ids = input_ids + offsets
+        output = self.store.get_many(
+            shifted_input_ids, self.layer_id, device=input_ids.device
+        )
+        return output
+
+
+class Engram(nn.Module):
+    def __init__(
+        self,
+        layer_id: int,
+        vocab_table: Optional[torch.Tensor] = None,
+        store_manager=None,
+    ):
+        super().__init__()
+        self.layer_id = layer_id
+        self.enable_prefetch = engram_cfg.enable_prefetch
+        self._prefetch_embeddings: Optional[torch.Tensor] = None
+        self._prefetch_event: Optional[torch.cuda.Event] = None
+        self._prefetch_shape: Optional[tuple[int, int]] = None
+        self._prefetch_stream: Optional[torch.cuda.Stream] = (
+            torch.cuda.Stream() if torch.cuda.is_available() else None
+        )
+        logger.info(
+            "Engram init: layer_id=%d, hidden_size=%d, hc_mult=%d, "
+            "vocab_size=%d, num_layers=%d, max_ngram_size=%d, "
+            "n_embed_per_ngram=%d, n_head_per_ngram=%d, "
+            "engram_vocab_size=%s, kernel_size=%d, store_backend=%s",
+            layer_id,
+            backbone_config.hidden_size,
+            backbone_config.hc_mult,
+            backbone_config.vocab_size,
+            backbone_config.num_layers,
+            engram_cfg.max_ngram_size,
+            engram_cfg.n_embed_per_ngram,
+            engram_cfg.n_head_per_ngram,
+            engram_cfg.engram_vocab_size,
+            engram_cfg.kernel_size,
+            engram_cfg.store_backend,
+        )
+        self.hash_mapping = NgramHashMapping(
+            engram_vocab_size=engram_cfg.engram_vocab_size,
+            max_ngram_size=engram_cfg.max_ngram_size,
+            n_embed_per_ngram=engram_cfg.n_embed_per_ngram,
+            n_head_per_ngram=engram_cfg.n_head_per_ngram,
+            layer_ids=engram_cfg.layer_ids,
+            tokenizer_name_or_path=engram_cfg.tokenizer_name_or_path,
+            pad_id=engram_cfg.pad_id,
+            seed=engram_cfg.seed,
+        )
+
+        list_of_N = [
+            x
+            for y in self.hash_mapping.vocab_size_across_layers[self.layer_id]
+            for x in y
+        ]
+        logger.info("Engram layer %d vocab sizes: %s", self.layer_id, list_of_N)
+
+        total_N = sum(list_of_N)
+        embedding_dim = engram_cfg.n_embed_per_ngram // engram_cfg.n_head_per_ngram
+        vocab_table = (
+            torch.arange(total_N, dtype=torch.float16)
+            .unsqueeze(1)
+            .expand(-1, embedding_dim)
+        )
+
+        engram_store = None
+        if store_manager is not None:
+            engram_store = store_manager.get_or_create_store(
+                layer_id=self.layer_id,
+                vocab_size=total_N,
+                embedding_dim=embedding_dim,
+            )
+
+        self.multi_head_embedding = MultiHeadEmbedding(
+            list_of_N=list_of_N,
+            layer_id=self.layer_id,
+            D=engram_cfg.n_embed_per_ngram // engram_cfg.n_head_per_ngram,
+            vocab_table=vocab_table,
+            store=engram_store,
+        )
+        self.short_conv = ShortConv(
+            hidden_size=backbone_config.hidden_size,
+            kernel_size=engram_cfg.kernel_size,
+            dilation=engram_cfg.max_ngram_size,
+            hc_mult=backbone_config.hc_mult,
+        )
+        engram_hidden_size = (
+            engram_cfg.max_ngram_size - 1
+        ) * engram_cfg.n_embed_per_ngram
+        self.hc_mult = backbone_config.hc_mult
+        self.hidden_size = backbone_config.hidden_size
+        self.eps = 1e-6
+
+        self.value_proj = nn.Linear(engram_hidden_size, self.hidden_size)
+        self.key_projs_all = nn.Linear(
+            engram_hidden_size, self.hidden_size * self.hc_mult
+        )
+        self.norm1_weight = nn.Parameter(torch.ones(self.hc_mult, self.hidden_size))
+        self.norm2_weight = nn.Parameter(torch.ones(self.hc_mult, self.hidden_size))
+
+    def start_prefetch(
+        self,
+        input_ids: torch.Tensor,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if not self.enable_prefetch:
+            return
+
+        if input_ids.device != device:
+            input_ids = input_ids.to(device=device)
+        hash_input_ids = self.hash_mapping.hash_torch(input_ids, layer_id=self.layer_id)
+
+        if self._prefetch_stream is not None and device.type == "cuda":
+            stream = self._prefetch_stream
+            with torch.cuda.stream(stream):
+                embeddings = self.multi_head_embedding(hash_input_ids).flatten(
+                    start_dim=-2
+                )
+                if embeddings.dtype != dtype:
+                    embeddings = embeddings.to(dtype=dtype)
+            event = torch.cuda.Event()
+            event.record(stream)
+            self._prefetch_event = event
+            self._prefetch_embeddings = embeddings
+        else:
+            embeddings = self.multi_head_embedding(hash_input_ids).flatten(start_dim=-2)
+            if embeddings.dtype != dtype:
+                embeddings = embeddings.to(dtype=dtype)
+            self._prefetch_event = None
+            self._prefetch_embeddings = embeddings
+
+        self._prefetch_shape = tuple(input_ids.shape[:2])
+
+    def _consume_prefetch(self, input_ids: torch.Tensor) -> Optional[torch.Tensor]:
+        if not self.enable_prefetch:
+            return None
+        if self._prefetch_embeddings is None:
+            return None
+        if (
+            self._prefetch_shape is not None
+            and tuple(input_ids.shape[:2]) != self._prefetch_shape
+        ):
+            self._prefetch_embeddings = None
+            self._prefetch_event = None
+            self._prefetch_shape = None
+            return None
+
+        if self._prefetch_event is not None:
+            torch.cuda.current_stream().wait_event(self._prefetch_event)
+        embeddings = self._prefetch_embeddings
+        self._prefetch_embeddings = None
+        self._prefetch_event = None
+        self._prefetch_shape = None
+        return embeddings
+
+    def parallel_rms_norm(self, x, weight):
+        # x shape: (batch, seq, hc_mult, hidden_size)
+        # weight shape: (hc_mult, hidden_size)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.eps)
+        return x * weight
+
+    def forward(self, hidden_states, input_ids):
+        """
+        hidden_states: [B, L, HC_MULT, D]
+        input_ids: [B, L]
+        """
+        embeddings = self._consume_prefetch(input_ids)
+        if embeddings is None:
+            if input_ids.device != hidden_states.device:
+                input_ids = input_ids.to(device=hidden_states.device)
+            hash_input_ids = self.hash_mapping.hash_torch(
+                input_ids, layer_id=self.layer_id
+            )
+            embeddings = self.multi_head_embedding(hash_input_ids).flatten(start_dim=-2)
+        if embeddings.dtype != hidden_states.dtype:
+            embeddings = embeddings.to(dtype=hidden_states.dtype)
+
+        keys = self.key_projs_all(embeddings).view(
+            *embeddings.shape[:2], self.hc_mult, self.hidden_size
+        )
+        normed_key = self.parallel_rms_norm(keys, self.norm1_weight)
+        normed_query = self.parallel_rms_norm(hidden_states, self.norm2_weight)
+
+        gate = (normed_key * normed_query).sum(dim=-1) / math.sqrt(self.hidden_size)
+        gate = gate.abs().clamp_min(1e-6).sqrt() * gate.sign()
+        gate = gate.sigmoid().unsqueeze(-1)
+
+        v_projected = self.value_proj(embeddings).unsqueeze(2)
+        value = gate * v_projected
+
+        output = value + self.short_conv(value)
+        return output
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, layer_id: int):
+        super().__init__()
+        self.attn = lambda x: x
+        self.moe = lambda x: x
+        self.engram = None
+        if layer_id in engram_cfg.layer_ids:
+            self.engram = Engram(layer_id=layer_id)
+
+    def forward(self, input_ids, hidden_states):
+        if self.engram is not None:
+            hidden_states = (
+                self.engram(hidden_states=hidden_states, input_ids=input_ids)
+                + hidden_states
+            )
+        hidden_states = self.attn(hidden_states) + hidden_states
+        hidden_states = self.moe(hidden_states) + hidden_states
+        return hidden_states
+
+
+if __name__ == "__main__":
+    engram_cfg = build_engram_config_from_cli()
+    backbone_config = BackBoneConfig()
+
+    LLM = [
+        nn.Embedding(backbone_config.vocab_size, backbone_config.hidden_size),
+        *[TransformerBlock(layer_id=i) for i in range(backbone_config.num_layers)],
+        nn.Linear(backbone_config.hidden_size, backbone_config.vocab_size),
+    ]
+
+    text = "Only Alexander the Great could tame the horse Bucephalus."
+    tokenizer = AutoTokenizer.from_pretrained(
+        engram_cfg.tokenizer_name_or_path, trust_remote_code=True
+    )
+    input_ids = tokenizer(text, return_tensors="pt").input_ids
+
+    B, L = input_ids.shape
+
+    for idx, layer in enumerate(LLM):
+        if idx == 0:
+            hidden_states = LLM[0](input_ids)
+            # mock hyper-connection: expand to (B, L, HC_MULT, D)
+            hidden_states = hidden_states.unsqueeze(2).expand(
+                -1, -1, backbone_config.hc_mult, -1
+            )
+        elif idx == len(LLM) - 1:
+            # mock hyper-connection: collapse back to (B, L, D)
+            hidden_states = hidden_states[:, :, 0, :]
+            output = layer(hidden_states)
+        else:
+            hidden_states = layer(input_ids=input_ids, hidden_states=hidden_states)

--- a/python/sglang/srt/models/engram/engram.py
+++ b/python/sglang/srt/models/engram/engram.py
@@ -561,24 +561,17 @@ class Engram(nn.Module):
 
         if input_ids.device != device:
             input_ids = input_ids.to(device=device)
-        hash_input_ids = self.hash_mapping.hash_torch(input_ids, layer_id=self.layer_id)
 
         if self._prefetch_stream is not None and device.type == "cuda":
             stream = self._prefetch_stream
             with torch.cuda.stream(stream):
-                embeddings = self.multi_head_embedding(hash_input_ids).flatten(
-                    start_dim=-2
-                )
-                if embeddings.dtype != dtype:
-                    embeddings = embeddings.to(dtype=dtype)
+                embeddings = self.compute_embeddings(input_ids, dtype=dtype)
             event = torch.cuda.Event()
             event.record(stream)
             self._prefetch_event = event
             self._prefetch_embeddings = embeddings
         else:
-            embeddings = self.multi_head_embedding(hash_input_ids).flatten(start_dim=-2)
-            if embeddings.dtype != dtype:
-                embeddings = embeddings.to(dtype=dtype)
+            embeddings = self.compute_embeddings(input_ids, dtype=dtype)
             self._prefetch_event = None
             self._prefetch_embeddings = embeddings
 
@@ -613,6 +606,90 @@ class Engram(nn.Module):
         x = x * torch.rsqrt(variance + self.eps)
         return x * weight
 
+    # ------------------------------------------------------------------
+    # Stage A: hash + embedding lookup (input_ids → embeddings)
+    # Depends only on input_ids; safe to run ahead of time or on a
+    # different device backend.  Subclasses may override to use custom
+    # kernels (e.g. CPU-offloaded or fused CUDA implementations).
+    # ------------------------------------------------------------------
+    def compute_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        """Stage A: token compression → n-gram hashing → embedding lookup.
+
+        Args:
+            input_ids: ``[B, L]`` token ids.
+            dtype: cast output to this dtype when provided.
+
+        Returns:
+            embeddings: ``[B, L, (max_ngram_size-1) * n_embed_per_ngram]``
+        """
+        hash_input_ids = self.hash_mapping.hash_torch(
+            input_ids, layer_id=self.layer_id
+        )
+        embeddings = self.multi_head_embedding(hash_input_ids).flatten(start_dim=-2)
+        if dtype is not None and embeddings.dtype != dtype:
+            embeddings = embeddings.to(dtype=dtype)
+        return embeddings
+
+    # ------------------------------------------------------------------
+    # Stage B: key/value projections + norms (embeddings → keys, values)
+    # Depends only on embeddings (Stage A output); independent of the
+    # current hidden_states.  Subclasses may override for fused or
+    # quantised projection kernels.
+    # ------------------------------------------------------------------
+    def compute_kv_projections(
+        self,
+        embeddings: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Stage B: linear projections and RMS-norm for keys and values.
+
+        Args:
+            embeddings: ``[B, L, engram_hidden_size]``
+
+        Returns:
+            normed_key: ``[B, L, HC_MULT, D]`` — normalised key tensor.
+            v_projected: ``[B, L, 1, D]``       — projected value tensor.
+        """
+        keys = self.key_projs_all(embeddings).view(
+            *embeddings.shape[:2], self.hc_mult, self.hidden_size
+        )
+        normed_key = self.parallel_rms_norm(keys, self.norm1_weight)
+        v_projected = self.value_proj(embeddings).unsqueeze(2)
+        return normed_key, v_projected
+
+    # ------------------------------------------------------------------
+    # Stage C: gated mixing + short convolution (hidden_states → output)
+    # Depends on hidden_states (previous layer) and Stage A/B outputs.
+    # Subclasses may override to use custom attention or conv kernels.
+    # ------------------------------------------------------------------
+    def compute_mixing(
+        self,
+        hidden_states: torch.Tensor,
+        normed_key: torch.Tensor,
+        v_projected: torch.Tensor,
+    ) -> torch.Tensor:
+        """Stage C: scaled dot-product gating and short convolution.
+
+        Args:
+            hidden_states: ``[B, L, HC_MULT, D]``
+            normed_key:    ``[B, L, HC_MULT, D]``
+            v_projected:   ``[B, L, 1, D]``
+
+        Returns:
+            output: ``[B, L, HC_MULT, D]``
+        """
+        normed_query = self.parallel_rms_norm(hidden_states, self.norm2_weight)
+
+        gate = (normed_key * normed_query).sum(dim=-1) / math.sqrt(self.hidden_size)
+        gate = gate.abs().clamp_min(1e-6).sqrt() * gate.sign()
+        gate = gate.sigmoid().unsqueeze(-1)
+
+        value = gate * v_projected
+        return value + self.short_conv(value)
+
     def forward(self, hidden_states, input_ids):
         """
         hidden_states: [B, L, HC_MULT, D]
@@ -622,28 +699,12 @@ class Engram(nn.Module):
         if embeddings is None:
             if input_ids.device != hidden_states.device:
                 input_ids = input_ids.to(device=hidden_states.device)
-            hash_input_ids = self.hash_mapping.hash_torch(
-                input_ids, layer_id=self.layer_id
-            )
-            embeddings = self.multi_head_embedding(hash_input_ids).flatten(start_dim=-2)
+            embeddings = self.compute_embeddings(input_ids)
         if embeddings.dtype != hidden_states.dtype:
             embeddings = embeddings.to(dtype=hidden_states.dtype)
 
-        keys = self.key_projs_all(embeddings).view(
-            *embeddings.shape[:2], self.hc_mult, self.hidden_size
-        )
-        normed_key = self.parallel_rms_norm(keys, self.norm1_weight)
-        normed_query = self.parallel_rms_norm(hidden_states, self.norm2_weight)
-
-        gate = (normed_key * normed_query).sum(dim=-1) / math.sqrt(self.hidden_size)
-        gate = gate.abs().clamp_min(1e-6).sqrt() * gate.sign()
-        gate = gate.sigmoid().unsqueeze(-1)
-
-        v_projected = self.value_proj(embeddings).unsqueeze(2)
-        value = gate * v_projected
-
-        output = value + self.short_conv(value)
-        return output
+        normed_key, v_projected = self.compute_kv_projections(embeddings)
+        return self.compute_mixing(hidden_states, normed_key, v_projected)
 
 
 class TransformerBlock(nn.Module):

--- a/python/sglang/srt/models/engram/triton_ops/__init__.py
+++ b/python/sglang/srt/models/engram/triton_ops/__init__.py
@@ -1,0 +1,1 @@
+"""Triton kernels for Engram."""

--- a/python/sglang/srt/models/engram/triton_ops/engram_triton.py
+++ b/python/sglang/srt/models/engram/triton_ops/engram_triton.py
@@ -1,0 +1,311 @@
+"""Triton kernels for Engram forward fusion."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    triton = None
+    tl = None
+    TRITON_AVAILABLE = False
+
+
+def _pick_block_h(hidden_size: int) -> int:
+    if hidden_size <= 64:
+        return 64
+    if hidden_size <= 128:
+        return 128
+    if hidden_size <= 256:
+        return 256
+    return 512
+
+
+def _pick_block_c(hidden_size: int) -> int:
+    if hidden_size <= 64:
+        return 64
+    if hidden_size <= 128:
+        return 128
+    if hidden_size <= 256:
+        return 256
+    return 512
+
+
+@triton.jit
+def _gate_value_kernel(
+    normed_key_ptr,
+    normed_query_ptr,
+    value_ptr,
+    output_ptr,
+    stride_nk_b,
+    stride_nk_l,
+    stride_nk_g,
+    stride_nk_h,
+    stride_nq_b,
+    stride_nq_l,
+    stride_nq_g,
+    stride_nq_h,
+    stride_val_b,
+    stride_val_l,
+    stride_val_h,
+    stride_out_b,
+    stride_out_l,
+    stride_out_g,
+    stride_out_h,
+    B,
+    L,
+    G,
+    scale,
+    H: tl.constexpr,
+    eps: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    total = B * L * G
+    if pid >= total:
+        return
+
+    g = pid % G
+    pid = pid // G
+    l = pid % L
+    b = pid // L
+
+    acc = tl.zeros([1], dtype=tl.float32)
+    for h in tl.static_range(0, H, BLOCK_H):
+        offs = h + tl.arange(0, BLOCK_H)
+        mask = offs < H
+        nk = tl.load(
+            normed_key_ptr
+            + b * stride_nk_b
+            + l * stride_nk_l
+            + g * stride_nk_g
+            + offs * stride_nk_h,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        nq = tl.load(
+            normed_query_ptr
+            + b * stride_nq_b
+            + l * stride_nq_l
+            + g * stride_nq_g
+            + offs * stride_nq_h,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        acc += tl.sum(nk * nq, axis=0)
+
+    gate = acc / scale
+    abs_gate = tl.maximum(tl.abs(gate), eps)
+    sign_gate = tl.where(gate > 0, 1.0, tl.where(gate < 0, -1.0, 0.0))
+    gate = tl.sqrt(abs_gate) * sign_gate
+    gate = tl.sigmoid(gate)
+
+    for h in tl.static_range(0, H, BLOCK_H):
+        offs = h + tl.arange(0, BLOCK_H)
+        mask = offs < H
+        val = tl.load(
+            value_ptr + b * stride_val_b + l * stride_val_l + offs * stride_val_h,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        out = val * gate
+        tl.store(
+            output_ptr
+            + b * stride_out_b
+            + l * stride_out_l
+            + g * stride_out_g
+            + offs * stride_out_h,
+            out,
+            mask=mask,
+        )
+
+
+def gate_value_fused(
+    normed_key: torch.Tensor,
+    normed_query: torch.Tensor,
+    value_proj: torch.Tensor,
+    hidden_size: int,
+    eps: float = 1e-6,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("Triton is not available")
+    if normed_key.device.type != "cuda":
+        raise RuntimeError("Triton kernel requires CUDA tensors")
+
+    if out is None:
+        out = torch.empty(
+            (*normed_key.shape[:-1], hidden_size),
+            device=normed_key.device,
+            dtype=value_proj.dtype,
+        )
+
+    B, L, G, H = normed_key.shape
+    if H != hidden_size:
+        raise ValueError("hidden_size mismatch for gate_value_fused")
+
+    grid = (B * L * G,)
+    block_h = _pick_block_h(H)
+    num_warps = 4 if block_h <= 128 else 8
+
+    _gate_value_kernel[grid](
+        normed_key,
+        normed_query,
+        value_proj,
+        out,
+        normed_key.stride(0),
+        normed_key.stride(1),
+        normed_key.stride(2),
+        normed_key.stride(3),
+        normed_query.stride(0),
+        normed_query.stride(1),
+        normed_query.stride(2),
+        normed_query.stride(3),
+        value_proj.stride(0),
+        value_proj.stride(1),
+        value_proj.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        B,
+        L,
+        G,
+        float(math.sqrt(hidden_size)),
+        H=H,
+        eps=eps,
+        BLOCK_H=block_h,
+        num_warps=num_warps,
+    )
+
+    return out
+
+
+@triton.jit
+def _rms_norm_and_transpose_kernel(
+    X_ptr,  # (B, T, G, C)
+    W_ptr,  # (G, C)
+    Y_ptr,  # (B, G*C, T)
+    eps,
+    B,
+    T,
+    G,
+    C,
+    stride_xb,
+    stride_xt,
+    stride_xg,
+    stride_xc,
+    stride_yb,
+    stride_ygc,
+    stride_yt,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    b = row_idx // (T * G)
+    rem = row_idx % (T * G)
+    t = rem // G
+    g = rem % G
+
+    X_ptr += b * stride_xb + t * stride_xt + g * stride_xg
+    W_ptr += g * C
+
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < C
+    x = tl.load(X_ptr + cols * stride_xc, mask=mask, other=0.0).to(tl.float32)
+    w = tl.load(W_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+
+    xf = x.to(tl.float32)
+    var = tl.sum(xf * xf, axis=0) / C
+    rsqrt = tl.math.rsqrt(var + eps)
+    out = xf * rsqrt * w
+
+    y_base = Y_ptr + b * stride_yb + g * C * stride_ygc + t * stride_yt
+    tl.store(y_base + cols * stride_ygc, out, mask=mask)
+
+
+def shortconv_preprocess(x, weights, eps):
+    B, T, G, C = x.shape
+    y = torch.empty((B, G * C, T), device=x.device, dtype=x.dtype)
+
+    BLOCK_SIZE = triton.next_power_of_2(C)
+
+    grid = (B * T * G,)
+
+    _rms_norm_and_transpose_kernel[grid](
+        x,
+        weights,
+        y,
+        eps,
+        B,
+        T,
+        G,
+        C,
+        x.stride(0),
+        x.stride(1),
+        x.stride(2),
+        x.stride(3),
+        y.stride(0),
+        y.stride(1),
+        y.stride(2),
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return y
+
+
+@triton.jit
+def _rms_norm_fused_kernel(
+    X_ptr,
+    W_ptr,
+    Y_ptr,
+    stride_row,
+    N_cols,
+    eps,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+
+    x_row_ptr = X_ptr + row_idx * stride_row
+    y_row_ptr = Y_ptr + row_idx * stride_row
+
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < N_cols
+
+    x = tl.load(x_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+
+    x_sq = x * x
+    var = tl.sum(x_sq, axis=0) / N_cols
+    inv_std = tl.extra.cuda.libdevice.rsqrt(var + eps)
+
+    w = tl.load(W_ptr + cols, mask=mask).to(tl.float32)
+    y = x * inv_std * w
+
+    tl.store(y_row_ptr + cols, y, mask=mask)
+
+
+def rms_norm_group_fused(x, weights, eps=1e-5):
+    orig_shape = x.shape
+    N = orig_shape[-1]
+    x_2d = x.reshape(-1, N)
+    M, _ = x_2d.shape
+
+    y = torch.empty_like(x_2d)
+    BLOCK_SIZE = triton.next_power_of_2(N)
+
+    _rms_norm_fused_kernel[(M,)](
+        x_2d,
+        weights,
+        y,
+        x_2d.stride(0),
+        N,
+        eps,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=4 if N <= 1024 else 8,
+    )
+    return y.reshape(*orig_shape)

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -44,11 +44,18 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from sglang.srt.mem_cache.engram import (
+    EngramStoreConfig,
+    EngramStoreManager,
+    get_global_engram_store_manager,
+    set_global_engram_store_manager,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     kv_cache_scales_loader,
 )
+from sglang.srt.models.engram.engram import Engram, backbone_config, engram_cfg
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, make_layers
 
@@ -406,6 +413,200 @@ class Qwen2Model(nn.Module):
                 raise RuntimeError(
                     "Self attention has no KV cache scaling " "factor attribute!"
                 )
+
+
+class Qwen2MoelEngram(Qwen2Model):
+    def __init__(
+        self,
+        config: Qwen2Config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        decoder_layer_type: type[nn.Module] = Qwen2DecoderLayer,
+        alt_stream: Optional[torch.cuda.Stream] = None,
+        engram_layer_ids: Optional[List[int]] = None,
+    ) -> None:
+        super().__init__(
+            config,
+            quant_config=quant_config,
+            prefix=prefix,
+            decoder_layer_type=decoder_layer_type,
+            alt_stream=alt_stream,
+        )
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.engram_layer_ids = set(engram_layer_ids or engram_cfg.layer_ids)
+        self.engram_modules: Dict[int, Engram] = {}
+        self.engram_store_manager: Optional[EngramStoreManager] = None
+        if self.tp_rank == 0:
+            self._init_engram_modules()
+
+    def _init_engram_modules(self) -> None:
+        if not self.engram_layer_ids:
+            return
+
+        backbone_config.hidden_size = self.config.hidden_size
+        backbone_config.vocab_size = self.config.vocab_size
+        backbone_config.num_layers = self.config.num_hidden_layers
+        if hasattr(self.config, "tokenizer_name_or_path"):
+            engram_cfg.tokenizer_name_or_path = self.config.tokenizer_name_or_path
+        elif hasattr(self.config, "_name_or_path"):
+            engram_cfg.tokenizer_name_or_path = self.config._name_or_path
+        if (
+            hasattr(self.config, "pad_token_id")
+            and self.config.pad_token_id is not None
+        ):
+            engram_cfg.pad_id = self.config.pad_token_id
+
+        self.engram_store_manager = get_global_engram_store_manager()
+        if self.engram_store_manager is None:
+            store_cfg = EngramStoreConfig(
+                store_backend=engram_cfg.store_backend,
+                layer_ids=list(sorted(self.engram_layer_ids)),
+            )
+            self.engram_store_manager = EngramStoreManager(store_cfg)
+            set_global_engram_store_manager(self.engram_store_manager)
+
+        for layer_id in sorted(self.engram_layer_ids):
+            if self.start_layer <= layer_id < self.end_layer:
+                self.engram_modules[layer_id] = Engram(
+                    layer_id=layer_id,
+                    store_manager=self.engram_store_manager,
+                )
+
+    def _prepare_engram_hidden_states(
+        self, hidden_states: torch.Tensor
+    ) -> Optional[torch.Tensor]:
+        if hidden_states.dim() == 4:
+            return hidden_states
+        if hidden_states.dim() == 3:
+            batch_size, seq_len, hidden_size = hidden_states.shape
+            return hidden_states.unsqueeze(2).expand(
+                batch_size, seq_len, backbone_config.hc_mult, hidden_size
+            )
+        if hidden_states.dim() == 2:
+            seq_len, hidden_size = hidden_states.shape
+            return (
+                hidden_states.unsqueeze(0)
+                .unsqueeze(2)
+                .expand(1, seq_len, backbone_config.hc_mult, hidden_size)
+            )
+        return None
+
+    def _prepare_engram_input_ids(
+        self, input_ids: Optional[torch.Tensor]
+    ) -> Optional[torch.Tensor]:
+        if input_ids is None:
+            return None
+        if input_ids.dim() == 1:
+            input_ids = input_ids.unsqueeze(0)
+        elif input_ids.dim() > 2:
+            input_ids = input_ids.view(input_ids.size(0), -1)
+        return input_ids.detach()
+
+    def _run_engram(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        input_ids: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        engram_hidden_states = self._prepare_engram_hidden_states(hidden_states)
+        if engram_hidden_states is None:
+            return None
+        engram = self.engram_modules.get(layer_id)
+        if engram is None:
+            return None
+        engram_input_ids = self._prepare_engram_input_ids(input_ids)
+        if engram_input_ids is None:
+            output = torch.zeros_like(engram_hidden_states)
+        else:
+            output = engram(engram_hidden_states, engram_input_ids)
+        if output.device != hidden_states.device:
+            output = output.to(hidden_states.device)
+        if output.dtype != hidden_states.dtype:
+            output = output.to(hidden_states.dtype)
+        return output
+
+    def _start_engram_prefetch(
+        self,
+        input_ids: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+    ) -> None:
+        engram_input_ids = self._prepare_engram_input_ids(input_ids)
+        if engram_input_ids is None:
+            return
+        device = hidden_states.device
+        dtype = hidden_states.dtype
+        for layer_id in sorted(self.engram_layer_ids):
+            if self.start_layer <= layer_id < self.end_layer:
+                engram = self.engram_modules.get(layer_id)
+                if engram is not None:
+                    engram.start_prefetch(engram_input_ids, device, dtype)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+
+        if self.pp_group.is_first_rank:
+            if input_embeds is None:
+                hidden_states = self.embed_tokens(input_ids)
+            else:
+                hidden_states = input_embeds
+            residual = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        if self.tp_rank == 0:
+            if (
+                forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+                or forward_batch.forward_mode.is_decode()
+            ):
+                self._start_engram_prefetch(input_ids, hidden_states)
+
+        aux_hidden_states = []
+        for i in range(self.start_layer, self.end_layer):
+            if i in self.layers_to_capture:
+                aux_hidden_states.append(
+                    hidden_states + residual if residual is not None else hidden_states
+                )
+            if i in self.engram_layer_ids:
+                if self.tp_rank == 0:
+                    engram_output = self._run_engram(i, hidden_states, input_ids)
+                    if engram_output is not None:
+                        hidden_states = hidden_states + engram_output.sum() * 0
+                else:
+                    # TODO: Transfer engram embeddings to other ranks if necessary
+                    pass
+            layer = self.layers[i]
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                forward_batch,
+                residual,
+            )
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                }
+            )
+        else:
+            if hidden_states.shape[0] != 0:
+                if residual is None:
+                    hidden_states = self.norm(hidden_states)
+                else:
+                    hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) == 0:
+            return hidden_states
+
+        return hidden_states, aux_hidden_states
 
 
 class Qwen2ForCausalLM(nn.Module):

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -1,5 +1,5 @@
-# Adapted from qwen2.py
 import logging
+import os
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
@@ -27,7 +27,7 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.models.qwen2 import Qwen2MLP as Qwen3MLP
-from sglang.srt.models.qwen2 import Qwen2Model
+from sglang.srt.models.qwen2 import Qwen2Model, Qwen2MoelEngram
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, is_cuda, is_npu
@@ -334,6 +334,23 @@ class Qwen3Model(Qwen2Model):
         )
 
 
+class Qwen3ModelEngram(Qwen2MoelEngram):
+    def __init__(
+        self,
+        config: Qwen3Config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        alt_stream = torch.cuda.Stream() if _is_cuda else None
+        super().__init__(
+            config=config,
+            quant_config=quant_config,
+            prefix=prefix,
+            decoder_layer_type=Qwen3DecoderLayer,
+            alt_stream=alt_stream,
+        )
+
+
 class Qwen3ForCausalLM(nn.Module):
     # BitandBytes specific attributes
     default_bitsandbytes_target_modules = [
@@ -364,7 +381,9 @@ class Qwen3ForCausalLM(nn.Module):
         self.pp_group = get_pp_group()
         self.config = config
         self.quant_config = quant_config
-        self.model = Qwen3Model(
+        use_engram = os.getenv("ENABLE_ENGRAM", "0").lower() in ("1", "true")
+        model_cls = Qwen3ModelEngram if use_engram else Qwen3Model
+        self.model = model_cls(
             config, quant_config=quant_config, prefix=add_prefix("model", prefix)
         )
 

--- a/test/srt/engram/run_all_tests.py
+++ b/test/srt/engram/run_all_tests.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run all Engram integration tests in sequence.
+
+Usage (from repo root):
+    python test/srt/engram/run_all_tests.py
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+
+TESTS = [
+    ("Test 1: Import paths", "test_import_paths.py"),
+    ("Test 2: Local store + manager", "test_local_store_manager.py"),
+    ("Test 3: Engram E2E", "test_engram_e2e.py"),
+]
+
+
+def main() -> None:
+    print("=" * 70)
+    print("Engram Integration Test Suite")
+    print("=" * 70)
+
+    failed = []
+    for label, script in TESTS:
+        path = BENCH_DIR / script
+        print(f"\n{'─' * 70}")
+        print(f"Running: {label}  ({script})")
+        print(f"{'─' * 70}")
+        ret = subprocess.call([sys.executable, str(path)])
+        if ret != 0:
+            failed.append(label)
+
+    print(f"\n{'=' * 70}")
+    if not failed:
+        print(f"ALL {len(TESTS)} TESTS PASSED")
+    else:
+        print(f"FAILED {len(failed)}/{len(TESTS)} TESTS:")
+        for f in failed:
+            print(f"  - {f}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/srt/engram/test_engram_e2e.py
+++ b/test/srt/engram/test_engram_e2e.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Test 3: End-to-end Engram module + EngramStoreManager integration.
+
+Verifies:
+  - Engram module accepts a store_manager and uses it to create stores
+  - The store instance in MultiHeadEmbedding matches the manager's store
+  - Forward pass produces correct output shapes
+  - Backward compatibility: Engram without store_manager still works
+
+Usage:
+    python test/srt/engram/test_engram_e2e.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import torch
+
+from sglang.srt.mem_cache.engram import EngramStoreConfig, EngramStoreManager
+from sglang.srt.mem_cache.engram.local_engram_store import LocalEngramStore
+from sglang.srt.models.engram import engram as engram_mod
+from sglang.srt.models.engram.engram import BackBoneConfig, Engram, EngramConfig
+
+LAYER_IDS = [1]
+HIDDEN = 1024
+HC_MULT = 4
+BATCH = 2
+SEQ = 32
+
+
+def _setup_configs():
+    engram_mod.engram_cfg = EngramConfig(
+        tokenizer_name_or_path="deepseek-ai/DeepSeek-V3",
+        engram_vocab_size=[1024, 1024],
+        max_ngram_size=3,
+        n_embed_per_ngram=512,
+        n_head_per_ngram=8,
+        layer_ids=LAYER_IDS,
+        pad_id=2,
+        seed=0,
+        kernel_size=4,
+        store_backend="local",
+        enable_prefetch=False,
+    )
+    engram_mod.backbone_config = BackBoneConfig(
+        hidden_size=HIDDEN,
+        hc_mult=HC_MULT,
+        vocab_size=129280,
+        num_layers=2,
+    )
+
+
+def test_with_store_manager():
+    print("\n--- Test: Engram with EngramStoreManager ---")
+    _setup_configs()
+
+    store_cfg = EngramStoreConfig(store_backend="local", layer_ids=LAYER_IDS)
+    mgr = EngramStoreManager(store_cfg)
+
+    model = Engram(layer_id=1, store_manager=mgr)
+    print(f"  Store type: {type(model.multi_head_embedding.store).__name__}")
+    assert isinstance(
+        model.multi_head_embedding.store, LocalEngramStore
+    ), f"Expected LocalEngramStore, got {type(model.multi_head_embedding.store).__name__}"
+    print("  [PASS] Store is LocalEngramStore from manager")
+
+    assert mgr.has_layer(1), "Layer 1 should be registered"
+    assert (
+        mgr.get_store(1) is model.multi_head_embedding.store
+    ), "Store identity mismatch"
+    print("  [PASS] Store identity matches manager's registry")
+
+    input_ids = torch.randint(0, 129280, (BATCH, SEQ))
+    hidden = torch.randn(BATCH, SEQ, HC_MULT, HIDDEN)
+    with torch.no_grad():
+        out = model(hidden_states=hidden, input_ids=input_ids)
+    assert out.shape == (BATCH, SEQ, HC_MULT, HIDDEN), f"Unexpected shape: {out.shape}"
+    print(f"  [PASS] Forward output shape: {out.shape}")
+
+    mgr.close()
+    print("  [PASS] Manager closed without error")
+
+
+def test_without_store_manager():
+    print("\n--- Test: Engram without store_manager (backward compat) ---")
+    _setup_configs()
+
+    model = Engram(layer_id=1, store_manager=None)
+    print(f"  Store type: {type(model.multi_head_embedding.store).__name__}")
+    assert isinstance(model.multi_head_embedding.store, LocalEngramStore)
+    print("  [PASS] Fallback creates LocalEngramStore directly")
+
+    input_ids = torch.randint(0, 129280, (BATCH, SEQ))
+    hidden = torch.randn(BATCH, SEQ, HC_MULT, HIDDEN)
+    with torch.no_grad():
+        out = model(hidden_states=hidden, input_ids=input_ids)
+    assert out.shape == (BATCH, SEQ, HC_MULT, HIDDEN), f"Unexpected shape: {out.shape}"
+    print(f"  [PASS] Forward output shape: {out.shape}")
+
+
+def test_multi_layer():
+    print("\n--- Test: Multiple Engram layers sharing one manager ---")
+    layer_ids = [1, 15]
+    engram_mod.engram_cfg = EngramConfig(
+        tokenizer_name_or_path="deepseek-ai/DeepSeek-V3",
+        engram_vocab_size=[1024, 1024],
+        max_ngram_size=3,
+        n_embed_per_ngram=512,
+        n_head_per_ngram=8,
+        layer_ids=layer_ids,
+        pad_id=2,
+        seed=0,
+        kernel_size=4,
+        store_backend="local",
+        enable_prefetch=False,
+    )
+    engram_mod.backbone_config = BackBoneConfig(
+        hidden_size=HIDDEN,
+        hc_mult=HC_MULT,
+        vocab_size=129280,
+        num_layers=30,
+    )
+
+    store_cfg = EngramStoreConfig(store_backend="local", layer_ids=layer_ids)
+    mgr = EngramStoreManager(store_cfg)
+
+    models = {}
+    for lid in layer_ids:
+        models[lid] = Engram(layer_id=lid, store_manager=mgr)
+
+    assert mgr.has_layer(1) and mgr.has_layer(15), "Both layers should be registered"
+    assert mgr.get_store(1) is not mgr.get_store(
+        15
+    ), "Each layer should have its own store"
+    print("  [PASS] Two layers have independent stores in one manager")
+
+    for lid in layer_ids:
+        input_ids = torch.randint(0, 129280, (BATCH, SEQ))
+        hidden = torch.randn(BATCH, SEQ, HC_MULT, HIDDEN)
+        with torch.no_grad():
+            out = models[lid](hidden_states=hidden, input_ids=input_ids)
+        assert out.shape == (BATCH, SEQ, HC_MULT, HIDDEN)
+    print(f"  [PASS] Forward pass correct for both layers")
+
+    mgr.close()
+    print("  [PASS] Manager closed without error")
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Test 3: End-to-end Engram + EngramStoreManager")
+    print("=" * 60)
+
+    test_with_store_manager()
+    test_without_store_manager()
+    test_multi_layer()
+
+    print("\n" + "=" * 60)
+    print("ALL PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/srt/engram/test_import_paths.py
+++ b/test/srt/engram/test_import_paths.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Test 1: Verify all import paths are correct after restructuring.
+
+Usage:
+    python test/srt/engram/test_import_paths.py
+"""
+from __future__ import annotations
+
+import sys
+import traceback
+
+
+def _check(label: str, fn):
+    try:
+        fn()
+        print(f"  [PASS] {label}")
+        return True
+    except Exception as e:
+        print(f"  [FAIL] {label}: {e}")
+        traceback.print_exc()
+        return False
+
+
+def main() -> None:
+    results = []
+    print("=" * 60)
+    print("Test 1: Import path verification")
+    print("=" * 60)
+
+    # --- mem_cache.engram package ---
+    print("\n[mem_cache.engram]")
+    results.append(
+        _check(
+            "EngramStore, EngramStoreConfig",
+            lambda: __import__(
+                "sglang.srt.mem_cache.engram",
+                fromlist=["EngramStore", "EngramStoreConfig"],
+            ),
+        )
+    )
+    results.append(
+        _check(
+            "EngramStoreManager + global accessors",
+            lambda: __import__(
+                "sglang.srt.mem_cache.engram",
+                fromlist=[
+                    "EngramStoreManager",
+                    "get_global_engram_store_manager",
+                    "set_global_engram_store_manager",
+                ],
+            ),
+        )
+    )
+    results.append(
+        _check(
+            "LocalEngramStore",
+            lambda: __import__(
+                "sglang.srt.mem_cache.engram.local_engram_store",
+                fromlist=["LocalEngramStore"],
+            ),
+        )
+    )
+    results.append(
+        _check(
+            "engram_store_manager module",
+            lambda: __import__(
+                "sglang.srt.mem_cache.engram.engram_store_manager",
+                fromlist=[
+                    "EngramStoreManager",
+                    "get_global_engram_store_manager",
+                    "set_global_engram_store_manager",
+                    "close_global_engram_store_manager",
+                ],
+            ),
+        )
+    )
+
+    # --- models.engram package ---
+    print("\n[models.engram]")
+    results.append(
+        _check(
+            "Engram, backbone_config, engram_cfg",
+            lambda: __import__(
+                "sglang.srt.models.engram.engram",
+                fromlist=["Engram", "backbone_config", "engram_cfg"],
+            ),
+        )
+    )
+    results.append(
+        _check(
+            "EngramConfig, BackBoneConfig",
+            lambda: __import__(
+                "sglang.srt.models.engram.engram",
+                fromlist=["EngramConfig", "BackBoneConfig"],
+            ),
+        )
+    )
+    results.append(
+        _check(
+            "engram module (for engram_mod pattern)",
+            lambda: __import__("sglang.srt.models.engram", fromlist=["engram"]),
+        )
+    )
+
+    # --- cross-package: qwen2.py ---
+    print("\n[models.qwen2 -> engram integration]")
+    results.append(
+        _check(
+            "Qwen2MoelEngram class",
+            lambda: __import__("sglang.srt.models.qwen2", fromlist=["Qwen2MoelEngram"]),
+        )
+    )
+
+    # --- summary ---
+    passed = sum(results)
+    total = len(results)
+    print("\n" + "=" * 60)
+    if passed == total:
+        print(f"ALL PASSED ({passed}/{total})")
+    else:
+        print(f"FAILED: {total - passed}/{total} checks failed")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/srt/engram/test_local_store_manager.py
+++ b/test/srt/engram/test_local_store_manager.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Test 2: Verify LocalEngramStore works correctly through EngramStoreManager.
+
+Tests the full lifecycle: create manager -> get_or_create_store -> put_sharded
+-> get_one -> get_many -> close.
+
+Usage:
+    python test/srt/engram/test_local_store_manager.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import torch
+
+from sglang.srt.mem_cache.engram import EngramStoreConfig, EngramStoreManager
+from sglang.srt.mem_cache.engram.local_engram_store import LocalEngramStore
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Test 2: LocalEngramStore via EngramStoreManager")
+    print("=" * 60)
+
+    vocab_size = 2048
+    embedding_dim = 64
+    layer_ids = [1, 15]
+
+    cfg = EngramStoreConfig(store_backend="local", layer_ids=layer_ids)
+    mgr = EngramStoreManager(cfg)
+    print(f"  Created EngramStoreManager with backend='local', layers={layer_ids}")
+
+    # --- create stores for both layers ---
+    stores = {}
+    for lid in layer_ids:
+        s = mgr.get_or_create_store(
+            layer_id=lid, vocab_size=vocab_size, embedding_dim=embedding_dim
+        )
+        assert isinstance(
+            s, LocalEngramStore
+        ), f"Expected LocalEngramStore, got {type(s).__name__}"
+        stores[lid] = s
+    print("  [PASS] get_or_create_store returns LocalEngramStore for each layer")
+
+    # --- idempotency ---
+    for lid in layer_ids:
+        s2 = mgr.get_or_create_store(
+            layer_id=lid, vocab_size=vocab_size, embedding_dim=embedding_dim
+        )
+        assert s2 is stores[lid], "get_or_create_store must return the same object"
+    print("  [PASS] get_or_create_store is idempotent (same object)")
+
+    # --- put_sharded + get_many + get_one ---
+    vocab_table = torch.arange(vocab_size * embedding_dim, dtype=torch.float16).view(
+        vocab_size, embedding_dim
+    )
+    device = torch.device("cpu")
+
+    for lid in layer_ids:
+        store = stores[lid]
+        store.put_sharded(vocab_table)
+
+        indices = torch.tensor([0, 1, 42, 100, 999, vocab_size - 1], dtype=torch.long)
+        result = store.get_many(indices, layer_id=lid, device=device)
+        expected = vocab_table[indices]
+        assert torch.equal(result, expected), f"get_many mismatch on layer {lid}"
+
+        for idx in [0, 42, vocab_size - 1]:
+            single = store.get_one(idx, layer_id=lid, device=device)
+            assert torch.equal(
+                single, vocab_table[idx]
+            ), f"get_one mismatch on layer {lid}, index {idx}"
+
+    print(f"  [PASS] put_sharded / get_many / get_one correct for all layers")
+
+    # --- get_one out-of-range returns zeros ---
+    zero_vec = stores[1].get_one(-1, layer_id=1, device=device)
+    assert torch.equal(
+        zero_vec, torch.zeros(embedding_dim, dtype=torch.float16)
+    ), "OOB get_one should return zeros"
+    zero_vec = stores[1].get_one(vocab_size + 100, layer_id=1, device=device)
+    assert torch.equal(
+        zero_vec, torch.zeros(embedding_dim, dtype=torch.float16)
+    ), "OOB get_one should return zeros"
+    print("  [PASS] get_one out-of-range returns zero vector")
+
+    # --- global accessor ---
+    from sglang.srt.mem_cache.engram import (
+        close_global_engram_store_manager,
+        get_global_engram_store_manager,
+        set_global_engram_store_manager,
+    )
+
+    assert get_global_engram_store_manager() is None, "Global should start as None"
+    set_global_engram_store_manager(mgr)
+    assert get_global_engram_store_manager() is mgr, "Global should be our manager"
+    close_global_engram_store_manager()
+    assert (
+        get_global_engram_store_manager() is None
+    ), "Global should be None after close"
+    print("  [PASS] global accessor set/get/close lifecycle correct")
+
+    print("\n" + "=" * 60)
+    print("ALL PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

[Engram](https://arxiv.org/pdf/2601.07372) is a conditional memory mechanism for LLMs that augments Transformer inference with n-gram hash-based embedding lookups. Its massive embedding tables exhibit sparse access patterns and are well-suited for offloading to lower-tier memory.

This PR integrates the Engram module into SGLang, with a clean separation between the model-computation side and the storage side. It also introduces prototype support for Qwen2 and Qwen3 models with Engram enabled (currently implements the architectural compute flow rather than a full model for performance simulation and infrastructure validation). It provides pluggable storage backends to store Engram embeddings in local DRAM.

Relates to #19907

This PR provides the initial infrastructure for Engram in SGLang. The current implementation performs the computation part of Engram primarily on the GPU, while storing the massive embedding tables in DRAM.

## Modifications

### New: `python/sglang/srt/mem_cache/engram/` — storage side

A new package that manages Engram embedding tables independently of the KV cache. Engram stores are **not** KV cache backends; they run alongside whatever HiCache backend is configured.

- **`engram_store.py`** — `EngramStore` abstract base class (`put_sharded`, `get_one`, `get_many`, `close`) and `EngramStoreConfig`.
- **`local_engram_store.py`** — Default backend: CPU DRAM tensors, no external dependencies.
- **`engram_store_manager.py`** — `EngramStoreManager`: a per-process registry and lazy factory for per-layer `EngramStore` instances, with global singleton accessors (`get/set/close_global_engram_store_manager`).

### New: `python/sglang/srt/models/engram/` — computation side

- **`engram.py`** — Core Engram module: `NgramHashMapping` (prime-modulo n-gram hashing, NumPy + Torch paths), `MultiHeadEmbedding` (multi-head embedding lookup via `EngramStore`), `Engram` (gating, value projection, short depthwise convolution, async CUDA-stream prefetch), and `ShortConv`. Also defines `EngramConfig` and `BackBoneConfig` global config objects.
- **`triton_ops/engram_triton.py`** — Optional fused Triton kernels for gate-value computation, grouped RMSNorm, and short-conv preprocessing (activated via `ENGRAM_TRITON=1`).

### Modified: `python/sglang/srt/models/qwen2.py`

- Added `Qwen2MoelEngram` — a `Qwen2Model` subclass that injects `Engram` modules at configured layer IDs, initialises the global `EngramStoreManager`, and runs async embedding prefetch before each forward pass.

### Modified: `python/sglang/srt/models/qwen3.py`

- Added `Qwen3ModelEngram` (inherits `Qwen2MoelEngram`) and `Qwen3ForCausalLM` opt-in via `ENABLE_ENGRAM=1|true`.

### New: `test/srt/engram/`

Three integration tests runnable via `python test/srt/engram/run_all_tests.py`:
1. **`test_import_paths.py`** — verifies all module import paths are resolvable.
2. **`test_local_store_manager.py`** — tests `LocalEngramStore` lifecycle through `EngramStoreManager` (put/get correctness, idempotency, global accessor).
3. **`test_engram_e2e.py`** — end-to-end forward pass with `EngramStoreManager`, backward compatibility (no manager), and multi-layer scenarios.

### New: `python/sglang/srt/mem_cache/engram/README.md`

Documents architecture, the storage backend with environment variable references and launch commands, quick start, configuration table, and a TODO list.

## Accuracy Tests

This PR introduces a new module that runs in parallel with the existing forward pass. The Engram output is currently added with a zero-coefficient (`engram_output.sum() * 0`) so it does not affect model logits. Existing model accuracy is therefore unchanged.

Integration correctness is verified by `test/srt/engram/run_all_tests.py`, which covers store put/get round-trips and end-to-end `Engram` forward pass shape correctness.

## Benchmarking and Profiling
**Experimental Setup:** Single L20 GPU, Batch Size = 256, Sequence Length = 512 tokens.

| Model | Baseline (tokens/s) | +Engram (DRAM) (tokens/s) | Performance Delta |
| :--- | :--- | :--- | :--- |
| **Qwen3-4B** | 6183.9 | 5683.7 | -8.09% |
| **Qwen3-8B** | 4185.6 | 3909.7 | -6.59% |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (`test/srt/engram/`)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (`mem_cache/engram/README.md`)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).