### PR TITLE
Fix predict.fill_(100) decode hang on byte-token models (#20154)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -190,6 +190,10 @@ from sglang.srt.observability.trace import process_tracing_init, trace_set_threa
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import (
+    SIMULATE_ACC_LEN,
+    set_simulate_safe_token_id,
+)
 from sglang.srt.utils import (
     DynamicGradMode,
     broadcast_pyobj,
@@ -354,6 +358,11 @@ class Scheduler(
 
         # Init tokenizer
         self.init_tokenizer()
+
+        # Set a safe token ID for SIMULATE_ACC_LEN benchmarking mode.
+        # Must happen after tokenizer init so we can encode a known-safe string.
+        if SIMULATE_ACC_LEN > 0 and self.tokenizer is not None:
+            set_simulate_safe_token_id(self.tokenizer)
 
         # Init moe config and GEMM config (FP8 GEMM, etc.)
         self.init_moe_gemm_config()

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -46,6 +46,12 @@ logger = logging.getLogger(__name__)
 SIMULATE_ACC_LEN = envs.SGLANG_SIMULATE_ACC_LEN.get()  # turn off if < 0
 SIMULATE_ACC_METHOD = envs.SGLANG_SIMULATE_ACC_METHOD.get()
 
+# Safe token ID used by SIMULATE_ACC_LEN to fill predicted tokens.
+# Must decode cleanly (no replacement char) and not be an EOS token.
+# Initialized via set_simulate_safe_token_id() from the scheduler once the
+# tokenizer is available.  Falls back to 0 if never set.
+_SIMULATE_SAFE_TOKEN_ID: int = 0
+
 TREE_TRAVERSE_TIME_THRESHOLD = 1  # TODO: set this properly
 TREE_SPEC_KERNEL_AVAILABLE = _is_cuda  # This kernel is only available for CUDA now
 
@@ -56,6 +62,31 @@ def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
 
     # TODO(lsyin): also skip when 1) step = 1 or 2) standalone draft model
     return not server_args.enable_multi_layer_eagle
+
+
+def set_simulate_safe_token_id(tokenizer) -> None:
+    """Compute a token ID that decodes cleanly for SIMULATE_ACC_LEN mode.
+
+    Encodes the ASCII character "d" through the tokenizer and uses the
+    first resulting token ID.  This avoids byte-token models (e.g. Kimi-K2.5)
+    where low IDs (0-255) decode to replacement characters, stalling the
+    detokenizer.
+    """
+    global _SIMULATE_SAFE_TOKEN_ID
+    try:
+        ids = tokenizer.encode("d", add_special_tokens=False)
+        if ids:
+            _SIMULATE_SAFE_TOKEN_ID = ids[0]
+            logger.info(
+                "SIMULATE_ACC_LEN safe token ID set to %d", _SIMULATE_SAFE_TOKEN_ID
+            )
+    except Exception as e:
+        logger.warning(
+            "Failed to compute safe token ID for SIMULATE_ACC_LEN, "
+            "falling back to %d: %s",
+            _SIMULATE_SAFE_TOKEN_ID,
+            e,
+        )
 
 
 @triton.jit
@@ -563,7 +594,7 @@ def generate_simulated_accept_index(
         simulate_acc_len, device=accept_index.device
     )
     accept_length.fill_(simulate_acc_len - 1)
-    predict.fill_(100)  # some legit token id
+    predict.fill_(_SIMULATE_SAFE_TOKEN_ID)
     return sim_accept_index
 
 


### PR DESCRIPTION
Use tokenizer-derived safe token ID instead of hardcoded 100, which causes
detokenizer hangs on byte-token models like Kimi-K2.5.

Closes #20154