### PR TITLE
[Docs/Fix] Fix quantization doc inaccuracies and fix ROCm NVFP4 bug

### DIFF
--- a/docs/advanced_features/quantization.md
+++ b/docs/advanced_features/quantization.md
@@ -21,9 +21,9 @@ to guard against abnormal quantization loss regressions.
 
 The following table summarizes quantization method support across NVIDIA and AMD GPUs.
 
-| Method | NVIDIA GPUs | AMD GPUs (MI300X/MI325X/MI350X) | Notes |
-|--------|:-----------:|:-------------------------------:|-------|
-| `fp8` | Yes | Yes | Aiter or Triton backend on AMD |
+| Method | NVIDIA GPUs | AMD GPUs | Notes |
+|--------|:-----------:|:--------:|-------|
+| `fp8` | Yes (Hopper/SM90+, Blackwell/SM100+) | Yes (MI250/MI300X/MI325X/MI350X) | Aiter or Triton backend on AMD |
 | `mxfp4` | Yes | Yes | Requires CDNA3/CDNA4 with MXFP support; uses Aiter |
 | `blockwise_int8` | Yes | Yes | Triton-based, works on both platforms |
 | `w8a8_int8` | Yes | Yes | |
@@ -37,9 +37,9 @@ The following table summarizes quantization method support across NVIDIA and AMD
 | `awq_marlin` | Yes | No | Marlin kernels are CUDA-only |
 | `gptq_marlin` | Yes | No | Marlin kernels are CUDA-only |
 | `gguf` | Yes | No | CUDA-only kernels in sgl-kernel |
-| `modelopt` / `modelopt_fp8` | Yes | No | NVIDIA ModelOpt, requires NVIDIA hardware |
-| `modelopt_fp4` | Yes (Blackwell) | No | NVIDIA Blackwell only |
-| `petit_nvfp4` | Yes (Blackwell) | No | NVIDIA NvFP4, Blackwell only |
+| `modelopt` / `modelopt_fp8` | Yes (Hopper/SM90+) | No | [NVIDIA ModelOpt](https://github.com/NVIDIA/Model-Optimizer); requires NVIDIA hardware |
+| `modelopt_fp4` | Yes (Blackwell/SM100+) | No | [NVIDIA ModelOpt](https://github.com/NVIDIA/Model-Optimizer); native FP4 on Blackwell (B200, GB200) |
+| `petit_nvfp4` | No | Yes (MI250/MI300X/MI325X) | Enables NVFP4 on ROCm via [Petit](https://github.com/causalflow-ai/petit-kernel); use `modelopt_fp4` on NVIDIA Blackwell. Auto-selected when loading NVFP4 models on AMD. See [LMSYS blog](https://lmsys.org/blog/2025-09-21-petit-amdgpu/) and [AMD ROCm blog](https://rocm.blogs.amd.com/artificial-intelligence/fp4-mixed-precision/README.html). |
 | `bitsandbytes` | Yes | Experimental | Depends on bitsandbytes ROCm support |
 | `torchao` (`int4wo`, etc.) | Yes | Partial | `int4wo` not supported on AMD; other methods may work |
 
@@ -330,7 +330,7 @@ pip install nvidia-modelopt
 
 ##### Quantization and Export Workflow
 
-SGLang provides an example script that demonstrates the complete ModelOpt quantization and export workflow:
+SGLang provides an example script that demonstrates the complete ModelOpt quantization and export workflow. Run from the SGLang repository root (see [modelopt_quantize_and_export.py](https://github.com/sgl-project/sglang/blob/main/examples/usage/modelopt_quantize_and_export.py)):
 
 ```bash
 # Quantize and export a model using ModelOpt FP8 quantization
@@ -339,7 +339,7 @@ python examples/usage/modelopt_quantize_and_export.py quantize \
     --export-dir ./quantized_tinyllama_fp8 \
     --quantization-method modelopt_fp8
 
-# For FP4 quantization
+# For FP4 quantization (requires Blackwell GPU)
 python examples/usage/modelopt_quantize_and_export.py quantize \
     --model-path TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
     --export-dir ./quantized_tinyllama_fp4 \
@@ -395,15 +395,16 @@ python -m sglang.launch_server \
     --port 30000 --host 0.0.0.0
 ```
 
-Or using the Python API:
+Or using the Python API (use the same path as `modelopt_export_path` from the quantize step):
 
 ```python
 import sglang as sgl
 
 def main():
     # Deploy exported ModelOpt quantized model
+    # Path must match modelopt_export_path from quantize step (e.g., ./exported_model)
     llm = sgl.Engine(
-        model_path="./quantized_tinyllama_fp8",
+        model_path="./exported_model",
         quantization="modelopt",
     )
 
@@ -444,7 +445,7 @@ python examples/usage/modelopt_quantize_and_export.py quantize \
 # The checkpoint can be reused for future quantization runs and skip calibration
 ```
 
-**Export-only Workflow**: If you have a pre-existing fake quantized ModelOpt checkpoint, you can export it directly:
+**Export-only Workflow**: If you have a pre-existing fake quantized ModelOpt checkpoint, you can export it directly. See [LoadConfig](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/configs/load_config.py) for the full API:
 
 ```python
 from sglang.srt.configs.device_config import DeviceConfig
@@ -463,7 +464,7 @@ load_config = LoadConfig(
     modelopt_export_path="./exported_model",
 )
 
-# Load and export the model
+# Load and export the model (DeviceConfig defaults to device="cuda")
 model_loader = get_model_loader(load_config, model_config)
 model_loader.load_model(model_config=model_config, device_config=DeviceConfig())
 ```
@@ -523,6 +524,8 @@ Other layers (e.g. projections in the attention layers) have their weights quant
 - [GPTQModel](https://github.com/ModelCloud/GPTQModel)
 - [LLM Compressor](https://github.com/vllm-project/llm-compressor/)
 - [NVIDIA Model Optimizer (ModelOpt)](https://github.com/NVIDIA/Model-Optimizer)
+- [NVIDIA Model Optimizer LLM PTQ](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/llm_ptq)
+- [Petit: NVFP4 on ROCm](https://github.com/causalflow-ai/petit-kernel) — [LMSYS blog](https://lmsys.org/blog/2025-09-21-petit-amdgpu/), [AMD ROCm blog](https://rocm.blogs.amd.com/artificial-intelligence/fp4-mixed-precision/README.html)
 - [Torchao: PyTorch Architecture Optimization](https://github.com/pytorch/ao)
 - [vLLM Quantization](https://docs.vllm.ai/en/latest/quantization/)
 - [auto-round](https://github.com/intel/auto-round)

--- a/docs/platforms/amd_gpu.md
+++ b/docs/platforms/amd_gpu.md
@@ -116,13 +116,14 @@ With your AMD system properly configured and SGLang installed, you can now fully
 
 ## Quantization on AMD GPUs
 
-The [Quantization documentation](../advanced_features/quantization.md#platform-compatibility) has a full compatibility matrix. The short version: FP8, AWQ, MXFP4, W8A8, GPTQ, compressed-tensors, and Quark all work on AMD. Methods that depend on Marlin or NVIDIA-specific kernels (`awq_marlin`, `gptq_marlin`, `gguf`, `modelopt_fp8`, `modelopt_fp4`, `petit_nvfp4`) do not.
+The [Quantization documentation](../advanced_features/quantization.md#platform-compatibility) has a full compatibility matrix. The short version: FP8, AWQ, MXFP4, W8A8, GPTQ, compressed-tensors, Quark, and **petit_nvfp4** (NVFP4 on ROCm via [Petit](https://github.com/causalflow-ai/petit-kernel)) all work on AMD. Methods that depend on Marlin or NVIDIA-specific kernels (`awq_marlin`, `gptq_marlin`, `gguf`, `modelopt_fp8`, `modelopt_fp4`) do not.
 
 A few things to keep in mind:
 
 - FP8 works via Aiter or Triton. Pre-quantized FP8 models like DeepSeek-V3/R1 work out of the box.
 - AWQ uses Triton dequantization kernels on AMD. The faster Marlin path is not available.
 - MXFP4 requires CDNA3/CDNA4 and `SGLANG_USE_AITER=1`.
+- `petit_nvfp4` enables NVFP4 models (e.g., [Llama 3.3 70B FP4](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP4)) on MI250/MI300X via [Petit](https://github.com/causalflow-ai/petit-kernel). Install with `pip install petit-kernel`; no `--quantization` flag needed when loading pre-quantized NVFP4 models.
 - `quark_int4fp8_moe` is an AMD-only online quantization method for MoE models on CDNA3/CDNA4.
 
 Several of these backends are accelerated by [Aiter](https://github.com/ROCm/aiter). Enable it with:

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -162,25 +162,40 @@ class QuantizationConfig(ABC):
     def _modelopt_override_quantization_method(
         cls, hf_quant_config, user_quant
     ) -> Optional[str]:
-        """Shared ModelOpt quantization method override logic."""
+        """Shared ModelOpt quantization method override logic.
+
+        On ROCm, NVFP4/FP4 checkpoints are served by PetitNvFp4Config
+        instead of ModelOptFp4Config, so this method returns None for
+        FP4 on ROCm to let PetitNvFp4Config.override_quantization_method
+        handle the dispatch.
+        """
+        from sglang.srt.utils import is_hip
+
         if hf_quant_config is None:
             return None
 
-        # Check if this is a ModelOpt config
         quant_algo = hf_quant_config.get("quant_algo", "").upper()
+        is_fp4 = "NVFP4" in quant_algo or "FP4" in quant_algo
+
+        # On ROCm, yield FP4 to PetitNvFp4Config
+        if is_hip() and is_fp4:
+            return None
 
         # If user specified generic "modelopt", auto-detect the specific method
         if user_quant == "modelopt":
             if "FP8" in quant_algo:
                 return "modelopt_fp8"
-            elif "NVFP4" in quant_algo or "FP4" in quant_algo:
+            elif is_fp4:
                 return "modelopt_fp4"
 
         # The hf_quant_config may be a parsed quant config, so we need to check the
         # quant_method.
-        if hf_quant_config.get("quant_method", "") == "modelopt_fp8":
+        quant_method = hf_quant_config.get("quant_method", "")
+        if quant_method == "modelopt_fp8":
             return "modelopt_fp8"
-        elif hf_quant_config.get("quant_method", "") == "modelopt_fp4":
+        elif quant_method == "modelopt_fp4":
+            if is_hip():
+                return None  # Let PetitNvFp4Config handle this on ROCm
             return "modelopt_fp4"
 
         return None

--- a/python/sglang/srt/layers/quantization/petit.py
+++ b/python/sglang/srt/layers/quantization/petit.py
@@ -107,8 +107,16 @@ class PetitNvFp4Config(QuantizationConfig):
 
     @classmethod
     def is_petit_nvfp4_compatible(cls, quant_config: Dict[str, Any]) -> bool:
+        """Check if this NVFP4 checkpoint can run on ROCm via Petit.
+        Accepts quant_method 'modelopt' (from producer) or 'modelopt_fp4' (from _parse_modelopt_quant_config).
+        """
         quant_method = quant_config.get("quant_method", "").lower()
-        return _is_hip and quant_method == "modelopt"
+        quant_algo = quant_config.get("quant_algo", "").upper()
+        return (
+            _is_hip
+            and quant_method in ("modelopt", "modelopt_fp4")
+            and ("NVFP4" in quant_algo or "FP4" in quant_algo)
+        )
 
     def is_layer_excluded(self, prefix: str, exclude_modules: list):
         for pattern in exclude_modules:


### PR DESCRIPTION
## Motivation

Closes #20301 : the quantization documentation had several inaccuracies:

1. **Platform table was AMD-biased** — lacked NVIDIA GPU specifics (Hopper/SM90+, Blackwell/SM100+)
2. **Incorrect petit_nvfp4 description** — doc stated "NVIDIA NvFP4, Blackwell only" when Petit actually enables NVFP4 on **ROCm (AMD)**, not on NVIDIA
3. **Outdated/incorrect examples** — ModelOpt Python API examples needed verification and path consistency
4. **Missing source citations** — no references for Petit, ModelOpt, etc.

While fixing the documentation, I discovered and fixed a **bug**: NVFP4 models could not be auto-detected on ROCm. The override logic always selected `modelopt_fp4` (NVIDIA-only) before `PetitNvFp4Config` could run, causing `ValueError: modelopt_fp4 quantization is currently not supported in ROCm`.

## Modifications

### Documentation

- **`docs/advanced_features/quantization.md`**
  - Platform Compatibility table: add NVIDIA GPU info (Hopper/SM90+, Blackwell/SM100+), correct `petit_nvfp4` as AMD-only (MI250/MI300X/MI325X via [Petit](https://github.com/causalflow-ai/petit-kernel))
  - Add source citations: [LMSYS blog](https://lmsys.org/blog/2025-09-21-petit-amdgpu/), [AMD ROCm blog](https://rocm.blogs.amd.com/artificial-intelligence/fp4-mixed-precision/README.html), NVIDIA ModelOpt links
  - Fix ModelOpt Python API examples: deploy path consistency (`./exported_model`), add LoadConfig/script source links
  - Reference section: add Petit, ModelOpt LLM PTQ links

- **`docs/platforms/amd_gpu.md`**
  - Remove `petit_nvfp4` from "do not support" list
  - Add `petit_nvfp4` usage: NVFP4 models on MI250/MI300X, `pip install petit-kernel`, no `--quantization` flag needed

### Code (Bug Fix)

- **`python/sglang/srt/layers/quantization/base_config.py`**
  - `_modelopt_override_quantization_method`: On ROCm, return `None` for FP4/NVFP4 so `PetitNvFp4Config.override_quantization_method` can handle it. Previously, `ModelOptFp8Config` (key `"modelopt"`) was always returning `"modelopt_fp4"` and breaking before Petit could run.

- **`python/sglang/srt/layers/quantization/petit.py`**
  - `is_petit_nvfp4_compatible`: Accept `quant_method` `"modelopt_fp4"` (from `_parse_modelopt_quant_config`) in addition to `"modelopt"`, and verify `quant_algo` contains NVFP4/FP4.

## Accuracy Tests

None. This PR only affects documentation and the quantization method selection logic on ROCm. No changes to model forward or kernel outputs.

## Benchmarking and Profiling

N/A. No inference speed impact.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
