### PR TITLE
[Bug] Qwen3.5 with AWQ Quantization Startup issue

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -165,6 +165,7 @@ from sglang.srt.utils import (
     get_cpu_ids_by_node,
     get_local_ip_auto,
     init_custom_process_group,
+    is_blackwell,
     is_hip,
     is_host_cpu_arm64,
     is_npu,
@@ -685,6 +686,18 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             server_args.attention_backend = "triton"
             server_args.disable_cuda_graph = True
+
+        if (
+            self.hybrid_gdn_config is not None
+            and getattr(self.hybrid_gdn_config, "model_type", None)
+            in {"qwen3_5_text", "qwen3_5_moe_text"}
+            and is_blackwell()
+            and server_args.attention_backend == "flashinfer"
+        ):
+            logger.info(
+                "Switching attention backend to triton for Qwen3.5 hybrid GDN on Blackwell."
+            )
+            server_args.attention_backend = "triton"
 
         if self.is_multimodal:
             if not self.is_multimodal_chunked_prefill_supported:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -71,6 +71,7 @@ from sglang.srt.models.qwen2_moe import Qwen2MoeMLP, Qwen2MoeSparseMoeBlock
 
 # Models
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from sglang.srt.models.utils import WeightsMapper
 
 # Utils
 from sglang.srt.utils import (
@@ -1076,6 +1077,14 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
 
 
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
+    # Qwen3.5 already remaps weight names in load_weights().
+    # Keep mapper simple so quant ignore names still match Qwen3.5 layer names.
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_substr={
+            "attn.qkv": "attn.qkv_proj",
+        },
+    )
+
     def __init__(
         self,
         config: Qwen3_5Config,
@@ -1185,6 +1194,12 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
 class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
     """Qwen3.5 MoE Vision-Language Model."""
+
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_substr={
+            "attn.qkv": "attn.qkv_proj",
+        },
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Fix for #19406 
Tracked at: #20069 

error message

``` 
RuntimeError: ... gptq_marlin_repack.cuh:309: size_n = 32 is not divisible by tile_n_size = 64
```

Also flashinfer backend not supported for gdn models on blackwell architecture, auto switch to triton

## Modifications

<!-- Detail the changes made in this pull request. -->

The crash came from the Marlin repack path during quantized weight processing, in_proj_a/in_proj_b (width 32) were intended to be ignored by quantization (see quant config), but inherited name mapping caused ignore-name mismatch, so these layers were quantized by mistake and hit Marlin.

- Added a Qwen3.5-specific hf_to_sglang_mapper override in qwen3_5.py (kept only attn.qkv -> attn.qkv_proj) so quant ignore names for in_proj_a/in_proj_b match correctly.
- Added a Qwen3.5-only Blackwell backend guard in model_runner.py: when model type is qwen3_5_text / qwen3_5_moe_text and backend defaults to flashinfer, switch to triton.


## Accuracy Tests


Using the Original model vs cyankiwi Qwen3.5 model  (same source as the original issue) on C-Eval:

  - 4B : 75.3
  - 4B AWQ 4-bit: 74.4


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
