### PR TITLE
[Typo] Fix H200 doc links pointing to H20 section in deepseek_v3.md

### DIFF
--- a/docs/basic_usage/deepseek_v3.md
+++ b/docs/basic_usage/deepseek_v3.md
@@ -68,7 +68,7 @@ Detailed commands for reference:
 - [8 x H200](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#using-docker-recommended)
 - [4 x B200, 8 x B200](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-one-b200-node)
 - [8 x MI300X](../platforms/amd_gpu.md#running-deepseek-v3)
-- [2 x 8 x H200](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-two-h208-nodes)
+- [2 x 8 x H200](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-two-h2008-nodes-and-docker)
 - [4 x 8 x A100](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-four-a1008-nodes)
 - [8 x A100 (AWQ)](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-8-a100a800-with-awq-quantization)
 - [16 x A100 (INT8)](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-16-a100a800-with-int8-quantization)
@@ -150,7 +150,7 @@ Data parallelism attention is not recommended for low-latency, small-batch use c
 
 **Description**: For users with limited memory on a single node, SGLang supports serving DeepSeek Series Models, including DeepSeek V3, across multiple nodes using tensor parallelism. This approach partitions the model parameters across multiple GPUs or nodes to handle models that are too large for one node's memory.
 
-**Usage**: Check [here](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-2-h208) for usage examples.
+**Usage**: Check [here](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#example-serving-with-two-h2008-nodes-and-docker) for usage examples.
 
 ### Block-wise FP8
 


### PR DESCRIPTION
## Motivation

Fix incorrect documentation links that pointed H200 content to the H20 section. H20 and H200 are different GPUs.

## Modifications

- `sglang/docs/basic_usage/deepseek_v3.md`:
  - Line 71: Update `[2 x 8 x H200]` link from `#example-serving-with-two-h208-nodes` (H20) to `#example-serving-with-two-h2008-nodes-and-docker` (H200)
  - Line 153: Update the "Check here" link in the Multi-Node Tensor Parallelism section from invalid anchor `#example-serving-with-2-h208` to `#example-serving-with-two-h2008-nodes-and-docker`

## Accuracy Tests

N/A – Documentation link fixes only

## Benchmarking and Profiling

N/A – Documentation link fixes only

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).