### PR TITLE
Enable multi-thread weight loading by default

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -479,7 +479,7 @@ class DefaultModelLoader(BaseModelLoader):
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
         extra_config = self.load_config.model_loader_extra_config
-        use_multithread = extra_config.get("enable_multithread_load", False)
+        use_multithread = extra_config.get("enable_multithread_load", True)
         hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
             source.model_or_path, source.revision, source.fall_back_to_pt
         )


### PR DESCRIPTION
Ref: https://github.com/sgl-project/sglang/issues/12529

Since a lot of CI tests require this to pass (and we can consider it tested because they use it heavily), this should be fine.

This only affects DefaultModelLoader, and the RemoteInstanceModelLoader is a completely separate class, so there should be no performance changes in that case.