### PR TITLE
Fix Test* mixin classes being collected as standalone pytest tests

### DIFF
--- a/python/sglang/test/kits/ebnf_constrained_kit.py
+++ b/python/sglang/test/kits/ebnf_constrained_kit.py
@@ -3,7 +3,8 @@ import json
 import requests
 
 
-class TestEBNFConstrainedMixin:
+class EBNFConstrainedMixin:
+
     ebnf_grammar = 'root ::= "test"'  # Default grammar
 
     def _run_decode_ebnf(

--- a/python/sglang/test/kits/json_constrained_kit.py
+++ b/python/sglang/test/kits/json_constrained_kit.py
@@ -5,7 +5,8 @@ import openai
 import requests
 
 
-class TestJSONConstrainedMixin:
+class JSONConstrainedMixin:
+
     json_schema = json.dumps(
         {
             "type": "object",

--- a/python/sglang/test/kits/regex_constrained_kit.py
+++ b/python/sglang/test/kits/regex_constrained_kit.py
@@ -3,7 +3,8 @@ import json
 import requests
 
 
-class TestRegexConstrainedMixin:
+class RegexConstrainedMixin:
+
     def _run_decode_regex(
         self,
         regex,

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -2056,6 +2056,7 @@ def _distributed_worker(rank, world_size, backend, port, func, result_queue, kwa
 
 
 class CustomTestCase(unittest.TestCase):
+
     def _callTestMethod(self, method):
         max_retry = envs.SGLANG_TEST_MAX_RETRY.get()
         if max_retry is None:

--- a/test/registered/constrained_decoding/test_constrained_decoding.py
+++ b/test/registered/constrained_decoding/test_constrained_decoding.py
@@ -2,9 +2,9 @@ import unittest
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-from sglang.test.kits.ebnf_constrained_kit import TestEBNFConstrainedMixin
-from sglang.test.kits.json_constrained_kit import TestJSONConstrainedMixin
-from sglang.test.kits.regex_constrained_kit import TestRegexConstrainedMixin
+from sglang.test.kits.ebnf_constrained_kit import EBNFConstrainedMixin
+from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
+from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -49,22 +49,22 @@ class ServerWithGrammar(CustomTestCase):
 
 class TestXGrammarBackend(
     ServerWithGrammar,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     backend = "xgrammar"
 
 
-class TestOutlinesBackend(ServerWithGrammar, TestJSONConstrainedMixin):
+class TestOutlinesBackend(ServerWithGrammar, JSONConstrainedMixin):
     backend = "outlines"
 
 
 class TestLLGuidanceBackend(
     ServerWithGrammar,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     backend = "llguidance"
 

--- a/test/registered/distributed/test_dp_attention.py
+++ b/test/registered/distributed/test_dp_attention.py
@@ -8,10 +8,10 @@ from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
-from sglang.test.kits.ebnf_constrained_kit import TestEBNFConstrainedMixin
-from sglang.test.kits.json_constrained_kit import TestJSONConstrainedMixin
+from sglang.test.kits.ebnf_constrained_kit import EBNFConstrainedMixin
+from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
 from sglang.test.kits.radix_cache_server_kit import run_radix_attention_test
-from sglang.test.kits.regex_constrained_kit import TestRegexConstrainedMixin
+from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_IMAGE_URL,
@@ -30,9 +30,9 @@ register_cuda_ci(est_time=350, suite="stage-b-test-large-2-gpu")
 
 class TestDPAttentionDP2TP2(
     CustomTestCase,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     @classmethod
     def setUpClass(cls):
@@ -75,9 +75,9 @@ class TestDPAttentionDP2TP2(
 
 class TestDPRetract(
     CustomTestCase,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     @classmethod
     def setUpClass(cls):
@@ -115,9 +115,9 @@ class TestDPRetract(
 
 class TestDPAttentionDP2TP2DeepseekV3MTP(
     CustomTestCase,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     @classmethod
     def setUpClass(cls):

--- a/test/registered/distributed/test_dp_attention_large.py
+++ b/test/registered/distributed/test_dp_attention_large.py
@@ -7,9 +7,9 @@ from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
-from sglang.test.kits.ebnf_constrained_kit import TestEBNFConstrainedMixin
-from sglang.test.kits.json_constrained_kit import TestJSONConstrainedMixin
-from sglang.test.kits.regex_constrained_kit import TestRegexConstrainedMixin
+from sglang.test.kits.ebnf_constrained_kit import EBNFConstrainedMixin
+from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
+from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_IMAGE_URL,
@@ -28,9 +28,9 @@ register_cuda_ci(est_time=350, suite="stage-c-test-4-gpu-h100")
 
 class TestDPAttentionDP2TP4(
     CustomTestCase,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     @classmethod
     def setUpClass(cls):
@@ -68,9 +68,9 @@ class TestDPAttentionDP2TP4(
 
 class TestDPAttentionDP2TP2DeepseekV3MTP(
     CustomTestCase,
-    TestJSONConstrainedMixin,
-    TestEBNFConstrainedMixin,
-    TestRegexConstrainedMixin,
+    JSONConstrainedMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
 ):
     @classmethod
     def setUpClass(cls):

--- a/test/registered/openai_server/features/test_json_mode.py
+++ b/test/registered/openai_server/features/test_json_mode.py
@@ -17,7 +17,7 @@ register_cuda_ci(est_time=109, suite="stage-b-test-small-1-gpu")
 register_amd_ci(est_time=180, suite="stage-b-test-small-1-gpu-amd")
 
 
-class TestJSONModeMixin:
+class JSONModeMixin:
     """Mixin class containing JSON mode test methods"""
 
     def test_json_mode_response(self):
@@ -119,15 +119,15 @@ class ServerWithGrammarBackend(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
 
-class TestJSONModeXGrammar(ServerWithGrammarBackend, TestJSONModeMixin):
+class TestJSONModeXGrammar(ServerWithGrammarBackend, JSONModeMixin):
     backend = "xgrammar"
 
 
-class TestJSONModeOutlines(ServerWithGrammarBackend, TestJSONModeMixin):
+class TestJSONModeOutlines(ServerWithGrammarBackend, JSONModeMixin):
     backend = "outlines"
 
 
-class TestJSONModeLLGuidance(ServerWithGrammarBackend, TestJSONModeMixin):
+class TestJSONModeLLGuidance(ServerWithGrammarBackend, JSONModeMixin):
     backend = "llguidance"
 
 

--- a/test/registered/spec/eagle/test_eagle_constrained_decoding.py
+++ b/test/registered/spec/eagle/test_eagle_constrained_decoding.py
@@ -3,8 +3,8 @@ import unittest
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
-from sglang.test.kits.json_constrained_kit import TestJSONConstrainedMixin
-from sglang.test.kits.regex_constrained_kit import TestRegexConstrainedMixin
+from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
+from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE,
     DEFAULT_TARGET_MODEL_EAGLE,
@@ -18,7 +18,7 @@ register_cuda_ci(est_time=100, suite="stage-b-test-large-1-gpu")
 
 
 class TestEagleConstrainedDecoding(
-    CustomTestCase, TestRegexConstrainedMixin, TestJSONConstrainedMixin
+    CustomTestCase, RegexConstrainedMixin, JSONConstrainedMixin
 ):
     max_running_requests = 64
     attention_backend = "triton"


### PR DESCRIPTION
  ---                                                                                                                                                                                                      
  Mixin classes named Test*Mixin were collected by pytest as standalone test classes, causing AttributeError when test methods accessed attributes (base_url, model) only set in concrete subclasses'
  setUpClass.                                                                                                                                                                                              
                                                                                                                                                                                                           
  Add __test__ = False to mixin classes and __test__ = True to CustomTestCase to override the inherited flag via MRO.

  Fixes #20243

  Motivation

  Pytest collects classes starting with Test as test classes. Mixin classes like TestJSONConstrainedMixin, TestEBNFConstrainedMixin, TestRegexConstrainedMixin, and TestJSONModeMixin are collected as
  standalone native pytest test classes (<Class>) because they:

  1. Have names starting with Test
  2. Contain methods starting with test_
  3. Do not inherit from unittest.TestCase

  When pytest tries to run these mixin classes directly, their test methods access self.base_url, self.model, etc., which are only initialized in concrete subclasses' setUpClass, causing AttributeError.

  Modifications

  - Add __test__ = False to 4 mixin classes to prevent pytest from collecting them as standalone test classes:
    - python/sglang/test/kits/json_constrained_kit.py — TestJSONConstrainedMixin
    - python/sglang/test/kits/ebnf_constrained_kit.py — TestEBNFConstrainedMixin
    - python/sglang/test/kits/regex_constrained_kit.py — TestRegexConstrainedMixin
    - test/registered/openai_server/features/test_json_mode.py — TestJSONModeMixin
  - Add __test__ = True to CustomTestCase in python/sglang/test/test_utils.py to override the inherited __test__ = False from mixins via MRO, ensuring concrete test classes are still collected.

  Accuracy Tests

  N/A — This change only affects pytest test collection behavior, no model output changes.

  Benchmarking and Profiling

  N/A — This change only affects pytest test collection behavior, no inference speed impact.

  Test Results

  Before fix — mixin classes were incorrectly collected as standalone test classes:
  $ python -m pytest test/registered/constrained_decoding/test_constrained_decoding.py --collect-only
  collected 67 items   # includes 21 tests from mixin classes

  <Class TestEBNFConstrainedMixin>        ← incorrectly collected
  <Class TestJSONConstrainedMixin>        ← incorrectly collected
  <Class TestRegexConstrainedMixin>       ← incorrectly collected
  <UnitTestCase TestXGrammarBackend>      ← correct
  ...

  $ python -m pytest test/registered/openai_server/features/test_json_mode.py --collect-only
  collected 8 items   # includes 2 tests from mixin class

  <Class TestJSONModeMixin>               ← incorrectly collected
  <UnitTestCase TestJSONModeXGrammar>     ← correct
  ...

  After fix — only concrete test classes are collected:
  $ python -m pytest test/registered/constrained_decoding/test_constrained_decoding.py --collect-only
  collected 46 items   # mixin classes excluded

  <UnitTestCase TestXGrammarBackend>      ← correct
  <UnitTestCase TestOutlinesBackend>      ← correct
  <UnitTestCase TestLLGuidanceBackend>    ← correct

  $ python -m pytest test/registered/openai_server/features/test_json_mode.py --collect-only
  collected 6 items   # mixin class excluded

  <UnitTestCase TestJSONModeXGrammar>     ← correct
  <UnitTestCase TestJSONModeOutlines>     ← correct
  <UnitTestCase TestJSONModeLLGuidance>   ← correct

  Checklist

  - Format your code according to the https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit.
  - Add unit tests according to the https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests.
  - Update documentation according to https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations.
  - Provide accuracy and speed benchmark results according to https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy and
  https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed.
  - Follow the SGLang code style https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance.

  Review Process

  1. Ping Merge Oncalls to start the PR flow. See the https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process.
  2. Get approvals from https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS and other reviewers.
  3. Trigger CI tests with https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests or contact authorized users to do so.
    - /tag-run-ci-label, /rerun-failed-ci, /tag-and-rerun-ci
  4. After green CI and required approvals, ask Merge Oncalls to merge.
