### PR TITLE
[test] Fix bfloat16 tolerance in test_selective_state_update

### DIFF
--- a/test/registered/layers/mamba/test_mamba_ssm.py
+++ b/test/registered/layers/mamba/test_mamba_ssm.py
@@ -99,7 +99,7 @@ def test_selective_state_update(dim, dstate, has_z, itype):
 
     rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (5e-3, 1e-2)
     if itype == torch.bfloat16:
-        rtol, atol = 1e-2, 5e-2
+        rtol, atol = 1e-2, 1e-1
         if torch.version.hip:
             atol *= 2
     # set seed


### PR DESCRIPTION
The test_selective_state_update fails sporadically with bfloat16 on different random seeds due to insufficient tolerance for mixed-precision operations. The current tolerance (rtol=1e-2, atol=5e-2) doesn't account for bfloat16 rounding error accumulation through the computation pipeline: state→einsum(fp32)→silu_gating(mixed)→bf16.

Testing with seed 444 (worst case) shows failures on both CUDA and XPU, confirming this is inherent to bfloat16 precision, not platform-specific.

Update tolerance to rtol=1e-2, atol=1e-1

This ensures robust testing across different random seeds while still validating functional correctness.

Tested: All 54 parameter combinations pass with seeds 0, 1, 42, 222, 444