### PR TITLE
[Bugfix] NUMA binding process improve and cgroup visible CPU bug fix

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -573,6 +573,7 @@ class Engine(EngineScoreMixin, EngineBase):
                         server_args, tp_rank
                     )
 
+                    physical_gpu_id = gpu_id
                     with maybe_reindex_device_id(gpu_id) as gpu_id:
                         proc = mp.Process(
                             target=run_scheduler_process_func,
@@ -589,8 +590,14 @@ class Engine(EngineScoreMixin, EngineBase):
                                 writer,
                             ),
                         )
-                        with memory_saver_adapter.configure_subprocess(), numa_utils.configure_subprocess(
-                            server_args, gpu_id
+                        with (
+                            memory_saver_adapter.configure_subprocess(),
+                            numa_utils.configure_subprocess(
+                                server_args,
+                                gpu_id,
+                                manual_numa_index=len(scheduler_procs),
+                                physical_gpu_id=physical_gpu_id,
+                            ),
                         ):
                             proc.start()
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -503,6 +503,7 @@ class DataParallelController:
                     )
                 )
 
+                physical_gpu_id = gpu_id
                 with self.env_lock, maybe_reindex_device_id(gpu_id) as gpu_id:
                     proc = mp.Process(
                         target=self.run_scheduler_process_func,
@@ -519,8 +520,14 @@ class DataParallelController:
                             writer,
                         ),
                     )
-                    with memory_saver_adapter.configure_subprocess(), numa_utils.configure_subprocess(
-                        server_args, gpu_id
+                    with (
+                        memory_saver_adapter.configure_subprocess(),
+                        numa_utils.configure_subprocess(
+                            server_args,
+                            gpu_id,
+                            manual_numa_index=len(self.scheduler_procs),
+                            physical_gpu_id=physical_gpu_id,
+                        ),
                     ):
                         proc.start()
                 self.scheduler_procs.append(proc)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2126,6 +2126,17 @@ def set_gpu_proc_affinity(
         # HT off
         bind_cpu_ids = [id for id in range(start_cpu_id, end_cpu_id)]
 
+    cgroup_allowed_cpu_ids = set(p.cpu_affinity())
+    bind_cpu_ids = sorted(set(bind_cpu_ids).intersection(cgroup_allowed_cpu_ids))
+    if not bind_cpu_ids:
+        logger.warning(
+            "Skip CPU affinity for gpu_id=%s: target CPUs do not intersect "
+            "current cgroup CPU set %s",
+            gpu_id,
+            sorted(cgroup_allowed_cpu_ids),
+        )
+        return
+
     # set cpu_affinity to current process
     p.cpu_affinity(bind_cpu_ids)
     logger.info(f"Process {pid} gpu_id {gpu_id} is running on CPUs: {p.cpu_affinity()}")

--- a/python/sglang/srt/utils/numa_utils.py
+++ b/python/sglang/srt/utils/numa_utils.py
@@ -5,7 +5,9 @@ import math
 import multiprocessing
 import os
 import random
+import shlex
 import shutil
+import subprocess
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -23,24 +25,121 @@ logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def configure_subprocess(server_args: ServerArgs, gpu_id: int):
+def configure_subprocess(
+    server_args: ServerArgs,
+    gpu_id: int,
+    *,
+    manual_numa_index: Optional[int] = None,
+    physical_gpu_id: Optional[int] = None,
+):
     if envs.SGLANG_NUMA_BIND_V2.get():
-        numa_node = get_numa_node_if_available(server_args, gpu_id)
+        numa_node = get_numa_node_if_available(
+            server_args,
+            gpu_id,
+            manual_numa_index=manual_numa_index,
+            physical_gpu_id=physical_gpu_id,
+        )
         if numa_node is not None:
-            numactl_args = f"--cpunodebind={numa_node} --membind={numa_node}"
-            executable, debug_str = _create_numactl_executable(
-                numactl_args=numactl_args
-            )
-            with _mp_set_executable(executable=executable, debug_str=debug_str):
-                yield
-                return
+            numactl_args = _resolve_numactl_args(numa_node)
+            if numactl_args:
+                executable, debug_str = _create_numactl_executable(
+                    numactl_args=numactl_args
+                )
+                with _mp_set_executable(executable=executable, debug_str=debug_str):
+                    yield
+                    return
     yield
 
 
-def _create_numactl_executable(numactl_args: str):
+def _parse_cpu_list(cpu_list: str):
+    cpus = set()
+    for part in cpu_list.strip().split(","):
+        if not part:
+            continue
+        if "-" in part:
+            start, end = part.split("-", 1)
+            cpus.update(range(int(start), int(end) + 1))
+        else:
+            cpus.add(int(part))
+    return cpus
+
+
+def _get_cpus_for_numa_node(numa_node: int):
+    try:
+        with open(
+            f"/sys/devices/system/node/node{numa_node}/cpulist", "r"
+        ) as cpu_list_file:
+            return _parse_cpu_list(cpu_list_file.read())
+    except Exception as e:
+        logger.debug("Failed to read CPUs for NUMA node %s: %s", numa_node, e)
+        return set()
+
+
+def _get_allowed_cpus_for_numa_node(numa_node: int):
+    node_cpus = _get_cpus_for_numa_node(numa_node)
+    if not node_cpus:
+        return []
+
+    allowed_cpus = set(psutil.Process().cpu_affinity())
+    return sorted(node_cpus.intersection(allowed_cpus))
+
+
+def _probe_numactl_args(numactl_args):
+    try:
+        result = subprocess.run(
+            ["numactl", *numactl_args, "true"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        logger.debug("numactl command not found, skipping NUMA node configuration")
+        return False
+    except Exception as e:
+        logger.warning("Failed to probe numactl args %s: %s", numactl_args, e)
+        return False
+
+
+def _resolve_numactl_args(numa_node: int):
+    allowed_cpus = _get_allowed_cpus_for_numa_node(numa_node)
+    cpu_arg = (
+        f"--physcpubind={','.join(map(str, allowed_cpus))}" if allowed_cpus else None
+    )
+    if not allowed_cpus:
+        logger.warning(
+            "No CPUs from NUMA node %s are allowed by current cgroup CPU set %s",
+            numa_node,
+            psutil.Process().cpu_affinity(),
+        )
+
+    for mode_arg in (f"--membind={numa_node}", f"--preferred={numa_node}"):
+        args = [arg for arg in (cpu_arg, mode_arg) if arg]
+        if _probe_numactl_args(args):
+            if mode_arg.startswith("--preferred"):
+                logger.warning(
+                    "Falling back to --preferred=%s for subprocess NUMA binding",
+                    numa_node,
+                )
+            return args
+
+    if cpu_arg is not None and _probe_numactl_args([cpu_arg]):
+        logger.warning(
+            "Failed to enable memory binding for NUMA node %s; using CPU-only binding",
+            numa_node,
+        )
+        return [cpu_arg]
+
+    return []
+
+
+def _create_numactl_executable(numactl_args):
     old_executable = os.fsdecode(multiprocessing.spawn.get_executable())
-    script = f'''#!/bin/sh
-exec numactl {numactl_args} {old_executable} "$@"'''
+    quoted_numactl_args = " ".join(shlex.quote(arg) for arg in numactl_args)
+    script = (
+        "#!/bin/sh\n"
+        f'exec numactl {quoted_numactl_args} {shlex.quote(old_executable)} "$@"'
+    )
     path = Path(
         f"/tmp/sglang_temp_file_{time.time()}_{random.randrange(0, 10000000)}.sh"
     )
@@ -67,7 +166,13 @@ def _mp_set_executable(executable: str, debug_str: str):
         logger.debug(f"mp.set_executable revert to {old_executable}")
 
 
-def get_numa_node_if_available(server_args: ServerArgs, gpu_id: int) -> Optional[int]:
+def get_numa_node_if_available(
+    server_args: ServerArgs,
+    gpu_id: int,
+    *,
+    manual_numa_index: Optional[int] = None,
+    physical_gpu_id: Optional[int] = None,
+) -> Optional[int]:
     """
     Returns the NUMA node for the given GPU id. If it is not set in the server_args, it will try to query the NUMA node for the GPU.
     If the NUMA node is not available, has already been configured externally, or the user lacks permission to set NUMA affinity, it will return None.
@@ -80,9 +185,12 @@ def get_numa_node_if_available(server_args: ServerArgs, gpu_id: int) -> Optional
         The NUMA node for the given GPU id or None if it is not available.
     """
     if server_args.numa_node is not None:
-        return server_args.numa_node[gpu_id]
+        numa_index = gpu_id if manual_numa_index is None else manual_numa_index
+        return server_args.numa_node[numa_index]
     if _is_numa_available():
-        queried_numa_node = _query_numa_node_for_gpu(gpu_id)
+        queried_numa_node = _query_numa_node_for_gpu(
+            gpu_id if physical_gpu_id is None else physical_gpu_id
+        )
         if len(queried_numa_node) == 0:
             return None
         if len(queried_numa_node) > 1:
@@ -110,6 +218,24 @@ def get_libnuma():
 
 
 def numa_bind_to_node(node: int):
+    allowed_cpus = _get_allowed_cpus_for_numa_node(node)
+    if allowed_cpus:
+        try:
+            psutil.Process().cpu_affinity(allowed_cpus)
+        except Exception as e:
+            logger.warning(
+                "Failed to bind current process to NUMA node %s CPUs %s: %s",
+                node,
+                allowed_cpus,
+                e,
+            )
+    else:
+        logger.warning(
+            "No CPUs from NUMA node %s are allowed by current cgroup CPU set %s",
+            node,
+            psutil.Process().cpu_affinity(),
+        )
+
     libnuma = get_libnuma()
 
     if libnuma is None or libnuma.numa_available() < 0:
@@ -145,17 +271,17 @@ def _is_numa_available() -> bool:
     if not os.path.isdir("/sys/devices/system/node/node1"):
         return False
 
-    # Check if affinity is already constrained
+    # A constrained affinity is expected in container/cgroup environments. Later
+    # bind steps intersect NUMA-local CPUs with the current allowed CPU set.
     pid = os.getpid()
     process = psutil.Process(pid)
     cpu_affinity = process.cpu_affinity()
     all_cpus = list(range(psutil.cpu_count()))
     constrained_affinity = cpu_affinity != all_cpus
     if constrained_affinity:
-        logger.warning(
-            "NUMA affinity is already constrained for process, skipping NUMA node configuration for GPU. Remove your constraints to allow automatic configuration."
+        logger.debug(
+            "NUMA affinity is already constrained for process; using cgroup-aware CPU binding."
         )
-        return False
 
     if not shutil.which("numactl") and envs.SGLANG_NUMA_BIND_V2.get():
         logger.debug(

--- a/test/registered/utils/test_numa_utils.py
+++ b/test/registered/utils/test_numa_utils.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.utils.numa_utils import (
+    _get_allowed_cpus_for_numa_node,
     _is_numa_available,
     _query_numa_node_for_gpu,
     get_numa_node_if_available,
@@ -26,16 +27,20 @@ class TestIsNumaAvailable(unittest.TestCase):
     def test_returns_false_when_no_numa_nodes(self, _mock_isdir):
         self.assertFalse(_is_numa_available())
 
+    @patch("sglang.srt.utils.numa_utils._can_set_mempolicy", return_value=True)
+    @patch("sglang.srt.utils.numa_utils.shutil.which", return_value="/usr/bin/numactl")
     @patch("sglang.srt.utils.numa_utils._is_cuda", True)
     @patch("os.path.isdir", return_value=True)
     @patch("sglang.srt.utils.numa_utils.psutil")
-    def test_returns_false_when_affinity_constrained(self, mock_psutil, _mock_isdir):
+    def test_returns_true_when_affinity_constrained(
+        self, mock_psutil, _mock_isdir, _mock_which, _mock_mempolicy
+    ):
         mock_process = MagicMock()
         mock_process.cpu_affinity.return_value = [0, 1]
         mock_psutil.Process.return_value = mock_process
         mock_psutil.cpu_count.return_value = 128
 
-        self.assertFalse(_is_numa_available())
+        self.assertTrue(_is_numa_available())
 
     @patch("sglang.srt.utils.numa_utils._can_set_mempolicy", return_value=True)
     @patch("sglang.srt.utils.numa_utils.shutil.which", return_value="/usr/bin/numactl")
@@ -208,6 +213,10 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
         self.assertEqual(get_numa_node_if_available(args, 2), 0)
         self.assertEqual(get_numa_node_if_available(args, 3), 1)
 
+    def test_returns_explicit_numa_node_from_manual_index(self):
+        args = self._make_server_args(numa_node=[2, 3, 0, 1])
+        self.assertEqual(get_numa_node_if_available(args, 0, manual_numa_index=1), 3)
+
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=False)
     def test_returns_none_when_numa_not_available(self, _mock_avail):
         args = self._make_server_args(numa_node=None)
@@ -224,6 +233,13 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
     def test_returns_queried_single_node(self, _mock_avail, _mock_gpu):
         args = self._make_server_args(numa_node=None)
         self.assertEqual(get_numa_node_if_available(args, 0), 1)
+
+    @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[1])
+    @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
+    def test_uses_physical_gpu_id_for_auto_detection(self, _mock_avail, mock_gpu):
+        args = self._make_server_args(numa_node=None)
+        self.assertEqual(get_numa_node_if_available(args, 0, physical_gpu_id=3), 1)
+        mock_gpu.assert_called_once_with(3)
 
     @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[0, 2])
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
@@ -247,6 +263,20 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
         self.assertEqual(result, 5)
         _mock_avail.assert_not_called()
         _mock_gpu.assert_not_called()
+
+
+class TestCgroupCpuFiltering(unittest.TestCase):
+    @patch("sglang.srt.utils.numa_utils._get_cpus_for_numa_node")
+    @patch("sglang.srt.utils.numa_utils.psutil.Process")
+    def test_allowed_cpus_intersect_numa_node_cpus(
+        self, mock_process_cls, mock_get_cpus_for_numa_node
+    ):
+        process = MagicMock()
+        process.cpu_affinity.return_value = [1, 2, 4]
+        mock_process_cls.return_value = process
+        mock_get_cpus_for_numa_node.return_value = {0, 1, 2, 3}
+
+        self.assertEqual(_get_allowed_cpus_for_numa_node(0), [1, 2])
 
 
 def _get_gpu_name():


### PR DESCRIPTION
## Motivation

Refine NUMA and CPU binding process 
bug fix #20077 & #20073 along with fix manual `--numa-node` binding when `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=1`

## Modifications

Mostly on utils/common.py and utils/numa_utils.py.

Behaviors now:

- `SGLANG_AUTO_NUMA_BIND` remains the main environment variable entry point, with its default value changed to True.
- `SGLANG_NUMA_BIND_V2` no longer determines old vs. new behavior; both paths now use the same new binder.- 
- Users can disable automatic NUMA binding via `SGLANG_AUTO_NUMA_BIND=0`; this disables both the scheduler subprocess auto-binding and HiCache auto-binding.
- Legacy CLI arguments remain functional without errors but are marked as deprecated, and they take priority over automatic detection.
- Priority is fixed as: `--numa-node` > `--disable-hicache-numa-detect` > `SGLANG_AUTO_NUMA_BIND` > auto-detection, preventing issues where incompatibilities and cannot be manually overridden.
- When --numa-node is specified, the user-designated NUMA node is used directly, skipping automatic NUMA node selection; CPU binding is changed to use CPU cores under that node that are permitted by the current cgroup.
- `--disable-hicache-numa-detect` only disables HiCache-triggered automatic binding, without overriding explicit --numa-node.


## Accuracy Tests



## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
