### PR TITLE
perf(qwen3_5): replace einops rearrange with torch.flatten in GatedDe…

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -20,7 +20,6 @@ from typing import Iterable, Optional, Set, Tuple, Union
 
 import torch
 import torch.nn as nn
-from einops import rearrange
 
 # Configs
 from sglang.srt.configs.qwen3_5 import (
@@ -287,7 +286,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         z = z.reshape(-1, z.shape[-1])
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
         output, _ = self.out_proj(core_attn_out)
         return output
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->


## Motivation

`einops.rearrange` performs Python-level string parsing and validation on **every call**. In `Qwen3_5GatedDeltaNet.forward()`, the pattern `rearrange(x, "... h d -> ... (h d)")` is a simple flatten of the last two dimensions — equivalent to `torch.flatten(-2)`, which is a zero-copy view operation with no parsing overhead.

This call runs on every forward pass through every GDN layer in the model, so the overhead accumulates significantly.

## Changes

- Replace `rearrange(core_attn_out, "... h d -> ... (h d)")` with `core_attn_out.flatten(-2)` in `Qwen3_5GatedDeltaNet.forward()`
- Remove unused `from einops import rearrange` import

## Profiling Results

Profiled on **Qwen3.5-9B**, H100 80GB, TP=1, CUDA graphs disabled, using `sglang.bench_serving` with torch profiler. Perfetto SQL queries filtered to only `GatedDeltaNet` ancestor slices.

### Baseline (einops)
| name | call_count | avg_dur_us | total_dur_us |
|---|---|---|---|
| `einops/einops.py(561): rearrange` | 720 | 12.67 | 9125.43 |

### Optimized (torch.flatten)
| name | call_count | avg_dur_us | total_dur_us | min_dur_us | max_dur_us |
|---|---|---|---|---|---|
| `<built-in method flatten>` | 720 | 4.74 | 3410.18 | 3.97 | 67.35 |
| `aten::flatten` | 720 | 2.50 | 1797.94 | 2.09 | 65.37 |

### Summary
- **Per-call: 2.67x faster** (12.67 us → 4.74 us)
- **Total time: 63% reduction** (9125 us → 3410 us across 720 calls)
- **5715 us saved** per profiled window

## Profiling Reproduction Commands

### 1. Launch server
```bash
export SGLANG_TORCH_PROFILER_DIR=/path/to/traces

python -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-9B \
  --port 30000 --tp 1 --disable-cuda-graph
```

### 2. Run profiling benchmark
```bash
export PYTHONPATH=/path/to/sglang/python:$PYTHONPATH
export SGLANG_TORCH_PROFILER_DIR=/path/to/traces

python -m sglang.bench_serving \
  --backend sglang \
  --model Qwen/Qwen3.5-9B \
  --num-prompts 10 --random-input-len 256 --random-output-len 32 \
  --dataset-name random --profile
```

### 3. Perfetto SQL queries

**Baseline** (einops rearrange in GatedDeltaNet):
```sql
SELECT s.name, COUNT(*) AS call_count,
       AVG(s.dur)/1000.0 AS avg_dur_us, SUM(s.dur)/1000.0 AS total_dur_us
FROM slice s
WHERE s.name LIKE '%rearrange%'
  AND EXISTS (SELECT 1 FROM ancestor_slice(s.id) a WHERE a.name LIKE '%GatedDeltaNet%')
GROUP BY s.name;
```

**Optimized** (flatten in GatedDeltaNet):
```sql
SELECT s.name, COUNT(*) AS call_count,
       AVG(s.dur)/1000.0 AS avg_dur_us, SUM(s.dur)/1000.0 AS total_dur_us,
       MIN(s.dur)/1000.0 AS min_dur_us, MAX(s.dur)/1000.0 AS max_dur_us
FROM slice s
WHERE s.name LIKE '%flatten%'
  AND EXISTS (SELECT 1 FROM ancestor_slice(s.id) a WHERE a.name LIKE '%GatedDeltaNet%')
GROUP BY s.name;
```

<img width="2672" height="1432" alt="Screenshot 2026-03-11 at 2 40 54 PM" src="https://github.com/user-attachments/assets/f43038ec-f3c9-4fe5-9624-c031334833d5" />
<img width="2672" height="1432" alt="Screenshot 2026-03-11 at 2 41 08 PM" src="https://github.com/user-attachments/assets/d400840a-4db5-4b4f-80e9-1338d54a7d90" />


## Correctness

`flatten(-2)` is semantically identical to `rearrange("... h d -> ... (h d)")` — both merge the last two dimensions into one. No behavior change.

Ran GSM8k to test performance and accuracy


| Metric | Baseline (einops) | Optimized (native) |
|---|---|---|
| **Accuracy** | **0.905** | **0.900** |
| Invalid | 0.000 | 0.000 |
| Latency | 28.075s | 26.704s |
| Output throughput | 789.6 tok/s | 828.1 tok/s |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
