### PR TITLE
[Bugfix] Fix write-through events not processed when scheduler is idle

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2145,6 +2145,9 @@ class Scheduler(
             for req in ready_grammar_requests:
                 self._add_request_to_queue(req)
 
+        if self.enable_hierarchical_cache:
+            self.tree_cache.check_hicache_events()
+
         if self.enable_priority_preemption:
             # Reset batch_is_full to try preemption with a prefill adder.
             self.running_batch.batch_is_full = False
@@ -2168,9 +2171,6 @@ class Scheduler(
         ):
             self.running_batch.batch_is_full = True
             return None
-
-        if self.enable_hierarchical_cache:
-            self.tree_cache.check_hicache_events()
 
         # Get priority queue
         self.policy.calc_priority(self.waiting_queue, self.running_batch)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

### Motivation

I am developing CXL memory-based KV cache sharing ([Maru](https://github.com/xcena-dev/maru)). HiCache's 3-tier hierarchy (L1 GPU → L2 Host → L3 Storage) is a great fit for this, so I integrated it as an L3 backend and started validation testing.

During KV sharing tests between two SGLang instances, I found that write-through completions are never flushed to L3 storage while the scheduler is idle. `check_hicache_events()` is called inside `_get_new_batch_prefill_raw()` after an early return that fires when `waiting_queue` is empty. During idle periods, the method returns before reaching `check_hicache_events()`, so the write-through pipeline (GPU→Host→L3) never completes and the other instance sees zero cache hits.
This bug affects all HiCache L3 backends (not just Maru) when using write-through policy.

### Modifications

Move `check_hicache_events()` call before the early-return condition in `_get_new_batch_prefill_raw()`, so write-through completions and prefetch events are processed on every scheduler tick regardless of whether new prefill work is available.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).