### PR TITLE
Support Triton MLA FP8 KV cache

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
-from sgl_kernel.utils import is_arch_support_pdl
-
 import triton
 import triton.language as tl
+from sgl_kernel.utils import is_arch_support_pdl
+
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -29,11 +29,17 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpecInput
 
 
-def _mla_decode_kv_splits_cap(base_max_kv_splits: int, sm_count: int) -> int:
+_MLA_DECODE_MIN_BLOCK_KV = 32
+
+
+def _mla_decode_kv_splits_cap(
+    base_max_kv_splits: int, sm_count: int, max_context_len: int
+) -> int:
     if sm_count <= 0:
         return base_max_kv_splits
-    cap = next_power_of_2(sm_count * 2)
-    return max(base_max_kv_splits, cap)
+    sm_cap = next_power_of_2(sm_count)
+    ctx_cap = next_power_of_2(triton.cdiv(max_context_len, _MLA_DECODE_MIN_BLOCK_KV))
+    return max(base_max_kv_splits, min(sm_cap, ctx_cap))
 
 
 def logit_capping_mod(logit_capping_method, logit_cap):
@@ -138,7 +144,9 @@ class TritonAttnBackend(AttentionBackend):
         self.max_kv_splits = model_runner.server_args.triton_attention_num_kv_splits
         if self.use_mla:
             self.max_kv_splits = _mla_decode_kv_splits_cap(
-                self.max_kv_splits, self.device_core_count
+                self.max_kv_splits,
+                self.device_core_count,
+                self.max_context_len,
             )
         self.use_pdl = is_arch_support_pdl()
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
+from sgl_kernel.utils import is_arch_support_pdl
+
 import triton
 import triton.language as tl
-
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
@@ -26,6 +27,13 @@ if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.speculative.spec_info import SpecInput
+
+
+def _mla_decode_kv_splits_cap(base_max_kv_splits: int, sm_count: int) -> int:
+    if sm_count <= 0:
+        return base_max_kv_splits
+    cap = next_power_of_2(sm_count * 2)
+    return max(base_max_kv_splits, cap)
 
 
 def logit_capping_mod(logit_capping_method, logit_cap):
@@ -128,6 +136,11 @@ class TritonAttnBackend(AttentionBackend):
             "SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS", "false"
         )
         self.max_kv_splits = model_runner.server_args.triton_attention_num_kv_splits
+        if self.use_mla:
+            self.max_kv_splits = _mla_decode_kv_splits_cap(
+                self.max_kv_splits, self.device_core_count
+            )
+        self.use_pdl = is_arch_support_pdl()
 
         self.allow_bidirectional_attention_in_extend = (
             model_runner.server_args.disable_cuda_graph
@@ -887,13 +900,22 @@ class TritonAttnBackend(AttentionBackend):
         else:
             # Save KV cache first (must do this before unified kernel)
             if save_kv_cache:
-                if (
-                    self.use_mla or layer.k_scale is None
-                ):  # Triton MLA currently doesn't support quantized kv cache
+                if layer.k_scale is None:
                     forward_batch.token_to_kv_pool.set_kv_buffer(
                         layer,
                         forward_batch.out_cache_loc,
                         k,
+                        v,
+                    )
+                elif self.use_mla:
+                    # For MLA, scale K manually before storing since MLATokenToKVPool
+                    # doesn't accept scale parameters. Clone to protect k from mutation
+                    # since it's used later in the attention kernel.
+                    k_scaled = k.clone().div_(layer.k_scale)
+                    forward_batch.token_to_kv_pool.set_kv_buffer(
+                        layer,
+                        forward_batch.out_cache_loc,
+                        k_scaled,
                         v,
                     )
                 else:
@@ -1139,7 +1161,11 @@ class TritonAttnBackend(AttentionBackend):
         logits_soft_cap = logit_capping_mod(layer.logit_capping_method, layer.logit_cap)
 
         if save_kv_cache:
-            if self.use_mla:  # Triton MLA currently doesn't support quantized kv cache
+            if self.use_mla:
+                if layer.k_scale is not None:
+                    # MLATokenToKVPool doesn't accept scale parameters; k is unused
+                    # after this point in decode, so scale in place.
+                    k.div_(layer.k_scale)
                 forward_batch.token_to_kv_pool.set_kv_buffer(
                     layer,
                     forward_batch.out_cache_loc,
@@ -1197,6 +1223,8 @@ class TritonAttnBackend(AttentionBackend):
             logit_cap=logits_soft_cap,
             sinks=sinks,
             xai_temperature_len=layer.xai_temperature_len,
+            has_mla=self.use_mla,
+            use_pdl=self.use_pdl,
         )
         return o
 

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -24,7 +24,6 @@ import logging
 
 import triton
 import triton.language as tl
-
 from sglang.srt.utils import is_hip
 
 _is_hip = is_hip()
@@ -281,6 +280,8 @@ def _fwd_grouped_kernel_stage1(
     xai_temperature_len: tl.constexpr,
     Lk: tl.constexpr,
     Lv: tl.constexpr,
+    HAS_MLA: tl.constexpr = False,
+    USE_PDL: tl.constexpr = False,
 ):
     cur_batch = tl.program_id(0)
     cur_head_id = tl.program_id(1)
@@ -329,36 +330,35 @@ def _fwd_grouped_kernel_stage1(
     e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
     acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
 
+    # Hoist loop-invariant base offsets
+    base_offs_k = cur_kv_head * stride_buf_kh + offs_d[:, None]
+    if BLOCK_DPE > 0:
+        base_offs_kpe = cur_kv_head * stride_buf_kh + offs_dpe[:, None]
+    if not HAS_MLA:
+        base_offs_v = cur_kv_head * stride_buf_vh + offs_dv[None, :]
+
     if split_kv_end > split_kv_start:
         q = tl.load(Q + offs_q, mask=(mask_h[:, None]) & (mask_d[None, :]), other=0.0)
         if BLOCK_DPE > 0:
             qpe = tl.load(
                 Q + off_qpe, mask=(mask_h[:, None]) & (mask_dpe[None, :]), other=0.0
             )
-        for start_n in range(split_kv_start, split_kv_end, BLOCK_N):
+        for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
             offs_n = start_n + tl.arange(0, BLOCK_N)
             kv_loc = tl.load(
                 kv_indices + cur_batch_kv_start_idx + offs_n,
                 mask=offs_n < split_kv_end,
                 other=0,
             )
-            offs_buf_k = (
-                kv_loc[None, :] * stride_buf_kbs
-                + cur_kv_head * stride_buf_kh
-                + offs_d[:, None]
-            )
+            offs_buf_k = kv_loc[None, :] * stride_buf_kbs + base_offs_k
             k = tl.load(
                 K_Buffer + offs_buf_k,
                 mask=(offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
                 other=0.0,
             )
-            qk = tl.dot(q, k.to(q.dtype))
+            qk = tl.dot(q.to(k.dtype), k)
             if BLOCK_DPE > 0:
-                offs_buf_kpe = (
-                    kv_loc[None, :] * stride_buf_kbs
-                    + cur_kv_head * stride_buf_kh
-                    + offs_dpe[:, None]
-                )
+                offs_buf_kpe = kv_loc[None, :] * stride_buf_kbs + base_offs_kpe
                 kpe = tl.load(
                     K_Buffer + offs_buf_kpe,
                     mask=(offs_n[None, :] < split_kv_end) & (mask_dpe[:, None]),
@@ -376,17 +376,15 @@ def _fwd_grouped_kernel_stage1(
             qk = tl.where(
                 mask_h[:, None] & (offs_n[None, :] < split_kv_end), qk, float("-inf")
             )
-
-            offs_buf_v = (
-                kv_loc[:, None] * stride_buf_vbs
-                + cur_kv_head * stride_buf_vh
-                + offs_dv[None, :]
-            )
-            v = tl.load(
-                V_Buffer + offs_buf_v,
-                mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
-                other=0.0,
-            )
+            if HAS_MLA:
+                v = tl.trans(k)
+            else:
+                offs_buf_v = kv_loc[:, None] * stride_buf_vbs + base_offs_v
+                v = tl.load(
+                    V_Buffer + offs_buf_v,
+                    mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                    other=0.0,
+                )
 
             n_e_max = tl.maximum(tl.max(qk, 1), e_max)
             re_scale = tl.exp(e_max - n_e_max)
@@ -422,6 +420,9 @@ def _fwd_grouped_kernel_stage1(
             mask=mask_h,
         )
 
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def _decode_grouped_att_m_fwd(
     q,
@@ -436,6 +437,8 @@ def _decode_grouped_att_m_fwd(
     sm_scale_withk,
     logit_cap,
     xai_temperature_len=-1,
+    has_mla=False,
+    use_pdl=False,
 ):
     BLOCK = 32
     Lk = k_buffer.shape[-1]
@@ -508,6 +511,8 @@ def _decode_grouped_att_m_fwd(
         num_stages=num_stages,
         Lk=Lk,
         Lv=Lv,
+        HAS_MLA=has_mla,
+        USE_PDL=use_pdl,
         **extra_kargs,
     )
 
@@ -531,9 +536,13 @@ def _fwd_kernel_stage2(
     BLOCK_DV: tl.constexpr,
     Lv: tl.constexpr,
     HAS_SINK: tl.constexpr,
+    USE_PDL: tl.constexpr = False,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - tl.load(
         kv_indptr + cur_batch
@@ -594,6 +603,7 @@ def _decode_softmax_reducev_fwd(
     num_kv_splits,
     max_kv_splits,
     sinks=None,
+    use_pdl=False,
 ):
     batch, head_num = q.shape[0], q.shape[1]
     Lv = v_buffer.shape[-1]
@@ -627,8 +637,10 @@ def _decode_softmax_reducev_fwd(
         BLOCK_DV=BLOCK_DV,
         Lv=Lv,
         HAS_SINK=HAS_SINK,
+        USE_PDL=use_pdl,
         num_warps=4,
         num_stages=2,
+        **({"launch_pdl": True} if use_pdl else {}),
         **extra_kargs,
     )
 
@@ -694,6 +706,8 @@ def decode_attention_fwd_grouped(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    has_mla=False,
+    use_pdl=False,
 ):
     _decode_grouped_att_m_fwd(
         q,
@@ -708,6 +722,8 @@ def decode_attention_fwd_grouped(
         sm_scale_withk,
         logit_cap,
         xai_temperature_len,
+        has_mla=has_mla,
+        use_pdl=use_pdl,
     )
     _decode_softmax_reducev_fwd(
         attn_logits,
@@ -720,6 +736,7 @@ def decode_attention_fwd_grouped(
         num_kv_splits,
         max_kv_splits,
         sinks,
+        use_pdl=use_pdl,
     )
 
 
@@ -740,6 +757,8 @@ def decode_attention_fwd(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    has_mla=False,
+    use_pdl=False,
 ):
     assert max_kv_splits == attn_logits.shape[2]
     assert q.shape[0] <= kv_indptr.shape[0] - 1
@@ -784,4 +803,6 @@ def decode_attention_fwd(
             logit_cap=logit_cap,
             sinks=sinks,
             xai_temperature_len=xai_temperature_len,
+            has_mla=has_mla,
+            use_pdl=use_pdl,
         )

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -24,6 +24,7 @@ import logging
 
 import triton
 import triton.language as tl
+
 from sglang.srt.utils import is_hip
 
 _is_hip = is_hip()

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -340,6 +340,7 @@ def _fwd_grouped_kernel_stage1(
 
     if split_kv_end > split_kv_start:
         q = tl.load(Q + offs_q, mask=(mask_h[:, None]) & (mask_d[None, :]), other=0.0)
+        q_k = q.to(K_Buffer.dtype.element_ty)
         if BLOCK_DPE > 0:
             qpe = tl.load(
                 Q + off_qpe, mask=(mask_h[:, None]) & (mask_dpe[None, :]), other=0.0
@@ -357,7 +358,7 @@ def _fwd_grouped_kernel_stage1(
                 mask=(offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
                 other=0.0,
             )
-            qk = tl.dot(q.to(k.dtype), k)
+            qk = tl.dot(q_k, k)
             if BLOCK_DPE > 0:
                 offs_buf_kpe = kv_loc[None, :] * stride_buf_kbs + base_offs_kpe
                 kpe = tl.load(
@@ -563,7 +564,7 @@ def _fwd_kernel_stage2(
         tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
     )
 
-    for split_kv_id in range(0, MAX_KV_SPLITS):
+    for split_kv_id in tl.range(0, MAX_KV_SPLITS, num_stages=2):
         split_kv_start = kv_len_per_split * split_kv_id
         split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -17,9 +17,9 @@ It supports page size = 1 and prefill with KV cache (i.e. extend).
 """
 
 import torch
-
 import triton
 import triton.language as tl
+
 from sglang.srt.layers.attention.triton_ops.prefill_attention import (
     context_attention_fwd,
 )

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -17,9 +17,9 @@ It supports page size = 1 and prefill with KV cache (i.e. extend).
 """
 
 import torch
+
 import triton
 import triton.language as tl
-
 from sglang.srt.layers.attention.triton_ops.prefill_attention import (
     context_attention_fwd,
 )
@@ -382,7 +382,6 @@ def _fwd_kernel(
                 mask=(mask_n[None, :]) & (mask_d[:, None]),
                 other=0.0,
             )
-
             qk = tl.dot(q.to(k.dtype), k)
             if BLOCK_DPE > 0:
                 offs_kpe = (
@@ -887,7 +886,6 @@ def _fwd_kernel_unified(
                 other=0.0,
             )
 
-            # Compute QK
             qk = tl.dot(q.to(k.dtype), k)
             if BLOCK_DPE > 0:
                 offs_kpe = (


### PR DESCRIPTION
Inspire by https://github.com/sgl-project/sglang/pull/18882

Recently some users of SM120 need this feature for FP8 KV cache (currently, Flashinfer will be slower and doesn't support FP8 Attention), XQA only support limited heaad dim (DP attention only and R1 head dim, not Kimi/etc.). Before, Triton backend will be really slow under MLA and long seq len (found by Claude). And add PDL to the stage 2 kernel.

Credit to @koush from vLLM for this: `v = tl.trans(k)`, the KV split heuristics, and taking out loop invariant in https://github.com/vllm-project/vllm/pull/33529, it's a really smart idea... thanks a lot!

```
python3 -m sglang.launch_server \
  --model moonshotai/Kimi-K2.5 \
  --tp 8 \
  --trust-remote-code \
  --attention-backend triton \
  --kv-cache-dtype fp8_e4m3 \
  --reasoning-parser kimi_k2 \
  --tool-call-parser kimi_k2 \
  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}' \
  --mem-fraction-static 0.85
```

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 20 --num-questions 1319 --parallel 512
```

```
for SEQ_LEN in 4096 8192 65536 131072 196608; do
    python3 -m sglang.bench_serving \
        --backend sglang \
        --flush-cache \
        --dataset-name random \
        --random-input-len $SEQ_LEN \
        --random-output-len 1024 \
        --random-range-ratio 1.0 \
        --num-prompts 1 \
        --max-concurrency 1 \
        --output-file res_before.jsonl
done
```

```
SGLANG_TORCH_PROFILER_DIR="./" \
SGLANG_PROFILE_RECORD_SHAPES=true \
SGLANG_PROFILE_WITH_STACK=true \
python3 -m sglang.bench_one_batch_server \
  --model baseten-admin/glm-4.7-fp8-attn-fp4-mlp \
  --base-url http://localhost:30000 \
  --batch-size 1 \
  --input-len 131000 \
  --output-len 1024 \
  --profile \
  --profile-steps 10 \
  --show-report \
  --profile-by-stage
```

Before:
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
|----|-------------------|--------------------|---------------------|----------------|------------------|---------------|----------------|------------------|---------------|-----------------------|
|  0 |             1.000 |            328.067 |              82.017 |        279.931 |          279.931 |       279.931 |         11.916 |           11.916 |        11.916 |                82.017 |
|  1 |             1.000 |            478.334 |              59.792 |        516.055 |          516.055 |       516.055 |         16.215 |           16.215 |        16.215 |                59.792 |
|  2 |             1.000 |            602.623 |               9.416 |      30793.310 |        30793.310 |     30793.310 |         76.129 |           76.129 |        76.129 |                 9.416 |
|  3 |             1.000 |            498.541 |               3.895 |     114885.706 |       114885.706 |    114885.706 |        144.565 |          144.565 |       144.565 |                 3.895 |
|  4 |             1.000 |            420.031 |               2.188 |     250071.627 |       250071.627 |    250071.627 |        212.914 |          212.914 |       212.914 |                 2.188 |

<img width="1051" height="179" alt="Screenshot 2026-03-13 at 12 31 34 PM" src="https://github.com/user-attachments/assets/c342d132-893b-4a0d-b6d2-a6ec9cf04e33" />

```
Accuracy: 0.939
Invalid: 0.000
Latency: 62.885 s
Output throughput: 2131.234 token/s
```

After:
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
|----|-------------------|--------------------|---------------------|----------------|------------------|---------------|----------------|------------------|---------------|-----------------------|
|  0 |             1.000 |            411.705 |             102.926 |        285.106 |          285.106 |       285.106 |          9.435 |            9.435 |         9.435 |               102.926 |
|  1 |             1.000 |            766.120 |              95.765 |        516.598 |          516.598 |       516.598 |          9.935 |            9.935 |         9.935 |                95.765 |
|  2 |             1.000 |           1467.699 |              22.933 |      30797.604 |        30797.604 |     30797.604 |         13.532 |           13.532 |        13.532 |                22.933 |
|  3 |             1.000 |            989.565 |               7.731 |     115659.736 |       115659.736 |    115659.736 |         16.410 |           16.410 |        16.410 |                 7.731 |
|  4 |             1.000 |            729.160 |               3.798 |     250134.658 |       250134.658 |    250134.658 |         19.057 |           19.057 |        19.057 |                 3.798 |
<img width="1247" height="441" alt="Screenshot 2026-03-13 at 1 15 06 PM" src="https://github.com/user-attachments/assets/633e8da9-fd9e-4363-8cdf-7c0579e83d52" />



```
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:09<00:00, 18.91it/s]
Accuracy: 0.939
Invalid: 0.000
Latency: 69.751 s
Output throughput: 1918.854 token/s
```

Perf table:
| Row | TPOT Before (ms) | TPOT After (ms) | % Improvement |
|:----|:-----------------|:----------------|:--------------|
| 0   | 11.92            | 9.44            | 20.8%         |
| 1   | 16.21            | 9.94            | 38.7%         |
| 2   | 76.13            | 13.53           | 82.2%         |
| 3   | 144.57           | 16.41           | 88.7%         |
| 4   | 212.91           | 19.06           | 91.1%         |

I test Dpsk GQPA result. Only because I switch nodes, and I don't want to wait for kimi download...

```
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1-0528 --tp 8 --trust-remote-code --attention-backend triton --kv-cache-dtype fp8_e4m3
```

Before:
Repeat: 8, mean: 0.801
`['0.774', '0.796', '0.808', '0.815', '0.765', '0.821', '0.809', '0.820']`

After PR:
Repeat: 8, mean: 0.808
`['0.816', '0.838', '0.821', '0.801', '0.810', '0.776', '0.789', '0.813']`
