### PR TITLE
[Fix] Pass input_embeds through to language_model in multimodal models

### DIFF
--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -386,6 +386,11 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
         # This really does cost me sometime
         positions += 1
 
+        if input_embeds is not None:
+            return self.language_model(
+                input_ids, positions, forward_batch, input_embeds, **kwargs
+            )
+
         # Replace image id with PAD if the image token if OOV, to avoid index-errors
         if input_ids is not None and self.config.image_token_index >= self.vocab_size:
             special_image_mask = input_ids == self.config.image_token_index

--- a/python/sglang/srt/models/gemma3n_mm.py
+++ b/python/sglang/srt/models/gemma3n_mm.py
@@ -421,10 +421,8 @@ class Gemma3nForConditionalGeneration(PreTrainedModel):
                 forward_batch,
             )
 
-        if (input_ids is None) ^ (input_embeds is not None):
-            raise ValueError(
-                "You must specify exactly one of input_ids or inputs_embeds"
-            )
+        if input_ids is None:
+            raise ValueError("input_ids must be provided when input_embeds is not.")
 
         if input_ids is not None:
             # Prepare per-layer inputs from inputs_ids

--- a/python/sglang/srt/models/gemma3n_mm.py
+++ b/python/sglang/srt/models/gemma3n_mm.py
@@ -408,12 +408,24 @@ class Gemma3nForConditionalGeneration(PreTrainedModel):
         **kwargs: object,
     ) -> LogitsProcessor:
         """Forward pass for multimodal Gemma3n."""
+        positions += 1
+
+        if input_embeds is not None:
+            hidden_states = self.language_model(
+                None, positions, forward_batch, input_embeds, **kwargs
+            )
+            return self.logits_processor(
+                input_ids,
+                hidden_states,
+                self.language_model.embed_tokens,
+                forward_batch,
+            )
+
         if (input_ids is None) ^ (input_embeds is not None):
             raise ValueError(
                 "You must specify exactly one of input_ids or inputs_embeds"
             )
 
-        positions += 1
         if input_ids is not None:
             # Prepare per-layer inputs from inputs_ids
             per_layer_inputs_mask = torch.logical_and(

--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -641,6 +641,10 @@ class InternVLChatModel(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: torch.Tensor = None,
     ) -> torch.Tensor:
+        if input_embeds is not None:
+            return self.language_model(
+                input_ids, positions, forward_batch, input_embeds
+            )
 
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -761,14 +761,23 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
                     f"(3, seq_len) positions, but got {positions.size()}"
                 )
 
-        hidden_states = general_mm_embed_routine(
-            input_ids=input_ids,
-            forward_batch=forward_batch,
-            language_model=self.model,
-            multimodal_model=self,
-            positions=positions,
-            pp_proxy_tensors=pp_proxy_tensors,
-        )
+        if input_embeds is not None:
+            hidden_states = self.model(
+                input_ids,
+                positions,
+                forward_batch,
+                input_embeds,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+        else:
+            hidden_states = general_mm_embed_routine(
+                input_ids=input_ids,
+                forward_batch=forward_batch,
+                language_model=self.model,
+                multimodal_model=self,
+                positions=positions,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
 
         aux_hidden_states = None
         if self.capture_aux_hidden_states:

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -554,13 +554,18 @@ class Qwen2VLForConditionalGeneration(nn.Module):
                     f"(3, seq_len) positions, but got {positions.size()}"
                 )
 
-        hidden_states = general_mm_embed_routine(
-            input_ids=input_ids,
-            forward_batch=forward_batch,
-            language_model=self.model,
-            multimodal_model=self,
-            positions=positions,
-        )
+        if input_embeds is not None:
+            hidden_states = self.model(
+                input_ids, positions, forward_batch, input_embeds
+            )
+        else:
+            hidden_states = general_mm_embed_routine(
+                input_ids=input_ids,
+                forward_batch=forward_batch,
+                language_model=self.model,
+                multimodal_model=self,
+                positions=positions,
+            )
 
         if get_embedding:
             return self.pooler(hidden_states, forward_batch)

--- a/python/sglang/srt/models/step3_vl.py
+++ b/python/sglang/srt/models/step3_vl.py
@@ -865,6 +865,14 @@ class Step3VLForConditionalGeneration(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: torch.Tensor = None,
     ) -> torch.Tensor:
+        if input_embeds is not None:
+            hidden_states = self.model(
+                input_ids, positions, forward_batch, input_embeds
+            )
+            return self.logits_processor(
+                input_ids, hidden_states, self.lm_head, forward_batch
+            )
+
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,


### PR DESCRIPTION
## Motivation

Six multimodal model wrappers accept `input_embeds` in their `forward()` signature but **silently drop it** — `general_mm_embed_routine` does its own embedding lookup from `input_ids` and never sees the precomputed embeds. Requests providing `input_embeds` (e.g. for RL with learned embeddings) produce garbage output because the model embeds the fake `[1]*seq_len` placeholder input_ids from the scheduler instead.

Affected models (all have `input_embeds` in the signature with zero body references):

| Model | Class |
|---|---|
| `gemma3_mm.py` | `Gemma3ForConditionalGeneration` |
| `gemma3n_mm.py` | `Gemma3nForConditionalGeneration` |
| `qwen2_vl.py` | `Qwen2VLForConditionalGeneration` |
| `qwen2_5_vl.py` | `Qwen2_5_VLForConditionalGeneration` |
| `internvl.py` | `InternVLChatModel` |
| `step3_vl.py` | `Step3VLForConditionalGeneration` |

The underlying text models (`Gemma3ForCausalLM`, `Qwen2Model`, etc.) already handle `input_embeds` correctly — they just never receive it.

## Modifications

When `input_embeds is not None`, bypass `general_mm_embed_routine` and call the language model directly. Per-model adaptations:

- **gemma3_mm, gemma3n_mm**: `positions += 1` must happen before the bypass (Gemma3 uses 1-indexed positions). gemma3n additionally passes `input_ids=None` to its text model (which has an XOR check rejecting both) and calls `logits_processor` separately since its `language_model` is the backbone, not a ForCausalLM.
- **qwen2_vl, qwen2_5_vl**: if/else on `hidden_states` so the `get_embedding` / `pp_group` / `aux_hidden_states` tail stays shared (no early-return, no duplication).
- **internvl**: simplest — `language_model` is a ForCausalLM returning logits directly.
- **step3_vl**: `self.model` is the backbone, `logits_processor` called after.

## Accuracy Tests

Verified manually on Gemma3-4B-Instruct with `--disable-radix-cache` — before fix, `input_embeds` requests returned repeated `\"\\n\"` garbage; after fix, output matches the equivalent `input_ids` request.

The existing `test/registered/core/test_input_embeddings.py` uses a text-only model (Llama-3.2-1B) so doesn't exercise MM wrappers. Adding a gemma3/qwen-vl input_embeds test would require loading a larger VLM — happy to add one if desired.

## Benchmarking and Profiling

N/A — early-return, no hot-path changes for the MM image/video case.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [ ] Add unit tests — manual verification on gemma3 (see above); VLM model load cost for a CI test is substantial
- [ ] Update documentation as needed — N/A