### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/docs/basic_usage/minimax_m2.md
+++ b/docs/basic_usage/minimax_m2.md
@@ -83,3 +83,52 @@ curl http://localhost:8000/v1/chat/completions \
         ]
     }'
 ```
+
+## Using MiniMax API with SGLang Frontend
+
+In addition to self-hosted deployment, you can use MiniMax models through the [MiniMax API](https://platform.minimax.io/) with SGLang's frontend language via the built-in `MiniMax` backend.
+
+### Setup
+
+Set the `MINIMAX_API_KEY` environment variable:
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+### Usage
+
+```python
+import sglang as sgl
+
+backend = sgl.MiniMax("MiniMax-M2.5")
+sgl.set_default_backend(backend)
+
+@sgl.function
+def chat(s, question):
+    s += sgl.user(question)
+    s += sgl.assistant(sgl.gen("answer"))
+
+state = chat.run(question="What is MiniMax?")
+print(state["answer"])
+```
+
+### Available Models
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.5` | Default. Peak performance, ultimate value. 204K context window. |
+| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile. 204K context window. |
+
+### Configuration
+
+```python
+# Custom base URL (e.g., for users in mainland China)
+backend = sgl.MiniMax(
+    "MiniMax-M2.5",
+    api_key="your-api-key",
+    base_url="https://api.minimaxi.com/v1",
+)
+```
+
+For more details on the MiniMax API, see the [MiniMax Platform Documentation](https://platform.minimax.io/docs/api-reference/text-openai-api).

--- a/docs/basic_usage/minimax_m2.md
+++ b/docs/basic_usage/minimax_m2.md
@@ -101,7 +101,7 @@ export MINIMAX_API_KEY="your-api-key"
 ```python
 import sglang as sgl
 
-backend = sgl.MiniMax("MiniMax-M2.5")
+backend = sgl.MiniMax("MiniMax-M3")
 sgl.set_default_backend(backend)
 
 @sgl.function
@@ -117,15 +117,16 @@ print(state["answer"])
 
 | Model | Description |
 |-------|-------------|
-| `MiniMax-M2.5` | Default. Peak performance, ultimate value. 204K context window. |
-| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile. 204K context window. |
+| `MiniMax-M3` | Default. Latest generation, 512K context window, up to 128K max output, image input support. |
+| `MiniMax-M2.7` | Previous generation, strong agentic and coding performance. |
+| `MiniMax-M2.7-highspeed` | Same as M2.7, faster and lower latency. |
 
 ### Configuration
 
 ```python
 # Custom base URL (e.g., for users in mainland China)
 backend = sgl.MiniMax(
-    "MiniMax-M2.5",
+    "MiniMax-M3",
     api_key="your-api-key",
     base_url="https://api.minimaxi.com/v1",
 )

--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -63,6 +63,7 @@ from sglang.version import __version__
 
 Anthropic = LazyImport("sglang.lang.backend.anthropic", "Anthropic")
 LiteLLM = LazyImport("sglang.lang.backend.litellm", "LiteLLM")
+MiniMax = LazyImport("sglang.lang.backend.minimax", "MiniMax")
 OpenAI = LazyImport("sglang.lang.backend.openai", "OpenAI")
 VertexAI = LazyImport("sglang.lang.backend.vertexai", "VertexAI")
 
@@ -100,6 +101,7 @@ __all__ = [
     "ServerArgs",
     "Anthropic",
     "LiteLLM",
+    "MiniMax",
     "OpenAI",
     "VertexAI",
     "global_config",

--- a/python/sglang/lang/backend/minimax.py
+++ b/python/sglang/lang/backend/minimax.py
@@ -1,0 +1,73 @@
+import os
+from typing import Optional
+
+from sglang.lang.backend.openai import OpenAI
+from sglang.lang.chat_template import ChatTemplate
+from sglang.lang.interpreter import StreamExecutor
+from sglang.lang.ir import SglSamplingParams
+
+
+MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMax(OpenAI):
+    """Backend for MiniMax models via the OpenAI-compatible API.
+
+    MiniMax provides an OpenAI-compatible API endpoint. This backend
+    configures the OpenAI client with MiniMax's default base URL and
+    API key, and adjusts parameters to comply with MiniMax constraints.
+
+    Usage:
+        import sglang as sgl
+        backend = sgl.MiniMax("MiniMax-M2.5")
+        sgl.set_default_backend(backend)
+    """
+
+    def __init__(
+        self,
+        model_name: str = "MiniMax-M2.5",
+        is_chat_model: Optional[bool] = None,
+        chat_template: Optional[ChatTemplate] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        resolved_api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+        resolved_base_url = base_url or os.environ.get(
+            "MINIMAX_BASE_URL", MINIMAX_DEFAULT_BASE_URL
+        )
+
+        super().__init__(
+            model_name=model_name,
+            is_chat_model=is_chat_model if is_chat_model is not None else True,
+            chat_template=chat_template,
+            api_key=resolved_api_key,
+            base_url=resolved_base_url,
+            *args,
+            **kwargs,
+        )
+
+    def _clamp_temperature(self, sampling_params: SglSamplingParams):
+        """MiniMax requires temperature in (0.0, 1.0]. Clamp 0 to a small value."""
+        if sampling_params.temperature <= 0:
+            sampling_params = sampling_params.clone()
+            sampling_params.temperature = 0.01
+        return sampling_params
+
+    def generate(
+        self,
+        s: StreamExecutor,
+        sampling_params: SglSamplingParams,
+        spec_var_name: str = None,
+    ):
+        sampling_params = self._clamp_temperature(sampling_params)
+        return super().generate(s, sampling_params, spec_var_name)
+
+    def generate_stream(
+        self,
+        s: StreamExecutor,
+        sampling_params: SglSamplingParams,
+    ):
+        sampling_params = self._clamp_temperature(sampling_params)
+        return super().generate_stream(s, sampling_params)

--- a/python/sglang/lang/backend/minimax.py
+++ b/python/sglang/lang/backend/minimax.py
@@ -19,13 +19,13 @@ class MiniMax(OpenAI):
 
     Usage:
         import sglang as sgl
-        backend = sgl.MiniMax("MiniMax-M2.5")
+        backend = sgl.MiniMax("MiniMax-M3")
         sgl.set_default_backend(backend)
     """
 
     def __init__(
         self,
-        model_name: str = "MiniMax-M2.5",
+        model_name: str = "MiniMax-M3",
         is_chat_model: Optional[bool] = None,
         chat_template: Optional[ChatTemplate] = None,
         api_key: Optional[str] = None,

--- a/test/manual/lang_frontend/test_minimax_backend.py
+++ b/test/manual/lang_frontend/test_minimax_backend.py
@@ -1,0 +1,33 @@
+import unittest
+
+from sglang import MiniMax, set_default_backend
+from sglang.test.test_programs import (
+    test_expert_answer,
+    test_mt_bench,
+    test_stream,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestMiniMaxBackend(CustomTestCase):
+    chat_backend = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.chat_backend = MiniMax("MiniMax-M2.5")
+
+    def test_mt_bench(self):
+        set_default_backend(self.chat_backend)
+        test_mt_bench()
+
+    def test_stream(self):
+        set_default_backend(self.chat_backend)
+        test_stream()
+
+    def test_expert_answer(self):
+        set_default_backend(self.chat_backend)
+        test_expert_answer()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/manual/lang_frontend/test_minimax_backend.py
+++ b/test/manual/lang_frontend/test_minimax_backend.py
@@ -14,7 +14,7 @@ class TestMiniMaxBackend(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.chat_backend = MiniMax("MiniMax-M2.5")
+        cls.chat_backend = MiniMax("MiniMax-M3")
 
     def test_mt_bench(self):
         set_default_backend(self.chat_backend)


### PR DESCRIPTION
## Summary
Upgrade the SGLang frontend `MiniMax` backend to use **MiniMax-M3** as the default model. M3 is the latest generation (512K context, 128K max output, image input support) and replaces MiniMax-M2.5 as the default. MiniMax-M2.7 and MiniMax-M2.7-highspeed are kept as alternatives.

## Changes
- `python/sglang/lang/backend/minimax.py` — switch the default `model_name` from `MiniMax-M2.5` to `MiniMax-M3`
- `test/manual/lang_frontend/test_minimax_backend.py` — use `MiniMax-M3` in the manual backend test
- `docs/basic_usage/minimax_m2.md` — update the "Available Models" table to list `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`; update usage example to use M3
- Default backend wiring (registration, temperature clamp, base URL, env var) is unchanged — M3 is a drop-in replacement on the same `api.minimax.io/v1` endpoint

## Why
MiniMax-M3 is the latest model from MiniMax. It supports a 512K context window, up to 128K max output, and image input. Using M3 as the default gives users the strongest out-of-the-box model, while M2.7 and M2.7-highspeed remain available for users who prefer them.

## Usage

```python
import sglang as sgl

# Default model is now MiniMax-M3
backend = sgl.MiniMax()  # equivalent to sgl.MiniMax("MiniMax-M3")
sgl.set_default_backend(backend)

@sgl.function
def chat(s, question):
    s += sgl.user(question)
    s += sgl.assistant(sgl.gen("answer"))

state = chat.run(question="What is MiniMax?")
print(state["answer"])
```

## Available Models

| Model | Description |
|-------|-------------|
| `MiniMax-M3` | Default. Latest generation, 512K context, 128K max output, image input support. |
| `MiniMax-M2.7` | Previous generation, strong agentic and coding performance. |
| `MiniMax-M2.7-highspeed` | Same as M2.7, faster and lower latency. |

## API Documentation
- MiniMax OpenAI-Compatible API: https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing
- Manual frontend test (`test/manual/lang_frontend/test_minimax_backend.py`) updated to use M3
- M2.7 and M2.7-highspeed can still be selected by passing the model name explicitly





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26833955590](https://github.com/sgl-project/sglang/actions/runs/26833955590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26833958483](https://github.com/sgl-project/sglang/actions/runs/26833958483)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->