### PR TITLE
[Feature] Introduce Pod Attention for Mixed Chunk Prefill

### DIFF
--- a/Usage.txt
+++ b/Usage.txt
@@ -1,0 +1,17 @@
+cd /workspace/pod/sglang/python
+python -m pip install -e . -v \
+  -i https://pypi.tuna.tsinghua.edu.cn/simple \
+  --extra-index-url https://pypi.nvidia.com 
+
+code /usr/local/lib/python3.12/dist-packages/flashinfer/data/include/flashinfer/attention/batch_pod.cuh
+替换成/workspace/batch_pod.cu
+code /usr/local/lib/python3.12/dist-packages/flashinfer/data/csrc/batch_pod.cu
+添加头文件
+#include <cassert>
+rm -rf ~/.cache/flashinfer/
+
+测试一下代码输出，如果正常吐字就没有问题
+代码第一次运行速度会比较慢，可以稍微等一下
+cd /workspace/pod/sglang/
+python test.py
+

--- a/Usage.txt
+++ b/Usage.txt
@@ -1,4 +1,4 @@
-cd /workspace/pod/sglang/python
+cd /workspace/sglang/python
 python -m pip install -e . -v \
   -i https://pypi.tuna.tsinghua.edu.cn/simple \
   --extra-index-url https://pypi.nvidia.com 
@@ -12,6 +12,6 @@ rm -rf ~/.cache/flashinfer/
 
 测试一下代码输出，如果正常吐字就没有问题
 代码第一次运行速度会比较慢，可以稍微等一下
-cd /workspace/pod/sglang/
+cd /workspace/sglang/
 python test.py
 

--- a/batch_pod.cuh
+++ b/batch_pod.cuh
@@ -1,0 +1,419 @@
+#ifndef FLASHINFER_BATCH_POD_CUH_
+#define FLASHINFER_BATCH_POD_CUH_
+
+#include <cooperative_groups.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include "../cp_async.cuh"
+#include "../fastdiv.cuh"
+#include "../frag_layout_swizzle.cuh"
+#include "../layout.cuh"
+#include "../math.cuh"
+#include "../mma.cuh"
+#include "../page.cuh"
+#include "../permuted_smem.cuh"
+#include "../pos_enc.cuh"
+#include "../utils.cuh"
+#include "cascade.cuh"
+#include "decode.cuh"
+#include "mask.cuh"
+#include "prefill.cuh"
+#include "variants.cuh"
+
+namespace flashinfer {
+
+namespace cg = cooperative_groups;
+using cp_async::SharedMemFillMode;
+using mma::MMAMode;
+
+enum Operation {
+  PREFILL = 0,
+  DECODE = 1,
+};
+
+// Block factor constants (moved outside kernel for better compilation)
+constexpr int kBlkFactorP = 1;
+constexpr int kBlkFactorD = 1;
+
+// Scheduler result structure for better memory layout
+struct SchedulerResult {
+  int linear_bid;
+  int op;
+};
+
+template <typename KTraits_P, typename KTraits_D, typename PrefillParams, typename DecodeParams>
+__global__ __launch_bounds__(std::max(
+    KTraits_P::NUM_THREADS,
+    KTraits_D::NUM_THREADS)) void BatchPODWithKVCacheTensorKernel(const __grid_constant__
+                                                                      PrefillParams prefill_params,
+                                                                  const __grid_constant__
+                                                                      DecodeParams decode_params,
+                                                                  int* sm_aware_sched,
+                                                                  int num_sm) {
+  extern __shared__ uint8_t smem[];
+  // PREFILL VARS
+  const uint32_t padded_bsize_p = prefill_params.padded_batch_size;
+  const uint32_t num_kv_heads_p = prefill_params.paged_kv.num_heads;
+
+  // DECODE VARS
+  const uint32_t padded_bsize_d = decode_params.padded_batch_size;
+  const uint32_t num_kv_heads_d = decode_params.paged_kv.num_heads;
+
+  // THREADBLOCKS
+  const uint32_t prefill_blocks = padded_bsize_p * num_kv_heads_p;
+  const uint32_t decode_blocks = padded_bsize_d * num_kv_heads_d;
+
+  int op = 0;
+  int linear_bid = 0;
+
+  // SM-aware CTA scheduler
+  if (threadIdx.x == 0) {
+    // TODO_AK: If num_threads dont match, use virtual sub-CTAs.
+    // Requires changing block-level sync in main prefill/decode kernels.
+
+    // Get SM ID for this threadblock
+    int smid = 0;
+    asm volatile("mov.u32 %0, %smid;" : "=r"(smid));
+
+    // Clamp smid to num_sm to avoid out-of-bounds access
+    smid = (smid < num_sm) ? smid : num_sm - 1;
+
+    // No need for division when blk_factor = 1
+    const int prefill_slots = prefill_blocks;
+    const int decode_slots = decode_blocks;
+
+    // Handle empty batch cases to avoid div-by-zero
+    if (prefill_slots == 0 && decode_slots == 0) {
+      // Nothing to do - mark as invalid
+      op = -1;
+      linear_bid = 0;
+    } else if (prefill_slots == 0) {
+      // Pure decode mode: all SMs work on decode
+      op = DECODE;
+      linear_bid = atomicAdd(&sm_aware_sched[num_sm + DECODE], 1);
+    } else if (decode_slots == 0) {
+      // Pure prefill mode: all SMs work on prefill
+      op = PREFILL;
+      linear_bid = atomicAdd(&sm_aware_sched[num_sm + PREFILL], 1);
+    } else {
+      // Mixed mode: use SM-aware scheduler with both prefill and decode
+      // Allocate work based on ratio of slots to minimize fallback
+      if (prefill_slots <= decode_slots) {
+        const int total_tags = decode_slots / prefill_slots + 1;
+        const int tag = atomicAdd(&sm_aware_sched[smid], 1);
+        op = (tag % total_tags == 0) ? PREFILL : DECODE;
+      } else {
+        const int pref_tags = prefill_slots / decode_slots;
+        const int tag = atomicAdd(&sm_aware_sched[smid], 1);
+        op = (tag % (pref_tags + 1) < pref_tags) ? PREFILL : DECODE;
+      }
+
+      // Get the next blockId for that operation
+      linear_bid = atomicAdd(&sm_aware_sched[num_sm + op], 1);
+
+      // If out of range, try to switch to the other operation
+      if ((op == PREFILL && linear_bid >= prefill_slots) ||
+          (op == DECODE && linear_bid >= decode_slots)) {
+        // Try the other operation
+        int other_op = 1 - op;
+        int other_bid = atomicAdd(&sm_aware_sched[num_sm + other_op], 1);
+
+        // Only switch if the other operation has work available
+        if ((other_op == PREFILL && other_bid < prefill_slots) ||
+            (other_op == DECODE && other_bid < decode_slots)) {
+          op = other_op;
+          linear_bid = other_bid;
+        } else {
+          // No work available - mark as invalid
+          op = -1;
+          linear_bid = 0;
+        }
+      }
+    }
+
+    // Write the blockId and operation to shared memory using structure
+    auto& result = *reinterpret_cast<SchedulerResult*>(smem);
+    result.linear_bid = linear_bid;
+    result.op = op;
+  }
+
+  // Sync to wait for scheduler to finish and broadcast results
+  __syncthreads();
+  auto& result = *reinterpret_cast<SchedulerResult*>(smem);
+  linear_bid = result.linear_bid;
+  op = result.op;
+
+  // Early exit for invalid operations (no work available)
+  if (op < 0) return;
+
+  if (op == PREFILL) {
+    auto& smem_storage = reinterpret_cast<typename KTraits_P::SharedStorage&>(smem);
+
+    const uint32_t bx = linear_bid % padded_bsize_p;
+    const uint32_t kv_head_idx = linear_bid / padded_bsize_p;
+
+    const uint32_t linear_tid = threadIdx.x;
+    // Return if threadId exceeds number of threads for this op
+    if (linear_tid >= 32 * KTraits_P::NUM_WARPS_Q * KTraits_P::NUM_WARPS_KV) return;
+
+    const dim3 tid = dim3(linear_tid % 32, (linear_tid / 32) % KTraits_P::NUM_WARPS_Q,
+                          (linear_tid / 32) / KTraits_P::NUM_WARPS_Q);
+
+    BatchPrefillWithPagedKVCacheDevice<KTraits_P>(prefill_params, smem_storage, tid, bx,
+                                                  kv_head_idx, num_kv_heads_p);
+  } else /* OP == DECODE */ {
+    auto& smem_storage = reinterpret_cast<typename KTraits_D::SharedStorage&>(smem);
+
+    const uint32_t bx = linear_bid % padded_bsize_d;
+    const uint32_t kv_head_idx = linear_bid / padded_bsize_d;
+
+    const uint32_t linear_tid = threadIdx.x;
+    // Return if threadId exceeds number of threads for this op
+    if (linear_tid >= 32 * KTraits_D::NUM_WARPS_Q * KTraits_D::NUM_WARPS_KV) return;
+
+    const dim3 tid = dim3(linear_tid % 32, (linear_tid / 32) % KTraits_D::NUM_WARPS_Q,
+                          (linear_tid / 32) / KTraits_D::NUM_WARPS_Q);
+
+    BatchPrefillWithPagedKVCacheDevice<KTraits_D>(decode_params, smem_storage, tid, bx, kv_head_idx,
+                                                  num_kv_heads_d);
+  }
+}
+
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
+          bool USE_FP16_QK_REDUCTION, uint32_t CTA_TILE_Q_P, MaskMode MASK_MODE_P,
+          uint32_t CTA_TILE_Q_D, MaskMode MASK_MODE_D, typename PrefillAttentionVariant,
+          typename DecodeAttentionVariant, typename PrefillParams, typename DecodeParams>
+cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
+                                                typename PrefillParams::DTypeO* tmp_v_p,
+                                                float* tmp_s_p, DecodeParams decode_params,
+                                                typename DecodeParams::DTypeO* tmp_v_d,
+                                                float* tmp_s_d, bool enable_pdl,
+                                                cudaStream_t stream, int* sm_aware_sched) {
+  static_assert(std::is_same<typename PrefillParams::DTypeQ, typename DecodeParams::DTypeQ>::value);
+  static_assert(
+      std::is_same<typename PrefillParams::DTypeKV, typename DecodeParams::DTypeKV>::value);
+  static_assert(std::is_same<typename PrefillParams::DTypeO, typename DecodeParams::DTypeO>::value);
+  // Ensure heads match
+  assert(prefill_params.paged_kv.num_heads == decode_params.paged_kv.num_heads);
+  assert(prefill_params.num_qo_heads == decode_params.num_qo_heads);
+
+  // Common variables for both prefill and decode
+  const uint32_t num_qo_heads = prefill_params.num_qo_heads;
+  const uint32_t num_kv_heads = prefill_params.paged_kv.num_heads;
+
+  // Get device properties once
+  int dev_id = 0;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+
+  int max_smem_per_sm = 0;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm,
+                                              cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
+
+  int num_sm = 0;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+
+  constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+  constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
+
+  // Prefill variable setup
+  using DTypeQ_P = typename PrefillParams::DTypeQ;
+  using DTypeKV_P = typename PrefillParams::DTypeKV;
+  using DTypeO_P = typename PrefillParams::DTypeO;
+  const uint32_t padded_batch_size_p = prefill_params.padded_batch_size;
+  constexpr uint32_t NUM_MMA_Q_P = get_num_mma_q(CTA_TILE_Q_P);
+  constexpr uint32_t NUM_WARPS_Q_P = get_num_warps_q(CTA_TILE_Q_P);
+  constexpr uint32_t NUM_WARPS_KV_P = get_num_warps_kv(CTA_TILE_Q_P);
+
+  using DTypeQKAccum_P =
+      typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_P, half>, half,
+                                float>::type;
+
+  // Decode vars setup
+  using DTypeQ_D = typename DecodeParams::DTypeQ;
+  using DTypeKV_D = typename DecodeParams::DTypeKV;
+  using DTypeO_D = typename DecodeParams::DTypeO;
+  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
+  constexpr uint32_t NUM_MMA_Q_D = get_num_mma_q(CTA_TILE_Q_D);
+  constexpr uint32_t NUM_WARPS_Q_D = get_num_warps_q(CTA_TILE_Q_D);
+  constexpr uint32_t NUM_WARPS_KV_D = get_num_warps_kv(CTA_TILE_Q_D);
+
+  // constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+  // constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
+  using DTypeQKAccum_D =
+      typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_D, half>, half,
+                                float>::type;
+
+  // we expect each sm execute two threadblocks
+  // TODO(Zihao): fix the following computation
+  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM_QK * sizeof(DTypeQ_D) * 16) ? 2 : 1;
+  const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
+
+  // Prefill params
+  constexpr uint32_t max_num_mma_kv_reg_p =
+      (HEAD_DIM_VO >= 128 && NUM_MMA_Q_P == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+       !USE_FP16_QK_REDUCTION)
+          ? 2
+          : (8 / NUM_MMA_Q_P);
+  const uint32_t max_num_mma_kv_smem_p =
+      (max_smem_per_threadblock / (16 * HEAD_DIM_QK * sizeof(DTypeQ_P)) -
+       NUM_MMA_Q_P * NUM_WARPS_Q_P) /
+      (2 * NUM_WARPS_KV_P);
+
+  // Decode params
+  constexpr uint32_t max_num_mma_kv_reg_d =
+      (HEAD_DIM_VO >= 128 && NUM_MMA_Q_D == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+       !USE_FP16_QK_REDUCTION)
+          ? 2
+          : (8 / NUM_MMA_Q_D);
+  const uint32_t max_num_mma_kv_smem_d =
+      (max_smem_per_threadblock / (16 * HEAD_DIM_QK * sizeof(DTypeQ_D)) -
+       NUM_MMA_Q_D * NUM_WARPS_Q_D) /
+      (2 * NUM_WARPS_KV_D);
+
+  // control NUM_MMA_KV for maximum warp occupancy
+  DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_p, max_num_mma_kv_reg_p), NUM_MMA_KV_P, {
+    using KTraits_P = KernelTraits<MASK_MODE_P, CTA_TILE_Q_P, NUM_MMA_Q_P, NUM_MMA_KV_P,
+                                   NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P,
+                                   POS_ENCODING_MODE, DTypeQ_P, DTypeKV_P, DTypeO_P, DTypeQKAccum_P,
+                                   typename PrefillParams::IdType, PrefillAttentionVariant>;
+
+    if constexpr (KTraits_P::IsInvalid()) {
+      // Invalid configuration, skip
+      std::ostringstream err_msg;
+      err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q_P
+              << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+              << " NUM_MMA_KV=" << NUM_MMA_KV_P << " NUM_WARPS_Q=" << NUM_WARPS_Q_P
+              << " NUM_WARPS_KV=" << NUM_WARPS_KV_P
+              << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                 " and report the issue to the developers.";
+      FLASHINFER_ERROR(err_msg.str());
+    } else {
+      // Decode stuff
+      // TODO: Is there a way to avoid this nested dispatch?
+      DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_d, max_num_mma_kv_reg_d), NUM_MMA_KV_D, {
+        using KTraits_D =
+            KernelTraits<MASK_MODE_D, CTA_TILE_Q_D, NUM_MMA_Q_D, NUM_MMA_KV_D, NUM_MMA_D_QK,
+                         NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, DTypeQ_D,
+                         DTypeKV_D, DTypeO_D, DTypeQKAccum_D, typename DecodeParams::IdType,
+                         DecodeAttentionVariant>;
+        if constexpr (KTraits_D::IsInvalid()) {
+          // Invalid configuration, skip
+          std::ostringstream err_msg;
+          err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q_D
+                  << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+                  << " NUM_MMA_KV=" << NUM_MMA_KV_D << " NUM_WARPS_Q=" << NUM_WARPS_Q_D
+                  << " NUM_WARPS_KV=" << NUM_WARPS_KV_D
+                  << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                     " and report the issue to the developers.";
+          FLASHINFER_ERROR(err_msg.str());
+        } else {
+          // End decode stuff
+          constexpr uint32_t num_threads_p = (NUM_WARPS_Q_P * NUM_WARPS_KV_P) * WARP_SIZE;
+          size_t smem_size_p = sizeof(typename KTraits_P::SharedStorage);
+          size_t smem_size_d = sizeof(typename KTraits_D::SharedStorage);
+
+          auto kernel =
+              BatchPODWithKVCacheTensorKernel<KTraits_P, KTraits_D, PrefillParams, DecodeParams>;
+
+          // Setup new prefill params if (not) split
+          auto o_p = prefill_params.o;
+          auto lse_p = prefill_params.lse;
+          if (tmp_v_p == nullptr) {
+            // do not partition kv
+            prefill_params.partition_kv = false;
+          } else {
+            prefill_params.partition_kv = true;
+            prefill_params.o = tmp_v_p;
+            prefill_params.lse = tmp_s_p;
+          }
+
+          // Setup new decode params if (not) split
+          auto o_d = decode_params.o;
+          auto lse_d = decode_params.lse;
+          if (tmp_v_d == nullptr) {
+            // do not partition kv
+            decode_params.partition_kv = false;
+          } else {
+            decode_params.partition_kv = true;
+            decode_params.o = tmp_v_d;
+            decode_params.lse = tmp_s_d;
+          }
+          int nblks_p(padded_batch_size_p * 1 * num_kv_heads);
+          int nthrs_p(32 * NUM_WARPS_Q_P * NUM_WARPS_KV_P);
+
+          int nblks_d(padded_batch_size_d * 1 * num_kv_heads);
+          int nthrs_d(32 * NUM_WARPS_Q_D * NUM_WARPS_KV_D);
+
+          // ******* Select final combined sizes here ******* /
+          size_t smem_size = max(smem_size_p, smem_size_d);
+          int nblks = nblks_p + nblks_d;
+          int nthrs = max(nthrs_p, nthrs_d);
+          //  ************************************************ /
+
+          // Initialize scheduler array: [0..num_sm-1] per-sm counters, [num_sm+0] prefill global, [num_sm+1] decode global
+          FLASHINFER_CUDA_CALL(
+              cudaMemsetAsync(sm_aware_sched, 0, sizeof(int) * (num_sm + 2), stream));
+
+          // Setup kernel arguments
+          void* args[] = {(void*)&prefill_params, (void*)&decode_params, (void*)&sm_aware_sched, (void*)&num_sm};
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+          // Launch kernel
+          if (enable_pdl) {
+            cudaLaunchAttribute attribute[1];
+            cudaLaunchConfig_t config;
+            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+            attribute[0].val.programmaticStreamSerializationAllowed = 1;
+            config.attrs = attribute;
+            config.numAttrs = 1;
+            config.gridDim = nblks;
+            config.blockDim = nthrs;
+            config.dynamicSmemBytes = smem_size;
+            config.stream = stream;
+            FLASHINFER_CUDA_CALL(
+                cudaLaunchKernelEx(&config, kernel, prefill_params, decode_params, sm_aware_sched, num_sm));
+          } else {
+            FLASHINFER_CUDA_CALL(
+                cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+          }
+
+          // Post-kernel stuff for split-kv prefill
+          if (tmp_v_p != nullptr) {
+            if constexpr (PrefillAttentionVariant::use_softmax) {
+              FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
+                  tmp_v_p, tmp_s_p, prefill_params.merge_indptr, o_p, lse_p,
+                  prefill_params.max_total_num_rows, prefill_params.total_num_rows, num_qo_heads,
+                  HEAD_DIM_VO, enable_pdl, stream));
+            } else {
+              FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
+                  tmp_v_p, prefill_params.merge_indptr, o_p, prefill_params.max_total_num_rows,
+                  prefill_params.total_num_rows, num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
+            }
+          }
+          // Post-kernel stuff for split-kv decode
+          if (tmp_v_d != nullptr) {
+            if constexpr (DecodeAttentionVariant::use_softmax) {
+              FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
+                  tmp_v_d, tmp_s_d, decode_params.merge_indptr, o_d, lse_d,
+                  decode_params.max_total_num_rows, decode_params.total_num_rows, num_qo_heads,
+                  HEAD_DIM_VO, enable_pdl, stream));
+            } else {
+              FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
+                  tmp_v_d, decode_params.merge_indptr, o_d, decode_params.max_total_num_rows,
+                  decode_params.total_num_rows, num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
+            }
+          }
+        }
+      });
+    }
+  });
+  return cudaSuccess;
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_BATCH_POD_CUH_

--- a/batch_pod.cuh
+++ b/batch_pod.cuh
@@ -34,16 +34,6 @@ enum Operation {
   DECODE = 1,
 };
 
-// Block factor constants (moved outside kernel for better compilation)
-constexpr int kBlkFactorP = 1;
-constexpr int kBlkFactorD = 1;
-
-// Scheduler result structure for better memory layout
-struct SchedulerResult {
-  int linear_bid;
-  int op;
-};
-
 template <typename KTraits_P, typename KTraits_D, typename PrefillParams, typename DecodeParams>
 __global__ __launch_bounds__(std::max(
     KTraits_P::NUM_THREADS,
@@ -51,8 +41,7 @@ __global__ __launch_bounds__(std::max(
                                                                       PrefillParams prefill_params,
                                                                   const __grid_constant__
                                                                       DecodeParams decode_params,
-                                                                  int* sm_aware_sched,
-                                                                  int num_sm) {
+                                                                  int* sm_aware_sched) {
   extern __shared__ uint8_t smem[];
   // PREFILL VARS
   const uint32_t padded_bsize_p = prefill_params.padded_batch_size;
@@ -66,95 +55,86 @@ __global__ __launch_bounds__(std::max(
   const uint32_t prefill_blocks = padded_bsize_p * num_kv_heads_p;
   const uint32_t decode_blocks = padded_bsize_d * num_kv_heads_d;
 
-  int op = 0;
-  int linear_bid = 0;
-
+  int op;
+  int linear_bid;
   // SM-aware CTA scheduler
   if (threadIdx.x == 0) {
     // TODO_AK: If num_threads dont match, use virtual sub-CTAs.
     // Requires changing block-level sync in main prefill/decode kernels.
+    constexpr int blk_factor_p = 1;
+    constexpr int blk_factor_d = 1;
 
-    // Get SM ID for this threadblock
-    int smid = 0;
-    asm volatile("mov.u32 %0, %smid;" : "=r"(smid));
+    // SM-aware threadblock scheduler code
+    // Find out which SM this threadblock is scheduled on
+    int num_SMs;
+    // WARNING: nsmid has only been tested on A100/H100, and matches SM count
+    // No guarantee this will work on other GPUs
+    asm volatile("mov.u32 %0, %nsmid;" : "=r"(num_SMs));
+    asm volatile("mov.u32 %0, %smid;" : "=r"(linear_bid));
+    const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
+    const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
 
-    // Clamp smid to num_sm to avoid out-of-bounds access
-    smid = (smid < num_sm) ? smid : num_sm - 1;
-
-    // No need for division when blk_factor = 1
-    const int prefill_slots = prefill_blocks;
-    const int decode_slots = decode_blocks;
-
-    // Handle empty batch cases to avoid div-by-zero
-    if (prefill_slots == 0 && decode_slots == 0) {
-      // Nothing to do - mark as invalid
-      op = -1;
-      linear_bid = 0;
-    } else if (prefill_slots == 0) {
-      // Pure decode mode: all SMs work on decode
-      op = DECODE;
-      linear_bid = atomicAdd(&sm_aware_sched[num_sm + DECODE], 1);
+    // Handle cases where one or both slot counts are zero to avoid divide-by-zero.
+    if (prefill_slots == 0) {
+      // No prefill blocks, always run DECODE
+      op = 1;
     } else if (decode_slots == 0) {
-      // Pure prefill mode: all SMs work on prefill
-      op = PREFILL;
-      linear_bid = atomicAdd(&sm_aware_sched[num_sm + PREFILL], 1);
-    } else {
-      // Mixed mode: use SM-aware scheduler with both prefill and decode
-      // Allocate work based on ratio of slots to minimize fallback
-      if (prefill_slots <= decode_slots) {
-        const int total_tags = decode_slots / prefill_slots + 1;
-        const int tag = atomicAdd(&sm_aware_sched[smid], 1);
-        op = (tag % total_tags == 0) ? PREFILL : DECODE;
-      } else {
-        const int pref_tags = prefill_slots / decode_slots;
-        const int tag = atomicAdd(&sm_aware_sched[smid], 1);
-        op = (tag % (pref_tags + 1) < pref_tags) ? PREFILL : DECODE;
+      // No decode blocks, always run PREFILL
+      op = 0;
+    } else if (prefill_slots <= decode_slots) {
+      // Total tags = (decode + prefill) / min(decode, prefill)
+      // = 1 + decode / prefill; when prefill < decode
+      const int total_tags = decode_slots / prefill_slots + 1;
+      // For this SM, what's the next operation we want to run?
+      op = (atomicAdd(&sm_aware_sched[linear_bid], 1) % total_tags);
+      if (op > 0) {
+        op = 1 ;
       }
+    } else {
+      // Total tags = (decode + prefill) / min(decode, prefill)
+      // = 1 + prefill / decode; when decode < prefill
+      const int pref_tags = prefill_slots / decode_slots;
 
-      // Get the next blockId for that operation
-      linear_bid = atomicAdd(&sm_aware_sched[num_sm + op], 1);
-
-      // If out of range, try to switch to the other operation
-      if ((op == PREFILL && linear_bid >= prefill_slots) ||
-          (op == DECODE && linear_bid >= decode_slots)) {
-        // Try the other operation
-        int other_op = 1 - op;
-        int other_bid = atomicAdd(&sm_aware_sched[num_sm + other_op], 1);
-
-        // Only switch if the other operation has work available
-        if ((other_op == PREFILL && other_bid < prefill_slots) ||
-            (other_op == DECODE && other_bid < decode_slots)) {
-          op = other_op;
-          linear_bid = other_bid;
-        } else {
-          // No work available - mark as invalid
-          op = -1;
-          linear_bid = 0;
-        }
+      // For this SM, what's the next operation we want to run?
+      op = (atomicAdd(&sm_aware_sched[linear_bid], 1) % (pref_tags + 1));
+      if (op < pref_tags) {
+        op = 0;
+      } else {
+        op = 1;
       }
     }
 
-    // Write the blockId and operation to shared memory using structure
-    auto& result = *reinterpret_cast<SchedulerResult*>(smem);
-    result.linear_bid = linear_bid;
-    result.op = op;
+    // Get the next blockId for that operation
+    linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+    // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
+    if (op == 0 && linear_bid >= prefill_slots) {
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
+      op = !op;
+    } else if (op == 1 && linear_bid >= decode_slots) {
+      op = !op;
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
+    }
+    // Write the blockId and operation to shared memory
+    ((int*)smem)[0] = linear_bid;
+    ((int*)smem)[1] = op;
   }
-
-  // Sync to wait for scheduler to finish and broadcast results
+  // Sync to wait for dynamic scheduler to finish
   __syncthreads();
-  auto& result = *reinterpret_cast<SchedulerResult*>(smem);
-  linear_bid = result.linear_bid;
-  op = result.op;
-
-  // Early exit for invalid operations (no work available)
-  if (op < 0) return;
+  // Fetch from shared memory the assigned blockId and operation.
+  linear_bid = ((int*)smem)[0];
+  op = ((int*)smem)[1];
+  // Sync to force all threads to wait
+  __syncthreads();
 
   if (op == PREFILL) {
     auto& smem_storage = reinterpret_cast<typename KTraits_P::SharedStorage&>(smem);
+    // dim3 nblks_d(padded_batch_size_d, 1, num_kv_heads);
+    if (linear_bid >= prefill_blocks) return;
 
     const uint32_t bx = linear_bid % padded_bsize_p;
     const uint32_t kv_head_idx = linear_bid / padded_bsize_p;
 
+    // dim3 nthrs_d(32, NUM_WARPS_Q_D, NUM_WARPS_KV_D);
     const uint32_t linear_tid = threadIdx.x;
     // Return if threadId exceeds number of threads for this op
     if (linear_tid >= 32 * KTraits_P::NUM_WARPS_Q * KTraits_P::NUM_WARPS_KV) return;
@@ -166,10 +146,13 @@ __global__ __launch_bounds__(std::max(
                                                   kv_head_idx, num_kv_heads_p);
   } else /* OP == DECODE */ {
     auto& smem_storage = reinterpret_cast<typename KTraits_D::SharedStorage&>(smem);
+    // dim3 nblks_d(padded_batch_size_d, 1, num_kv_heads);
+    if (linear_bid >= decode_blocks) return;
 
     const uint32_t bx = linear_bid % padded_bsize_d;
     const uint32_t kv_head_idx = linear_bid / padded_bsize_d;
 
+    // dim3 nthrs_d(32, NUM_WARPS_Q_D, NUM_WARPS_KV_D);
     const uint32_t linear_tid = threadIdx.x;
     // Return if threadId exceeds number of threads for this op
     if (linear_tid >= 32 * KTraits_D::NUM_WARPS_Q * KTraits_D::NUM_WARPS_KV) return;
@@ -199,24 +182,15 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   // Ensure heads match
   assert(prefill_params.paged_kv.num_heads == decode_params.paged_kv.num_heads);
   assert(prefill_params.num_qo_heads == decode_params.num_qo_heads);
-
   // Common variables for both prefill and decode
   const uint32_t num_qo_heads = prefill_params.num_qo_heads;
   const uint32_t num_kv_heads = prefill_params.paged_kv.num_heads;
 
-  // Get device properties once
   int dev_id = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-
   int max_smem_per_sm = 0;
   FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm,
                                               cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
-
-  int num_sm = 0;
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
-
-  constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
-  constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
 
   // Prefill variable setup
   using DTypeQ_P = typename PrefillParams::DTypeQ;
@@ -230,6 +204,11 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   using DTypeQKAccum_P =
       typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_P, half>, half,
                                 float>::type;
+
+  const uint32_t group_size = num_qo_heads / num_kv_heads;
+  const uint_fastdiv group_size_fastdiv(group_size);
+  constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+  constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
 
   // Decode vars setup
   using DTypeQ_D = typename DecodeParams::DTypeQ;
@@ -268,6 +247,7 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q_D);
+  // TODO(Zihao): fix the following computation
   const uint32_t max_num_mma_kv_smem_d =
       (max_smem_per_threadblock / (16 * HEAD_DIM_QK * sizeof(DTypeQ_D)) -
        NUM_MMA_Q_D * NUM_WARPS_Q_D) /
@@ -353,12 +333,14 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
           int nthrs = max(nthrs_p, nthrs_d);
           //  ************************************************ /
 
-          // Initialize scheduler array: [0..num_sm-1] per-sm counters, [num_sm+0] prefill global, [num_sm+1] decode global
+          int num_sm = 0;
+          FLASHINFER_CUDA_CALL(
+              cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
           FLASHINFER_CUDA_CALL(
               cudaMemsetAsync(sm_aware_sched, 0, sizeof(int) * (num_sm + 2), stream));
 
           // Setup kernel arguments
-          void* args[] = {(void*)&prefill_params, (void*)&decode_params, (void*)&sm_aware_sched, (void*)&num_sm};
+          void* args[] = {(void*)&prefill_params, (void*)&decode_params, (void*)&sm_aware_sched};
           FLASHINFER_CUDA_CALL(
               cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
@@ -375,7 +357,7 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
             config.dynamicSmemBytes = smem_size;
             config.stream = stream;
             FLASHINFER_CUDA_CALL(
-                cudaLaunchKernelEx(&config, kernel, prefill_params, decode_params, sm_aware_sched, num_sm));
+                cudaLaunchKernelEx(&config, kernel, prefill_params, decode_params, sm_aware_sched));
           } else {
             FLASHINFER_CUDA_CALL(
                 cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.srt.utils.common import is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.nsa.nsa_indexer import BaseIndexerMetadata
@@ -99,7 +98,7 @@ class AttentionBackend(ABC):
                 save_kv_cache=save_kv_cache,
                 **kwargs,
             )
-        elif forward_batch.forward_mode.is_mixed() and is_npu():
+        elif forward_batch.forward_mode.is_mixed():
             return self.forward_mixed(
                 q,
                 k,
@@ -153,8 +152,15 @@ class AttentionBackend(ABC):
         forward_batch: ForwardBatch,
         save_kv_cache: bool = True,
     ):
-        """Run a forward for mix."""
-        raise NotImplementedError()
+        """Run a forward for mix. Defaults to extend path."""
+        return self.forward_extend(
+            q,
+            k,
+            v,
+            layer,
+            forward_batch,
+            save_kv_cache=save_kv_cache,
+        )
 
     def support_triton(self):
         """Check if the current backend supports triton."""

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -87,7 +87,24 @@ class AttentionBackend(ABC):
         **kwargs,
     ):
         """Run forward on an attention layer."""
-        if forward_batch.forward_mode.is_idle():
+        pod_enabled = (
+            hasattr(self, "use_pod")
+            and self.use_pod
+            and hasattr(self, "forward_metadata_pod")
+            and self.forward_metadata_pod is not None
+        )
+
+        if pod_enabled:
+            return self.forward_pod(
+                q,
+                k,
+                v,
+                layer,
+                forward_batch,
+                save_kv_cache=save_kv_cache,
+                **kwargs,
+            )
+        elif forward_batch.forward_mode.is_idle():
             return q.new_empty(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
         elif forward_batch.forward_mode.is_decode():
             return self.forward_decode(
@@ -144,6 +161,18 @@ class AttentionBackend(ABC):
         """Run a forward for extend."""
         raise NotImplementedError()
 
+    def forward_pod(
+            self,
+            q: torch.Tensor,
+            k: torch.Tensor,
+            v: torch.Tensor,
+            layer: RadixAttention,
+            forward_batch: ForwardBatch,
+            save_kv_cache: bool = True,
+        ):
+            """Run a forward for POD (Prefill-Optimized Decoding) mode."""
+            raise NotImplementedError()
+            
     def forward_mixed(
         self,
         q: torch.Tensor,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -499,7 +499,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 num_decode_reqs = 0
                 num_prefill_reqs = bs
 
-            if num_prefill_reqs > 0 or num_decode_reqs > 0:
+            if num_prefill_reqs > 0 and num_decode_reqs > 0:
                 self.indices_updater_pod.update(
                     forward_batch.req_pool_indices,
                     forward_batch.seq_lens,
@@ -1031,6 +1031,8 @@ class FlashInferAttnBackend(AttentionBackend):
             q_d,
             paged_kv_cache,
             causal_p=True,
+            k_scale=layer.k_scale_float,
+            v_scale=layer.v_scale_float,
         )
 
         num_tokens_p = o_p.size(0)
@@ -1763,7 +1765,7 @@ class FlashInferIndicesUpdaterPOD:
             q_data_type=self.q_data_type, kv_data_type=self.data_type,
         )
 
-        
+
 class FlashInferMultiStepDraftBackend:
     """
     Wrap multiple flashinfer attention backends as one for multiple consecutive

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -295,7 +295,8 @@ class FlashInferAttnBackend(AttentionBackend):
         # Using two wrappers is unnecessary in the current PR, but are prepared for future PRs
         self.prefill_wrappers_paged = []
         self.prefill_wrappers_verify = []
-        self.decode_wrappers = []self.pod_wrappers = []
+        self.decode_wrappers = []
+        self.pod_wrappers = []
         for _ in range(self.num_wrappers):
             if self.use_pod and not skip_prefill:
                 self.pod_wrappers.append(
@@ -305,29 +306,29 @@ class FlashInferAttnBackend(AttentionBackend):
                     )
                 )
             if not skip_prefill:
-                    self.prefill_wrappers_paged.append(
-                        BatchPrefillWithPagedKVCacheWrapper(
-                            self.workspace_buffer,
-                            "NHD",
-                            backend="fa2",
-                        )
-                    )
-                    self.prefill_wrappers_verify.append(
-                        BatchPrefillWithPagedKVCacheWrapper(
-                            self.workspace_buffer,
-                            "NHD",
-                        )
-                    )
-                self.decode_wrappers.append(
-                    BatchDecodeWithPagedKVCacheWrapper(
+                self.prefill_wrappers_paged.append(
+                    BatchPrefillWithPagedKVCacheWrapper(
                         self.workspace_buffer,
                         "NHD",
-                        use_tensor_cores=self.decode_use_tensor_cores,
+                        backend="fa2",
                     )
                 )
+                self.prefill_wrappers_verify.append(
+                    BatchPrefillWithPagedKVCacheWrapper(
+                        self.workspace_buffer,
+                        "NHD",
+                    )
+                )
+            self.decode_wrappers.append(
+                BatchDecodeWithPagedKVCacheWrapper(
+                    self.workspace_buffer,
+                    "NHD",
+                    use_tensor_cores=self.decode_use_tensor_cores,
+                )
+            )
 
         # Create indices updater
-         if self.use_pod and not skip_prefill:
+        if self.use_pod and not skip_prefill:
             self.indices_updater_pod = FlashInferIndicesUpdaterPOD(
                 model_runner, self
             )
@@ -1703,8 +1704,8 @@ class FlashInferIndicesUpdaterPOD:
             bs_p = bs - num_decode_reqs
             bs_d = num_decode_reqs
 
-            seq_lens_p = seq_lens.narrow(0, 0, bs_p) if bs_p > 0 else seq_lens.new_zeros(0, device=seq_lens.device, dtype=seq_lens.dtype)
-            seq_lens_d = seq_lens.narrow(0, bs_p, bs_d) if bs_d > 0 else seq_lens.new_zeros(0, device=seq_lens.device, dtype=seq_lens.dtype)
+            seq_lens_p = seq_lens.narrow(0, 0, bs_p) if bs_p > 0 else self._pod_empty_tensor_0
+            seq_lens_d = seq_lens.narrow(0, bs_p, bs_d) if bs_d > 0 else self._pod_empty_tensor_0
 
             paged_kernel_lens_sum_p = seq_lens_p.sum() if bs_p > 0 else 0
             paged_kernel_lens_sum_d = seq_lens_d.sum() if bs_d > 0 else 0

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -46,6 +46,7 @@ if envs.SGLANG_ENABLE_TORCH_COMPILE.get():
 if is_flashinfer_available():
     from flashinfer import (
         BatchDecodeWithPagedKVCacheWrapper,
+        BatchPODWithPagedKVCacheWrapper,
         BatchPrefillWithPagedKVCacheWrapper,
         BatchPrefillWithRaggedKVCacheWrapper,
         fast_decode_plan,
@@ -101,12 +102,38 @@ class PrefillMetadata:
     multi_item_params: Optional[MultiItemScoringParams] = None
 
 
+@dataclass
+class PODMetadata:
+    pod_wrappers: List[BatchPODWithPagedKVCacheWrapper]
+
+
 # Reuse this workspace buffer across all flashinfer wrappers
 global_workspace_buffer = None
 
 # Use as a fast path to override the indptr in flashinfer's plan function
 # This is used to remove some host-to-device copy overhead.
 global_override_indptr_cpu = None
+
+# Global output buffer for POD mode
+_global_pod_output_buffer = None
+_global_pod_output_size = 0
+
+
+def _get_pod_output_buffer(
+    size: int, dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    global _global_pod_output_buffer, _global_pod_output_size
+
+    if _global_pod_output_buffer is None or _global_pod_output_size < size:
+        new_size = (
+            max(size, _global_pod_output_size * 2)
+            if _global_pod_output_size > 0
+            else size * 2
+        )
+        _global_pod_output_buffer = torch.empty(new_size, dtype=dtype, device=device)
+        _global_pod_output_size = new_size
+
+    return _global_pod_output_buffer[:size]
 
 
 class FlashInferAttnBackend(AttentionBackend):
@@ -143,6 +170,10 @@ class FlashInferAttnBackend(AttentionBackend):
         self.max_context_len = model_runner.model_config.context_len
         self.skip_prefill = skip_prefill
         self.is_multimodal = model_runner.model_config.is_multimodal
+        self.use_pod = (
+            model_runner.server_args.enable_flashinfer_pod_attention
+            and model_runner.server_args.enable_mixed_chunk
+        )
 
         assert not (
             model_runner.sliding_window_size is not None
@@ -211,11 +242,16 @@ class FlashInferAttnBackend(AttentionBackend):
             self.workspace_buffer = global_workspace_buffer
         max_bs = model_runner.req_to_token_pool.size
         if kv_indptr_buf is None:
+            # For POD mode, we need 2 kv_indptr buffers (prefill + decode)
+            # For other modes, we need num_wrappers kv_indptr buffers
+            num_kv_indptr = (
+                2 if (self.use_pod and not skip_prefill) else self.num_wrappers
+            )
             self.kv_indptr = [
                 torch.zeros(
                     (max_bs + 1,), dtype=torch.int32, device=model_runner.device
                 )
-                for _ in range(self.num_wrappers)
+                for _ in range(num_kv_indptr)
             ]
         else:
             assert self.num_wrappers == 1
@@ -230,11 +266,16 @@ class FlashInferAttnBackend(AttentionBackend):
             self.kv_last_page_len = kv_last_page_len_buf
 
         if not self.skip_prefill:
+            # For POD mode, we need 2 qo_indptr buffers (prefill + decode)
+            # For other modes, we need num_wrappers qo_indptr buffers
+            num_qo_indptr = (
+                2 if (self.use_pod and not skip_prefill) else self.num_wrappers
+            )
             self.qo_indptr = [
                 torch.zeros(
                     (max_bs + 1,), dtype=torch.int32, device=model_runner.device
                 )
-                for _ in range(self.num_wrappers)
+                for _ in range(num_qo_indptr)
             ]
 
         fmha_backend = "auto"
@@ -258,7 +299,15 @@ class FlashInferAttnBackend(AttentionBackend):
         self.prefill_wrappers_paged = []
         self.prefill_wrappers_verify = []
         self.decode_wrappers = []
+        self.pod_wrappers = []
         for _ in range(self.num_wrappers):
+            if self.use_pod and not skip_prefill:
+                self.pod_wrappers.append(
+                    BatchPODWithPagedKVCacheWrapper(
+                        self.workspace_buffer,
+                        "NHD",
+                    )
+                )
             if not skip_prefill:
                 self.prefill_wrappers_paged.append(
                     BatchPrefillWithPagedKVCacheWrapper(
@@ -281,15 +330,18 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
             )
 
-        # Create indices updater
+        # Create indices updaters
+        self.indices_updater_decode = FlashInferIndicesUpdaterDecode(model_runner, self)
         if not skip_prefill:
             self.indices_updater_prefill = FlashInferIndicesUpdaterPrefill(
                 model_runner, self
             )  # for verify
-        self.indices_updater_decode = FlashInferIndicesUpdaterDecode(model_runner, self)
+        if self.use_pod and not skip_prefill:
+            self.indices_updater_pod = FlashInferIndicesUpdaterPOD(model_runner, self)
 
         # Other metadata
         self.forward_metadata: Union[PrefillMetadata, DecodeMetadata] = None
+        self.forward_metadata_pod: Optional[PODMetadata] = None
 
         self.decode_cuda_graph_metadata = {}
         self.prefill_cuda_graph_metadata = {}  # For verify
@@ -418,6 +470,34 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
+        self.forward_metadata_pod = None
+        if (
+            self.use_pod
+            and not self.skip_prefill
+            and forward_batch.forward_mode.is_mixed()
+        ):
+            prefix_lens = forward_batch.extend_prefix_lens
+            bs = len(forward_batch.req_pool_indices)
+
+            num_decode_reqs = forward_batch.num_decoding_reqs or 0
+            num_prefill_reqs = bs - num_decode_reqs
+
+            if num_prefill_reqs > 0 and num_decode_reqs > 0:
+                self.indices_updater_pod.update(
+                    forward_batch.req_pool_indices,
+                    forward_batch.seq_lens,
+                    forward_batch.seq_lens_cpu,
+                    forward_batch.seq_lens_sum,
+                    prefix_lens,
+                    pod_wrappers=self.pod_wrappers,
+                    encoder_lens=forward_batch.encoder_lens,
+                    spec_info=None,
+                    num_decode_reqs=num_decode_reqs,
+                )
+
+                self.forward_metadata_pod = PODMetadata(self.pod_wrappers)
+                return
+
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 forward_batch.req_pool_indices,
@@ -890,6 +970,71 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+    def forward_mixed(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        # If POD metadata is not available, fallback to extend path
+        if self.forward_metadata_pod is None:
+            return self.forward_extend(
+                q, k, v, layer, forward_batch, save_kv_cache=save_kv_cache
+            )
+
+        pod_wrapper = self.forward_metadata_pod.pod_wrappers[
+            self._get_wrapper_idx(layer)
+        ]
+
+        if not q.is_contiguous():
+            q = q.contiguous()
+
+        num_decoding_reqs = forward_batch.num_decoding_reqs or 0
+        num_prefill_tokens = forward_batch.extend_num_tokens - num_decoding_reqs
+
+        q_p = q[:num_prefill_tokens].view(-1, layer.tp_q_head_num, layer.head_dim)
+        q_d = q[num_prefill_tokens:].view(-1, layer.tp_q_head_num, layer.head_dim)
+
+        paged_kv_cache = forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+
+        if k is not None and v is not None:
+            forward_batch.token_to_kv_pool.set_kv_buffer(
+                layer, forward_batch.out_cache_loc, k, v, layer.k_scale, layer.v_scale
+            )
+
+        o_p, o_d = pod_wrapper.run(
+            q_p,
+            paged_kv_cache,
+            q_d,
+            paged_kv_cache,
+            causal_p=True,
+            k_scale=layer.k_scale_float,
+            v_scale=layer.v_scale_float,
+        )
+
+        num_tokens_p = o_p.size(0)
+        num_tokens_d = o_d.size(0)
+        hidden_size = layer.tp_q_head_num * layer.head_dim
+
+        o = _get_pod_output_buffer(
+            (num_tokens_p + num_tokens_d) * hidden_size, o_p.dtype, o_p.device
+        )
+        o = o.view(num_tokens_p + num_tokens_d, hidden_size)
+
+        if num_tokens_p > 0:
+            o[:num_tokens_p] = o_p.reshape(num_tokens_p, hidden_size)
+        if num_tokens_d > 0:
+            o[num_tokens_p:] = o_d.reshape(num_tokens_d, hidden_size)
+
+        if layer.layer_id == 0:
+            logger.info(
+                f"forward pod, prefill tokens: {num_tokens_p}, decode tokens: {num_tokens_d}"
+            )
+        return o.view(-1, hidden_size)
 
     def _get_wrapper_idx(self, layer: RadixAttention):
         if self.num_wrappers == 1:
@@ -1448,6 +1593,199 @@ class FlashInferIndicesUpdaterPrefill:
             token_pos_in_items_ptr=token_pos_in_items_ptr,
             token_pos_in_items_len=token_pos_in_items_len,
             max_item_len_ptr=max_item_len_ptr,
+        )
+
+
+class FlashInferIndicesUpdaterPOD:
+    def __init__(self, model_runner: ModelRunner, attn_backend: FlashInferAttnBackend):
+        # Parse Constants
+        self.num_qo_heads = (
+            model_runner.model_config.num_attention_heads // get_attention_tp_size()
+        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            get_attention_tp_size()
+        )
+        self.head_dim = model_runner.model_config.head_dim
+        self.data_type = model_runner.kv_cache_dtype
+        self.q_data_type = model_runner.dtype
+        self.attn_backend = attn_backend
+
+        # Buffers and wrappers
+        self.kv_indptr = attn_backend.kv_indptr
+        self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.pod_wrappers = attn_backend.pod_wrappers
+
+        # Pre-allocate buffers
+        max_bs = model_runner.req_to_token_pool.size
+        kv_indices_size = max_bs * model_runner.model_config.context_len + 256
+        device = model_runner.device
+
+        self._pod_last_page_len_buffer = torch.ones(
+            max_bs, dtype=torch.int32, device=device
+        )
+        self._pod_qo_indptr_p_buffer = torch.zeros(
+            max_bs + 1, dtype=torch.int32, device=device
+        )
+        self._pod_kv_indices_buffer = torch.empty(
+            kv_indices_size * 2,  # Reserve space for both prefill and decode
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # Pre-allocate empty tensors for else branches
+        self._pod_empty_tensor_1 = torch.zeros(1, dtype=torch.int32, device=device)
+        self._pod_empty_tensor_0 = torch.zeros(0, dtype=torch.int32, device=device)
+
+        # Pre-compute qo_indptr pattern for decode: [0, 1, 2, ..., max_bs]
+        self._pod_qo_indptr_d_pattern = torch.arange(
+            max_bs + 1, dtype=torch.int32, device=device
+        )
+
+        # Dispatch the update function
+        # POD mode currently only supports single wrapper
+        assert self.attn_backend.num_wrappers == 1
+        self.update = self.update_single_wrapper
+
+    def update(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        seq_lens_sum: int,
+        prefix_lens: torch.Tensor,
+        pod_wrappers: List[BatchPODWithPagedKVCacheWrapper],
+        encoder_lens: Optional[torch.Tensor],
+        spec_info: Optional[SpecInput],
+        num_decode_reqs: int = 0,
+    ):
+        # Keep the signature for type checking. It will be assigned during runtime.
+        raise NotImplementedError()
+
+    def update_single_wrapper(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        seq_lens_sum: int,
+        prefix_lens: torch.Tensor,
+        pod_wrappers: List[BatchPODWithPagedKVCacheWrapper],
+        encoder_lens: Optional[torch.Tensor],
+        spec_info: Optional[SpecInput],
+        num_decode_reqs: int = 0,
+    ):
+        pod_wrappers = pod_wrappers or self.pod_wrappers
+        self.call_begin_forward(
+            pod_wrappers[0],
+            req_pool_indices,
+            seq_lens,
+            prefix_lens,
+            num_decode_reqs,
+            spec_info,
+        )
+
+    def call_begin_forward(
+        self,
+        pod_wrapper: BatchPODWithPagedKVCacheWrapper,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        num_decode_reqs: int,
+        spec_info: Optional[SpecInput],
+    ):
+        if spec_info is None:
+            bs = len(seq_lens)
+            bs_p = bs - num_decode_reqs
+            bs_d = num_decode_reqs
+
+            seq_lens_p = (
+                seq_lens.narrow(0, 0, bs_p) if bs_p > 0 else self._pod_empty_tensor_0
+            )
+            seq_lens_d = (
+                seq_lens.narrow(0, bs_p, bs_d) if bs_d > 0 else self._pod_empty_tensor_0
+            )
+
+            paged_kernel_lens_sum_p = seq_lens_p.sum() if bs_p > 0 else 0
+            paged_kernel_lens_sum_d = seq_lens_d.sum() if bs_d > 0 else 0
+
+            kv_indptr_p = self.kv_indptr[0]
+            kv_indptr_d = self.kv_indptr[1]
+
+            if bs_p > 0:
+                cumsum_p = torch.cumsum(seq_lens_p, dim=0)
+                kv_indptr_p[1 : bs_p + 1] = cumsum_p
+            if bs_d > 0:
+                cumsum_d = torch.cumsum(seq_lens_d, dim=0)
+                kv_indptr_d[1 : bs_d + 1] = cumsum_d
+
+            if bs_p > 0:
+                kv_indptr_p_buf = kv_indptr_p[: bs_p + 1]
+                kv_indices_p = self._pod_kv_indices_buffer[
+                    : paged_kernel_lens_sum_p + 256
+                ]
+                create_flashinfer_kv_indices_triton[(bs_p,)](
+                    self.req_to_token,
+                    req_pool_indices[:bs_p],
+                    seq_lens_p,
+                    kv_indptr_p_buf,
+                    None,
+                    kv_indices_p,
+                    self.req_to_token.shape[1],
+                )
+                last_page_len_p = self._pod_last_page_len_buffer[:bs_p]
+                qo_indptr_p = self._pod_qo_indptr_p_buffer[: bs_p + 1]
+                prefix_lens_p = prefix_lens.narrow(0, 0, bs_p)
+                qo_indptr_p[1 : bs_p + 1] = torch.cumsum(
+                    seq_lens_p - prefix_lens_p, dim=0
+                )
+            else:
+                kv_indptr_p_buf = self._pod_empty_tensor_1
+                kv_indices_p = self._pod_empty_tensor_1
+                qo_indptr_p = self._pod_empty_tensor_1
+                last_page_len_p = self._pod_empty_tensor_0
+
+            if bs_d > 0:
+                kv_indptr_d_buf = kv_indptr_d[: bs_d + 1]
+                kv_indices_d = self._pod_kv_indices_buffer[
+                    paged_kernel_lens_sum_p : paged_kernel_lens_sum_p
+                    + paged_kernel_lens_sum_d
+                    + 256
+                ]
+                create_flashinfer_kv_indices_triton[(bs_d,)](
+                    self.req_to_token,
+                    req_pool_indices[bs_p:],
+                    seq_lens_d,
+                    kv_indptr_d_buf,
+                    None,
+                    kv_indices_d,
+                    self.req_to_token.shape[1],
+                )
+                last_page_len_d = self._pod_last_page_len_buffer[:bs_d]
+                qo_indptr_d = self._pod_qo_indptr_d_pattern[: bs_d + 1]
+            else:
+                kv_indptr_d_buf = self._pod_empty_tensor_1
+                kv_indices_d = self._pod_empty_tensor_1
+                qo_indptr_d = self._pod_empty_tensor_1
+                last_page_len_d = self._pod_empty_tensor_0
+        else:
+            raise NotImplementedError(
+                "Speculative decoding not supported in POD mode yet"
+            )
+
+        pod_wrapper.begin_forward(
+            qo_indptr_p,
+            kv_indptr_p_buf,
+            kv_indices_p,
+            last_page_len_p,
+            qo_indptr_d,
+            kv_indptr_d_buf,
+            kv_indices_d,
+            last_page_len_d,
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            1,
+            q_data_type=self.q_data_type,
+            kv_data_type=self.data_type,
         )
 
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -48,6 +48,7 @@ if is_flashinfer_available():
         BatchDecodeWithPagedKVCacheWrapper,
         BatchPrefillWithPagedKVCacheWrapper,
         BatchPrefillWithRaggedKVCacheWrapper,
+        BatchPODWithPagedKVCacheWrapper,
         fast_decode_plan,
     )
     from flashinfer.cascade import merge_state
@@ -101,12 +102,42 @@ class PrefillMetadata:
     multi_item_params: Optional[MultiItemScoringParams] = None
 
 
+@dataclass
+class PODMetadata:
+    pod_wrappers: List[BatchPODWithPagedKVCacheWrapper]
+
+
 # Reuse this workspace buffer across all flashinfer wrappers
 global_workspace_buffer = None
 
 # Use as a fast path to override the indptr in flashinfer's plan function
 # This is used to remove some host-to-device copy overhead.
 global_override_indptr_cpu = None
+
+# Global cache for empty tensors in POD mode: (device, dtype, num_heads, head_dim) -> Tensor
+_global_empty_q_cache = {}
+
+# Global output buffer for POD mode
+_global_pod_output_buffer = None
+_global_pod_output_size = 0
+
+
+def _get_cached_empty_q(device: torch.device, dtype: torch.dtype, num_heads: int, head_dim: int) -> torch.Tensor:
+    key = (device, dtype, num_heads, head_dim)
+    if key not in _global_empty_q_cache:
+        _global_empty_q_cache[key] = torch.empty((0, num_heads, head_dim), dtype=dtype, device=device)
+    return _global_empty_q_cache[key]
+
+
+def _get_pod_output_buffer(size: int, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+    global _global_pod_output_buffer, _global_pod_output_size
+
+    if _global_pod_output_buffer is None or _global_pod_output_size < size:
+        new_size = max(size, _global_pod_output_size * 2) if _global_pod_output_size > 0 else size * 2
+        _global_pod_output_buffer = torch.empty(new_size, dtype=dtype, device=device)
+        _global_pod_output_size = new_size
+
+    return _global_pod_output_buffer[:size]
 
 
 class FlashInferAttnBackend(AttentionBackend):
@@ -143,6 +174,7 @@ class FlashInferAttnBackend(AttentionBackend):
         self.max_context_len = model_runner.model_config.context_len
         self.skip_prefill = skip_prefill
         self.is_multimodal = model_runner.model_config.is_multimodal
+        self.use_pod = model_runner.use_pod
 
         assert not (
             model_runner.sliding_window_size is not None
@@ -211,11 +243,14 @@ class FlashInferAttnBackend(AttentionBackend):
             self.workspace_buffer = global_workspace_buffer
         max_bs = model_runner.req_to_token_pool.size
         if kv_indptr_buf is None:
+            # For POD mode, we need 2 kv_indptr buffers (prefill + decode)
+            # For other modes, we need num_wrappers kv_indptr buffers
+            num_kv_indptr = 2 if (self.use_pod and not skip_prefill) else self.num_wrappers
             self.kv_indptr = [
                 torch.zeros(
                     (max_bs + 1,), dtype=torch.int32, device=model_runner.device
                 )
-                for _ in range(self.num_wrappers)
+                for _ in range(num_kv_indptr)
             ]
         else:
             assert self.num_wrappers == 1
@@ -230,11 +265,14 @@ class FlashInferAttnBackend(AttentionBackend):
             self.kv_last_page_len = kv_last_page_len_buf
 
         if not self.skip_prefill:
+           # For POD mode, we need 2 qo_indptr buffers (prefill + decode)
+            # For other modes, we need num_wrappers qo_indptr buffers
+            num_qo_indptr = 2 if (self.use_pod and not skip_prefill) else self.num_wrappers
             self.qo_indptr = [
                 torch.zeros(
                     (max_bs + 1,), dtype=torch.int32, device=model_runner.device
                 )
-                for _ in range(self.num_wrappers)
+                for _ in range(num_qo_indptr)
             ]
 
         fmha_backend = "auto"
@@ -257,39 +295,52 @@ class FlashInferAttnBackend(AttentionBackend):
         # Using two wrappers is unnecessary in the current PR, but are prepared for future PRs
         self.prefill_wrappers_paged = []
         self.prefill_wrappers_verify = []
-        self.decode_wrappers = []
+        self.decode_wrappers = []self.pod_wrappers = []
         for _ in range(self.num_wrappers):
+            if self.use_pod and not skip_prefill:
+                self.pod_wrappers.append(
+                    BatchPODWithPagedKVCacheWrapper(
+                        self.workspace_buffer,
+                        "NHD",
+                    )
+                )
             if not skip_prefill:
-                self.prefill_wrappers_paged.append(
-                    BatchPrefillWithPagedKVCacheWrapper(
+                    self.prefill_wrappers_paged.append(
+                        BatchPrefillWithPagedKVCacheWrapper(
+                            self.workspace_buffer,
+                            "NHD",
+                            backend="fa2",
+                        )
+                    )
+                    self.prefill_wrappers_verify.append(
+                        BatchPrefillWithPagedKVCacheWrapper(
+                            self.workspace_buffer,
+                            "NHD",
+                        )
+                    )
+                self.decode_wrappers.append(
+                    BatchDecodeWithPagedKVCacheWrapper(
                         self.workspace_buffer,
                         "NHD",
-                        backend="fa2",
+                        use_tensor_cores=self.decode_use_tensor_cores,
                     )
                 )
-                self.prefill_wrappers_verify.append(
-                    BatchPrefillWithPagedKVCacheWrapper(
-                        self.workspace_buffer,
-                        "NHD",
-                    )
-                )
-            self.decode_wrappers.append(
-                BatchDecodeWithPagedKVCacheWrapper(
-                    self.workspace_buffer,
-                    "NHD",
-                    use_tensor_cores=self.decode_use_tensor_cores,
-                )
-            )
 
         # Create indices updater
-        if not skip_prefill:
-            self.indices_updater_prefill = FlashInferIndicesUpdaterPrefill(
+         if self.use_pod and not skip_prefill:
+            self.indices_updater_pod = FlashInferIndicesUpdaterPOD(
                 model_runner, self
-            )  # for verify
-        self.indices_updater_decode = FlashInferIndicesUpdaterDecode(model_runner, self)
+            )
+        else:
+            self.indices_updater_decode = FlashInferIndicesUpdaterDecode(model_runner, self)
+            if not skip_prefill:
+                self.indices_updater_prefill = FlashInferIndicesUpdaterPrefill(
+                    model_runner, self
+                )  # for verify
 
         # Other metadata
         self.forward_metadata: Union[PrefillMetadata, DecodeMetadata] = None
+        self.forward_metadata_pod: Optional[PODMetadata] = None
 
         self.decode_cuda_graph_metadata = {}
         self.prefill_cuda_graph_metadata = {}  # For verify
@@ -418,7 +469,53 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        if forward_batch.forward_mode.is_decode_or_idle():
+        if self.use_pod and not self.skip_prefill:
+            if forward_batch.forward_mode.is_decode_or_idle():
+                if forward_batch.seq_lens_cpu is not None:
+                    prefix_lens = (forward_batch.seq_lens_cpu - 1).tolist()
+                else:
+                    prefix_lens = [
+                        max(0, x - 1) for x in forward_batch.seq_lens.tolist()
+                    ]
+            else:
+                prefix_lens = forward_batch.extend_prefix_lens
+
+            extend_no_prefix = (
+                not any(forward_batch.extend_prefix_lens_cpu)
+                if forward_batch.extend_prefix_lens_cpu
+                else False
+            )
+
+            bs = len(forward_batch.req_pool_indices)
+
+            if forward_batch.forward_mode.is_decode_or_idle():
+                num_decode_reqs = bs
+                num_prefill_reqs = 0
+            elif forward_batch.decoding_reqs is not None:
+                num_decode_reqs = len(forward_batch.decoding_reqs)
+                num_prefill_reqs = bs - num_decode_reqs
+            else:
+                num_decode_reqs = 0
+                num_prefill_reqs = bs
+
+            if num_prefill_reqs > 0 or num_decode_reqs > 0:
+                self.indices_updater_pod.update(
+                    forward_batch.req_pool_indices,
+                    forward_batch.seq_lens,
+                    forward_batch.seq_lens_cpu,
+                    forward_batch.seq_lens_sum,
+                    prefix_lens,
+                    pod_wrappers=self.pod_wrappers,
+                    encoder_lens=forward_batch.encoder_lens,
+                    spec_info=None,
+                    num_decode_reqs=num_decode_reqs,
+                )
+
+                self.forward_metadata_pod = PODMetadata(
+                    self.pod_wrappers
+                )
+                return
+        elif forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
@@ -890,6 +987,66 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+    def forward_pod(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        pod_wrapper = self.forward_metadata_pod.pod_wrappers[
+            self._get_wrapper_idx(layer)
+        ]
+
+        if not q.is_contiguous():
+            q = q.contiguous()
+
+        decode_start = forward_batch.decode_start_or_none
+        empty_q = _get_cached_empty_q(q.device, q.dtype, layer.tp_q_head_num, layer.head_dim)
+
+        if decode_start is not None:
+            q_p = q[:decode_start].view(-1, layer.tp_q_head_num, layer.head_dim)
+            q_d = q[decode_start:].view(-1, layer.tp_q_head_num, layer.head_dim)
+        elif forward_batch.forward_mode.is_decode_or_idle():
+            q_p = empty_q
+            q_d = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+        else:
+            q_p = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+            q_d = empty_q
+
+        paged_kv_cache = forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+
+        if k is not None and v is not None:
+            forward_batch.token_to_kv_pool.set_kv_buffer(
+                layer, forward_batch.out_cache_loc, k, v, layer.k_scale, layer.v_scale
+            )
+
+        o_p, o_d = pod_wrapper.run(
+            q_p,
+            paged_kv_cache,
+            q_d,
+            paged_kv_cache,
+            causal_p=True,
+        )
+
+        num_tokens_p = o_p.size(0)
+        num_tokens_d = o_d.size(0)
+        hidden_size = layer.tp_q_head_num * layer.head_dim
+
+        o = _get_pod_output_buffer(
+            (num_tokens_p + num_tokens_d) * hidden_size, o_p.dtype, o_p.device
+        )
+        o = o.view(num_tokens_p + num_tokens_d, hidden_size)
+
+        if num_tokens_p > 0:
+            o[:num_tokens_p] = o_p.reshape(num_tokens_p, hidden_size)
+        if num_tokens_d > 0:
+            o[num_tokens_p:] = o_d.reshape(num_tokens_d, hidden_size)
+
+        return o.view(-1, hidden_size)
 
     def _get_wrapper_idx(self, layer: RadixAttention):
         if self.num_wrappers == 1:
@@ -1451,6 +1608,161 @@ class FlashInferIndicesUpdaterPrefill:
         )
 
 
+class FlashInferIndicesUpdaterPOD:
+    def __init__(self, model_runner: ModelRunner, attn_backend: FlashInferAttnBackend):
+        # Parse Constants
+        self.num_qo_heads = (
+            model_runner.model_config.num_attention_heads // get_attention_tp_size()
+        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            get_attention_tp_size()
+        )
+        self.head_dim = model_runner.model_config.head_dim
+        self.data_type = model_runner.kv_cache_dtype
+        self.q_data_type = model_runner.dtype
+        self.attn_backend = attn_backend
+
+        # Buffers and wrappers
+        self.kv_indptr = attn_backend.kv_indptr
+        self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.pod_wrappers = attn_backend.pod_wrappers
+
+        # Pre-allocate buffers
+        max_bs = model_runner.req_to_token_pool.size
+        kv_indices_size = max_bs * model_runner.model_config.context_len + 256
+        device = model_runner.device
+
+        self._pod_last_page_len_buffer = torch.ones(max_bs, dtype=torch.int32, device=device)
+        self._pod_qo_indptr_p_buffer = torch.zeros(max_bs + 1, dtype=torch.int32, device=device)
+        self._pod_kv_indices_buffer = torch.empty(
+            kv_indices_size * 2,  # Reserve space for both prefill and decode
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # Pre-allocate empty tensors for else branches
+        self._pod_empty_tensor_1 = torch.zeros(1, dtype=torch.int32, device=device)
+        self._pod_empty_tensor_0 = torch.zeros(0, dtype=torch.int32, device=device)
+
+        # Pre-compute qo_indptr pattern for decode: [0, 1, 2, ..., max_bs]
+        self._pod_qo_indptr_d_pattern = torch.arange(max_bs + 1, dtype=torch.int32, device=device)
+
+        # Dispatch the update function
+        # POD mode currently only supports single wrapper
+        assert self.attn_backend.num_wrappers == 1
+        self.update = self.update_single_wrapper
+
+    def update(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        seq_lens_sum: int,
+        prefix_lens: torch.Tensor,
+        pod_wrappers: List[BatchPODWithPagedKVCacheWrapper],
+        encoder_lens: Optional[torch.Tensor],
+        spec_info: Optional[SpecInput],
+        num_decode_reqs: int = 0,
+    ):
+        # Keep the signature for type checking. It will be assigned during runtime.
+        raise NotImplementedError()
+
+    def update_single_wrapper(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        seq_lens_sum: int,
+        prefix_lens: torch.Tensor,
+        pod_wrappers: List[BatchPODWithPagedKVCacheWrapper],
+        encoder_lens: Optional[torch.Tensor],
+        spec_info: Optional[SpecInput],
+        num_decode_reqs: int = 0,
+    ):
+        pod_wrappers = pod_wrappers or self.pod_wrappers
+        self.call_begin_forward(
+            pod_wrappers[0],
+            req_pool_indices,
+            seq_lens,
+            prefix_lens,
+            num_decode_reqs,
+            spec_info,
+        )
+
+    def call_begin_forward(
+        self,
+        pod_wrapper: BatchPODWithPagedKVCacheWrapper,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        num_decode_reqs: int,
+        spec_info: Optional[SpecInput],
+    ):
+        if spec_info is None:
+            bs = len(seq_lens)
+            bs_p = bs - num_decode_reqs
+            bs_d = num_decode_reqs
+
+            seq_lens_p = seq_lens.narrow(0, 0, bs_p) if bs_p > 0 else seq_lens.new_zeros(0, device=seq_lens.device, dtype=seq_lens.dtype)
+            seq_lens_d = seq_lens.narrow(0, bs_p, bs_d) if bs_d > 0 else seq_lens.new_zeros(0, device=seq_lens.device, dtype=seq_lens.dtype)
+
+            paged_kernel_lens_sum_p = seq_lens_p.sum() if bs_p > 0 else 0
+            paged_kernel_lens_sum_d = seq_lens_d.sum() if bs_d > 0 else 0
+
+            kv_indptr_p = self.kv_indptr[0]
+            kv_indptr_d = self.kv_indptr[1]
+
+            if bs_p > 0:
+                cumsum_p = torch.cumsum(seq_lens_p, dim=0)
+                kv_indptr_p[1 : bs_p + 1] = cumsum_p
+            if bs_d > 0:
+                cumsum_d = torch.cumsum(seq_lens_d, dim=0)
+                kv_indptr_d[1 : bs_d + 1] = cumsum_d
+
+            if bs_p > 0:
+                kv_indptr_p_buf = kv_indptr_p[: bs_p + 1]
+                kv_indices_p = self._pod_kv_indices_buffer[:paged_kernel_lens_sum_p + 256]
+                create_flashinfer_kv_indices_triton[(bs_p,)](
+                    self.req_to_token, req_pool_indices[:bs_p], seq_lens_p,
+                    kv_indptr_p_buf, None, kv_indices_p, self.req_to_token.shape[1],
+                )
+                last_page_len_p = self._pod_last_page_len_buffer[:bs_p]
+                qo_indptr_p = self._pod_qo_indptr_p_buffer[:bs_p + 1]
+                prefix_lens_p = prefix_lens.narrow(0, 0, bs_p)
+                qo_indptr_p[1 : bs_p + 1] = torch.cumsum(seq_lens_p - prefix_lens_p, dim=0)
+            else:
+                kv_indptr_p_buf = self._pod_empty_tensor_1
+                kv_indices_p = self._pod_empty_tensor_1
+                qo_indptr_p = self._pod_empty_tensor_1
+                last_page_len_p = self._pod_empty_tensor_0
+
+            if bs_d > 0:
+                kv_indptr_d_buf = kv_indptr_d[: bs_d + 1]
+                kv_indices_d = self._pod_kv_indices_buffer[
+                    paged_kernel_lens_sum_p : paged_kernel_lens_sum_p + paged_kernel_lens_sum_d + 256
+                ]
+                create_flashinfer_kv_indices_triton[(bs_d,)](
+                    self.req_to_token, req_pool_indices[bs_p:], seq_lens_d,
+                    kv_indptr_d_buf, None, kv_indices_d, self.req_to_token.shape[1],
+                )
+                last_page_len_d = self._pod_last_page_len_buffer[:bs_d]
+                qo_indptr_d = self._pod_qo_indptr_d_pattern[:bs_d + 1]
+            else:
+                kv_indptr_d_buf = self._pod_empty_tensor_1
+                kv_indices_d = self._pod_empty_tensor_1
+                qo_indptr_d = self._pod_empty_tensor_1
+                last_page_len_d = self._pod_empty_tensor_0
+        else:
+            raise NotImplementedError("Speculative decoding not supported in POD mode yet")
+
+        pod_wrapper.begin_forward(
+            qo_indptr_p, kv_indptr_p_buf, kv_indices_p, last_page_len_p,
+            qo_indptr_d, kv_indptr_d_buf, kv_indices_d, last_page_len_d,
+            self.num_qo_heads, self.num_kv_heads, self.head_dim, 1,
+            q_data_type=self.q_data_type, kv_data_type=self.data_type,
+        )
+
+        
 class FlashInferMultiStepDraftBackend:
     """
     Wrap multiple flashinfer attention backends as one for multiple consecutive

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1789,11 +1789,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 for r in running_batch.reqs
             ]
         )
+        prefill_token_count = self.extend_num_tokens
         self.extend_lens.extend([1] * running_bs)
         self.extend_num_tokens += running_bs
         # TODO (lianmin): Revisit this. It should be seq_len - 1
         self.extend_logprob_start_lens.extend([0] * running_bs)
-        self.is_prefill_only = False
+        self.is_prefill_only = Falses
+
+        self.decode_start_or_none = prefill_token_count
+        self.decoding_reqs = running_batch.reqs
 
     def new_tokens_required_next_decode(
         self, selected_indices: Optional[List[int]] = None
@@ -1944,6 +1948,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
+        self.decode_start_or_none = None
+        self.decoding_reqs = None
         bs = len(self.reqs)
 
         if self.is_spec_v2:
@@ -2234,6 +2240,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_indices=self.mamba_track_indices,
             mamba_track_mask=self.mamba_track_mask,
             mamba_track_seqlens=self.mamba_track_seqlens,
+            decode_start_or_none=getattr(self, 'decode_start_or_none', None),
+            decoding_reqs=getattr(self, 'decoding_reqs', None),
         )
 
     def copy(self):
@@ -2412,3 +2420,7 @@ class ModelWorkerBatch:
     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
     mamba_track_mask: Optional[torch.Tensor] = None  # shape: [b], bool
     mamba_track_seqlens: Optional[torch.Tensor] = None  # shape: [b], int64
+
+    # For POD mode
+    decode_start_or_none: Optional[int] = None
+    decoding_reqs: Optional[List[Req]] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1794,7 +1794,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_num_tokens += running_bs
         # TODO (lianmin): Revisit this. It should be seq_len - 1
         self.extend_logprob_start_lens.extend([0] * running_bs)
-        self.is_prefill_only = Falses
+        self.is_prefill_only = False
 
         self.decode_start_or_none = prefill_token_count
         self.decoding_reqs = running_batch.reqs

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1292,6 +1292,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     extend_lens: List[int] = None
     extend_num_tokens: Optional[int] = None
     decoding_reqs: List[Req] = None
+    num_decoding_reqs: Optional[int] = None
     extend_logprob_start_lens: List[int] = None
     # It comes empty list if logprob is not required.
     extend_input_logprob_token_ids: Optional[torch.Tensor] = None
@@ -1475,7 +1476,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if self.is_dllm():
             # For DLLM, we use a separate forward mode
             self.forward_mode = ForwardMode.DLLM_EXTEND
-
+        self.num_decoding_reqs = 0
         # Init tensors
         reqs = self.reqs
         input_ids = [r.fill_ids[len(r.prefix_indices) :] for r in reqs]
@@ -1795,6 +1796,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_logprob_start_lens.extend([0] * running_bs)
         self.is_prefill_only = False
 
+        self.num_decoding_reqs = running_bs
+        logger.info(
+            f"Mixed batch scheduling, perfill batch:{self.extend_num_tokens - running_bs}, decode batch:{running_bs}"
+        )
+
     def new_tokens_required_next_decode(
         self, selected_indices: Optional[List[int]] = None
     ):
@@ -1930,6 +1936,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.req_pool_indices = torch.empty(0, dtype=torch.int32, device=self.device)
         self.seq_lens_sum = 0
         self.extend_num_tokens = 0
+        self.num_decoding_reqs = 0
         self.sampling_info = SamplingBatchInfo.from_schedule_batch(
             self,
             self.model_config.vocab_size,
@@ -1944,6 +1951,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
+        self.num_decoding_reqs = 0
         bs = len(self.reqs)
 
         if self.is_spec_v2:
@@ -2234,6 +2242,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_indices=self.mamba_track_indices,
             mamba_track_mask=self.mamba_track_mask,
             mamba_track_seqlens=self.mamba_track_seqlens,
+            num_decoding_reqs=self.num_decoding_reqs or 0,
         )
 
     def copy(self):
@@ -2412,3 +2421,6 @@ class ModelWorkerBatch:
     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
     mamba_track_mask: Optional[torch.Tensor] = None  # shape: [b], bool
     mamba_track_seqlens: Optional[torch.Tensor] = None  # shape: [b], int64
+
+    # For POD mode
+    num_decoding_reqs: Optional[int] = None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -392,6 +392,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             req_pool_indices=batch.req_pool_indices,
             seq_lens=batch.seq_lens,
             out_cache_loc=batch.out_cache_loc,
+            decode_start_or_none=batch.decode_start_or_none,
+            decoding_reqs=batch.decoding_reqs,
             mamba_track_indices=batch.mamba_track_indices,
             mamba_track_mask=batch.mamba_track_mask,
             mamba_track_seqlens=batch.mamba_track_seqlens,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -375,6 +375,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
+    # For POD mode
+    decode_start_or_none: Optional[int] = None
+    decoding_reqs: Optional[List] = None
+
     @classmethod
     def init_new(
         cls,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -375,6 +375,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
+    # For mixed chunked prefill (POD mode)
+    num_decoding_reqs: Optional[int] = None
+
     @classmethod
     def init_new(
         cls,
@@ -388,6 +391,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             req_pool_indices=batch.req_pool_indices,
             seq_lens=batch.seq_lens,
             out_cache_loc=batch.out_cache_loc,
+            num_decoding_reqs=batch.num_decoding_reqs or 0,
             mamba_track_indices=batch.mamba_track_indices,
             mamba_track_mask=batch.mamba_track_mask,
             mamba_track_seqlens=batch.mamba_track_seqlens,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -313,6 +313,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.is_hybrid_swa_compress = model_config.is_hybrid_swa_compress
         self.use_mla_backend = self.model_config.attention_arch == AttentionArch.MLA
         self.attention_chunk_size = model_config.attention_chunk_size
+        self.use_pod = server_args.enable_flashinfer_pod and server_args.enable_mixed_chunk
         self.forward_pass_id = 0
         self.init_new_workspace = False
         self.draft_model_idx = draft_model_idx
@@ -2222,6 +2223,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             **kwargs,
         )
 
+    def forward_pod(
+        self,
+        forward_batch: ForwardBatch,
+        skip_attn_backend_init: bool = False,
+        pp_proxy_tensors=None,
+    ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
+        if not skip_attn_backend_init:
+            self.attn_backend.init_forward_metadata(forward_batch)
+        kwargs = {}
+        if self.support_pp:
+            kwargs["pp_proxy_tensors"] = pp_proxy_tensors
+        return self.model.forward(
+            forward_batch.input_ids,
+            forward_batch.positions,
+            forward_batch,
+            **kwargs,
+        )
+
     def forward_split_prefill(
         self,
         forward_batch: ForwardBatch,
@@ -2343,7 +2362,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 server_args=self.server_args,
             )
 
-        if forward_batch.forward_mode.is_decode():
+        if self.use_pod :
+            ret = self.forward_pod(
+                forward_batch,
+                skip_attn_backend_init=skip_attn_backend_init,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+        elif forward_batch.forward_mode.is_mixed():
+            ret = self.forward_extend(
+                forward_batch,
+                skip_attn_backend_init=skip_attn_backend_init,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+        elif forward_batch.forward_mode.is_decode():
             ret = self.forward_decode(
                 forward_batch,
                 skip_attn_backend_init=skip_attn_backend_init,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -444,6 +444,7 @@ class ServerArgs:
         None  # auto-detect based on hardware/kv_cache_dtype
     )
     disable_flashinfer_autotune: bool = False
+    enable_flashinfer_pod: bool = False
 
     # Speculative decoding
     speculative_algorithm: Optional[str] = None
@@ -3668,6 +3669,12 @@ class ServerArgs:
             default=ServerArgs.disable_flashinfer_autotune,
             action="store_true",
             help="Disable FlashInfer autotuning.",
+        )
+        parser.add_argument(
+            "--enable-flashinfer-pod",
+            action="store_true",
+            default=ServerArgs.enable_flashinfer_pod,
+            help="Enable FlashInfer POD mode.",
         )
 
         # Speculative decoding

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -444,6 +444,7 @@ class ServerArgs:
         None  # auto-detect based on hardware/kv_cache_dtype
     )
     disable_flashinfer_autotune: bool = False
+    enable_flashinfer_pod_attention: bool = False
 
     # Speculative decoding
     speculative_algorithm: Optional[str] = None
@@ -3669,6 +3670,12 @@ class ServerArgs:
             action="store_true",
             help="Disable FlashInfer autotuning.",
         )
+        parser.add_argument(
+            "--enable-flashinfer-pod-attention",
+            action="store_true",
+            default=ServerArgs.enable_flashinfer_pod_attention,
+            help="Enable FlashInfer POD mode.",
+        )
 
         # Speculative decoding
         parser.add_argument(
@@ -4877,6 +4884,11 @@ class ServerArgs:
         assert (
             self.tp_size * self.pp_size
         ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
+
+        if self.enable_flashinfer_pod_attention:
+            assert (
+                self.enable_mixed_chunk
+            ), "enable_flashinfer_pod_attention requires enable_mixed_chunk"
 
         if self.pp_size > 1:
             assert (

--- a/test.py
+++ b/test.py
@@ -1,0 +1,142 @@
+from sglang.test.doc_patch import launch_server_cmd, execute_shell_command
+from sglang.utils import wait_for_server, print_highlight, terminate_process
+import os
+import subprocess
+import requests
+import json
+import time
+import threading
+
+os.environ['CUDA_VISIBLE_DEVICES'] = '2'
+os.environ['SGLANG_ENABLE_TORCH_COMPILE'] = '0'
+os.environ['FLASHINFER_DISABLE_VERSION_CHECK'] = '1'
+os.environ['SGLANG_DISABLE_CUDNN_CHECK'] = '1'
+os.environ['HF_HUB_OFFLINE'] = '1'
+os.environ['PYTHONPATH'] = '/workspace/pod/sglang/python:$PYTHONPATH'
+os.environ['SGLANG_USE_MODELSCOPE'] = 'true'
+
+
+# This is equivalent to running the following command in your terminal
+
+server_process, port = launch_server_cmd(
+    """
+python3 -m sglang.launch_server  --model-path Qwen/Qwen3-8B \
+ --host 0.0.0.0 --attention-backend flashinfer --tp=1 --disable-cuda-graph \
+ --skip-server-warmup  --enable-mixed-chunk \
+ --enable-flashinfer-pod  --chunked-prefill-size 512
+"""
+)
+
+wait_for_server(f"http://localhost:{port}")
+
+# 定义发送请求的函数
+def send_chat_request(messages, max_tokens=1000, temperature=0.0):
+    url = f"http://localhost:{port}/v1/chat/completions"
+    headers = {"Content-Type": "application/json"}
+    data = {
+        "model": "default",
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": False
+    }
+    response = requests.post(url, headers=headers, json=data)
+    result = response.json()
+    return result
+
+'''# 测试 1: 简单请求验证 POD attention 基本功能
+print("=== 测试 1: 简单请求验证 POD attention ===")
+result1 = send_chat_request([{"role": "user", "content": "你好，请用一句话介绍 POD attention。"}], max_tokens=200)
+print("响应:", result1["choices"][0]["message"]["content"])
+
+# 测试 2: 长中文请求测试
+print("\n=== 测试 2: 长中文请求测试 ===")
+long_prompt = """你是一位专业的内容创作者，请根据以下要求生成一段原创文字：主题围绕人工智能如何改变现代教育，内容需兼具信息性与可读性，适合普通读者理解。请避免使用过于专业的术语，若必须使用，请附带简明解释。文章应包含三个核心部分：首先，简要介绍当前教育体系面临的主要挑战（如资源不均、个性化不足等）；其次，具体说明人工智能在解决这些问题中的实际应用（例如智能辅导系统、自适应学习平台、自动化评估工具等），并列举一两个真实或典型的案例加以佐证；最后，探讨 AI 融入教育可能带来的潜在风险或伦理问题（如数据隐私、算法偏见、师生关系弱化等），并提出建设性的应对建议。整体语气应保持客观、理性但不失温度，字数控制在 600 字以内。请确保逻辑连贯、段落分明，并以中文输出。不要添加标题或小标题，直接以正文形式呈现。此外，请勿引用未经核实的数据或虚构不存在的研究成果，所有陈述应基于当前（截至2025年）已知的主流技术发展和教育实践。如果你对某些细节不确定，请优先选择概括性描述而非具体数字。最终目标是让读者在阅读后，既能理解 AI 对教育的积极影响，也能意识到其中需要谨慎对待的问题，从而形成全面而平衡的认知。"""
+result2 = send_chat_request([{"role": "user", "content": long_prompt}], max_tokens=3000)
+print("响应:", result2["choices"][0]["message"]["content"])
+
+# 测试 3: Mixed Chunk 模式测试（并发请求触发 POD mixed mode）
+print("\n=== 测试 3: Mixed Chunk 模式测试 ===")
+
+# 用于存储结果的容器
+long_request_result = {"done": False, "response": None}
+
+def long_request_thread():
+    """长请求：会进入 decode 阶段"""
+    print("[线程1] 启动长请求...")
+    response = send_chat_request([{"role": "user", "content": long_prompt}], max_tokens=100)
+    long_request_result["response"] = response
+    long_request_result["done"] = True
+    print("[线程1] 长请求完成！")
+
+# 启动长请求线程
+thread1 = threading.Thread(target=long_request_thread)
+thread1.start()
+
+# 等待 1 秒，确保长请求已经完成 prefill 并进入 decode 阶段
+print("[主线程] 等待 1 秒，让长请求进入 decode 阶段...")
+time.sleep(0.5)  # 增加到 0.5 秒，确保长请求完成 prefill 并开始 decode
+
+# 此时发送第二个请求，会触发 mixed mode（新请求 prefill + 旧请求 decode）
+print("[主线程] 发送短请求，触发 mixed mode...")
+short_prompt = "请用一句话解释什么是机器学习。"
+result3 = send_chat_request([{"role": "user", "content": short_prompt}], max_tokens=1000)
+print("[主线程] 短请求响应:", result3["choices"][0]["message"]["content"])
+
+# 等待长请求完成
+thread1.join()
+long_content = long_request_result["response"]["choices"][0]["message"]["content"]
+print(f"\n[主线程] 长请求最终响应:")
+print(f"  完整长度: {len(long_content)} 字符")
+print(f"  内容预览: {long_content[:300]}...")
+'''
+# 测试 4: 多次并发请求测试 mixed mode 稳定性
+'''print("\n=== 测试 4: 多次并发 Mixed Chunk 测试 ===")'''
+
+def concurrent_mixed_test():
+    """测试多次并发请求是否稳定"""
+    results = []
+
+    def worker(prompt, max_tokens, delay):
+        if delay > 0:
+            time.sleep(delay)
+        resp = send_chat_request([{"role": "user", "content": prompt}], max_tokens=max_tokens)
+        results.append(resp)
+        '''print(f"  [完成] prompt 长度: {len(prompt)}, tokens: {max_tokens}")'''
+
+    # 启动多个并发请求
+    threads = []
+    prompts = [
+        ("请以系统化、循序渐进的方式解释量子计算的基础原理：先从“量子计算与经典计算的差异”切入，说明为什么经典比特只能表示0或1，而量子计算使用量子比特能够带来新的信息表示与计算范式；随后详细阐述量子比特（qubit）的数学表示与物理实现思路，解释基态|0⟩、|1⟩、振幅与相位的含义，以及测量导致的概率结果与塌缩过程；进一步重点说明量子叠加的概念、直观理解与其在计算中形成“量子并行性”的原因，同时澄清叠加并不等同于一次得到所有答案；再深入介绍量子纠缠的定义、典型纠缠态示例、纠缠所带来的非经典相关性，以及它为何是量子算法、量子通信与量子误差校正的重要资源；最后简要概括量子门、干涉与典型算法如何利用叠加与纠缠产生潜在加速，并提及噪声、退相干与纠错等现实挑战。", 1000, 0.0),    # 第一个立即开始，长文本
+        ("请用面向初学者但保持技术严谨的方式解释“什么是深度学习”：先说明深度学习与机器学习、传统统计建模之间的关系，解释“深度”一词为何对应多层神经网络的层级结构；再描述神经网络如何通过多层非线性变换学习从低级到高级的特征表示，强调端到端训练与自动特征学习相对于手工特征工程的差异；要求介绍常见网络结构及其适用场景，例如CNN在图像中的局部感受野与权重共享思想、RNN/LSTM在序列建模中的记忆机制、Transformer的自注意力如何捕捉长程依赖；同时概括训练流程（损失函数、反向传播、梯度下降、正则化与早停等）和对数据与算力的需求；最后请列举深度学习典型应用（视觉、语音、NLP、推荐、生成式任务）并点出局限性（可解释性、数据偏差、泛化与鲁棒性、成本与能耗）", 1000, 0.0),         # 延迟 0.0 秒，触发 mixed
+        ("请从语言设计理念、运行环境、生态系统与工程实践四个维度，全面比较Python与JavaScript的差异：先说明两者各自最典型的应用场景（Python在数据分析、AI、自动化、后端与科研；JavaScript在浏览器端交互、前端工程化以及Node.js后端）；再比较语法与代码组织方式（缩进与花括号、模块系统、包管理、常见编码风格）；进一步解释两者的执行模型与并发机制差异（Python解释器与GIL对多线程的影响、asyncio；JavaScript事件循环、回调/Promise/async-await），以及这对I/O密集与CPU密集任务的意义；同时对比类型系统与开发体验（动态类型、类型标注/TypeScript、调试与工具链）；最后从工程落地角度讨论性能、部署方式、跨平台能力、社区库质量与学习曲线，并给出在“做Web应用、做数据科学、做脚本自动化、做全栈开发”这几类目标下的选型建议与原因。", 1000, 0.0),  # 延迟 0.0 秒
+        ("请用通俗但完整的方式介绍区块链技术的基本概念及其应用：首先解释区块链作为“分布式账本”的含义，说明数据如何以区块为单位组织、通过哈希指针形成链式结构，从而具备难以篡改与可追溯特性；其次阐述共识机制在无中心化信任场景中的作用，要求对比PoW、PoS等机制的基本思路、优缺点与安全假设；再说明公链、联盟链、私链的差异，以及节点、钱包、地址、私钥签名、交易广播与确认的基本流程；进一步介绍智能合约的概念、可编程性带来的业务自动执行能力，以及其常见风险（漏洞、可升级性、预言机问题）；最后请列举区块链在数字资产与支付清算、供应链溯源、跨境结算、身份与凭证、数据确权、去中心化金融（DeFi）、NFT与数字内容等领域的代表性应用，并指出现实挑战，如吞吐量、扩容、隐私保护、监管合规与能源消耗等。", 1000, 0.0),  # 延迟 0.0 秒
+        ("请围绕“机器学习中的过拟合问题如何解决”给出结构化回答：先定义过拟合与欠拟合，并解释它们在训练集与验证/测试集表现上的典型特征；再从成因角度分析为什么模型容量过大、数据量不足、噪声或标签错误、训练过久、特征泄漏等会导致过拟合；随后系统梳理常用对策，包括数据层面（更多数据、数据增强、清洗异常与纠正标签）、模型层面（降低复杂度、特征选择、剪枝、限制树深、减少参数）、训练层面（正则化L1/L2、Dropout、早停Early Stopping、交叉验证、学习率与训练轮数控制）、集成方法（Bagging、随机森林、Boosting的正则化形式）以及超参数调优策略；同时说明如何正确划分数据集、如何使用验证集与K折交叉验证评估泛化；最后给出在分类、回归与深度学习场景下的具体做法示例，并提醒注意数据泄漏与评估指标选择对结论的影响。", 1000, 0.0),   # 延迟 0.0 秒
+        ("请简要但覆盖全面地说明自然语言处理（NLP）的主要任务有哪些，并要求按“基础处理—理解—生成—应用系统”层级组织：先列出基础文本处理任务，如分词/词形还原、词性标注、命名实体识别、句法分析（依存/成分）与核心指代消解，并说明这些任务为更高级应用提供结构化信息；再概括语义理解类任务，如文本分类、情感分析、主题识别、语义相似度、信息抽取（关系抽取、事件抽取）、阅读理解与问答，以及它们在实际业务中的用途；随后说明文本生成与对话相关任务，包括机器翻译、摘要生成、对话系统、文本改写与风格迁移、代码生成与多模态生成中的文本部分；同时提及检索与推荐中的NLP任务，如语义检索、搜索排序、RAG中的检索与重写；最后要求给出典型应用场景（客服、舆情、办公自动化、教育、医疗、法律）并点出关键挑战，如歧义、长文本、事实一致性、偏见与安全、低资源语言与领域迁移等。", 1000, 0.0),  # 延迟 0.0 秒
+        ("请解释“什么是计算机视觉”并列举其常见应用：首先给出定义，说明计算机视觉旨在让机器从图像与视频中感知、理解并进行决策或生成内容；接着按任务类别介绍核心问题，如图像分类、目标检测、语义/实例分割、关键点与姿态估计、跟踪、光流、3D重建与深度估计，以及OCR与文档理解等；要求说明这些任务分别解决什么问题、输出形式是什么（类别、框、掩码、关键点、轨迹等）；再概述常用技术路线，从传统特征到深度学习模型（CNN、ViT、检测框架如Faster R-CNN/YOLO、分割网络等）的演进；最后列出实际应用：人脸识别与门禁、安防监控、工业质检、医疗影像辅助诊断、无人机巡检、零售盘点、自动驾驶感知、AR/VR、内容审核与生成式视觉，并补充挑战，如光照与遮挡、实时性、数据标注成本、泛化与鲁棒性、隐私合规等。", 1000, 0.0) ,   # 延迟 0.0 秒
+        ("请解释强化学习的基本概念并说明其在游戏中的应用：先用“智能体—环境—状态—动作—奖励”框架定义强化学习，解释目标是学习一项策略使长期累计回报最大化；再区分基于价值的方法（Q-learning、DQN）、基于策略的方法（Policy Gradient、PPO）以及Actor-Critic结构，并说明探索与利用的矛盾、折扣因子与回合式/连续式任务的差异；同时介绍马尔可夫决策过程（MDP）的基本要素，解释为什么状态表示、奖励设计与终止条件对学习效果至关重要；随后结合游戏场景阐述强化学习如何通过自博弈、模拟器交互与经验回放提升策略，并举例说明在Atari、围棋/象棋、MOBA或策略游戏中训练时面临的稀疏奖励、长时序信用分配、多智能体协作与对抗、以及样本效率问题；最后讨论强化学习从游戏走向现实控制（机器人、推荐、调度）时的挑战，如安全探索、仿真到现实迁移与可解释性。", 1000, 0.0) ,   # 延迟 0.0 秒
+        ("请介绍生成对抗网络（GAN）是什么以及它如何工作：首先说明GAN是一类生成模型，由生成器（Generator）与判别器（Discriminator）构成，通过对抗训练学习数据分布；要求用直观语言解释两者的分工：生成器从随机噪声或条件输入生成样本，判别器判断样本来自真实数据还是生成数据；再解释训练过程为何是一个最小最大博弈，生成器试图“骗过”判别器、判别器不断提高鉴别能力，最终在理想状态下生成样本与真实分布难以区分；同时介绍条件GAN、CycleGAN等变体的基本思路与适用任务（图像到图像转换、风格迁移、超分辨率）；要求说明常见训练难点，如模式崩溃、梯度消失、训练不稳定，以及WGAN、谱归一化、标签平滑等改进方法的动机；最后列举GAN在图像生成、数据增强、图像修复、虚拟人物与内容创作中的应用，并提醒其潜在风险，如深度伪造、版权与安全治理问题。", 1000, 0.0)  ,  # 延迟 0.0 秒
+        ("请介绍自动驾驶技术的核心原理和挑战，并按“感知—定位—预测—规划—控制—系统安全”链路展开：先说明自动驾驶如何通过多传感器（摄像头、毫米波雷达、激光雷达、超声波、IMU/GNSS）获取环境信息，并进行时间同步与融合；再解释感知模块的关键任务（车道线、交通灯标志、车辆行人检测与跟踪、占用网格/BEV表征），以及定位与建图（高精地图、SLAM、融合定位）的作用；随后说明对周围交通参与者行为的预测如何为规划提供先验，规划如何在规则、舒适性与安全约束下生成轨迹（全局路径、局部轨迹、决策），控制模块如何将轨迹转化为转向、油门、制动；进一步要求讨论数据闭环、仿真测试、OTA与监控体系；最后重点列出挑战：长尾场景与极端天气、传感器噪声与遮挡、实时性与算力、可解释与验证困难、功能安全与冗余、网络与对抗安全、法规与责任界定、以及规模化落地的成本与商业模式问题。", 1000, 0.0)    # 延迟 0.0 秒
+    ]
+
+    for prompt, tokens, delay in prompts:
+        t = threading.Thread(target=worker, args=(prompt, tokens, delay))
+        threads.append(t)
+        t.start()
+
+    # 等待所有线程完成
+    for t in threads:
+        t.join()
+
+# 输出所有结果
+    for i, resp in enumerate(results):
+        content = resp['choices'][0]['message']['content']
+        print(f"\n结果 {i+1}:")
+        print(f"{content}")
+
+concurrent_mixed_test()
+
+'''# 清理
+print("\n=== 测试完成 ===")'''
+
+terminate_process(server_process)

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ os.environ['SGLANG_ENABLE_TORCH_COMPILE'] = '0'
 os.environ['FLASHINFER_DISABLE_VERSION_CHECK'] = '1'
 os.environ['SGLANG_DISABLE_CUDNN_CHECK'] = '1'
 os.environ['HF_HUB_OFFLINE'] = '1'
-os.environ['PYTHONPATH'] = '/workspace/pod/sglang/python:$PYTHONPATH'
+os.environ['PYTHONPATH'] = '/workspac/sglang/python:$PYTHONPATH'
 os.environ['SGLANG_USE_MODELSCOPE'] = 'true'
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Mixed Chunk Prefill is an advanced scheduling mode in SGLang that executes Prefill and Decode requests within the same batch to improve GPU utilization. However，Prefill and Decode attention kernels are executed serially, leaving GPU resources underutilized.
Our work integrates POD-Attention ([https://arxiv.org/pdf/2410.18038]) into SGLang, which fuses Prefill and Decode attention into a single kernel that executes both concurrently, utilizing compute and memory bandwidth simultaneously.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Based on FlashInfer attention backend,  introduced POD-Attention as a new feature that fuses prefill and decode attention into a single kernel. It can be enabled via --enable-flashinfer-pod-attention.
2. POD-Attention kernel is only activated when all three flags are specified simultaneously: --attention-backend flashinfer, --enable-mixed-chunk, and --enable-flashinfer-pod-attention. If any of these flags is missing, the system falls back to the standard FlashInfer attention backend without any changes to existing behavior.
3. Within Mixed ChunkPrefill mode, the POD-Attention kernel is selectively applied — only batches containing both prefill and decode requests are routed to it. Pure prefill or pure decode batches automatically fall back to the original FlashInfer backend, ensuring no performance regression in non-hybrid scenarios.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Accuracy validation was conducted on H800 using benchmark/gsm8k/bench_sglang.py with POD-Attention enabled. 
```
Accuracy: 0.944
Invalid: 0.000
Latency: 230.691 s
Output throughput: 289.656 token/s
```
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Tested on H20 comparing Mixed (baseline) vs POD at chunk_size = 1024 and 2048:
<img width="5217" height="5717" alt="Req Speedup_all_configs_bars" src="https://github.com/user-attachments/assets/1ae9f3ff-4e5b-4688-8f71-5f5f951edacf" />
<img width="5206" height="5717" alt="TPOT Improv_all_configs_bars" src="https://github.com/user-attachments/assets/796ebb4b-3f63-4e9b-8896-63d19fb155ea" />
<img width="5255" height="5717" alt="TTFT Improv_all_configs_bars" src="https://github.com/user-attachments/assets/b71caf52-f6f6-43e4-bdd8-f08627af2f07" />

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
