### PR TITLE
feat: add banner to sgl-model-gateway

### DIFF
--- a/sgl-model-gateway/bindings/python/src/sglang_router/launch_router.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/launch_router.py
@@ -41,6 +41,18 @@ def launch_router(args: argparse.Namespace) -> Optional[Router]:
             mini_lb = MiniLoadBalancer(router_args)
             mini_lb.start()
         else:
+            print(
+                "\n"
+                "==============================================================================\n"
+                "WARNING: This copy of sgl-model-gateway is DEPRECATED and no longer maintained.\n"
+                "The actively maintained version has moved to:\n"
+                "  https://github.com/lightseekorg/smg\n"
+                "\n"
+                "Please migrate to the standalone repository for the latest features,\n"
+                "bug fixes, and security updates.\n"
+                "==============================================================================\n",
+                file=sys.stderr,
+            )
             if Router is None:
                 raise RuntimeError("Rust Router is not installed")
             router_args._validate_router_args()

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -1153,6 +1153,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    eprintln!("\n{}", "=".repeat(78));
+    eprintln!(
+        "WARNING: This copy of sgl-model-gateway is DEPRECATED and no longer maintained."
+    );
+    eprintln!("The actively maintained version has moved to:");
+    eprintln!("  https://github.com/lightseekorg/smg");
+    eprintln!();
+    eprintln!("Please migrate to the standalone repository for the latest features,");
+    eprintln!("bug fixes, and security updates.");
+    eprintln!("{}\n", "=".repeat(78));
+
     let prefill_urls = parse_prefill_args();
 
     let mut filtered_args: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary

Adds a deprecation warning banner to sgl-model-gateway directing users to the new standalone repository

- **Rust `main.rs`**: prints banner to stderr on startup
- **Python `launch_router.py`**: prints banner to stderr only when using the Rust router path (not mini LB)

## Test plan

- [ ] Run the Rust binary and verify the deprecation banner appears on stderr
- [ ] Run `smg launch` via Python and verify the banner appears
- [ ] Run with `--mini-lb` and verify no banner is shown