### PR TITLE
[BugFix] PPMissingLayer in DummyModelLoader

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -113,6 +113,7 @@ from sglang.srt.utils import (
     rank0_log,
     set_weight_attrs,
 )
+from sglang.srt.layers.utils.common import PPMissingLayer
 
 if TYPE_CHECKING:
     from sglang.srt.configs.device_config import DeviceConfig
@@ -1284,7 +1285,6 @@ class DummyModelLoader(BaseModelLoader):
                     self.load_config,
                     quant_config,
                 )
-            from sglang.srt.layers.utils.common import PPMissingLayer
             for _, module in model.named_modules():
                 
                 # PPMissingLayer overrides attribute access to always
@@ -1293,7 +1293,7 @@ class DummyModelLoader(BaseModelLoader):
                 # a crash: 
                 #   - module.is_weights_quantized() -> self() -> self.forward()
                 # PPMissingLayer.forward expects either args or kwargs
-                if type(module) is PPMissingLayer:
+                if isinstance(module, PPMissingLayer):
                     continue
 
                 quant_method = getattr(module, "quant_method", None)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1284,8 +1284,18 @@ class DummyModelLoader(BaseModelLoader):
                     self.load_config,
                     quant_config,
                 )
-
+            from sglang.srt.layers.utils.common import PPMissingLayer
             for _, module in model.named_modules():
+                
+                # PPMissingLayer overrides attribute access to always
+                # return `self`
+                # The quant checks will fire because of this which causes
+                # a crash: 
+                #   - module.is_weights_quantized() -> self() -> self.forward()
+                # PPMissingLayer.forward expects either args or kwargs
+                if type(module) is PPMissingLayer:
+                    continue
+
                 quant_method = getattr(module, "quant_method", None)
                 if quant_method is not None:
                     # Skip FusedMoE layers already quantized during init (FP8 or FP4)


### PR DESCRIPTION
## Motivation

When running pipeline parallel with `load_format=dummy`, the model crashes during `DummyModelLoader.load_model` due to the attribute override of `PPMissingLayer`.

```python
                quant_method = getattr(module, "quant_method", None)
                if quant_method is not None:
                    # Skip FusedMoE layers already quantized during init (FP8 or FP4)
                    if (
                        hasattr(module, "is_weights_quantized")
                        and module.is_weights_quantized() <-- crashes here
                    ):
                        continue
```
Since `PPMissingLayer`'s attribute access [returns](https://github.com/sgl-project/sglang/blob/e1eb25880f80520d0feae26da8239d3b4a26c54e/python/sglang/srt/layers/utils/common.py#L72-L76) `self` for attributes not found in `nn.Identity`, the call to `is_weights_quantized` errors:
```
module.is_weights_quantized() -> self() -> self.forward() -> crash, since `PPMissingLayer.forward` requires either args or kwargs
```
 
## Modifications
Fix is to skip this check explicitly for `PPMissingLayer` modules:
```
if type(module) is PPMissingLayer:
    continue
```
