### PR TITLE
[SGLang-Diffusion LLM] Add inference support for d3LLM models (arXiv:2601.07568)

### DIFF
--- a/docs/supported_models/text_generation/diffusion_language_models.md
+++ b/docs/supported_models/text_generation/diffusion_language_models.md
@@ -4,7 +4,7 @@ Diffusion language models have shown promise for non-autoregressive text generat
 
 ## Example Launch Command
 
-SGLang supports different DLLM algorithms such as `LowConfidence` and `JointThreshold`.
+SGLang supports different DLLM algorithms such as `LowConfidence`, `JointThreshold`, and `FullAttnMultiBlock`.
 
 ```shell
 python3 -m sglang.launch_server \
@@ -49,6 +49,24 @@ max_post_edit_steps: 16
 # 2-gram repetition penalty (default 0).
 # An empirical value of 3 is often sufficient to mitigate most repetitions.
 penalty_lambda: 0
+```
+
+FullAttnMultiBlock Config (for bidirectional models like LLaDA and DREAM):
+
+```yaml
+# Confidence threshold for accepting predicted tokens
+# Range: 0.0 - 1.0
+threshold: 0.5
+# Additional threshold increment per decoding step
+block_add: 0.1
+# Threshold for considering a token as "decoded"
+decoded_thresh: 0.95
+# Sub-block size for parallel decoding
+sub_block_size: 32
+# Number of iterations to delay before caching
+cache_delay_iter: 2
+# Interval for refreshing the attention cache
+refresh_interval: 10000
 ```
 
 ## Example Client Code Snippet
@@ -104,8 +122,12 @@ curl -X POST "http://127.0.0.1:30000/generate" \
 
 Below the supported models are summarized in a table.
 
-| Model Family               | Example Model                | Description                                                                                          |
-| -------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
-| **LLaDA2.0 (mini, flash)** | `inclusionAI/LLaDA2.0-flash` | LLaDA2.0-flash is a diffusion language model featuring a 100B Mixture-of-Experts (MoE) architecture. |
-| **SDAR (JetLM)**           | `JetLM/SDAR-8B-Chat`         | SDAR series diffusion language model (Chat), dense architecture.                                 |
-| **SDAR (JetLM)**           | `JetLM/SDAR-30B-A3B-Chat`    | SDAR series diffusion language model (Chat), MoE architecture.                                   |
+| Model Family               | Example Model                | Algorithm           | Description                                                                                          |
+| -------------------------- | ---------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------- |
+| **LLaDA2.0 (mini, flash)** | `inclusionAI/LLaDA2.0-mini`  | LowConfidence       | LLaDA2.0-mini is a diffusion language model with dense architecture.                                 |
+| **LLaDA2.0 (mini, flash)** | `inclusionAI/LLaDA2.0-flash` | LowConfidence       | LLaDA2.0-flash is a diffusion language model featuring a 100B Mixture-of-Experts (MoE) architecture. |
+| **LLaDA2.1-mini**          | `inclusionAI/LLaDA2.1-mini`  | LowConfidence       | LLaDA2.1-mini is an improved version of LLaDA2.0-mini with better performance.                       |
+| **d3LLM-LLaDA**            | `d3LLM/d3LLM_LLaDA`          | FullAttnMultiBlock  | Bidirectional diffusion LLM based on LLaDA architecture with full attention.                         |
+| **d3LLM-Dream**            | `d3LLM/d3LLM_Dream`          | FullAttnMultiBlock  | Bidirectional diffusion LLM based on DREAM architecture with full attention.                         |
+| **SDAR (JetLM)**           | `JetLM/SDAR-8B-Chat`         | JointThreshold      | SDAR series diffusion language model (Chat), dense architecture.                                     |
+| **SDAR (JetLM)**           | `JetLM/SDAR-30B-A3B-Chat`    | JointThreshold      | SDAR series diffusion language model (Chat), MoE architecture.                                       |

--- a/python/sglang/srt/dllm/algorithm/entropy_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/entropy_threshold.py
@@ -1,0 +1,126 @@
+from typing import List, Tuple, Union
+
+import torch
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+def sample_tokens_with_entropy(logits, temperature=1.0):
+    """Compute entropy and sample tokens. Copied from d3LLM."""
+    original_probs = torch.softmax(logits, dim=-1)
+    log_probs = torch.log(original_probs + 1e-8)
+    entropy = -torch.sum(original_probs * log_probs, dim=-1)
+
+    if temperature == 0:
+        samples = torch.argmax(logits, dim=-1)
+    else:
+        scaled_logits = logits / temperature
+        # Convert to probabilities and sample
+        probs = torch.softmax(scaled_logits, dim=-1)
+        samples = torch.multinomial(probs, num_samples=1).squeeze(-1)
+
+    return entropy, samples
+
+
+class EntropyThreshold(DllmAlgorithm):
+
+    def __init__(
+        self,
+        config: DllmConfig,
+    ):
+        super().__init__(config)
+        self.threshold = config.algorithm_config.get("threshold", 0.95)
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
+        batch_size = forward_batch.batch_size
+        # Per-item token counts: supports variable-length sequences (needs_full_prefill)
+        item_lens = forward_batch.extend_seq_lens_cpu
+        offsets = [0]
+        for l in item_lens:
+            offsets.append(offsets[-1] + l)
+        start_list = []
+        mask_index = forward_batch.input_ids == self.mask_id
+
+        # Fast path: if there is no mask token, forward and save kv cache
+        if torch.sum(mask_index).item() == 0:
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+
+            next_token_ids = []
+            return logits_output, next_token_ids, can_run_cuda_graph
+
+        # Calculate start positions for each batch item
+        for i in range(batch_size):
+            block_input_ids = forward_batch.input_ids[offsets[i] : offsets[i + 1]]
+            block_mask_index = block_input_ids == self.mask_id
+            start = item_lens[i] - torch.sum(block_mask_index).item()
+            start_list.append(start)
+
+        nfe = 0
+        for _ in range(self.block_size):
+            mask_index = forward_batch.input_ids == self.mask_id
+            if torch.sum(mask_index).item() == 0:
+                break
+
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            nfe += 1
+            logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+            for batch_id in range(batch_size):
+                s, e = offsets[batch_id], offsets[batch_id + 1]
+                block_input_ids = forward_batch.input_ids[s:e]
+                block_mask_index = block_input_ids == self.mask_id
+                if torch.sum(block_mask_index).item() == 0:
+                    continue
+                curr_logits = logits_output.full_logits[s:e]
+
+                # Entropy-based selection (matching d3LLM's entropy_threshold algorithm)
+                mask_logits = curr_logits[block_mask_index]
+                entropy, x0 = sample_tokens_with_entropy(mask_logits, temperature=0)
+
+                x = block_input_ids.clone()
+                full_entropy = torch.full_like(
+                    block_input_ids, float("inf"), dtype=curr_logits.dtype
+                )
+
+                x[block_mask_index] = x0
+                full_entropy[block_mask_index] = entropy
+
+                num_mask = block_mask_index.sum().item()
+                selected_entropy, select_index = torch.topk(
+                    full_entropy, num_mask, largest=False
+                )
+                transfer_index = torch.zeros_like(block_input_ids, dtype=torch.bool)
+
+                # Always accept the lowest-entropy token; accept others if entropy < threshold
+                transfer_index[select_index[0]] = True
+                for k in range(1, num_mask):
+                    if selected_entropy[k] < self.threshold:
+                        transfer_index[select_index[k]] = True
+                    else:
+                        transfer_index[select_index[k]] = False
+
+                block_input_ids[transfer_index] = x[transfer_index]
+
+        out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+        nfe += 1
+        logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+        # Build per-sequence next_token_ids using variable-length offsets
+        next_token_ids_list = [
+            forward_batch.input_ids[offsets[i] + start_list[i] : offsets[i + 1]]
+            for i in range(batch_size)
+        ]
+
+        # Token per forward: attach nfe so it flows via customized_info -> meta_info
+        logits_output.customized_info = {"nfe": [nfe] * batch_size}
+        return logits_output, next_token_ids_list, can_run_cuda_graph
+
+
+Algorithm = EntropyThreshold

--- a/python/sglang/srt/dllm/algorithm/full_attn_multi_block.py
+++ b/python/sglang/srt/dllm/algorithm/full_attn_multi_block.py
@@ -1,0 +1,241 @@
+"""Full-attention multi-block decoding for bidirectional dLLMs (e.g. Dream).
+
+Matches d3LLM's _sample_multi_block behavior: all max_new_tokens masks are
+present from the start. Multiple blocks are decoded in parallel, with new
+blocks activated based on previous block's decoding progress.
+
+Key matching with d3LLM _sample_multi_block (no cache):
+  - ALL mask positions up to rightmost active block are eligible for decoding
+    (not just fully-activated blocks) — entropy threshold is the only gate
+  - Forced progress only applies to the first fully-activated block
+  - block_add_threshold=0.1 and decoded_token_threshold=0.95 are the defaults
+    matching d3LLM's eval commands for parallel multi-block decoding
+"""
+
+from typing import List, Tuple, Union
+
+import torch
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class FullAttnMultiBlock(DllmAlgorithm):
+    """Multi-block parallel decoding with entropy threshold for full-attention dLLMs.
+
+    Config keys (from algorithm_config YAML):
+      threshold               - entropy threshold for token acceptance  (default: 0.4)
+      block_add_threshold     - prev block progress to add next block   (default: 0.1)
+      decoded_token_threshold - prev progress for full activation       (default: 0.95)
+      cache_delay_iter        - NFE delay before "cached" state         (default: 10000)
+      refresh_interval        - periodic refresh interval               (default: 10000)
+    """
+
+    def __init__(self, config: DllmConfig):
+        super().__init__(config)
+        self.threshold = config.algorithm_config.get("threshold", 0.4)
+        self.block_add_threshold = config.algorithm_config.get(
+            "block_add_threshold", 0.1
+        )
+        self.decoded_token_threshold = config.algorithm_config.get(
+            "decoded_token_threshold", 0.95
+        )
+        self.cache_delay_iter = config.algorithm_config.get("cache_delay_iter", 10000)
+        self.refresh_interval = config.algorithm_config.get("refresh_interval", 10000)
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
+        batch_size = forward_batch.batch_size
+        if batch_size == 0 or forward_batch.input_ids.numel() == 0:
+            return LogitsProcessorOutput(next_token_logits=torch.empty(0)), [], True
+
+        item_lens = forward_batch.extend_seq_lens_cpu
+        offsets = [0]
+        for l in item_lens:
+            offsets.append(offsets[-1] + l)
+
+        # Use origin_input_lens if available, otherwise fall back to mask counting
+        origin_lens = forward_batch.dllm_origin_input_lens
+
+        # Per-item setup: calculate start positions and mask counts
+        start_list = []
+        gen_lengths = []
+        for i in range(batch_size):
+            ids = forward_batch.input_ids[offsets[i] : offsets[i + 1]]
+            n_masks = (ids == self.mask_id).sum().item()
+            if origin_lens is not None:
+                start_list.append(origin_lens[i])
+                gen_lengths.append(item_lens[i] - origin_lens[i])
+            else:
+                start_list.append(item_lens[i] - n_masks)
+                gen_lengths.append(n_masks)
+
+        # Fast path: no masks - all tokens already decoded
+        if (forward_batch.input_ids == self.mask_id).sum().item() == 0:
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            # Return the generated portion (from start_list[i] to end) for each item
+            next_token_ids_list = [
+                forward_batch.input_ids[offsets[i] + start_list[i] : offsets[i + 1]]
+                for i in range(batch_size)
+            ]
+            return out.logits_output, next_token_ids_list, out.can_run_graph
+
+        # Build block states per item (matches d3LLM block_states dict)
+        # Block 0 = prompt (always complete). Gen blocks start from 1.
+        item_blocks = []
+        for i in range(batch_size):
+            num_blocks = (gen_lengths[i] + self.block_size - 1) // self.block_size
+            blocks = []
+            for k in range(num_blocks):
+                bs = start_list[i] + k * self.block_size
+                be = min(bs + self.block_size, start_list[i] + gen_lengths[i])
+                blocks.append(
+                    {
+                        "start": bs,
+                        "end": be,
+                        "total": be - bs,
+                        "mask_count": be - bs,
+                        "is_active": k == 0,  # block has been "added"
+                        "is_fully_active": k
+                        == 0,  # prev block progress >= decoded_token_threshold
+                        "completed_at_nfe": None,
+                        "is_cached": False,
+                    }
+                )
+            item_blocks.append(blocks)
+
+        nfe = 0
+        logits_output = None
+        can_run_cuda_graph = False
+        max_nfe = sum(gen_lengths) + batch_size  # Upper bound on iterations
+
+        while True:
+            # Check termination: all masks decoded
+            if (forward_batch.input_ids == self.mask_id).sum().item() == 0:
+                break
+
+            # Safety check: prevent infinite loop
+            if nfe >= max_nfe:
+                break
+
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            nfe += 1
+            logits_output = out.logits_output
+            can_run_cuda_graph = out.can_run_graph
+
+            for i in range(batch_size):
+                s, e = offsets[i], offsets[i + 1]
+                ids = forward_batch.input_ids[s:e]
+                logits = logits_output.full_logits[s:e]
+                blocks = item_blocks[i]
+
+                # Update block activation based on previous block progress
+                for k in range(1, len(blocks)):
+                    prev = blocks[k - 1]
+                    prev_progress = 1 - prev["mask_count"] / prev["total"]
+                    if not blocks[k]["is_active"]:
+                        if (
+                            prev_progress >= self.block_add_threshold
+                            or prev["mask_count"] == 0
+                        ):
+                            blocks[k]["is_active"] = True
+                    if blocks[k]["is_active"] and not blocks[k]["is_fully_active"]:
+                        if prev_progress >= self.decoded_token_threshold:
+                            blocks[k]["is_fully_active"] = True
+
+                # Find rightmost active block end (matches d3LLM: any block that
+                # is_fully_active OR has mask_count > 0 determines active_end)
+                active_end = 0
+                for blk in blocks:
+                    if blk["is_active"] and (
+                        blk["is_fully_active"] or blk["mask_count"] > 0
+                    ):
+                        active_end = blk["end"]
+
+                if active_end == 0:
+                    continue
+
+                # Build decode mask: ALL mask positions up to active_end
+                # (matches d3LLM: mask_index_for_decode[:, active_end:] = 0)
+                decode_mask = ids[:active_end].eq(self.mask_id)
+                n_decode = decode_mask.sum().item()
+                if n_decode == 0:
+                    continue
+
+                # Entropy-based denoising across all decodable positions
+                mask_logits = logits[:active_end][decode_mask]
+                probs = torch.softmax(mask_logits.float(), dim=-1)
+                entropy = -torch.sum(probs * torch.log(probs + 1e-12), dim=-1)
+                x0 = torch.argmax(mask_logits, dim=-1)
+
+                full_entropy = torch.full(
+                    (active_end,), float("inf"), dtype=entropy.dtype, device=ids.device
+                )
+                full_x0 = ids[:active_end].clone()
+                full_entropy[decode_mask] = entropy
+                full_x0[decode_mask] = x0
+
+                # Global entropy threshold (matches d3LLM)
+                transfer = (full_entropy < self.threshold) & decode_mask
+
+                # Per-block forced progress for first fully-activated block
+                # (matches d3LLM: force even if other blocks accepted tokens)
+                first_fa_blk = None
+                for blk in blocks:
+                    if blk["is_fully_active"] and blk["mask_count"] > 0:
+                        first_fa_blk = blk
+                        break
+                if first_fa_blk is not None:
+                    bs_, be_ = first_fa_blk["start"], min(
+                        first_fa_blk["end"], active_end
+                    )
+                    blk_transfer = transfer[bs_:be_]
+                    if not blk_transfer.any():
+                        blk_mask = ids[bs_:be_].eq(self.mask_id)
+                        blk_ent = full_entropy[bs_:be_].clone()
+                        blk_ent[~blk_mask] = float("inf")
+                        best = blk_ent.argmin()
+                        transfer[bs_ + best] = True
+
+                # Update ids in-place: expand transfer mask to full ids length
+                full_transfer = torch.zeros(
+                    len(ids), dtype=torch.bool, device=ids.device
+                )
+                full_transfer[:active_end] = transfer
+                ids[full_transfer] = full_x0[transfer]
+
+                # Update block mask counts and completion tracking
+                for blk in blocks:
+                    if blk["mask_count"] > 0:
+                        new_count = (
+                            ids[blk["start"] : blk["end"]].eq(self.mask_id).sum().item()
+                        )
+                        if new_count == 0 and blk["completed_at_nfe"] is None:
+                            blk["completed_at_nfe"] = nfe
+                        blk["mask_count"] = new_count
+
+        # Final forward for fresh logits (needed by sglang framework)
+        if (
+            logits_output is None
+            or (forward_batch.input_ids == self.mask_id).sum().item() > 0
+        ):
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            nfe += 1
+            logits_output = out.logits_output
+            can_run_cuda_graph = out.can_run_graph
+
+        next_token_ids_list = [
+            forward_batch.input_ids[offsets[i] + start_list[i] : offsets[i + 1]]
+            for i in range(batch_size)
+        ]
+        logits_output.customized_info = {"nfe": [nfe] * batch_size}
+        return logits_output, next_token_ids_list, can_run_cuda_graph
+
+
+Algorithm = FullAttnMultiBlock

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -12,12 +12,20 @@ class DllmConfig:
         block_size: int,
         mask_id: int,
         max_running_requests: int,
+        needs_full_prefill: bool = False,
+        pad_full_generation: bool = False,
     ):
         self.algorithm = algorithm
         self.algorithm_config = algorithm_config
         self.block_size = block_size
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
+        # Bidirectional models (e.g. Dream) cannot use prefix KV cache;
+        # they must recompute all tokens every forward pass.
+        self.needs_full_prefill = needs_full_prefill
+        # Full-attention algorithms pad ALL max_new_tokens masks at once
+        # instead of adding block_size masks per round.
+        self.pad_full_generation = pad_full_generation
 
     @staticmethod
     def from_server_args(
@@ -31,17 +39,25 @@ class DllmConfig:
             model_path=server_args.model_path,
             model_revision=server_args.revision,
         )
-        DLLM_PARAMS = {
-            "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
-            "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
-            "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
-        }
-
+        needs_full_prefill = False
         arch = model_config.hf_config.architectures[0]
-        if arch in DLLM_PARAMS:
-            params = DLLM_PARAMS[arch]
-            block_size = params["block_size"]
-            mask_id = params["mask_id"]
+        if arch == "LLaDA2MoeModelLM":
+            block_size = 32
+            mask_id = 156895
+        elif arch == "Qwen3ForCausalLM":
+            block_size = 32
+            mask_id = 151670
+        elif arch == "DreamModel":
+            block_size = 32
+            mask_id = 151666
+            needs_full_prefill = True
+        elif arch == "LLaDAModelLM":
+            block_size = 32
+            mask_id = 126336
+            needs_full_prefill = True
+        elif arch in {"SDARForCausalLM", "SDARMoeForCausalLM"}:
+            block_size = 4
+            mask_id = 151669
         else:
             raise RuntimeError(f"Unknown diffusion LLM: {arch}")
 
@@ -66,10 +82,19 @@ class DllmConfig:
             # Parse common algorithm configurations
             block_size = algorithm_config.get("block_size", block_size)
 
+        # Full-attention algorithms pad ALL max_new_tokens masks at once
+        _FULL_GEN_PAD_ALGORITHMS = {"FullAttnMultiBlock"}
+        pad_full_generation = (
+            needs_full_prefill
+            and server_args.dllm_algorithm in _FULL_GEN_PAD_ALGORITHMS
+        )
+
         return DllmConfig(
             algorithm=server_args.dllm_algorithm,
             algorithm_config=algorithm_config,
             block_size=block_size,
             mask_id=mask_id,
             max_running_requests=max_running_requests,
+            needs_full_prefill=needs_full_prefill,
+            pad_full_generation=pad_full_generation,
         )

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -19,6 +19,7 @@ class DllmReqPhase(str, enum.Enum):
 class ReqDllmMixin:
     def init_diffusion_llm(self: Req, dllm_config: DllmConfig):
         self.dllm_phase: Optional[DllmReqPhase] = None
+        self.dllm_ids = []  # For full-attention bidirectional models (LLaDA, DREAM)
         self.dllm_block_offset = 0
         self.dllm_config = dllm_config
 
@@ -54,16 +55,39 @@ class ReqDllmMixin:
             self.dllm_phase = DllmReqPhase.STAGING_DECODE
 
     def _init_fill_ids_for_dllm(self: Req):
-        self.dllm_block_offset = (
-            0
-            if not self.fill_ids
-            else self.dllm_block_offset + self.dllm_config.block_size
-        )
-        self.fill_ids = (
-            self.origin_input_ids
-            + self.output_ids
-            + [self.dllm_config.mask_id] * self.dllm_config.block_size
-        )
+        # For full-attention bidirectional models (LLaDA, DREAM), use dllm_ids
+        if getattr(self.dllm_config, "pad_full_generation", False) or getattr(
+            self.dllm_config, "needs_full_prefill", False
+        ):
+            if not self.dllm_ids:
+                if self.dllm_config.pad_full_generation:
+                    # Full-attention algorithms: pad ALL max_new_tokens masks at once
+                    num_masks = self.sampling_params.max_new_tokens
+                else:
+                    num_masks = self.dllm_config.block_size
+                self.dllm_ids = (
+                    self.origin_input_ids + [self.dllm_config.mask_id] * num_masks
+                )
+            else:
+                if not self.dllm_config.needs_full_prefill:
+                    self.dllm_block_offset += self.dllm_config.block_size
+                if not self.dllm_config.pad_full_generation:
+                    self.dllm_ids += [
+                        self.dllm_config.mask_id
+                    ] * self.dllm_config.block_size
+            self.fill_ids = self.dllm_ids
+        else:
+            # Original dLLM logic (e.g., d3llm)
+            self.dllm_block_offset = (
+                0
+                if not self.fill_ids
+                else self.dllm_block_offset + self.dllm_config.block_size
+            )
+            self.fill_ids = (
+                self.origin_input_ids
+                + self.output_ids
+                + [self.dllm_config.mask_id] * self.dllm_config.block_size
+            )
 
     def _update_block_offset_for_dllm(self):
         prefix_len = len(self.prefix_indices)

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -68,29 +68,41 @@ class SchedulerDllmMixin:
         if result.copy_done is not None:
             result.copy_done.synchronize()
 
-        if result.next_token_ids:
-            self.token_to_kv_pool_allocator.free_group_begin()
+        self.token_to_kv_pool_allocator.free_group_begin()
 
-            for idx in range(batch.batch_size()):
-                req = batch.reqs[idx]
+        for idx in range(batch.batch_size()):
+            req = batch.reqs[idx]
+            new_tokens = 0
 
+            if result.next_token_ids and len(result.next_token_ids) > idx:
                 next_token_ids = result.next_token_ids[idx].tolist()
                 new_tokens = len(next_token_ids)
-                if new_tokens == 0:
-                    continue
 
-                req.fill_ids[-new_tokens:] = next_token_ids[:]
-                self.num_generated_tokens += new_tokens
+                if new_tokens > 0:
+                    req.fill_ids[-new_tokens:] = next_token_ids[:]
+                    self.num_generated_tokens += new_tokens
+                    req.output_ids.extend(next_token_ids)
 
-                req.output_ids.extend(next_token_ids)
-                req.check_finished(new_accepted_len=new_tokens)
+            # For needs_full_prefill dLLM: sync output_ids from fill_ids if not yet done
+            if req.is_dllm() and req.dllm_config.needs_full_prefill:
+                expected_output_len = len(req.fill_ids) - len(req.origin_input_ids)
+                if len(req.output_ids) < expected_output_len:
+                    new_output_ids = req.fill_ids[len(req.origin_input_ids) :]
+                    new_tokens = len(new_output_ids) - len(req.output_ids)
+                    req.output_ids = new_output_ids
 
-                if req.finished():
-                    release_kv_cache(req, self.tree_cache)
-                    req.time_stats.set_completion_time()
+            req.check_finished(new_accepted_len=max(new_tokens, 1))
 
-            self.stream_output(batch.reqs, batch.return_logprob)
-            self.token_to_kv_pool_allocator.free_group_end()
+            if req.finished():
+                # For needs_full_prefill, don't insert to radix cache (recomputes each round)
+                is_insert = not (req.is_dllm() and req.dllm_config.needs_full_prefill)
+                release_kv_cache(req, self.tree_cache, is_insert=is_insert)
+                req.time_stats.set_completion_time()
+
+            self.maybe_collect_customized_info(idx, req, result.logits_output)
+
+        self.stream_output(batch.reqs, batch.return_logprob)
+        self.token_to_kv_pool_allocator.free_group_end()
 
         can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
         self.report_prefill_stats(

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -504,7 +504,11 @@ async def health_generate(request: Request) -> Response:
     ):
         return Response(status_code=200)
 
-    sampling_params = {"max_new_tokens": 1, "temperature": 0.0}
+    # For dLLM models, use larger max_new_tokens to ensure proper decoding
+    max_new_tokens = 1
+    if _global_state.tokenizer_manager.server_args.dllm_algorithm is not None:
+        max_new_tokens = 64  # Must be >= block_size (typically 32)
+    sampling_params = {"max_new_tokens": max_new_tokens, "temperature": 0.0}
     rid = f"HEALTH_CHECK_{time.time()}"
 
     if _global_state.tokenizer_manager.is_image_gen:
@@ -1800,6 +1804,9 @@ def _execute_server_warmup(server_args: ServerArgs):
     else:
         request_name = "/encode"
     max_new_tokens = 8 if model_info["is_generation"] else 1
+    # For dLLM models, use larger max_new_tokens to ensure proper decoding
+    if server_args.dllm_algorithm is not None:
+        max_new_tokens = 64  # Must be >= block_size (typically 32)
     json_data = {
         "sampling_params": {
             "temperature": 0,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -667,12 +667,18 @@ class FlashInferAttnBackend(AttentionBackend):
                     )
                 )
             seq_lens_sum = seq_lens.sum().item()
+            # Bidirectional models (ENCODER_ONLY) don't save KV cache,
+            # so prefix_lens must be 0 to recompute all tokens each pass.
+            if self.dllm_config.needs_full_prefill:
+                dllm_prefix_lens = torch.zeros_like(seq_lens)
+            else:
+                dllm_prefix_lens = seq_lens - self.dllm_config.block_size
             self.indices_updater_prefill.update(
                 req_pool_indices,
                 seq_lens,
                 seq_lens.cpu(),  # may add a little overhead in capture stage
                 seq_lens_sum,
-                prefix_lens=seq_lens - self.dllm_config.block_size,
+                prefix_lens=dllm_prefix_lens,
                 prefill_wrappers=prefill_wrappers,
                 use_ragged=True,
                 encoder_lens=encoder_lens,
@@ -731,12 +737,16 @@ class FlashInferAttnBackend(AttentionBackend):
                 spec_info=spec_info,
             )
         elif forward_mode.is_dllm_extend():
+            if self.dllm_config.needs_full_prefill:
+                dllm_prefix_lens = torch.zeros_like(seq_lens[:bs])
+            else:
+                dllm_prefix_lens = seq_lens - self.dllm_config.block_size
             self.indices_updater_prefill.update(
                 req_pool_indices[:bs],
                 seq_lens[:bs],
                 seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
                 seq_lens_sum,
-                prefix_lens=seq_lens - self.dllm_config.block_size,
+                prefix_lens=dllm_prefix_lens,
                 prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
                 use_ragged=True,
                 encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -880,7 +880,13 @@ class Req(ReqDllmMixin):
         max_prefix_len = max(max_prefix_len, 0)
         token_ids = self.fill_ids[:max_prefix_len]
 
-        if tree_cache is not None:
+        # Bidirectional dLLM models (ENCODER_ONLY attention) recompute all tokens
+        # every round, so keep prefix_indices empty and skip tree cache matching.
+        if self.is_dllm() and self.dllm_config.needs_full_prefill:
+            self.prefix_indices = torch.empty((0,), dtype=torch.int64)
+            self.last_node = None
+            self.cache_protected_len = 0
+        elif tree_cache is not None:
             if cow_mamba is None:
                 cow_mamba = tree_cache.supports_mamba()
             match_result = tree_cache.match_prefix(
@@ -1502,6 +1508,18 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens = seq_lens_tensor
         self.seq_lens_cpu = seq_lens_cpu
         self.extend_num_tokens = extend_num_tokens
+
+        # For needs_full_prefill models: free old KV slots before reallocating,
+        # since the full sequence is re-sent each round and prefix_indices is empty.
+        if self.is_dllm() and self.dllm_config.needs_full_prefill:
+            for req in reqs:
+                if req.kv_committed_len > 0 and req.req_pool_idx is not None:
+                    old_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, : req.kv_committed_len
+                    ]
+                    self.token_to_kv_pool_allocator.free(old_indices)
+                    req.kv_committed_len = 0
+                    req.cache_protected_len = 0
 
         # Allocate memory
         out_cache_loc, req_pool_indices_tensor, req_pool_indices = alloc_for_extend(
@@ -2278,6 +2296,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             dimensions=self.dimensions,
             dllm_block_offsets=[req.dllm_block_offset for req in self.reqs],
             dllm_config=self.dllm_config,
+            dllm_origin_input_lens=(
+                [len(req.origin_input_ids) for req in self.reqs]
+                if self.is_dllm()
+                else None
+            ),
             reqs=self.reqs,
             has_grammar=self.has_grammar,
             mamba_track_indices=self.mamba_track_indices,
@@ -2464,6 +2487,7 @@ class ModelWorkerBatch:
     # Diffusion LLM
     dllm_block_offsets: Optional[List[int]] = None
     dllm_config: Optional[DllmConfig] = None
+    dllm_origin_input_lens: Optional[List[int]] = None
 
     # For constrained decoding
     # FIXME(lsyin): remove this after fully overlap grammar

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -438,7 +438,11 @@ class PrefillAdder:
         self.dllm_block_size = dllm_config.block_size
         max_running_reqs = dllm_config.max_running_requests
 
-        self.rem_dllm_tokens = max_running_reqs * self.dllm_block_size
+        if dllm_config.needs_full_prefill:
+            # Bidirectional models process full sequences; use a large token budget.
+            self.rem_dllm_tokens = max_running_reqs * self.rem_input_tokens
+        else:
+            self.rem_dllm_tokens = max_running_reqs * self.dllm_block_size
 
     def _get_running_request_total_token_offset(self, req: Req) -> int:
         return (
@@ -532,6 +536,10 @@ class PrefillAdder:
         self.log_input_tokens += extend_input_len
 
     def _get_dllm_remain_tokens(self) -> int:
+        if self.dllm_config.needs_full_prefill:
+            # Bidirectional models process full sequences; don't cap at block_size.
+            return max(self.rem_dllm_tokens, 0)
+
         _rem_tokens = min(
             self.rem_dllm_tokens,
             self.dllm_block_size,
@@ -546,11 +554,17 @@ class PrefillAdder:
         # FIXME: consider the case when rem_dllm_tokens < dllm_block_size,
         # the diffusion unmask process may have some problems
         # Make sure at least one page is available
-        trunc_len = (
-            min(self.rem_dllm_tokens, self.dllm_block_size)
-            // self.page_size
-            * self.page_size
-        )
+        if self.dllm_config.needs_full_prefill:
+            # Bidirectional models: send full sequence (no prefix KV reuse)
+            trunc_len = (
+                (len(req.fill_ids) - prefix_len) // self.page_size * self.page_size
+            )
+        else:
+            trunc_len = (
+                min(self.rem_dllm_tokens, self.dllm_block_size)
+                // self.page_size
+                * self.page_size
+            )
 
         req.extend_input_len = trunc_len
         req.fill_ids = req.fill_ids[: prefix_len + trunc_len]
@@ -560,6 +574,9 @@ class PrefillAdder:
         self._update_prefill_budget(prefix_len, trunc_len, 0)
 
     def _req_inc_lock_ref(self, req: Req):
+        # For needs_full_prefill dLLM, last_node may be None (no tree cache matching)
+        if req.last_node is None:
+            return
         if self.is_hybrid_swa:
             swa_uuid_for_lock = self.tree_cache.inc_lock_ref(req.last_node)
             req.swa_uuid_for_lock = swa_uuid_for_lock
@@ -623,6 +640,10 @@ class PrefillAdder:
 
     @contextmanager
     def _lock_node(self, last_node: TreeNode):
+        # For needs_full_prefill dLLM, last_node may be None (no tree cache matching)
+        if last_node is None:
+            yield None
+            return
         try:
             if self.tree_cache.supports_swa() and self.tree_cache.is_tree_cache():
                 swa_uuid_for_lock = self.tree_cache.inc_lock_ref(last_node)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2019,6 +2019,9 @@ class Scheduler(
             self.handle_embedding_request(tokenized_req)
 
     def stash_chunked_request(self, req: Req):
+        # Skip cache_unfinished_req for needs_full_prefill dLLM (recomputes full sequence each round)
+        if req.is_dllm() and req.dllm_config.needs_full_prefill:
+            return
         self.tree_cache.cache_unfinished_req(req, chunked=True)
 
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -610,7 +610,7 @@ class RadixCache(BasePrefixCache):
         return EvictResult(num_tokens_evicted=num_evicted)
 
     def inc_lock_ref(self, node: TreeNode):
-        if self.disable:
+        if self.disable or node is None:
             return 0
 
         delta = 0
@@ -625,7 +625,7 @@ class RadixCache(BasePrefixCache):
         return delta
 
     def dec_lock_ref(self, node: TreeNode):
-        if self.disable:
+        if self.disable or node is None:
             return 0
 
         delta = 0

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -468,6 +468,23 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner, num_tokens_per_bs=1):
     capture_bs = [bs for bs in capture_bs if bs <= model_runner.req_to_token_pool.size]
     capture_bs = list(sorted(set(capture_bs)))
     assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"
+
+    # Workaround for Blackwell (SM >= 10.0): capturing multiple CUDA graphs
+    # with different batch sizes causes earlier-captured graphs to become invalid
+    # on replay (cudaErrorIllegalAddress / cudaErrorIllegalInstruction).
+    # Only capture the maximum BS and pad smaller batches to it.
+    if (
+        len(capture_bs) > 1
+        and num_tokens_per_bs > 1  # dLLM / speculative mode (more tokens per BS)
+        and torch.cuda.is_available()
+        and torch.cuda.get_device_capability()[0] >= 10
+    ):
+        logger.warning(
+            f"Blackwell GPU detected: only capturing max BS={capture_bs[-1]} "
+            f"(requested {capture_bs}). Smaller batches will be padded."
+        )
+        capture_bs = [capture_bs[-1]]
+
     compile_bs = (
         [bs for bs in capture_bs if bs <= server_args.torch_compile_max_bs]
         if server_args.enable_torch_compile
@@ -572,11 +589,16 @@ class CudaGraphRunner:
 
         # Init PDMux if needed
         self.maybe_init_pdmux()
+        # For non-full-prefill dLLM, seq_len_fill_value stays at block_size.
+        # The real fix for Blackwell is in flashinfer_backend: passing
+        # max_sequence_kv=max_context_len to stabilise _max_kv_len across
+        # capture and replay (see call_begin_forward in FlashInferIndicesUpdaterPrefill).
         self.seq_len_fill_value = (
             self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
             if self.dllm_config is None
             else self.dllm_config.block_size
         )
+        self._disable_dllm_cuda_graph = False
 
         self.encoder_len_fill_value = 0
 
@@ -704,12 +726,23 @@ class CudaGraphRunner:
             else True
         )
 
+        # dLLM with needs_full_prefill may have variable-length inputs
+        is_dllm_supported = (
+            (
+                forward_batch.batch_size * self.num_tokens_per_bs
+                == forward_batch.input_ids.numel()
+            )
+            if self.is_dllm and self.dllm_config.needs_full_prefill
+            else True
+        )
+
         return (
             is_bs_supported
             and is_encoder_lens_supported
             and is_tbo_supported
             and capture_hidden_mode_matches
             and is_ngram_supported
+            and is_dllm_supported
         )
 
     def _init_profile_context_and_memory_record(self):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -422,6 +422,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For dumper: request IDs for cross-step sequence tracking
     rids: Optional[List[str]] = None
 
+    # For diffusion LLM: original input lengths (before adding mask tokens)
+    dllm_origin_input_lens: Optional[List[int]] = None
+
     @classmethod
     def init_new(
         cls,
@@ -468,6 +471,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             dimensions=batch.dimensions,
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
             rids=[req.rid for req in batch.reqs],
+            dllm_origin_input_lens=batch.dllm_origin_input_lens,
         )
         device = model_runner.device
 
@@ -516,14 +520,25 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             block_size = batch.dllm_config.block_size
             # Use int64 for AMD rotary embedding kernel compatibility
             positions_dtype = torch.int64 if is_hip() or _is_npu else torch.int32
-            ret.positions = torch.tensor(
-                [
-                    i
-                    for block_offset in batch.dllm_block_offsets
-                    for i in range(block_offset, block_offset + block_size)
-                ],
-                dtype=positions_dtype,
-            ).to(device, non_blocking=True)
+            if batch.dllm_config.needs_full_prefill:
+                # Bidirectional models: positions cover the full sequence per request
+                if batch.seq_lens_cpu is not None:
+                    seq_lens_list = batch.seq_lens_cpu.tolist()
+                else:
+                    seq_lens_list = batch.seq_lens.cpu().tolist()
+                ret.positions = torch.tensor(
+                    [i for seq_len in seq_lens_list for i in range(seq_len)],
+                    dtype=positions_dtype,
+                ).to(device, non_blocking=True)
+            else:
+                ret.positions = torch.tensor(
+                    [
+                        i
+                        for block_offset in batch.dllm_block_offsets
+                        for i in range(block_offset, block_offset + block_size)
+                    ],
+                    dtype=positions_dtype,
+                ).to(device, non_blocking=True)
         elif (
             ret.spec_info is not None
             and getattr(ret.spec_info, "positions", None) is not None

--- a/python/sglang/srt/models/d3llm_llada.py
+++ b/python/sglang/srt/models/d3llm_llada.py
@@ -1,0 +1,186 @@
+"""SGLang d3LLM-LLaDA model (LLaDA-8B with full bidirectional attention).
+
+d3LLM-LLaDA is architecturally identical to LLaMA but uses bidirectional
+(non-causal) attention and a custom weight naming scheme. This class extends
+LlamaForCausalLM, patches config fields, sets encoder-only attention, and
+provides weight name remapping.
+
+Weight mapping (d3LLM-LLaDA → sglang Llama):
+  model.transformer.wte.weight          → model.embed_tokens.weight
+  model.transformer.ln_f.weight         → model.norm.weight
+  model.transformer.ff_out.weight       → lm_head.weight
+  blocks.{i}.q_proj / k_proj / v_proj   → layers.{i}.self_attn.qkv_proj (sharded)
+  blocks.{i}.attn_out                   → layers.{i}.self_attn.o_proj
+  blocks.{i}.attn_norm                  → layers.{i}.input_layernorm
+  blocks.{i}.ff_proj                    → layers.{i}.mlp.gate_up_proj (shard 0)
+  blocks.{i}.up_proj                    → layers.{i}.mlp.gate_up_proj (shard 1)
+  blocks.{i}.ff_out                     → layers.{i}.mlp.down_proj
+  blocks.{i}.ff_norm                    → layers.{i}.post_attention_layernorm
+"""
+
+from typing import Iterable, Optional, Tuple
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.llama import LlamaForCausalLM
+
+
+def _patch_llada_config(config):
+    """Add Llama-compatible attributes missing from LLaDAConfig."""
+    if not hasattr(config, "num_key_value_heads") or config.num_key_value_heads is None:
+        config.num_key_value_heads = getattr(
+            config, "n_kv_heads", config.num_attention_heads
+        )
+    if not hasattr(config, "intermediate_size") or config.intermediate_size is None:
+        config.intermediate_size = getattr(
+            config, "mlp_hidden_size", config.hidden_size * 4
+        )
+    if (
+        not hasattr(config, "max_position_embeddings")
+        or config.max_position_embeddings is None
+    ):
+        config.max_position_embeddings = getattr(config, "max_sequence_length", 4096)
+    if not hasattr(config, "hidden_act"):
+        config.hidden_act = "silu"
+    if not hasattr(config, "head_dim"):
+        config.head_dim = config.hidden_size // config.num_attention_heads
+    if not hasattr(config, "rope_scaling"):
+        config.rope_scaling = None
+    if not hasattr(config, "rope_theta"):
+        config.rope_theta = 500000.0
+    # LLaDA has separate lm_head (ff_out) despite PretrainedConfig defaulting True
+    config.tie_word_embeddings = False
+    if not hasattr(config, "vocab_size") or config.vocab_size is None:
+        config.vocab_size = getattr(config, "embedding_size", 126464)
+    return config
+
+
+# --- Weight name remapping ------------------------------------------------
+
+# Global (non-layer) weights
+_GLOBAL_MAP = {
+    "model.transformer.wte.weight": "model.embed_tokens.weight",
+    "model.transformer.ln_f.weight": "model.norm.weight",
+    "model.transformer.ff_out.weight": "lm_head.weight",
+}
+
+# Per-layer stacked params: (llada_suffix, sglang_suffix, shard_id)
+_STACKED = [
+    (".q_proj.", ".self_attn.q_proj.", "q"),
+    (".k_proj.", ".self_attn.k_proj.", "k"),
+    (".v_proj.", ".self_attn.v_proj.", "v"),
+    (".ff_proj.", ".mlp.gate_proj.", 0),
+    (".up_proj.", ".mlp.up_proj.", 1),
+]
+
+# Per-layer simple renames: (llada_suffix, sglang_suffix)
+_SIMPLE = [
+    (".attn_out.", ".self_attn.o_proj."),
+    (".attn_norm.", ".input_layernorm."),
+    (".ff_norm.", ".post_attention_layernorm."),
+    (".ff_out.", ".mlp.down_proj."),
+]
+
+
+def _remap_name(name: str):
+    """Convert a LLaDA weight name to sglang Llama name + optional shard id."""
+    if name in _GLOBAL_MAP:
+        return _GLOBAL_MAP[name], None
+
+    # blocks.N → layers.N
+    name = name.replace("model.transformer.blocks.", "model.layers.")
+
+    for old, new, sid in _STACKED:
+        if old in name:
+            return name.replace(old, new), sid
+
+    for old, new in _SIMPLE:
+        if old in name:
+            return name.replace(old, new), None
+
+    return name, None
+
+
+class LLaDAModelLM(LlamaForCausalLM):
+    def __init__(self, config, quant_config=None, prefix=""):
+        config = _patch_llada_config(config)
+        super().__init__(config, quant_config, prefix)
+        # dLLM needs full logits over all tokens (not just the last one).
+        self.logits_processor = LogitsProcessor(config, return_full_logits=True)
+        # LLaDA uses full bidirectional (non-causal) attention.
+        for layer in self.model.layers:
+            if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "attn"):
+                layer.self_attn.attn.attn_type = AttentionType.ENCODER_ONLY
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+
+        if self.pp_group.is_last_rank and not get_embedding:
+            # LLaDA predicts the current position directly (no right-shift).
+            return self.logits_processor(
+                input_ids,
+                hidden_states,
+                self.lm_head,
+                forward_batch,
+            )
+
+        if get_embedding:
+            return self.pooler(hidden_states, forward_batch)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        """Load LLaDA checkpoint weights with name remapping to Llama layout."""
+        # Llama fused-parameter mapping used by parent's weight loaders
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+
+        for name, loaded_weight in weights:
+            name, shard_id = _remap_name(name)
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            if shard_id is not None:
+                # Fuse into QKV or gate_up
+                for fused, single, sid in stacked_params_mapping:
+                    if single in name:
+                        name = name.replace(single, fused)
+                        break
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                param.weight_loader(param, loaded_weight, shard_id)
+            else:
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(
+                    param, "weight_loader", lambda p, w: p.data.copy_(w)
+                )
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = LLaDAModelLM

--- a/python/sglang/srt/models/dream.py
+++ b/python/sglang/srt/models/dream.py
@@ -1,0 +1,70 @@
+"""SGLang Dream model (d3LLM-Dream, Qwen2.5-7B with full bidirectional attention)."""
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+
+
+class DreamModel(Qwen2ForCausalLM):
+    def __init__(self, config, quant_config=None, prefix=""):
+        super().__init__(config, quant_config, prefix)
+        # dLLM needs full logits over all tokens (not just the last one).
+        self.logits_processor = LogitsProcessor(config, return_full_logits=True)
+        # Dream uses full bidirectional (non-causal) attention; patch all layers.
+        for layer in self.model.layers:
+            if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "attn"):
+                layer.self_attn.attn.attn_type = AttentionType.ENCODER_ONLY
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+
+        if self.pp_group.is_last_rank and not get_embedding:
+            # Dream's logits are next-token style: logits[i] predicts position i+1.
+            # dLLM algorithms expect logits[i] to predict position i.
+            # Right-shift hidden_states per sequence so the logits align correctly.
+            if forward_batch.forward_mode.is_dllm_extend():
+                seq_lens = forward_batch.extend_seq_lens_cpu
+                if seq_lens is not None:
+                    # Variable-length sequences (real forward pass)
+                    parts = hidden_states.split(seq_lens)
+                else:
+                    # CUDA graph capture: all sequences are equal length
+                    bs = forward_batch.batch_size
+                    parts = hidden_states.view(bs, -1, hidden_states.shape[-1])
+                hidden_states = torch.cat(
+                    [torch.cat([p[:1], p[:-1]], dim=0) for p in parts], dim=0
+                )
+
+            return self.logits_processor(
+                input_ids,
+                hidden_states,
+                self.lm_head,
+                forward_batch,
+            )
+
+        if get_embedding:
+            return self.pooler(hidden_states, forward_batch)
+        return hidden_states
+
+
+EntryClass = DreamModel

--- a/test/registered/dllm/test_dllm_gsm8k.py
+++ b/test/registered/dllm/test_dllm_gsm8k.py
@@ -1,0 +1,179 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=600, suite="stage-b-test-large-1-gpu")
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.send_one import BenchArgs, send_one_prompt
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+
+def create_dllm_config(threshold: float, cache_delay_iter: int) -> str:
+    """Create a temporary YAML config file for dLLM algorithm."""
+    import yaml
+
+    config = {
+        "threshold": threshold,
+        "block_size": 32,
+        "cache_delay_iter": cache_delay_iter,
+    }
+    fd, path = tempfile.mkstemp(suffix=".yaml", prefix="dllm_config_")
+    with os.fdopen(fd, "w") as f:
+        yaml.dump(config, f)
+    return path
+
+
+class TestD3LLMLLaDA(CustomTestCase):
+    config_path = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "d3LLM/d3LLM_LLaDA"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        # Create config with threshold=0.5, cache_delay_iter=2 (matching sglang_gsm8k_cot.sh)
+        cls.config_path = create_dllm_config(threshold=0.5, cache_delay_iter=2)
+
+        other_args = [
+            "--trust-remote-code",
+            "--tp-size",
+            "1",
+            "--mem-fraction-static",
+            "0.8",
+            "--max-running-requests",
+            "2",
+            "--attention-backend",
+            "flashinfer",
+            "--dllm-algorithm",
+            "FullAttnMultiBlock",
+            "--dllm-algorithm-config",
+            cls.config_path,
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        if cls.config_path and os.path.exists(cls.config_path):
+            os.remove(cls.config_path)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=1,
+            data_path=None,
+            num_questions=100,
+            max_new_tokens=256,
+            parallel=16,
+            host="127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"{metrics=}")
+
+        self.assertGreater(metrics["accuracy"], 0.70)
+        self.assertGreater(metrics["output_throughput"], 100)
+
+    def test_bs_1_speed(self):
+        args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=256)
+        acc_length, speed = send_one_prompt(args)
+
+        print(f"{speed=:.2f}")
+
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_bs_1_speed (d3LLM_LLaDA) with tp1\n"
+                f"{speed=:.2f} token/s\n"
+            )
+            self.assertGreater(speed, 200)
+
+
+class TestD3LLMDream(CustomTestCase):
+    config_path = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "d3LLM/d3LLM_Dream"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        # Create config with threshold=0.4, cache_delay_iter=1 (matching sglang_gsm8k_cot.sh)
+        cls.config_path = create_dllm_config(threshold=0.4, cache_delay_iter=1)
+
+        other_args = [
+            "--trust-remote-code",
+            "--tp-size",
+            "1",
+            "--mem-fraction-static",
+            "0.8",
+            "--max-running-requests",
+            "2",
+            "--attention-backend",
+            "flashinfer",
+            "--dllm-algorithm",
+            "FullAttnMultiBlock",
+            "--dllm-algorithm-config",
+            cls.config_path,
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+        if cls.config_path and os.path.exists(cls.config_path):
+            os.remove(cls.config_path)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=1,
+            data_path=None,
+            num_questions=100,
+            max_new_tokens=256,
+            parallel=16,
+            host="127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"{metrics=}")
+
+        self.assertGreater(metrics["accuracy"], 0.75)
+        self.assertGreater(metrics["output_throughput"], 90)
+
+    def test_bs_1_speed(self):
+        args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=256)
+        acc_length, speed = send_one_prompt(args)
+
+        print(f"{speed=:.2f}")
+
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_bs_1_speed (d3LLM_Dream) with tp1\n"
+                f"{speed=:.2f} token/s\n"
+            )
+            self.assertGreater(speed, 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds SGLang serving support for **d3LLM** ([arXiv:2601.07568](https://arxiv.org/abs/2601.07568)), an ultra-fast diffusion language model based on pseudo-trajectory distillation. d3LLM achieves significantly higher tokens-per-forward (TPF) than vanilla diffusion LLMs while maintaining competitive accuracy, enabling up to 3×-5× end-to-end speedup over autoregressive baselines on H800 and B200.

Two models are supported:

- **d3LLM-LLaDA** (8B) — an ultra-fast diffusion LLM, distilled from LLaDA, using full-sequence bidirectional attention
- **d3LLM-Dream** (7B) — an ultra-fast diffusion LLM, distilled from Dream, using full-sequence bidirectional attention

Both models require bidirectional attention (instead of the block-causal diffusion in existing LLaDA 2.0/2.1), which demands a new dLLM decoding method support in SGLang.

### Key Changes

**New Files:**
- `models/d3llm_llada.py`, `models/dream.py`: Model implementations for d3LLM-LLaDA and d3LLM-Dream
- `dllm/algorithm/entropy_threshold.py`: `EntropyThreshold` decoding algorithm
- `dllm/algorithm/full_attn_multi_block.py`: `FullAttnMultiBlock` decoding algorithm for d3LLM multi-block parallel decoding with bidirectional attention

**Modified Files:**
- `dllm/config.py`: Add `needs_full_prefill` and `pad_full_generation` flags to `DllmConfig`
- `dllm/mixin/req.py`, `dllm/mixin/scheduler.py`: Handle full-prefill mode in request lifecycle
- `flashinfer_backend.py`: Zero out `prefix_lens` when `needs_full_prefill` is enabled
- `schedule_batch.py`: Skip tree-cache matching for full-prefill models; free old KV slots before re-extend
- `schedule_policy.py`: Adjust token budget and truncation for full-prefill mode
- `forward_batch_info.py`: Build positions from full `seq_len` for bidirectional attention
- `cuda_graph_runner.py`: Disable CUDA graph for variable-length full-prefill inputs; work around Blackwell (SM≥10) multi-BS capture instability
- `http_server.py`: Increase `max_new_tokens` for dLLM health checks to ensure proper warmup
- `radix_cache.py`: Add `None` guard for `node` in `inc_lock_ref` / `dec_lock_ref`

**Tests & Docs:**
- `test/registered/dllm/test_dllm_gsm8k.py`: GSM8K benchmark test for d3LLM models
- `docs/supported_models/text_generation/diffusion_language_models.md`: Updated documentation

## Benchmark Results

**Dataset:** GSM8K-CoT (zero-shot)  
**Decoding:** FullAttnMultiBlock  
**TP Size:** 1

| Model | Threshold | Batch Size | B200 TPS | H800 TPS | A800 TPS | TPF | Accuracy |
|-------|-----------|------------|----------|----------|----------|-----|----------|
| d3LLM-LLaDA (8B dense) | 0.5 | 1 | 1240.99 | 545.31 | 251.61 | 9.91 | 75.36% |
| d3LLM-LLaDA (8B dense) | 0.5 | 4 | 1310.18 | 551.87 | 249.98 | 8.56 | 75.12% |
| d3LLM-Dream (7B dense) | 0.4 | 1 | 586.77 | 280.48 | 125.57 | 4.89 | 80.89% |
| d3LLM-Dream (7B dense) | 0.4 | 4 | 676.81 | 281.82 | 127.85 | 4.22 | 80.76% |

> **TPS** = Tokens Per Second, **TPF** = Tokens Per Forward (average forward passes per token)

## Usage Example

```bash
# Launch server with d3LLM-LLaDA
python -m sglang.launch_server \
    --model d3LLM/d3LLM_LLaDA \
    --trust-remote-code \
    --attention-backend flashinfer \
    --dllm-algorithm FullAttnMultiBlock \
    --mem-fraction-static 0.8 \
    --cuda-graph-max-bs 32

# Launch server with d3LLM-Dream
python -m sglang.launch_server \
    --model d3LLM/d3LLM_Dream \
    --trust-remote-code \
    --attention-backend flashinfer \
    --dllm-algorithm FullAttnMultiBlock \
    --mem-fraction-static 0.8 \
    --cuda-graph-max-bs 32
```

## Test Plan

- [x] Verified accuracy matches HuggingFace reference implementation
- [x] Tested on B200, H800, A800 GPUs
- [x] Added `test_dllm_gsm8k.py` for CI integration
- [x] Confirmed no regression on existing LLaDA 2.x models