### PR TITLE
[Bug] Fix TCP_NODELAY not being set due to uvicorn fd= AF_UNIX misidentification

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2142,7 +2142,11 @@ def _setup_and_run_http_server(
                 ssl_ca_certs=server_args.ssl_ca_certs,
                 ssl_keyfile_password=server_args.ssl_keyfile_password,
             )
-            config.load()  # Validate config eagerly; fail fast before spawning workers
+            # Note: do NOT call config.load() here. The multi-worker path
+            # uses spawn to create child processes, which pickles the config.
+            # config.load() resolves the app import string into the actual app
+            # object (with unpicklable closures), breaking pickling. Each child
+            # calls config.load() independently in Server._serve().
             server = uvicorn.Server(config)
             Multiprocess(config, target=server.run, sockets=[reserved_socket]).run()
     finally:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2053,9 +2053,13 @@ def _setup_and_run_http_server(
         if server_args.tokenizer_worker_num == 1:
             if server_args.enable_ssl_refresh:
                 # Use Config/Server API for access to the SSLContext.
+                # Pass the pre-bound socket via sockets= instead of fd= to
+                # preserve the correct address family (AF_INET/AF_INET6).
+                # uvicorn's fd= path hardcodes AF_UNIX in socket.fromfd(),
+                # which causes the event loop to skip TCP_NODELAY on accepted
+                # connections (both asyncio and uvloop check sock.family).
                 config = uvicorn.Config(
                     app,
-                    fd=reserved_socket.fileno(),
                     root_path=server_args.fastapi_root_path,
                     log_level=server_args.log_level_http or server_args.log_level,
                     timeout_keep_alive=envs.SGLANG_TIMEOUT_KEEP_ALIVE.get(),
@@ -2080,7 +2084,7 @@ def _setup_and_run_http_server(
                     )
                     logger.info("SSL certificate auto-refresh enabled.")
                     try:
-                        await server.serve()
+                        await server.serve(sockets=[reserved_socket])
                     finally:
                         refresher.stop()
 
@@ -2088,10 +2092,11 @@ def _setup_and_run_http_server(
 
                 asyncio.run(_run_with_ssl_refresh())
             else:
-                # Default case, one tokenizer process
-                uvicorn.run(
+                # Default case, one tokenizer process.
+                # Use Config/Server API with sockets= instead of uvicorn.run(fd=)
+                # to preserve the correct socket family. See comment above.
+                config = uvicorn.Config(
                     app,
-                    fd=reserved_socket.fileno(),
                     root_path=server_args.fastapi_root_path,
                     log_level=server_args.log_level_http or server_args.log_level,
                     timeout_keep_alive=envs.SGLANG_TIMEOUT_KEEP_ALIVE.get(),
@@ -2101,9 +2106,15 @@ def _setup_and_run_http_server(
                     ssl_ca_certs=server_args.ssl_ca_certs,
                     ssl_keyfile_password=server_args.ssl_keyfile_password,
                 )
+                server = uvicorn.Server(config)
+                server.run(sockets=[reserved_socket])
         else:
-            # Multiple tokenizer and http processes
+            # Multiple tokenizer and http processes.
+            # Build Config/Server manually and use Multiprocess directly with
+            # sockets= to bypass uvicorn's config.bind_socket() which wraps
+            # the fd as AF_UNIX (breaking TCP_NODELAY). See comment above.
             from uvicorn.config import LOGGING_CONFIG
+            from uvicorn.supervisors import Multiprocess
 
             LOGGING_CONFIG["loggers"]["sglang.srt.entrypoints.http_server"] = {
                 "handlers": ["default"],
@@ -2119,9 +2130,8 @@ def _setup_and_run_http_server(
                     "SSL refresh will be disabled."
                 )
 
-            uvicorn.run(
+            config = uvicorn.Config(
                 "sglang.srt.entrypoints.http_server:app",
-                fd=reserved_socket.fileno(),
                 root_path=server_args.fastapi_root_path,
                 log_level=server_args.log_level_http or server_args.log_level,
                 timeout_keep_alive=envs.SGLANG_TIMEOUT_KEEP_ALIVE.get(),
@@ -2132,6 +2142,9 @@ def _setup_and_run_http_server(
                 ssl_ca_certs=server_args.ssl_ca_certs,
                 ssl_keyfile_password=server_args.ssl_keyfile_password,
             )
+            config.load()  # Validate config eagerly; fail fast before spawning workers
+            server = uvicorn.Server(config)
+            Multiprocess(config, target=server.run, sockets=[reserved_socket]).run()
     finally:
         # Close the reserved socket after uvicorn exits or on any error
         # This ensures the port is released even if initialization fails


### PR DESCRIPTION
## Motivation

PR #17754 introduced early port reservation by pre-binding a TCP socket and passing it to uvicorn via `fd=reserved_socket.fileno()`. This inadvertently broke `TCP_NODELAY` on all HTTP connections.

**Root cause:** uvicorn's `fd=` code path hardcodes `socket.AF_UNIX` in `socket.fromfd()` ([server.py](https://github.com/encode/uvicorn/blob/main/src/uvicorn/server.py) and [config.py](https://github.com/encode/uvicorn/blob/main/src/uvicorn/config.py)), misidentifying TCP sockets as Unix domain sockets. This causes the event loop (both asyncio and uvloop) to skip setting `TCP_NODELAY` on accepted connections, since they check `sock.family in {AF_INET, AF_INET6}` before calling `setsockopt`.

Without `TCP_NODELAY`, Nagle's algorithm buffers small packets for up to ~40ms before sending — significant for a streaming inference server sending many small token chunks.

## Changes

Replace `fd=reserved_socket.fileno()` with `sockets=[reserved_socket]` in all three uvicorn startup paths, which preserves the correct `AF_INET`/`AF_INET6` socket family:

| Code path | Before | After |
|-----------|--------|-------|
| SSL refresh (single-worker) | `Config(fd=...)` + `server.serve()` | `Config(...)` + `server.serve(sockets=[...])` |
| Default (single-worker) | `uvicorn.run(fd=...)` | `Config(...)` + `Server` + `server.run(sockets=[...])` |
| Multi-worker | `uvicorn.run(fd=..., workers=N)` | `Config(...)` + `Server` + `Multiprocess(..., sockets=[...]).run()` |

The early port reservation from #17754 is fully preserved — only the handoff to uvicorn changes.

## Test Results

Tested on `ion-user-9` with `lmsysorg/sglang:dev` image, `meta-llama/Llama-3.1-8B-Instruct`, single H100 GPU.

Used `pidfd_getfd` + `getsockopt(TCP_NODELAY)` to directly inspect server-side accepted socket options:

| Test | TCP_NODELAY | Inference | Status |
|------|------------|-----------|--------|
| Baseline (`fd=` path, no fix) | **0 (OFF)** | works | BUG confirmed |
| Fixed — single worker | **1 (ON)** | works | PASS |
| Fixed — multi-worker (`--tokenizer-worker-num 2`) | **1 (ON)** | works | PASS |
| Fixed — SSL (`--ssl-keyfile/--ssl-certfile`) | **1 (ON)** | works | PASS |

### Verification method

```python
# Server-side accepted socket inspection via pidfd_getfd syscall
libc.syscall(SYS_pidfd_open, server_pid, 0)   # get pidfd
libc.syscall(SYS_pidfd_getfd, pidfd, fd, 0)    # dup server's fd into our process
s = socket.socket(fileno=local_fd)
s.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)  # 0=BUG, 1=FIXED
```

**Baseline output (BUG):**
```
Server-side accepted socket:
  Family:      2 (AF_INET)
  TCP_NODELAY: 0
RESULT: TCP_NODELAY NOT SET (BUG)
```

**Fixed output (all 3 paths):**
```
Server-side accepted socket:
  Family:      2 (AF_INET)
  TCP_NODELAY: 1
RESULT: TCP_NODELAY IS SET (GOOD)
```

## Notes

- The multi-worker path uses `Multiprocess` from `uvicorn.supervisors` directly, bypassing `config.bind_socket()` which also contains the `AF_UNIX` bug
- `config.load()` must NOT be called before `Multiprocess` — it resolves the app import string into an unpicklable object, breaking multiprocessing spawn
- The double-close of `reserved_socket` (uvicorn shutdown + finally block) is safe — `socket.close()` is idempotent in Python, and actually safer than the old `fd=` path where two different Python socket objects shared the same fd

🤖 Generated with [Claude Code](https://claude.com/claude-code)