### PR TITLE
[Bugfix] Fix GLM-4.6V vision regression in glm4v_moe and glm_ocr

### DIFF
--- a/python/sglang/srt/models/glm4v_moe.py
+++ b/python/sglang/srt/models/glm4v_moe.py
@@ -281,5 +281,7 @@ class Glm4vMoeForConditionalGeneration(Glm4vForConditionalGeneration):
                     else:
                         logger.warning(f"Parameter {name} not found in params_dict")
 
+        self.visual.patch_embed.copy_conv3d_weight_to_linear()
+
 
 EntryClass = [Glm4vMoeForConditionalGeneration]

--- a/python/sglang/srt/models/glm4v_moe.py
+++ b/python/sglang/srt/models/glm4v_moe.py
@@ -281,7 +281,8 @@ class Glm4vMoeForConditionalGeneration(Glm4vForConditionalGeneration):
                     else:
                         logger.warning(f"Parameter {name} not found in params_dict")
 
-        self.visual.patch_embed.copy_conv3d_weight_to_linear()
+        if not is_nextn:
+            self.visual.patch_embed.copy_conv3d_weight_to_linear()
 
 
 EntryClass = [Glm4vMoeForConditionalGeneration]

--- a/python/sglang/srt/models/glm_ocr.py
+++ b/python/sglang/srt/models/glm_ocr.py
@@ -431,7 +431,8 @@ class GlmOcrForConditionalGeneration(Glm4vForConditionalGeneration):
                     )
                 weight_loader(param, loaded_weight)
 
-        self.visual.patch_embed.copy_conv3d_weight_to_linear()
+        if not is_nextn:
+            self.visual.patch_embed.copy_conv3d_weight_to_linear()
 
 
 EntryClass = [GlmOcrForConditionalGeneration]

--- a/python/sglang/srt/models/glm_ocr.py
+++ b/python/sglang/srt/models/glm_ocr.py
@@ -431,5 +431,7 @@ class GlmOcrForConditionalGeneration(Glm4vForConditionalGeneration):
                     )
                 weight_loader(param, loaded_weight)
 
+        self.visual.patch_embed.copy_conv3d_weight_to_linear()
+
 
 EntryClass = [GlmOcrForConditionalGeneration]


### PR DESCRIPTION
## Motivation

PR #20033 replaced `Conv3d` with `Linear` in `Glm4vVisionPatchEmbed` and added `copy_conv3d_weight_to_linear()` at the end of `glm4v.py`'s `load_weights()`. However, `glm4v_moe.py` and `glm_ocr.py` have their own `load_weights()` overrides and the call was not added there. This left the `Linear` layer with **random weights**, causing the vision encoder to produce garbage embeddings — the model outputs text completely unrelated to the image content.

## Fix

Add the missing `self.visual.patch_embed.copy_conv3d_weight_to_linear()` call at the end of `load_weights()` in both `glm4v_moe.py` and `glm_ocr.py`.

## Test Plan

- Verified with GLM-4.6V-FP8 (glm4v_moe) on B200 TP=4: vision responses now correctly describe image content
- Root cause confirmed via `git bisect` over 625 commits (v0.5.9 → 7a1ca538)

Fixes #20462