### PR TITLE
fix: Add .text property to HttpResponse to prevent AttributeError

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -139,9 +139,19 @@ def normalize_base_url(host: str, port: int) -> str:
 class HttpResponse:
     def __init__(self, resp):
         self.resp = resp
+        self._body = None
+
+    def _read_body(self):
+        if self._body is None:
+            self._body = self.resp.read()
+        return self._body
 
     def json(self):
-        return json.loads(self.resp.read())
+        return json.loads(self._read_body())
+
+    @property
+    def text(self):
+        return self._read_body().decode("utf-8", errors="replace")
 
     @property
     def status_code(self):

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -16,7 +16,7 @@ import warnings
 import weakref
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
-from functools import wraps
+from functools import cached_property, wraps
 from io import BytesIO
 from json import dumps
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
@@ -139,19 +139,17 @@ def normalize_base_url(host: str, port: int) -> str:
 class HttpResponse:
     def __init__(self, resp):
         self.resp = resp
-        self._body = None
 
-    def _read_body(self):
-        if self._body is None:
-            self._body = self.resp.read()
-        return self._body
+    @cached_property
+    def _body(self):
+        return self.resp.read()
 
     def json(self):
-        return json.loads(self._read_body())
+        return json.loads(self._body)
 
     @property
     def text(self):
-        return self._read_body().decode("utf-8", errors="replace")
+        return self._body.decode("utf-8", errors="replace")
 
     @property
     def status_code(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
`HttpResponse` in utils.py is a lightweight wrapper around urllib's raw response, providing `.json()` and `.status_code`. However, it has never had a `.text` property.

`RuntimeEndpoint._assert_success()` assumes .text exists as a fallback when `.json()` fails on error responses:
```
def _assert_success(self, res):
    if res.status_code != 200:
        try:
            content = res.json()
        except json.JSONDecodeError:
            content = res.text  # ← HttpResponse has no .text
        raise RuntimeError(content)
```
When a server returns a non-200 response (e.g. 500/502/404) with a non-JSON body, the full call chain is:
```
test_disaggregation_basic.py  TestDisaggregationAccuracy.test_gsm8k()
  → few_shot_gsm8k.py         run_eval() → RuntimeEndpoint(lb_url)
    → runtime_endpoint.py      __init__() → http_request(url + "/get_model_info")
      → utils.py               http_request() → urlopen() raises HTTPError
                                              → return HttpResponse(e)  # wraps the error
    → runtime_endpoint.py      _assert_success(res)
                                  res.status_code != 200  → True
                                  res.json()              → JSONDecodeError (body is not JSON)
                                  res.text                → 💥 AttributeError
```
This AttributeError masks the actual server error message, making it impossible to diagnose the root cause from CI logs. This is tracked as a 50% flaky failure in test_disaggregation_basic.py (Issue #17050).

Additionally, urllib's resp.read() is a one-shot stream — once consumed by .json(), a subsequent .text call would return empty content even if the attribute existed. This PR addresses both issues.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
