### PR TITLE
[Test] Fix OOM in TestQwen35PPAccuracy by setting mem-fraction-static

### DIFF
--- a/test/registered/distributed/test_pp_single_node.py
+++ b/test/registered/distributed/test_pp_single_node.py
@@ -368,6 +368,8 @@ class TestQwen35PPAccuracy(unittest.TestCase):
                 pp_size,
                 "--chunked-prefill-size",
                 256,
+                "--mem-fraction-static",
+                "0.9",
             ],
         )
 


### PR DESCRIPTION
## Summary
- Add `--mem-fraction-static 0.9` to `TestQwen35PPAccuracy` pipeline parallelism test to prevent OOM failures in CI

## Test plan
- [ ] Verify `TestQwen35PPAccuracy` passes in CI without OOM errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)