### PR TITLE
Fix port overflow in DP attention path when base port is near 65535

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7953,13 +7953,28 @@ class PortArgs:
         else:
             # DP attention. Use TCP + port to handle both single-node and multi-node.
             if server_args.nnodes == 1 and server_args.dist_init_addr is None:
-                na = NetworkAddress("127.0.0.1", server_args.port + ZMQ_TCP_PORT_DELTA)
+                derived_port = server_args.port + ZMQ_TCP_PORT_DELTA
+                if derived_port > 65535:
+                    derived_port = server_args.port - ZMQ_TCP_PORT_DELTA
+                na = NetworkAddress("127.0.0.1", derived_port)
             else:
                 na = NetworkAddress.parse(server_args.dist_init_addr)
 
             dist_init_host = na.host
             dist_init_port = na.port
-            port_base = dist_init_port + 1
+
+            # We need 5 consecutive ports from port_base for:
+            # port_base, detokenizer, rpc, metrics, scheduler.
+            # In multi-node, all nodes derive ports independently from
+            # dist_init_port, so the derivation must be deterministic
+            # (no availability-based search). If incrementing would
+            # overflow the valid TCP range, decrement instead.
+            NUM_DERIVED_PORTS = 5
+            if dist_init_port + NUM_DERIVED_PORTS > 65535:
+                port_base = dist_init_port - NUM_DERIVED_PORTS - 1
+            else:
+                port_base = dist_init_port + 1
+
             detokenizer_port = port_base + 1
             rpc_port = port_base + 2
             metrics_port = port_base + 3

--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -49,9 +49,19 @@ def find_process_using_port(port: int) -> Optional[psutil.Process]:
     return None
 
 
+MAX_VALID_PORT = 65535
+
+
 def wait_port_available(
     port: int, port_name: str, timeout_s: int = 30, raise_exception: bool = True
 ) -> bool:
+    if port < 0 or port > MAX_VALID_PORT:
+        raise ValueError(
+            f"{port_name} has invalid port number {port}. "
+            f"Valid TCP port range is 0-{MAX_VALID_PORT}."
+        )
+
+    error_message = f"{port_name} at {port} is not available"
     for i in range(timeout_s):
         if is_port_available(port):
             return True
@@ -62,12 +72,12 @@ def wait_port_available(
                 logger.warning(
                     f"The port {port} is in use, but we could not find the process that uses it."
                 )
-
-            pid = process.pid
-            error_message = f"{port_name} is used by a process already. {process.name()=}' {process.cmdline()=} {process.status()=} {pid=}"
-            logger.info(
-                f"port {port} is in use. Waiting for {i} seconds for {port_name} to be available. {error_message}"
-            )
+            else:
+                pid = process.pid
+                error_message = f"{port_name} is used by a process already. {process.name()=}' {process.cmdline()=} {process.status()=} {pid=}"
+                logger.info(
+                    f"port {port} is in use. Waiting for {i} seconds for {port_name} to be available. {error_message}"
+                )
         time.sleep(0.1)
 
     if raise_exception:


### PR DESCRIPTION
## Motivation

When using `--enable-dp-attention` with a high base port (e.g., assigned by SLURM near 65535), SGLang derives TCP ports by incrementing from the dist-init port (`port_base + 1` through `port_base + 4`). These derived ports can exceed the valid TCP range (0–65535), causing crashes with `AttributeError: 'NoneType' object has no attribute 'pid'`.

This is a follow-up to PR #2826 which fixed a similar overflow in the non-DP path. The non-DP path has since been rewritten to use IPC, but the DP attention path still uses TCP ports with arithmetic offsets and no bounds checking.

Fixes #20257

## Modifications

**`python/sglang/srt/server_args.py`**:
- Single-node DP: Use `port - ZMQ_TCP_PORT_DELTA` instead of `port + ZMQ_TCP_PORT_DELTA` when the sum would exceed 65535 (same decrement approach as #2826)
- Multi-node DP: When `dist_init_port + NUM_DERIVED_PORTS > 65535`, derive `port_base` by decrementing instead of incrementing. The derivation stays deterministic so all nodes agree on the same ports without communication.

**`python/sglang/srt/utils/common.py`**:
- Add upfront port range validation in `wait_port_available()` — invalid ports now get a clear `ValueError` instead of cryptic crashes
- Fix bug where `find_process_using_port()` returning `None` causes `AttributeError: 'NoneType' object has no attribute 'pid'` (the `process.pid` access was outside the null check's `else` branch)
- Initialize `error_message` before the loop to avoid `UnboundLocalError` when the timeout is hit without entering the logging branch

## Accuracy Tests

N/A — this change only affects port allocation logic, not model outputs.

## Benchmarking and Profiling

N/A — this change only affects port allocation at startup, not inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26878668473](https://github.com/sgl-project/sglang/actions/runs/26878668473)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26878668181](https://github.com/sgl-project/sglang/actions/runs/26878668181)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->