### PR TITLE
Revert "[Scheduler] Decouple `maybe_send_health_check_signal` from `process_batch_result`"

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -980,8 +980,6 @@ class SchedulerDisaggregationDecodeMixin:
             # Update last_batch
             self.last_batch = batch
 
-            self.maybe_send_health_check_signal()
-
     @torch.no_grad()
     def event_loop_overlap_disagg_decode(self: Scheduler):
         self.result_queue = deque()
@@ -1018,8 +1016,6 @@ class SchedulerDisaggregationDecodeMixin:
 
             # Update last_batch
             self.last_batch = batch
-
-            self.maybe_send_health_check_signal()
 
     def _run_batch_prebuilt(
         self: Scheduler, batch: ScheduleBatch

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -381,8 +381,6 @@ class SchedulerDisaggregationPrefillMixin:
             # Update last_batch
             self.last_batch = batch
 
-            self.maybe_send_health_check_signal()
-
     @torch.no_grad()
     def event_loop_overlap_disagg_prefill(self: Scheduler) -> None:
         self.result_queue = deque()
@@ -422,8 +420,6 @@ class SchedulerDisaggregationPrefillMixin:
 
             # Update last_batch
             self.last_batch = batch
-
-            self.maybe_send_health_check_signal()
 
     def process_batch_result_disagg_prefill(
         self: Scheduler,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1259,8 +1259,6 @@ class Scheduler(
 
             # Update last_batch
             self.last_batch = batch
-
-            self.maybe_send_health_check_signal()
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
 
@@ -1316,8 +1314,6 @@ class Scheduler(
 
             # Update last_batch
             self.last_batch = batch
-
-            self.maybe_send_health_check_signal()
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.self_check_during_busy()
 
@@ -2621,6 +2617,7 @@ class Scheduler(
 
         self.log_batch_result_stats(batch, result)
         self._maybe_clear_mm_inputs(batch)
+        self.maybe_send_health_check_signal()
 
     def maybe_send_health_check_signal(self):
         if self.return_health_check_ct:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -139,8 +139,6 @@ class SchedulerPPMixin:
 
                 self.pp_outputs = next_pp_outputs
 
-            self.maybe_send_health_check_signal()
-
             # When the server is idle, self-check and re-init some states
             if server_is_idle:
                 self.self_check_during_idle()
@@ -315,8 +313,6 @@ class SchedulerPPMixin:
                 consensus_bootstrapped_rids = next_consensus_bootstrapped_rids
 
                 self.running_batch.batch_is_full = False
-
-            self.maybe_send_health_check_signal()
 
             # When the server is idle, self-check and re-init some states
             if server_is_idle and len(self.disagg_prefill_inflight_queue) == 0:
@@ -507,8 +503,6 @@ class SchedulerPPMixin:
             )
             if self.server_args.disaggregation_decode_enable_offload_kvcache:
                 queue_size += len(self.decode_offload_manager.ongoing_offload)
-
-            self.maybe_send_health_check_signal()
 
             if server_is_idle and queue_size == 0:
                 self.self_check_during_idle()

--- a/python/sglang/srt/multiplex/multiplexing_mixin.py
+++ b/python/sglang/srt/multiplex/multiplexing_mixin.py
@@ -219,5 +219,3 @@ class SchedulerMultiplexMixin:
                         self.split_prefill_batch = None
                         wait_prefill_kernel_done = False
                         adjust_stream_group = True
-
-            self.maybe_send_health_check_signal()


### PR DESCRIPTION
Reverts sgl-project/sglang#20227

In SGLang, we define a server as "healthy" when the GPU works well, which means, when we send a health check request:
- When the server is totally idle, we should run this request to test the GPU's health.
- When the server is not idle (has running requests or waiting requests), there should be at least one batch output.

So the `maybe_send_health_check_signal` should be coupled with batch result processing.

The PR to be reverted cannot guarantee when there are requests stuck in the waiting queue.