### PR TITLE
fix(dp-attn): use globally synchronized is_extend_in_batch for overlap

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1193,11 +1193,10 @@ class Scheduler(
         disable_overlap_for_batch = (
             envs.SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP.get()
             and batch
-            and batch.forward_mode.is_extend()
+            and getattr(batch, "is_extend_in_batch", batch.forward_mode.is_extend())
             and self.last_batch
-            and self.last_batch.forward_mode.is_extend()
+            and getattr(self.last_batch, "is_extend_in_batch", self.last_batch.forward_mode.is_extend())
         )
-
         # We do not support overlap + spec + grammar yet,
         # so we need to turn off overlap for this batch.
         # TODO(lsyin): support overlap + spec + grammar

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1195,7 +1195,11 @@ class Scheduler(
             and batch
             and getattr(batch, "is_extend_in_batch", batch.forward_mode.is_extend())
             and self.last_batch
-            and getattr(self.last_batch, "is_extend_in_batch", self.last_batch.forward_mode.is_extend())
+            and getattr(
+                self.last_batch,
+                "is_extend_in_batch",
+                self.last_batch.forward_mode.is_extend(),
+            )
         )
         # We do not support overlap + spec + grammar yet,
         # so we need to turn off overlap for this batch.


### PR DESCRIPTION
**Fixes:** #20315

### Description: Prevent GPU Deadlock in DP Attention Overlap

In DP Attention mode, calculating [disable_overlap_for_batch](cci:1://file:///Users/karthik/Documents/projects/sglang/python/sglang/srt/managers/scheduler.py:1189:4-1210:61) inside [event_loop_overlap](cci:1://file:///Users/karthik/Documents/projects/sglang/python/sglang/srt/managers/scheduler.py:1135:4-1187:45) using the localized `batch.forward_mode.is_extend()` causes split-brain GPU deadlocks. When DP ranks process misaligned request cycles—for example, if Rank 0 decides to prefill (`EXTEND`) while Rank 1 has no new requests and only decodes (`DECODE`)—Rank 0 evaluates `True` to disable overlap, while Rank 1 evaluates `False`. 

This divergent control flow instructs the ranks to interact with their GPU streams out of sync, triggering a collective hardware starvation (seen as identical py-spy stack traces stuck at `cuEventSynchronize`, leading to global watchdog timeouts).

**The Fix:**
This patch replaces the localized `forward_mode.is_extend()` evaluation with the globally synchronized attribute (`is_extend_in_batch`) natively generated beforehand by the [prepare_mlp_sync_batch](cci:1://file:///Users/karthik/Documents/projects/sglang/python/sglang/srt/managers/scheduler_dp_attn_mixin.py:226:4-238:9) `AllGather` collective. 

If DP Attention is engaged, `is_extend_in_batch` calculates the `.max()` intended state across the network, guaranteeing uniform boolean evaluation across all ranks, and ensuring perfect coordination when disabling overlapping prefill loops.
