### PR TITLE
Fix global server args not set error in test_triton_moe_wna16.py

### DIFF
--- a/test/manual/test_triton_moe_wna16.py
+++ b/test/manual/test_triton_moe_wna16.py
@@ -118,8 +118,6 @@ def quantize_weights(
 
 
 def torch_moe(a, w1, w2, score, topk):
-    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
-
     B, D = a.shape
     a = a.view(B, -1, D).repeat(1, topk, 1).reshape(-1, D)
     out = torch.zeros(B * topk, w2.shape[1], dtype=a.dtype, device=a.device)
@@ -159,6 +157,7 @@ def test_fused_moe_wn16(
     has_zp: bool,
     weight_bits: int,
 ):
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
     print(m, n, k, e, topk, dtype, group_size, has_zp, weight_bits)
     a = torch.randn((m, k), device=get_device(), dtype=dtype) / 10
     w1 = torch.randn((e, 2 * n, k), device=get_device(), dtype=dtype) / 10


### PR DESCRIPTION
  ---                                                                                                                                                                                                      
  Title: Fix global server args not set error in test_triton_moe_wna16.py
                                                                                                                                                                                                           
  Body:                                                                                                                                                                                                    

  ## Motivation

  Fixes part of #20243

  `test_triton_moe_wna16.py` fails with `ValueError: Global server args is not set yet!` because `set_global_server_args_for_scheduler()` is called inside `torch_moe()` (line 252), but `fused_moe()`
  (line 239) needs it earlier via `fused_experts_impl()` → `get_global_server_args().enable_fused_moe_sum_all_reduce`.

  ## Modifications

  Move `set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))` from `torch_moe()` to the beginning of `test_fused_moe_wn16()`, ensuring it is set before both `select_experts()` and
  `fused_moe()` are called.

  ## Accuracy Tests

  N/A — This change only fixes test initialization order, no model output is affected.

  ## Benchmarking and Profiling

  N/A — No inference logic changed.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] ~~Add unit tests~~ (this PR fixes an existing test)
  - [ ] ~~Update documentation~~ (not applicable)
  - [ ] ~~Provide accuracy and speed benchmark results~~ (not applicable)
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
