### PR TITLE
[Feat][NVFP4] Add pytorch backend for dense NVFP4 GEMM

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -17,6 +17,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
 )
 from sglang.srt.layers.quantization.fp4_utils import get_fp4_gemm_runner_backend
 from sglang.srt.layers.quantization.modelopt_quant import (
+    _apply_nvfp4_linear_pytorch,
     enable_flashinfer_fp4_gemm,
     fp4_gemm,
     fp4_quantize,
@@ -91,6 +92,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
         layer.register_parameter("input_global_scale", input_global_scale)
 
     def process_weights_after_loading(self, layer) -> None:
+        fp4_backend = get_fp4_gemm_runner_backend()
         global_input_scale = layer.input_global_scale.max().to(torch.float32)
         layer.input_global_scale = Parameter(global_input_scale, requires_grad=False)
 
@@ -98,7 +100,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
             layer.weight_global_scale.max().to(torch.float32), requires_grad=False
         )
 
-        if get_fp4_gemm_runner_backend().is_flashinfer_trtllm():
+        if fp4_backend.is_flashinfer_trtllm():
             # FlashInfer TRTLLM FP4 GEMM requires a different weight layout.
             # FlashInfer provides nvfp4_quantize to quantize + shuffle the
             # layout but we use our own quantization so we have to call
@@ -124,6 +126,10 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
             layer.weight_packed = Parameter(
                 layer.weight_packed.data, requires_grad=False
             )
+            if fp4_backend.is_pytorch():
+                layer.weight_packed_pytorch = layer.weight_packed.data.view(
+                    torch.float4_e2m1fn_x2
+                )
 
         layer.alpha = Parameter(
             1 / (layer.input_global_scale * layer.weight_global_scale),
@@ -139,6 +145,21 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
         output_dtype = x.dtype
         w_n, _ = layer.weight_packed.shape
         output_shape = [x.shape[0], w_n]
+        fp4_backend = get_fp4_gemm_runner_backend()
+
+        if fp4_backend.is_pytorch():
+            return _apply_nvfp4_linear_pytorch(
+                x=x,
+                weight=getattr(layer, "weight_packed_pytorch", layer.weight_packed),
+                weight_scale=layer.weight_scale,
+                input_global_scale=layer.input_global_scale,
+                alpha=layer.alpha,
+                output_dtype=output_dtype,
+                output_shape=output_shape,
+                output_size=w_n,
+                bias=bias,
+                fp4_quantize_fn=fp4_quantize,
+            )
 
         # quantize BF16 or FP16 to (FP4 and interleaved block scale)
         x_fp4, x_blockscale = fp4_quantize(x, layer.input_global_scale)

--- a/python/sglang/srt/layers/quantization/fp4_utils.py
+++ b/python/sglang/srt/layers/quantization/fp4_utils.py
@@ -20,6 +20,7 @@ class Fp4GemmRunnerBackend(Enum):
     FLASHINFER_CUDNN = "flashinfer_cudnn"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
+    PYTORCH = "pytorch"
 
     def is_auto(self) -> bool:
         return self == Fp4GemmRunnerBackend.AUTO
@@ -38,6 +39,9 @@ class Fp4GemmRunnerBackend(Enum):
 
     def is_flashinfer(self) -> bool:
         return self.value.startswith("flashinfer_")
+
+    def is_pytorch(self) -> bool:
+        return self == Fp4GemmRunnerBackend.PYTORCH
 
     def get_flashinfer_backend(self) -> str:
         """Get the backend string to pass to FlashInfer's mm_fp4 API.

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -158,6 +158,41 @@ def fp4_gemm(
         return cutlass_fp4_gemm(input, weight, input_sf, weight_sf, alpha, out_dtype)
 
 
+def _apply_nvfp4_linear_pytorch(
+    *,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    input_global_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    output_shape: list[int],
+    output_size: int,
+    bias: torch.Tensor | None,
+    fp4_quantize_fn=fp4_quantize,
+) -> torch.Tensor:
+    """Run NVFP4 GEMM through PyTorch torch._scaled_mm with runtime input quantization."""
+    x_fp4, x_scale_interleaved = fp4_quantize_fn(x, input_global_scale)
+
+    if weight.dtype == torch.uint8:
+        weight = weight.view(torch.float4_e2m1fn_x2)
+
+    out = torch._scaled_mm(
+        x_fp4.view(torch.float4_e2m1fn_x2),
+        weight.T,
+        scale_a=x_scale_interleaved.reshape(-1),
+        scale_b=weight_scale.reshape(-1),
+        out_dtype=output_dtype,
+    )
+    out = out * alpha
+    out = slice_nvfp4_output(out, output_size)
+
+    if bias is not None:
+        out = out + bias
+
+    return out.view(*output_shape)
+
+
 if is_cuda() and (not is_sm120_supported()) and (fp4_quantize is not None):
 
     @register_fake_if_exists("sgl_kernel::scaled_fp4_quant")
@@ -1372,6 +1407,7 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         input_scale_2 = layer.input_scale.max().to(torch.float32)
         weight_scale_2 = layer.weight_scale_2.max().to(torch.float32)
+        fp4_backend = get_fp4_gemm_runner_backend()
 
         # Keep per-shard scales intact for hot reload; derive scalar params below.
         copy_or_rebind_param(
@@ -1384,7 +1420,17 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
         # Store original output size before any padding
         layer.output_size_per_partition = layer.weight.shape[0]
 
-        if get_fp4_gemm_runner_backend().is_flashinfer_trtllm():
+        if fp4_backend.is_pytorch():
+            layer.weight_pytorch = layer.weight.data.view(torch.float4_e2m1fn_x2)
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_interleaved",
+                swizzle_blockscale(layer.weight_scale),
+            )
+            layer.weights_padding_cols = 0
+            return
+
+        if fp4_backend.is_flashinfer_trtllm():
             # FlashInfer TRTLLM FP4 GEMM requires a different weight layout.
             # FlashInfer provides nvfp4_quantize to quantize + shuffle the
             # layout but we use our own quantization so we have to call
@@ -1472,11 +1518,25 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
     ) -> torch.Tensor:
         output_dtype = x.dtype
         x_m, _ = x.shape
+        fp4_backend = get_fp4_gemm_runner_backend()
 
         # Get original output size (before padding) and padded weight size
         output_size = layer.output_size_per_partition
         w_n, _ = layer.weight.shape
         output_shape = [x_m, output_size]
+
+        if fp4_backend.is_pytorch():
+            return _apply_nvfp4_linear_pytorch(
+                x=x,
+                weight=getattr(layer, "weight_pytorch", layer.weight),
+                weight_scale=layer.weight_scale_interleaved,
+                input_global_scale=layer.input_scale_inv,
+                alpha=layer.alpha,
+                output_dtype=output_dtype,
+                output_shape=output_shape,
+                output_size=output_size,
+                bias=bias,
+            )
 
         # Quantize BF16 or FP16 to (FP4 and interleaved block scale)
         x_fp4, x_scale_interleaved = fp4_quantize(x, layer.input_scale_inv)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -221,6 +221,7 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cudnn",
     "flashinfer_cutlass",
     "flashinfer_trtllm",
+    "pytorch",
 ]
 
 MAMBA_SSM_DTYPE_CHOICES = ["float32", "bfloat16", "float16"]
@@ -4783,7 +4784,8 @@ class ServerArgs:
             "'cutlass' (SGLang CUTLASS kernel), "
             "'flashinfer_cutlass' (FlashInfer CUTLASS backend), "
             "'flashinfer_cudnn' (FlashInfer cuDNN backend, optimal on CUDA 13+ with cuDNN 9.15+), "
-            "'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling). ",
+            "'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling), "
+            "'pytorch' (PyTorch torch._scaled_mm backend; requires PyTorch float4 support and bfloat16 activations). ",
         )
         parser.add_argument(
             "--disable-flashinfer-autotune",

--- a/test/registered/quant/test_nvfp4_gemm.py
+++ b/test/registered/quant/test_nvfp4_gemm.py
@@ -81,5 +81,10 @@ class TestFP4GemmFlashinferTrtllm(FP4GemmBase, unittest.TestCase):
     backend = "flashinfer_trtllm"
 
 
+@unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
+class TestFP4GemmPyTorch(FP4GemmBase, unittest.TestCase):
+    backend = "pytorch"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add support for `--fp4-gemm-backend=pytorch` for dense NVFP4 GEMM using `torch._scaled_mm`. This requires `torch.float4_e2m1fn_x2` support, which we already use for FP4 KV cache, and currently supports BF16 activations/outputs only.

## Accuracy Tests

### Dense

```shell
sglang serve --model-path nvidia/Llama-3.1-8B-Instruct-NVFP4 --tensor-parallel-size 8 --attention-backend trtllm_mha --fp4-gemm-backend pytorch --quantization modelopt_fp4 --trust-remote-code
```

```shell
python -m sglang.test.few_shot_gsm8k --host 127.0.0.1 --port 30000 --num-shots 20 --num-questions 1319 --max-new-tokens 512 --parallel 1319

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:12<00:00, 104.13it/s]
Accuracy: 0.700
Invalid: 0.001
Latency: 12.697 s
Output throughput: 11234.221 token/s
```

### MoE

```shell
sglang serve --model-path nvidia/DeepSeek-V3.2-NVFP4 --tensor-parallel-size 8 --data-parallel-size 8 --enable-dp-attention --kv-cache-dtype fp8_e4m3 --attention-backend nsa --nsa-prefill-backend trtllm --nsa-decode-backend trtllm --reasoning-parser deepseek-v3 --tool-call-parser deepseekv32 --moe-runner-backend flashinfer_trtllm --fp4-gemm-backend pytorch --quantization modelopt_fp4 --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 96}'
```

```shell
python benchmark/gsm8k/bench_sglang.py --num-shots 20 --num-questions 1319 --parallel 1319

100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:16<00:00, 78.04it/s]
Accuracy: 0.954
Invalid: 0.000
Latency: 16.907 s
Output throughput: 7521.776 token/s
```

## Benchmarking and Profiling