### PR TITLE
[Bug Fix] Fix /v1/responses reporting zero token usage

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -465,10 +465,12 @@ class OpenAIServingResponses(OpenAIServingChat):
             )
 
             # Calculate usage from actual output
-            if hasattr(final_res, "meta_info"):
-                num_prompt_tokens = final_res.meta_info.get("prompt_tokens", 0)
-                num_generated_tokens = final_res.meta_info.get("completion_tokens", 0)
-                num_cached_tokens = final_res.meta_info.get("cached_tokens", 0)
+            if isinstance(final_res, dict) and "meta_info" in final_res:
+                meta_info = final_res["meta_info"]
+                num_prompt_tokens = meta_info.get("prompt_tokens", 0)
+                num_generated_tokens = meta_info.get("completion_tokens", 0)
+                num_cached_tokens = meta_info.get("cached_tokens", 0)
+                num_reasoning_tokens = meta_info.get("reasoning_tokens", 0)
             elif hasattr(final_res, "prompt_token_ids") and hasattr(
                 final_res, "outputs"
             ):


### PR DESCRIPTION
## Motivation

Fixes #20171

The `/v1/responses` endpoint always reports `prompt_tokens=0`, `completion_tokens=0`, `total_tokens=0` regardless of actual usage.

## Root Cause

In `serving_responses.py` line 468, `hasattr(final_res, "meta_info")` is used to check for usage data, but `final_res` is a plain dict. `hasattr` checks object attributes, not dict keys, so it always returns `False` and falls through to the zero-fallback branch.

Secondary bug: the `meta_info` branch uses attribute access (`final_res.meta_info.get(...)`) instead of dict access, and never assigns `num_reasoning_tokens`, which would cause `UnboundLocalError` once the primary bug is fixed.

## Modifications

- Replace `hasattr(final_res, "meta_info")` with `isinstance(final_res, dict) and "meta_info" in final_res`
- Replace attribute access `final_res.meta_info.get(...)` with dict access `final_res["meta_info"].get(...)`
- Add `num_reasoning_tokens` initialization in the meta_info branch

## Checklist
- [x] Format: `ruff check` passes
- [x] Minimal change - only the buggy lines are modified

This contribution was developed with AI assistance (Claude Code).