### PR TITLE
Fix InternVisionEncoder CUDA graph path returning tuple instead of BaseModelOutput

### DIFF
--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -346,14 +346,8 @@ class InternVisionEncoder(nn.Module):
             return_dict (`bool`, *optional*):
                 Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
         """
-        if self.enable_cg and (not output_hidden_states):
-            # graph path only returns last_hidden_state
-            hidden_states = inputs_embeds.to(device=inputs_embeds.device).contiguous()
-            hidden_states = self.cuda_graph_runner.run(hidden_states)
-            if not return_dict:
-                return (hidden_states,)
-            return BaseModelOutput(last_hidden_state=hidden_states, hidden_states=None)
-
+        # Resolve defaults before the CUDA graph fast path so that
+        # `not None` doesn't accidentally evaluate to True.
         output_hidden_states = (
             output_hidden_states
             if output_hidden_states is not None
@@ -362,6 +356,14 @@ class InternVisionEncoder(nn.Module):
         return_dict = (
             return_dict if return_dict is not None else self.config.use_return_dict
         )
+
+        if self.enable_cg and (not output_hidden_states):
+            # graph path only returns last_hidden_state
+            hidden_states = inputs_embeds.to(device=inputs_embeds.device).contiguous()
+            hidden_states = self.cuda_graph_runner.run(hidden_states)
+            if not return_dict:
+                return (hidden_states,)
+            return BaseModelOutput(last_hidden_state=hidden_states, hidden_states=None)
 
         encoder_states = () if output_hidden_states else None
         hidden_states = inputs_embeds


### PR DESCRIPTION
## Problem

When serving VLMs that use the RADIO vision encoder (e.g. `NVIDIA-Nemotron-Nano-12B-v2-VL`) with CUDA graph enabled, image requests crash with:

```
AssertionError: assert isinstance(encoder_outputs, BaseModelOutput)
```

## Root Cause

In `InternVisionEncoder.forward()`, the CUDA graph fast path checks `return_dict` before resolving its default value of `None`:

```python
def forward(self, inputs_embeds, output_hidden_states=None, return_dict=None):
    if self.enable_cg and (not output_hidden_states):
        hidden_states = self.cuda_graph_runner.run(hidden_states)
        if not return_dict:           # not None → True
            return (hidden_states,)   # always returns tuple
        return BaseModelOutput(...)   # dead code
```

`RadioModel.forward()` calls `self.encoder.forward(inputs_embeds=hidden_states)` without passing `return_dict`, so it defaults to `None`. Since `not None` is `True`, the branch always returns a raw tuple.

## Fix

Move the default-resolution for `return_dict` and `output_hidden_states` above the CUDA graph branch so the check works correctly.

Fixes #20638