### PR TITLE
[DP Attention] Optimize dp_padding_mode selection for dp_size=1 in extend mode

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -64,13 +64,20 @@ class DpPaddingMode(IntEnum):
     def get_dp_padding_mode(
         cls, is_extend_in_batch, global_num_tokens: List[int]
     ) -> DpPaddingMode:
-        if is_extend_in_batch:
+        dp_size = get_attention_dp_size()
+
+        # When is_extend_in_batch and dp_size > 1, use SUM_LEN to avoid padding
+        # overhead from uneven token distribution.
+        # For dp_size=1, max_len equals sum_len, so prefer MAX_LEN mode
+        # to enable symmetric memory optimization (needed for NSA CP, etc.).
+        if is_extend_in_batch and dp_size > 1:
             return DpPaddingMode.SUM_LEN
 
         # we choose the mode that minimizes the communication cost
+        # prefer MAX_LEN when communication cost is equal to enable symmetric memory
         max_len = max(global_num_tokens)
         sum_len = sum(global_num_tokens)
-        if sum_len * 2 > max_len * get_attention_dp_size():
+        if sum_len * 2 >= max_len * dp_size:
             return cls.MAX_LEN
         else:
             return cls.SUM_LEN


### PR DESCRIPTION
CC @yizhang2077 @ShangmingCai @nvcastet @ch-wan @merrymercy @Fridge003 PTAL, thx. 

## Motivation

When dp_size=1, the `MAX_LEN` and `SUM_LEN` modes have identical communication overhead since max_len equals sum_len. Previously, extend mode(`get_dp_padding_mode`) unconditionally used `SUM_LEN`, which prevented symmetric memory from being used (via disabled=True).

Now with dp_size=1, we prefer `MAX_LEN` mode to enable symmetric memory optimizations needed for NSA CP and other features.


https://github.com/sgl-project/sglang/blob/abc672e7177b3ec366c2791845447e3f121fdfc9/python/sglang/srt/layers/dp_attention.py#L64-L68

https://github.com/sgl-project/sglang/blob/abc672e7177b3ec366c2791845447e3f121fdfc9/python/sglang/srt/layers/dp_attention.py#L119-L125

https://github.com/sgl-project/sglang/blob/abc672e7177b3ec366c2791845447e3f121fdfc9/python/sglang/srt/layers/dp_attention.py#L129-L135

## Modifications
Update the logic of  `get_dp_padding_mode` :

  - Only use `SUM_LEN` for extend mode when `dp_size > 1`.
  - Prefer MAX_LEN when communication cost is equal (`>=` instead of `>`).
  - This allows symmetric memory optimization for NSA CP and other use cases.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
