### PR TITLE
[AMD] avoid correction_bias_dtype dtype convert

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -272,15 +272,12 @@ class MoEGate(nn.Module):
         )
         if config.topk_method == "noaux_tc":
             correction_bias_dtype = torch.float32
-            if quant_config is not None:
+            if _use_aiter:
+                correction_bias_dtype = torch.bfloat16
+            elif quant_config is not None:
                 if (
                     quant_config.get_name() == "modelopt_fp4"
                     and get_moe_runner_backend().is_flashinfer_trtllm()
-                ):
-                    correction_bias_dtype = torch.bfloat16
-                elif _use_aiter and quant_config.get_name() in (
-                    "fp8",
-                    "compressed_tensors",
                 ):
                     correction_bias_dtype = torch.bfloat16
             self.e_score_correction_bias = nn.Parameter(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -272,12 +272,16 @@ class MoEGate(nn.Module):
         )
         if config.topk_method == "noaux_tc":
             correction_bias_dtype = torch.float32
-            if _use_aiter:
-                correction_bias_dtype = torch.bfloat16
-            elif quant_config is not None:
+            if quant_config is not None:
                 if (
                     quant_config.get_name() == "modelopt_fp4"
                     and get_moe_runner_backend().is_flashinfer_trtllm()
+                ):
+                    correction_bias_dtype = torch.bfloat16
+                elif _use_aiter and quant_config.get_name() in (
+                    "fp8",
+                    "compressed_tensors",
+                    "quark",
                 ):
                     correction_bias_dtype = torch.bfloat16
             self.e_score_correction_bias = nn.Parameter(


### PR DESCRIPTION
@Duyi-Wang @ZhaiFeiyue 

## Motivation

In the previous modifications #19843, only the cases of `fp8` and `compressed_tensors` quantization were considered. In mxfp4 quantization, `correction_bias_dtype` also needs to use the `torch.bfloat16` data type to avoid additional data type casting.

## Modifications

On HIP, change the dtype of  `correction_bias_dtype` to bf16.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
Model: `DeepSeek-R1-0528-MXFP4`

## Before Optimization

| Input Length | Output Length | Concurrency | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| 1024 | 1024 | 1 | 75.67 | 75.13 | 83.06 | 6.81 | 6.81 | 6.83 |
| 8192 | 1024 | 1 | 451.71 | 500.79 | 871.70 | 7.41 | 7.41 | 7.46 |

## After Optimization

| Input Length | Output Length | Concurrency | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) | Mean TTFT Speedup | Mean TPOT Speedup |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| 1024 | 1024 | 1 | 74.60 | 73.61 | 83.02 | 6.70 | 6.70 | 6.72 | 1.01x | 1.02x |
| 8192 | 1024 | 1 | 200.49 | 197.15 | 218.33 | 7.31 | 7.31 | 7.35 | 2.25x | 1.01x |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
