### PR TITLE
Fix/bench seed reset

### DIFF
--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -427,6 +427,14 @@ def run_one_case(
     gsp_question_len: int = BenchArgs.gsp_question_len,
     gsp_output_len: int = BenchArgs.gsp_output_len,
 ):
+    # Reset random seed before each case so repeated benchmark runs use
+    # identical input data (same expert routing pattern every time).
+    # Without this, random.shuffle in the data loader produces different
+    # inputs across repeats, causing up to 25% throughput variance for
+    # MoE models with expert-parallel dispatch.
+    random.seed(BenchArgs.seed)
+    np.random.seed(BenchArgs.seed)
+
     if backend == "vllm":
         # You need to have export VLLM_SERVER_DEV_MODE=1 in your environment to use this endpoint.
         response = requests.post(url + "/reset_prefix_cache", timeout=DEFAULT_TIMEOUT)

--- a/python/sglang/test/bench_one_batch_server_internal.py
+++ b/python/sglang/test/bench_one_batch_server_internal.py
@@ -426,14 +426,15 @@ def run_one_case(
     gsp_system_prompt_len: int = BenchArgs.gsp_system_prompt_len,
     gsp_question_len: int = BenchArgs.gsp_question_len,
     gsp_output_len: int = BenchArgs.gsp_output_len,
+    seed: int = BenchArgs.seed,
 ):
     # Reset random seed before each case so repeated benchmark runs use
     # identical input data (same expert routing pattern every time).
     # Without this, random.shuffle in the data loader produces different
     # inputs across repeats, causing up to 25% throughput variance for
     # MoE models with expert-parallel dispatch.
-    random.seed(BenchArgs.seed)
-    np.random.seed(BenchArgs.seed)
+    random.seed(seed)
+    np.random.seed(seed)
 
     if backend == "vllm":
         # You need to have export VLLM_SERVER_DEV_MODE=1 in your environment to use this endpoint.
@@ -461,7 +462,7 @@ def run_one_case(
         dataset_path=dataset_path,
         tokenize_prompt=dataset_name not in ("mmmu", "generated-shared-prefix"),
         backend=backend,
-        seed=BenchArgs.seed,
+        seed=seed,
         gsp_num_groups=actual_gsp_groups,
         gsp_prompts_per_group=(batch_size + actual_gsp_groups - 1) // actual_gsp_groups,
         gsp_system_prompt_len=gsp_system_prompt_len,
@@ -767,10 +768,6 @@ def run_benchmark_internal(
     bench_args: BenchArgs,
     launch_server_func: Callable = launch_server,
 ):
-    # set random seed
-    random.seed(bench_args.seed)
-    np.random.seed(bench_args.seed)
-
     # launch a server or use the provided base_url
     if bench_args.base_url:
         proc, base_url = None, bench_args.base_url
@@ -872,6 +869,7 @@ def run_benchmark_internal(
                 parallel_batch=bench_args.parallel_batch,
                 backend=bench_args.backend,
                 model_name=model_name,
+                seed=bench_args.seed,
                 **gsp_kwargs,
             )
         print("=" * 8 + " Warmup End   " + "=" * 8 + "\n")
@@ -908,6 +906,7 @@ def run_benchmark_internal(
                     cache_hit_rate=bench_args.cache_hit_rate,
                     backend=bench_args.backend,
                     model_name=model_name,
+                    seed=bench_args.seed,
                     **gsp_kwargs,
                 )
             )
@@ -953,6 +952,7 @@ def run_benchmark_internal(
                             profile_output_dir=bench_args.profile_output_dir,
                             backend=bench_args.backend,
                             model_name=model_name,
+                            seed=bench_args.seed,
                             **gsp_kwargs,
                         )
                     )


### PR DESCRIPTION
## Motivation

<!-- Describe the purpose and goals of this pull request. -->
  - Reset `random.seed()` and `np.random.seed()` at the start of each `run_one_case` call in `bench_one_batch_server_internal.py`
  - Previously, the seed was only set once in `run_benchmark_internal`, so `random.shuffle()` in the data loader consumed random state across repeated runs,  
  producing different input tokens each time                                                                                                                  
  - For MoE models with expert-parallel dispatch (e.g., DeepSeek-V3 with DeepEP), different input tokens lead to different expert routing patterns, causing up
   to **25% throughput variance** between identical benchmark runs                                                                                            
  - Also fixed a bug where `BenchArgs.seed` (class default `42`) was hardcoded instead of using the user's `--seed` CLI value — the `--seed` flag was
  effectively ignored for per-case seed resets and dataset generation                                                                                         
                  
## Modifications

<!-- Detail the changes made in this pull request. -->
                                                                                                                                               
  - Add `seed` parameter to `run_one_case()` (with `BenchArgs.seed` as default), following existing pattern for other BenchArgs fields                        
  - Pass `bench_args.seed` from all 3 call sites (warmup, benchmark, profile)                                                                                 
  - Remove redundant initial seed setting in `run_benchmark_internal` (no code between it and the first `run_one_case` depends on random state)               






## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
