### PR TITLE
[Kernel/Docker/CMake] Add CCCL support for CUDA 13 in CMake and update Dockerfile

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -394,7 +394,7 @@ add_subdirectory(
     ${CMAKE_CURRENT_BINARY_DIR}/mscclpp-build
 )
 find_package(CCCL QUIET PATHS "${CUDAToolkit_LIBRARY_DIR}/cmake/cccl")
-if (CCCL_FOUND AND CUDAToolkit_VERSION_MAJOR GREATER 12 AND TARGET CCCL::CCCL)
+if (CCCL_FOUND AND "${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0" AND TARGET CCCL::CCCL)
     message(STATUS "Linking CCCL::CCCL to mscclpp_obj for CUDA ${CUDA_VERSION}")
     target_link_libraries(mscclpp_obj PRIVATE CCCL::CCCL)
 endif()

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -393,6 +393,11 @@ add_subdirectory(
     ${repo-mscclpp_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/mscclpp-build
 )
+find_package(CCCL QUIET PATHS "${CUDAToolkit_LIBRARY_DIR}/cmake/cccl")
+if (CCCL_FOUND AND CUDAToolkit_VERSION_MAJOR GREATER 12 AND TARGET CCCL::CCCL)
+    message(STATUS "Linking CCCL::CCCL to mscclpp_obj for CUDA ${CUDA_VERSION}")
+    target_link_libraries(mscclpp_obj PRIVATE CCCL::CCCL)
+endif()
 
 target_link_libraries(common_ops_sm90_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt mscclpp_static)
 target_link_libraries(common_ops_sm100_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt mscclpp_static)

--- a/sgl-kernel/Dockerfile
+++ b/sgl-kernel/Dockerfile
@@ -24,9 +24,6 @@ ENV PATH=/opt/cmake/bin:${PATH}
 ENV LD_LIBRARY_PATH=/lib64:${LD_LIBRARY_PATH}
 ENV NINJA_STATUS="[%f/%t %es] "
 ENV FLASHINFER_CUDA_ARCH_LIST="8.0 8.9 9.0a 10.0a 12.0a"
-# CUDA headers path
-ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include/cccl${CPLUS_INCLUDE_PATH:+:${CPLUS_INCLUDE_PATH}}
-ENV C_INCLUDE_PATH=/usr/local/cuda/include/cccl${C_INCLUDE_PATH:+:${C_INCLUDE_PATH}}
 
 # Install build dependencies
 RUN yum install gcc gcc-c++ make wget tar numactl-devel libibverbs -y --nogpgcheck \


### PR DESCRIPTION
Related: #14066 #17600 #18800

## Motivation

CUDA 13 introduced CCCL 3.0, which moved several headers from:

- `${CTK_ROOT}/include/cuda/`
- `${CTK_ROOT}/include/cub/`
- `${CTK_ROOT}/include/thrust/`

to:

- `${CTK_ROOT}/include/cccl/cuda/`
- `${CTK_ROOT}/include/cccl/cub/`
- `${CTK_ROOT}/include/cccl/thrust/`

Per NVIDIA's migration guide, this can break builds for translation units compiled by the host compiler alone, because unlike `nvcc`, host compilers do not automatically pick up the new CCCL include layout. One common symptom is:

`fatal error: cuda/atomic: No such file or directory`

`mscclpp` is one of the affected dependencies. The `mscclpp` revision currently pinned in `sgl-kernel` predates the upstream CUDA 13 fix, so its CMake logic does not yet know that `CCCL::CCCL` must be linked for CUDA 13+ builds.

As a result, source builds of `sgl-kernel` on CUDA 13 currently rely on a Docker-specific include path workaround instead of handling the issue in the build system itself.

## Problem with the current workaround

The current workaround injects CCCL-related include behavior from `sgl-kernel/Dockerfile`.(https://github.com/sgl-project/sglang/blob/25e38216b6af2472949f17b1ec0f4e476768d334/sgl-kernel/Dockerfile#L28-29)

This has a few drawbacks:

- It only helps Docker-based builds.
- It does not help local/source builds outside Docker, which is a common workflow for kernel development and experimentation.
- It places a compiler configuration issue in environment setup instead of in CMake.
- It applies outside the actual dependency boundary where the problem occurs.
- It can introduce unnecessary or hidden side effects for CUDA versions that do not need this workaround.

There is also an ongoing Docker-layer attempt in #18800, but that still addresses the symptom at the container/environment level rather than in the build configuration of the affected target.

## Modifications

This PR moves the workaround to the correct layer by applying a minimal CMake-side fix:

- After adding the pinned `mscclpp` subdirectory, try to locate CCCL via:
  `find_package(CCCL QUIET PATHS "${CUDAToolkit_LIBRARY_DIR}/cmake/cccl")`
- If `CCCL` is found and the CUDA major version is greater than 12, link `CCCL::CCCL` to `mscclpp_obj`
- Remove the Dockerfile-only environment workaround

This keeps the fix scoped to the actual dependency that needs it, and makes both Docker and non-Docker source builds use the same build logic.

## Why this approach

Upstream `mscclpp` has already addressed this in commit `51a86630ff8ffafd9b044581b383cf26658b4e6f` ("Build fixes (#696)"), which adds CUDA 13 CCCL handling in CMake.

However, the pinned `mscclpp` revision in `sgl-kernel` is significantly older. Bumping the dependency directly would pull in a much larger set of upstream changes and would require broader validation.

Instead, this PR backports only the relevant CUDA 13 CCCL CMake fix in a minimal and readable form. This keeps the diff small, limits behavioral change, and aligns with the upstream direction without taking on the risk of a full dependency upgrade.

## Scope and impact

- This change only affects build configuration.
- There is no kernel logic or runtime behavior change.
- CUDA 12 and earlier should remain unaffected because the additional linkage is only applied for CUDA 13+ when `CCCL::CCCL` is available.
- This is best understood as a mitigation for the currently pinned `mscclpp` revision.

Once `sgl-kernel` upgrades to an `mscclpp` version that already includes proper CUDA 13 support, this local backport may become unnecessary.

## Scope and impact

- This change only affects build configuration.
- There is no kernel logic or runtime behavior change.
- CUDA 12 and earlier should remain unaffected because the additional linkage is only applied for CUDA 13+ when `CCCL::CCCL` is available.
- This is best understood as a mitigation for the currently pinned `mscclpp` revision.

Once `sgl-kernel` upgrades to an `mscclpp` version that already includes proper CUDA 13 support, this local backport may become unnecessary.

## Accuracy Tests

N/A. This PR only changes build configuration and does not modify kernel math or runtime execution logic.

## Benchmarking and Profiling

N/A. This PR does not change runtime code paths or performance-sensitive kernels.

## References

- NVIDIA CCCL 2.x -> 3.0 migration guide:
  https://nvidia.github.io/cccl/unstable/cccl/3.0_migration_guide.html
- Upstream `mscclpp` CUDA 13 CMake fix:
  https://github.com/microsoft/mscclpp/commit/51a86630ff8ffafd9b044581b383cf26658b4e6f

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.





