### PR TITLE
[diffusion] server: add Prometheus metrics to multimodal_gen

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -24,6 +24,10 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 )
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
+from sglang.multimodal_gen.runtime.utils.common import (
+    add_prometheus_middleware,
+    add_prometheus_track_response_middleware,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.version import __version__
 
@@ -271,6 +275,10 @@ def create_app(server_args: ServerArgs):
     Create and configure the FastAPI application instance.
     """
     app = FastAPI(lifespan=lifespan)
+
+    if server_args.enable_metrics:
+        add_prometheus_middleware(app)
+        add_prometheus_track_response_middleware(app)
 
     app.include_router(health_router)
     app.include_router(vertex_router)

--- a/python/sglang/multimodal_gen/runtime/launch_server.py
+++ b/python/sglang/multimodal_gen/runtime/launch_server.py
@@ -16,6 +16,7 @@ from sglang.multimodal_gen.runtime.server_args import (
     prepare_server_args,
     set_global_server_args,
 )
+from sglang.multimodal_gen.runtime.utils.common import set_prometheus_multiproc_dir
 from sglang.multimodal_gen.runtime.utils.logging_utils import configure_logger, logger
 
 
@@ -64,6 +65,9 @@ def launch_server(server_args: ServerArgs, launch_http_server: bool = True):
         launch_http_server: False for offline local mode
     """
     configure_logger(server_args)
+
+    if server_args.enable_metrics:
+        set_prometheus_multiproc_dir()
 
     # Start a new server with multiple worker processes
     logger.info("Starting server...")

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -326,6 +326,7 @@ class ServerArgs:
 
     # Logging
     log_level: str = "info"
+    enable_metrics: bool = False
 
     @property
     def broker_port(self) -> int:
@@ -917,6 +918,12 @@ class ServerArgs:
             type=str,
             default=ServerArgs.log_level,
             help="The logging level of all loggers.",
+        )
+        parser.add_argument(
+            "--enable-metrics",
+            action=StoreBoolean,
+            default=ServerArgs.enable_metrics,
+            help="Enable Prometheus metrics on /metrics.",
         )
         parser.add_argument(
             "--backend",

--- a/python/sglang/multimodal_gen/runtime/utils/common.py
+++ b/python/sglang/multimodal_gen/runtime/utils/common.py
@@ -4,11 +4,15 @@ import ipaddress
 import logging
 import os
 import platform
+import re
 import signal
 import socket
 import sys
+import tempfile
 import threading
+import time
 from functools import lru_cache
+from typing import Dict, Tuple
 
 import psutil
 import torch
@@ -16,6 +20,28 @@ import zmq
 
 # use the native logger to avoid circular import
 logger = logging.getLogger(__name__)
+
+# Temporary directory for prometheus multiprocess mode
+# Cleaned up automatically when this object is garbage collected
+prometheus_multiproc_dir: tempfile.TemporaryDirectory
+
+
+def set_prometheus_multiproc_dir():
+    # Set prometheus multiprocess directory
+    # sglang uses prometheus multiprocess mode
+    # we need to set this before importing prometheus_client
+    # https://prometheus.github.io/client_python/multiprocess/
+    global prometheus_multiproc_dir
+
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        logger.debug("User set PROMETHEUS_MULTIPROC_DIR detected.")
+        prometheus_multiproc_dir = tempfile.TemporaryDirectory(
+            dir=os.environ["PROMETHEUS_MULTIPROC_DIR"]
+        )
+    else:
+        prometheus_multiproc_dir = tempfile.TemporaryDirectory()
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
+    logger.debug("PROMETHEUS_MULTIPROC_DIR: %s", os.environ["PROMETHEUS_MULTIPROC_DIR"])
 
 
 def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = None):
@@ -122,6 +148,180 @@ def is_port_available(port):
             return False
         except OverflowError:
             return False
+
+
+def add_prometheus_middleware(app):
+    # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
+    from prometheus_client import (
+        GC_COLLECTOR,
+        PLATFORM_COLLECTOR,
+        PROCESS_COLLECTOR,
+        CollectorRegistry,
+        make_asgi_app,
+        multiprocess,
+    )
+    from starlette.routing import Mount
+
+    registry = CollectorRegistry()
+    registry.register(GC_COLLECTOR)
+    registry.register(PLATFORM_COLLECTOR)
+    registry.register(PROCESS_COLLECTOR)
+    multiprocess.MultiProcessCollector(registry)
+    metrics_route = Mount("/metrics", make_asgi_app(registry=registry))
+
+    # Workaround for 307 Redirect for /metrics
+    metrics_route.path_regex = re.compile("^/metrics(?P<path>.*)$")
+    app.routes.append(metrics_route)
+
+
+class RefCountedGauge:
+    def __init__(self, gauge):
+        self._gauge = gauge
+        self._refcount: Dict[str, int] = {}
+
+    def inc(self, key: str):
+        if key in self._refcount:
+            self._refcount[key] += 1
+        else:
+            self._refcount[key] = 1
+            self._gauge.inc()
+
+    def dec(self, key: str):
+        if key in self._refcount:
+            self._refcount[key] -= 1
+            if self._refcount[key] == 0:
+                del self._refcount[key]
+                self._gauge.dec()
+
+
+def add_prometheus_track_response_middleware(app):
+    from prometheus_client import Counter, Gauge, Histogram, Summary
+
+    http_request_counter = Counter(
+        name="sglang:http_requests_total",
+        documentation="Total number of HTTP requests by endpoint and method",
+        labelnames=["endpoint", "method"],
+    )
+
+    http_response_counter = Counter(
+        name="sglang:http_responses_total",
+        documentation="Total number of HTTP responses by endpoint and status code",
+        labelnames=["endpoint", "status_code", "method"],
+    )
+
+    http_requests_active = Gauge(
+        name="sglang:http_requests_active",
+        documentation="Number of currently active HTTP requests",
+        labelnames=["endpoint", "method"],
+        multiprocess_mode="livesum",
+    )
+
+    http_request_size = Summary(
+        name="sglang:http_request_size_bytes",
+        documentation=(
+            "Content length of incoming requests by endpoint. "
+            "Only value of header is respected. Otherwise ignored."
+        ),
+        labelnames=["endpoint"],
+    )
+
+    http_response_size = Summary(
+        name="sglang:http_response_size_bytes",
+        documentation=(
+            "Content length of outgoing responses by endpoint. "
+            "Only value of header is respected. Otherwise ignored."
+        ),
+        labelnames=["endpoint"],
+    )
+
+    http_request_latency = Histogram(
+        name="sglang:http_request_latency_seconds",
+        documentation="End-to-end HTTP request latency in seconds",
+        labelnames=["endpoint", "status_code", "method"],
+        buckets=(
+            0.4,
+            0.8,
+            2.0,
+            4.0,
+            8.0,
+            10.0,
+            20.0,
+            60.0,
+            80.0,
+            100.0,
+            200.0,
+        ),
+    )
+
+    routing_keys_active = RefCountedGauge(
+        Gauge(
+            name="sglang:routing_keys_active",
+            documentation="Number of unique routing keys with active requests",
+            multiprocess_mode="livesum",
+        )
+    )
+
+    @app.middleware("http")
+    async def track_http_status_code(request, call_next):
+        # With recording all requests, we have the risk of high cardinality if requests have arbitrary unhandled paths.
+        # But given that SGLang engines with metrics enabled are usually behind routers this looks safe.
+        path, _is_handled_path = _get_fastapi_request_path(request)
+        method = request.method
+        routing_key = request.headers.get("x-smg-routing-key")
+
+        start_time = time.monotonic()
+        http_request_counter.labels(endpoint=path, method=method).inc()
+        http_requests_active.labels(endpoint=path, method=method).inc()
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                http_request_size.labels(endpoint=path).observe(float(content_length))
+            except ValueError:
+                pass
+        if routing_key:
+            routing_keys_active.inc(routing_key)
+        status_code = "500"
+        response = None
+        try:
+            response = await call_next(request)
+            status_code = str(response.status_code)
+            http_response_counter.labels(
+                endpoint=path,
+                method=method,
+                status_code=status_code,
+            ).inc()
+
+            return response
+        finally:
+            response_length = (
+                response.headers.get("content-length") if response else None
+            )
+            if response_length is not None:
+                try:
+                    http_response_size.labels(endpoint=path).observe(
+                        float(response_length)
+                    )
+                except ValueError:
+                    pass
+            http_request_latency.labels(
+                endpoint=path,
+                method=method,
+                status_code=status_code,
+            ).observe(time.monotonic() - start_time)
+            http_requests_active.labels(endpoint=path, method=method).dec()
+            if routing_key:
+                routing_keys_active.dec(routing_key)
+
+
+def _get_fastapi_request_path(request) -> Tuple[str, bool]:
+    from starlette.routing import Match
+
+    for route in request.app.routes:
+        match, _child_scope = route.matches(request.scope)
+        if match == Match.FULL:
+            return route.path, True
+
+    return request.url.path, False
 
 
 def get_zmq_socket(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  - Add Prometheus metrics support to the multimodal_gen HTTP server so it exposes runtime/process metrics and HTTP size/latency metrics for observability.

## Modifications

  - Add Prometheus multiprocess registry setup and default collectors (GC/platform/process).
  - Register /metrics endpoint and HTTP metrics middleware in `multimodal_gen` server.
  - Add HTTP request/response size summaries and long‑latency buckets.
  - Add `--enable-metrics` flag and initialize multiprocess env for metrics.

## Accuracy Tests

- Not applicable (no model output changes).

## Benchmarking and Profiling

- Not applicable (observability-only change).

## Testing 
- Tested by running against Qwen/Image model, the metrics recorded e.g. are below:
```
curl http://127.0.0.1:8122/metrics
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 12533.0
python_gc_objects_collected_total{generation="1"} 1143.0
python_gc_objects_collected_total{generation="2"} 1172.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 1653.0
python_gc_collections_total{generation="1"} 150.0
python_gc_collections_total{generation="2"} 9.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="12",patchlevel="13",version="3.12.13"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.6469712896e+010
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 1.141387264e+09
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.77317686411e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 32.0
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 57.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP sglang:routing_keys_active Number of unique routing keys with active requests
# TYPE sglang:routing_keys_active gauge
sglang:routing_keys_active 0.0
# HELP sglang:http_requests_active Number of currently active HTTP requests
# TYPE sglang:http_requests_active gauge
sglang:http_requests_active{endpoint="/v1/images/generations",method="POST"} 0.0
sglang:http_requests_active{endpoint="/metrics",method="GET"} 1.0
# HELP sglang:http_requests_total Total number of HTTP requests by endpoint and method
# TYPE sglang:http_requests_total counter
sglang:http_requests_total{endpoint="/v1/images/generations",method="POST"} 1.0
sglang:http_requests_total{endpoint="/metrics",method="GET"} 1.0
# HELP sglang:http_responses_total Total number of HTTP responses by endpoint and status code
# TYPE sglang:http_responses_total counter
sglang:http_responses_total{endpoint="/v1/images/generations",method="POST",status_code="200"} 1.0
# HELP sglang:http_request_size_bytes Content length of incoming requests by endpoint. Only value of header is respected. Otherwise ignored.
# TYPE sglang:http_request_size_bytes summary
sglang:http_request_size_bytes_count{endpoint="/v1/images/generations"} 1.0
sglang:http_request_size_bytes_sum{endpoint="/v1/images/generations"} 165.0
# HELP sglang:http_response_size_bytes Content length of outgoing responses by endpoint. Only value of header is respected. Otherwise ignored.
# TYPE sglang:http_response_size_bytes summary
sglang:http_response_size_bytes_count{endpoint="/v1/images/generations"} 1.0
sglang:http_response_size_bytes_sum{endpoint="/v1/images/generations"} 130050.0
# HELP sglang:http_request_latency_seconds End-to-end HTTP request latency in seconds
# TYPE sglang:http_request_latency_seconds histogram
sglang:http_request_latency_seconds_sum{endpoint="/v1/images/generations",method="POST",status_code="200"} 107.35179584100842
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="0.1",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="0.2",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="0.4",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="0.6",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="0.8",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="1.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="2.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="4.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="6.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="8.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="10.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="20.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="40.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="60.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="80.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="100.0",method="POST",status_code="200"} 0.0
sglang:http_request_latency_seconds_bucket{endpoint="/v1/images/generations",le="+Inf",method="POST",status_code="200"} 1.0
sglang:http_request_latency_seconds_count{endpoint="/v1/images/generations",method="POST",status_code="200"} 1.0
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
