### PR TITLE
[Feature] SANA Model Improvement

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/sana.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/sana.py
@@ -5,8 +5,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.models.embeddings import PixArtAlphaTextProjection, TimestepEmbedding
 
+from sglang.jit_kernel.diffusion.triton.scale_shift import fuse_scale_shift_kernel
 from sglang.multimodal_gen.configs.models.dits.sana import SanaConfig
-from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
+from sglang.multimodal_gen.runtime.layers.elementwise import MulAdd
+from sglang.multimodal_gen.runtime.layers.layernorm import LayerNorm, RMSNorm
 from sglang.multimodal_gen.runtime.layers.visual_embedding import Timesteps
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
@@ -49,12 +51,12 @@ class SanaAdaLayerNormSingle(nn.Module):
 class SanaModulatedNorm(nn.Module):
     def __init__(self, dim, eps=1e-6):
         super().__init__()
-        self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=eps)
+        self.norm = LayerNorm(dim, elementwise_affine=False, eps=eps)
 
     def forward(self, x, temb, scale_shift_table):
         x = self.norm(x)
         shift, scale = (scale_shift_table[None] + temb[:, None]).chunk(2, dim=1)
-        x = x * (1 + scale) + shift
+        x = fuse_scale_shift_kernel(x, scale, shift)
         return x
 
 
@@ -196,7 +198,7 @@ class SanaTransformerBlock(nn.Module):
 
         self.scale_shift_table = nn.Parameter(torch.randn(6, dim) / dim**0.5)
 
-        self.norm1 = nn.LayerNorm(dim, elementwise_affine=False, eps=norm_eps)
+        self.norm1 = LayerNorm(dim, elementwise_affine=False, eps=norm_eps)
         self.attn1 = SanaLinearAttention(
             query_dim=dim,
             num_heads=num_attention_heads,
@@ -205,7 +207,7 @@ class SanaTransformerBlock(nn.Module):
             bias=attention_bias,
         )
 
-        self.norm2 = nn.LayerNorm(dim, elementwise_affine=False, eps=norm_eps)
+        self.norm2 = LayerNorm(dim, elementwise_affine=False, eps=norm_eps)
         self.attn2 = SanaCrossAttention(
             query_dim=dim,
             cross_attention_dim=cross_attention_dim,
@@ -215,6 +217,8 @@ class SanaTransformerBlock(nn.Module):
         )
 
         self.ff = GLUMBConv(in_channels=dim, out_channels=dim, expand_ratio=mlp_ratio)
+
+        self.fuse_mul_add = MulAdd()
 
     def forward(
         self,
@@ -232,9 +236,9 @@ class SanaTransformerBlock(nn.Module):
         ).chunk(6, dim=1)
 
         norm_hidden = self.norm1(hidden_states)
-        norm_hidden = norm_hidden * (1 + scale_msa) + shift_msa
+        norm_hidden = fuse_scale_shift_kernel(norm_hidden, scale_msa, shift_msa)
         attn_output = self.attn1(norm_hidden)
-        hidden_states = hidden_states + gate_msa * attn_output
+        hidden_states = self.fuse_mul_add(attn_output, gate_msa, hidden_states, k=0)
 
         attn_output = self.attn2(
             hidden_states, encoder_hidden_states, encoder_attention_mask
@@ -242,11 +246,11 @@ class SanaTransformerBlock(nn.Module):
         hidden_states = hidden_states + attn_output
 
         norm_hidden = self.norm2(hidden_states)
-        norm_hidden = norm_hidden * (1 + scale_mlp) + shift_mlp
+        norm_hidden = fuse_scale_shift_kernel(norm_hidden, scale_mlp, shift_mlp)
         norm_hidden = norm_hidden.unflatten(1, (height, width)).permute(0, 3, 1, 2)
         ff_output = self.ff(norm_hidden)
         ff_output = ff_output.flatten(2, 3).permute(0, 2, 1)
-        hidden_states = hidden_states + gate_mlp * ff_output
+        hidden_states = self.fuse_mul_add(ff_output, gate_mlp, hidden_states, k=0)
 
         return hidden_states
 
@@ -333,7 +337,6 @@ class SanaTransformer2DModel(CachableDiT, OffloadableDiTMixin):
         **kwargs,
     ) -> torch.Tensor:
 
-        # Input validation - fail fast
         if encoder_hidden_states is None:
             raise ValueError("SANA forward pass requires encoder_hidden_states")
 

--- a/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
@@ -244,9 +244,7 @@ class Gemma2DecoderLayer(nn.Module):
             prefix=f"{prefix}.mlp",
         )
         self.input_layernorm = RMSNorm(self.hidden_size, eps=arch.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(
-            self.hidden_size, eps=arch.rms_norm_eps
-        )
+        self.post_attention_layernorm = RMSNorm(self.hidden_size, eps=arch.rms_norm_eps)
         self.pre_feedforward_layernorm = RMSNorm(
             self.hidden_size, eps=arch.rms_norm_eps
         )

--- a/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
@@ -24,6 +24,7 @@ from sglang.multimodal_gen.configs.models.encoders.base import BaseEncoderOutput
 from sglang.multimodal_gen.configs.models.encoders.gemma2 import Gemma2Config
 from sglang.multimodal_gen.runtime.distributed import get_tp_world_size
 from sglang.multimodal_gen.runtime.layers.activation import GeluAndMul
+from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
 from sglang.multimodal_gen.runtime.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -37,21 +38,6 @@ from sglang.multimodal_gen.runtime.layers.vocab_parallel_embedding import (
 from sglang.multimodal_gen.runtime.loader.weight_utils import default_weight_loader
 
 logger = logging.getLogger(__name__)
-
-
-class Gemma2RMSNorm(nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.zeros(dim))
-
-    def _norm(self, x):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
-
-    def forward(self, x):
-        output = self._norm(x.float())
-        output = output * (1.0 + self.weight.float())
-        return output.type_as(x)
 
 
 class Gemma2MLP(nn.Module):
@@ -257,14 +243,14 @@ class Gemma2DecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",
         )
-        self.input_layernorm = Gemma2RMSNorm(self.hidden_size, eps=arch.rms_norm_eps)
-        self.post_attention_layernorm = Gemma2RMSNorm(
+        self.input_layernorm = RMSNorm(self.hidden_size, eps=arch.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
             self.hidden_size, eps=arch.rms_norm_eps
         )
-        self.pre_feedforward_layernorm = Gemma2RMSNorm(
+        self.pre_feedforward_layernorm = RMSNorm(
             self.hidden_size, eps=arch.rms_norm_eps
         )
-        self.post_feedforward_layernorm = Gemma2RMSNorm(
+        self.post_feedforward_layernorm = RMSNorm(
             self.hidden_size, eps=arch.rms_norm_eps
         )
 
@@ -321,7 +307,7 @@ class Gemma2Model(nn.Module):
             ]
         )
 
-        self.norm = Gemma2RMSNorm(arch.hidden_size, eps=arch.rms_norm_eps)
+        self.norm = RMSNorm(arch.hidden_size, eps=arch.rms_norm_eps)
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids) * self.embed_scale
@@ -415,8 +401,15 @@ class Gemma2Model(nn.Module):
                 if name not in params_dict:
                     continue
                 param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
+                # Gemma2 RMSNorm uses (1+weight) with zeros init; sglang RMSNorm uses
+                # weight with ones init. Transform: sglang.weight = 1 + hf.weight
+                if name.endswith("layernorm.weight") or name == "norm.weight":
+                    param.data.copy_((loaded_weight + 1.0).to(param.dtype))
+                else:
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
 
             loaded_params.add(name)
         return loaded_params

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -1097,13 +1097,18 @@ class DenoisingStage(PipelineStage):
                             trajectory_timesteps.append(t_host)
                             trajectory_latents.append(latents)
 
-                        # Update progress bar
+                        # Update progress bar (add scheduler.order per update so total
+                        # reaches num_inference_steps; e.g. DPM-Solver order=2 -> 10*2=20)
                         if i == num_timesteps - 1 or (
                             (i + 1) > num_warmup_steps
                             and (i + 1) % self.scheduler.order == 0
                             and progress_bar is not None
                         ):
-                            progress_bar.update()
+                            n = min(
+                                self.scheduler.order,
+                                num_inference_steps - progress_bar.n,
+                            )
+                            progress_bar.update(n)
 
                         if not is_warmup:
                             self.step_profile()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_av.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_av.py
@@ -612,13 +612,18 @@ class LTX2AVDenoisingStage(DenoisingStage):
                             if audio_latents is not None:
                                 trajectory_audio_latents.append(audio_latents)
 
-                        # Update progress bar
+                        # Update progress bar (add scheduler.order per update so total
+                        # reaches num_inference_steps; e.g. DPM-Solver order=2 -> 10*2=20)
                         if i == num_timesteps - 1 or (
                             (i + 1) > num_warmup_steps
                             and (i + 1) % self.scheduler.order == 0
                             and progress_bar is not None
                         ):
-                            progress_bar.update()
+                            n = min(
+                                self.scheduler.order,
+                                num_inference_steps - progress_bar.n,
+                            )
+                            progress_bar.update(n)
 
                         if not is_warmup:
                             self.step_profile()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
@@ -193,13 +193,18 @@ class DmdDenoisingStage(DenoisingStage):
                         else:
                             latents = pred_video
 
-                        # Update progress bar
+                        # Update progress bar (add scheduler.order per update so total
+                        # reaches len(timesteps); e.g. DPM-Solver order=2 -> 10*2=20)
                         if i == len(timesteps) - 1 or (
                             (i + 1) > num_warmup_steps
                             and (i + 1) % self.scheduler.order == 0
                             and progress_bar is not None
                         ):
-                            progress_bar.update()
+                            n = min(
+                                self.scheduler.order,
+                                len(timesteps) - progress_bar.n,
+                            )
+                            progress_bar.update(n)
 
                     self.step_profile()
 


### PR DESCRIPTION
Related PR: #19234 

## Motivation

Improve SANA text-to-image inference performance via fused kernel optimizations and fix the denoising progress bar display for high-order schedulers (e.g., DPM-Solver++).

## Modifications

### SANA DiT (sana.py)
- Replace `nn.LayerNorm` with sglang `LayerNorm` for Triton fast path
- Use `fuse_scale_shift_kernel` for AdaLN modulation (`norm * (1+scale) + shift`)
- Use `MulAdd` for fused `gate*attn_output + residual`

### Gemma2 text encoder (gemma2.py)
- Replace `Gemma2RMSNorm` with sglang `RMSNorm` for Triton/CUDA fused path
- Add weight transform `1 + loaded_weight` in `load_weights` for HF checkpoint compatibility

### Denoising progress bar (denoising.py, denoising_av.py, denoising_dmd.py)
- Update progress bar by `scheduler.order` instead of 1 so it reaches total (e.g., 20/20)
- Fixes DPM-Solver++ (order=2) showing 10/20 instead of 20/20

## Accuracy Tests

No change to model outputs; kernel fusion preserves numerical behavior. Existing SANA checkpoints load correctly with the Gemma2 weight transform.

## Benchmarking and Profiling

Benchmarking is worked on A100 (40GB).

| Type | Baseline | Optimized | Improvement |
|------|----------|-----------|-------------|
| Cold latency | 20.299s | 21.310s | — |
| Warm latency (mean) | 2.969s ± 0.010s | 2.817s ± 0.015s | **−0.152s (−5.1%)** |
| Warm latency (median) | 2.966s | 2.813s | **−5.2%** |
| Warm latency (min) | 2.957s | 2.805s | — |
| Warm latency (max) | 2.983s | 2.843s | — |
| GPU Memory | 15,396 MB | 15,396 MB | — |

> Warm benchmark: 5 sequential requests after 2 warmup requests.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).