### PR TITLE
[bugfix] Add prev_prefix_len parameter to HiMambaRadixCache's _insert_helper()

### DIFF
--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -678,10 +678,6 @@ class HiMambaRadixCache(MambaRadixCache):
                 node = new_node
 
             if node.evicted:
-                # Unevicted nodes take ownership of the request's KV pages.
-                # Do NOT count them in total_prefix_length, otherwise
-                # cache_finished_req / cache_unfinished_req will free those
-                # pages even though the tree now references them.
                 self._unevict_node(node, value[:prefix_len])
             else:
                 if prev_prefix_len < total_prefix_length + prefix_len:

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -647,6 +647,7 @@ class HiMambaRadixCache(MambaRadixCache):
         value,
         mamba_value,
         chunked: bool = False,
+        prev_prefix_len: int = 0,
     ) -> Tuple[int, bool]:
         assert mamba_value is not None, "Mamba value should not be None here."
         node.last_access_time = get_last_access_time()
@@ -683,6 +684,9 @@ class HiMambaRadixCache(MambaRadixCache):
                 # pages even though the tree now references them.
                 self._unevict_node(node, value[:prefix_len])
             else:
+                if prev_prefix_len < total_prefix_length + prefix_len:
+                    start = max(0, prev_prefix_len - total_prefix_length)
+                    self.token_to_kv_pool_allocator.free(value[start:prefix_len])
                 total_prefix_length += prefix_len
                 self._inc_hit_count(node, chunked)
 


### PR DESCRIPTION
## Motivation

After PR #19429, new parameter prev_prefix_len was added to MambaRadixCache's _insert_helper() but is missing for HiMambaRadixCache's _insert_helper(). The parameter needs to be added.

Moreover, #19429 moved duplicate-prefix KV release into MambaRadixCache's  _insert_helper(), the same logic should also be applied to HiMambaRadixCache. 

The logic belongs only in the else branch, not under if node.evicted, because the two cases have different ownership semantics:
  - if node.evicted: the matched prefix has tree metadata but no live device KV. _unevict_node(node, value[:prefix_len]) restores that node from the request’s KV pages, so those pages are not duplicates and must be retained.
  - else: the matched prefix already has live device KV, so the corresponding request KV pages are redundant. Pages beyond prev_prefix_len should be freed here, matching MambaRadixCache behavior.

## Modifications

prev_prefix_len is added and duplicate KV release logic is also added

## Accuracy Tests

## Benchmarking and Profiling

## Misc

I realized that no unittest was added against HiMambaRadixCache when it was introduced in PR #19663, maybe I can help to add one in new future to cover similar mistakes.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
