### PR TITLE
eagle3 support dp-attention for deepseek

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -406,6 +406,7 @@ class LayerCommunicator:
         hidden_states: torch.Tensor,
         residual: torch.Tensor,
         forward_batch: ForwardBatch,
+        quant_format: str = "",
         captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ):
@@ -413,6 +414,7 @@ class LayerCommunicator:
             hidden_states,
             residual,
             forward_batch,
+            quant_format=quant_format,
             post_residual_addition=post_residual_addition,
         )
         if captured_last_layer_outputs is not None:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1490,6 +1490,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         is_nextn: bool = False,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -1614,6 +1615,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         zero_allocator: BumpAllocator,
         gemm_output_zero_allocator: BumpAllocator = None,
         llama_4_scaling: Optional[torch.Tensor] = None,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> torch.Tensor:
         quant_format = (
             "mxfp4"
@@ -1642,11 +1644,14 @@ class DeepseekV2DecoderLayer(nn.Module):
             )
         )
 
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states,
-            residual,
-            forward_batch,
-            quant_format,
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                quant_format,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+            )
         )
 
         hidden_states = self.self_attn(
@@ -1977,14 +1982,6 @@ class DeepseekV2Model(nn.Module):
                 else get_global_expert_distribution_recorder().with_current_layer(i)
             )
             with ctx:
-                if i in self.layers_to_capture:
-                    if self.enable_a2a_moe and i > self.first_k_dense_replace:
-                        aux_hidden_state = tensor_model_parallel_all_gather(
-                            hidden_states + residual, dim=0
-                        )
-                        aux_hidden_states.append(aux_hidden_state)
-                    else:
-                        aux_hidden_states.append(hidden_states + residual)
                 layer = self.layers[i]
                 hidden_states, residual = layer(
                     positions,
@@ -1994,6 +1991,9 @@ class DeepseekV2Model(nn.Module):
                     zero_allocator,
                     gemm_output_zero_allocator,
                     llama_4_scaling,
+                    captured_last_layer_outputs=(
+                        aux_hidden_states if i in self.layers_to_capture else None
+                    ),
                 )
 
         if normal_end_layer != self.end_layer:


### PR DESCRIPTION
## Motivation
This commit enables Eagle3 speculative decoding to work with data-parallel attention for DeepSeek models. The previous implementation had layer output capture logic in the model level, which didn't properly integrate with the layer communicator's DP-attention workflow. This refactoring ensures that captured layer outputs are correctly handled when DP-attention is enabled.

## Modifications
- Moved layer output capture logic from the model-level loop into `DeepseekV2DecoderLayer.forward()`
- Added `captured_last_layer_outputs` parameter to both `__init__` and `forward` methods
- Replaced `prepare_attn()` with `prepare_attn_and_capture_last_layer_outputs()` to handle both DP-attention preparation and output capturing in a single call
- This change makes the capture logic more modular and ensures it works correctly with DP-attention's tensor communication patterns

## Accuracy Tests

## Benchmarking and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).