### PR TITLE
[AMD] Add aiter.topk_softmax for fused_topk

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -129,6 +129,7 @@ if _is_cuda or _is_hip or _is_xpu:
 if _use_aiter:
     try:
         from aiter import biased_grouped_topk as aiter_biased_grouped_topk
+        from aiter import topk_softmax as aiter_topk_softmax
     except ImportError:
         raise ImportError("aiter is required when SGLANG_USE_AITER is set to True")
 
@@ -511,12 +512,24 @@ def fused_topk(
     topk_ids = torch.empty(M, topk, dtype=torch.int32, device=hidden_states.device)
 
     if scoring_func == "softmax":
-        topk_softmax(
-            topk_weights,
-            topk_ids,
-            gating_output,
-            renormalize,
-        )
+        if _use_aiter:
+            token_expert_indices = torch.empty(
+                M, topk, dtype=torch.int32, device=hidden_states.device
+            )
+            aiter_topk_softmax(
+                topk_weights,
+                topk_ids,
+                token_expert_indices,
+                gating_output,
+                renormalize,
+            )
+        else:
+            topk_softmax(
+                topk_weights,
+                topk_ids,
+                gating_output,
+                renormalize,
+            )
     elif scoring_func == "sigmoid":
         topk_sigmoid(
             topk_weights,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR introduces `aiter.topk_softmax` to support `fused_topk` used in Qwen3.5-397B-A17B .

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
python3 benchmark/mmmu/bench_sglang.py --concurrency 64 --port 8000 --max-new-tokens 512
```

```
{'Accounting': {'acc': 1.0, 'num': 2},
 'Agriculture': {'acc': 1.0, 'num': 4},
 'Art': {'acc': 0.909, 'num': 11},
 'Art_Theory': {'acc': 1.0, 'num': 8},
 'Basic_Medical_Science': {'acc': 1.0, 'num': 4},
 'Biology': {'acc': 1.0, 'num': 1},
 'Clinical_Medicine': {'acc': 0.0, 'num': 1},
 'Computer_Science': {'acc': 1.0, 'num': 2},
 'Design': {'acc': 1.0, 'num': 14},
 'Economics': {'acc': 1.0, 'num': 4},
 'Finance': {'acc': 1.0, 'num': 2},
 'Geography': {'acc': 1.0, 'num': 3},
 'History': {'acc': 1.0, 'num': 2},
 'Literature': {'acc': 0.938, 'num': 16},
 'Manage': {'acc': 1.0, 'num': 2},
 'Marketing': {'acc': 1.0, 'num': 5},
 'Math': {'acc': 1.0, 'num': 2},
 'Overall': {'acc': 0.97, 'num': 99},
 'Overall-Art and Design': {'acc': 0.97, 'num': 33},
 'Overall-Business': {'acc': 1.0, 'num': 15},
 'Overall-Health and Medicine': {'acc': 0.909, 'num': 11},
 'Overall-Humanities and Social Science': {'acc': 0.963, 'num': 27},
 'Overall-Science': {'acc': 1.0, 'num': 7},
 'Overall-Tech and Engineering': {'acc': 1.0, 'num': 6},
 'Pharmacy': {'acc': 1.0, 'num': 3},
 'Physics': {'acc': 1.0, 'num': 1},
 'Psychology': {'acc': 1.0, 'num': 4},
 'Public_Health': {'acc': 1.0, 'num': 3},
 'Sociology': {'acc': 1.0, 'num': 5}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.97
```
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Origin kernel in prefill (8k in):
<img width="964" height="592" alt="1" src="https://github.com/user-attachments/assets/77e1ba35-e6e9-49e8-b545-61807836209d" />
Aiter kernel in prefill (8K in)

<img width="1138" height="664" alt="32" src="https://github.com/user-attachments/assets/d25f010c-04aa-482b-816a-f2be67b80903" />

Version:
sglang 0.5.6.post3.dev2176+gc6a99e43b
aiter: 0.1.10.post4.dev0+g6a0e7b26c.d20260222
torch 2.9.1+rocm7.2.0.lw.git7e1940d4
mi350

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
