### PR TITLE
Fix GPTQ Marlin MoE dtype mismatch for bfloat16 models

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -85,12 +85,12 @@ def fused_marlin_moe(
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"
     assert w2.is_contiguous(), "Expert weights2 must be contiguous"
     assert hidden_states.dtype in [torch.float16, torch.bfloat16]
-    assert (
-        hidden_states.dtype == w1_scale.dtype
-    ), f"moe_wna16_marlin_gemm assumes hidden_states.dtype ({hidden_states.dtype}) == w1_scale.dtype ({w1_scale.dtype})"
-    assert (
-        hidden_states.dtype == w2_scale.dtype
-    ), f"moe_wna16_marlin_gemm assumes hidden_states.dtype ({hidden_states.dtype}) == w2_scale.dtype ({w2_scale.dtype})"
+    # The Marlin kernel requires hidden_states and scale dtypes to match.
+    # GPTQ scales are typically fp16 even when the model runs in bf16,
+    # so cast hidden_states to the scale dtype and cast back at the end.
+    orig_dtype = hidden_states.dtype
+    if hidden_states.dtype != w1_scale.dtype:
+        hidden_states = hidden_states.to(w1_scale.dtype)
     assert num_bits in [4, 8]
 
     M, K = hidden_states.shape
@@ -217,4 +217,6 @@ def fused_marlin_moe(
         output,
         routed_scaling_factor,
     )
+    if output.dtype != orig_dtype:
+        output = output.to(orig_dtype)
     return output


### PR DESCRIPTION
## Problem

GPTQ-Int4 quantized MoE models crash with `AssertionError: moe_wna16_marlin_gemm assumes hidden_states.dtype (torch.bfloat16) == w1_scale.dtype (torch.float16)` when served with `dtype=bfloat16`.

GPTQ weight scales are always stored as float16, but when the model loads in bfloat16, `hidden_states` has a different dtype than the scales.

## Fix

Cast `hidden_states` to the scale dtype before the Marlin kernel call, and cast the output back to the original dtype afterward.

Fixes #20599