### PR TITLE
[Diffusion] Fix compile graph broken by flashinfer rope

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
+++ b/python/sglang/multimodal_gen/runtime/layers/rotary_embedding/utils.py
@@ -5,6 +5,28 @@ from typing import Optional, Tuple
 import torch
 
 from sglang.jit_kernel.diffusion.triton.rotary import apply_rotary_embedding
+from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.srt.utils.custom_op import register_custom_op_from_extern
+
+_is_cuda = current_platform.is_cuda()
+if _is_cuda:
+    try:
+        from flashinfer.rope import (
+            apply_rope_with_cos_sin_cache_inplace as _flashinfer_apply_rope_inplace,
+        )
+    except Exception:
+        _flashinfer_apply_rope_inplace = None
+else:
+    _flashinfer_apply_rope_inplace = None
+
+if _flashinfer_apply_rope_inplace is not None:
+    flashinfer_apply_rope_inplace = register_custom_op_from_extern(
+        _flashinfer_apply_rope_inplace,
+        op_name="flashinfer_apply_rope_with_cos_sin_cache_inplace",
+        mutates_args=["query", "key"],
+    )
+else:
+    flashinfer_apply_rope_inplace = None
 
 
 def _apply_rotary_emb(
@@ -67,9 +89,7 @@ def apply_flashinfer_rope_qk_inplace(
     if head_size != d:
         raise ValueError(f"head_size mismatch: inferred {d}, but head_size={head_size}")
 
-    try:
-        from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
-    except ImportError:
+    if flashinfer_apply_rope_inplace is None:
         # Triton fallback for AMD/ROCm where FlashInfer is not available
         import warnings
 
@@ -110,7 +130,7 @@ def apply_flashinfer_rope_qk_inplace(
 
     q_flat = q.reshape(bsz * seqlen, nheads * d).contiguous()
     k_flat = k.reshape(bsz * seqlen, nheads * d).contiguous()
-    apply_rope_with_cos_sin_cache_inplace(
+    flashinfer_apply_rope_inplace(
         positions=positions,
         query=q_flat,
         key=k_flat,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Benchmark methodology

I compared `main` against the patched version that wraps `apply_flashinfer_rope_qk_inplace` as a compile-friendly custom op.

Performance measurement:
- I ran the same five `sglang generate` commands on both versions.
- I added only `--perf-dump-path <json>` to collect stage-level timings.
- Denoise latency was read from the `DenoisingStage` entry in the perf dump JSON.
- No graph-break logging was enabled during the perf run, so the timing results were not polluted by debug instrumentation.

Graph-break measurement:
- I ran the same five commands again, separately from the perf runs.
- For these diagnostic runs, I enabled `TORCH_LOGS=graph_breaks`.
- I counted graph breaks from stderr by counting lines matching `"[__graph_breaks] ... Graph break"`.
- I also counted occurrences of `rotary_embedding/utils.py` in the graph-break logs to verify whether the RoPE helper itself was still causing breaks.


## Benchmark commands

### qwen-image-2512

```shell
sglang generate --model-path=Qwen/Qwen-Image-2512  --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k" '--negative-prompt= ' --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.0 --seed=42 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false
```

### qwen-image-edit-2511

```shell
sglang generate --model-path=Qwen/Qwen-Image-Edit-2511 '--prompt=Transform into anime style' '--negative-prompt= ' --image-path=/workspace/gen_benchmark/figs/cat.png --width=1024 --height=1024 --num-inference-steps=50  --guidance-scale=4.0 --seed=42 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false 
```

### flux.1.dev 

```shell
sglang generate --model-path=black-forest-labs/FLUX.1-dev  --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k" --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.0 --seed=42 --save-output  --warmup=True --enable-torch-compile
```

### flux.2.dev

```shell
sglang generate --model-path black-forest-labs/FLUX.2-dev --prompt "A Logo With Bold Large Text: SGL Diffusion" --width=1024 --height=1024 --dit-layerwise-offload false --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload true --vae-cpu-offload false
```

### Tongyi-MAI/Z-Image-Turbo

```shell
sglang generate --model-path=Tongyi-MAI/Z-Image-Turbo --log-level=info --prompt='A fantasy landscape with mountains and a river, detailed, vibrant colors' --width=1024 --height=1024 --num-inference-steps=9 --guidance-scale=0.0 --seed=42 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false
```

## Results

<img width="639" height="329" alt="图片" src="https://github.com/user-attachments/assets/8eafb418-620e-44f2-80dd-7ba8518c9109" />

The patch removes the graph breaks originating from `rotary_embedding/utils.py` in all tested models (2 -> 0), reduces total graph-break count in every case, and improves or preserves denoise latency across the benchmark set, with the largest gain on Qwen Image.

## Profile

```shell
sglang generate --model-path=Qwen/Qwen-Image-2512  --prompt="A futuristic cyberpunk city at night, neon lights reflecting on wet streets, highly detailed, 8k" '--negative-prompt= ' --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.0 --seed=42 --save-output --enable-torch-compile --warmup --dit-cpu-offload false --text-encoder-cpu-offload false --profile
```

<img width="1024" height="1024" alt="A_futuristic_cyberpunk_city_at_night_neon_lights_reflecting_on_wet_streets_highly_detailed_8k_20260316-104401_cf911fa5" src="https://github.com/user-attachments/assets/c29f567c-8dcd-4c43-ba4a-e3c515e65185" />


- main

<img width="935" height="868" alt="图片" src="https://github.com/user-attachments/assets/83b2f651-9de5-4962-b460-853b499fab1a" />

5ms763us

<img width="580" height="397" alt="图片" src="https://github.com/user-attachments/assets/351b0992-0c1c-4c51-9570-444985b4a1b9" />

rope kernel is not covered by torch compile graph

- pr

<img width="1037" height="867" alt="图片" src="https://github.com/user-attachments/assets/40b56cf5-533c-4fd2-bd6e-258e8654a5f7" />

4ms592us

<img width="391" height="267" alt="图片" src="https://github.com/user-attachments/assets/3d433b61-241d-4834-a02b-4dfe158951ab" />


rope kernel is covered by torch compile graph

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
