### PR TITLE
[AMD] Add 4-GPU test suite for MI325 runners

### DIFF
--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -32,6 +32,7 @@ on:
           - nightly-accuracy-2-gpu-vlm
           - nightly-perf-2-gpu-text
           - nightly-perf-2-gpu-vlm
+          - nightly-4-gpu
           - nightly-accuracy-8-gpu
           - nightly-8-gpu-grok1-int4
           - nightly-8-gpu-grok2
@@ -249,6 +250,37 @@ jobs:
             -e SGLANG_USE_AITER=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-perf-vlm-2-gpu --nightly --timeout-per-file 7200 ${{ inputs.continue_on_error && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # ============================================== MI30x 4-GPU Tests ==============================================
+  # 4-GPU Nightly Tests - Dumper/Comparator E2E, VLM Encoder DP
+  nightly-4-gpu:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-4-gpu,'))
+    runs-on: linux-mi325-4gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Nightly Test (4-GPU)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-4-gpu --nightly --continue-on-error --timeout-per-file 3600 || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
@@ -1322,6 +1354,8 @@ jobs:
       # MI30x Accuracy Tests
       - nightly-accuracy-2-gpu
       - nightly-accuracy-2-gpu-vlm
+      # MI30x 4-GPU Tests
+      - nightly-4-gpu
       - nightly-accuracy-8-gpu
       # MI30x Performance Tests - excluded from check (perf failures don't block CI)
       # - nightly-perf-2-gpu-text

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -42,6 +42,7 @@ on:
           - stage-b-test-large-2-gpu-amd
           - multimodal-gen-test-1-gpu-amd
           - multimodal-gen-test-2-gpu-amd
+          - stage-c-test-4-gpu-amd
           - stage-c-test-large-8-gpu-amd
           - stage-c-test-large-8-gpu-amd-mi35x
           - stage-b-test-large-8-gpu-disaggregation-amd
@@ -778,6 +779,46 @@ jobs:
           free -h
 
 
+  stage-c-test-4-gpu-amd:
+    needs: [check-changes, call-gate, stage-b-test-small-1-gpu-amd, stage-b-test-large-2-gpu-amd]
+    if: |
+      always() &&
+      (
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-c-test-4-gpu-amd,')) ||
+        (
+          !(inputs.target_stage || inputs.target_stage_select) &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-mi325-4gpu-sglang]
+        part: [0, 1, 2]
+    runs-on: ${{matrix.runner}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Run test
+        timeout-minutes: 60
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-4-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+
   stage-c-test-large-8-gpu-amd:
     needs: [check-changes, call-gate, stage-b-test-small-1-gpu-amd, stage-b-test-large-2-gpu-amd]
     if: |
@@ -997,6 +1038,7 @@ jobs:
         stage-b-test-large-1-gpu-amd,
         stage-b-test-large-2-gpu-amd,
         stage-b-test-large-8-gpu-35x-disaggregation-amd,
+        stage-c-test-4-gpu-amd,
         stage-c-test-large-8-gpu-amd,
         stage-c-test-large-8-gpu-amd-mi35x,
       ]

--- a/test/registered/debug_utils/test_engine_dumper_comparator_e2e.py
+++ b/test/registered/debug_utils/test_engine_dumper_comparator_e2e.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -35,6 +35,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=300, suite="nightly-4-gpu", nightly=True)
+register_amd_ci(est_time=300, suite="nightly-amd-4-gpu", nightly=True)
 
 MODEL = "Qwen/Qwen3-30B-A3B"
 BASELINE_TP = 2

--- a/test/registered/distributed/test_dp_attention_large.py
+++ b/test/registered/distributed/test_dp_attention_large.py
@@ -5,7 +5,7 @@ import requests
 
 from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.kits.ebnf_constrained_kit import TestEBNFConstrainedMixin
 from sglang.test.kits.json_constrained_kit import TestJSONConstrainedMixin
@@ -24,6 +24,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=350, suite="stage-c-test-4-gpu-h100")
+register_amd_ci(est_time=350, suite="stage-c-test-4-gpu-amd")
 
 
 class TestDPAttentionDP2TP4(

--- a/test/registered/distributed/test_pp_single_node.py
+++ b/test/registered/distributed/test_pp_single_node.py
@@ -15,7 +15,7 @@ import requests
 from sglang.bench_one_batch_server import BenchArgs as OneBatchBenchArgs
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
@@ -32,6 +32,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=500, suite="stage-c-test-4-gpu-h100")
+register_amd_ci(est_time=500, suite="stage-c-test-4-gpu-amd")
 
 
 class TestPPAccuracy(unittest.TestCase):

--- a/test/registered/rl/test_multi_instance_release_memory_occupation.py
+++ b/test/registered/rl/test_multi_instance_release_memory_occupation.py
@@ -12,7 +12,7 @@ from torch.distributed.device_mesh import init_device_mesh
 from transformers import AutoModelForCausalLM
 
 from sglang.srt.entrypoints.engine import Engine as SglangEngine
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_BASE,
@@ -21,6 +21,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=64, suite="stage-c-test-4-gpu-h100")
+register_amd_ci(est_time=64, suite="stage-c-test-4-gpu-amd")
 
 TEST_SUITE = dict(
     model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,

--- a/test/registered/rl/test_return_routed_experts.py
+++ b/test/registered/rl/test_return_routed_experts.py
@@ -12,7 +12,7 @@ from sglang.srt.layers.moe.routed_experts_capturer import (
     extract_routed_experts_from_meta_info,
 )
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_ENABLE_ROUTED_EXPERTS_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -22,6 +22,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=360, suite="stage-c-test-4-gpu-h100")
+register_amd_ci(est_time=360, suite="stage-c-test-4-gpu-amd")
 
 SHAREGPT_URL = (
     "https://huggingface.co/datasets/anon8231489123/"

--- a/test/registered/spec/eagle/test_eagle_dp_attention.py
+++ b/test/registered/spec/eagle/test_eagle_dp_attention.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.environ import envs
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.send_one import BenchArgs, send_one_prompt
 from sglang.test.test_utils import (
@@ -22,6 +22,7 @@ from sglang.test.test_utils import (
 
 # EAGLE3 with DP attention (tp=2, dp=2, requires 4 GPUs)
 register_cuda_ci(est_time=200, suite="stage-c-test-4-gpu-h100")
+register_amd_ci(est_time=200, suite="stage-c-test-4-gpu-amd")
 
 
 class TestEAGLE3EngineDPAttention(CustomTestCase):
@@ -50,7 +51,7 @@ class TestEAGLE3EngineDPAttention(CustomTestCase):
             "--moe-dense-tp-size",
             "1",
             "--attention-backend",
-            "fa3",
+            "triton" if is_in_amd_ci() else "fa3",
             "--mem-fraction-static",
             "0.75",
             "--cuda-graph-max-bs",

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -8,17 +8,19 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_in_amd_ci,
     is_in_ci,
     popen_launch_server,
 )
 
 register_cuda_ci(est_time=500, suite="nightly-4-gpu", nightly=True)
+register_amd_ci(est_time=500, suite="nightly-amd-4-gpu", nightly=True)
 
 MODELS = [
     SimpleNamespace(model="Qwen/Qwen2.5-VL-72B-Instruct", mmmu_accuracy=0.55),
@@ -127,8 +129,8 @@ class TestVLMEncoderDP(CustomTestCase):
             process_env = os.environ.copy()
             if custom_env:
                 process_env.update(custom_env)
-            # if test vlm with cuda_ipc feature, open this env_var
-            process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
+            if not is_in_amd_ci():
+                process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
 
             # Prepare stdout/stderr redirection if needed
             stdout_file = None

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -31,6 +31,7 @@ PER_COMMIT_SUITES = {
         "stage-b-test-large-8-gpu-35x-disaggregation-amd",
         "stage-b-test-large-1-gpu-amd",
         "stage-b-test-large-2-gpu-amd",
+        "stage-c-test-4-gpu-amd",
         "stage-c-test-large-8-gpu-amd",
         "stage-c-test-large-8-gpu-amd-mi35x",
     ],
@@ -82,6 +83,7 @@ NIGHTLY_SUITES = {
         "nightly-amd-1-gpu",
         "nightly-amd-1-gpu-mi35x",
         "nightly-amd-1-gpu-zimage-turbo",
+        "nightly-amd-4-gpu",
         "nightly-amd-8-gpu",
         "nightly-amd-vlm",
         # MI35x 8-GPU suite (different model configs)


### PR DESCRIPTION
## Summary
- Enable 4-GPU CI tests on AMD MI325 using the new `linux-mi325-4gpu-sglang` runner label
- Port 8 tests from NVIDIA H100 4-GPU suites (`stage-c-test-4-gpu-h100` / `nightly-4-gpu`) to AMD
- Register new suites: `stage-c-test-4-gpu-amd` (PR) and `nightly-amd-4-gpu` (nightly)

## Changes

### PR suite (`stage-c-test-4-gpu-amd`) — 5 tests
| Test | Config | Notes |
|------|--------|-------|
| `test_pp_single_node` | tp2/pp2, tp1/pp4, dp2/pp2 | Pipeline parallelism with Llama, Qwen3, DeepSeek |
| `test_dp_attention_large` | tp4/dp2 | DP attention + constrained decoding (already has `is_in_amd_ci()` checks) |
| `test_return_routed_experts` | tp4/dp4/dp-attention | RL routed expert capture, CUDA graphs disabled |
| `test_multi_instance_release_memory_occupation` | dp2/tp2 | RL multi-instance memory management |
| `test_eagle_dp_attention` | tp2/dp2 | EAGLE3 speculative decoding (fa3→triton on AMD, already has AMD thresholds) |

### Nightly suite (`nightly-amd-4-gpu`) — 2 tests
| Test | Config | Notes |
|------|--------|-------|
| `test_engine_dumper_comparator_e2e` | tp2 vs tp4, dp2 | Debug tensor dumper/comparator, CUDA graphs disabled |
| `test_encoder_dp` | tp4 | VLM encoder DP MMMU eval (skip CUDA IPC transport on AMD) |

### Workflow changes
- `pr-test-amd.yml`: Add `stage-c-test-4-gpu-amd` job (3 partitions, 60min timeout, stage-c gating)
- `nightly-test-amd.yml`: Add `nightly-4-gpu` job (120min timeout)
- `run_suite.py`: Register `stage-c-test-4-gpu-amd` and `nightly-amd-4-gpu` suites

### Tests NOT ported (for reference)
- `test_local_attn` — hardcoded SM90 + FA3 requirement
- `test_gpt_oss_4gpu` — mxfp4 variant is NVIDIA HW-specific (AMD already has 8-GPU bf16 version)
- `test_qwen3_next_models*` / `test_qwen3_next_models_pcg` — Mamba/SSM kernel ROCm support TBD
- `test_release_memory_occupation` — disabled even on NVIDIA
- `test_epd_disaggregation` — transfer backend needs ROCm validation

## Test plan
- [ ] Verify `stage-c-test-4-gpu-amd` job picks up all 5 registered tests via `run_suite.py --hw amd --suite stage-c-test-4-gpu-amd`
- [ ] Verify `nightly-amd-4-gpu` job picks up both nightly tests
- [ ] Run on `linux-mi325-4gpu-sglang` runner via workflow_dispatch with `target_stage=stage-c-test-4-gpu-amd`
- [ ] Confirm EAGLE3 test uses triton backend on AMD and fa3 on NVIDIA