### PR TITLE
[CI] Fix B200 runner label for scheduled runs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -249,7 +249,7 @@ jobs:
           # Use kernel-build runner only when sgl_kernel changes are detected AND we're not in target_stage mode
           # (target_stage skips wheel builds, so we can't use custom kernels)
           # Use API-based detection (filter-api) for target_stage mode, otherwise use dorny/paths-filter (filter)
-          sgl_kernel="${{ steps.filter-api.outputs.sgl_kernel || steps.filter.outputs.sgl_kernel || steps.run-mode.outputs.run_all_tests }}"
+          sgl_kernel="${{ steps.filter-api.outputs.sgl_kernel || steps.filter.outputs.sgl_kernel }}"
           target_stage="${{ inputs.target_stage }}"
           if [[ "$sgl_kernel" == "true" && -z "$target_stage" ]]; then
             echo "b200_runner=4-gpu-b200-kernel" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Scheduled runs and `run_all_tests` dispatches incorrectly route B200 stage-c jobs to the `4-gpu-b200-kernel` label because `run_all_tests=true` gets OR'd into the `sgl_kernel` check for the B200 runner tag
- Fix: remove `run_all_tests` from the B200 runner tag logic — scheduled runs now use `4-gpu-b200` (all 5 runners). PRs with actual `sgl-kernel/` file changes still correctly route to `4-gpu-b200-kernel` via the path filters