### PR TITLE
fix(kimi_k2): use local index for tool_index in non-streaming detect_and_parse

### DIFF
--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -80,20 +80,19 @@ class KimiK2Detector(BaseFormatDetector):
             logger.debug("function_call_tuples: %s", function_call_tuples)
 
             tool_calls = []
-            for match in function_call_tuples:
+            for i, match in enumerate(function_call_tuples):
                 function_id, function_args = match
                 m = self.tool_call_id_regex.match(function_id)
                 if not m:
                     logger.warning("Unexpected tool_call_id format: %s", function_id)
                     continue
                 function_name = m.group("name")
-                function_idx = int(m.group("index"))
 
                 logger.debug(f"function_name {function_name}")
 
                 tool_calls.append(
                     ToolCallItem(
-                        tool_index=function_idx,
+                        tool_index=i,
                         name=function_name,
                         parameters=function_args,
                     )


### PR DESCRIPTION
## Motivation

  In non-streaming mode, `KimiK2Detector.detect_and_parse` uses the model's global index from the `tool_call_id` (e.g. `functions.read:5` → `tool_index=5`) directly. However, `_process_tool_call_id` in `serving_chat.py` is designed to compute the global index itself via `history_tool_calls_cnt + tool_index`. This
   causes double-counting of history tool calls.

  **Example:** If there are 5 historical tool calls and the model outputs `functions.read:5`, the non-streaming path produces `functions.read:10` (5+5) instead of the correct `functions.read:5` (5+0).

  The streaming path (`parse_streaming_increment`) does not have this issue because it uses `self.current_tool_id` — a local counter starting from 0 — as `tool_index`.

  ## Modifications

  - In `KimiK2Detector.detect_and_parse`, changed `tool_index` from the model's global index (`function_idx` parsed from regex) to the local enumerate index (`i`), consistent with the streaming path.
  - Removed the now-unused `function_idx` variable.

  ## Accuracy Tests

  N/A — this is a bug fix in tool call ID generation logic, not model output.

  ## Benchmarking and Profiling

  N/A — no impact on inference speed.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

  ## Review Process

  1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
  2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
  3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
     - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
  4. After green CI and required approvals, ask Merge Oncalls to merge.