### PR TITLE
feat: emit per-iteration forward pass metrics via ZMQ PUB

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1293,6 +1293,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     split_forward_batch: ForwardBatch = None
     seq_lens_cpu_cache: torch.Tensor = None
 
+    # Forward-pass metrics
+    fpm_start_time: float = 0.0
+
     # Stream
     has_stream: bool = False
 
@@ -2312,6 +2315,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_seqlens=self.mamba_track_seqlens,
             dp_cooperation_info=self.dp_cooperation_info,
             prefill_stats=self.prefill_stats,
+            fpm_start_time=self.fpm_start_time,
         )
 
     def maybe_evict_swa(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2618,6 +2618,11 @@ class Scheduler(
             self.process_batch_result_idle(batch, result)
 
         self.log_batch_result_stats(batch, result)
+
+        # Emit forward pass metrics (every iteration when enabled)
+        if self.enable_fpm:
+            self._emit_forward_pass_metrics(batch)
+
         self._maybe_clear_mm_inputs(batch)
         self.maybe_send_health_check_signal()
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2440,6 +2440,7 @@ class Scheduler(
     ) -> Union[GenerationBatchResult, EmbeddingBatchResult]:
         """Run a batch."""
         self.forward_ct += 1
+        batch.fpm_start_time = time.monotonic()
 
         # Whether to run the profiler
         self._profile_batch_predicate(batch)

--- a/python/sglang/srt/observability/forward_pass_metrics.py
+++ b/python/sglang/srt/observability/forward_pass_metrics.py
@@ -1,0 +1,211 @@
+"""
+Forward pass metrics for per-iteration scheduler telemetry.
+
+Emits per-iteration scheduling metrics over ZMQ PUB so that external
+consumers can observe scheduler behavior in real time without polling
+Prometheus.
+
+Uses msgspec.Struct for zero-copy serialization.
+
+Data flow::
+
+    Scheduler process:
+        SchedulerMetricsMixin._emit_forward_pass_metrics()
+          -> _FpmPublisherThread -> ZMQ PUB (localhost)
+
+    External consumer:
+        ZMQ SUB -> deserialize ForwardPassMetrics
+
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from itertools import count
+
+import msgspec
+
+logger = logging.getLogger(__name__)
+
+
+class WelfordAccumulator:
+    """Welford's online algorithm for count / sum / population-variance.
+
+    Numerically stable single-pass computation.
+    """
+
+    __slots__ = ("n", "s", "_mean", "_m2")
+
+    def __init__(self) -> None:
+        self.n = 0
+        self.s = 0
+        self._mean = 0.0
+        self._m2 = 0.0
+
+    def add(self, v: int) -> None:
+        self.n += 1
+        self.s += v
+        delta = v - self._mean
+        self._mean += delta / self.n
+        delta2 = v - self._mean
+        self._m2 += delta * delta2
+
+    def variance(self) -> float:
+        if self.n == 0:
+            return 0.0
+        return self._m2 / self.n
+
+
+class ScheduledRequestMetrics(
+    msgspec.Struct,
+    frozen=True,
+    gc=False,
+):
+    """Metrics for requests scheduled in this iteration."""
+
+    num_prefill_requests: int = 0
+    sum_prefill_tokens: int = 0
+    var_prefill_length: float = 0.0
+    sum_prefill_kv_tokens: int = 0
+    num_decode_requests: int = 0
+    sum_decode_kv_tokens: int = 0
+    var_decode_kv_tokens: float = 0.0
+
+
+class QueuedRequestMetrics(
+    msgspec.Struct,
+    frozen=True,
+    gc=False,
+):
+    """Metrics for requests waiting in the queue."""
+
+    num_prefill_requests: int = 0
+    sum_prefill_tokens: int = 0
+    var_prefill_length: float = 0.0
+    num_decode_requests: int = 0
+    sum_decode_kv_tokens: int = 0
+    var_decode_kv_tokens: float = 0.0
+
+
+class ForwardPassMetrics(
+    msgspec.Struct,
+    frozen=True,
+    gc=False,
+):
+    """Per-iteration metrics emitted by the scheduler.
+
+    One message per scheduler iteration (one per forward pass).
+    ``wall_time`` is ``time.monotonic()`` at emit time; consumers can
+    compute inter-iteration cadence from successive deltas.
+    An idle heartbeat (all zeros, wall_time=0) is emitted when the
+    engine transitions from active to idle.
+    """
+
+    worker_id: str = ""
+    dp_rank: int = 0
+    wall_time: float = 0.0
+    scheduled_requests: ScheduledRequestMetrics = ScheduledRequestMetrics()
+    queued_requests: QueuedRequestMetrics = QueuedRequestMetrics()
+
+
+_encoder = msgspec.msgpack.Encoder()
+_decoder = msgspec.msgpack.Decoder(ForwardPassMetrics)
+
+
+def encode(metrics: ForwardPassMetrics) -> bytes:
+    return _encoder.encode(metrics)
+
+
+def decode(data: bytes) -> ForwardPassMetrics:
+    return _decoder.decode(data)
+
+
+class _FpmPublisherThread:
+    """Background thread that serializes and sends ForwardPassMetrics over ZMQ.
+
+    Also emits periodic heartbeats when idle.
+    """
+
+    SHUTDOWN_TIMEOUT: float = 1.0
+    HEARTBEAT_INTERVAL: float = 1.0
+
+    def __init__(
+        self,
+        endpoint: str,
+        worker_id: str,
+        dp_rank: int,
+        max_queue_size: int = 10_000,
+    ) -> None:
+        import zmq
+
+        self._queue: queue.Queue[ForwardPassMetrics | None] = queue.Queue(
+            maxsize=max_queue_size
+        )
+        self._seq = count()
+        self._worker_id = worker_id
+        self._dp_rank = dp_rank
+
+        self._ctx = zmq.Context.instance()
+        self._pub = self._ctx.socket(zmq.PUB)
+        self._pub.bind(endpoint)
+        self._zmq = zmq
+
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="fpm-zmq-publisher"
+        )
+        self._thread.start()
+
+    def publish(self, metrics: ForwardPassMetrics) -> None:
+        if not self._running:
+            return
+        try:
+            self._queue.put_nowait(metrics)
+        except queue.Full:
+            pass
+
+    def shutdown(self) -> None:
+        self._running = False
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass
+        self._thread.join(timeout=self.SHUTDOWN_TIMEOUT)
+        try:
+            self._pub.close(linger=0)
+        except Exception:
+            pass
+
+    def _run(self) -> None:
+        zmq = self._zmq
+        topic = b""
+        last_publish = time.monotonic()
+
+        while self._running or not self._queue.empty():
+            try:
+                metrics = self._queue.get(timeout=self.HEARTBEAT_INTERVAL)
+                if metrics is None:
+                    break
+            except queue.Empty:
+                if time.monotonic() - last_publish >= self.HEARTBEAT_INTERVAL:
+                    metrics = ForwardPassMetrics(
+                        worker_id=self._worker_id,
+                        dp_rank=self._dp_rank,
+                    )
+                else:
+                    continue
+
+            try:
+                payload = encode(metrics)
+                seq_bytes = next(self._seq).to_bytes(8, "big")
+                self._pub.send_multipart(
+                    (topic, seq_bytes, payload), flags=zmq.NOBLOCK
+                )
+                last_publish = time.monotonic()
+            except zmq.Again:
+                pass
+            except Exception:
+                logger.warning("FPM publisher send failed", exc_info=True)

--- a/python/sglang/srt/observability/forward_pass_metrics.py
+++ b/python/sglang/srt/observability/forward_pass_metrics.py
@@ -98,8 +98,7 @@ class ForwardPassMetrics(
     """Per-iteration metrics emitted by the scheduler.
 
     One message per scheduler iteration (one per forward pass).
-    ``wall_time`` is ``time.monotonic()`` at emit time; consumers can
-    compute inter-iteration cadence from successive deltas.
+    ``wall_time`` is the iteration duration in seconds.
     An idle heartbeat (all zeros, wall_time=0) is emitted when the
     engine transitions from active to idle.
     """

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -170,7 +170,9 @@ class SchedulerMetricsMixin:
 
             self._fpm_dp_rank = self.dp_rank if self.dp_rank is not None else 0
             port = fpm_base_port + self._fpm_dp_rank
-            self._fpm_worker_id = ""
+            self._fpm_worker_id = getattr(
+                self.server_args, "forward_pass_metrics_worker_id", ""
+            )
             self._fpm_publisher = _FpmPublisherThread(
                 f"tcp://*:{port}",
                 worker_id=self._fpm_worker_id,
@@ -192,6 +194,78 @@ class SchedulerMetricsMixin:
             self.kv_event_publisher = EventPublisherFactory.create(
                 kv_events_config, self.attn_dp_rank
             )
+
+    def _build_scheduled_request_metrics(self: Scheduler, batch: ScheduleBatch):
+        from sglang.srt.observability.forward_pass_metrics import (
+            ScheduledRequestMetrics,
+            WelfordAccumulator,
+        )
+
+        num_prefill_requests = 0
+        sum_prefill_tokens = 0
+        sum_prefill_kv_tokens = 0
+        prefill_lengths = WelfordAccumulator()
+
+        if batch.forward_mode.is_mixed():
+            decode_req_ids = {
+                id(req) for req in batch.decoding_reqs or []
+            }
+            prefill_reqs = [
+                req for req in batch.reqs if id(req) not in decode_req_ids
+            ]
+        elif batch.forward_mode.is_extend():
+            prefill_reqs = batch.reqs
+        else:
+            prefill_reqs = []
+
+        if prefill_reqs:
+            stats = batch.prefill_stats
+            for req in prefill_reqs:
+                prefill_lengths.add(len(req.origin_input_ids))
+            num_prefill_requests = stats.num_new_seqs if stats else len(prefill_reqs)
+            sum_prefill_tokens = stats.log_input_tokens if stats else 0
+            sum_prefill_kv_tokens = stats.log_hit_tokens if stats else 0
+
+        decode_kv = WelfordAccumulator()
+        if batch.forward_mode.is_mixed():
+            for req in batch.decoding_reqs or []:
+                decode_kv.add(req.seqlen)
+        elif batch.forward_mode.is_decode():
+            for sl in batch.seq_lens_cpu:
+                decode_kv.add(int(sl))
+
+        return ScheduledRequestMetrics(
+            num_prefill_requests=num_prefill_requests,
+            sum_prefill_tokens=sum_prefill_tokens,
+            var_prefill_length=prefill_lengths.variance(),
+            sum_prefill_kv_tokens=sum_prefill_kv_tokens,
+            num_decode_requests=decode_kv.n,
+            sum_decode_kv_tokens=decode_kv.s,
+            var_decode_kv_tokens=decode_kv.variance(),
+        )
+
+    def _build_queued_request_metrics(self: Scheduler):
+        from sglang.srt.observability.forward_pass_metrics import (
+            QueuedRequestMetrics,
+            WelfordAccumulator,
+        )
+
+        prefill_q = WelfordAccumulator()
+        decode_q = WelfordAccumulator()
+        for req in self.waiting_queue:
+            if len(req.output_ids) > 0:
+                decode_q.add(req.seqlen)
+            else:
+                prefill_q.add(len(req.origin_input_ids))
+
+        return QueuedRequestMetrics(
+            num_prefill_requests=prefill_q.n,
+            sum_prefill_tokens=prefill_q.s,
+            var_prefill_length=prefill_q.variance(),
+            num_decode_requests=decode_q.n,
+            sum_decode_kv_tokens=decode_q.s,
+            var_decode_kv_tokens=decode_q.variance(),
+        )
 
     def update_spec_metrics(self: Scheduler, bs: int, num_accepted_tokens: int):
         self.spec_num_accepted_tokens += num_accepted_tokens + bs
@@ -639,61 +713,14 @@ class SchedulerMetricsMixin:
 
         from sglang.srt.observability.forward_pass_metrics import (
             ForwardPassMetrics,
-            QueuedRequestMetrics,
-            ScheduledRequestMetrics,
-            WelfordAccumulator,
-        )
-
-        # Scheduled requests
-        if batch.forward_mode.is_extend():
-            prefill_lengths = WelfordAccumulator()
-            for req in batch.reqs:
-                prefill_lengths.add(len(req.origin_input_ids))
-
-            stats = batch.prefill_stats
-            scheduled = ScheduledRequestMetrics(
-                num_prefill_requests=stats.num_new_seqs if stats else len(batch.reqs),
-                sum_prefill_tokens=stats.log_input_tokens if stats else 0,
-                sum_prefill_kv_tokens=stats.log_hit_tokens if stats else 0,
-                var_prefill_length=prefill_lengths.variance(),
-            )
-        elif batch.forward_mode.is_decode():
-            decode_kv = WelfordAccumulator()
-            for sl in batch.seq_lens_cpu:
-                decode_kv.add(int(sl))
-
-            scheduled = ScheduledRequestMetrics(
-                num_decode_requests=decode_kv.n,
-                sum_decode_kv_tokens=decode_kv.s,
-                var_decode_kv_tokens=decode_kv.variance(),
-            )
-        else:
-            scheduled = ScheduledRequestMetrics()
-
-        # Queued requests
-        prefill_q = WelfordAccumulator()
-        decode_q = WelfordAccumulator()
-        for req in self.waiting_queue:
-            if len(req.output_ids) > 0:
-                decode_q.add(req.seqlen)
-            else:
-                prefill_q.add(len(req.origin_input_ids))
-
-        queued = QueuedRequestMetrics(
-            num_prefill_requests=prefill_q.n,
-            sum_prefill_tokens=prefill_q.s,
-            var_prefill_length=prefill_q.variance(),
-            num_decode_requests=decode_q.n,
-            sum_decode_kv_tokens=decode_q.s,
-            var_decode_kv_tokens=decode_q.variance(),
         )
 
         fpm = ForwardPassMetrics(
             worker_id=self._fpm_worker_id,
             dp_rank=self._fpm_dp_rank,
-            wall_time=time.monotonic(),
-            scheduled_requests=scheduled,
-            queued_requests=queued,
+            wall_time=max(0.0, time.monotonic() - batch.fpm_start_time),
+            scheduled_requests=self._build_scheduled_request_metrics(batch),
+            queued_requests=self._build_queued_request_metrics(),
         )
         self._fpm_publisher.publish(fpm)
 

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -160,6 +160,29 @@ class SchedulerMetricsMixin:
         if self.enable_kv_cache_events:
             self.init_kv_events(self.server_args.kv_events_config)
 
+        # Forward Pass Metrics (FPM) -- per-iteration scheduler telemetry
+        self.enable_fpm = False
+        fpm_base_port = self.server_args.forward_pass_metrics_port
+        if fpm_base_port is not None and self.attn_tp_rank == 0:
+            from sglang.srt.observability.forward_pass_metrics import (
+                _FpmPublisherThread,
+            )
+
+            self._fpm_dp_rank = self.dp_rank if self.dp_rank is not None else 0
+            port = fpm_base_port + self._fpm_dp_rank
+            self._fpm_worker_id = ""
+            self._fpm_publisher = _FpmPublisherThread(
+                f"tcp://*:{port}",
+                worker_id=self._fpm_worker_id,
+                dp_rank=self._fpm_dp_rank,
+            )
+            self.enable_fpm = True
+            logger.info(
+                "FPM: ZMQ PUB bound on tcp://*:%d (dp_rank=%d)",
+                port,
+                self._fpm_dp_rank,
+            )
+
         self.scheduler_status_logger = SchedulerStatusLogger.maybe_create(
             enable_metrics=self.enable_metrics
         )
@@ -605,6 +628,79 @@ class SchedulerMetricsMixin:
         if events:
             batch = KVEventBatch(ts=time.time(), events=events)
             self.kv_event_publisher.publish(batch)
+
+    def _emit_forward_pass_metrics(
+        self: Scheduler,
+        batch: ScheduleBatch,
+    ):
+        """Emit per-iteration ForwardPassMetrics over ZMQ PUB."""
+        if not self.enable_fpm:
+            return
+
+        from sglang.srt.observability.forward_pass_metrics import (
+            ForwardPassMetrics,
+            QueuedRequestMetrics,
+            ScheduledRequestMetrics,
+            WelfordAccumulator,
+        )
+
+        # Scheduled requests
+        if batch.forward_mode.is_extend():
+            prefill_lengths = WelfordAccumulator()
+            for req in batch.reqs:
+                prefill_lengths.add(len(req.origin_input_ids))
+
+            stats = batch.prefill_stats
+            scheduled = ScheduledRequestMetrics(
+                num_prefill_requests=stats.num_new_seqs if stats else len(batch.reqs),
+                sum_prefill_tokens=stats.log_input_tokens if stats else 0,
+                sum_prefill_kv_tokens=stats.log_hit_tokens if stats else 0,
+                var_prefill_length=prefill_lengths.variance(),
+            )
+        elif batch.forward_mode.is_decode():
+            decode_kv = WelfordAccumulator()
+            for sl in batch.seq_lens_cpu:
+                decode_kv.add(int(sl))
+
+            scheduled = ScheduledRequestMetrics(
+                num_decode_requests=decode_kv.n,
+                sum_decode_kv_tokens=decode_kv.s,
+                var_decode_kv_tokens=decode_kv.variance(),
+            )
+        else:
+            scheduled = ScheduledRequestMetrics()
+
+        # Queued requests
+        prefill_q = WelfordAccumulator()
+        decode_q = WelfordAccumulator()
+        for req in self.waiting_queue:
+            if len(req.output_ids) > 0:
+                decode_q.add(req.seqlen)
+            else:
+                prefill_q.add(len(req.origin_input_ids))
+
+        queued = QueuedRequestMetrics(
+            num_prefill_requests=prefill_q.n,
+            sum_prefill_tokens=prefill_q.s,
+            var_prefill_length=prefill_q.variance(),
+            num_decode_requests=decode_q.n,
+            sum_decode_kv_tokens=decode_q.s,
+            var_decode_kv_tokens=decode_q.variance(),
+        )
+
+        fpm = ForwardPassMetrics(
+            worker_id=self._fpm_worker_id,
+            dp_rank=self._fpm_dp_rank,
+            wall_time=time.monotonic(),
+            scheduled_requests=scheduled,
+            queued_requests=queued,
+        )
+        self._fpm_publisher.publish(fpm)
+
+    def _shutdown_fpm(self: Scheduler):
+        """Shut down the FPM publisher thread."""
+        if self.enable_fpm:
+            self._fpm_publisher.shutdown()
 
     def _log_hicache_stats(self: Scheduler):
         """Populate HiCache host-tier stats on self.stats.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -409,6 +409,7 @@ class ServerArgs:
     decode_log_interval: int = 40
     enable_request_time_stats_logging: bool = False
     kv_events_config: Optional[str] = None
+    forward_pass_metrics_port: Optional[int] = None
     enable_trace: bool = False
     otlp_traces_endpoint: str = "localhost:4317"
 
@@ -4033,6 +4034,13 @@ class ServerArgs:
             type=str,
             default=None,
             help="Config in json format for NVIDIA dynamo KV event publishing. Publishing will be enabled if this flag is used.",
+        )
+        parser.add_argument(
+            "--forward-pass-metrics-port",
+            type=int,
+            default=None,
+            help="Base TCP port for per-iteration forward pass metrics ZMQ publisher. "
+            "Each DP rank binds on port + dp_rank. Disabled when not set.",
         )
         parser.add_argument(
             "--enable-trace",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -410,6 +410,7 @@ class ServerArgs:
     enable_request_time_stats_logging: bool = False
     kv_events_config: Optional[str] = None
     forward_pass_metrics_port: Optional[int] = None
+    forward_pass_metrics_worker_id: str = ""
     enable_trace: bool = False
     otlp_traces_endpoint: str = "localhost:4317"
 

--- a/test/manual/test_forward_pass_metrics.py
+++ b/test/manual/test_forward_pass_metrics.py
@@ -1,0 +1,191 @@
+"""
+Manual test for Forward Pass Metrics (FPM) ZMQ PUB/SUB path.
+
+Tests:
+1. Schema encode/decode roundtrip
+2. _FpmPublisherThread ZMQ PUB -> ZMQ SUB end-to-end
+3. Heartbeat emission on idle
+"""
+
+import sys
+import time
+
+import zmq
+
+
+def test_schema_roundtrip():
+    from sglang.srt.observability.forward_pass_metrics import (
+        ForwardPassMetrics,
+        QueuedRequestMetrics,
+        ScheduledRequestMetrics,
+        WelfordAccumulator,
+        decode,
+        encode,
+    )
+
+    # WelfordAccumulator
+    acc = WelfordAccumulator()
+    for v in [10, 20, 30]:
+        acc.add(v)
+    assert acc.n == 3
+    assert acc.s == 60
+    var = acc.variance()
+    assert abs(var - 66.667) < 0.01, f"Expected ~66.667, got {var}"
+
+    # Encode/decode roundtrip
+    fpm = ForwardPassMetrics(
+        worker_id="test-worker",
+        dp_rank=1,
+        wall_time=0.042,
+        scheduled_requests=ScheduledRequestMetrics(
+            num_prefill_requests=5,
+            sum_prefill_tokens=1024,
+            var_prefill_length=33.3,
+            sum_prefill_kv_tokens=512,
+            num_decode_requests=32,
+            sum_decode_kv_tokens=8192,
+            var_decode_kv_tokens=100.0,
+        ),
+        queued_requests=QueuedRequestMetrics(
+            num_prefill_requests=3,
+            sum_prefill_tokens=768,
+            var_prefill_length=25.0,
+            num_decode_requests=1,
+            sum_decode_kv_tokens=128,
+            var_decode_kv_tokens=0.0,
+        ),
+    )
+
+    data = encode(fpm)
+    fpm2 = decode(data)
+
+    assert fpm2.worker_id == "test-worker"
+    assert fpm2.dp_rank == 1
+    assert fpm2.wall_time == 0.042
+    assert fpm2.scheduled_requests.num_prefill_requests == 5
+    assert fpm2.scheduled_requests.sum_prefill_tokens == 1024
+    assert fpm2.scheduled_requests.num_decode_requests == 32
+    assert fpm2.queued_requests.num_prefill_requests == 3
+
+    print("PASS: schema roundtrip")
+
+
+def test_zmq_pub_sub():
+    """Test _FpmPublisherThread -> ZMQ SUB end-to-end."""
+    from sglang.srt.observability.forward_pass_metrics import (
+        ForwardPassMetrics,
+        ScheduledRequestMetrics,
+        _FpmPublisherThread,
+        decode,
+    )
+
+    port = 29999
+    endpoint = f"tcp://127.0.0.1:{port}"
+
+    # Start publisher
+    pub = _FpmPublisherThread(
+        f"tcp://*:{port}",
+        worker_id="test-pub",
+        dp_rank=0,
+    )
+
+    # Connect subscriber
+    ctx = zmq.Context()
+    sub = ctx.socket(zmq.SUB)
+    sub.connect(endpoint)
+    sub.setsockopt(zmq.SUBSCRIBE, b"")
+    sub.setsockopt(zmq.RCVTIMEO, 5000)  # 5s timeout
+
+    # ZMQ PUB/SUB needs time to connect
+    time.sleep(0.5)
+
+    # Publish a metric
+    fpm = ForwardPassMetrics(
+        worker_id="test-pub",
+        dp_rank=0,
+        wall_time=0.05,
+        scheduled_requests=ScheduledRequestMetrics(
+            num_prefill_requests=10,
+            sum_prefill_tokens=2048,
+            num_decode_requests=64,
+            sum_decode_kv_tokens=16384,
+        ),
+    )
+    pub.publish(fpm)
+
+    # Receive
+    frames = sub.recv_multipart()
+    assert len(frames) == 3, f"Expected 3 frames, got {len(frames)}"
+
+    topic, seq_bytes, payload = frames
+    assert topic == b""
+    seq = int.from_bytes(seq_bytes, "big")
+    assert seq == 0
+
+    received = decode(payload)
+    assert received.worker_id == "test-pub"
+    assert received.scheduled_requests.num_prefill_requests == 10
+    assert received.scheduled_requests.sum_decode_kv_tokens == 16384
+    print(f"PASS: ZMQ PUB/SUB (seq={seq}, {len(payload)} bytes)")
+
+    # Publish a second message -- seq should increment
+    pub.publish(fpm)
+    frames2 = sub.recv_multipart()
+    seq2 = int.from_bytes(frames2[1], "big")
+    assert seq2 == 1, f"Expected seq=1, got {seq2}"
+    print(f"PASS: sequence incremented (seq={seq2})")
+
+    # Cleanup
+    pub.shutdown()
+    sub.close()
+    ctx.term()
+
+
+def test_heartbeat():
+    """Test that heartbeat messages are emitted when idle."""
+    from sglang.srt.observability.forward_pass_metrics import (
+        _FpmPublisherThread,
+        decode,
+    )
+
+    port = 29998
+    endpoint = f"tcp://127.0.0.1:{port}"
+
+    pub = _FpmPublisherThread(
+        f"tcp://*:{port}",
+        worker_id="heartbeat-test",
+        dp_rank=0,
+    )
+    # Override heartbeat interval for faster test
+    pub.HEARTBEAT_INTERVAL = 0.3
+
+    ctx = zmq.Context()
+    sub = ctx.socket(zmq.SUB)
+    sub.connect(endpoint)
+    sub.setsockopt(zmq.SUBSCRIBE, b"")
+    sub.setsockopt(zmq.RCVTIMEO, 3000)
+
+    time.sleep(0.5)
+
+    # Don't publish anything -- wait for heartbeat
+    try:
+        frames = sub.recv_multipart()
+        heartbeat = decode(frames[2])
+        assert heartbeat.worker_id == "heartbeat-test"
+        assert heartbeat.wall_time == 0.0  # idle heartbeat
+        assert heartbeat.scheduled_requests.num_prefill_requests == 0
+        print("PASS: heartbeat received")
+    except zmq.Again:
+        print("FAIL: no heartbeat received within timeout")
+        sys.exit(1)
+
+    pub.shutdown()
+    sub.close()
+    ctx.term()
+
+
+if __name__ == "__main__":
+    test_schema_roundtrip()
+    test_zmq_pub_sub()
+    test_heartbeat()
+    print("\nAll tests passed!")

--- a/test/unit/test_forward_pass_metrics.py
+++ b/test/unit/test_forward_pass_metrics.py
@@ -1,0 +1,130 @@
+import types
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.observability.scheduler_metrics_mixin import (
+    PrefillStats,
+    SchedulerMetricsMixin,
+)
+
+
+class _FakeReq:
+    def __init__(self, prompt_len: int, output_len: int = 0):
+        self.origin_input_ids = list(range(prompt_len))
+        self.output_ids = list(range(output_len))
+        self.seqlen = prompt_len + output_len
+
+
+class _FakeForwardMode:
+    def __init__(self, *, is_mixed: bool = False, is_extend: bool = False):
+        self._is_mixed = is_mixed
+        self._is_extend = is_extend
+
+    def is_mixed(self):
+        return self._is_mixed
+
+    def is_extend(self, include_draft_extend_v2: bool = False):
+        return self._is_extend
+
+    def is_decode(self):
+        return not self._is_mixed and not self._is_extend
+
+
+class _CollectingPublisher:
+    def __init__(self):
+        self.metrics = []
+
+    def publish(self, metrics):
+        self.metrics.append(metrics)
+
+
+class _DummyPublisherThread:
+    def __init__(self, endpoint: str, worker_id: str, dp_rank: int, **_: object):
+        self.endpoint = endpoint
+        self.worker_id = worker_id
+        self.dp_rank = dp_rank
+
+    def shutdown(self):
+        pass
+
+
+class _DummyScheduler(SchedulerMetricsMixin):
+    pass
+
+
+class TestForwardPassMetrics(unittest.TestCase):
+    def test_emit_mixed_batch_separates_prefill_and_decode(self):
+        scheduler = _DummyScheduler()
+        scheduler.enable_fpm = True
+        scheduler._fpm_worker_id = "worker-7"
+        scheduler._fpm_dp_rank = 3
+        scheduler._fpm_publisher = _CollectingPublisher()
+        scheduler.waiting_queue = [_FakeReq(6), _FakeReq(4, output_len=2)]
+
+        prefill_a = _FakeReq(10)
+        prefill_b = _FakeReq(14)
+        decode_req = _FakeReq(8, output_len=3)
+        batch = types.SimpleNamespace(
+            forward_mode=_FakeForwardMode(is_mixed=True, is_extend=True),
+            reqs=[prefill_a, prefill_b, decode_req],
+            decoding_reqs=[decode_req],
+            prefill_stats=PrefillStats(
+                log_input_tokens=12,
+                log_hit_tokens=5,
+                new_token_ratio=1.0,
+                num_running_reqs=types.SimpleNamespace(),
+                num_new_seqs=2,
+            ),
+            seq_lens_cpu=[decode_req.seqlen],
+            fpm_start_time=100.0,
+        )
+
+        with patch(
+            "sglang.srt.observability.scheduler_metrics_mixin.time.monotonic",
+            return_value=104.5,
+        ):
+            scheduler._emit_forward_pass_metrics(batch)
+
+        self.assertEqual(len(scheduler._fpm_publisher.metrics), 1)
+        metrics = scheduler._fpm_publisher.metrics[0]
+        self.assertEqual(metrics.worker_id, "worker-7")
+        self.assertEqual(metrics.dp_rank, 3)
+        self.assertEqual(metrics.wall_time, 4.5)
+        self.assertEqual(metrics.scheduled_requests.num_prefill_requests, 2)
+        self.assertEqual(metrics.scheduled_requests.sum_prefill_tokens, 12)
+        self.assertEqual(metrics.scheduled_requests.sum_prefill_kv_tokens, 5)
+        self.assertEqual(metrics.scheduled_requests.num_decode_requests, 1)
+        self.assertEqual(
+            metrics.scheduled_requests.sum_decode_kv_tokens, decode_req.seqlen
+        )
+        self.assertEqual(metrics.queued_requests.num_prefill_requests, 1)
+        self.assertEqual(metrics.queued_requests.num_decode_requests, 1)
+
+    def test_init_metrics_uses_server_worker_id(self):
+        scheduler = _DummyScheduler()
+        scheduler.server_args = types.SimpleNamespace(
+            enable_metrics=False,
+            enable_metrics_for_all_schedulers=False,
+            extra_metric_labels=None,
+            forward_pass_metrics_port=20380,
+            forward_pass_metrics_worker_id="endpoint-42",
+        )
+        scheduler.attn_tp_rank = 0
+        scheduler.dp_rank = 2
+        scheduler.enable_kv_cache_events = False
+
+        with patch(
+            "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
+            _DummyPublisherThread,
+        ):
+            scheduler.init_metrics(tp_rank=0, pp_rank=0, dp_rank=2)
+
+        self.assertTrue(scheduler.enable_fpm)
+        self.assertEqual(scheduler._fpm_worker_id, "endpoint-42")
+        self.assertEqual(scheduler._fpm_dp_rank, 2)
+        self.assertEqual(scheduler._fpm_publisher.worker_id, "endpoint-42")
+        self.assertEqual(scheduler._fpm_publisher.dp_rank, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `ForwardPassMetrics` emission from the scheduler on every forward pass iteration via ZMQ PUB socket
- Enables external consumers (planners, routers) to observe real-time scheduling behavior without polling Prometheus
- Controlled via `--forward-pass-metrics-port` server arg -- zero overhead when not set
- Background publisher thread keeps serialization off the scheduler hot path
- Wire format uses msgspec msgpack for zero-copy serialization

## Motivation

External orchestration systems need per-iteration scheduling telemetry to make informed routing decisions. The existing KV metrics (from #6721) provide block-level cache occupancy, but planners also need request-level scheduling data: how many prefill/decode requests ran, token counts, KV context lengths, queue depth, and iteration wall time.

This uses sglang's existing `SchedulerMetricsMixin` -- no scheduler subclass needed.

## Data emitted per iteration

| Field | Description |
|---|---|
| `wall_time` | Schedule + forward + output processing duration |
| `num_prefill_requests` | Prefill requests in this batch |
| `sum_prefill_tokens` | Freshly computed prefill tokens |
| `sum_prefill_kv_tokens` | Prefix cache hits (read, not computed) |
| `var_prefill_length` | Variance of prompt lengths |
| `num_decode_requests` | Decode requests in this batch |
| `sum_decode_kv_tokens` | Total KV context length across decode requests |
| `var_decode_kv_tokens` | Variance of decode KV lengths |
| Queued request equivalents | Same fields for waiting queue snapshot |

## Architecture

```
Scheduler process:
  SchedulerMetricsMixin._emit_forward_pass_metrics()
    -> _FpmPublisherThread (daemon) -> ZMQ PUB (localhost:{port + dp_rank})

External consumer:
  ZMQ SUB -> deserialize ForwardPassMetrics
```

## How to enable

```bash
python -m sglang.launch_server --model-path <model> --forward-pass-metrics-port 20380
```

## Files changed

- **New**: `python/sglang/srt/observability/forward_pass_metrics.py` -- ForwardPassMetrics schema, WelfordAccumulator, _FpmPublisherThread
- **Modified**: `python/sglang/srt/observability/scheduler_metrics_mixin.py` -- init FPM publisher, `_emit_forward_pass_metrics()`, `_shutdown_fpm()`
- **Modified**: `python/sglang/srt/managers/scheduler.py` -- record batch start time, emit FPM from `process_batch_result()`
- **Modified**: `python/sglang/srt/server_args.py` -- add `forward_pass_metrics_port` field and `--forward-pass-metrics-port` CLI flag
- **New**: `test/manual/test_forward_pass_metrics.py` -- schema roundtrip, ZMQ PUB/SUB e2e, heartbeat

## Test plan

- [x] Unit tests: schema encode/decode roundtrip, WelfordAccumulator correctness
- [x] ZMQ PUB/SUB e2e: publisher thread -> subscriber receives correct frames
- [x] Heartbeat: idle publisher emits heartbeat within interval
- [x] Live server: launched sglang with `--forward-pass-metrics-port 20380`, sent requests, verified prefill/decode metrics arrive with correct values