### PR TITLE
Use Flashinfer for target_verify in GDN model for SM120

### DIFF
--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -210,7 +210,8 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                     runner.server_args.attention_backend == "triton"
                     or runner.server_args.attention_backend == "trtllm_mha"
                     or runner.server_args.attention_backend == "fa4"
-                ), "triton or trtllm_mha or fa4 backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend triton or --attention-backend trtllm_mha to specify the backend."
+                    or runner.server_args.attention_backend == "flashinfer"
+                ), "triton, trtllm_mha, fa4, or flashinfer backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend to specify the backend."
             if is_npu():
                 assert (
                     runner.server_args.attention_backend == "ascend"


### PR DESCRIPTION


When the context is long (32000 ISL, 1024 OSL) target verify will be very very slow, due to using Triton prefill which has no split-KV optimization (and, using decode Triton will also no help), in fact it will be a bit slower.

Although there is trtllm-gen, it only support XQA decode (no prefill), so we can use Flashinfer with FA2 impl (for full attention). And now, it will select Flashinfer by default. Uncertain why this gate is intially created, but I leave this pattern for now.

Before:
<img width="1252" height="713" alt="Screenshot 2026-03-14 at 10 21 13 PM" src="https://github.com/user-attachments/assets/44f15bed-3f3b-4755-9c22-859e83e300be" />

```
python -m sglang.test.run_eval --base-url http://localhost:30000 --eval-name gsm8k --num-examples 200 --max-tokens 16000 --repeat 5 --num-threads 48 --num-shots 5 --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --chat-template-kwargs '{"enable_thinking": true}'
```

`'scores': ['0.990', '0.985', '0.980', '0.985', '0.980'], 'mean_score': np.float64(0.984)}`

After:
<img width="1253" height="497" alt="Screenshot 2026-03-14 at 10 21 25 PM" src="https://github.com/user-attachments/assets/5883a054-b22e-4df9-be53-5d2c37cdb338" />

`'scores': ['0.980', '0.990', '0.980', '0.980', '0.980'], 'mean_score': np.float64(0.982)}`

Fix #20709
