### PR TITLE
[AMD][AITER] Guard _use_mla_ps_kernel with self.use_mla in draft_extend_v2 paths

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1313,7 +1313,7 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
             max_q_len = num_tokens_per_bs
 
-            if _use_mla_ps_kernel:
+            if self.use_mla and _use_mla_ps_kernel:
                 num_kv_splits = self.max_split_per_batch
 
                 self.make_mla_meta_data(
@@ -1656,7 +1656,7 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
             max_q_len = num_tokens_per_bs
 
-            if _use_mla_ps_kernel:
+            if self.use_mla and _use_mla_ps_kernel:
 
                 num_kv_splits = self.max_split_per_batch
 


### PR DESCRIPTION
## Motivation

This PR fixes #16027 — non-MLA models (e.g. GLM-4.7) crash with `AttributeError: 'AiterAttnBackend' object has no attribute 'max_split_per_batch'` when using EAGLE speculative decoding with the AITER attention backend on ROCm.

The root cause: the global flag `_use_mla_ps_kernel` defaults to `True`, but `self.max_split_per_batch` is only initialized inside the `if self.use_mla:` block in `__init__`. Two code paths in `is_draft_extend_v2()` branches check `if _use_mla_ps_kernel:` without verifying `self.use_mla` first, causing the crash on non-MLA models.

A previous fix attempt (PR #16682) was closed without merge.

## Modifications

Added `self.use_mla and` guard to two bare `if _use_mla_ps_kernel:` checks in `aiter_backend.py`:

1. `init_forward_metadata_capture_cuda_graph` — `is_draft_extend_v2()` branch (line 1316)
2. `init_forward_metadata_replay_cuda_graph` — `is_draft_extend_v2()` branch (line 1659)

This matches the existing pattern used in all other code paths (e.g. `init_cuda_graph_state` at line 1086, `is_draft_extend()` at line 1725).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
