### PR TITLE
[Fix] Slice input_embeds to extend_input_len in prepare_for_extend

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1513,8 +1513,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
             # If input_embeds are available, store them
             if req.input_embeds is not None:
-                # If req.input_embeds is already a list, append its content directly
-                input_embeds.extend(req.input_embeds)  # Use extend to avoid nesting
+                # Slice to match extend_input_len — PrefillAdder truncates
+                # fill_ids/extend_input_len on chunk overflow but not input_embeds.
+                input_embeds.extend(
+                    req.input_embeds[pre_len : pre_len + req.extend_input_len]
+                )
 
             multimodal_inputs.append(req.multimodal_inputs)
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1942,6 +1942,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
         bs = len(self.reqs)
+        # Decode embeds the last output token via embed_tokens; clear the stale
+        # prefill-time tensor so it doesn't leak into ForwardBatch.
+        self.input_embeds = None
 
         if self.is_spec_v2:
             # TODO(spec-v2): all spec v2 should go through this path

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2245,6 +2245,8 @@ class Scheduler(
             self.is_mixed_chunk
             and not self.running_batch.is_empty()
             and not (new_batch.return_logprob or self.running_batch.return_logprob)
+            # mix_with_running cats input_ids but not input_embeds — shapes would mismatch
+            and new_batch.input_embeds is None
         ):
             # TODO (lianmin): support return_logprob + mixed chunked prefill
             self.running_batch.filter_batch(v1_spec_info_filtered=True)

--- a/test/registered/embedding/test_input_embeds_chunked.py
+++ b/test/registered/embedding/test_input_embeds_chunked.py
@@ -1,0 +1,189 @@
+"""Regression tests for input_embeds shape-mismatch bugs.
+
+Covers two bugs with the same crash signature
+(RuntimeError: shape mismatch in set_kv_buffer) but opposite polarity:
+
+- Chunked prefill truncation (#20376): PrefillAdder truncates fill_ids and
+  extend_input_len on chunk overflow but not input_embeds, so the full array
+  flows through while out_cache_loc is sized for the truncated length.
+  Polarity: cache_k > loc.
+
+- Retraction with output_ids (#14110): after retraction, fill_ids includes
+  accumulated output_ids but input_embeds only covers origin_input_ids.
+  Polarity: cache_k < loc.
+"""
+
+import unittest
+
+import requests
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=150, suite="stage-b-test-small-1-gpu")
+register_amd_ci(est_time=150, suite="stage-b-test-small-1-gpu-amd")
+
+CHUNKED_PREFILL_SIZE = 256
+
+# Shared reference model — loaded once per process, not per test class.
+_MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+_tokenizer = None
+_ref_model = None
+
+
+def _load_ref():
+    global _tokenizer, _ref_model
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(_MODEL)
+        _ref_model = AutoModelForCausalLM.from_pretrained(_MODEL)
+
+
+def _embeds_for(text: str) -> list[list[float]]:
+    _load_ref()
+    ids = _tokenizer(text, return_tensors="pt")["input_ids"]
+    embeds = _ref_model.get_input_embeddings()(ids)
+    return embeds.squeeze(0).to(torch.float32).tolist()
+
+
+def _generate(base_url, input_embeds, max_new_tokens, ignore_eos=False, timeout=120):
+    resp = requests.post(
+        f"{base_url}/generate",
+        json={
+            "input_embeds": input_embeds,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": max_new_tokens,
+                "ignore_eos": ignore_eos,
+            },
+        },
+        timeout=timeout,
+    )
+    return resp
+
+
+class TestInputEmbedsChunkedAndRetract(CustomTestCase):
+    """Single server launch covering both bugs.
+
+    Both tests require --disable-radix-cache (for input_embeds). The chunked
+    prefill test needs a small --chunked-prefill-size. The retraction test
+    uses SGLANG_TEST_RETRACT to deterministically force retraction every few
+    scheduler iterations regardless of KV pressure.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # SGLANG_TEST_RETRACT forces retraction periodically; this is
+        # deterministic and doesn't require guessing KV budgets.
+        with envs.SGLANG_TEST_RETRACT.override(True):
+            cls.process = popen_launch_server(
+                _MODEL,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--disable-radix-cache",
+                    "--chunked-prefill-size",
+                    str(CHUNKED_PREFILL_SIZE),
+                    "--cuda-graph-max-bs",
+                    "4",
+                ],
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _assert_server_alive(self):
+        self.assertIsNone(self.process.poll(), "server process crashed")
+
+    def test_chunked_prefill_truncation_and_continuation(self):
+        """Regression test for #20376.
+
+        A single request longer than chunked_prefill_size deterministically
+        exercises both (a) first-chunk truncation and (b) chunk continuation,
+        without any concurrent-timing dependency. Pre-fix this crashes in
+        set_kv_buffer on both chunks.
+        """
+        # ~80 tokens each repetition; 6 repetitions exceeds CHUNKED_PREFILL_SIZE
+        # comfortably. Token count is model-dependent so assert it.
+        text = "The quick brown fox jumps over the lazy dog. " * 40
+        embeds = _embeds_for(text)
+        self.assertGreater(
+            len(embeds),
+            CHUNKED_PREFILL_SIZE,
+            f"prompt must exceed chunked_prefill_size={CHUNKED_PREFILL_SIZE} "
+            f"to trigger chunking; got {len(embeds)} tokens",
+        )
+
+        resp = _generate(self.base_url, embeds, max_new_tokens=8)
+        self.assertEqual(resp.status_code, 200, resp.text[:300])
+        body = resp.json()
+        self.assertIn("text", body)
+        self.assertIsInstance(body["text"], str)
+        self._assert_server_alive()
+
+    def test_chunked_prefill_batch_truncation(self):
+        """Regression test for #20376 — multi-request batch case.
+
+        A batch POST with total tokens > chunked_prefill_size goes through a
+        single ZMQ send, so all requests land in the same scheduler iteration
+        and the PrefillAdder is forced to truncate at least one. This matches
+        the original thundering-herd trigger without HTTP timing races.
+        """
+        text = "The quick brown fox jumps over the lazy dog. " * 8
+        embeds = _embeds_for(text)
+        seq_len = len(embeds)
+
+        # Enough batched requests to overflow the chunk budget.
+        n = max(4, CHUNKED_PREFILL_SIZE // seq_len + 2)
+        self.assertGreater(n * seq_len, CHUNKED_PREFILL_SIZE)
+
+        resp = _generate(self.base_url, [embeds] * n, max_new_tokens=8)
+        self.assertEqual(resp.status_code, 200, resp.text[:300])
+        results = resp.json()
+        self.assertEqual(len(results), n)
+        for r in results:
+            self.assertIn("text", r)
+        self._assert_server_alive()
+
+    def test_retraction_with_output_ids(self):
+        """Regression test for #14110.
+
+        SGLANG_TEST_RETRACT forces retraction every few scheduler iterations.
+        Combined with ignore_eos and a reasonable max_new_tokens, at least one
+        request is retracted mid-decode with non-empty output_ids, then
+        re-prefilled. Pre-#14110 this crashes (cache_k < loc) because fill_ids
+        includes output_ids but input_embeds does not.
+        """
+        text = "The quick brown fox jumps over the lazy dog. " * 4
+        embeds = _embeds_for(text)
+
+        # Batch of requests with enough decode steps that SGLANG_TEST_RETRACT
+        # (interval=3 by default) fires mid-decode.
+        n = 4
+        resp = _generate(
+            self.base_url,
+            [embeds] * n,
+            max_new_tokens=32,
+            ignore_eos=True,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text[:300])
+        results = resp.json()
+        self.assertEqual(len(results), n)
+        for r in results:
+            self.assertIn("text", r)
+        self._assert_server_alive()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/embedding/test_input_embeds_chunked.py
+++ b/test/registered/embedding/test_input_embeds_chunked.py
@@ -21,7 +21,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -30,8 +30,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=150, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=150, suite="stage-b-test-small-1-gpu-amd")
+register_cuda_ci(est_time=45, suite="stage-b-test-small-1-gpu")
 
 CHUNKED_PREFILL_SIZE = 256
 


### PR DESCRIPTION
## Motivation

When `PrefillAdder` truncates a request on chunk overflow (`rem_chunk_tokens` exceeded), it adjusts `fill_ids` and `extend_input_len` but **not** `req.input_embeds`. `prepare_for_extend` then appends the full-length embedding array while `out_cache_loc` is sized for the truncated `extend_input_len`, causing:

```
RuntimeError: shape mismatch: value tensor of shape [N, ...]
  cannot be broadcast to indexing result of shape [M, ...]
```

in `set_kv_buffer`, with **N > M** (opposite polarity to the retraction bug in #14110, which is N < M — that's a different bug, same crash signature).

**Trigger condition:** many input_embeds requests arrive in one scheduler iteration (thundering herd) and their total tokens exceed `chunked_prefill_size`. In our RL setup this happens at rollout start immediately after `update_weights_from_distributed` — 256 requests land near-simultaneously. With 125-token prompts and `chunked_prefill_size=8192`: 65 requests fit (8125 tokens), request #66 gets truncated to 67 tokens but its 125-token embedding array flows through unsliced.

The `input_ids` path already handles this correctly since `fill_ids` itself is truncated by the adder.

## Modifications

Slice `req.input_embeds` with `[pre_len : pre_len + req.extend_input_len]` to match what was already applied to `fill_ids`. No-op for non-chunked requests (`pre_len=0`, `extend_input_len=len(embeds)`).

Chunk continuation works because `ChunkCache.cache_unfinished_req` sets `prefix_indices` to the processed length after each chunk, and `req.input_embeds` is never mutated — so chunk 2 correctly slices `[trunc_len : trunc_len + remaining]`.

## Accuracy Tests

This is a runtime crash fix. Verified on Qwen2.5-7B-Instruct with `--disable-radix-cache --chunked-prefill-size 8192` under concurrent input_embeds load — previously crashed reliably at the chunking boundary, now completes cleanly.

No new unit test — the trigger requires concurrent load exceeding `chunked_prefill_size`, hard to repro in the serial `test_input_embeddings.py`. Same precedent as #17850 (merged chunked-prefill race fix without new test).

## Benchmarking and Profiling

N/A — stability fix, no hot-path changes. Slice is a no-op for the common (non-chunked) case.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [ ] Add unit tests — manual repro verification (see above)
- [ ] Update documentation as needed — N/A

---

**Note:** this PR will have a trivial merge conflict with #20205 (same lines, `.extend()` → `.append()`). Correct resolution: `.append(req.input_embeds[pre_len : pre_len + req.extend_input_len])`.