### PR TITLE
Fix optional parameter parsing in the MiniMax M2 tool parser

### DIFF
--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -138,15 +138,12 @@ class MinimaxM2Detector(BaseFormatDetector):
         Returns:
             The converted value
         """
-        if value.lower() == "null":
+        # Check if the VALUE itself indicates null (not just if null is allowed)
+        if value.lower() in ("null", "none", "nil"):
             return None
 
         # Normalize types
         normalized_types = [t.lower() for t in param_types]
-
-        # Try null first if it's in the list
-        if "null" in normalized_types or value.lower() in ("null", "none", "nil"):
-            return None
 
         # Try each type in order of preference (most specific first, string as fallback)
         # Priority: integer > number > boolean > object > array > string


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR resolves an issue with optional parameter parsing in the MiniMax M2 tool parser. This has been fixed in https://github.com/vllm-project/vllm/pull/32342 

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Serving commands:

```bash
python3 -m sglang.launch_server \
    --model-path /model \
    --tp 4 \
    --trust-remote-code \
    --host 0.0.0.0 --port 8000 \
    --tool-call-parser minimax-m2 \
    --reasoning-parser minimax-append-think
```

Test:

```bash
curl -X POST "http://localhost:8000/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [{
      "role": "user",
      "content": "使用 run_shell 工具，command 参数是 date，logfile 参数必须是 /tmp/foo（不是空值）"
    }],
    "tools": [{
      "type": "function",
      "function": {
        "name": "run_shell",
        "description": "执行 shell 命令",
        "parameters": {
          "type": "object",
          "properties": {
            "command": {"type": "string"},
            "logfile": {"type": ["string", "null"]}
          },
          "required": ["command"]
        }
      }
    }],
    "tool_choice": "auto"
  }'
```

Original response (before fix):

```json
{
  "id": "7d68284efacb4c8485f75b94fa19cc06",
  "object": "chat.completion",
  "created": 1773374282,
  "model": "default",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "<think>The user wants me to use the `run_shell` tool with the `date` command and a logfile of `/tmp/foo`. Let me make this call.\n</think>\n\nI'll use the `run_shell` tool to execute the `date` command and log the output to `/tmp/foo`.\n",
        "reasoning_content": null,
        "tool_calls": [
          {
            "id": "call_1e31df779a0949d892f62a2e",
            "index": 0,
            "type": "function",
            "function": {
              "name": "run_shell",
              "arguments": "{\"command\": \"date\", \"logfile\": null}"
            }
          }
        ]
      },
      "logprobs": null,
      "finish_reason": "tool_calls",
      "matched_stop": null
    }
  ],
  "usage": {
    "prompt_tokens": 226,
    "total_tokens": 325,
    "completion_tokens": 99,
    "prompt_tokens_details": null,
    "reasoning_tokens": 0
  },
  "metadata": {
    "weight_version": "default"
  }
}
```

Fixed response:

```json
{
  "id": "bb8e9ff25df04febbd77185d81ec60a7",
  "object": "chat.completion",
  "created": 1773373716,
  "model": "default",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "<think>The user wants me to use the `run_shell` tool to execute the `date` command and log the output to `/tmp/foo`. Let me do that.\n</think>\n\n\n",
        "reasoning_content": null,
        "tool_calls": [
          {
            "id": "call_652d91c7fabe40a48879a74b",
            "index": 0,
            "type": "function",
            "function": {
              "name": "run_shell",
              "arguments": "{\"command\": \"date\", \"logfile\": \"/tmp/foo\"}"
            }
          }
        ]
      },
      "logprobs": null,
      "finish_reason": "tool_calls",
      "matched_stop": null
    }
  ],
  "usage": {
    "prompt_tokens": 226,
    "total_tokens": 300,
    "completion_tokens": 74,
    "prompt_tokens_details": null,
    "reasoning_tokens": 0
  },
  "metadata": {
    "weight_version": "default"
  }
}
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
