### PR TITLE
[diffusion] Batch serial CFG for Qwen-Image to reduce denoising overhead

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -399,6 +399,9 @@ class PipelineConfig:
     def prepare_neg_cond_kwargs(self, batch, device, rotary_emb, dtype):
         return {}
 
+    def prepare_serial_cfg_kwargs(self, batch, device, rotary_emb, dtype):
+        return None
+
     @staticmethod
     def add_cli_args(
         parser: FlexibleArgumentParser, prefix: str = ""

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -1,5 +1,6 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 
+import os
 from dataclasses import dataclass, field
 from typing import Callable
 
@@ -200,7 +201,33 @@ class QwenImagePipelineConfig(ImagePipelineConfig):
         txt_cos_sin_cache = torch.cat([txt_cos_half, txt_sin_half], dim=-1)
         return img_cos_sin_cache, txt_cos_sin_cache
 
-    def _prepare_cond_kwargs(self, batch, prompt_embeds, rotary_emb, device, dtype):
+    @staticmethod
+    def _pad_cfg_tensor(tensor: torch.Tensor, target_seq_len: int) -> torch.Tensor:
+        pad_len = target_seq_len - tensor.shape[1]
+        if pad_len <= 0:
+            return tensor
+        pad_shape = (*tensor.shape[:1], pad_len, *tensor.shape[2:])
+        pad = tensor.new_zeros(pad_shape)
+        return torch.cat([tensor, pad], dim=1)
+
+    @staticmethod
+    def _align_prompt_attention_mask(
+        prompt_attention_mask: torch.Tensor, prompt_embeds: torch.Tensor
+    ) -> torch.Tensor:
+        seq_len = prompt_embeds.shape[1]
+        if prompt_attention_mask.shape[1] == seq_len:
+            return prompt_attention_mask
+        return prompt_attention_mask[:, -seq_len:]
+
+    def _prepare_cond_kwargs(
+        self,
+        batch,
+        prompt_embeds,
+        rotary_emb,
+        device,
+        dtype,
+        prompt_attention_mask=None,
+    ):
         batch_size = prompt_embeds[0].shape[0]
         height = batch.height
         width = batch.width
@@ -216,13 +243,24 @@ class QwenImagePipelineConfig(ImagePipelineConfig):
             ]
         ] * batch_size
         txt_seq_lens = [prompt_embeds[0].shape[1]]
+        if prompt_attention_mask is not None:
+            txt_seq_lens = prompt_attention_mask.sum(dim=1).tolist()
+
+        cond_kwargs = {
+            "img_shapes": img_shapes,
+            "txt_seq_lens": txt_seq_lens,
+            "freqs_cis": None,
+        }
+        if prompt_attention_mask is not None:
+            prompt_attention_mask = self._align_prompt_attention_mask(
+                prompt_attention_mask, prompt_embeds[0]
+            )
+            txt_seq_lens = prompt_attention_mask.sum(dim=1).tolist()
+            cond_kwargs["txt_seq_lens"] = txt_seq_lens
+            cond_kwargs["encoder_hidden_states_mask"] = prompt_attention_mask
 
         if rotary_emb is None:
-            return {
-                "img_shapes": img_shapes,
-                "txt_seq_lens": txt_seq_lens,
-                "freqs_cis": None,
-            }
+            return cond_kwargs
 
         freqs_cis = self.get_freqs_cis(
             img_shapes, txt_seq_lens, rotary_emb, device, dtype
@@ -230,21 +268,80 @@ class QwenImagePipelineConfig(ImagePipelineConfig):
 
         img_cache, txt_cache = freqs_cis
         img_cache = shard_rotary_emb_for_sp(img_cache)
-        return {
-            "txt_seq_lens": txt_seq_lens,
-            "freqs_cis": (img_cache, txt_cache),
-            "img_shapes": img_shapes,
-        }
+        cond_kwargs["freqs_cis"] = (img_cache, txt_cache)
+        return cond_kwargs
 
     def prepare_pos_cond_kwargs(self, batch, device, rotary_emb, dtype):
         return self._prepare_cond_kwargs(
-            batch, batch.prompt_embeds, rotary_emb, device, dtype
+            batch,
+            batch.prompt_embeds,
+            rotary_emb,
+            device,
+            dtype,
+            prompt_attention_mask=batch.prompt_attention_mask[0],
         )
 
     def prepare_neg_cond_kwargs(self, batch, device, rotary_emb, dtype):
         return self._prepare_cond_kwargs(
-            batch, batch.negative_prompt_embeds, rotary_emb, device, dtype
+            batch,
+            batch.negative_prompt_embeds,
+            rotary_emb,
+            device,
+            dtype,
+            prompt_attention_mask=batch.negative_attention_mask[0],
         )
+
+    def prepare_serial_cfg_kwargs(self, batch, device, rotary_emb, dtype):
+        if (
+            os.environ.get("SGLANG_QWEN_IMAGE_BATCHED_SERIAL_CFG", "1") != "1"
+            or not batch.do_classifier_free_guidance
+            or not batch.prompt_embeds
+            or not batch.negative_prompt_embeds
+            or not batch.prompt_attention_mask
+            or not batch.negative_attention_mask
+        ):
+            return None
+
+        pos_prompt_embeds = self.get_pos_prompt_embeds(batch)
+        neg_prompt_embeds = self.get_neg_prompt_embeds(batch)
+
+        if (
+            not isinstance(pos_prompt_embeds, list)
+            or not isinstance(neg_prompt_embeds, list)
+            or len(pos_prompt_embeds) != 1
+            or len(neg_prompt_embeds) != 1
+        ):
+            return None
+
+        pos_prompt = pos_prompt_embeds[0]
+        neg_prompt = neg_prompt_embeds[0]
+        pos_mask = self._align_prompt_attention_mask(batch.prompt_attention_mask[0], pos_prompt)
+        neg_mask = self._align_prompt_attention_mask(batch.negative_attention_mask[0], neg_prompt)
+        max_seq_len = max(pos_prompt.shape[1], neg_prompt.shape[1])
+
+        combined_prompt_embeds = torch.cat(
+            [
+                self._pad_cfg_tensor(neg_prompt, max_seq_len),
+                self._pad_cfg_tensor(pos_prompt, max_seq_len),
+            ],
+            dim=0,
+        )
+        combined_prompt_mask = torch.cat(
+            [
+                self._pad_cfg_tensor(neg_mask, max_seq_len),
+                self._pad_cfg_tensor(pos_mask, max_seq_len),
+            ],
+            dim=0,
+        )
+
+        return self._prepare_cond_kwargs(
+            batch,
+            [combined_prompt_embeds],
+            rotary_emb,
+            device,
+            dtype,
+            prompt_attention_mask=combined_prompt_mask,
+        ) | {"encoder_hidden_states": [combined_prompt_embeds]}
 
     def post_denoising_loop(self, latents, batch):
         # unpack latents for qwen-image

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -667,6 +667,20 @@ class DenoisingStage(PipelineStage):
         else:
             neg_cond_kwargs = {}
 
+        serial_cfg_kwargs = None
+        if batch.do_classifier_free_guidance and not server_args.enable_cfg_parallel:
+            serial_cfg_kwargs = server_args.pipeline_config.prepare_serial_cfg_kwargs(
+                batch,
+                self.device,
+                getattr(self.transformer, "rotary_emb", None),
+                dtype=target_dtype,
+            )
+            if serial_cfg_kwargs is not None:
+                serial_cfg_kwargs = self.prepare_extra_func_kwargs(
+                    getattr(self.transformer, "forward", self.transformer),
+                    serial_cfg_kwargs,
+                )
+
         return {
             "extra_step_kwargs": extra_step_kwargs,
             "target_dtype": target_dtype,
@@ -686,6 +700,7 @@ class DenoisingStage(PipelineStage):
             "reserved_frames_mask": reserved_frames_mask_sp,  # Use SP-sharded version
             "seq_len": seq_len,
             "guidance": guidance,
+            "serial_cfg_kwargs": serial_cfg_kwargs,
         }
 
     def _post_denoising_loop(
@@ -992,6 +1007,7 @@ class DenoisingStage(PipelineStage):
         reserved_frames_mask = prepared_vars["reserved_frames_mask"]
         seq_len = prepared_vars["seq_len"]
         guidance = prepared_vars["guidance"]
+        serial_cfg_kwargs = prepared_vars["serial_cfg_kwargs"]
 
         # Initialize lists for ODE trajectory
         trajectory_timesteps: list[torch.Tensor] = []
@@ -1076,6 +1092,7 @@ class DenoisingStage(PipelineStage):
                             server_args=server_args,
                             guidance=guidance,
                             latents=latents,
+                            serial_cfg_kwargs=serial_cfg_kwargs,
                         )
 
                         # Save noise_pred to batch for external access (e.g., ComfyUI)
@@ -1350,6 +1367,12 @@ class DenoisingStage(PipelineStage):
             **kwargs,
         )
 
+    @staticmethod
+    def _duplicate_cfg_batch(tensor: torch.Tensor | None) -> torch.Tensor | None:
+        if tensor is None:
+            return None
+        return torch.cat([tensor, tensor], dim=0)
+
     def _predict_noise_with_cfg(
         self,
         current_model: nn.Module,
@@ -1366,6 +1389,7 @@ class DenoisingStage(PipelineStage):
         server_args,
         guidance,
         latents,
+        serial_cfg_kwargs: dict[str, Any] | None,
     ):
         """
         Predict the noise residual with classifier-free guidance.
@@ -1389,8 +1413,37 @@ class DenoisingStage(PipelineStage):
         noise_pred_cond: torch.Tensor | None = None
         noise_pred_uncond: torch.Tensor | None = None
         cfg_rank = get_classifier_free_guidance_rank()
+        use_serial_cfg_batch = (
+            batch.do_classifier_free_guidance
+            and not server_args.enable_cfg_parallel
+            and serial_cfg_kwargs is not None
+        )
+
+        if use_serial_cfg_batch:
+            batch.is_cfg_negative = False
+            with set_forward_context(
+                current_timestep=timestep_index,
+                attn_metadata=attn_metadata,
+                forward_batch=batch,
+            ):
+                noise_pred = self._predict_noise(
+                    current_model=current_model,
+                    latent_model_input=self._duplicate_cfg_batch(latent_model_input),
+                    timestep=self._duplicate_cfg_batch(timestep),
+                    target_dtype=target_dtype,
+                    guidance=self._duplicate_cfg_batch(guidance),
+                    **image_kwargs,
+                    **serial_cfg_kwargs,
+                )
+                noise_pred = server_args.pipeline_config.slice_noise_pred(
+                    noise_pred, latents
+                )
+            noise_pred_uncond, noise_pred_cond = noise_pred.chunk(2, dim=0)
+
         # positive pass
-        if not (server_args.enable_cfg_parallel and cfg_rank != 0):
+        if not use_serial_cfg_batch and not (
+            server_args.enable_cfg_parallel and cfg_rank != 0
+        ):
             batch.is_cfg_negative = False
             with set_forward_context(
                 current_timestep=timestep_index,
@@ -1415,7 +1468,10 @@ class DenoisingStage(PipelineStage):
             return noise_pred_cond
 
         # negative pass
-        if not server_args.enable_cfg_parallel or cfg_rank != 0:
+        if (
+            not use_serial_cfg_batch
+            and (not server_args.enable_cfg_parallel or cfg_rank != 0)
+        ):
             batch.is_cfg_negative = True
             with set_forward_context(
                 current_timestep=timestep_index,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR optimizes the Qwen-Image denoising path by batching the serial CFG cond/uncond forward passes into a single model forward.

Before this change, each denoising step runs two separate transformer forwards:
- one for conditional prompt
- one for unconditional prompt

After this change, the two branches are packed into one batch and executed together, then combined with the same CFG formula as before.

The code mainly writed by gpt.5.4 high with codex.

## Why this is equivalent

This change does not modify the denoising algorithm itself.

The guidance computation remains:

`eps = eps_uncond + guidance_scale * (eps_cond - eps_uncond)`

The only difference is execution structure:
- before: `f(cond)` and `f(uncond)` are executed as two separate forwards
- after: `[f(uncond), f(cond)]` are executed in one batched forward

So this is algorithmically equivalent to the original serial CFG path, aside from expected floating-point differences from batching / kernel selection.

## Why it is faster

The main benefit is lower per-step overhead.

On the previous path, every denoising step paid the framework / runtime / launch overhead twice because cond and uncond were executed separately. With this change, that overhead is paid once per step, which reduces launch gaps and improves `torch.compile` efficiency.

In short:
- fewer transformer invocations per denoising step
- less Python/runtime overhead between cond/uncond branches
- better batching efficiency on GPU


## main

```shell
sglang generate --model-path=Qwen/Qwen-Image-2512  --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k" '--negative-prompt= ' --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.0 --seed=42 --save-output --warmup --dit-cpu-offload false --text-encoder-cpu-offload false --enable-torch-compile  
```

```shell
[03-12 08:39:01] [InputValidationStage] started...
[03-12 08:39:01] [InputValidationStage] finished in 0.0000 seconds
[03-12 08:39:01] [TextEncodingStage] started...
[03-12 08:39:01] [TextEncodingStage] finished in 0.0368 seconds
[03-12 08:39:01] [LatentPreparationStage] started...
[03-12 08:39:01] [LatentPreparationStage] finished in 0.0002 seconds
[03-12 08:39:01] [TimestepPreparationStage] started...
[03-12 08:39:01] [TimestepPreparationStage] finished in 0.0006 seconds
[03-12 08:39:01] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:15<00:00,  3.28it/s]
[03-12 08:39:16] [DenoisingStage] average time per step: 0.3052 seconds
[03-12 08:39:16] [DenoisingStage] finished in 15.2640 seconds
[03-12 08:39:16] [DecodingStage] started...
[03-12 08:39:16] [DecodingStage] finished in 0.0092 seconds
[03-12 08:39:16] Peak GPU memory: 63.26 GB, Peak allocated: 61.10 GB, Memory pool overhead: 2.17 GB (3.4%), Remaining GPU memory at peak: 77.14 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[03-12 08:39:16] Output saved to outputs/A_futuristic_cyberpunk_city_at_night_neon_lights_reflecting_on_wet_streets_highly_detailed_8k_20260312-083851_2d77b2ae.png
[03-12 08:39:16] Pixel data generated successfully in 25.22 seconds
[03-12 08:39:16] Completed batch processing. Generated 1 outputs in 25.22 seconds
[03-12 08:39:16] Warmed-up request processed in 15.31 seconds (with warmup excluded)
[03-12 08:39:16] Memory usage - Max peak: 64780.00 MB, Avg peak: 64780.00 MB
```

<img width="800" height="230" alt="6d24a412-6240-49e6-85e8-804c862df125" src="https://github.com/user-attachments/assets/45b709c4-806a-490f-b904-072030eca3e2" />
<img width="1024" height="1024" alt="A_futuristic_cyberpunk_city_at_night_neon_lights_reflecting_on_wet_streets_highly_detailed_8k_20260311-143754_f4e34aca" src="https://github.com/user-attachments/assets/3ce0a4ea-adca-4f37-9ca5-dc20abaf4612" />



## pr

```shell
sglang generate --model-path=Qwen/Qwen-Image-2512  --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k" '--negative-prompt= ' --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.0 --seed=42 --save-output --warmup --dit-cpu-offload false --text-encoder-cpu-offload false --enable-torch-compile  
```

```shell
[03-12 08:37:24] [InputValidationStage] started...
[03-12 08:37:24] [InputValidationStage] finished in 0.0000 seconds
[03-12 08:37:24] [TextEncodingStage] started...
[03-12 08:37:24] [TextEncodingStage] finished in 0.0369 seconds
[03-12 08:37:24] [LatentPreparationStage] started...
[03-12 08:37:24] [LatentPreparationStage] finished in 0.0002 seconds
[03-12 08:37:24] [TimestepPreparationStage] started...
[03-12 08:37:24] [TimestepPreparationStage] finished in 0.0006 seconds
[03-12 08:37:24] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:12<00:00,  3.92it/s]
[03-12 08:37:37] [DenoisingStage] average time per step: 0.2553 seconds
[03-12 08:37:37] [DenoisingStage] finished in 12.7667 seconds
[03-12 08:37:37] [DecodingStage] started...
[03-12 08:37:37] [DecodingStage] finished in 0.0937 seconds
[03-12 08:37:37] Peak GPU memory: 63.27 GB, Peak allocated: 61.10 GB, Memory pool overhead: 2.17 GB (3.4%), Remaining GPU memory at peak: 77.13 GB. Components that could stay resident (based on the last request workload): []. Related offload server args to disable: None
[03-12 08:37:38] Output saved to outputs/A_futuristic_cyberpunk_city_at_night_neon_lights_reflecting_on_wet_streets_highly_detailed_8k_20260312-083718_2686a361.png
```

<img width="659" height="210" alt="47c5eb6d-8305-40f8-bc29-3a41bdebf63f" src="https://github.com/user-attachments/assets/0f6caad2-e910-47f9-b9b4-6127a2908a14" />

<img width="1024" height="1024" alt="A_futuristic_cyberpunk_city_at_night_neon_lights_reflecting_on_wet_streets_highly_detailed_8k_20260311-143754_f4e34aca" src="https://github.com/user-attachments/assets/a58b907b-4367-42ae-96ab-aed1e05437c6" />


## results

- Denoising average step time: `0.3052s -> 0.2553s (17.5%)`
- Denoising stage total time: `15.2640s -> 12.7667s (19.5%)`

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
