### PR TITLE
fix: adding teacache.params back to sampling params as intended

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -156,6 +156,9 @@ class SamplingParams:
 
     # TeaCache parameters
     enable_teacache: bool = False
+    teacache_params: Any = (
+        None  # TeaCacheParams or WanTeaCacheParams, set by model-specific subclass
+    )
 
     # Profiling
     profile: bool = False

--- a/python/sglang/multimodal_gen/configs/sample/wan.py
+++ b/python/sglang/multimodal_gen/configs/sample/wan.py
@@ -212,26 +212,10 @@ class Wan2_2_Base_SamplingParams(SamplingParams):
         "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
     )
 
-    teacache_params: WanTeaCacheParams = field(
-        default_factory=lambda: WanTeaCacheParams(
-            teacache_thresh=0.20,
-            use_ret_steps=False,
-            ret_steps_coeffs=[
-                -3.03318725e05,
-                4.90537029e04,
-                -2.65530556e03,
-                5.87365115e01,
-                -3.15583525e-01,
-            ],
-            non_ret_steps_coeffs=[
-                -5784.54975374,
-                5449.50911966,
-                -1811.16591783,
-                256.27178429,
-                -13.02252404,
-            ],
-        )
-    )
+    # TODO(Wan2.2): TeaCache coefficients need to be calibrated for Wan2.2 by
+    # profiling L1 distances across timesteps. Until then, teacache_params is None
+    # and enable_teacache will be accepted but silently no-op.
+    # Consider using Cache-DiT (SGLANG_CACHE_DIT_ENABLED=1) as an alternative.
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/configs/sample/wan.py
+++ b/python/sglang/multimodal_gen/configs/sample/wan.py
@@ -212,6 +212,27 @@ class Wan2_2_Base_SamplingParams(SamplingParams):
         "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
     )
 
+    teacache_params: WanTeaCacheParams = field(
+        default_factory=lambda: WanTeaCacheParams(
+            teacache_thresh=0.20,
+            use_ret_steps=False,
+            ret_steps_coeffs=[
+                -3.03318725e05,
+                4.90537029e04,
+                -2.65530556e03,
+                5.87365115e01,
+                -3.15583525e-01,
+            ],
+            non_ret_steps_coeffs=[
+                -5784.54975374,
+                5449.50911966,
+                -1811.16591783,
+                256.27178429,
+                -13.02252404,
+            ],
+        )
+    )
+
 
 @dataclass
 class Wan2_2_TI2V_5B_SamplingParam(Wan2_2_Base_SamplingParams):

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -768,7 +768,9 @@ TWO_GPU_CASES_A = [
             prompt=T2V_PROMPT,
         ),
     ),
-    # TeaCache acceleration test for Wan2.2 T2V A14B
+    # TeaCache smoke test for Wan2.2 T2V A14B — verifies enable_teacache=True
+    # doesn't crash. Perf check disabled because Wan2.2-specific TeaCache
+    # coefficients are not yet calibrated (teacache_params=None, so no speedup).
     DiffusionTestCase(
         "wan2_2_t2v_a14b_teacache_2gpu",
         DiffusionServerArgs(
@@ -781,6 +783,7 @@ TWO_GPU_CASES_A = [
             prompt=T2V_PROMPT,
             extras={"enable_teacache": True},
         ),
+        run_perf_check=False,
     ),
     # LoRA test case for transformer_2 support
     DiffusionTestCase(

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -768,6 +768,20 @@ TWO_GPU_CASES_A = [
             prompt=T2V_PROMPT,
         ),
     ),
+    # TeaCache acceleration test for Wan2.2 T2V A14B
+    DiffusionTestCase(
+        "wan2_2_t2v_a14b_teacache_2gpu",
+        DiffusionServerArgs(
+            model_path=DEFAULT_WAN_2_2_T2V_A14B_MODEL_NAME_FOR_TEST,
+            modality="video",
+            custom_validator="video",
+            num_gpus=2,
+        ),
+        DiffusionSamplingParams(
+            prompt=T2V_PROMPT,
+            extras={"enable_teacache": True},
+        ),
+    ),
     # LoRA test case for transformer_2 support
     DiffusionTestCase(
         "wan2_2_t2v_a14b_lora_2gpu",


### PR DESCRIPTION
## Motivation

Currently, adding enable_teacache=true fails with 'Req' object has no attribute 'teacache_params'. This bug was introduced in PR #19964 which intended to remove teacache_params from the request body so fallback to sampling params to be handled, but teacache_params were not on sampling params.

Also added teacache params for Wan 2.2 using the Wan2.1 14B coefficients as a proxy so that enable_teacache actually takes effect.

## Modifications

Adding teacache_params back to sampling params and added teacache_params: to class Wan2_2_Base_SamplingParams.

## Accuracy Tests

```
python3 -m
  sglang.multimodal_gen.runtime.entrypoints.cli.main
  serve \
    --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers \
    --dit-layerwise-offload \
    --host 0.0.0.0 --port 8080

  Request:
  curl "http://localhost:8080/v1/videos" \
    -F "prompt=A dog running through a park" \
    -F "size=832x480" \
    -F "num_frames=81" \
    -F "fps=24" \
    -F "num_inference_steps=50" \
    -F "guidance_scale=5.0" \
    -F "negative_prompt=blurry, low quality, distorted"
   \
    -F "seed=42" \
    -F "enable_teacache=true"
```

https://github.com/user-attachments/assets/ac55e858-feb0-457b-8ac9-73173c2a0b5a



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
