### PR TITLE
[fix]: flashinfer_cutlass block FP8 GEMM for non-block-aligned weight dimensions

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -536,10 +536,12 @@ def flashinfer_gemm_w8a8_block_fp8_linear_with_fallback(
             f"m={m} n={n} k={k} block_size={block_size}"
         )
         assert x_scale.dtype == torch.float32, (
-            f"FlashInfer CUTLASS groupwise FP8 expects x_scale dtype float32, got {x_scale.dtype}."
+            "FlashInfer CUTLASS groupwise FP8 expects x_scale dtype float32, "
+            f"got {x_scale.dtype}."
         )
         assert weight_scale.dtype == torch.float32, (
-            f"FlashInfer CUTLASS groupwise FP8 expects weight_scale dtype float32, got {weight_scale.dtype}."
+            "FlashInfer CUTLASS groupwise FP8 expects weight_scale dtype float32, "
+            f"got {weight_scale.dtype}."
         )
     # TRTLLM path continues using the original quantized scale layout.
     output = gemm_fp8_nt_groupwise(

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -513,33 +513,33 @@ def flashinfer_gemm_w8a8_block_fp8_linear_with_fallback(
         block_n, block_k = block_size
         m, k = input_2d.shape
         n = weight.shape[0]
-        expected_x_scale_shape = (k // block_k, m)
-        expected_weight_scale_shape = (k // block_k, n // block_n)
-        if x_scale.shape == (m, k // block_k):
+        # ceil_div is required (not //) because n or k may not be block-size multiples.
+        # The quantizer allocates ceil_div tiles to cover any partial trailing block.
+        expected_x_scale_shape = (ceil_div(k, block_k), m)
+        expected_weight_scale_shape = (ceil_div(k, block_k), ceil_div(n, block_n))
+        if x_scale.shape == (m, ceil_div(k, block_k)):
             x_scale = x_scale.transpose(-1, -2).contiguous()
-        if weight_scale.shape == (n // block_n, k // block_k):
+        if weight_scale.shape == (ceil_div(n, block_n), ceil_div(k, block_k)):
             weight_scale = weight_scale.transpose(-1, -2).contiguous()
         assert x_scale.shape == expected_x_scale_shape, (
             "FlashInfer CUTLASS groupwise FP8 expects A scale layout "
-            f"(k//block_k, m) for scale_major_mode='MN', got {tuple(x_scale.shape)}; "
+            f"(ceil_div(k,block_k), m) for scale_major_mode='MN', got {tuple(x_scale.shape)}; "
             f"expected {expected_x_scale_shape}. "
             f"strides={x_scale.stride()} is_contiguous={x_scale.is_contiguous()} "
             f"m={m} n={n} k={k} block_size={block_size}"
         )
         assert weight_scale.shape == expected_weight_scale_shape, (
             "FlashInfer CUTLASS groupwise FP8 expects B scale layout "
-            f"(k//block_k, n//block_n) for scale_major_mode='MN', got {tuple(weight_scale.shape)}; "
-            f"expected {expected_weight_scale_shape}. "
+            f"(ceil_div(k,block_k), ceil_div(n,block_n)) for scale_major_mode='MN', "
+            f"got {tuple(weight_scale.shape)}; expected {expected_weight_scale_shape}. "
             f"strides={weight_scale.stride()} is_contiguous={weight_scale.is_contiguous()} "
             f"m={m} n={n} k={k} block_size={block_size}"
         )
         assert x_scale.dtype == torch.float32, (
-            "FlashInfer CUTLASS groupwise FP8 expects x_scale dtype float32, "
-            f"got {x_scale.dtype}."
+            f"FlashInfer CUTLASS groupwise FP8 expects x_scale dtype float32, got {x_scale.dtype}."
         )
         assert weight_scale.dtype == torch.float32, (
-            "FlashInfer CUTLASS groupwise FP8 expects weight_scale dtype float32, "
-            f"got {weight_scale.dtype}."
+            f"FlashInfer CUTLASS groupwise FP8 expects weight_scale dtype float32, got {weight_scale.dtype}."
         )
     # TRTLLM path continues using the original quantized scale layout.
     output = gemm_fp8_nt_groupwise(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The `flashinfer_cutlass` backend's scale layout normalisation used floor division (`//`) when computing expected scale shapes and detecting whether transposition was needed. This assumes weight N and K dimensions are always multiples of the block size. When they are not, the transpose guards fail to fire and the subsequent shape assertions raise an `AssertionError` on load.

An example case where this matters is [zai-org/GLM-5-FP8](https://huggingface.co/zai-org/GLM-5-FP8), where the fused QKV projection output size is `q_lora_rank + kv_lora_rank + qk_rope_head_dim`, resulting in `n=2624` which is not block-aligned.

## Modifications

The fix replaces `//` with `ceil_div` throughout the scale shape checks and transpose guards, matching the quantizer's own behaviour of allocating `ceil_div` tiles to cover any partial trailing block.

**Important Note:** This change requires a corresponding fix in `flashinfer` (https://github.com/flashinfer-ai/flashinfer/pull/2787), where a related bug in the SM120 groupwise wrapper causes it to misidentify padding requirements for non-block-aligned N due to reading `n_dim` from a transposed weight tensor (see linked PR for details). Without that fix, inference will run without errors, but will silently produce wrong output for the non-block-aligned N case... which is probably worse than just failing with an `AssertionError` on load.

We can either wait for the `flashinfer` fix before making this change, or work around the bug by handling the padding here. Let me know what you think is best.

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
