### PR TITLE
[Diffusion] Bump up cache-dit & support quant for diffusers backend

### DIFF
--- a/docs/diffusion/performance/cache/cache_dit.md
+++ b/docs/diffusion/performance/cache/cache_dit.md
@@ -231,7 +231,7 @@ attention_backend: "flash" # '_flash_3' for Hopper
 
 ### Quantization
 
-You can also specify the quantization config in the yaml file. For example, define a yaml file `quantize.yaml` that contains:
+You can also specify the quantization config in the yaml file, required `torchao>=0.16.0`. For example, define a yaml file `quantize.yaml` that contains:
 
 ```yaml
 quantize_config: # quantization configuration for transformer modules

--- a/docs/diffusion/performance/cache/cache_dit.md
+++ b/docs/diffusion/performance/cache/cache_dit.md
@@ -70,6 +70,7 @@ cache_config:
   taylorseer_order: 1
   # Must set the num_inference_steps for SCM. The SCM will automatically
   # generate the steps computation mask based on the num_inference_steps.
+  # Reference: https://cache-dit.readthedocs.io/en/latest/user_guide/CACHE_API/#scm-steps-computation-masking
   num_inference_steps: 28
   steps_computation_mask: fast
 ```

--- a/docs/diffusion/performance/cache/cache_dit.md
+++ b/docs/diffusion/performance/cache/cache_dit.md
@@ -30,6 +30,8 @@ flow requires cache-dit >= 1.2.0 (`cache_dit.load_configs`).
 
 Define a `cache.yaml` file that contains:
 
+- DBCache + TaylorSeer
+
 ```yaml
 cache_config:
   max_warmup_steps: 8
@@ -53,6 +55,43 @@ sglang generate \
   --prompt "A beautiful sunset over the mountains"
 ```
 
+- DBCache + TaylorSeer + SCM (Step Computation Mask)
+
+```yaml
+cache_config:
+  max_warmup_steps: 8
+  warmup_interval: 2
+  max_cached_steps: -1
+  max_continuous_cached_steps: 2
+  Fn_compute_blocks: 1
+  Bn_compute_blocks: 0
+  residual_diff_threshold: 0.12
+  enable_taylorseer: true
+  taylorseer_order: 1
+  # Must set the num_inference_steps for SCM. The SCM will automatically
+  # generate the steps computation mask based on the num_inference_steps.
+  num_inference_steps: 28
+  steps_computation_mask: fast
+```
+
+- DBCache + TaylorSeer + SCM (Step Computation Mask) + Cache CFG
+
+```yaml
+cache_config:
+  max_warmup_steps: 8
+  warmup_interval: 2
+  max_cached_steps: -1
+  max_continuous_cached_steps: 2
+  Fn_compute_blocks: 1
+  Bn_compute_blocks: 0
+  residual_diff_threshold: 0.12
+  enable_taylorseer: true
+  taylorseer_order: 1
+  num_inference_steps: 28
+  steps_computation_mask: fast
+  enable_sperate_cfg: true # e.g, Qwen-Image, Wan, Chroma, Ovis-Image, etc.
+```
+
 ### Distributed inference
 
 - 1D Parallelism
@@ -62,9 +101,7 @@ Define a parallelism only config yaml `parallel.yaml` file that contains:
 ```yaml
 parallelism_config:
   ulysses_size: auto
-  parallel_kwargs:
-    attention_backend: native
-    extra_parallel_modules: ["text_encoder", "vae"]
+  attention_backend: native
 ```
 
 Then, apply the distributed inference acceleration config from yaml. `ulysses_size: auto` means that cache-dit will auto detect the `world_size` as the ulysses_size. Otherwise, you should manually set it as specific int number, e.g, 4.
@@ -88,9 +125,7 @@ You can also define a 2D parallelism config yaml `parallel_2d.yaml` file that co
 parallelism_config:
   ulysses_size: auto
   tp_size: 2
-  parallel_kwargs:
-    attention_backend: native
-    extra_parallel_modules: ["text_encoder", "vae"]
+  attention_backend: native
 ```
 Then, apply the 2D parallelism config from yaml. Here `tp_size: 2` means using tensor parallelism with size 2. The `ulysses_size: auto` means that cache-dit will auto detect the `world_size // tp_size` as the ulysses_size.
 
@@ -103,11 +138,55 @@ parallelism_config:
   ulysses_size: 2
   ring_size: 2
   tp_size: 2
-  parallel_kwargs:
-    attention_backend: native
-    extra_parallel_modules: ["text_encoder", "vae"]
+  attention_backend: native
 ```
 Then, apply the 3D parallelism config from yaml. Here `ulysses_size: 2`, `ring_size: 2`, `tp_size: 2` means using ulysses parallelism with size 2, ring parallelism with size 2 and tensor parallelism with size 2.
+
+- Ulysses Anything Attention
+
+To enable Ulysses Anything Attention, you can define a parallelism config yaml `parallel_uaa.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: auto
+  attention_backend: native
+  ulysses_anything: true
+```
+
+- Ulysses FP8 Communication
+
+For device that don't have NVLink support, you can enable Ulysses FP8 Communication to further reduce the communication overhead. You can define a parallelism config yaml `parallel_fp8.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: auto
+  attention_backend: native
+  ulysses_float8: true
+```
+
+- Async Ulysses CP
+
+You can also enable async ulysses CP to overlap the communication and computation. Define a parallelism config yaml `parallel_async.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: auto
+  attention_backend: native
+  ulysses_async: true # Now, only support for FLUX.1, Qwen-Image, Ovis-Image and Z-Image.
+```
+Then, apply the config from yaml. Here `ulysses_async: true` means enabling async ulysses CP.
+
+- TE-P and VAE-P
+
+You can also specify the extra parallel modules in the yaml config. For example, define a parallelism config yaml `parallel_extra.yaml` file that contains:
+
+```yaml
+parallelism_config:
+  ulysses_size: auto
+  attention_backend: native
+  extra_parallel_modules: ["text_encoder", "vae"]
+```
+
 
 ### Hybrid Cache and Parallelism
 
@@ -126,9 +205,8 @@ cache_config:
   taylorseer_order: 1
 parallelism_config:
   ulysses_size: auto
-  parallel_kwargs:
-    attention_backend: native
-    extra_parallel_modules: ["text_encoder", "vae"]
+  attention_backend: native
+  extra_parallel_modules: ["text_encoder", "vae"]
 ```
 
 Then, apply the hybrid cache and parallel acceleration config from yaml.
@@ -141,6 +219,72 @@ sglang generate \
   --cache-dit-config hybrid.yaml \
   --prompt "A beautiful sunset over the mountains"
 ```
+
+### Attention Backend
+
+In some cases, users may want to only specify the attention backend without any other optimization configs. In this case, you can define a yaml file `attention.yaml` that only contains:
+
+```yaml
+attention_backend: "flash" # '_flash_3' for Hopper
+```
+
+### Quantization
+
+You can also specify the quantization config in the yaml file. For example, define a yaml file `quantize.yaml` that contains:
+
+```yaml
+quantize_config: # quantization configuration for transformer modules
+  # float8 (DQ), float8_weight_only, float8_blockwise, int8 (DQ), int8_weight_only, etc.
+  quant_type: "float8"
+  # layers to exclude from quantization (transformer). layers that contains any of the
+  # keywords in the exclude_layers list will be excluded from quantization. This is useful
+  # for some sensitive layers that are not robust to quantization, e.g., embedding layers.
+  exclude_layers:
+    - "embedder"
+    - "embed"
+  verbose: false # whether to print verbose logs during quantization
+```
+Then, apply the quantization config from yaml. Please also enable torch.compile for better performance if you are using quantization. For example:
+
+```bash
+sglang generate \
+  --backend diffusers \
+  --model-path Qwen/Qwen-Image \
+  --warmup \
+  --cache-dit-config quantize.yaml \
+  --enable-torch-compile \
+  --dit-cpu-offload false \
+  --text-encoder-cpu-offload false \
+  --prompt "A beautiful sunset over the mountains"
+```
+
+### Combined Configs: Cache + Parallelism + Quantization
+
+You can also combine all the above configs together in a single yaml file `combined.yaml` that contains:
+
+```yaml
+cache_config:
+  max_warmup_steps: 8
+  warmup_interval: 2
+  max_cached_steps: -1
+  max_continuous_cached_steps: 2
+  Fn_compute_blocks: 1
+  Bn_compute_blocks: 0
+  residual_diff_threshold: 0.12
+  enable_taylorseer: true
+  taylorseer_order: 1
+parallelism_config:
+  ulysses_size: auto
+  attention_backend: native
+  extra_parallel_modules: ["text_encoder", "vae"]
+quantize_config:
+  quant_type: "float8"
+  exclude_layers:
+    - "embedder"
+    - "embed"
+  verbose: false
+```
+Then, apply the combined cache, parallelism and quantization config from yaml. Please also enable torch.compile for better performance if you are using quantization.
 
 ## Advanced Configuration
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -114,7 +114,7 @@ diffusion = [
   "st_attn==0.0.7 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "vsa==0.0.4 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "runai_model_streamer>=0.15.5",
-  "cache-dit==1.2.3",
+  "cache-dit==1.3.0",
   "addict==2.4.0",
   "av==16.1.0",
   "scikit-image==0.25.2",


### PR DESCRIPTION
Bump up cache-dit & support quant for diffusers backend (~48% speedup for FLUX.1-dev on L20). Need #20338 ready.

Cache-DiT v1.3.0 is a major release after v.1.2.0, the major changes incude:  

- [x] Optimize VAE Parallel comm, use batched isend/irecv 
- [x] 2D/3D Parallelism: Hybrid CP(USP) + TP, e.g, SP2 + TP2
- [x] Support USP (hybrid ulysses and ring attention) 
- [x] New models support: GLM-Image, FLUX.2-Klein, Helios, FireRed-Image-Edit, and more. 
- [x] Support pass a quantize_config to `enable_cache` API and load from config yaml 
- [x] FP8 Blockwise dynamic quantization support 
- [x] AMD GPUs support 
- [x] ... 

The major changes related to **SGLang Diffusion** are that Cache-DiT v1.3.0 has **improved its configs loading functions**, enabling support for nearly all optimizations configured in the YAML file. These optimizations include:

- [hybrid cache acceleration](https://cache-dit.readthedocs.io/en/latest/user_guide/CACHE_API/) (DBCache, TaylorSeer, SCM, etc.);   
- comprehensive [parallelism](https://cache-dit.readthedocs.io/en/latest/user_guide/CONTEXT_PARALLEL/) optimizations, including Context Parallelism, Tensor Parallelism, hybrid 2D or 3D parallelism, and dedicated extra parallelism support for Text Encoder, VAE, and ControlNet; 
- Ulysses Anything Attention, Async Ulysses CP, Ulysses FP8 Comm; 
- quantization (float8 (DQ), float8_weight_only, float8_blockwise, int8 (DQ), int8_weight_only, etc.)

Please refer to [LOAD_CONFIGS](https://cache-dit.readthedocs.io/en/latest/user_guide/LOAD_CONFIGS/) for more details. This allows all optimizations in cache-dit to be used in **SGLang Diffusion**, greatly optimizing diffusers backend inference performance.

## Benchmarking and Profiling

NVIDIA L20 x 1, FLUX.1-dev, 28 steps, 1024 x 1024

|diffusers backend, baseline|diffusers backend + fp8 quantize|
|:---:|:---:|
|20.46s|13.81s (~48% speedup)|
|<img width="1024" height="1024" alt="flux_diffusers_torch_compile" src="https://github.com/user-attachments/assets/d8534b66-485c-4400-a0a3-a916b3cfdfc8" />|<img width="1024" height="1024" alt="flux_diffusers_torch_compile_float8" src="https://github.com/user-attachments/assets/821f0b0d-e17b-45c7-8196-9669be078657" />|

NVIDIA H200 x 1, FLUX.1-dev, 28 steps, 1024 x 1024
|diffusers backend, baseline|diffusers backend + fp8 quantize|
|:---:|:---:|
|3.73s|2.77s (~35% speedup)|
|<img width="1024" height="1024" alt="flux_diffusers_torch_compile_h200" src="https://github.com/user-attachments/assets/addceeed-526b-46a7-990a-c6b8cf215119" />|<img width="1024" height="1024" alt="flux_diffusers_torch_compile_fp8_h200" src="https://github.com/user-attachments/assets/40c7cc60-62d9-4f8e-bc8e-b89a5873a7a0" />

- upgrade torchao

```bash
pip install -U torchao # >= 0.16.0
```

- test configs

https://github.com/vipshop/cache-dit/tree/main/examples/configs

```bash
git clone https://github.com/vipshop/cache-dit && cd examples/configs
```

- quantize.yaml

```yaml
quantize_config: # quantization configuration for transformer modules
  quant_type: "float8" # float8 (DQ), float8_weight_only, float8_blockwise, int8 (DQ), int8_weight_only, etc.
  exclude_layers:  # layers to exclude from quantization (transformer)
    - "embedder"
    - "embed"
  verbose: false # whether to print verbose logs during quantization
```

- NVIDIA L20 w/o FP8: 20.46s (Diffusers backend, baseline)

```bash
# NVIDIA L20 (Ada)
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --warmup-steps 28 \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --enable-torch-compile \
  --save-output --output-path outputs --output-file-name flux_diffusers_torch_compile.png

# Output logs:
[03-11 12:37:45] Scheduler bind at endpoint: tcp://127.0.0.1:5599
[03-11 12:37:45] Initializing distributed environment with world_size=1, device=cuda:0, timeout=3600
[03-11 12:37:45] Setting distributed timeout to 3600 seconds
[03-11 12:37:46] No pipeline_class_name specified, using model_index.json
[03-11 12:37:46] Using diffusers backend for model '/workspace/dev/vipdev/hf_models/FLUX.1-dev' (explicitly requested)
[03-11 12:37:46] Using pipeline from model_index.json: DiffusersPipeline
[03-11 12:37:46] Loading diffusers pipeline from /workspace/dev/vipdev/hf_models/FLUX.1-dev
[03-11 12:37:46] Model already exists locally and is complete
[03-11 12:37:46] Loading diffusers pipeline with dtype=torch.bfloat16
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 39.88it/s]
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 219/219 [00:00<00:00, 9109.64it/s]
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 196/196 [00:00<00:00, 9801.88it/s]
Loading pipeline components...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  7.90it/s]
[03-11 12:37:56] Applied torch.compile to transformer component of the pipeline
[03-11 12:37:56] Loaded diffusers pipeline: FluxPipeline
[03-11 12:37:56] Pipeline instantiated
[03-11 12:37:56] Worker 0: Initialized device, model, and distributed environment.
[03-11 12:37:56] Worker 0: Scheduler loop started.
[03-11 12:37:56] Processing prompt 1/1: A fantasy landscape with mountains and a river, detailed, vibrant colors
[03-11 12:37:56] Processing warmup req... (1/1)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:36<00:00,  1.32s/it]
[03-11 12:38:35] Warmup req (1/1) processed in 38.30 seconds
[03-11 12:38:35] [DiffusersExecutionStage] started...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:19<00:00,  1.44it/s]
[03-11 12:38:55] [DiffusersExecutionStage] finished in 20.4576 seconds
[03-11 12:38:55] Peak GPU memory: 35.83 GB, Peak allocated: 33.83 GB, Memory pool overhead: 2.01 GB (5.6%), Remaining GPU memory at peak: 9.15 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[03-11 12:38:56] Output saved to outputs/flux_diffusers_torch_compile.png
[03-11 12:38:56] Pixel data generated successfully in 59.35 seconds
[03-11 12:38:56] Completed batch processing. Generated 1 outputs in 59.35 seconds
[03-11 12:38:56] Warmed-up request processed in 20.46 seconds (with warmup excluded)
[03-11 12:38:56] Memory usage - Max peak: 36694.00 MB, Avg peak: 36694.00 MB
```
Warmed-up request processed in `20.46` seconds

- NVIDIA L20 w/ FP8: 13.81s (vs 20.46s, 48% speedup), (Diffusers backend + quantize)

```bash
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --warmup-steps 28 \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --cache-dit-config ./quantize.yaml \
  --enable-torch-compile \
  --save-output --output-path outputs --output-file-name flux_diffusers_torch_compile_float8.png

# Output logs:
[03-11 09:24:39] Scheduler bind at endpoint: tcp://127.0.0.1:5580
[03-11 09:24:39] Initializing distributed environment with world_size=1, device=cuda:0, timeout=3600
[03-11 09:24:39] Setting distributed timeout to 3600 seconds
[03-11 09:24:40] No pipeline_class_name specified, using model_index.json
[03-11 09:24:40] Using diffusers backend for model '/workspace/dev/vipdev/hf_models/FLUX.1-dev' (explicitly requested)
[03-11 09:24:40] Using pipeline from model_index.json: DiffusersPipeline
[03-11 09:24:40] Loading diffusers pipeline from /workspace/dev/vipdev/hf_models/FLUX.1-dev
[03-11 09:24:40] Model already exists locally and is complete
[03-11 09:24:40] Loading diffusers pipeline with dtype=torch.bfloat16
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 196/196 [00:00<00:00, 10009.54it/s]
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 219/219 [00:00<00:00, 9843.88it/s]
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 39.15it/s]
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  7.76it/s]
[03-11 09:24:50] [Cache-DiT] cache_config is None, skip cache acceleration for FluxPipeline.
[03-11 09:24:53] [Cache-DiT] Quantized        Module: FluxTransformer2DModel
[03-11 09:24:53] [Cache-DiT] Quantized        Method: float8
[03-11 09:24:53] [Cache-DiT] Quantized Linear Layers:   496
[03-11 09:24:53] [Cache-DiT] Skipped   Linear Layers:     8
[03-11 09:24:53] [Cache-DiT] Total     Linear Layers:   504
[03-11 09:24:53] [Cache-DiT] Total     (all)  Layers:  1279
[03-11 09:24:53] Enabled cache-dit for diffusers pipeline
[03-11 09:24:53] Applied torch.compile to transformer component of the pipeline
[03-11 09:24:53] Loaded diffusers pipeline: FluxPipeline
[03-11 09:24:53] Pipeline instantiated
[03-11 09:24:53] Worker 0: Initialized device, model, and distributed environment.
[03-11 09:24:53] Worker 0: Scheduler loop started.
[03-11 09:24:53] Processing prompt 1/1: A fantasy landscape with mountains and a river, detailed, vibrant colors
[03-11 09:24:53] Processing warmup req... (1/1)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [01:24<00:00,  3.03s/it]
[03-11 09:26:19] Warmup req (1/1) processed in 85.98 seconds
[03-11 09:26:19] [DiffusersExecutionStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 28/28 [00:13<00:00,  2.13it/s]
[03-11 09:26:33] [DiffusersExecutionStage] finished in 13.8018 seconds
[03-11 09:26:33] Peak GPU memory: 24.87 GB, Peak allocated: 22.80 GB, Memory pool overhead: 2.07 GB (8.3%), Remaining GPU memory at peak: 20.12 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[03-11 09:26:34] Output saved to outputs/flux_diffusers_torch_compile_float8.png
[03-11 09:26:34] Pixel data generated successfully in 100.43 seconds
[03-11 09:26:34] Completed batch processing. Generated 1 outputs in 100.43 seconds
[03-11 09:26:34] Warmed-up request processed in 13.81 seconds (with warmup excluded)
[03-11 09:26:34] Memory usage - Max peak: 25468.00 MB, Avg peak: 25468.00 MB
```
Warmed-up request processed in `13.81` seconds 

For NVIDIA H200 (Hopper): 3.73s -> 2.77s

```bash
# NVIDIA H200 (Hopper, Diffusers backend baseline, flash_3)
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --warmup-steps 28 \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --enable-torch-compile \
  --cache-dit-config ./hopper/flash_3.yaml \
  --save-output --output-path outputs --output-file-name flux_diffusers_torch_compile_h200.png

# NVIDIA H200 (Hopper, Diffusers backend, flash_3 + quantize)
sglang generate \
  --model-path=$FLUX_DIR \
  --backend diffusers \
  --log-level=info \
  --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' \
  --width=1024 \
  --height=1024 \
  --num-inference-steps=28 \
  --warmup \
  --warmup-steps 28 \
  --dit-cpu-offload false \
  --text-encoder-cpu-offload false \
  --enable-torch-compile \
  --cache-dit-config ./hopper/quantize.yaml \
  --save-output --output-path outputs --output-file-name flux_diffusers_torch_compile_fp8_h200.png
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

cc @mickqian @RubiaCx 