### PR TITLE
perf: sort prefill requests by lora_id in scheduler

### DIFF
--- a/python/sglang/srt/lora/backend/torch_backend.py
+++ b/python/sglang/srt/lora/backend/torch_backend.py
@@ -144,7 +144,6 @@ class TorchNativeLoRABackend(BaseLoRABackend):
             slice_offsets=output_offset,
             base_output=base_output,
         )
-
         return output_tensor
 
     def init_cuda_graph_batch_info(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -317,6 +317,7 @@ class Scheduler(
         )
         self.enable_lora = server_args.enable_lora
         self.enable_lora_overlap_loading = server_args.enable_lora_overlap_loading
+        self.lora_sort_by_adapter = server_args.lora_sort_by_adapter
         self.max_loras_per_batch = server_args.max_loras_per_batch
         self.enable_overlap = not server_args.disable_overlap_schedule
         self.enable_pdmux = server_args.enable_pdmux
@@ -2305,6 +2306,11 @@ class Scheduler(
         self.running_bs = len(self.running_batch.reqs)
 
         set_time_batch(can_run_list, "set_forward_entry_time")
+
+        # Sort by lora_id to group requests using the same adapter together,
+        # reducing the number of LoRA GEMM segments in the batch.
+        if self.lora_sort_by_adapter:
+            can_run_list.sort(key=lambda req: req.lora_id or "")
 
         # Create a new batch
         new_batch = ScheduleBatch.init_new(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -459,6 +459,7 @@ class ServerArgs:
     max_loras_per_batch: int = 8
     lora_eviction_policy: str = "lru"
     lora_backend: str = "csgmv"
+    lora_sort_by_adapter: bool = False
     max_lora_chunk_size: Optional[int] = 16
 
     # Kernel backend
@@ -4267,6 +4268,12 @@ class ServerArgs:
             help="Choose the kernel backend for multi-LoRA serving.",
         )
         parser.add_argument(
+            "--lora-sort-by-adapter",
+            action="store_true",
+            default=ServerArgs.lora_sort_by_adapter,
+            help="Sort prefill requests by LoRA adapter ID to group same-adapter requests together, reducing the number of GEMM segments.",
+        )
+        parser.add_argument(
             "--max-lora-chunk-size",
             type=int,
             default=ServerArgs.max_lora_chunk_size,
@@ -5965,6 +5972,12 @@ class ServerArgs:
                 assert len(self.lora_paths) <= self.max_loaded_loras, (
                     "The number of LoRA paths should not exceed max_loaded_loras. "
                     f"max_loaded_loras={self.max_loaded_loras}, lora_paths={len(self.lora_paths)}"
+                )
+
+            if self.lora_sort_by_adapter and self.enable_priority_scheduling:
+                raise ValueError(
+                    "--lora-sort-by-adapter cannot be used with --enable-priority-scheduling "
+                    "as it would override priority ordering and cause priority inversion."
                 )
 
             if self.max_lora_chunk_size is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When multiple LoRA adapters are used, requests arrive interleaved (e.g., `[v1, v2, v3, v4, v1, v2, ...]`). The torch-native backend uses `torch.unique_consecutive` to merge segments, but since requests aren't grouped by adapter, each request becomes its own segment — resulting in one GEMM per request instead of one per unique adapter.

torch-native backend works better than csgmv for prefill (embeddings) with LoRA 

## Modifications

Add `--lora-sort-by-adapter` server arg (default off). When enabled, the scheduler sorts prefill requests by `lora_id` before batch construction. Since all downstream metadata is built from the sorted list, tokens arrive naturally grouped by adapter with zero GPU overhead. `unique_consecutive` then optimally merges segments.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

```bash
python -m sglang.launch_server \
  --model-path $BASE_MODEL --host 0.0.0.0 --port 30000 \
  --is-embedding --dtype float16 --disable-radix-cache \
  --chunked-prefill-size -1 --max-prefill-tokens 32768 \
  --lora-backend torch_native \
  --lora-paths v1=$ADAPTER v2=$ADAPTER v3=$ADAPTER v4=$ADAPTER

python -m sglang.bench_serving \
  --backend sglang-embedding --host 127.0.0.1 --port 30000 \
  --model $BASE_MODEL --dataset-name random \
  --random-input-len 2048 --random-range-ratio 1.0 \
  --num-prompts 1000 --request-rate 150 \
  --lora-name v1 v2 v3 v4
```

Model: Qwen3-Embeddings-0.6B, Adapter: rank 64 on qkv_proj + o_proj, 4 adapters loaded.

| Configuration                     | Achieved RPS       | Achieved TPS   |
|-----------------------------------|-------------------:|---------------:|
| Base (no adapters queried)        |             136.99 |     280,414.38 |
| Main (4 adapters, unsorted)       |             122.65 |     251,059.67 |
| This change (4 adapters, sorted)  |  135.44 (+10.4%)   |     277,235.68 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
