### PR TITLE
Remove is_dynamo_compiling() workaround in norm dispatch (#20246)

### DIFF
--- a/sgl-kernel/python/sgl_kernel/elementwise.py
+++ b/sgl-kernel/python/sgl_kernel/elementwise.py
@@ -105,19 +105,10 @@ def rmsnorm(
     output: torch.Tensor
         Normalized tensor, shape (batch_size, hidden_size).
     """
-    # torch.compiler.is_dynamo_compiling(): FlashInfer norm paths are not safe under
-    # torch.compile(..., fullgraph=True). Dynamo traces into FlashInfer's JIT module
-    # loading path, which calls Path.exists() / os.stat() — both untraceable — causing
-    # the entire compilation to fail. We fall back to the internal implementation while
-    # tracing as a temporary workaround. Once the upstream fix is merged and we upgrade
-    # FlashInfer, this check can be removed.
-    # See: https://github.com/flashinfer-ai/flashinfer/issues/2734
-    #      https://github.com/flashinfer-ai/flashinfer/pull/2733
     if (
         input.device.type == "musa"
         or not _has_flashinfer
         or input.dtype not in _FLASHINFER_NORM_SUPPORTED_DTYPES
-        or torch.compiler.is_dynamo_compiling()
     ):
         return _rmsnorm_internal(input, weight, eps, out, enable_pdl)
     else:
@@ -154,12 +145,10 @@ def fused_add_rmsnorm(
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
         If None, will be automatically enabled on Hopper architecture.
     """
-    # See is_dynamo_compiling() comment in rmsnorm() above.
     if (
         input.device.type == "musa"
         or not _has_flashinfer
         or input.dtype not in _FLASHINFER_NORM_SUPPORTED_DTYPES
-        or torch.compiler.is_dynamo_compiling()
     ):
         _fused_add_rmsnorm_internal(input, residual, weight, eps, enable_pdl)
     else:
@@ -197,12 +186,10 @@ def gemma_rmsnorm(
     output: torch.Tensor
         Gemma Normalized tensor, shape (batch_size, hidden_size).
     """
-    # See is_dynamo_compiling() comment in rmsnorm() above.
     if (
         input.device.type == "musa"
         or not _has_flashinfer
         or input.dtype not in _FLASHINFER_NORM_SUPPORTED_DTYPES
-        or torch.compiler.is_dynamo_compiling()
     ):
         return _gemma_rmsnorm_internal(input, weight, eps, out, enable_pdl)
     else:
@@ -239,12 +226,10 @@ def gemma_fused_add_rmsnorm(
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
         If None, will be automatically enabled on Hopper architecture.
     """
-    # See is_dynamo_compiling() comment in rmsnorm() above.
     if (
         input.device.type == "musa"
         or not _has_flashinfer
         or input.dtype not in _FLASHINFER_NORM_SUPPORTED_DTYPES
-        or torch.compiler.is_dynamo_compiling()
     ):
         _gemma_fused_add_rmsnorm_internal(input, residual, weight, eps, enable_pdl)
     else:


### PR DESCRIPTION
Remove `is_dynamo_compiling()` guard from norm dispatch functions.
No longer needed after upstream FlashInfer fix (flashinfer-ai/flashinfer#2733).

Closes #20246