### PR TITLE
remove mamba slot alloc in prefix match stage

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -861,7 +861,6 @@ class Req(ReqDllmMixin):
     def init_next_round_input(
         self,
         tree_cache: Optional[BasePrefixCache] = None,
-        cow_mamba: Optional[bool] = None,
     ):
         if self.is_dllm():
             self._init_fill_ids_for_dllm()
@@ -878,13 +877,10 @@ class Req(ReqDllmMixin):
         token_ids = self.fill_ids[:max_prefix_len]
 
         if tree_cache is not None:
-            if cow_mamba is None:
-                cow_mamba = tree_cache.supports_mamba()
             match_result = tree_cache.match_prefix(
                 MatchPrefixParams(
                     key=RadixKey(token_ids=token_ids, extra_key=self.extra_key),
                     req=self,
-                    cow_mamba=cow_mamba,
                 )
             )
             (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1796,7 +1796,7 @@ class Scheduler(
 
     def _prefetch_kvcache(self, req: Req):
         if self.enable_hicache_storage:
-            req.init_next_round_input(self.tree_cache, cow_mamba=False)
+            req.init_next_round_input(self.tree_cache)
             last_host_node = (
                 req.last_host_backup_node
                 if req.last_host_backup_node is not None
@@ -2929,12 +2929,6 @@ class Scheduler(
                     req, self.req_to_metadata_buffer_idx_allocator
                 )
 
-            # For mamba radix cache
-            if (
-                req.mamba_pool_idx is not None
-                and self.disaggregation_mode != DisaggregationMode.DECODE
-            ):
-                release_kv_cache(req, self.tree_cache, is_insert=False)
             logger.debug(f"Abort queued request. {req.rid=}")
 
         # Delete the requests in the grammar queue

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -38,8 +38,6 @@ class MatchPrefixParams:
 
     key: RadixKey
 
-    # Mamba specific
-    cow_mamba: bool = False
     req: Optional[Req] = None
 
 

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -810,7 +810,6 @@ class HiMambaRadixCache(MambaRadixCache):
         best_value_len: int,
         deepest_node: TreeNode,
     ) -> MatchResult:
-        cow_mamba = params.cow_mamba
         req = params.req
 
         # Full LRU: skip evicted nodes for full_lru_list
@@ -858,24 +857,6 @@ class HiMambaRadixCache(MambaRadixCache):
             and not last_host_backup_node.backuped
         ):
             last_host_backup_node = last_host_backup_node.parent
-
-        mamba_node = best_last_node
-        if cow_mamba and mamba_node.mamba_value is not None:
-            if req.mamba_pool_idx is None:
-                dst_index = self.req_to_token_pool.mamba_pool.alloc(1)
-                if dst_index is None:
-                    self.inc_lock_ref(mamba_node)
-                    self.evict_mamba(1)
-                    dst_index = self.req_to_token_pool.mamba_pool.alloc(1)
-                    self.dec_lock_ref(mamba_node)
-                    assert dst_index is not None, "Can not alloc mamba cache"
-                src_index = mamba_node.mamba_value
-                self.req_to_token_pool.mamba_pool.copy_from(src_index, dst_index)
-                req.mamba_pool_idx = dst_index[0]
-            else:
-                src_index = mamba_node.mamba_value
-                dst_index = req.mamba_pool_idx.unsqueeze(0)
-                self.req_to_token_pool.mamba_pool.copy_from(src_index, dst_index)
 
         value = value[:best_value_len]
         if value:

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -987,7 +987,6 @@ class MambaRadixCache(BasePrefixCache):
         best_value_len: int,
     ) -> MatchResult:
         """Post-process the matched result."""
-        cow_mamba = params.cow_mamba
         req = params.req
 
         # update time for matched nodes, and make nodes closer to root to be least recently used
@@ -1019,26 +1018,6 @@ class MambaRadixCache(BasePrefixCache):
             )
         else:
             mamba_branching_seqlen = None
-
-        # Copy mamba state to req local space if cow is true
-        if cow_mamba and last_node.mamba_value is not None:
-            # for reqs without mamba cache
-            if req.mamba_pool_idx is None:
-                dst_index = self.req_to_token_pool.mamba_pool.alloc(1)
-                # try to alloc again, protect last_node from eviction
-                if dst_index is None:
-                    self.inc_lock_ref(last_node)
-                    self.evict(EvictParams(num_tokens=0, mamba_num=1))
-                    dst_index = self.req_to_token_pool.mamba_pool.alloc(1)
-                    self.dec_lock_ref(last_node)
-                    assert dst_index is not None, "Can not alloc mamba cache"
-                src_index = last_node.mamba_value
-                self.req_to_token_pool.mamba_pool.copy_from(src_index, dst_index)
-                req.mamba_pool_idx = dst_index[0]
-            else:
-                src_index = last_node.mamba_value
-                dst_index = req.mamba_pool_idx.unsqueeze(0)
-                self.req_to_token_pool.mamba_pool.copy_from(src_index, dst_index)
 
         value = value[:best_value_len]
         if value:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -530,6 +530,11 @@ class HybridReqToTokenPool(ReqToTokenPool):
                 ), f"Not enough space for mamba cache, try to increase --mamba-full-memory-ratio or --max-mamba-cache-size. {mid=}, {self.mamba_pool.size=}, {self.mamba_pool.available_size()=}, {len(reqs)=}"
                 mid = mid[0]
                 req.mamba_pool_idx = mid
+                # for radix cache, copy mamba state from last node in tree
+                if req.last_node is not None and req.last_node.mamba_value is not None:
+                    self.mamba_pool.copy_from(
+                        req.last_node.mamba_value, mid.unsqueeze(0)
+                    )
             mamba_indices.append(mid)
             if self.enable_mamba_extra_buffer:
                 if req.mamba_ping_pong_track_buffer is None:

--- a/test/registered/radix_cache/test_mamba_unittest.py
+++ b/test/registered/radix_cache/test_mamba_unittest.py
@@ -369,7 +369,7 @@ class TestMamba(unittest.TestCase):
         req9_token_ids = [1, 2, 3, 4, 5, 6, 7]
         req9 = make_dummy_req()
         result = tree.match_prefix(
-            MatchPrefixParams(key=RadixKey(req9_token_ids), req=req9, cow_mamba=True)
+            MatchPrefixParams(key=RadixKey(req9_token_ids), req=req9)
         )
         kv_indices, last_node = result.device_indices, result.last_device_node
         assert req9.mamba_pool_idx is not None

--- a/test/registered/radix_cache/test_mamba_unittest.py
+++ b/test/registered/radix_cache/test_mamba_unittest.py
@@ -372,15 +372,8 @@ class TestMamba(unittest.TestCase):
             MatchPrefixParams(key=RadixKey(req9_token_ids), req=req9)
         )
         kv_indices, last_node = result.device_indices, result.last_device_node
-        assert req9.mamba_pool_idx is not None
-        assert torch.all(
-            mamba_pool.mamba_cache.conv[0][:, req9.mamba_pool_idx]
-            == mamba_pool.mamba_cache.conv[0][:, last_node.mamba_value]
-        )
-        assert torch.all(
-            mamba_pool.mamba_cache.temporal[:, req9.mamba_pool_idx]
-            == mamba_pool.mamba_cache.temporal[:, last_node.mamba_value]
-        )
+        assert len(kv_indices) == 7
+        assert len(last_node.key) == 2
 
         print(tree.available_and_evictable_str())
         print(available_and_evictable_str(tree))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
1. remove alloc mamba in radix tree `match_prefix`, to avoid requests holding resources in waiting queue and cause mamba slot leak, requests in waiting queue should not have `mamba_pool_idx`.
2. copy mamba state by using last node mamba_value
3. remove cow_mamba parameters since we do not need to copy in `match_prefix` stage
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
python3 benchmark/gsm8k/bench_sglang.py --num-questions 1300 
Accuracy: 0.945
Invalid: 0.000
Latency: 142.681 s
Output throughput: 1522.246 token/s
```

```
python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 4096 --repeat 8
{'chars': np.float64(6681.075757575758), 'chars:std': np.float64(3964.9693961546045), 'score:std': np.float64(0.4990808815757758), 'scores': ['0.556', '0.520', '0.551', '0.520', '0.530', '0.515', '0.535', '0.530'], 'mean_score': np.float64(0.5321969696969697)}
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #22985417549](https://github.com/sgl-project/sglang/actions/runs/22985417549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->