### PR TITLE
[Diffusion] Feat: support teacache for glm-image, qwen-image et.al

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/flux.py
+++ b/python/sglang/multimodal_gen/configs/sample/flux.py
@@ -1,10 +1,27 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.configs.sample.teacache import TeaCacheParams
+
+
+@dataclass
+class FluxTeaCacheParams(TeaCacheParams):
+    """TeaCache parameters for Flux models."""
+
+    teacache_thresh: float = 0.2
+    coefficients: list[float] = field(
+        default_factory=lambda: [
+            7.33226126e02,
+            -4.01131952e02,
+            6.75869174e01,
+            -3.14987800e00,
+            9.61237896e-02,
+        ]
+    )
 
 
 @dataclass
@@ -17,6 +34,8 @@ class FluxSamplingParams(SamplingParams):
     guidance_scale: float = 1.0
     negative_prompt: str = None
     num_inference_steps: int = 50
+
+    teacache_params: FluxTeaCacheParams = field(default_factory=FluxTeaCacheParams)
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/configs/sample/glmimage.py
+++ b/python/sglang/multimodal_gen/configs/sample/glmimage.py
@@ -1,6 +1,31 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.configs.sample.teacache import TeaCacheParams
+
+
+@dataclass
+class GlmImageTeaCacheParams(TeaCacheParams):
+    """TeaCache parameters for GLM-Image model.
+
+    GLM-Image uses the standard TeaCache approach with modulated input
+    computed from the timestep embedding (temb).
+    """
+
+    # Default threshold tuned for GLM-Image quality/speed tradeoff
+    teacache_thresh: float = 0.2
+
+    # Default polynomial coefficients for L1 rescaling
+    # These may need tuning specific to GLM-Image
+    coefficients: list[float] = field(
+        default_factory=lambda: [
+            -6071.632298241158,
+            1837.6579251847247,
+            -172.12278847677337,
+            7.159036598427308,
+            -0.07853601464946189,
+        ]
+    )
 
 
 @dataclass
@@ -10,3 +35,7 @@ class GlmImageSamplingParams(SamplingParams):
     num_frames: int = 1
     guidance_scale: float = 1.5
     num_inference_steps: int = 30
+
+    teacache_params: GlmImageTeaCacheParams = field(
+        default_factory=GlmImageTeaCacheParams
+    )

--- a/python/sglang/multimodal_gen/configs/sample/qwenimage.py
+++ b/python/sglang/multimodal_gen/configs/sample/qwenimage.py
@@ -1,9 +1,26 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.configs.sample.teacache import TeaCacheParams
+
+
+@dataclass
+class QwenImageTeaCacheParams(TeaCacheParams):
+    """TeaCache parameters for Qwen-Image models."""
+
+    teacache_thresh: float = 0.2
+    coefficients: list[float] = field(
+        default_factory=lambda: [
+            7.33226126e02,
+            -4.01131952e02,
+            6.75869174e01,
+            -3.14987800e00,
+            9.61237896e-02,
+        ]
+    )
 
 
 @dataclass
@@ -13,6 +30,10 @@ class QwenImageSamplingParams(SamplingParams):
     # Denoising stage
     guidance_scale: float = 4.0
     num_inference_steps: int = 50
+
+    teacache_params: QwenImageTeaCacheParams = field(
+        default_factory=QwenImageTeaCacheParams
+    )
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/runtime/cache/teacache.py
+++ b/python/sglang/multimodal_gen/runtime/cache/teacache.py
@@ -159,6 +159,19 @@ class TeaCacheMixin:
             self.previous_residual_negative: torch.Tensor | None = None
             self.accumulated_rel_l1_distance_negative: float = 0.0
 
+    def _update_teacache_status(self) -> None:
+        # Reads enable_teacache flag from forward_batch context.
+        # Lazy import required to avoid circular dependency with runtime.managers.
+        from sglang.multimodal_gen.runtime.managers.forward_context import (
+            get_forward_context,
+        )
+
+        forward_context = get_forward_context()
+        forward_batch = forward_context.forward_batch if forward_context else None
+        self.enable_teacache = forward_batch is not None and getattr(
+            forward_batch, "enable_teacache", False
+        )
+
     def reset_teacache_state(self) -> None:
         """Reset all TeaCache state at the start of each generation task."""
         self.cnt = 0
@@ -366,12 +379,26 @@ class TeaCacheMixin:
         return not should_calc
 
     def retrieve_cached_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """Retrieve cached states by adding residual.
-
-        This default implementation handles CFG-aware caching by retrieving
-        the appropriate residual based on the current CFG branch.
-        """
+        # Adds cached residual to hidden_states. CFG-aware: uses separate residual
+        # for negative branch (previous_residual_negative) vs positive branch.
         if not self.is_cfg_negative:
             return hidden_states + self.previous_residual
         else:
             return hidden_states + self.previous_residual_negative
+
+    def teacache_skip_or_prepare(
+        self, hidden_states: torch.Tensor, temb: torch.Tensor
+    ) -> tuple[bool, torch.Tensor | None]:
+        # Combined cache check + preparation for block execution.
+        # Returns (True, cached_result) to skip blocks entirely.
+        # Returns (False, original_tensor) to run blocks; original is cloned for later caching.
+        if self.should_skip_forward_for_cached_states(temb=temb):
+            return True, self.retrieve_cached_states(hidden_states)
+        return False, hidden_states.clone() if self.enable_teacache else None
+
+    def teacache_finalize(
+        self, hidden_states: torch.Tensor, original: torch.Tensor | None
+    ) -> None:
+        # Called after block execution to cache the residual (output - original).
+        if self.enable_teacache and original is not None:
+            self.maybe_cache_states(hidden_states, original)

--- a/python/sglang/multimodal_gen/runtime/cache/teacache.py
+++ b/python/sglang/multimodal_gen/runtime/cache/teacache.py
@@ -124,9 +124,16 @@ class TeaCacheMixin:
         accumulated_rel_l1_distance_negative: L1 distance for negative branch.
     """
 
-    # Models that support CFG cache separation (wan/hunyuan/zimage)
-    # Models not in this set (flux/qwen) auto-disable TeaCache when CFG is enabled
-    _CFG_SUPPORTED_PREFIXES: set[str] = {"wan", "hunyuan", "zimage"}
+    # Models that support CFG cache separation
+    # Models not in this set auto-disable TeaCache when CFG is enabled
+    _CFG_SUPPORTED_PREFIXES: set[str] = {
+        "wan",
+        "hunyuan",
+        "zimage",
+        "glmimage",
+        "flux",
+        "qwenimage",
+    }
     config: DiTConfig
 
     def _init_teacache_state(self) -> None:
@@ -199,15 +206,19 @@ class TeaCacheMixin:
         diff = modulated_inp - prev_modulated_inp
         rel_l1 = (diff.abs().mean() / prev_modulated_inp.abs().mean()).cpu().item()
 
-        # Apply polynomial rescaling
-        rescale_func = np.poly1d(coefficients)
+        # Apply polynomial rescaling if coefficients provided, else use raw L1
+        if coefficients:
+            rescale_func = np.poly1d(coefficients)
+            rescaled_l1 = rescale_func(rel_l1)
+        else:
+            rescaled_l1 = rel_l1
 
         accumulated_rel_l1_distance = (
             self.accumulated_rel_l1_distance_negative
             if self.is_cfg_negative
             else self.accumulated_rel_l1_distance
         )
-        accumulated_rel_l1_distance = accumulated_rel_l1_distance + rescale_func(rel_l1)
+        accumulated_rel_l1_distance = accumulated_rel_l1_distance + rescaled_l1
 
         if accumulated_rel_l1_distance >= teacache_thresh:
             # Threshold exceeded: force compute and reset accumulator
@@ -272,14 +283,15 @@ class TeaCacheMixin:
         forward_batch = forward_context.forward_batch
 
         # Early return checks
-        if (
-            forward_batch is None
-            or not forward_batch.enable_teacache
-            or forward_batch.teacache_params is None
-        ):
+        if forward_batch is None:
             return None
 
-        teacache_params = forward_batch.teacache_params
+        if not getattr(forward_batch, "enable_teacache", False):
+            return None
+
+        teacache_params = getattr(forward_batch, "teacache_params", None)
+        if teacache_params is None:
+            return None
 
         # Extract common values
         current_timestep = forward_context.current_timestep
@@ -302,15 +314,64 @@ class TeaCacheMixin:
         )
 
     def maybe_cache_states(
-        self, hidden_states: torch.Tensor, original_hidden_states: torch.Tensor
+        self, hidden_states: torch.Tensor, original_hidden_states: torch.Tensor | None
     ) -> None:
-        """Cache states for later retrieval. Override in subclass if needed."""
-        pass
+        """Cache residual (output - input) for later retrieval.
+
+        This default implementation handles CFG-aware caching by storing
+        separate residuals for positive and negative branches.
+        """
+        if original_hidden_states is None:
+            return
+
+        residual = hidden_states - original_hidden_states
+        if not self.is_cfg_negative:
+            self.previous_residual = residual
+        else:
+            self.previous_residual_negative = residual
 
     def should_skip_forward_for_cached_states(self, **kwargs: dict[str, Any]) -> bool:
-        """Check if forward can be skipped using cached states."""
-        return False
+        """Check if forward can be skipped using cached states.
+
+        Subclasses should call this with `temb` (modulated input) in kwargs.
+        Example: `should_skip_forward_for_cached_states(temb=temb)`
+
+        Returns:
+            True if forward should be skipped (use cached residual).
+        """
+        if not self.enable_teacache:
+            return False
+        ctx = self._get_teacache_context()
+        if ctx is None:
+            return False
+
+        temb = kwargs.get("temb")
+        if temb is None:
+            return False
+
+        self.is_cfg_negative = ctx.is_cfg_negative
+
+        is_boundary_step = (
+            ctx.current_timestep == 0
+            or ctx.current_timestep >= ctx.num_inference_steps - 1
+        )
+
+        should_calc = self._compute_teacache_decision(
+            modulated_inp=temb,
+            is_boundary_step=is_boundary_step,
+            coefficients=ctx.coefficients,
+            teacache_thresh=ctx.teacache_thresh,
+        )
+
+        return not should_calc
 
     def retrieve_cached_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """Retrieve cached states. Must be implemented by subclass."""
-        raise NotImplementedError("retrieve_cached_states is not implemented")
+        """Retrieve cached states by adding residual.
+
+        This default implementation handles CFG-aware caching by retrieving
+        the appropriate residual based on the current CFG branch.
+        """
+        if not self.is_cfg_negative:
+            return hidden_states + self.previous_residual
+        else:
+            return hidden_states + self.previous_residual_negative

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -18,8 +18,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch.nn import LayerNorm as LayerNorm
-
 from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import (
@@ -27,6 +25,8 @@ from diffusers.models.normalization import (
     AdaLayerNormZero,
     AdaLayerNormZeroSingle,
 )
+from torch.nn import LayerNorm as LayerNorm
+
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
+
 from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import (
@@ -25,8 +26,6 @@ from diffusers.models.normalization import (
     AdaLayerNormZero,
     AdaLayerNormZeroSingle,
 )
-from torch.nn import LayerNorm as LayerNorm
-
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
@@ -50,7 +49,6 @@ from sglang.multimodal_gen.runtime.layers.visual_embedding import (
     CombinedTimestepGuidanceTextProjEmbeddings,
     CombinedTimestepTextProjEmbeddings,
 )
-from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
@@ -589,8 +587,8 @@ class FluxTransformerBlock(nn.Module):
             prefix=f"{prefix}.attn" if prefix else "attn",
         )
 
-        self.norm2 = LayerNorm(dim, eps=1e-6, elementwise_affine=False)
-        self.norm2_context = LayerNorm(dim, eps=1e-6, elementwise_affine=False)
+        self.norm2 = nn.LayerNorm(dim, eps=1e-6, elementwise_affine=False)
+        self.norm2_context = nn.LayerNorm(dim, eps=1e-6, elementwise_affine=False)
 
         nunchaku_enabled = (
             quant_config is not None
@@ -866,11 +864,7 @@ class FluxTransformer2DModel(CachableDiT, OffloadableDiTMixin):
                 [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
 
         """
-        forward_context = get_forward_context()
-        forward_batch = forward_context.forward_batch if forward_context else None
-        self.enable_teacache = forward_batch is not None and getattr(
-            forward_batch, "enable_teacache", False
-        )
+        self._update_teacache_status()
 
         if (
             joint_attention_kwargs is not None
@@ -899,14 +893,11 @@ class FluxTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             ip_hidden_states = self.encoder_hid_proj(ip_adapter_image_embeds)
             joint_attention_kwargs.update({"ip_hidden_states": ip_hidden_states})
 
-        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
+        skip, hs_or_orig = self.teacache_skip_or_prepare(hidden_states, temb)
 
-        if should_skip_forward:
-            hidden_states = self.retrieve_cached_states(hidden_states)
+        if skip:
+            hidden_states = hs_or_orig
         else:
-            if self.enable_teacache:
-                original_hidden_states = hidden_states.clone()
-
             for block in self.transformer_blocks:
                 encoder_hidden_states, hidden_states = block(
                     hidden_states=hidden_states,
@@ -923,9 +914,7 @@ class FluxTransformer2DModel(CachableDiT, OffloadableDiTMixin):
                     freqs_cis=freqs_cis,
                     joint_attention_kwargs=joint_attention_kwargs,
                 )
-
-            if self.enable_teacache:
-                self.maybe_cache_states(hidden_states, original_hidden_states)
+            self.teacache_finalize(hidden_states, hs_or_orig)
 
         hidden_states = self.norm_out(hidden_states, temb)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
+from torch.nn import LayerNorm as LayerNorm
+
 from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import (
@@ -25,8 +27,6 @@ from diffusers.models.normalization import (
     AdaLayerNormZero,
     AdaLayerNormZeroSingle,
 )
-from torch.nn import LayerNorm as LayerNorm
-
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
@@ -50,6 +50,7 @@ from sglang.multimodal_gen.runtime.layers.visual_embedding import (
     CombinedTimestepGuidanceTextProjEmbeddings,
     CombinedTimestepTextProjEmbeddings,
 )
+from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
@@ -865,6 +866,12 @@ class FluxTransformer2DModel(CachableDiT, OffloadableDiTMixin):
                 [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
 
         """
+        forward_context = get_forward_context()
+        forward_batch = forward_context.forward_batch if forward_context else None
+        self.enable_teacache = forward_batch is not None and getattr(
+            forward_batch, "enable_teacache", False
+        )
+
         if (
             joint_attention_kwargs is not None
             and joint_attention_kwargs.get("scale", None) is not None
@@ -892,22 +899,33 @@ class FluxTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             ip_hidden_states = self.encoder_hid_proj(ip_adapter_image_embeds)
             joint_attention_kwargs.update({"ip_hidden_states": ip_hidden_states})
 
-        for block in self.transformer_blocks:
-            encoder_hidden_states, hidden_states = block(
-                hidden_states=hidden_states,
-                encoder_hidden_states=encoder_hidden_states,
-                temb=temb,
-                freqs_cis=freqs_cis,
-                joint_attention_kwargs=joint_attention_kwargs,
-            )
-        for block in self.single_transformer_blocks:
-            encoder_hidden_states, hidden_states = block(
-                hidden_states=hidden_states,
-                encoder_hidden_states=encoder_hidden_states,
-                temb=temb,
-                freqs_cis=freqs_cis,
-                joint_attention_kwargs=joint_attention_kwargs,
-            )
+        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
+
+        if should_skip_forward:
+            hidden_states = self.retrieve_cached_states(hidden_states)
+        else:
+            if self.enable_teacache:
+                original_hidden_states = hidden_states.clone()
+
+            for block in self.transformer_blocks:
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    freqs_cis=freqs_cis,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+            for block in self.single_transformer_blocks:
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    freqs_cis=freqs_cis,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+
+            if self.enable_teacache:
+                self.maybe_cache_states(hidden_states, original_hidden_states)
 
         hidden_states = self.norm_out(hidden_states, temb)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -16,10 +16,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
+
 from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.normalization import AdaLayerNormContinuous
-
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
@@ -31,7 +31,6 @@ from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     NDRotaryEmbedding,
     apply_flashinfer_rope_qk_inplace,
 )
-from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
@@ -839,11 +838,7 @@ class Flux2Transformer2DModel(CachableDiT, OffloadableDiTMixin):
                 [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
 
         """
-        forward_context = get_forward_context()
-        forward_batch = forward_context.forward_batch if forward_context else None
-        self.enable_teacache = forward_batch is not None and getattr(
-            forward_batch, "enable_teacache", False
-        )
+        self._update_teacache_status()
 
         # 0. Handle input arguments
         if joint_attention_kwargs is not None:
@@ -869,14 +864,11 @@ class Flux2Transformer2DModel(CachableDiT, OffloadableDiTMixin):
         hidden_states, _ = self.x_embedder(hidden_states)
         encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
 
-        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
+        skip, hs_or_orig = self.teacache_skip_or_prepare(hidden_states, temb)
 
-        if should_skip_forward:
-            hidden_states = self.retrieve_cached_states(hidden_states)
+        if skip:
+            hidden_states = hs_or_orig
         else:
-            if self.enable_teacache:
-                original_hidden_states = hidden_states.clone()
-
             # 3. Calculate RoPE embeddings from image and text tokens
             # NOTE: the below logic means that we can't support batched inference with images of different resolutions or
             # text prompts of different lengths. Is this a use case we want to support?
@@ -906,8 +898,7 @@ class Flux2Transformer2DModel(CachableDiT, OffloadableDiTMixin):
             # Remove text tokens from concatenated stream
             hidden_states = hidden_states[:, num_txt_tokens:, ...]
 
-            if self.enable_teacache:
-                self.maybe_cache_states(hidden_states, original_hidden_states)
+            self.teacache_finalize(hidden_states, hs_or_orig)
 
         # 6. Output layers
         hidden_states = self.norm_out(hidden_states, temb)

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -16,10 +16,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-
 from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.normalization import AdaLayerNormContinuous
+
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -16,10 +16,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
+
 from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.normalization import AdaLayerNormContinuous
-
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm, apply_qk_norm
@@ -31,6 +31,7 @@ from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     NDRotaryEmbedding,
     apply_flashinfer_rope_qk_inplace,
 )
+from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
@@ -838,6 +839,12 @@ class Flux2Transformer2DModel(CachableDiT, OffloadableDiTMixin):
                 [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
 
         """
+        forward_context = get_forward_context()
+        forward_batch = forward_context.forward_batch if forward_context else None
+        self.enable_teacache = forward_batch is not None and getattr(
+            forward_batch, "enable_teacache", False
+        )
+
         # 0. Handle input arguments
         if joint_attention_kwargs is not None:
             joint_attention_kwargs = joint_attention_kwargs.copy()
@@ -862,34 +869,45 @@ class Flux2Transformer2DModel(CachableDiT, OffloadableDiTMixin):
         hidden_states, _ = self.x_embedder(hidden_states)
         encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
 
-        # 3. Calculate RoPE embeddings from image and text tokens
-        # NOTE: the below logic means that we can't support batched inference with images of different resolutions or
-        # text prompts of different lengths. Is this a use case we want to support?
-        # 4. Double Stream Transformer Blocks
-        for index_block, block in enumerate(self.transformer_blocks):
-            encoder_hidden_states, hidden_states = block(
-                hidden_states=hidden_states,
-                encoder_hidden_states=encoder_hidden_states,
-                temb_mod_params_img=double_stream_mod_img,
-                temb_mod_params_txt=double_stream_mod_txt,
-                freqs_cis=freqs_cis,
-                joint_attention_kwargs=joint_attention_kwargs,
-            )
-        # Concatenate text and image streams for single-block inference
-        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
 
-        # 5. Single Stream Transformer Blocks
-        for index_block, block in enumerate(self.single_transformer_blocks):
-            hidden_states = block(
-                hidden_states=hidden_states,
-                encoder_hidden_states=None,
-                temb_mod_params=single_stream_mod,
-                freqs_cis=freqs_cis,
-                joint_attention_kwargs=joint_attention_kwargs,
-                text_seq_len=num_txt_tokens,
-            )
-        # Remove text tokens from concatenated stream
-        hidden_states = hidden_states[:, num_txt_tokens:, ...]
+        if should_skip_forward:
+            hidden_states = self.retrieve_cached_states(hidden_states)
+        else:
+            if self.enable_teacache:
+                original_hidden_states = hidden_states.clone()
+
+            # 3. Calculate RoPE embeddings from image and text tokens
+            # NOTE: the below logic means that we can't support batched inference with images of different resolutions or
+            # text prompts of different lengths. Is this a use case we want to support?
+            # 4. Double Stream Transformer Blocks
+            for index_block, block in enumerate(self.transformer_blocks):
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb_mod_params_img=double_stream_mod_img,
+                    temb_mod_params_txt=double_stream_mod_txt,
+                    freqs_cis=freqs_cis,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+            # Concatenate text and image streams for single-block inference
+            hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+
+            # 5. Single Stream Transformer Blocks
+            for index_block, block in enumerate(self.single_transformer_blocks):
+                hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=None,
+                    temb_mod_params=single_stream_mod,
+                    freqs_cis=freqs_cis,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                    text_seq_len=num_txt_tokens,
+                )
+            # Remove text tokens from concatenated stream
+            hidden_states = hidden_states[:, num_txt_tokens:, ...]
+
+            if self.enable_teacache:
+                self.maybe_cache_states(hidden_states, original_hidden_states)
 
         # 6. Output layers
         hidden_states = self.norm_out(hidden_states, temb)

--- a/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
@@ -37,7 +37,6 @@ from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     apply_flashinfer_rope_qk_inplace,
 )
 from sglang.multimodal_gen.runtime.layers.visual_embedding import Timesteps
-from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
@@ -805,11 +804,7 @@ class GlmImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
         ###
         guidance: torch.Tensor = None,  # TODO: this should probably be removed
     ) -> Tuple[torch.Tensor]:
-        forward_context = get_forward_context()
-        forward_batch = forward_context.forward_batch if forward_context else None
-        self.enable_teacache = forward_batch is not None and getattr(
-            forward_batch, "enable_teacache", False
-        )
+        self._update_teacache_status()
 
         if kv_caches is not None:
             kv_caches.set_mode(kv_caches_mode)
@@ -855,14 +850,10 @@ class GlmImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
         temb = F.silu(temb)
 
         # 3. Transformer blocks
-        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
-
-        if should_skip_forward:
-            hidden_states = self.retrieve_cached_states(hidden_states)
+        skip, hs_or_orig = self.teacache_skip_or_prepare(hidden_states, temb)
+        if skip:
+            hidden_states = hs_or_orig
         else:
-            if self.enable_teacache:
-                original_hidden_states = hidden_states.clone()
-
             for idx, block in enumerate(self.transformer_blocks):
                 hidden_states, encoder_hidden_states = block(
                     hidden_states,
@@ -873,9 +864,7 @@ class GlmImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
                     attention_kwargs,
                     kv_cache=kv_caches[idx] if kv_caches is not None else None,
                 )
-
-            if self.enable_teacache:
-                self.maybe_cache_states(hidden_states, original_hidden_states)
+            self.teacache_finalize(hidden_states, hs_or_orig)
 
         # 4. Output norm & projection
         hidden_states = self.norm_out(hidden_states, temb)

--- a/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/glm_image.py
@@ -37,6 +37,7 @@ from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     apply_flashinfer_rope_qk_inplace,
 )
 from sglang.multimodal_gen.runtime.layers.visual_embedding import Timesteps
+from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
@@ -804,6 +805,12 @@ class GlmImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
         ###
         guidance: torch.Tensor = None,  # TODO: this should probably be removed
     ) -> Tuple[torch.Tensor]:
+        forward_context = get_forward_context()
+        forward_batch = forward_context.forward_batch if forward_context else None
+        self.enable_teacache = forward_batch is not None and getattr(
+            forward_batch, "enable_teacache", False
+        )
+
         if kv_caches is not None:
             kv_caches.set_mode(kv_caches_mode)
 
@@ -848,16 +855,27 @@ class GlmImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
         temb = F.silu(temb)
 
         # 3. Transformer blocks
-        for idx, block in enumerate(self.transformer_blocks):
-            hidden_states, encoder_hidden_states = block(
-                hidden_states,
-                encoder_hidden_states,
-                temb,
-                image_rotary_emb,
-                attention_mask,
-                attention_kwargs,
-                kv_cache=kv_caches[idx] if kv_caches is not None else None,
-            )
+        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
+
+        if should_skip_forward:
+            hidden_states = self.retrieve_cached_states(hidden_states)
+        else:
+            if self.enable_teacache:
+                original_hidden_states = hidden_states.clone()
+
+            for idx, block in enumerate(self.transformer_blocks):
+                hidden_states, encoder_hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    image_rotary_emb,
+                    attention_mask,
+                    attention_kwargs,
+                    kv_cache=kv_caches[idx] if kv_caches is not None else None,
+                )
+
+            if self.enable_teacache:
+                self.maybe_cache_states(hidden_states, original_hidden_states)
 
         # 4. Output norm & projection
         hidden_states = self.norm_out(hidden_states, temb)

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -5,16 +5,16 @@
 import functools
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import diffusers
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-import diffusers
 from diffusers.models.attention import FeedForward
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import AdaLayerNormContinuous
+
 from sglang.jit_kernel.diffusion.triton.scale_shift import (
     fuse_scale_shift_gate_select01_kernel,
 )

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -5,16 +5,16 @@
 import functools
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import diffusers
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+import diffusers
 from diffusers.models.attention import FeedForward
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import AdaLayerNormContinuous
-
 from sglang.jit_kernel.diffusion.triton.scale_shift import (
     fuse_scale_shift_gate_select01_kernel,
 )
@@ -43,6 +43,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.configs.nunchaku_config i
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     apply_flashinfer_rope_qk_inplace,
 )
+from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
@@ -1137,12 +1138,18 @@ class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
                 [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
             return_dict (`bool`, *optional*, defaults to `True`):
                 Whether or not to return a [`~models.transformer_2d.Transformer2DModelOutput`] instead of a plain
-                tuple.
+                `tuple`.
 
         Returns:
             If `return_dict` is True, an [`~models.transformer_2d.Transformer2DModelOutput`] is returned, otherwise a
             `tuple` where the first element is the sample tensor.
         """
+        forward_context = get_forward_context()
+        forward_batch = forward_context.forward_batch if forward_context else None
+        self.enable_teacache = forward_batch is not None and getattr(
+            forward_batch, "enable_teacache", False
+        )
+
         if (
             attention_kwargs is not None
             and attention_kwargs.get("scale", None) is not None
@@ -1178,29 +1185,41 @@ class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             temb_txt = temb
             temb_txt_silu = temb_img_silu
 
-        image_rotary_emb = freqs_cis
-        for index_block, block in enumerate(self.transformer_blocks):
-            encoder_hidden_states, hidden_states = block(
-                hidden_states=hidden_states,
-                encoder_hidden_states=encoder_hidden_states,
-                encoder_hidden_states_mask=encoder_hidden_states_mask,
-                temb_img_silu=temb_img_silu,
-                temb_txt_silu=temb_txt_silu,
-                image_rotary_emb=image_rotary_emb,
-                joint_attention_kwargs=attention_kwargs,
-                modulate_index=modulate_index,
-            )
+        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
 
-            # controlnet residual
-            if controlnet_block_samples is not None:
-                interval_control = len(self.transformer_blocks) / len(
-                    controlnet_block_samples
+        if should_skip_forward:
+            hidden_states = self.retrieve_cached_states(hidden_states)
+        else:
+            if self.enable_teacache:
+                original_hidden_states = hidden_states.clone()
+
+            image_rotary_emb = freqs_cis
+            for index_block, block in enumerate(self.transformer_blocks):
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_hidden_states_mask=encoder_hidden_states_mask,
+                    temb_img_silu=temb_img_silu,
+                    temb_txt_silu=temb_txt_silu,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=attention_kwargs,
+                    modulate_index=modulate_index,
                 )
-                interval_control = int(np.ceil(interval_control))
-                hidden_states = (
-                    hidden_states
-                    + controlnet_block_samples[index_block // interval_control]
-                )
+
+                # controlnet residual
+                if controlnet_block_samples is not None:
+                    interval_control = len(self.transformer_blocks) / len(
+                        controlnet_block_samples
+                    )
+                    interval_control = int(np.ceil(interval_control))
+                    hidden_states = (
+                        hidden_states
+                        + controlnet_block_samples[index_block // interval_control]
+                    )
+
+            if self.enable_teacache:
+                self.maybe_cache_states(hidden_states, original_hidden_states)
+
         # Use only the image part (hidden_states) from the dual-stream blocks
         hidden_states = self.norm_out(hidden_states, temb_txt)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -5,16 +5,16 @@
 import functools
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import diffusers
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+import diffusers
 from diffusers.models.attention import FeedForward
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import AdaLayerNormContinuous
-
 from sglang.jit_kernel.diffusion.triton.scale_shift import (
     fuse_scale_shift_gate_select01_kernel,
 )
@@ -43,7 +43,6 @@ from sglang.multimodal_gen.runtime.layers.quantization.configs.nunchaku_config i
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
     apply_flashinfer_rope_qk_inplace,
 )
-from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
@@ -1144,11 +1143,7 @@ class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             If `return_dict` is True, an [`~models.transformer_2d.Transformer2DModelOutput`] is returned, otherwise a
             `tuple` where the first element is the sample tensor.
         """
-        forward_context = get_forward_context()
-        forward_batch = forward_context.forward_batch if forward_context else None
-        self.enable_teacache = forward_batch is not None and getattr(
-            forward_batch, "enable_teacache", False
-        )
+        self._update_teacache_status()
 
         if (
             attention_kwargs is not None
@@ -1185,14 +1180,11 @@ class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
             temb_txt = temb
             temb_txt_silu = temb_img_silu
 
-        should_skip_forward = self.should_skip_forward_for_cached_states(temb=temb)
+        skip, hs_or_orig = self.teacache_skip_or_prepare(hidden_states, temb)
 
-        if should_skip_forward:
-            hidden_states = self.retrieve_cached_states(hidden_states)
+        if skip:
+            hidden_states = hs_or_orig
         else:
-            if self.enable_teacache:
-                original_hidden_states = hidden_states.clone()
-
             image_rotary_emb = freqs_cis
             for index_block, block in enumerate(self.transformer_blocks):
                 encoder_hidden_states, hidden_states = block(
@@ -1217,8 +1209,7 @@ class QwenImageTransformer2DModel(CachableDiT, OffloadableDiTMixin):
                         + controlnet_block_samples[index_block // interval_control]
                     )
 
-            if self.enable_teacache:
-                self.maybe_cache_states(hidden_states, original_hidden_states)
+            self.teacache_finalize(hidden_states, hs_or_orig)
 
         # Use only the image part (hidden_states) from the dual-stream blocks
         hidden_states = self.norm_out(hidden_states, temb_txt)


### PR DESCRIPTION

## Motivation


## Modifications


## Accuracy Tests

- All tests used default parameters，my GPU memory's tight, so I enabled layer offload for the bigger model（Qwen-image  et.al）
- Results are directly comparable under identical conditions.

| Model | ❌ No TeaCache | ✅ TeaCache  |
| :---: | :---: | :---: |
| **Qwen-Image-2512** | **156.12**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-154020_5e39b8af" src="https://github.com/user-attachments/assets/ff2ea07e-9b71-4d0d-ac3c-9444151caf10" /> | **61.29**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-154538_8358cc54" src="https://github.com/user-attachments/assets/860ae51e-0336-43af-a033-6e3f1676fe61" /> |
| **GLM-IMAGE** | **87.87**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-160354_cc167b0e" src="https://github.com/user-attachments/assets/e4533787-bc7c-4e6e-ba2c-aebd0664d78c" /> | **69.83**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-160614_07782f69" src="https://github.com/user-attachments/assets/c00cd7d5-0693-4abb-972d-3e0f7dd5ae05" />|
| **flux1** | **61.87**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-163913_254194f4" src="https://github.com/user-attachments/assets/616f446f-2a28-4ab8-8ec8-7c855e0948e0" /> | **21.98**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-164154_e8906659" src="https://github.com/user-attachments/assets/6d2980e3-2cc5-4e76-b913-2a3bb7e18158" /> |
| **flux2** | **5.95**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-164428_baf3c7b9" src="https://github.com/user-attachments/assets/1b0c2e1c-3083-4f33-9103-5f70beb4f7de" /> | **5.50**<br><img width="512" height="512" alt="a_young_girl_with_flowing_long_hair_wearing_a_white_halter_dress_and_smiling_sweetly _The_backgroun_20260312-164526_3dab1de2" src="https://github.com/user-attachments/assets/e29d22a8-0431-40b1-8c66-40dbc15e44b1" />|

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.





