### PR TITLE
Fix AWQ modules_to_not_convert not applied to FusedMoE layers

### DIFF
--- a/python/sglang/srt/layers/quantization/awq.py
+++ b/python/sglang/srt/layers/quantization/awq.py
@@ -179,6 +179,8 @@ class AWQConfig(QuantizationConfig):
                     return UnquantizedLinearMethod()
                 return AWQLinearAscendMethod(self)
             elif isinstance(layer, FusedMoE):
+                if is_layer_skipped_awq(prefix, self.modules_to_not_convert):
+                    return None
                 return AWQMoEAscendMethod(self)
             return None
 
@@ -322,6 +324,8 @@ class AWQMarlinConfig(QuantizationConfig):
                 )
             return AWQMarlinLinearMethod(self)
         elif isinstance(layer, FusedMoE):
+            if is_layer_skipped_awq(prefix, self.modules_to_not_convert):
+                return None
             from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 
             if not check_moe_marlin_supports_layer(layer, self.group_size):


### PR DESCRIPTION
## Motivation

When loading AWQ-quantized MoE models that exclude certain layers from quantization via `modules_to_not_convert` (e.g., `["model.layers.0."]`), the server crashes with:

```
KeyError: 'model.layers.0.mlp.experts.w13_weight'
```

This happens because `AWQConfig.get_quant_method()` and `AWQMarlinConfig.get_quant_method()` check `modules_to_not_convert` for `LinearBase` layers but skip this check for `FusedMoE` layers. As a result, excluded MoE layers still get AWQ-quantized parameters (`w13_qweight`, etc.) instead of unquantized ones (`w13_weight`), and the weight loader fails when trying to load bf16 checkpoint weights into AWQ parameters.

## Changes

Add `is_layer_skipped_awq()` check to the `FusedMoE` branch in both:
- `AWQConfig.get_quant_method()` (Ascend/NPU path)
- `AWQMarlinConfig.get_quant_method()` (main path)

When a FusedMoE layer matches `modules_to_not_convert`, return `None` so it falls back to `UnquantizedFusedMoEMethod` — consistent with how `MoeWNA16Config` already handles this case (see `moe_wna16.py` line 199-201).

## Test plan

- Tested with `QuantTrio/Qwen3.5-397B-A17B-AWQ` which has `modules_to_not_convert: ["model.layers.0.", "self_attn", "shared_expert", "linear_attn", ...]` — layer 0 MoE experts are bf16, layers 1-59 are INT4 AWQ
- Before fix: `KeyError: 'model.layers.0.mlp.experts.w13_weight'`
- After fix: layer 0 loads as unquantized FusedMoE, remaining layers load as AWQ