### PR TITLE
[Nemotron] Small reasoning parser fix

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -431,6 +431,7 @@ class Nemotron3Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         super().__init__(
             "<think>",
@@ -440,6 +441,13 @@ class Nemotron3Detector(BaseReasoningFormatDetector):
             continue_final_message=continue_final_message,
             previous_content=previous_content,
         )
+        self._force_nonempty_content = force_nonempty_content
+
+    def detect_and_parse(self, text: str) -> StreamingParseResult:
+        ret = super().detect_and_parse(text)
+        if self._force_nonempty_content and not ret.normal_text:
+            ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
+        return ret
 
 
 class ReasoningParser:
@@ -501,6 +509,10 @@ class ReasoningParser:
         ):
             kwargs["continue_final_message"] = True
             kwargs["previous_content"] = request.messages[-1].content
+
+        chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
+        if chat_template_kwargs.get("force_nonempty_content") is True:
+            kwargs["force_nonempty_content"] = True
 
         self.detector = detector_class(**kwargs)
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -6,6 +6,7 @@ from sglang.srt.parser.reasoning_parser import (
     Glm45Detector,
     KimiDetector,
     KimiK2Detector,
+    Nemotron3Detector,
     Qwen3Detector,
     ReasoningParser,
     StreamingParseResult,
@@ -510,6 +511,74 @@ class TestGlm45Detector(CustomTestCase):
         result = detector.detect_and_parse(text)
         self.assertEqual(result.reasoning_text, "More reasoning")
         self.assertEqual(result.normal_text, "<tool_call>tool call")
+
+
+class TestNemotron3Detector(CustomTestCase):
+    def setUp(self):
+        self.detector = Nemotron3Detector()
+
+    def test_init(self):
+        """Test Nemotron3Detector initialization."""
+        self.assertEqual(self.detector.think_start_token, "<think>")
+        self.assertEqual(self.detector.think_end_token, "</think>")
+        self.assertFalse(self.detector._in_reasoning)
+        self.assertTrue(self.detector.stream_reasoning)
+        self.assertFalse(self.detector._force_nonempty_content)
+
+    def test_detect_and_parse_complete_reasoning(self):
+        """Test parsing complete reasoning block."""
+        text = "<think>Let me think about this</think>The answer is 42."
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "Let me think about this")
+        self.assertEqual(result.normal_text, "The answer is 42.")
+
+    def test_detect_and_parse_no_thinking(self):
+        """Test parsing without thinking tokens."""
+        text = "Direct answer without thinking."
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, text)
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_detect_and_parse_reasoning_only(self):
+        """Test parsing when output is all reasoning (no content after </think>)."""
+        text = "<think>All reasoning, no answer</think>"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "All reasoning, no answer")
+        self.assertEqual(result.normal_text, "")
+
+    def test_force_nonempty_content_swaps_when_no_normal_text(self):
+        """Test force_nonempty_content swaps reasoning to content when content is empty."""
+        detector = Nemotron3Detector(force_nonempty_content=True)
+        text = "<think>All reasoning, no answer</think>"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, "All reasoning, no answer")
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_force_nonempty_content_no_swap_when_normal_text_exists(self):
+        """Test force_nonempty_content does not swap when content already exists."""
+        detector = Nemotron3Detector(force_nonempty_content=True)
+        text = "<think>Reasoning here</think>The answer is 42."
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "Reasoning here")
+        self.assertEqual(result.normal_text, "The answer is 42.")
+
+    def test_force_nonempty_content_truncated_reasoning(self):
+        """Test force_nonempty_content with truncated reasoning (no end token)."""
+        detector = Nemotron3Detector(force_nonempty_content=True)
+        text = "<think>Truncated reasoning without end token"
+        result = detector.detect_and_parse(text)
+        # Truncated reasoning has no normal_text, so swap should occur
+        self.assertEqual(result.normal_text, "Truncated reasoning without end token")
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_force_nonempty_content_no_thinking_tokens(self):
+        """Test force_nonempty_content with plain text (no thinking tokens)."""
+        detector = Nemotron3Detector(force_nonempty_content=True)
+        text = "Plain text without any thinking."
+        result = detector.detect_and_parse(text)
+        # Normal text already exists, no swap needed
+        self.assertEqual(result.normal_text, text)
+        self.assertEqual(result.reasoning_text, "")
 
 
 class TestReasoningParser(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
There are code agent use cases where parsing the output fails if no non-reasoning content is available. In such cases, we want to put the reasoning content as the regular content, and have the callers use that as the output.
Thus, we'll ask people to call the model as following:
```
client.chat.completions.create(
    messages=[...],
    temperature=...,
    reasoning_effort="low",
    extra_body={"chat_template_kwargs": {"force_nonempty_content": True}},
)
```

## Modifications

<!-- Detail the changes made in this pull request. -->
Add `force_nonempty_content` field to the Nemotron3Detector, optionally switching between regular and reasoning contents, if the first is empty and the field is set to `True`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
