### PR TITLE
[mamba] make extra buffer track indexs async ( 15.7% throughput promoting )

### DIFF
--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -234,14 +234,24 @@ class EagleVerifyInputV2Mixin:
 
             # Set mamba_track_indices for mamba prefix-cache state tracking
             if get_global_server_args().enable_mamba_extra_buffer():
-                batch.mamba_track_indices = torch.tensor(
-                    [
-                        req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx]
-                        for req in batch.reqs
-                    ],
-                    dtype=torch.int64,
-                    device=device,
+                # Fully on-GPU operation: stack all buffers and gather to avoid sync
+                ping_pong_buffers = torch.stack(
+                    [req.mamba_ping_pong_track_buffer for req in batch.reqs]
+                )  # (bs, 2)
+
+                # Fully async: use non_blocking to avoid CPU-GPU sync
+                # Create tensor on CPU first, then async copy to GPU
+                next_track_indices_cpu = torch.tensor(
+                    [req.mamba_next_track_idx for req in batch.reqs],
+                    dtype=torch.long,
                 )
+                next_track_indices = next_track_indices_cpu.to(
+                    device, non_blocking=True
+                )
+
+                batch.mamba_track_indices = torch.gather(
+                    ping_pong_buffers, dim=1, index=next_track_indices.unsqueeze(1)
+                ).squeeze(1)
                 batch.mamba_track_mask = None
                 batch.mamba_track_seqlens = None
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -241,13 +241,10 @@ class EagleVerifyInputV2Mixin:
 
                 # Fully async: use non_blocking to avoid CPU-GPU sync
                 # Create tensor on CPU first, then async copy to GPU
-                next_track_indices_cpu = torch.tensor(
+                next_track_indices = torch.tensor(
                     [req.mamba_next_track_idx for req in batch.reqs],
                     dtype=torch.long,
-                )
-                next_track_indices = next_track_indices_cpu.to(
-                    device, non_blocking=True
-                )
+                ).to(device, non_blocking=True)
 
                 batch.mamba_track_indices = torch.gather(
                     ping_pong_buffers, dim=1, index=next_track_indices.unsqueeze(1)


### PR DESCRIPTION
## Opti
Make extra buffer track indexs async. (With spec-v2 qwen3-next)

Serve cmd:
```plaintext
export  SGLANG_ENABLE_SPEC_V2=1
python3 -m sglang.launch_server --model-path /data/models/Qwen3-Next-80B-A3B-Instruct --chunked-prefill-size 8192 --host 0.0.0.0 --port 58888 --trust-remote-code --log-requests --collect-tokens-histogram --enable-metrics --enable-cache-report --served-model-name Qwen3-Next-80B-A3B-Instruct --tensor-parallel-size 4 --mem-fraction-static 0.8 --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --tool-call-parser qwen --log-requests-level 0 --mamba-scheduler-strategy extra_buffer --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 32}'
```

Befor:
```plaintext
python3 ./benchmark/gsm8k/bench_sglang.py --port 58888
100%|████████████████████████████████████████████████████████████████████████████████| 200/200 [00:33<00:00,  6.06it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 33.030 s
Output throughput: 991.602 token/s
```

After:
```plaintext
python3 ./benchmark/gsm8k/bench_sglang.py --port 58888
100%|████████████████████████████████████████████████████████████████████████████████| 200/200 [00:28<00:00,  7.01it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 28.550 s
Output throughput: 1147.404 token/s
```

**About 15.7% throughput promoting**


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

