### PR TITLE
 [bugfix] Fix NSA indexer ragged gather batch-view mismatch in CP round-robin split

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -538,11 +538,15 @@ class Indexer(MultiPlatformOp):
 
         ks, ke = metadata.get_indexer_kvcache_range()
 
-        seq_len_sum = forward_batch.seq_lens_sum
-        max_seq_len = torch.max(forward_batch.seq_lens_cpu).item()
+        # In CP round-robin-split, page tables may be filtered by metadata. The KV
+        # gather inputs must use the same filtered batch view to stay aligned.
+        seq_lens = metadata.get_seqlens_int32()
+        seq_lens_cpu = metadata.get_indexer_seq_len_cpu()
+        seq_len_sum = int(seq_lens.sum().item())
+        max_seq_len = int(seq_lens_cpu.max().item()) if len(seq_lens_cpu) != 0 else 0
         k_fp8, k_scale = forward_batch.token_to_kv_pool.get_index_k_scale_buffer(
             layer_id,
-            forward_batch.seq_lens,
+            seq_lens,
             block_tables,
             seq_len_sum,
             max_seq_len,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
 This PR fixes a crash in the NSA indexer prefill path when context parallelism is enabled with round-robin-split.

  The issue was caused by mixing two different batch views in _get_topk_ragged():

  - block_tables was already filtered by CP metadata
  - seq_lens / seq_lens_sum / max_seq_len were still taken from the unfiltered forward_batch

  This made the ragged gather inputs inconsistent and could lead to invalid indexing, scheduler exceptions, or illegal memory access.

## Repro

  Launch server:
```
export MODEL_PATH=/root/.cache/models/DeepSeek-V3.2
python3 -m sglang.launch_server \
  --model-path $MODEL_PATH \
  --trust-remote-code \
  --port 8000 \
  --host 0.0.0.0 \
  --attention-backend nsa \
  --enable-metrics \
  --mem-fraction-static 0.8 \
  --max-running-requests 128 \
  --enable-cache-report \
  --page-size 64 \
  --tp-size 8 \
  --tool-call-parser deepseekv32 \
  --reasoning-parser deepseek-v3 \
  --chunked-prefill-size 16384 \
  --nsa-decode-backend fa3 \
  --enable-nsa-prefill-context-parallel \
  --attn-cp-size 8 \
  --nsa-prefill-cp-mode round-robin-split
```
 
  Repro command:
```
python3 -m sglang.bench_serving \
  --backend sglang \
  --dataset-name random-ids \
  --random-input-len 4000 \
  --random-output-len 1000 \
  --random-range-ratio 0 \
  --max-concurrency 8 \
  --num-prompts 40 \
  --warmup-requests 40 \
  --ready-check-timeout-sec 300 \
  --host 127.0.0.1 \
  --port 8000 \
  --output-file /tmp/isl4000_osl1000_bs8.jsonl \
  --disable-tqdm
```


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
GSM8K result after fix:

  - baseline: accuracy=0.949, invalid=0.000
  - opt: accuracy=0.950, invalid=0.000

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
