### PR TITLE
bugfix: Disable Nagle's algorithm

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -439,6 +439,9 @@ def _prebind_listening_socket(host: str, port: int) -> socket.socket:
     sock = socket.socket(family=na.family, type=socket.SOCK_STREAM)
     # SO_REUSEADDR: Allows binding to a port in TIME_WAIT state
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    # TCP_NODELAY: Disable Nagle's algorithm to avoid ~40ms delayed ACK on response.
+    # https://brooker.co.za/blog/2024/05/09/nagle.html
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     try:
         sock.bind(na.to_bind_tuple())


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
After updating recent changes to sglang, we started noticing 40ms added latency on the response path of all HTTP requests such as `/generate`. This is important for real-time inference workloads.


## Modifications

<!-- Detail the changes made in this pull request. -->

By disabling Nagle's algorithm we fix this. Python async runtimes (asyncio, uvicorn, uvloop) automatically set `TCP_NODELAY`, so this was the behavior prior to last week's change #17754 by @xrwang8, so this PR is just re-applying previous behavior from a week ago to not delay TCP packets.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
We found a reduction in 40ms of `/generate` requests in our real-time workload, going down from 210ms per inference step to 170ms per inference step. This matches the previous behavior of sglang before regression in #17754.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
