### PR TITLE
Add Glm5ThinkingBudgetLogitProcessor for GLM-5 thinking budget support

### DIFF
--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -112,20 +112,24 @@ class ThinkingBudgetLogitProcessor(CustomLogitProcessor):
         return logits
 
 
-class Glm4MoeThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
+class GlmThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
+    """Base logit processor for GLM models with shared NEW_LINE_TOKEN_ID."""
+
+    NEW_LINE_TOKEN_ID: int = 198
+
+
+class Glm4MoeThinkingBudgetLogitProcessor(GlmThinkingBudgetLogitProcessor):
     """A logit processor that controls the length of thinking for GLM-4.5 / GLM-4.6 / GLM-4.5V / GLM-4.6V models."""
 
     THINKING_START_TOKEN_ID: int = 151350
     THINKING_END_TOKEN_ID: int = 151351
-    NEW_LINE_TOKEN_ID: int = 198
 
 
-class Glm5ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
+class Glm5ThinkingBudgetLogitProcessor(GlmThinkingBudgetLogitProcessor):
     """A logit processor that controls the length of thinking for GLM-5 models."""
 
     THINKING_START_TOKEN_ID: int = 154841
     THINKING_END_TOKEN_ID: int = 154842
-    NEW_LINE_TOKEN_ID: int = 198
 
 
 class Qwen3ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):

--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -120,6 +120,14 @@ class Glm4MoeThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
     NEW_LINE_TOKEN_ID: int = 198
 
 
+class Glm5ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
+    """A logit processor that controls the length of thinking for GLM-5 models."""
+
+    THINKING_START_TOKEN_ID: int = 154841
+    THINKING_END_TOKEN_ID: int = 154842
+    NEW_LINE_TOKEN_ID: int = 198
+
+
 class Qwen3ThinkingBudgetLogitProcessor(ThinkingBudgetLogitProcessor):
     """A logit processor that controls the length of thinking for Qwen3 models."""
 


### PR DESCRIPTION
## Motivation

Fixes #20274

GLM-5 models use a different tokenizer vocabulary from GLM-4.5/4.6/4.7.
The special token IDs for `<think>` (154841 vs 151350) and `</think>`
(154842 vs 151351) have changed, causing `Glm4MoeThinkingBudgetLogitProcessor`
to silently fail on GLM-5.

## Modifications

Add `Glm5ThinkingBudgetLogitProcessor` in
`python/sglang/srt/sampling/custom_logit_processor.py` with GLM-5 specific
token IDs (THINKING_START=154841, THINKING_END=154842, NEW_LINE=198).

## Accuracy Tests

Verified with curl requests on GLM-5-FP8:

1. **With `Glm5ThinkingBudgetLogitProcessor` + `thinking_budget: 100`**:
   thinking content truncated at ~100 tokens with `\n</think>` termination.
2. **Without thinking_budget**: thinking content outputs fully.
3. **With `Glm4MoeThinkingBudgetLogitProcessor` on GLM-5** (negative test):
   thinking_budget silently fails due to token ID mismatch — this is the bug.

## Checklist

- [x] Format code with pre-commit
- [x] Follow SGLang code style guidance
