### PR TITLE
add spec info for openai stream mode

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -139,6 +139,7 @@ class UsageInfo(BaseModel):
 
 class StreamOptions(BaseModel):
     include_usage: Optional[bool] = False
+    include_metadata: Optional[bool] = False
     continuous_usage_stats: Optional[bool] = False
 
 
@@ -405,6 +406,7 @@ class CompletionStreamResponse(BaseModel):
     model: str
     choices: List[CompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
+    metadata: Optional[Dict[str, Any]] = None
     sglext: Optional[SglExt] = None
 
     @model_serializer(mode="wrap")
@@ -895,6 +897,7 @@ class ChatCompletionStreamResponse(BaseModel):
     model: str
     choices: List[ChatCompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
+    metadata: Optional[Dict[str, Any]] = None
     sglext: Optional[SglExt] = None
 
     @model_serializer(mode="wrap")

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -304,3 +304,25 @@ class OpenAIServingBase(ABC):
                 )
 
         return body_routed_dp_rank
+
+    def _build_response_metadata(self, meta_info: dict) -> dict:
+        """Build response metadata including speculative decoding info if available.
+
+        Args:
+            meta_info: Dictionary containing metadata from the response.
+
+        Returns:
+            Dictionary with weight_version and speculative decoding metrics if present.
+        """
+        metadata = {"weight_version": meta_info.get("weight_version")}
+
+        spec_keys = (
+            "spec_accept_rate",
+            "spec_accept_length",
+            "spec_verify_ct",
+        )
+        spec_metadata = {key: meta_info[key] for key in spec_keys if key in meta_info}
+        if spec_metadata:
+            metadata.update(spec_metadata)
+
+        return metadata

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -861,22 +861,29 @@ class OpenAIServingChat(OpenAIServingBase):
                     yield f"data: {routed_experts_chunk.model_dump_json()}\n\n"
 
             # Additional usage chunk
-            if request.stream_options and request.stream_options.include_usage:
-                usage = UsageProcessor.calculate_streaming_usage(
-                    prompt_tokens,
-                    completion_tokens,
-                    cached_tokens,
-                    n_choices=request.n,
-                    enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
-                )
-                usage_chunk = ChatCompletionStreamResponse(
+            if request.stream_options:
+                metadata = None
+                if request.stream_options.include_metadata:
+                    metadata = self._build_response_metadata(content["meta_info"])
+
+                usage = None
+                if request.stream_options.include_usage:
+                    usage = UsageProcessor.calculate_streaming_usage(
+                        prompt_tokens,
+                        completion_tokens,
+                        cached_tokens,
+                        n_choices=request.n,
+                        enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
+                    )
+                last_chunk = ChatCompletionStreamResponse(
                     id=content["meta_info"]["id"],
                     created=int(time.time()),
                     choices=[],  # Empty choices array as per OpenAI spec
                     model=request.model,
                     usage=usage,
+                    metadata=metadata,
                 )
-                yield f"data: {usage_chunk.model_dump_json()}\n\n"
+                yield f"data: {last_chunk.model_dump_json()}\n\n"
 
         except ValueError as e:
             error = self.create_streaming_error_response(str(e))
@@ -1009,13 +1016,16 @@ class OpenAIServingChat(OpenAIServingBase):
             enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
         )
 
+        meta_info = ret[0]["meta_info"]
+        metadata = self._build_response_metadata(meta_info)
+
         return ChatCompletionResponse(
-            id=ret[0]["meta_info"]["id"],
+            id=meta_info["id"],
             created=created,
             model=request.model,
             choices=choices,
             usage=usage,
-            metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
+            metadata=metadata,
             sglext=response_sglext,
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -364,22 +364,29 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     yield f"data: {routed_experts_chunk.model_dump_json()}\n\n"
 
             # Handle final usage chunk
-            if request.stream_options and request.stream_options.include_usage:
-                usage = UsageProcessor.calculate_streaming_usage(
-                    prompt_tokens,
-                    completion_tokens,
-                    cached_tokens,
-                    n_choices=request.n,
-                    enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
-                )
-                final_usage_chunk = CompletionStreamResponse(
+            if request.stream_options:
+                metadata = None
+                if request.stream_options.include_metadata:
+                    metadata = self._build_response_metadata(content["meta_info"])
+
+                usage = None
+                if request.stream_options.include_usage:
+                    usage = UsageProcessor.calculate_streaming_usage(
+                        prompt_tokens,
+                        completion_tokens,
+                        cached_tokens,
+                        n_choices=request.n,
+                        enable_cache_report=self.tokenizer_manager.server_args.enable_cache_report,
+                    )
+                last_chunk = CompletionStreamResponse(
                     id=content["meta_info"]["id"],
                     created=created,
                     choices=[],
                     model=request.model,
                     usage=usage,
+                    metadata=metadata,
                 )
-                final_usage_data = final_usage_chunk.model_dump_json(exclude_none=True)
+                final_usage_data = last_chunk.model_dump_json(exclude_none=True)
                 yield f"data: {final_usage_data}\n\n"
 
         except Exception as e:
@@ -497,13 +504,16 @@ class OpenAIServingCompletion(OpenAIServingBase):
             ret, n_choices=request.n, enable_cache_report=cache_report
         )
 
+        meta_info = ret[0]["meta_info"]
+        metadata = self._build_response_metadata(meta_info)
+
         return CompletionResponse(
-            id=ret[0]["meta_info"]["id"],
+            id=meta_info["id"],
             model=request.model,
             created=created,
             choices=choices,
             usage=usage,
-            metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
+            metadata=metadata,
             sglext=response_sglext,
         )
 


### PR DESCRIPTION
## Motivation
The CompletionResponse already has metadata, but it lacks some useful information. Therefore, some specification information has been added to facilitate the observation of acceptance rates per sample.

## Modifications
**no-stream**: default output spec info
**stream**: by include_metadata control, like include_usage

## Accuracy Tests


## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
