### PR TITLE
fix(quantization): enable NVFP4 auto-detection on ROCm

### DIFF
--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -162,25 +162,40 @@ class QuantizationConfig(ABC):
     def _modelopt_override_quantization_method(
         cls, hf_quant_config, user_quant
     ) -> Optional[str]:
-        """Shared ModelOpt quantization method override logic."""
+        """Shared ModelOpt quantization method override logic.
+
+        On ROCm, NVFP4/FP4 checkpoints are served by PetitNvFp4Config
+        instead of ModelOptFp4Config, so this method returns None for
+        FP4 on ROCm to let PetitNvFp4Config.override_quantization_method
+        handle the dispatch.
+        """
+        from sglang.srt.utils import is_hip
+
         if hf_quant_config is None:
             return None
 
-        # Check if this is a ModelOpt config
         quant_algo = hf_quant_config.get("quant_algo", "").upper()
+        is_fp4 = "NVFP4" in quant_algo or "FP4" in quant_algo
+
+        # On ROCm, yield FP4 to PetitNvFp4Config
+        if is_hip() and is_fp4:
+            return None
 
         # If user specified generic "modelopt", auto-detect the specific method
         if user_quant == "modelopt":
             if "FP8" in quant_algo:
                 return "modelopt_fp8"
-            elif "NVFP4" in quant_algo or "FP4" in quant_algo:
+            elif is_fp4:
                 return "modelopt_fp4"
 
         # The hf_quant_config may be a parsed quant config, so we need to check the
         # quant_method.
-        if hf_quant_config.get("quant_method", "") == "modelopt_fp8":
+        quant_method = hf_quant_config.get("quant_method", "")
+        if quant_method == "modelopt_fp8":
             return "modelopt_fp8"
-        elif hf_quant_config.get("quant_method", "") == "modelopt_fp4":
+        elif quant_method == "modelopt_fp4":
+            if is_hip():
+                return None  # Let PetitNvFp4Config handle this on ROCm
             return "modelopt_fp4"
 
         return None

--- a/python/sglang/srt/layers/quantization/petit.py
+++ b/python/sglang/srt/layers/quantization/petit.py
@@ -107,8 +107,16 @@ class PetitNvFp4Config(QuantizationConfig):
 
     @classmethod
     def is_petit_nvfp4_compatible(cls, quant_config: Dict[str, Any]) -> bool:
+        """Check if this NVFP4 checkpoint can run on ROCm via Petit.
+        Accepts quant_method 'modelopt' (from producer) or 'modelopt_fp4' (from _parse_modelopt_quant_config).
+        """
         quant_method = quant_config.get("quant_method", "").lower()
-        return _is_hip and quant_method == "modelopt"
+        quant_algo = quant_config.get("quant_algo", "").upper()
+        return (
+            _is_hip
+            and quant_method in ("modelopt", "modelopt_fp4")
+            and ("NVFP4" in quant_algo or "FP4" in quant_algo)
+        )
 
     def is_layer_excluded(self, prefix: str, exclude_modules: list):
         for pattern in exclude_modules:


### PR DESCRIPTION
## Motivation

NVFP4 models could not be auto-detected on ROCm. The override logic always selected `modelopt_fp4` (NVIDIA-only) before `PetitNvFp4Config` could run, causing `ValueError: modelopt_fp4 quantization is currently not supported in ROCm`.

This fix allows NVFP4 checkpoints to be served on AMD GPUs (MI250/MI300X/MI325X) via Petit when loading pre-quantized models without explicitly specifying `--quantization`.

## Modifications

- **base_config.py**: On ROCm, `_modelopt_override_quantization_method` returns `None` for FP4/NVFP4 checkpoints so `PetitNvFp4Config.override_quantization_method` can handle them instead of `ModelOptFp4Config`.
- **petit.py**: `is_petit_nvfp4_compatible` now accepts `quant_method` `modelopt_fp4` (from `_parse_modelopt_quant_config`) in addition to `modelopt`, and verifies `quant_algo` contains NVFP4/FP4.

## Accuracy Tests

None. This PR only affects quantization method selection on ROCm. No changes to model forward or kernel outputs.

## Benchmarking and Profiling

N/A. No inference speed impact.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
