### PR TITLE
Fix Eagle3 draft worker crash with MLA attention backend on B200

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1730,6 +1730,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             self.attn_backend = self._get_attention_backend()
 
+    _MLA_ONLY_BACKENDS = {"trtllm_mla", "flashmla", "cutlass_mla"}
+
     def _get_attention_backend(self, init_new_workspace: bool = False):
         """Init attention kernel backend."""
         draft_attn_backend = self.server_args.speculative_draft_attention_backend
@@ -1741,6 +1743,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 draft_attn_backend,
                 init_new_workspace=init_new_workspace,
             )
+
+        # If draft worker is not MLA but the target model uses an MLA-only
+        # attention backend, fall back to flashinfer for the draft model.
+        if self.is_draft_worker and not self.use_mla_backend:
+            attn_backend_str = self.server_args.attention_backend
+            if attn_backend_str in self._MLA_ONLY_BACKENDS:
+                logger.info(
+                    f"Draft model is not MLA; falling back from "
+                    f"'{attn_backend_str}' to 'flashinfer' for draft worker."
+                )
+                self.prefill_attention_backend_str = "flashinfer"
+                self.decode_attention_backend_str = "flashinfer"
+                return self._get_attention_backend_from_str(
+                    "flashinfer",
+                    init_new_workspace=init_new_workspace,
+                )
 
         (
             self.prefill_attention_backend_str,

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 
 class DraftBackendFactory:
+    _MLA_ONLY_BACKENDS = {"trtllm_mla", "flashmla", "cutlass_mla"}
+
     def __init__(
         self,
         server_args: ServerArgs,
@@ -30,6 +32,18 @@ class DraftBackendFactory:
         )
         if backend_type is None:
             backend_type = self.server_args.attention_backend
+
+        # If the draft model is not MLA but the resolved backend is MLA-only,
+        # fall back to flashinfer (e.g. Eagle3 Llama draft + MLA target on B200).
+        if (
+            backend_type in self._MLA_ONLY_BACKENDS
+            and not self.draft_model_runner.use_mla_backend
+        ):
+            logger.info(
+                f"Draft model is not MLA; falling back from "
+                f"'{backend_type}' to 'flashinfer' for draft backend."
+            )
+            backend_type = "flashinfer"
 
         if backend_type not in backend_map:
             raise ValueError(error_template.format(backend_type=backend_type))


### PR DESCRIPTION
## Summary
- On B200 GPUs (sm100), the server auto-sets `attention_backend='trtllm_mla'` for MLA models like Kimi K2.5. When launching a non-MLA Eagle3 draft model (`LlamaForCausalLMEagle3`), both `ModelRunner._get_attention_backend()` and `DraftBackendFactory._create_backend()` inherit this MLA-only backend and crash with `ValueError: trtllm_mla backend can only be used with MLA models.`
- Fix: detect when a non-MLA draft worker would use an MLA-only backend (`trtllm_mla`, `flashmla`, `cutlass_mla`) and automatically fall back to `flashinfer`
- Two fix sites: `model_runner.py` (attention backend init) and `draft_utils.py` (draft backend factory)

[Failure example](https://github.com/sgl-project/sglang/actions/runs/22881473291/job/66385005342#step:4:4394)

## Test plan
- [x] Verify Kimi K2.5 + Eagle3 nightly test passes on B200 (the previously failing test)
- [x] Verify Kimi K2.5 base (non-Eagle3) variant is unaffected
- [x] Verify DeepSeek V3 + Eagle3 on B200 is unaffected (both models are MLA, so fallback should not trigger)