### PR TITLE
[Model] Fix NemotronH OOM on unified-mem systems: stream weights 

### DIFF
--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -774,12 +774,6 @@ class NemotronHForCausalLM(nn.Module):
     def load_weights(
         self, weights: Iterable[tuple[str, torch.Tensor]], is_mtp: bool = False
     ) -> None:
-        updated_weights = []
-        for name, loaded_weight in weights:
-            name = replace_prefix(name, self.remap_prefix)
-            name = replace_substrings(name, self.remap_substr)
-            updated_weights.append((name, loaded_weight))
-
         # - FusedMoe.w1 (aka gate_proj) should be up_proj since that's
         #   what the activation is applied to
         # - FusedMoe.w3 (aka up_proj) should be ignored since we're
@@ -793,7 +787,13 @@ class NemotronHForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
 
-        for name, loaded_weight in updated_weights:
+        # Stream weights directly from the generator to avoid buffering
+        # the entire checkpoint (~75 GB) into a Python list. On unified-
+        # memory systems (e.g. DGX Spark, 119 GB) the old buffered path
+        # caused OOM: skeleton 81.6 GB + buffer 75 GB = 157 GB peak.
+        for name, loaded_weight in weights:
+            name = replace_prefix(name, self.remap_prefix)
+            name = replace_substrings(name, self.remap_substr)
             if is_mtp:
                 if "mtp" not in name:
                     continue


### PR DESCRIPTION
## Motivation

On unified-memory systems like DGX Spark GB10 (119 GB shared CPU+GPU pool), the Nemotron-3-Super-120B-A12B-NVFP4 model (75 GB on disk) cannot load with the current NemotronHForCausalLM.load_weights() implementation. The method buffers the entire weight generator into a Python list before processing, causing a peak memory usage of ~157 GB (81.6 GB model skeleton + 75 GB weight buffer), which exceeds the  119 GB physical limit and triggers OOM.

## Modifications

  **`python/sglang/srt/models/nemotron_h.py`**
  - Remove the `updated_weights = []` buffer list in `load_weights()`
  - Move `expert_params_mapping` and `params_dict` computation before the loop
  - Iterate the `weights` generator directly, applying `replace_prefix`/`replace_substrings` inline
  - Reduces peak memory from ~157 GB to ~81.6 GB during weight loading


So now the keeps peak at ~81.6 GB.

  Tested end-to-end on DGX Spark GB10 with nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 using modelopt_mixed quantization:
```
  python3 -m sglang.launch_server \
    --model-path nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
    --disable-radix-cache --disable-cuda-graph \
    --max-total-tokens 8192 --context-length 4096 \
    --mamba-ssm-dtype bfloat16
```


then


```
  curl -s http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
      "messages": [{"role": "user", "content": "What is the capital of France?"}],
      "temperature": 0, "max_tokens": 256
    }' | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])"
  # Expected: Response contains "Paris"

  curl -s http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
      "messages": [{"role": "user", "content": "What is NVIDIA?"}],
      "temperature": 0, "max_tokens": 256
    }' | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])"
  # Expected: Response mentions GPU, graphics, AI, or semiconductor
```

  



