### PR TITLE
[Bugfix] fix len(rids) != num_seqs in tbo filter_batch()

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -902,6 +902,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
         self.req_pool_indices = self._pad_tensor_to_size(self.req_pool_indices, bs)
         self.lora_ids.extend((bs - len(self.lora_ids)) * [None])
+        if self.rids is not None:
+            self.rids.extend((bs - len(self.rids)) * [""])
 
         seq_len_fill_value = (
             model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
@@ -984,6 +986,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         self.forward_mode = getattr(self, "_original_forward_mode", self.forward_mode)
         self.batch_size = getattr(self, "_original_batch_size", self.batch_size)
         bs = self.batch_size
+
+        if self.rids is not None:
+            self.rids = self.rids[:bs]
 
         if self.spec_info is not None:
             if self.forward_mode.is_decode():  # draft


### PR DESCRIPTION
After #19418 , "rids" is added into keys in TboForwardBatchPreparer.filter_batch, but isn't synchronized during _pad_inputs_to_size(). This may result in an assertion error of len(rids) != num_seqs.

To fix it, add padding for rids in _pad_inputs_to_size() and truncate it in post_forward_mlp_sync_batch.

The bug can be reproduced by: 
```
python3 -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 \
 --dp-size 4 --enable-dp-attention --tp-size 4 --load-format dummy --moe-a2a-backend deepep \
 --enable-two-batch-overlap --disable-radix-cache --disable-cuda-graph --mem-fraction-static 0.5

python3 -m sglang.bench_serving --port 30000 --backend sglang --dataset-name random \
 --random-range-ratio 1 --warmup-requests 0 --random-output-len 20 --random-input-len 4 --num-prompt 5
```

before fix: AssertionError like
```
  File "python/sglang/srt/batch_overlap/two_batch_overlap.py", line 674, in filter_batch
    len(old_value) == num_seqs
AssertionError: key='rids' old_value=['809a5690017c4b579ce7c24179b0d067'] num_seqs=2 batch=ForwardBatch(forward_mode=<ForwardMode.DECODE: 2>, batch_size=2, input_ids=tensor([33838,     0], device='cuda:2'), req_pool_indices=tensor([1, 0], device='cuda:2'), seq_lens=tensor([5, 1], device='cuda:2'), out_cache_loc=tensor([19,  0], device='cuda:2'), seq_lens_sum=6, orig_seq_lens=tensor([5], device='cuda:2', dtype=torch.int32), out_cache_loc_swa=None, mamba_track_indices=None, mamba_track_mask=None, mamba_track_seqlens=None, seq_lens_cpu=tensor([5, 1]), return_logprob=False, top_logprobs_nums=None, token_ids_logprobs=None, next_token_logits_buffer=None, temp_scaled_logprobs=False, temperature=None, top_p_normalized_logprobs=False, top_p=None, positions=tensor([4, 0], device='cuda:2'), extend_num_tokens=None, extend_seq_lens=None, extend_prefix_lens=None, extend_start_loc=None, extend_prefix_lens_cpu=None, extend_seq_lens_cpu=None, extend_logprob_start_lens_cpu=None, extend_input_logprob_token_ids_gpu=None, hidden_states=None, residual=None, model_specific_states=None, split_index=0, mm_inputs=[None], encoder_cached=None, encoder_lens=None, encoder_lens_cpu=None, encoder_out_cache_loc=None, lora_ids=[None, None], input_embeds=None, token_type_ids=None, sampling_info=SamplingBatchInfo(temperatures=tensor([[1.]], device='cuda:2'), top_ps=tensor([1.], device='cuda:2'), top_ks=tensor([1], device='cuda:2', dtype=torch.int32), min_ps=tensor([0.], device='cuda:2'), is_all_greedy=True, need_top_p_sampling=False, need_top_k_sampling=True, need_min_p_sampling=False, vocab_size=151936, grammars=None, vocab_mask=None, apply_mask_func=None, penalizer_orchestrator=None, acc_linear_penalties=None, has_custom_logit_processor=False, custom_params=None, custom_logit_processor=None, sampling_seed=None, device='cuda', logit_bias=None), req_to_token_pool=<sglang.srt.mem_cache.memory_pool.ReqToTokenPool object at 0x7ef5e426fe00>, token_to_kv_pool=<sglang.srt.mem_cache.memory_pool.MHATokenToKVPool object at 0x7ef5e4040e00>, attn_backend=<sglang.srt.layers.attention.tbo_backend.TboAttnBackend object at 0x7ef5e44e5a60>, original_global_num_tokens_cpu=[2, 1, 1, 1], global_num_tokens_cpu=[2, 2, 2, 2], global_num_tokens_gpu=tensor([2, 2, 2, 2], device='cuda:2'), global_num_tokens_for_logprob_cpu=[2, 1, 1, 1], global_num_tokens_for_logprob_gpu=tensor([2, 1, 1, 1], device='cuda:2'), dp_padding_mode=<DpPaddingMode.MAX_LEN: 1>, dp_local_start_pos=None, dp_local_num_tokens=None, global_dp_buffer_len=8, is_extend_in_batch=False, all_extend_in_batch=False, can_run_dp_cuda_graph=False, global_forward_mode=<ForwardMode.DECODE: 2>, is_prefill_only=False, spec_info=None, spec_algorithm=<SpeculativeAlgorithm.NONE: 5>, mm_input_embeds=None, capture_hidden_mode=<CaptureHiddenMode.NULL: 0>, padded_static_len=-1, num_token_non_padded=tensor(1, device='cuda:2', dtype=torch.int32), num_token_non_padded_cpu=1, mrope_positions=None, tbo_split_seq_index=0, tbo_parent_token_range=None, tbo_padded_len=None, tbo_children=None, dimensions=None, nsa_cp_metadata=None, return_hidden_states_before_norm=False, rids=['809a5690017c4b579ce7c24179b0d067'])
```

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
