### PR TITLE
run-ci PR HiCacheFile: add optional direct_io mode for HiCacheFile backend

### DIFF
--- a/docs/advanced_features/hicache_file_direct_io.md
+++ b/docs/advanced_features/hicache_file_direct_io.md
@@ -8,6 +8,8 @@ This document explains how to enable and validate `direct_io` for the `HiCacheFi
 
 When enabled, file read/write operations in `HiCacheFile` use `os.open(..., O_DIRECT)` with `os.readv`/`os.writev`.
 
+For high-speed NVMe (especially PCIe Gen5 and above), bypassing page cache is often a better default for sustained write/read bandwidth, and it can also reduce page-cache DRAM pressure so CPU memory can be reserved for other workloads. 
+
 ### Why use Direct I/O?
 
 - Bypass page cache in high-throughput storage scenarios.

--- a/docs/advanced_features/hicache_file_direct_io.md
+++ b/docs/advanced_features/hicache_file_direct_io.md
@@ -1,0 +1,125 @@
+# HiCacheFile Direct I/O Guide
+
+This document explains how to enable and validate `direct_io` for the `HiCacheFile` storage backend.
+
+## Overview
+
+`HiCacheFile` now supports an optional Direct I/O mode (Linux `O_DIRECT`) through backend extra config.
+
+When enabled, file read/write operations in `HiCacheFile` use `os.open(..., O_DIRECT)` with `os.readv`/`os.writev`.
+
+### Why use Direct I/O?
+
+- Bypass page cache in high-throughput storage scenarios.
+- Reduce page-cache memory pressure so host memory can be used for other tasks.
+- Provide an explicit storage mode option for fast NVMe-based deployments.
+
+## Important Behavior
+
+- `direct_io` is **opt-in** and disabled by default.
+- This implementation is intentionally strict:
+  - no automatic fallback to buffered I/O
+  - no proactive alignment handling in code
+  - no pre-check that rewrites behavior
+- If your filesystem/kernel/buffer does not satisfy Direct I/O requirements, operations fail and logs will tell you to disable `direct_io`.
+
+## Configuration
+
+Pass settings through `--hicache-storage-backend-extra-config`.
+
+Example:
+
+```json
+{
+  "hicache_storage_pass_prefix_keys": true,
+  "direct_io": true,
+  "direct_io_alignment": 4096
+}
+```
+
+Fields:
+
+- `direct_io` (bool): enable/disable Direct I/O for `HiCacheFile`.
+- `direct_io_alignment` (int): alignment value for deployment documentation and operator reference (default `4096`).
+
+## Launch Example
+
+```bash
+python -m sglang.launch_server \
+  --model-path <MODEL_PATH> \
+  --host 0.0.0.0 \
+  --port 30000 \
+  --enable-hierarchical-cache \
+  --hicache-storage-backend file \
+  --hicache-ratio 1.2 \
+  --page-size 64 \
+  --hicache-storage-prefetch-policy wait_complete \
+  --hicache-storage-backend-extra-config '{"hicache_storage_pass_prefix_keys": true, "direct_io": true, "direct_io_alignment": 4096}'
+```
+
+Recommended cache directory:
+
+```bash
+export SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR=/mnt/nvme0n1/nfsrdma/testhicache
+mkdir -p "$SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR"
+```
+
+## Validation Checklist
+
+1. Confirm server starts with `direct_io=true`.
+2. Send traffic that triggers cache write/read.
+3. Check server logs:
+   - On failure, you should see `HiCacheFile direct_io read/write failed ...`.
+4. Optional syscall-level validation:
+
+```bash
+sudo strace -f -e trace=openat -p <SERVER_PID> 2>&1 | rg "O_DIRECT|hicache"
+```
+
+If `O_DIRECT` appears in open flags for cache files, direct path is active.
+
+## Benchmark Recommendations
+
+For fair comparison between buffered and direct I/O:
+
+- Keep model, prompt mix, request rate, and concurrency identical.
+- Use same cache directory and same storage device.
+- Run A/B:
+  - A: `"direct_io": false`
+  - B: `"direct_io": true`
+- Compare at least:
+  - throughput
+  - p50/p95 latency
+  - host memory/page-cache pressure
+
+## Troubleshooting
+
+### `direct_io` fails with `EINVAL`/`ENOTSUP`/similar
+
+Likely reasons:
+
+- filesystem/mount does not support `O_DIRECT`
+- buffer/size alignment constraints are not satisfied
+- environment/kernel restrictions
+
+Action:
+
+- disable direct I/O in config:
+
+```json
+{
+  "hicache_storage_pass_prefix_keys": true,
+  "direct_io": false
+}
+```
+
+### Server works with buffered mode but fails with direct mode
+
+This is expected in environments where direct path is unsupported or constrained.
+Use buffered mode for compatibility.
+
+## Operational Notes
+
+- Prefer enabling `direct_io` only after validating your target filesystem and workload.
+- Keep rollback simple by toggling `direct_io` to `false`.
+- Treat `direct_io` as a deployment tuning knob, not a universal default.

--- a/docs/advanced_features/hicache_file_direct_io.md
+++ b/docs/advanced_features/hicache_file_direct_io.md
@@ -8,7 +8,7 @@ This document explains how to enable and validate `direct_io` for the `HiCacheFi
 
 When enabled, file read/write operations in `HiCacheFile` use `os.open(..., O_DIRECT)` with `os.readv`/`os.writev`.
 
-For high-speed NVMe (especially PCIe Gen5 and above), bypassing page cache is often a better default for sustained write/read bandwidth, and it can also reduce page-cache DRAM pressure so CPU memory can be reserved for other workloads. 
+For high-speed NVMe (especially PCIe Gen5 and above), bypassing page cache is often a better default for sustained write/read bandwidth, and it can also reduce page-cache DRAM pressure so CPU memory can be reserved for other workloads.
 
 ### Why use Direct I/O?
 

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -316,7 +316,9 @@ class HiCacheFile(HiCacheStorage):
                 # Write through O_DIRECT + writev from tensor byte view.
                 # We intentionally keep it minimal (no proactive alignment handling).
                 try:
-                    io_view = memoryview(value.contiguous().view(dtype=torch.uint8).numpy())
+                    io_view = memoryview(
+                        value.contiguous().view(dtype=torch.uint8).numpy()
+                    )
                     num_bytes = len(io_view)
                     fd = os.open(
                         tensor_path,

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -192,6 +192,33 @@ class HiCacheFile(HiCacheStorage):
     ):
         self.file_path = envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.get() or file_path
 
+        # direct_io support:
+        # Optional direct I/O controls from --hicache-storage-backend-extra-config JSON.
+        # Example:
+        # {"direct_io": true, "direct_io_alignment": 4096}
+        #
+        # Design choice for this patch:
+        # - Keep original control flow for set/get as much as possible.
+        # - No automatic fallback in direct I/O mode.
+        # - No proactive alignment/staging logic; rely on kernel/filesystem behavior.
+        extra_config = storage_config.extra_config or {}
+        self._direct_io_requested = bool(extra_config.get("direct_io", False))
+        self._direct_io_alignment = int(extra_config.get("direct_io_alignment", 4096))
+        self._direct_io_available = all(
+            [
+                os.name == "posix",
+                hasattr(os, "O_DIRECT"),
+                hasattr(os, "readv"),
+                hasattr(os, "writev"),
+            ]
+        )
+        self._use_direct_io = self._direct_io_requested
+        if self._direct_io_requested:
+            logger.info(
+                "HiCacheFile direct_io requested. "
+                f"alignment={self._direct_io_alignment}, available={self._direct_io_available}"
+            )
+
         tp_rank, tp_size, model_name, is_mla_model = (
             storage_config.tp_rank,
             storage_config.tp_size,
@@ -220,6 +247,33 @@ class HiCacheFile(HiCacheStorage):
         key = self._get_suffixed_key(key)
         tensor_path = os.path.join(self.file_path, f"{key}.bin")
         try:
+            if self._use_direct_io:
+                # New direct I/O branch:
+                # Read directly with O_DIRECT + readv into target tensor byte view.
+                # We intentionally do not add pre-check/alignment-copy in this patch.
+                try:
+                    expected = target_location.numel() * target_location.element_size()
+                    io_view = memoryview(
+                        target_location.view(torch.uint8).contiguous().numpy()
+                    )
+                    fd = os.open(tensor_path, os.O_RDONLY | os.O_DIRECT)
+                    try:
+                        n = os.readv(fd, [io_view])
+                        if n != expected:
+                            raise IOError(f"Short read for {tensor_path}")
+                    finally:
+                        os.close(fd)
+                    return target_location
+                except OSError as e:
+                    logger.error(
+                        "HiCacheFile direct_io read failed for %s: %s. "
+                        "Please disable extra_config['direct_io'] if filesystem/kernel "
+                        "does not support O_DIRECT for this path.",
+                        tensor_path,
+                        e,
+                    )
+                    raise
+            # previous no direct_io path: original buffered readinto path
             expected = target_location.numel() * target_location.element_size()
             with open(tensor_path, "rb", buffering=0) as f:
                 buf = memoryview(target_location.view(torch.uint8).contiguous().numpy())
@@ -257,6 +311,35 @@ class HiCacheFile(HiCacheStorage):
         key = self._get_suffixed_key(key)
         tensor_path = os.path.join(self.file_path, f"{key}.bin")
         try:
+            if self._use_direct_io:
+                # New direct I/O branch:
+                # Write through O_DIRECT + writev from tensor byte view.
+                # We intentionally keep it minimal (no proactive alignment handling).
+                try:
+                    io_view = memoryview(value.contiguous().view(dtype=torch.uint8).numpy())
+                    num_bytes = len(io_view)
+                    fd = os.open(
+                        tensor_path,
+                        os.O_CREAT | os.O_TRUNC | os.O_WRONLY | os.O_DIRECT,
+                        0o644,
+                    )
+                    try:
+                        n = os.writev(fd, [io_view])
+                        if n != num_bytes:
+                            raise IOError(f"Short write for {tensor_path}")
+                    finally:
+                        os.close(fd)
+                    return True
+                except OSError as e:
+                    logger.error(
+                        "HiCacheFile direct_io write failed for %s: %s. "
+                        "Please disable extra_config['direct_io'] if filesystem/kernel "
+                        "does not support O_DIRECT for this path.",
+                        tensor_path,
+                        e,
+                    )
+                    raise
+            # previous no direct_io path: original numpy.tofile buffered write
             value.contiguous().view(dtype=torch.uint8).numpy().tofile(tensor_path)
             return True
         except Exception as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
This PR adds optional direct_io support to the HiCacheFile storage backend.

When enabled, HiCacheFile uses Linux O_DIRECT (os.open + os.readv/os.writev) for file read/write operations. The goal is to provide an explicit high-performance option for fast NVMe deployments, especially PCIe Gen5-class storage, where bypassing page cache can improve bandwidth behavior and reduce page-cache memory pressure.

Motivation
In high-throughput storage scenarios, buffered file I/O may become limited by kernel page-cache writeback behavior and can consume substantial DRAM for page cache.
This patch provides an operator-controlled mode to bypass page cache and reserve memory for other workloads.
<!-- Detail the changes made in this pull request. -->
What Changed
Updated HiCacheFile in python/sglang/srt/mem_cache/hicache_storage.py:

Added optional direct_io config parsing from hicache_storage_backend_extra_config.
Added direct read/write path using:
os.open(..., O_DIRECT)
os.readv(...)
os.writev(...)
Kept original buffered path intact as the default path (direct_io=false).
Added documentation:

docs/advanced_features/hicache_file_direct_io.md
Includes configuration, launch example, validation steps, benchmarking guidance, and troubleshooting.

Configuration
Use backend extra config:

{
  "hicache_storage_pass_prefix_keys": true,
  "direct_io": true,
  "direct_io_alignment": 4096
}
Behavior Notes
direct_io is opt-in (default remains buffered I/O).
This implementation is intentionally strict:
no automatic fallback behavior in direct path
no proactive alignment/staging logic in code
If filesystem/kernel/buffer constraints are not compatible with O_DIRECT, the direct path fails with clear logs; operators can disable direct_io in config.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
