### PR TITLE
[diffusion] Remove redundant identity preprocess_text functions for sglang-diffusion

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -97,10 +97,6 @@ class STA_Mode(str, Enum):
     NONE = None
 
 
-def preprocess_text(prompt: str) -> str:
-    return prompt
-
-
 def postprocess_text(output: BaseEncoderOutput, _text_inputs) -> torch.tensor:
     raise NotImplementedError
 
@@ -206,8 +202,8 @@ class PipelineConfig:
     def postprocess_image(self, image):
         return image.last_hidden_state
 
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (preprocess_text,)
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (None,)
     )
 
     # get prompt_embeds from encoder output

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
@@ -23,12 +23,10 @@ from sglang.multimodal_gen.configs.models.vaes.flux import Flux2VAEConfig, FluxV
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ImagePipelineConfig,
     ModelTaskType,
-    preprocess_text,
     shard_rotary_emb_for_sp,
 )
 from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import (
     clip_postprocess_text,
-    clip_preprocess_text,
 )
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import _pack_latents
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
@@ -65,8 +63,8 @@ class FluxPipelineConfig(ImagePipelineConfig):
         default_factory=lambda: ("bf16", "bf16")
     )
 
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (clip_preprocess_text, preprocess_text),
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (None, None),
     )
 
     postprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
@@ -650,8 +648,8 @@ class Flux2KleinPipelineConfig(Flux2PipelineConfig):
         default_factory=lambda: (Qwen3TextConfig(),)
     )
 
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (preprocess_text,),
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (None,),
     )
 
     postprocess_text_funcs: tuple[Callable[[str], str], ...] = field(

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
@@ -56,10 +56,6 @@ def llama_postprocess_text(outputs: BaseEncoderOutput, _text_inputs) -> torch.te
     return last_hidden_state
 
 
-def clip_preprocess_text(prompt: str) -> str:
-    return prompt
-
-
 def clip_postprocess_text(outputs: BaseEncoderOutput, _text_inputs) -> torch.tensor:
     pooler_output: torch.tensor = outputs.pooler_output
     return pooler_output
@@ -84,8 +80,8 @@ class HunyuanConfig(PipelineConfig):
     text_encoder_configs: tuple[EncoderConfig, ...] = field(
         default_factory=lambda: (LlamaConfig(), CLIPTextConfig())
     )
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (llama_preprocess_text, clip_preprocess_text)
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (llama_preprocess_text, None)
     )
     postprocess_text_funcs: tuple[Callable[[BaseEncoderOutput], torch.tensor], ...] = (
         field(default_factory=lambda: (llama_postprocess_text, clip_postprocess_text))

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -14,7 +14,6 @@ from sglang.multimodal_gen.configs.models.vaes.ltx_audio import LTXAudioVAEConfi
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
-    preprocess_text,
 )
 from sglang.multimodal_gen.runtime.distributed import (
     get_sp_parallel_rank,
@@ -189,8 +188,8 @@ class LTX2PipelineConfig(PipelineConfig):
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("bf16",))
     text_encoder_extra_args: list[dict] = field(default_factory=lambda: [{}])
 
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (preprocess_text,)
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (None,)
     )
     postprocess_text_funcs: tuple[
         Callable[[BaseEncoderOutput, dict], torch.Tensor], ...

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/sana.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/sana.py
@@ -30,7 +30,6 @@ from sglang.multimodal_gen.configs.models.vaes.sana import SanaVAEConfig
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     SpatialImagePipelineConfig,
-    preprocess_text,
 )
 
 
@@ -65,8 +64,8 @@ class SanaPipelineConfig(SpatialImagePipelineConfig):
 
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("bf16",))
 
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (preprocess_text,),
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (None,),
     )
 
     postprocess_text_funcs: tuple[Callable[[str], str], ...] = field(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -236,10 +236,12 @@ class TextEncodingStage(PipelineStage):
                 else {}
             )
 
-            processed_text_list: list[str] = []
-            for prompt_str in texts:
-                preprocessed = preprocess_func(prompt_str)
-                processed_text_list.append(preprocessed)
+            if preprocess_func is not None:
+                processed_text_list: list[str] = [
+                    preprocess_func(prompt_str) for prompt_str in texts
+                ]
+            else:
+                processed_text_list = texts
 
             # Prepare tokenizer args
             tok_kwargs = self.prepare_tokenizer_kwargs(


### PR DESCRIPTION
Replace `preprocess_text` (base.py) and `clip_preprocess_text` (hunyuan.py) identity functions with `None` to express "no preprocessing needed". TextEncodingStage now skips preprocessing when the function is None.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Remove redundant identity preprocess_text functions for sglang-diffusion for #19525 

## Modifications

  - Remove preprocess_text() from base.py and clip_preprocess_text() from hunyuan.py — both are identity functions (return prompt) that add no value
  - Use None in preprocess_text_funcs to express "no preprocessing needed"
  - Add None guard in TextEncodingStage.encode_text() to skip preprocessing when the function is None

## Tests
```sh
# Unit Tests
python -m pytest python/sglang/multimodal_gen/test/unit/ -v
================================================================ test session starts ================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/ainfra/base/bin/python
cachedir: .pytest_cache
rootdir: /home/ainfra/sglang/python
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 26 items                                                                                                                                  

python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py::TestLoRAFormatAdapter::test_lora_format_adapter_all_formats PASSED        [  3%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_boundary_ratio_range PASSED                  [  7%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_fps_must_be_positive_int PASSED              [ 11%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_guidance_rescale_must_be_finite_non_negative PASSED [ 15%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_guidance_scale_must_be_finite_non_negative_if_set PASSED [ 19%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_num_inference_steps_optional_but_if_set_must_be_positive PASSED [ 23%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_num_outputs_per_prompt_must_be_positive PASSED [ 26%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsValidate::test_prompt_path_suffix PASSED                    [ 30%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsSubclass::test_diffusers_generic_calls_base_post_init PASSED [ 34%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsSubclass::test_flux_defaults_resolution_when_not_provided PASSED [ 38%]
python/sglang/multimodal_gen/test/unit/test_sampling_params.py::TestSamplingParamsSubclass::test_flux_preserves_user_resolution PASSED        [ 42%]
python/sglang/multimodal_gen/test/unit/test_server_args_unit.py::TestServerArgsPathExpansion::test_absolute_path_is_unchanged FAILED          [ 46%]
python/sglang/multimodal_gen/test/unit/test_server_args_unit.py::TestServerArgsPathExpansion::test_tilde_model_path_is_expanded FAILED        [ 50%]
python/sglang/multimodal_gen/test/unit/test_server_args_unit.py::TestModelIdResolution::test_model_id_overrides_arbitrary_local_path PASSED   [ 53%]
python/sglang/multimodal_gen/test/unit/test_server_args_unit.py::TestModelIdResolution::test_model_id_unknown_falls_back_without_crash PASSED [ 57%]
python/sglang/multimodal_gen/test/unit/test_server_args_unit.py::TestModelIdResolution::test_model_id_works_after_tilde_expansion PASSED      [ 61%]
python/sglang/multimodal_gen/test/unit/test_server_args_unit.py::TestPipelineResolutionCliOverride::test_resolution_flag_overrides_qwen_image_layered_pipeline_config PASSED [ 65%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_upload_file_success PASSED                                                       [ 69%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_upload_and_cleanup PASSED                                                        [ 73%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_upload_failure_preserves_file PASSED                                             [ 76%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_disabled_storage_returns_none PASSED                                             [ 80%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_aws_url_with_region PASSED                                                       [ 84%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_aws_url_default_region PASSED                                                    [ 88%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_custom_endpoint_url PASSED                                                       [ 92%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_content_type_detection PASSED                                                    [ 96%]
python/sglang/multimodal_gen/test/unit/test_storage.py::test_integration_with_moto SKIPPED (moto/boto3 not installed)                         [100%]
...

# E2E Tests
sglang generate --model-path /home/ainfra/Sana_600M_1024px_diffusers --prompt "A cute cat sitting on a windowsill" --save-output  # success

```



## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. 
-->



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
