### PR TITLE
[BugFix] Preserve significant whitespace in GLM XML tool args

### DIFF
--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -759,7 +759,6 @@ class Glm47MoeDetector(BaseFormatDetector):
         arguments = {}
         for arg_key, arg_value in pairs:
             arg_key = arg_key.strip()
-            arg_value = arg_value.strip()
             arg_type = get_argument_type(func_name, arg_key, tools)
             parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
 

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -613,7 +613,6 @@ class Glm4MoeDetector(BaseFormatDetector):
         arguments = {}
         for arg_key, arg_value in pairs:
             arg_key = arg_key.strip()
-            arg_value = arg_value.strip()
             arg_type = get_argument_type(func_name, arg_key, tools)
             parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
 

--- a/test/registered/unit/function_call/test_glm47_moe_detector.py
+++ b/test/registered/unit/function_call/test_glm47_moe_detector.py
@@ -1379,6 +1379,51 @@ class TestGlm4ComplexJsonSchema(unittest.TestCase):
         self.assertEqual(params["query"], "test query")
         self.assertEqual(params["priority"], "high")
 
+    def test_preserve_significant_whitespace_in_string_arguments(self):
+        """Ensure GLM4/GLM47 preserve leading and trailing spaces for string args."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="apply_diff",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "old_string": {"type": "string"},
+                            "new_string": {"type": "string"},
+                        },
+                        "required": ["old_string", "new_string"],
+                    },
+                ),
+            )
+        ]
+
+        glm4_text = (
+            "<tool_call>apply_diff\n"
+            "<arg_key>old_string</arg_key>\n"
+            "<arg_value>    def foo():    </arg_value>\n"
+            "<arg_key>new_string</arg_key>\n"
+            "<arg_value>  def bar():</arg_value>\n"
+            "</tool_call>"
+        )
+        glm4_result = self.glm4_detector.detect_and_parse(glm4_text, tools)
+        self.assertEqual(len(glm4_result.calls), 1)
+        glm4_params = json.loads(glm4_result.calls[0].parameters)
+        self.assertEqual(glm4_params["old_string"], "    def foo():    ")
+        self.assertEqual(glm4_params["new_string"], "  def bar():")
+
+        glm47_text = (
+            "<tool_call>apply_diff"
+            "<arg_key>old_string</arg_key><arg_value>    def foo():    </arg_value>"
+            "<arg_key>new_string</arg_key><arg_value>  def bar():</arg_value>"
+            "</tool_call>"
+        )
+        glm47_result = self.glm47_detector.detect_and_parse(glm47_text, tools)
+        self.assertEqual(len(glm47_result.calls), 1)
+        glm47_params = json.loads(glm47_result.calls[0].parameters)
+        self.assertEqual(glm47_params["old_string"], "    def foo():    ")
+        self.assertEqual(glm47_params["new_string"], "  def bar():")
+
     def test_glm4_detector_streaming_with_complex_schema(self):
         """Test GLM4 detector streaming with complex schema."""
         chunks = [


### PR DESCRIPTION
## Summary
- remove `arg_value.strip()` from GLM XML argument parsing in both `Glm4MoeDetector` and `Glm47MoeDetector`
- keep `arg_key.strip()` unchanged (keys remain normalized)
- add a regression test to ensure leading/trailing whitespace in string-typed arguments is preserved for both detectors

## Why
`arg_value.strip()` removes meaningful indentation and trailing spaces from string arguments (e.g. code-editing tool calls), causing lossy parsing.

## Validation
- pre-commit on touched files passed

Fixes #20542
