### PR TITLE
[Bugfix] Fix INT8 quantization range on HIP and type annotation typo

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -785,7 +785,7 @@ class FlashInferMLAIndicesUpdaterPrefill:
 
     def update(
         self,
-        req_pool_indices: torch.Tnesor,
+        req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
         prefix_lens: torch.Tensor,

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -245,9 +245,10 @@ def _per_token_group_quant_8bit_raw(
     if _is_hip:
         if dtype == torch.int8:
             bit8_max = 127.0
+            bit8_min = -128.0
         else:
             bit8_max = 224.0
-        bit8_min = -bit8_max  # TODO incorrect for int8
+            bit8_min = -bit8_max
     else:
         if dtype == torch.int8:
             info = torch.iinfo(dtype)


### PR DESCRIPTION
## Motivation

Two small bugs found while reading the quantization and attention backend code:

### 1. Incorrect INT8 `bit8_min` on HIP/ROCm (`fp8_kernel.py`)

In `_per_token_group_quant_8bit_raw`, the HIP code path computes `bit8_min = -bit8_max` for all dtypes. This is correct for FP8 (symmetric range), but wrong for INT8 which has an asymmetric range of `[-128, 127]`.

The code was setting `bit8_min = -127` instead of `-128`, meaning the negative quantization range was clipped by 1. The non-HIP path correctly uses `torch.iinfo(dtype).min` (= -128). There was already a TODO comment acknowledging this: `# TODO incorrect for int8`.

### 2. Type annotation typo (`flashinfer_mla_backend.py`)

`torch.Tnesor` → `torch.Tensor` in `FlashInferMLAIndicesUpdaterPrefill.update()`.

## Modifications

- `python/sglang/srt/layers/quantization/fp8_kernel.py`: Set `bit8_min = -128.0` for INT8 on HIP instead of using `-bit8_max` (-127.0)
- `python/sglang/srt/layers/attention/flashinfer_mla_backend.py`: Fix `torch.Tnesor` → `torch.Tensor`

## Checklist
- [x] No formatting changes needed
- [x] No new tests needed (correctness fix for existing code path, typo fix)