### PR TITLE
[Diffusion] Add a benchmark for rmsnorm/fuse_add_rmsnorm

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_norm_impls.py
+++ b/python/sglang/jit_kernel/benchmark/bench_norm_impls.py
@@ -28,6 +28,7 @@ REPO_ROOT = KERNEL_PATH.parents[2]
 THIRD_PARTY_ROOT = REPO_ROOT / "third_party"
 
 FLAGGEMS_REPO = "https://github.com/flagos-ai/FlagGems.git"
+QUACK_REPO = "https://github.com/Dao-AILab/quack.git"
 
 TORCH_LN = "torch.nn.LayerNorm"
 SGL_RMS = "sglang.RMSNorm.forward_cuda"
@@ -267,6 +268,21 @@ def load_flaggems():
     return rms_norm, layer_norm, fused_add_rms_norm
 
 
+@functools.cache
+def load_quack():
+    repo_path = ensure_repo("quack", QUACK_REPO)
+    try:
+        quack_rmsnorm = importlib.import_module("quack.rmsnorm")
+    except ModuleNotFoundError:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-e", str(repo_path)],
+            check=True,
+        )
+        quack_rmsnorm = importlib.import_module("quack.rmsnorm")
+
+    return quack_rmsnorm.rmsnorm_fwd, quack_rmsnorm.layernorm_fwd
+
+
 def build_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: int):
     import flashinfer.norm as flashinfer_norm
     import sgl_kernel
@@ -279,6 +295,7 @@ def build_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: in
     flashinfer_out = torch.empty_like(x)
 
     flaggems_rms_norm, _, _ = load_flaggems()
+    quack_rmsnorm_fwd, _ = load_quack()
 
     providers = {
         "pytorch": lambda: F.rms_norm(x, (hidden_size,), weight, 1e-6),
@@ -287,6 +304,7 @@ def build_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: in
             x, weight, eps=1e-6, out=flashinfer_out
         ),
         "jit_rmsnorm": lambda: jit_rmsnorm(x, weight, jit_out, 1e-6),
+        "quack": lambda: quack_rmsnorm_fwd(x, weight, eps=1e-6),
         "triton_rms_norm_fn": lambda: rms_norm_fn(
             x, weight, bias=None, residual=None, eps=1e-6
         ),
@@ -315,6 +333,7 @@ def build_fused_add_rmsnorm_providers(
         residual.copy_(base_residual)
 
     _, _, flaggems_fused_add_rms_norm = load_flaggems()
+    quack_rmsnorm_fwd, _ = load_quack()
 
     def pytorch_impl():
         out = x + residual
@@ -332,6 +351,10 @@ def build_fused_add_rmsnorm_providers(
         ),
         "jit_fused_add_rmsnorm": (
             lambda: jit_fused_add_rmsnorm(x, residual, weight, 1e-6),
+            reset,
+        ),
+        "quack": (
+            lambda: quack_rmsnorm_fwd(x, weight, residual=residual, eps=1e-6),
             reset,
         ),
         "flaggems": (
@@ -360,6 +383,7 @@ def build_layernorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: 
     triton_out = torch.empty_like(x)
 
     _, flaggems_layer_norm, _ = load_flaggems()
+    _, quack_layernorm_fwd = load_quack()
 
     providers = {
         "pytorch": lambda: F.layer_norm(x, (hidden_size,), weight, bias, 1e-6),
@@ -367,6 +391,9 @@ def build_layernorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: 
             x, weight, bias, eps=1e-6, is_rms_norm=False, out=triton_out
         ),
         "flashinfer": lambda: flashinfer_norm.layernorm(
+            x, flashinfer_weight, flashinfer_bias, 1e-6
+        ),
+        "quack": lambda: quack_layernorm_fwd(
             x, flashinfer_weight, flashinfer_bias, 1e-6
         ),
         "flaggems": lambda: flaggems_layer_norm(x, (hidden_size,), weight, bias)[0],
@@ -490,12 +517,16 @@ def write_markdown(rows: list[dict[str, object]], output_path: Path) -> None:
                 continue
             provider_to_values: dict[str, list[float]] = {}
             provider_to_speedups: dict[str, list[float]] = {}
-            by_shape: dict[tuple[int, int], dict[str, float]] = {}
+            by_shape: dict[tuple[str, int, int], dict[str, float]] = {}
             for row in scoped:
                 provider = str(row["provider"])
                 value = float(row["median_us"])
                 provider_to_values.setdefault(provider, []).append(value)
-                shape = (int(row["batch_size"]), int(row["hidden_size"]))
+                shape = (
+                    str(row.get("shape_id", "")),
+                    int(row["batch_size"]),
+                    int(row["hidden_size"]),
+                )
                 by_shape.setdefault(shape, {})[provider] = value
             for shape, perf in by_shape.items():
                 if "pytorch" not in perf:

--- a/python/sglang/jit_kernel/benchmark/bench_norm_impls.py
+++ b/python/sglang/jit_kernel/benchmark/bench_norm_impls.py
@@ -18,10 +18,8 @@ import torch.nn.functional as F
 from sglang.jit_kernel.benchmark.utils import DEFAULT_DEVICE, is_in_ci
 from sglang.jit_kernel.diffusion.triton.norm import norm_infer, rms_norm_fn
 from sglang.jit_kernel.diffusion.triton.rmsnorm_onepass import triton_one_pass_rms_norm
-from sglang.jit_kernel.norm import (
-    fused_add_rmsnorm as jit_fused_add_rmsnorm,
-    rmsnorm as jit_rmsnorm,
-)
+from sglang.jit_kernel.norm import fused_add_rmsnorm as jit_fused_add_rmsnorm
+from sglang.jit_kernel.norm import rmsnorm as jit_rmsnorm
 from sglang.jit_kernel.utils import KERNEL_PATH
 
 os.environ.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
@@ -39,7 +37,9 @@ SGL_RES_LN = "sglang.ScaleResidualLayerNormScaleShift"
 SGL_LN_PAIR = f"{SGL_LN} / {SGL_RES_LN}"
 MOVA_LN_MIX = f"{TORCH_LN} / {SGL_LN_PAIR}"
 
-ACTUAL_DIFFUSION_GROUPS: list[tuple[str, str, list[tuple[str, str, tuple[int, ...], str]]]] = [
+ACTUAL_DIFFUSION_GROUPS: list[
+    tuple[str, str, list[tuple[str, str, tuple[int, ...], str]]]
+] = [
     (
         "qwen",
         "1 GPU",
@@ -266,6 +266,7 @@ def load_flaggems():
 
     return rms_norm, layer_norm, fused_add_rms_norm
 
+
 def build_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: int):
     import flashinfer.norm as flashinfer_norm
     import sgl_kernel
@@ -296,7 +297,9 @@ def build_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: in
     return providers
 
 
-def build_fused_add_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: int):
+def build_fused_add_rmsnorm_providers(
+    dtype: torch.dtype, batch_size: int, hidden_size: int
+):
     import flashinfer.norm as flashinfer_norm
     import sgl_kernel
 
@@ -332,7 +335,9 @@ def build_fused_add_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidde
             reset,
         ),
         "flaggems": (
-            lambda: flaggems_fused_add_rms_norm(x, residual, (hidden_size,), weight, 1e-6),
+            lambda: flaggems_fused_add_rms_norm(
+                x, residual, (hidden_size,), weight, 1e-6
+            ),
             reset,
         ),
     }
@@ -452,7 +457,9 @@ def write_markdown(rows: list[dict[str, object]], output_path: Path) -> None:
         seen: set[tuple[str, str, str, str, str, str]] = set()
         lines.append("## Diffusion Shape Cases")
         lines.append("")
-        lines.append("| Shape ID | Op | Model | GPU Config | Input Shape | Source Impl |")
+        lines.append(
+            "| Shape ID | Op | Model | GPU Config | Input Shape | Source Impl |"
+        )
         lines.append("|---|---|---|---|---|---|")
         for row in actual_shape_rows:
             key = (
@@ -475,7 +482,9 @@ def write_markdown(rows: list[dict[str, object]], output_path: Path) -> None:
             scoped = [
                 row
                 for row in rows
-                if row["op"] == op_name and row["dtype"] == dtype and row["status"] == "ok"
+                if row["op"] == op_name
+                and row["dtype"] == dtype
+                and row["status"] == "ok"
             ]
             if not scoped:
                 continue
@@ -493,11 +502,15 @@ def write_markdown(rows: list[dict[str, object]], output_path: Path) -> None:
                     continue
                 baseline = perf["pytorch"]
                 for provider, value in perf.items():
-                    provider_to_speedups.setdefault(provider, []).append(baseline / value)
+                    provider_to_speedups.setdefault(provider, []).append(
+                        baseline / value
+                    )
 
             lines.append(f"## {op_name} ({dtype})")
             lines.append("")
-            lines.append("| Provider | Geomean Speedup vs PyTorch | Median Latency (us) | Win Count |")
+            lines.append(
+                "| Provider | Geomean Speedup vs PyTorch | Median Latency (us) | Win Count |"
+            )
             lines.append("|---|---:|---:|---:|")
             wins: dict[str, int] = {}
             for perf in by_shape.values():

--- a/python/sglang/jit_kernel/benchmark/bench_norm_impls.py
+++ b/python/sglang/jit_kernel/benchmark/bench_norm_impls.py
@@ -1,0 +1,705 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import functools
+import importlib
+import math
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+
+from sglang.jit_kernel.benchmark.utils import DEFAULT_DEVICE, is_in_ci
+from sglang.jit_kernel.diffusion.triton.norm import norm_infer, rms_norm_fn
+from sglang.jit_kernel.diffusion.triton.rmsnorm_onepass import triton_one_pass_rms_norm
+from sglang.jit_kernel.norm import (
+    fused_add_rmsnorm as jit_fused_add_rmsnorm,
+    rmsnorm as jit_rmsnorm,
+)
+from sglang.jit_kernel.utils import KERNEL_PATH
+
+os.environ.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
+
+REPO_ROOT = KERNEL_PATH.parents[2]
+THIRD_PARTY_ROOT = REPO_ROOT / "third_party"
+
+FLAGGEMS_REPO = "https://github.com/flagos-ai/FlagGems.git"
+
+TORCH_LN = "torch.nn.LayerNorm"
+SGL_RMS = "sglang.RMSNorm.forward_cuda"
+SGL_FUSED = "sgl_kernel.fused_add_rmsnorm"
+SGL_LN = "sglang.LayerNormScaleShift"
+SGL_RES_LN = "sglang.ScaleResidualLayerNormScaleShift"
+SGL_LN_PAIR = f"{SGL_LN} / {SGL_RES_LN}"
+MOVA_LN_MIX = f"{TORCH_LN} / {SGL_LN_PAIR}"
+
+ACTUAL_DIFFUSION_GROUPS: list[tuple[str, str, list[tuple[str, str, tuple[int, ...], str]]]] = [
+    (
+        "qwen",
+        "1 GPU",
+        [
+            ("qwen_ln_4096x3072", "layernorm", (1, 4096, 3072), SGL_LN_PAIR),
+            ("qwen_ln_26x3072", "layernorm", (1, 26, 3072), SGL_LN_PAIR),
+            ("qwen_ln_6x3072", "layernorm", (1, 6, 3072), SGL_LN_PAIR),
+            ("qwen_rms_26x3584", "rmsnorm", (1, 26, 3584), SGL_RMS),
+            ("qwen_rms_6x3584", "rmsnorm", (1, 6, 3584), SGL_RMS),
+        ],
+    ),
+    (
+        "qwen-edit",
+        "1 GPU",
+        [
+            ("qwen_edit_ln_189x3072", "layernorm", (1, 189, 3072), SGL_LN_PAIR),
+            ("qwen_edit_ln_192x3072", "layernorm", (1, 192, 3072), SGL_LN_PAIR),
+            ("qwen_edit_ln_8308x3072", "layernorm", (1, 8308, 3072), TORCH_LN),
+            ("qwen_edit_rms_189x3584", "rmsnorm", (1, 189, 3584), SGL_RMS),
+            ("qwen_edit_rms_192x3584", "rmsnorm", (1, 192, 3584), SGL_RMS),
+        ],
+    ),
+    (
+        "flux",
+        "1 GPU",
+        [
+            ("flux_ln_77x768", "layernorm", (1, 77, 768), TORCH_LN),
+            ("flux_ln_512x3072", "layernorm", (1, 512, 3072), TORCH_LN),
+            ("flux_ln_4096x3072", "layernorm", (1, 4096, 3072), TORCH_LN),
+            ("flux_ln_4608x3072", "layernorm", (1, 4608, 3072), TORCH_LN),
+            ("flux_rms_512x4096", "rmsnorm", (1, 512, 4096), SGL_RMS),
+        ],
+    ),
+    (
+        "flux2",
+        "1 GPU",
+        [
+            ("flux2_ln_512x6144", "layernorm", (1, 512, 6144), TORCH_LN),
+            ("flux2_ln_4096x6144", "layernorm", (1, 4096, 6144), TORCH_LN),
+            ("flux2_ln_4608x6144", "layernorm", (1, 4608, 6144), TORCH_LN),
+            ("flux2_rms_4608x48x128", "rmsnorm", (1, 4608, 48, 128), SGL_RMS),
+        ],
+    ),
+    (
+        "zimage",
+        "1 GPU",
+        [
+            ("zimage_ln_4128x3840", "layernorm", (1, 4128, 3840), TORCH_LN),
+            ("zimage_rms_32x3840", "rmsnorm", (1, 32, 3840), SGL_RMS),
+            ("zimage_rms_4096x3840", "rmsnorm", (1, 4096, 3840), SGL_RMS),
+            ("zimage_rms_4128x3840", "rmsnorm", (1, 4128, 3840), SGL_RMS),
+            ("zimage_rms_512x2560", "rmsnorm", (1, 512, 2560), SGL_RMS),
+            ("zimage_rms_512x32x128", "rmsnorm", (1, 512, 32, 128), SGL_RMS),
+            ("zimage_rms_512x8x128", "rmsnorm", (1, 512, 8, 128), SGL_RMS),
+        ],
+    ),
+    (
+        "wan-ti2v",
+        "1 GPU",
+        [
+            ("wan_ti2v_ln_17850x3072", "layernorm", (1, 17850, 3072), SGL_LN_PAIR),
+            ("wan_ti2v_rms_17850x3072", "rmsnorm", (1, 17850, 3072), SGL_RMS),
+            ("wan_ti2v_rms_512x3072", "rmsnorm", (1, 512, 3072), SGL_RMS),
+            ("wan_ti2v_rms_512x4096", "rmsnorm", (1, 512, 4096), SGL_RMS),
+        ],
+    ),
+    (
+        "hunyuanvideo",
+        "1 GPU",
+        [
+            ("hunyuan_ln_46x768", "layernorm", (1, 46, 768), TORCH_LN),
+            ("hunyuan_ln_45x3072", "layernorm", (1, 45, 3072), SGL_LN_PAIR),
+            ("hunyuan_ln_27030x3072", "layernorm", (1, 27030, 3072), SGL_LN_PAIR),
+            ("hunyuan_ln_27075x3072", "layernorm", (1, 27075, 3072), SGL_LN),
+            ("hunyuan_rms_140x4096", "rmsnorm", (1, 140, 4096), SGL_RMS),
+            ("hunyuan_rms_45x24x128", "rmsnorm", (1, 45, 24, 128), SGL_RMS),
+            ("hunyuan_rms_27030x24x128", "rmsnorm", (1, 27030, 24, 128), SGL_RMS),
+            ("hunyuan_rms_27075x24x128", "rmsnorm", (1, 27075, 24, 128), SGL_RMS),
+            ("hunyuan_fused_add_140x4096", "fused_add_rmsnorm", (140, 4096), SGL_FUSED),
+        ],
+    ),
+    (
+        "mova-720p",
+        "4 GPU, ulysses=4, ring=1",
+        [
+            ("mova_ln_101x1536", "layernorm", (1, 101, 1536), MOVA_LN_MIX),
+            ("mova_ln_403x1536", "layernorm", (1, 403, 1536), TORCH_LN),
+            ("mova_ln_44100x5120", "layernorm", (1, 44100, 5120), MOVA_LN_MIX),
+            ("mova_ln_176400x5120", "layernorm", (1, 176400, 5120), SGL_LN),
+            ("mova_rms_101x1536", "rmsnorm", (1, 101, 1536), SGL_RMS),
+            ("mova_rms_101x5120", "rmsnorm", (1, 101, 5120), SGL_RMS),
+            ("mova_rms_44100x1536", "rmsnorm", (1, 44100, 1536), SGL_RMS),
+            ("mova_rms_44100x5120", "rmsnorm", (1, 44100, 5120), SGL_RMS),
+            ("mova_rms_512x1536", "rmsnorm", (1, 512, 1536), SGL_RMS),
+            ("mova_rms_512x4096", "rmsnorm", (1, 512, 4096), SGL_RMS),
+            ("mova_rms_512x5120", "rmsnorm", (1, 512, 5120), SGL_RMS),
+        ],
+    ),
+]
+
+ACTUAL_DIFFUSION_SHAPES: list[dict[str, object]] = [
+    {
+        "shape_id": shape_id,
+        "model": model,
+        "gpu_config": gpu_config,
+        "op": op,
+        "input_shape": list(input_shape),
+        "source_impl": source_impl,
+    }
+    for model, gpu_config, cases in ACTUAL_DIFFUSION_GROUPS
+    for shape_id, op, input_shape, source_impl in cases
+]
+
+
+def effective_rows_from_shape(input_shape: list[int]) -> int:
+    rows = 1
+    for dim in input_shape[:-1]:
+        rows *= dim
+    return rows
+
+
+def ensure_repo(repo_name: str, repo_url: str) -> Path:
+    repo_path = THIRD_PARTY_ROOT / repo_name
+    if repo_path.exists():
+        return repo_path
+    repo_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "clone", "--depth", "1", repo_url, str(repo_path)],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return repo_path
+
+
+def ensure_python_dep(module_name: str, package_name: str | None = None) -> None:
+    package_name = package_name or module_name
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", package_name],
+            check=True,
+        )
+
+
+def dtype_from_name(name: str) -> torch.dtype:
+    mapping = {
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "fp32": torch.float32,
+        "float32": torch.float32,
+    }
+    return mapping[name]
+
+
+def dtype_name(dtype: torch.dtype) -> str:
+    mapping = {
+        torch.bfloat16: "bf16",
+        torch.float16: "fp16",
+        torch.float32: "fp32",
+    }
+    return mapping[dtype]
+
+
+def normalize_hidden_sizes(text: str) -> list[int]:
+    return [int(x) for x in text.split(",") if x]
+
+
+def normalize_dtypes(text: str) -> list[torch.dtype]:
+    return [dtype_from_name(x.strip()) for x in text.split(",") if x.strip()]
+
+
+def prewarm(fn: Callable[[], object], iters: int = 3) -> None:
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+
+
+def benchmark_provider(
+    fn: Callable[[], object],
+    setup_fn: Callable[[], None] | None = None,
+    warmup: int = 10,
+    rep: int = 30,
+) -> tuple[float, float, float]:
+    for _ in range(warmup):
+        if setup_fn is not None:
+            setup_fn()
+        fn()
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    times_us: list[float] = []
+    for _ in range(rep):
+        if setup_fn is not None:
+            setup_fn()
+        start_event.record()
+        fn()
+        end_event.record()
+        end_event.synchronize()
+        times_us.append(start_event.elapsed_time(end_event) * 1000.0)
+
+    return statistics.median(times_us), max(times_us), min(times_us)
+
+
+def geometric_mean(values: list[float]) -> float:
+    if not values:
+        return float("nan")
+    return math.exp(sum(math.log(v) for v in values) / len(values))
+
+
+@functools.cache
+def load_flaggems():
+    ensure_python_dep("sqlalchemy")
+    ensure_repo("FlagGems", FLAGGEMS_REPO)
+    src_root = THIRD_PARTY_ROOT / "FlagGems" / "src"
+    if str(src_root) not in sys.path:
+        sys.path.insert(0, str(src_root))
+    from flag_gems.fused.fused_add_rms_norm import fused_add_rms_norm
+    from flag_gems.ops.layernorm import layer_norm
+    from flag_gems.ops.rms_norm import rms_norm
+
+    return rms_norm, layer_norm, fused_add_rms_norm
+
+def build_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: int):
+    import flashinfer.norm as flashinfer_norm
+    import sgl_kernel
+
+    x = torch.randn((batch_size, hidden_size), device=DEFAULT_DEVICE, dtype=dtype)
+    weight = torch.randn(hidden_size, device=DEFAULT_DEVICE, dtype=dtype)
+
+    jit_out = torch.empty_like(x)
+    sgl_out = torch.empty_like(x)
+    flashinfer_out = torch.empty_like(x)
+
+    flaggems_rms_norm, _, _ = load_flaggems()
+
+    providers = {
+        "pytorch": lambda: F.rms_norm(x, (hidden_size,), weight, 1e-6),
+        "sgl_kernel": lambda: sgl_kernel.rmsnorm(x, weight, eps=1e-6, out=sgl_out),
+        "flashinfer": lambda: flashinfer_norm.rmsnorm(
+            x, weight, eps=1e-6, out=flashinfer_out
+        ),
+        "jit_rmsnorm": lambda: jit_rmsnorm(x, weight, jit_out, 1e-6),
+        "triton_rms_norm_fn": lambda: rms_norm_fn(
+            x, weight, bias=None, residual=None, eps=1e-6
+        ),
+        "flaggems": lambda: flaggems_rms_norm(x, (hidden_size,), weight, 1e-6),
+    }
+    if hidden_size <= 128:
+        providers["triton_one_pass"] = lambda: triton_one_pass_rms_norm(x, weight, 1e-6)
+    return providers
+
+
+def build_fused_add_rmsnorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: int):
+    import flashinfer.norm as flashinfer_norm
+    import sgl_kernel
+
+    base_x = torch.randn((batch_size, hidden_size), device=DEFAULT_DEVICE, dtype=dtype)
+    base_residual = torch.randn_like(base_x)
+    weight = torch.randn(hidden_size, device=DEFAULT_DEVICE, dtype=dtype)
+
+    x = base_x.clone()
+    residual = base_residual.clone()
+
+    def reset():
+        x.copy_(base_x)
+        residual.copy_(base_residual)
+
+    _, _, flaggems_fused_add_rms_norm = load_flaggems()
+
+    def pytorch_impl():
+        out = x + residual
+        return F.rms_norm(out, (hidden_size,), weight, 1e-6)
+
+    providers = {
+        "pytorch": (pytorch_impl, reset),
+        "sgl_kernel": (
+            lambda: sgl_kernel.fused_add_rmsnorm(x, residual, weight, eps=1e-6),
+            reset,
+        ),
+        "flashinfer": (
+            lambda: flashinfer_norm.fused_add_rmsnorm(x, residual, weight, eps=1e-6),
+            reset,
+        ),
+        "jit_fused_add_rmsnorm": (
+            lambda: jit_fused_add_rmsnorm(x, residual, weight, 1e-6),
+            reset,
+        ),
+        "flaggems": (
+            lambda: flaggems_fused_add_rms_norm(x, residual, (hidden_size,), weight, 1e-6),
+            reset,
+        ),
+    }
+    return providers
+
+
+def build_layernorm_providers(dtype: torch.dtype, batch_size: int, hidden_size: int):
+    import flashinfer.norm as flashinfer_norm
+
+    x = torch.randn((batch_size, hidden_size), device=DEFAULT_DEVICE, dtype=dtype)
+    weight = torch.randn(hidden_size, device=DEFAULT_DEVICE, dtype=dtype)
+    bias = torch.randn(hidden_size, device=DEFAULT_DEVICE, dtype=dtype)
+    flashinfer_weight = torch.randn(
+        hidden_size, device=DEFAULT_DEVICE, dtype=torch.float32
+    )
+    flashinfer_bias = torch.randn(
+        hidden_size, device=DEFAULT_DEVICE, dtype=torch.float32
+    )
+
+    triton_out = torch.empty_like(x)
+
+    _, flaggems_layer_norm, _ = load_flaggems()
+
+    providers = {
+        "pytorch": lambda: F.layer_norm(x, (hidden_size,), weight, bias, 1e-6),
+        "triton_norm_infer": lambda: norm_infer(
+            x, weight, bias, eps=1e-6, is_rms_norm=False, out=triton_out
+        ),
+        "flashinfer": lambda: flashinfer_norm.layernorm(
+            x, flashinfer_weight, flashinfer_bias, 1e-6
+        ),
+        "flaggems": lambda: flaggems_layer_norm(x, (hidden_size,), weight, bias)[0],
+    }
+    return providers
+
+
+def maybe_benchmark(
+    op_name: str,
+    provider_name: str,
+    fn: Callable[[], object],
+    rows: list[dict[str, object]],
+    dtype: torch.dtype,
+    batch_size: int,
+    hidden_size: int,
+    reset: Callable[[], None] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> None:
+    metadata = metadata or {}
+    try:
+        median_us, max_us, min_us = benchmark_provider(fn, reset)
+        rows.append(
+            {
+                "op": op_name,
+                "provider": provider_name,
+                "dtype": dtype_name(dtype),
+                "batch_size": batch_size,
+                "hidden_size": hidden_size,
+                "median_us": median_us,
+                "min_us": min_us,
+                "max_us": max_us,
+                "status": "ok",
+                "error": "",
+                **metadata,
+            }
+        )
+    except Exception as exc:  # pragma: no cover - benchmark failures are data
+        rows.append(
+            {
+                "op": op_name,
+                "provider": provider_name,
+                "dtype": dtype_name(dtype),
+                "batch_size": batch_size,
+                "hidden_size": hidden_size,
+                "median_us": "",
+                "min_us": "",
+                "max_us": "",
+                "status": "unsupported",
+                "error": str(exc),
+                **metadata,
+            }
+        )
+
+
+def write_csv(rows: list[dict[str, object]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "op",
+                "provider",
+                "dtype",
+                "batch_size",
+                "hidden_size",
+                "median_us",
+                "min_us",
+                "max_us",
+                "shape_id",
+                "source_model",
+                "source_gpu_config",
+                "source_input_shape",
+                "source_impl",
+                "status",
+                "error",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_markdown(rows: list[dict[str, object]], output_path: Path) -> None:
+    lines: list[str] = []
+    lines.append("# Norm Benchmark Summary")
+    lines.append("")
+    actual_shape_rows = [row for row in rows if row.get("shape_id")]
+    if actual_shape_rows:
+        seen: set[tuple[str, str, str, str, str, str]] = set()
+        lines.append("## Diffusion Shape Cases")
+        lines.append("")
+        lines.append("| Shape ID | Op | Model | GPU Config | Input Shape | Source Impl |")
+        lines.append("|---|---|---|---|---|---|")
+        for row in actual_shape_rows:
+            key = (
+                str(row.get("shape_id", "")),
+                str(row.get("op", "")),
+                str(row.get("source_model", "")),
+                str(row.get("source_gpu_config", "")),
+                str(row.get("source_input_shape", "")),
+                str(row.get("source_impl", "")),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            lines.append(
+                f"| {key[0]} | {key[1]} | {key[2]} | {key[3]} | `{key[4]}` | {key[5]} |"
+            )
+        lines.append("")
+    for op_name in ("rmsnorm", "fused_add_rmsnorm", "layernorm"):
+        for dtype in sorted({row["dtype"] for row in rows}):
+            scoped = [
+                row
+                for row in rows
+                if row["op"] == op_name and row["dtype"] == dtype and row["status"] == "ok"
+            ]
+            if not scoped:
+                continue
+            provider_to_values: dict[str, list[float]] = {}
+            provider_to_speedups: dict[str, list[float]] = {}
+            by_shape: dict[tuple[int, int], dict[str, float]] = {}
+            for row in scoped:
+                provider = str(row["provider"])
+                value = float(row["median_us"])
+                provider_to_values.setdefault(provider, []).append(value)
+                shape = (int(row["batch_size"]), int(row["hidden_size"]))
+                by_shape.setdefault(shape, {})[provider] = value
+            for shape, perf in by_shape.items():
+                if "pytorch" not in perf:
+                    continue
+                baseline = perf["pytorch"]
+                for provider, value in perf.items():
+                    provider_to_speedups.setdefault(provider, []).append(baseline / value)
+
+            lines.append(f"## {op_name} ({dtype})")
+            lines.append("")
+            lines.append("| Provider | Geomean Speedup vs PyTorch | Median Latency (us) | Win Count |")
+            lines.append("|---|---:|---:|---:|")
+            wins: dict[str, int] = {}
+            for perf in by_shape.values():
+                best_provider = min(perf, key=perf.get)
+                wins[best_provider] = wins.get(best_provider, 0) + 1
+            for provider in sorted(provider_to_values):
+                geomean_speedup = geometric_mean(provider_to_speedups.get(provider, []))
+                median_latency = statistics.median(provider_to_values[provider])
+                win_count = wins.get(provider, 0)
+                lines.append(
+                    f"| {provider} | {geomean_speedup:.3f}x | {median_latency:.2f} | {win_count} |"
+                )
+            lines.append("")
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_suite(
+    hidden_sizes: list[int],
+    batch_sizes: list[int],
+    dtypes: list[torch.dtype],
+    ops: list[str],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for dtype in dtypes:
+        for batch_size in batch_sizes:
+            for hidden_size in hidden_sizes:
+                if "rmsnorm" in ops:
+                    rms_providers = build_rmsnorm_providers(
+                        dtype, batch_size, hidden_size
+                    )
+                    for provider_name, fn in rms_providers.items():
+                        maybe_benchmark(
+                            "rmsnorm",
+                            provider_name,
+                            fn,
+                            rows,
+                            dtype,
+                            batch_size,
+                            hidden_size,
+                        )
+
+                if "fused_add_rmsnorm" in ops:
+                    fused_providers = build_fused_add_rmsnorm_providers(
+                        dtype, batch_size, hidden_size
+                    )
+                    for provider_name, provider in fused_providers.items():
+                        fn, reset = provider
+                        maybe_benchmark(
+                            "fused_add_rmsnorm",
+                            provider_name,
+                            fn,
+                            rows,
+                            dtype,
+                            batch_size,
+                            hidden_size,
+                            reset,
+                        )
+
+                if "layernorm" in ops:
+                    layernorm_providers = build_layernorm_providers(
+                        dtype, batch_size, hidden_size
+                    )
+                    for provider_name, fn in layernorm_providers.items():
+                        maybe_benchmark(
+                            "layernorm",
+                            provider_name,
+                            fn,
+                            rows,
+                            dtype,
+                            batch_size,
+                            hidden_size,
+                        )
+    return rows
+
+
+def run_shape_suite(
+    shape_cases: list[dict[str, object]],
+    dtypes: list[torch.dtype],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for case in shape_cases:
+        op_name = str(case["op"])
+        input_shape = [int(x) for x in case["input_shape"]]
+        batch_size = effective_rows_from_shape(input_shape)
+        hidden_size = input_shape[-1]
+        metadata = {
+            "shape_id": str(case["shape_id"]),
+            "source_model": str(case["model"]),
+            "source_gpu_config": str(case["gpu_config"]),
+            "source_input_shape": str(input_shape),
+            "source_impl": str(case["source_impl"]),
+        }
+        for dtype in dtypes:
+            if op_name == "rmsnorm":
+                providers = build_rmsnorm_providers(dtype, batch_size, hidden_size)
+                for provider_name, fn in providers.items():
+                    maybe_benchmark(
+                        op_name,
+                        provider_name,
+                        fn,
+                        rows,
+                        dtype,
+                        batch_size,
+                        hidden_size,
+                        metadata=metadata,
+                    )
+            elif op_name == "fused_add_rmsnorm":
+                providers = build_fused_add_rmsnorm_providers(
+                    dtype, batch_size, hidden_size
+                )
+                for provider_name, provider in providers.items():
+                    fn, reset = provider
+                    maybe_benchmark(
+                        op_name,
+                        provider_name,
+                        fn,
+                        rows,
+                        dtype,
+                        batch_size,
+                        hidden_size,
+                        reset,
+                        metadata=metadata,
+                    )
+            elif op_name == "layernorm":
+                providers = build_layernorm_providers(dtype, batch_size, hidden_size)
+                for provider_name, fn in providers.items():
+                    maybe_benchmark(
+                        op_name,
+                        provider_name,
+                        fn,
+                        rows,
+                        dtype,
+                        batch_size,
+                        hidden_size,
+                        metadata=metadata,
+                    )
+            else:
+                raise ValueError(f"Unsupported op in shape preset: {op_name}")
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark RMSNorm/LayerNorm implementations across providers."
+    )
+    parser.add_argument(
+        "--hidden-sizes",
+        default="64,128,256,512,1024,2048,4096,8192,16384",
+        help="Comma-separated hidden sizes.",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        default="1,16,128,1024",
+        help="Comma-separated batch sizes.",
+    )
+    parser.add_argument(
+        "--dtypes",
+        default="bf16,fp16",
+        help="Comma-separated dtypes: bf16, fp16, fp32.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(REPO_ROOT / "outputs" / "norm_benchmarks"),
+        help="Directory for CSV/Markdown outputs.",
+    )
+    parser.add_argument(
+        "--ops",
+        default="rmsnorm,fused_add_rmsnorm,layernorm",
+        help="Comma-separated ops to benchmark.",
+    )
+    parser.add_argument(
+        "--shape-preset",
+        choices=["grid", "diffusion-actual"],
+        default="grid",
+        help="Use the default grid sweep or the captured diffusion workload shapes.",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for norm benchmarks.")
+
+    hidden_sizes = normalize_hidden_sizes(args.hidden_sizes)
+    batch_sizes = normalize_hidden_sizes(args.batch_sizes)
+    dtypes = normalize_dtypes(args.dtypes)
+    ops = [op.strip() for op in args.ops.split(",") if op.strip()]
+
+    if args.shape_preset == "diffusion-actual":
+        shape_cases = [case for case in ACTUAL_DIFFUSION_SHAPES if case["op"] in ops]
+        rows = run_shape_suite(shape_cases, dtypes)
+    else:
+        rows = run_suite(hidden_sizes, batch_sizes, dtypes, ops)
+    output_dir = Path(args.output_dir)
+    csv_path = output_dir / "norm_impls.csv"
+    md_path = output_dir / "norm_impls_summary.md"
+    write_csv(rows, csv_path)
+    write_markdown(rows, md_path)
+    print(f"Wrote {csv_path}")
+    print(f"Wrote {md_path}")
+
+
+if __name__ == "__main__":
+    if is_in_ci():
+        print("Skipping bench_norm_impls.py in CI")
+        sys.exit(0)
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

It's a benchmark for all rmsnorm/fuse_add_rmsnorm implements benchmark, included sgl-kernel, flashinfer-jit, sglang-jit, flaggems, triton_one_pass, pytorch, triton_rms_norm_fn, quack. This PR skips `bench_norm_impls.py` in CI because it is intended for manual benchmarking rather than regular CI checks. A follow-up PR will use the benchmark results to introduce a unified RMSNorm selection policy that picks the best-performing kernel for each scenario.

## H200 All Provider Winners by Shape

### rmsnorm (bf16)

| Winner | Win Count |
|---|---:|
| flashinfer | 17 |
| jit_rmsnorm | 4 |
| quack | 4 |
| pytorch | 1 |

| Shape ID | Model | GPU Config | Input Shape | Winner | Winner Latency (us) | All Providers |
|---|---|---|---|---|---:|---|
| flux2_rms_4608x48x128 | flux2 | 1 GPU | `[1, 4608, 48, 128]` | quack | 54.66 | quack=54.66, triton_one_pass=122.30, pytorch=144.74, flaggems=174.30, flashinfer=273.97, sgl_kernel=274.72, triton_rms_norm_fn=513.14 |
| flux_rms_512x4096 | flux | 1 GPU | `[1, 512, 4096]` | flashinfer | 10.96 | flashinfer=10.96, jit_rmsnorm=11.49, sgl_kernel=11.76, pytorch=15.46, quack=38.91, flaggems=51.36, triton_rms_norm_fn=413.25 |
| hunyuan_rms_140x4096 | hunyuanvideo | 1 GPU | `[1, 140, 4096]` | flashinfer | 10.75 | flashinfer=10.75, jit_rmsnorm=11.25, sgl_kernel=11.46, pytorch=15.33, quack=38.94, flaggems=51.44, triton_rms_norm_fn=403.74 |
| hunyuan_rms_27030x24x128 | hunyuanvideo | 1 GPU | `[1, 27030, 24, 128]` | quack | 105.44 | quack=105.44, triton_one_pass=171.71, pytorch=403.14, flaggems=431.68, triton_rms_norm_fn=768.00, flashinfer=787.62, sgl_kernel=788.53 |
| hunyuan_rms_27075x24x128 | hunyuanvideo | 1 GPU | `[1, 27075, 24, 128]` | quack | 105.90 | quack=105.90, triton_one_pass=172.72, pytorch=403.94, flaggems=432.66, triton_rms_norm_fn=784.53, flashinfer=789.04, sgl_kernel=789.81 |
| hunyuan_rms_45x24x128 | hunyuanvideo | 1 GPU | `[1, 45, 24, 128]` | flashinfer | 11.02 | flashinfer=11.02, sgl_kernel=11.97, pytorch=14.94, quack=39.41, flaggems=51.15, triton_one_pass=108.86, triton_rms_norm_fn=421.09 |
| mova_rms_101x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 101, 1536]` | flashinfer | 10.69 | flashinfer=10.69, jit_rmsnorm=11.07, sgl_kernel=11.49, pytorch=14.91, quack=40.34, flaggems=51.70, triton_rms_norm_fn=415.82 |
| mova_rms_101x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 101, 5120]` | flashinfer | 10.64 | flashinfer=10.64, jit_rmsnorm=11.09, sgl_kernel=11.36, pytorch=15.49, quack=38.80, flaggems=51.55, triton_rms_norm_fn=412.35 |
| mova_rms_44100x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 44100, 1536]` | jit_rmsnorm | 76.67 | jit_rmsnorm=76.67, flashinfer=83.28, sgl_kernel=83.81, pytorch=88.26, quack=91.23, flaggems=104.75, triton_rms_norm_fn=441.42 |
| mova_rms_44100x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 44100, 5120]` | quack | 239.95 | quack=239.95, jit_rmsnorm=249.92, pytorch=273.65, flaggems=282.82, flashinfer=312.45, sgl_kernel=312.94, triton_rms_norm_fn=612.03 |
| mova_rms_512x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 512, 1536]` | flashinfer | 10.66 | flashinfer=10.66, jit_rmsnorm=11.02, sgl_kernel=11.39, pytorch=14.80, quack=37.81, flaggems=50.64, triton_rms_norm_fn=411.39 |
| mova_rms_512x4096 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 512, 4096]` | flashinfer | 10.80 | flashinfer=10.80, jit_rmsnorm=11.49, sgl_kernel=11.68, pytorch=15.30, quack=38.48, flaggems=51.49, triton_rms_norm_fn=404.82 |
| mova_rms_512x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 512, 5120]` | flashinfer | 10.82 | flashinfer=10.82, jit_rmsnorm=11.33, sgl_kernel=11.68, pytorch=15.18, quack=38.14, flaggems=51.74, triton_rms_norm_fn=413.74 |
| qwen_edit_rms_189x3584 | qwen-edit | 1 GPU | `[1, 189, 3584]` | flashinfer | 10.69 | flashinfer=10.69, jit_rmsnorm=11.04, sgl_kernel=11.34, pytorch=15.33, quack=38.37, flaggems=50.66, triton_rms_norm_fn=398.22 |
| qwen_edit_rms_192x3584 | qwen-edit | 1 GPU | `[1, 192, 3584]` | flashinfer | 10.72 | flashinfer=10.72, jit_rmsnorm=11.07, sgl_kernel=11.63, pytorch=15.25, quack=37.71, flaggems=51.41, triton_rms_norm_fn=399.65 |
| qwen_rms_26x3584 | qwen | 1 GPU | `[1, 26, 3584]` | flashinfer | 10.58 | flashinfer=10.58, jit_rmsnorm=11.18, sgl_kernel=11.33, pytorch=14.91, quack=39.36, flaggems=51.47, triton_rms_norm_fn=419.65 |
| qwen_rms_6x3584 | qwen | 1 GPU | `[1, 6, 3584]` | flashinfer | 10.58 | flashinfer=10.58, jit_rmsnorm=11.06, sgl_kernel=11.33, pytorch=15.07, quack=38.90, flaggems=51.31, triton_rms_norm_fn=415.58 |
| wan_ti2v_rms_17850x3072 | wan-ti2v | 1 GPU | `[1, 17850, 3072]` | jit_rmsnorm | 65.81 | jit_rmsnorm=65.81, pytorch=73.26, flashinfer=76.34, sgl_kernel=76.86, quack=81.50, flaggems=92.50, triton_rms_norm_fn=443.81 |
| wan_ti2v_rms_512x3072 | wan-ti2v | 1 GPU | `[1, 512, 3072]` | flashinfer | 10.94 | flashinfer=10.94, jit_rmsnorm=11.49, sgl_kernel=11.62, pytorch=15.17, quack=38.64, flaggems=51.86, triton_rms_norm_fn=426.62 |
| wan_ti2v_rms_512x4096 | wan-ti2v | 1 GPU | `[1, 512, 4096]` | flashinfer | 10.93 | flashinfer=10.93, jit_rmsnorm=11.49, sgl_kernel=11.65, pytorch=15.33, quack=38.82, flaggems=51.23, triton_rms_norm_fn=419.42 |
| zimage_rms_32x3840 | zimage | 1 GPU | `[1, 32, 3840]` | flashinfer | 10.72 | flashinfer=10.72, jit_rmsnorm=11.30, sgl_kernel=11.34, pytorch=15.31, quack=39.39, flaggems=50.54, triton_rms_norm_fn=424.66 |
| zimage_rms_4096x3840 | zimage | 1 GPU | `[1, 4096, 3840]` | jit_rmsnorm | 24.99 | jit_rmsnorm=24.99, flashinfer=28.80, sgl_kernel=29.90, pytorch=30.14, quack=43.41, flaggems=56.30, triton_rms_norm_fn=418.93 |
| zimage_rms_4128x3840 | zimage | 1 GPU | `[1, 4128, 3840]` | jit_rmsnorm | 25.01 | jit_rmsnorm=25.01, flashinfer=29.26, sgl_kernel=29.98, pytorch=30.02, quack=43.17, flaggems=56.53, triton_rms_norm_fn=415.36 |
| zimage_rms_512x2560 | zimage | 1 GPU | `[1, 512, 2560]` | flashinfer | 10.99 | flashinfer=10.99, jit_rmsnorm=11.46, sgl_kernel=11.66, pytorch=14.99, quack=39.50, flaggems=51.54, triton_rms_norm_fn=412.70 |
| zimage_rms_512x32x128 | zimage | 1 GPU | `[1, 512, 32, 128]` | pytorch | 20.46 | pytorch=20.46, flashinfer=27.60, sgl_kernel=28.34, quack=39.71, flaggems=51.20, triton_one_pass=108.91, triton_rms_norm_fn=417.62 |
| zimage_rms_512x8x128 | zimage | 1 GPU | `[1, 512, 8, 128]` | flashinfer | 12.70 | flashinfer=12.70, sgl_kernel=13.38, pytorch=15.22, quack=41.39, flaggems=50.56, triton_one_pass=109.65, triton_rms_norm_fn=417.76 |

### rmsnorm (fp16)

| Winner | Win Count |
|---|---:|
| flashinfer | 17 |
| jit_rmsnorm | 4 |
| quack | 4 |
| pytorch | 1 |

| Shape ID | Model | GPU Config | Input Shape | Winner | Winner Latency (us) | All Providers |
|---|---|---|---|---|---:|---|
| flux2_rms_4608x48x128 | flux2 | 1 GPU | `[1, 4608, 48, 128]` | quack | 54.29 | quack=54.29, triton_one_pass=121.60, pytorch=144.45, flaggems=174.61, flashinfer=273.90, sgl_kernel=274.56, triton_rms_norm_fn=511.78 |
| flux_rms_512x4096 | flux | 1 GPU | `[1, 512, 4096]` | flashinfer | 11.22 | flashinfer=11.22, jit_rmsnorm=11.47, sgl_kernel=11.81, pytorch=15.46, quack=39.70, flaggems=51.71, triton_rms_norm_fn=417.46 |
| hunyuan_rms_140x4096 | hunyuanvideo | 1 GPU | `[1, 140, 4096]` | flashinfer | 10.72 | flashinfer=10.72, jit_rmsnorm=11.07, sgl_kernel=11.55, pytorch=15.49, quack=37.86, flaggems=52.24, triton_rms_norm_fn=405.36 |
| hunyuan_rms_27030x24x128 | hunyuanvideo | 1 GPU | `[1, 27030, 24, 128]` | quack | 104.69 | quack=104.69, triton_one_pass=172.56, pytorch=403.23, flaggems=432.22, triton_rms_norm_fn=781.09, flashinfer=787.74, sgl_kernel=788.53 |
| hunyuan_rms_27075x24x128 | hunyuanvideo | 1 GPU | `[1, 27075, 24, 128]` | quack | 105.06 | quack=105.06, triton_one_pass=172.37, pytorch=403.89, flaggems=433.02, triton_rms_norm_fn=774.30, flashinfer=789.09, sgl_kernel=790.19 |
| hunyuan_rms_45x24x128 | hunyuanvideo | 1 GPU | `[1, 45, 24, 128]` | flashinfer | 11.01 | flashinfer=11.01, sgl_kernel=11.95, pytorch=15.15, quack=38.48, flaggems=50.66, triton_one_pass=108.21, triton_rms_norm_fn=406.99 |
| mova_rms_101x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 101, 1536]` | flashinfer | 10.58 | flashinfer=10.58, sgl_kernel=11.28, jit_rmsnorm=11.30, pytorch=15.10, quack=39.49, flaggems=51.25, triton_rms_norm_fn=411.36 |
| mova_rms_101x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 101, 5120]` | flashinfer | 10.51 | flashinfer=10.51, jit_rmsnorm=11.10, sgl_kernel=11.34, pytorch=15.42, quack=38.78, flaggems=52.22, triton_rms_norm_fn=418.32 |
| mova_rms_44100x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 44100, 1536]` | jit_rmsnorm | 76.35 | jit_rmsnorm=76.35, flashinfer=83.23, sgl_kernel=83.68, pytorch=87.71, quack=92.11, flaggems=106.05, triton_rms_norm_fn=453.97 |
| mova_rms_44100x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 44100, 5120]` | quack | 238.50 | quack=238.50, jit_rmsnorm=249.04, pytorch=272.99, flaggems=281.55, flashinfer=305.92, sgl_kernel=306.58, triton_rms_norm_fn=611.79 |
| mova_rms_512x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 512, 1536]` | flashinfer | 10.70 | flashinfer=10.70, jit_rmsnorm=10.99, sgl_kernel=11.52, pytorch=14.91, quack=38.53, flaggems=51.46, triton_rms_norm_fn=415.60 |
| mova_rms_512x4096 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 512, 4096]` | flashinfer | 10.93 | flashinfer=10.93, jit_rmsnorm=11.30, sgl_kernel=11.65, pytorch=15.31, quack=37.79, flaggems=50.05, triton_rms_norm_fn=402.82 |
| mova_rms_512x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 512, 5120]` | flashinfer | 10.85 | flashinfer=10.85, jit_rmsnorm=11.25, sgl_kernel=11.73, pytorch=15.39, quack=37.82, flaggems=50.54, triton_rms_norm_fn=414.56 |
| qwen_edit_rms_189x3584 | qwen-edit | 1 GPU | `[1, 189, 3584]` | flashinfer | 10.69 | flashinfer=10.69, jit_rmsnorm=11.14, sgl_kernel=11.46, pytorch=15.33, quack=38.59, flaggems=50.46, triton_rms_norm_fn=399.01 |
| qwen_edit_rms_192x3584 | qwen-edit | 1 GPU | `[1, 192, 3584]` | flashinfer | 10.66 | flashinfer=10.66, jit_rmsnorm=11.04, sgl_kernel=11.49, pytorch=15.34, quack=37.66, flaggems=50.98, triton_rms_norm_fn=397.47 |
| qwen_rms_26x3584 | qwen | 1 GPU | `[1, 26, 3584]` | flashinfer | 10.48 | flashinfer=10.48, jit_rmsnorm=11.04, sgl_kernel=11.38, pytorch=15.01, quack=39.17, flaggems=50.62, triton_rms_norm_fn=420.91 |
| qwen_rms_6x3584 | qwen | 1 GPU | `[1, 6, 3584]` | flashinfer | 10.61 | flashinfer=10.61, jit_rmsnorm=11.20, sgl_kernel=11.42, pytorch=15.14, quack=38.72, flaggems=50.94, triton_rms_norm_fn=404.59 |
| wan_ti2v_rms_17850x3072 | wan-ti2v | 1 GPU | `[1, 17850, 3072]` | jit_rmsnorm | 65.49 | jit_rmsnorm=65.49, pytorch=72.96, flashinfer=74.86, sgl_kernel=75.68, quack=81.07, flaggems=93.47, triton_rms_norm_fn=448.58 |
| wan_ti2v_rms_512x3072 | wan-ti2v | 1 GPU | `[1, 512, 3072]` | flashinfer | 10.85 | flashinfer=10.85, jit_rmsnorm=11.31, sgl_kernel=11.70, pytorch=15.36, quack=39.10, flaggems=52.24, triton_rms_norm_fn=411.65 |
| wan_ti2v_rms_512x4096 | wan-ti2v | 1 GPU | `[1, 512, 4096]` | flashinfer | 10.98 | flashinfer=10.98, jit_rmsnorm=11.44, sgl_kernel=11.76, pytorch=15.54, quack=37.68, flaggems=51.49, triton_rms_norm_fn=423.02 |
| zimage_rms_32x3840 | zimage | 1 GPU | `[1, 32, 3840]` | flashinfer | 10.58 | flashinfer=10.58, jit_rmsnorm=11.09, sgl_kernel=11.34, pytorch=15.39, quack=39.15, flaggems=51.95, triton_rms_norm_fn=421.62 |
| zimage_rms_4096x3840 | zimage | 1 GPU | `[1, 4096, 3840]` | jit_rmsnorm | 24.90 | jit_rmsnorm=24.90, flashinfer=28.34, sgl_kernel=29.26, pytorch=30.29, quack=43.60, flaggems=56.67, triton_rms_norm_fn=427.34 |
| zimage_rms_4128x3840 | zimage | 1 GPU | `[1, 4128, 3840]` | jit_rmsnorm | 25.02 | jit_rmsnorm=25.02, flashinfer=28.74, sgl_kernel=29.31, pytorch=30.18, quack=42.61, flaggems=56.86, triton_rms_norm_fn=406.56 |
| zimage_rms_512x2560 | zimage | 1 GPU | `[1, 512, 2560]` | flashinfer | 11.01 | flashinfer=11.01, jit_rmsnorm=11.39, sgl_kernel=11.71, pytorch=15.12, quack=39.55, flaggems=51.55, triton_rms_norm_fn=418.90 |
| zimage_rms_512x32x128 | zimage | 1 GPU | `[1, 512, 32, 128]` | pytorch | 20.42 | pytorch=20.42, flashinfer=27.57, sgl_kernel=28.32, quack=38.70, flaggems=50.96, triton_one_pass=107.89, triton_rms_norm_fn=426.02 |
| zimage_rms_512x8x128 | zimage | 1 GPU | `[1, 512, 8, 128]` | flashinfer | 12.80 | flashinfer=12.80, sgl_kernel=13.39, pytorch=15.17, quack=38.98, flaggems=51.28, triton_one_pass=106.78, triton_rms_norm_fn=411.87 |

### fused_add_rmsnorm (bf16)

| Winner | Win Count |
|---|---:|
| jit_fused_add_rmsnorm | 1 |

| Shape ID | Model | GPU Config | Input Shape | Winner | Winner Latency (us) | All Providers |
|---|---|---|---|---|---:|---|
| hunyuan_fused_add_140x4096 | hunyuanvideo | 1 GPU | `[140, 4096]` | jit_fused_add_rmsnorm | 11.01 | jit_fused_add_rmsnorm=11.01, flashinfer=11.09, sgl_kernel=12.26, pytorch=21.23, flaggems=34.34, quack=46.19 |

### fused_add_rmsnorm (fp16)

| Winner | Win Count |
|---|---:|
| jit_fused_add_rmsnorm | 1 |

| Shape ID | Model | GPU Config | Input Shape | Winner | Winner Latency (us) | All Providers |
|---|---|---|---|---|---:|---|
| hunyuan_fused_add_140x4096 | hunyuanvideo | 1 GPU | `[140, 4096]` | jit_fused_add_rmsnorm | 10.93 | jit_fused_add_rmsnorm=10.93, flashinfer=11.26, sgl_kernel=12.21, pytorch=21.38, flaggems=34.56, quack=46.48 |

### layernorm (bf16)

| Winner | Win Count |
|---|---:|
| flashinfer | 11 |
| triton_norm_infer | 8 |
| pytorch | 4 |

| Shape ID | Model | GPU Config | Input Shape | Winner | Winner Latency (us) | All Providers |
|---|---|---|---|---|---:|---|
| flux2_ln_4096x6144 | flux2 | 1 GPU | `[1, 4096, 6144]` | triton_norm_infer | 50.38 | triton_norm_infer=50.38, pytorch=54.51, flaggems=63.84, flashinfer=75.36, quack=462.74 |
| flux2_ln_4608x6144 | flux2 | 1 GPU | `[1, 4608, 6144]` | triton_norm_infer | 53.87 | triton_norm_infer=53.87, pytorch=59.50, flaggems=68.00, flashinfer=83.41, quack=523.65 |
| flux2_ln_512x6144 | flux2 | 1 GPU | `[1, 512, 6144]` | flashinfer | 16.11 | flashinfer=16.11, pytorch=19.33, triton_norm_infer=26.90, flaggems=42.42, quack=93.10 |
| flux_ln_4096x3072 | flux | 1 GPU | `[1, 4096, 3072]` | pytorch | 32.99 | pytorch=32.99, triton_norm_infer=35.89, flaggems=47.50, flashinfer=54.64, quack=234.11 |
| flux_ln_4608x3072 | flux | 1 GPU | `[1, 4608, 3072]` | pytorch | 36.70 | pytorch=36.70, triton_norm_infer=38.51, flaggems=49.50, flashinfer=60.26, quack=261.39 |
| flux_ln_512x3072 | flux | 1 GPU | `[1, 512, 3072]` | flashinfer | 14.37 | flashinfer=14.37, pytorch=17.04, triton_norm_infer=26.48, flaggems=40.93, quack=56.45 |
| flux_ln_77x768 | flux | 1 GPU | `[1, 77, 768]` | flashinfer | 12.96 | flashinfer=12.96, pytorch=16.61, triton_norm_infer=27.33, flaggems=42.26, quack=42.67 |
| hunyuan_ln_27030x3072 | hunyuanvideo | 1 GPU | `[1, 27030, 3072]` | triton_norm_infer | 111.58 | triton_norm_infer=111.58, flaggems=117.10, pytorch=140.00, flashinfer=298.30, quack=1357.95 |
| hunyuan_ln_27075x3072 | hunyuanvideo | 1 GPU | `[1, 27075, 3072]` | triton_norm_infer | 111.31 | triton_norm_infer=111.31, flaggems=117.74, pytorch=140.34, flashinfer=298.80, quack=1360.42 |
| hunyuan_ln_45x3072 | hunyuanvideo | 1 GPU | `[1, 45, 3072]` | flashinfer | 13.09 | flashinfer=13.09, pytorch=17.02, triton_norm_infer=26.50, flaggems=41.82, quack=49.52 |
| hunyuan_ln_46x768 | hunyuanvideo | 1 GPU | `[1, 46, 768]` | flashinfer | 13.23 | flashinfer=13.23, pytorch=16.58, triton_norm_infer=26.94, flaggems=42.08, quack=42.16 |
| mova_ln_101x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 101, 1536]` | flashinfer | 13.14 | flashinfer=13.14, pytorch=16.67, triton_norm_infer=27.79, flaggems=42.38, quack=42.80 |
| mova_ln_176400x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 176400, 5120]` | triton_norm_infer | 1132.85 | triton_norm_infer=1132.85, flaggems=1149.25, quack=1153.90, pytorch=1368.69, flashinfer=2571.84 |
| mova_ln_403x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 403, 1536]` | flashinfer | 13.78 | flashinfer=13.78, pytorch=16.67, triton_norm_infer=26.19, quack=41.73, flaggems=42.42 |
| mova_ln_44100x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 44100, 5120]` | triton_norm_infer | 275.36 | triton_norm_infer=275.36, flaggems=285.38, quack=312.67, pytorch=333.97, flashinfer=638.46 |
| qwen_edit_ln_189x3072 | qwen-edit | 1 GPU | `[1, 189, 3072]` | flashinfer | 13.71 | flashinfer=13.71, pytorch=16.90, triton_norm_infer=27.28, flaggems=41.86, quack=49.81 |
| qwen_edit_ln_192x3072 | qwen-edit | 1 GPU | `[1, 192, 3072]` | flashinfer | 13.54 | flashinfer=13.54, pytorch=17.02, triton_norm_infer=26.48, flaggems=42.02, quack=50.56 |
| qwen_edit_ln_8308x3072 | qwen-edit | 1 GPU | `[1, 8308, 3072]` | triton_norm_infer | 50.62 | triton_norm_infer=50.62, pytorch=53.60, flaggems=61.54, flashinfer=99.84, quack=439.95 |
| qwen_ln_26x3072 | qwen | 1 GPU | `[1, 26, 3072]` | flashinfer | 13.22 | flashinfer=13.22, pytorch=16.77, triton_norm_infer=27.44, flaggems=42.29, quack=49.42 |
| qwen_ln_4096x3072 | qwen | 1 GPU | `[1, 4096, 3072]` | pytorch | 33.34 | pytorch=33.34, triton_norm_infer=37.54, flaggems=48.67, flashinfer=54.42, quack=235.78 |
| qwen_ln_6x3072 | qwen | 1 GPU | `[1, 6, 3072]` | flashinfer | 13.10 | flashinfer=13.10, pytorch=16.69, triton_norm_infer=26.50, flaggems=42.19, quack=48.64 |
| wan_ti2v_ln_17850x3072 | wan-ti2v | 1 GPU | `[1, 17850, 3072]` | triton_norm_infer | 82.27 | triton_norm_infer=82.27, flaggems=89.82, pytorch=97.09, flashinfer=200.75, quack=907.38 |
| zimage_ln_4128x3840 | zimage | 1 GPU | `[1, 4128, 3840]` | pytorch | 38.88 | pytorch=38.88, triton_norm_infer=39.06, flaggems=51.95, quack=54.46, flashinfer=58.90 |

### layernorm (fp16)

| Winner | Win Count |
|---|---:|
| pytorch | 15 |
| triton_norm_infer | 8 |

| Shape ID | Model | GPU Config | Input Shape | Winner | Winner Latency (us) | All Providers |
|---|---|---|---|---|---:|---|
| flux2_ln_4096x6144 | flux2 | 1 GPU | `[1, 4096, 6144]` | triton_norm_infer | 49.79 | triton_norm_infer=49.79, pytorch=54.27, flaggems=63.66, quack=411.41 |
| flux2_ln_4608x6144 | flux2 | 1 GPU | `[1, 4608, 6144]` | triton_norm_infer | 53.20 | triton_norm_infer=53.20, pytorch=59.36, flaggems=66.78, quack=464.90 |
| flux2_ln_512x6144 | flux2 | 1 GPU | `[1, 512, 6144]` | pytorch | 19.46 | pytorch=19.46, triton_norm_infer=26.98, flaggems=41.30, quack=84.11 |
| flux_ln_4096x3072 | flux | 1 GPU | `[1, 4096, 3072]` | pytorch | 32.62 | pytorch=32.62, triton_norm_infer=35.38, flaggems=47.38, quack=232.06 |
| flux_ln_4608x3072 | flux | 1 GPU | `[1, 4608, 3072]` | pytorch | 36.93 | pytorch=36.93, triton_norm_infer=38.03, flaggems=49.50, quack=259.17 |
| flux_ln_512x3072 | flux | 1 GPU | `[1, 512, 3072]` | pytorch | 16.86 | pytorch=16.86, triton_norm_infer=25.90, flaggems=41.66, quack=55.68 |
| flux_ln_77x768 | flux | 1 GPU | `[1, 77, 768]` | pytorch | 16.58 | pytorch=16.58, triton_norm_infer=26.50, quack=41.46, flaggems=41.52 |
| hunyuan_ln_27030x3072 | hunyuanvideo | 1 GPU | `[1, 27030, 3072]` | triton_norm_infer | 109.87 | triton_norm_infer=109.87, flaggems=115.73, pytorch=137.92, quack=1341.36 |
| hunyuan_ln_27075x3072 | hunyuanvideo | 1 GPU | `[1, 27075, 3072]` | triton_norm_infer | 110.69 | triton_norm_infer=110.69, flaggems=116.46, pytorch=139.07, quack=1343.58 |
| hunyuan_ln_45x3072 | hunyuanvideo | 1 GPU | `[1, 45, 3072]` | pytorch | 16.90 | pytorch=16.90, triton_norm_infer=26.45, flaggems=42.54, quack=49.25 |
| hunyuan_ln_46x768 | hunyuanvideo | 1 GPU | `[1, 46, 768]` | pytorch | 16.56 | pytorch=16.56, triton_norm_infer=25.98, quack=41.23, flaggems=42.21 |
| mova_ln_101x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 101, 1536]` | pytorch | 16.67 | pytorch=16.67, triton_norm_infer=26.78, quack=41.76, flaggems=42.19 |
| mova_ln_176400x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 176400, 5120]` | triton_norm_infer | 1079.26 | triton_norm_infer=1079.26, flaggems=1110.27, quack=1268.72, pytorch=1407.90 |
| mova_ln_403x1536 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 403, 1536]` | pytorch | 16.45 | pytorch=16.45, triton_norm_infer=26.93, quack=41.22, flaggems=42.62 |
| mova_ln_44100x5120 | mova-720p | 4 GPU, ulysses=4, ring=1 | `[1, 44100, 5120]` | triton_norm_infer | 269.50 | triton_norm_infer=269.50, flaggems=284.29, pytorch=329.18, quack=335.44 |
| qwen_edit_ln_189x3072 | qwen-edit | 1 GPU | `[1, 189, 3072]` | pytorch | 17.01 | pytorch=17.01, triton_norm_infer=26.62, flaggems=42.05, quack=49.97 |
| qwen_edit_ln_192x3072 | qwen-edit | 1 GPU | `[1, 192, 3072]` | pytorch | 16.83 | pytorch=16.83, triton_norm_infer=27.04, flaggems=41.36, quack=49.76 |
| qwen_edit_ln_8308x3072 | qwen-edit | 1 GPU | `[1, 8308, 3072]` | triton_norm_infer | 50.70 | triton_norm_infer=50.70, pytorch=53.07, flaggems=60.70, quack=434.35 |
| qwen_ln_26x3072 | qwen | 1 GPU | `[1, 26, 3072]` | pytorch | 16.91 | pytorch=16.91, triton_norm_infer=27.49, flaggems=42.78, quack=49.23 |
| qwen_ln_4096x3072 | qwen | 1 GPU | `[1, 4096, 3072]` | pytorch | 33.06 | pytorch=33.06, triton_norm_infer=36.10, flaggems=48.46, quack=232.83 |
| qwen_ln_6x3072 | qwen | 1 GPU | `[1, 6, 3072]` | pytorch | 16.78 | pytorch=16.78, triton_norm_infer=27.41, flaggems=42.46, quack=48.61 |
| wan_ti2v_ln_17850x3072 | wan-ti2v | 1 GPU | `[1, 17850, 3072]` | triton_norm_infer | 81.52 | triton_norm_infer=81.52, flaggems=88.46, pytorch=96.00, quack=896.66 |
| zimage_ln_4128x3840 | zimage | 1 GPU | `[1, 4128, 3840]` | pytorch | 38.78 | pytorch=38.78, triton_norm_infer=38.88, flaggems=51.46, quack=54.29 |



## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
