### PR TITLE
[Model] Support gpt-neox model

### DIFF
--- a/python/sglang/srt/models/gpt_neox.py
+++ b/python/sglang/srt/models/gpt_neox.py
@@ -1,0 +1,375 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Inference-only GPT-NeoX model compatible with HuggingFace weights."""
+
+from collections.abc import Iterable
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import nn
+from transformers import GPTNeoXConfig
+
+from sglang.srt.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from sglang.srt.layers.activation import get_act_fn
+from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
+from sglang.srt.layers.pooler import Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.utils import add_prefix, make_layers
+
+
+class GPTNeoXAttention(nn.Module):
+    def __init__(
+        self,
+        config: GPTNeoXConfig,
+        layer_id: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.total_num_heads = config.num_attention_heads
+        self.hidden_size = config.hidden_size
+        self.head_size = self.hidden_size // self.total_num_heads
+        self.bias = getattr(config, "attention_bias", True)
+        tensor_model_parallel_world_size = get_tensor_model_parallel_world_size()
+        assert self.total_num_heads % tensor_model_parallel_world_size == 0
+        self.num_heads = self.total_num_heads // tensor_model_parallel_world_size
+
+        self.query_key_value = QKVParallelLinear(
+            config.hidden_size,
+            self.head_size,
+            self.total_num_heads,
+            bias=self.bias,
+            quant_config=quant_config,
+            prefix=add_prefix("query_key_value", prefix),
+        )
+
+        self.dense = RowParallelLinear(
+            config.hidden_size,
+            config.hidden_size,
+            bias=self.bias,
+            quant_config=quant_config,
+            prefix=add_prefix("dense", prefix),
+        )
+
+        rope_theta = getattr(config, "rope_theta", 10000)
+        rope_scaling = getattr(config, "rope_scaling", None)
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+        self.rotary_emb = get_rope(
+            self.head_size,
+            rotary_dim=self.head_size,
+            max_position=max_position_embeddings,
+            base=rope_theta,
+            rope_scaling=rope_scaling,
+            partial_rotary_factor=partial_rotary_factor,
+        )
+
+        scaling = self.head_size**-0.5
+        self.attn = RadixAttention(
+            self.num_heads,
+            self.head_size,
+            scaling,
+            num_kv_heads=self.num_heads,
+            layer_id=layer_id,
+            quant_config=quant_config,
+            prefix=add_prefix("attn", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        qkv, _ = self.query_key_value(hidden_states)
+        q, k, v = qkv.chunk(chunks=3, dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v, forward_batch)
+        output, _ = self.dense(attn_output)
+        return output
+
+
+class GPTNeoXMLP(nn.Module):
+    def __init__(
+        self,
+        config: GPTNeoXConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.dense_h_to_4h = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            quant_config=quant_config,
+            prefix=add_prefix("dense_h_to_4h", prefix),
+        )
+        self.dense_4h_to_h = RowParallelLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("dense_4h_to_h", prefix),
+        )
+        self.act = get_act_fn(config.hidden_act)
+
+    def forward(self, hidden_states):
+        hidden_states, _ = self.dense_h_to_4h(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states, _ = self.dense_4h_to_h(hidden_states)
+        return hidden_states
+
+
+class GPTNeoXLayer(nn.Module):
+    def __init__(
+        self,
+        config: GPTNeoXConfig,
+        layer_id: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.use_parallel_residual = config.use_parallel_residual
+        self.input_layernorm = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+        self.post_attention_layernorm = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+        self.attention = GPTNeoXAttention(
+            config, layer_id, quant_config, prefix=add_prefix("attention", prefix)
+        )
+        self.mlp = GPTNeoXMLP(config, quant_config, prefix=add_prefix("mlp", prefix))
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+        else:
+            hidden_states = hidden_states + residual
+            residual = hidden_states
+
+        attn_input = self.input_layernorm(hidden_states)
+        attn_output = self.attention(
+            positions=positions,
+            hidden_states=attn_input,
+            forward_batch=forward_batch,
+        )
+
+        if self.use_parallel_residual:
+            mlp_input = self.post_attention_layernorm(hidden_states)
+            mlp_output = self.mlp(mlp_input)
+            hidden_states = mlp_output + attn_output
+        else:
+            attn_output = attn_output + hidden_states
+            residual = attn_output
+            mlp_input = self.post_attention_layernorm(attn_output)
+            mlp_output = self.mlp(mlp_input)
+            hidden_states = mlp_output
+
+        return hidden_states, residual
+
+
+class GPTNeoXModel(nn.Module):
+    def __init__(
+        self,
+        config: GPTNeoXConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.pp_group = get_pp_group()
+
+        if self.pp_group.is_first_rank:
+            self.embed_in = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=add_prefix("embed_in", prefix),
+            )
+        else:
+            self.embed_in = PPMissingLayer()
+
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: GPTNeoXLayer(
+                config=config, layer_id=idx, quant_config=quant_config, prefix=prefix
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix="layers",
+            return_tuple=True,
+        )
+
+        if self.pp_group.is_last_rank:
+            self.final_layer_norm = nn.LayerNorm(
+                config.hidden_size, eps=config.layer_norm_eps
+            )
+        else:
+            self.final_layer_norm = PPMissingLayer(return_tuple=True)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        input_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+        if self.pp_group.is_first_rank:
+            if input_embeds is not None:
+                hidden_states = input_embeds
+            else:
+                hidden_states = self.embed_in(input_ids)
+            residual = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        for layer in self.layers[self.start_layer : self.end_layer]:
+            hidden_states, residual = layer(
+                positions, hidden_states, forward_batch, residual
+            )
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        if residual is not None:
+            hidden_states = hidden_states + residual
+
+        hidden_states = self.final_layer_norm(hidden_states)
+        return hidden_states
+
+
+class GPTNeoXForCausalLM(nn.Module):
+    def __init__(
+        self,
+        config: GPTNeoXConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+
+        self.gpt_neox = GPTNeoXModel(
+            config, quant_config, prefix=add_prefix("gpt_neox", prefix)
+        )
+        self.embed_out = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("embed_out", prefix),
+        )
+
+        if self.config.tie_word_embeddings:
+            self.embed_out.weight = self.gpt_neox.embed_in.weight
+
+        self.logits_processor = LogitsProcessor(config)
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+        self.pp_group = get_pp_group()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        input_embeds: Optional[torch.Tensor] = None,
+        get_embedding: bool = False,
+    ) -> LogitsProcessorOutput:
+        hidden_states = self.gpt_neox(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+
+        if self.pp_group.is_last_rank:
+            if not get_embedding:
+                return self.logits_processor(
+                    input_ids, hidden_states, self.embed_out, forward_batch
+                )
+            else:
+                return self.pooler(hidden_states, forward_batch)
+        else:
+            return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> None:
+        params_dict = dict(self.named_parameters())
+
+        for name, loaded_weight in weights:
+            layer_id = get_layer_id(name)
+            if layer_id is not None and (
+                layer_id < self.gpt_neox.start_layer
+                or layer_id >= self.gpt_neox.end_layer
+            ):
+                continue
+
+            skip_keys = [
+                "attention.bias",
+                "attention.masked_bias",
+                "rotary_emb.inv_freq",
+                "rotary_emb.cos_cached",
+                "rotary_emb.sin_cached",
+            ]
+            if any(key in name for key in skip_keys) or name not in params_dict:
+                continue
+
+            param = params_dict[name]
+
+            if "query_key_value" in name:
+                output_dim = getattr(param, "output_dim", None)
+                num_heads = self.config.num_attention_heads
+
+                if output_dim is not None:
+                    loaded_weight_shape = loaded_weight.shape
+                    loaded_weight = loaded_weight.view(
+                        loaded_weight_shape[:output_dim]
+                        + (num_heads, 3, -1)
+                        + loaded_weight_shape[output_dim + 1 :]
+                    )
+                    loaded_weight = loaded_weight.transpose(output_dim, output_dim + 1)
+                    loaded_weight = loaded_weight.reshape(loaded_weight_shape)
+
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+
+
+EntryClass = GPTNeoXForCausalLM

--- a/test/registered/models/test_generation_models.py
+++ b/test/registered/models/test_generation_models.py
@@ -89,6 +89,7 @@ ALL_MODELS = [
         skip_long_prompt=True,
     ),
     ModelCase("facebook/opt-125m", skip_long_prompt=True),
+    ModelCase("EleutherAI/pythia-160m", trust_remote_code=True, skip_long_prompt=True),
     ModelCase(
         "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5",
         tp_size=2,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

# Support GPT-NeoX Series models

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Model Support issue: #7429 

This PR adds support for the GPT-NeoX series models (including the full Pythia family, GPT-NeoX-20B, etc.) in SGLang. We conducted comprehensive MMLU benchmarks and serving performance tests to verify both implementation accuracy and inference efficiency. Welcome feedback to refine the implementation!

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Ported GPT-NeoX model code from vllm (https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gpt_neox.py) to SGLang, following the official guide: https://docs.sglang.io/supported_models/extending/support_new_models.html#port-a-model-from-vllm-to-sglang.
2. Added ModelCase("EleutherAI/pythia-160m") in test_generation_models.py

## Accuracy Tests (EleutherAI/pythia-12b-deduped)

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### 1. SGLang vs vLLM: MMLU Benchmark Summary

| Metric | SGLang | vLLM |
| :--- | :--- | :--- |
| Average Accuracy | **0.2559** | 0.2554 |
| Total Latency (s) | **42.66** | 43.89 |

### 2. SGLang MMLU Detailed Results

| Category | SGLang Accuracy | vLLM Accuracy |
| :--- | :--- | :--- |
| **Humanities** | 0.2601 | 0.2589 |
| **STEM** | 0.2426 | 0.2477 |
| **Social Sciences** | 0.2408 | 0.2415 |
| **Other** | 0.2778 | 0.2716 |
| **Overall Average** | **0.2559** | **0.2554** |

#### Client cmd
lm_eval --model local-completions --model_args base_url=http://127.0.0.1:31000/v1/completions,model=/home/workspace/xxx/pythia-12b-deduped,tokenizer=/home/workspace/xxx/pythia-12b-deduped,tokenizer_backend=huggingface --tasks mmlu --num_fewshot 0

#### Server cmd (On 2 NVIDIA A100 GPU)
sglang:
python3 -m sglang.launch_server --model-path /home/workspace/xxx/pythia-12b-deduped --tp-size 2 --port 31000

vllm:
python3 -m vllm.entrypoints.openai.api_server --model /home/workspace/xxx/pythia-12b-deduped --tensor-parallel-size 2 --port 31000

## Benchmarking and Profiling (EleutherAI/pythia-12b-deduped)

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

### SGLang vs vLLM: Serving Performance Comparison

**Test Environment:**
- **Model:** `EleutherAI/pythia-12b-deduped`
- **Config:** Concurrency = 1, Random Input/Output = 1024/1024 tokens.

| Metric | SGLang | vLLM |
| :--- | :--- | :--- |
| Request Throughput (req/s) | 0.23 | 0.23 |
| Output Token Throughput (tok/s) | **98.92** | 96.15 |
| Total Token Throughput (tok/s) | **241.93** | 235.16 |
| Mean E2E Latency (ms) | **4263.44** | 4387.99 |
| Mean TTFT (ms) | 72.74 | 53.18 |
| Mean TPOT (ms) | **9.90** | 10.17 |
| Mean ITL (ms) | **9.95** | 10.32 |

#### Client cmd
sglang:
python -m sglang.bench_serving --backend sglang --host 127.0.0.1  --port 31000 --dataset-name random --num-prompts 10 --max-concurrency 1

vllm:
python -m sglang.bench_serving --backend vllm --host 127.0.0.1  --port 31000 --dataset-name random --num-prompts 10 --max-concurrency 1

#### Server cmd (On 2 NVIDIA A100 GPU)
same as the cmd mentioned in the “Accuracy Test” above

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
