### PR TITLE
[Kimi K2.5] fix: prevent content chunks after tool-call start

### DIFF
--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -55,6 +55,8 @@ class KimiK2Detector(BaseFormatDetector):
         self.tool_call_id_regex = re.compile(
             r"^(?:functions\.)?(?P<name>[\w\.]+):(?P<index>\d+)$"
         )
+        self._inside_tool_call_block = False
+        self._ignore_post_block_whitespace = False
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a KimiK2 format tool call."""
@@ -115,6 +117,9 @@ class KimiK2Detector(BaseFormatDetector):
         """
         self._buffer += new_text
         current_text = self._buffer
+        if self.bot_token in current_text:
+            self._inside_tool_call_block = True
+            self._ignore_post_block_whitespace = False
 
         # Check if we have a tool call (either the start token or individual tool call)
         has_tool_call = (
@@ -122,11 +127,22 @@ class KimiK2Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
+            contains_section_end_token = self.eot_token in current_text
             self._buffer = ""
-            for e_token in [self.eot_token, self.tool_call_end_token]:
-                if e_token in new_text:
-                    new_text = new_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=new_text)
+            normal_text = current_text.replace(self.tool_call_end_token, "").replace(
+                self.eot_token, ""
+            )
+
+            if contains_section_end_token:
+                self._inside_tool_call_block = False
+                self._ignore_post_block_whitespace = True
+
+            if self._inside_tool_call_block or self._ignore_post_block_whitespace:
+                if not normal_text.strip():
+                    return StreamingParseResult(normal_text="")
+                self._ignore_post_block_whitespace = False
+
+            return StreamingParseResult(normal_text=normal_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
@@ -193,7 +209,10 @@ class KimiK2Detector(BaseFormatDetector):
                             self.current_tool_id
                         ] += parsed_args_diff
 
-                    parsed_args = function_args.split("<|tool_call_end|>", 1)[0]
+                    contains_tool_call_end_token = (
+                        self.tool_call_end_token in function_args
+                    )
+                    parsed_args = function_args.split(self.tool_call_end_token, 1)[0]
                     if _is_complete_json(parsed_args):
                         try:
                             parsed_args = json.loads(parsed_args)
@@ -202,6 +221,9 @@ class KimiK2Detector(BaseFormatDetector):
                             ] = parsed_args
                         except json.JSONDecodeError:
                             pass
+
+                        if not contains_tool_call_end_token:
+                            return StreamingParseResult(normal_text="", calls=calls)
 
                         # Find the end of the current tool call and remove only that part from buffer
                         tool_call_end_pattern = (
@@ -212,7 +234,14 @@ class KimiK2Detector(BaseFormatDetector):
                         )
                         if match:
                             # Remove the completed tool call from buffer, keep any remaining content
-                            self._buffer = current_text[match.end() :]
+                            remaining_text = current_text[match.end() :]
+                            if remaining_text.startswith(self.eot_token):
+                                remaining_text = remaining_text[len(self.eot_token) :]
+                                self._inside_tool_call_block = False
+                                if not remaining_text.strip():
+                                    self._ignore_post_block_whitespace = True
+                                    remaining_text = ""
+                            self._buffer = remaining_text
                         else:
                             self._buffer = ""
 

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1024,8 +1024,10 @@ class TestKimiK2Detector(unittest.TestCase):
         ]
 
         tool_calls = []
+        normal_text = ""
         for chunk in chunks:
             result = self.detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
             for tool_call_chunk in result.calls:
                 if tool_call_chunk.tool_index is not None:
 
@@ -1042,6 +1044,7 @@ class TestKimiK2Detector(unittest.TestCase):
         self.assertEqual(len(tool_calls), 1)
         self.assertEqual(tool_calls[0]["name"], "get_weather")
         self.assertEqual(tool_calls[0]["parameters"], '{"city": "Paris"}')
+        self.assertEqual(normal_text, "")
 
     def test_streaming_multiple_tool_calls(self):
         """Test streaming incremental parsing of multiple tool calls."""
@@ -1056,8 +1059,10 @@ class TestKimiK2Detector(unittest.TestCase):
         ]
 
         tool_calls = []
+        normal_text = ""
         for chunk in chunks:
             result = self.detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
             for tool_call_chunk in result.calls:
                 if tool_call_chunk.tool_index is not None:
 
@@ -1076,6 +1081,64 @@ class TestKimiK2Detector(unittest.TestCase):
         self.assertEqual(tool_calls[0]["parameters"], '{"city": "Paris"}')
         self.assertEqual(tool_calls[1]["name"], "get_tourist_attractions")
         self.assertEqual(tool_calls[1]["parameters"], '{"city": "London"}')
+        self.assertEqual(normal_text, "")
+
+    def test_tool_call_completion_waits_for_end_token(self):
+        """Test that a complete JSON payload does not finish the tool call before the end token."""
+        chunks = [
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{",
+            '"city": "Paris"',
+            "}",
+        ]
+
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(self.detector.current_tool_id, 0)
+        self.assertTrue(self.detector.current_tool_name_sent)
+        self.assertEqual(
+            self.detector._buffer,
+            '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"city": "Paris"}',
+        )
+
+    def test_streaming_tool_call_ignores_trailing_section_whitespace(self):
+        """Test that post-tool-call structural whitespace never becomes normal text."""
+        chunks = [
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{",
+            '"city": "Paris"',
+            "}",
+            "<|tool_call_end|>",
+            "<|tool_calls_section_end|>",
+            " ",
+            " ",
+        ]
+
+        tool_calls = []
+        normal_text = ""
+        normal_text_chunks = []
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
+            normal_text_chunks.append(result.normal_text)
+            for tool_call_chunk in result.calls:
+                if tool_call_chunk.tool_index is not None:
+                    while len(tool_calls) <= tool_call_chunk.tool_index:
+                        tool_calls.append({"name": "", "parameters": ""})
+
+                    tc = tool_calls[tool_call_chunk.tool_index]
+                    if tool_call_chunk.name:
+                        tc["name"] += tool_call_chunk.name
+                    if tool_call_chunk.parameters:
+                        tc["parameters"] += tool_call_chunk.parameters
+
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+        self.assertEqual(tool_calls[0]["parameters"], '{"city": "Paris"}')
+        self.assertEqual(normal_text, "")
+        self.assertEqual(normal_text_chunks[-3:], ["", "", ""])
+        self.assertEqual(self.detector._buffer, "")
+        self.assertEqual(self.detector.current_tool_id, 1)
 
     def test_tool_call_completion(self):
         """Test that the buffer and state are reset after a tool call is completed."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->   Fix #20688.
For `tool-call-parser=kimi_k2`, there is a streaming bug where SGLang could emit non-null `delta.content` after tool-call streaming had already started. The reproduced failure mode was trailing structural whitespace being surfaced as normal content after the Kimi tool-call block finished.

## Modifications

<!-- Detail the changes made in this pull request. -->
  - Delay Kimi tool-call completion in `python/sglang/srt/function_call/kimik2_detector.py` until `<|tool_call_end|>` is actually observed which prevents a complete JSON payload by itself from prematurely closing the tool call
  - Keep the parser inside the Kimi tool-call block until the block terminators are consumed and prevents section tail tokens from falling into the normal-text path
  - Ignore whitespace-only chunks after the Kimi tool-call block ends which prevents trailing structural whitespace from being emitted as `delta.content`
  - Changed existing Kimi streaming tests in `test/registered/unit/function_call/test_function_call_parser.py` to assert `normal_text == ""` in valid streaming tool-call paths
  - Add tests for this fix in `test/registered/unit/function_call/test_function_call_parser.py` for complete-JSON-
  before-end-token and post-tool-call whitespace leakage

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. --> This change is limited to streaming/tool-call parsing.

Unit tests for Kimi K2 detector passes.
<img width="879" height="191" alt="image" src="https://github.com/user-attachments/assets/0ace33e6-d045-4c97-a1a3-c9b496c807fe" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
