### PR TITLE
[Fix] Abort input_embeds requests on retraction instead of clearing output_ids

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1124,14 +1124,6 @@ class Req(ReqDllmMixin):
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
 
-        # When using input_embeds, we cannot easily mix the original input embeddings
-        # with the newly generated output token IDs during re-prefill of retracted request.
-        # output_ids will have no use, but will lead to wrong size cache indexes.
-        # Therefore, we discard the generated output_ids and restart prefill and generation
-        # to ensure shape consistency in KV cache.
-        if self.input_embeds is not None:
-            self.output_ids = []
-
     def offload_kv_cache(self, req_to_token_pool, token_to_kv_pool_allocator):
         token_indices = req_to_token_pool.req_to_token[
             self.req_pool_idx, : self.seqlen - 1
@@ -1854,12 +1846,24 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
     def retract_all(self, server_args: ServerArgs):
-        retracted_reqs = self.reqs
+        retracted_reqs = []
+        reqs_to_abort = []
         for idx in range(len(self.reqs)):
+            req = self.reqs[idx]
+            if req.input_embeds is not None:
+                # See retract_decode for why retraction is unsafe here.
+                req.to_finish = FINISH_ABORT(
+                    "Engine pause requested. Requests using input_embeds "
+                    "cannot be safely retracted; aborting instead.",
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+                reqs_to_abort.append(req)
+            else:
+                retracted_reqs.append(req)
             self.release_req(idx, len(self.reqs) - idx, server_args)
 
-        self.filter_batch(retracted_reqs)
-        return retracted_reqs
+        self.filter_batch(self.reqs)
+        return retracted_reqs, reqs_to_abort
 
     def retract_decode(
         self, server_args: ServerArgs
@@ -1873,8 +1877,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # TODO(sang): Clean up finish path and support better retract
         # policy.
         if not server_args.speculative_algorithm:
+            # Prefer evicting requests that free the most KV (long output, short
+            # prompt). Sort input_embeds requests to the FRONT so they are popped
+            # LAST — retracting them cannot safely preserve decode progress (see
+            # the abort path below).
             sorted_indices.sort(
                 key=lambda i: (
+                    self.reqs[i].input_embeds is None,
                     len(self.reqs[i].output_ids),
                     -len(self.reqs[i].origin_input_ids),
                 ),
@@ -1882,22 +1891,48 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
         retracted_reqs = []
+        reqs_to_abort: List[Req] = []
         first_iter = True
         while first_iter or (
             not self.check_decode_mem(selected_indices=sorted_indices)
         ):
             if len(sorted_indices) == 1:
-                # Always keep at least one request
+                # Always keep at least one request (also prevents the
+                # new_token_ratio calculation below from dividing into zero
+                # and livelocking admission).
                 break
 
             first_iter = False
             idx = sorted_indices.pop()
             req = self.reqs[idx]
-            retracted_reqs.append(req)
+
+            if req.input_embeds is not None:
+                # Retracting an input_embeds request cannot preserve decode
+                # progress: re-prefill needs embeddings for the generated
+                # output_ids, but the model's embed_tokens (with its per-model
+                # scaling) is unreachable here, and clearing output_ids leaves
+                # per-step accumulators (logprobs, streaming offsets,
+                # cross-process detokenizer state) stale. Abort is the only
+                # correct outcome. Tune --schedule-conservativeness to reduce
+                # retraction pressure.
+                req.to_finish = FINISH_ABORT(
+                    "Out of memory during decode. Requests using input_embeds "
+                    "cannot be safely retracted (re-prefill would desync "
+                    "accumulated output state); aborting instead. Consider "
+                    "raising --schedule-conservativeness.",
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+                reqs_to_abort.append(req)
+                logger.warning(
+                    "retract_decode: aborted input_embeds request %s "
+                    "(retraction unsafe for input_embeds)",
+                    req.rid,
+                )
+            else:
+                retracted_reqs.append(req)
             # release memory and don't insert into the tree because we need the space instantly
             self.release_req(idx, len(sorted_indices), server_args)
 
-        reqs_to_abort: List[Req] = []
         if len(sorted_indices) <= 1 and not self.check_decode_mem(
             selected_indices=sorted_indices
         ):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3053,9 +3053,20 @@ class Scheduler(
         if recv_req.mode == "retract":
             self.running_batch.filter_batch(v1_spec_info_filtered=True)
             if len(self.running_batch.reqs) != 0:
-                retracted_reqs = self.running_batch.retract_all(self.server_args)
+                retracted_reqs, reqs_to_abort = self.running_batch.retract_all(
+                    self.server_args
+                )
                 for req in retracted_reqs:
                     self._add_request_to_queue(req)
+                for req in reqs_to_abort:
+                    abort_reason: FINISH_ABORT = req.to_finish
+                    self.send_to_tokenizer.send_output(
+                        AbortReq(
+                            finished_reason=abort_reason.to_json(),
+                            rid=req.rid,
+                        ),
+                        req,
+                    )
 
             self.running_batch.batch_is_full = False
             self.chunked_req = None

--- a/test/registered/embedding/test_input_embeds_chunked.py
+++ b/test/registered/embedding/test_input_embeds_chunked.py
@@ -155,20 +155,24 @@ class TestInputEmbedsChunkedAndRetract(CustomTestCase):
             self.assertIn("text", r)
         self._assert_server_alive()
 
-    def test_retraction_with_output_ids(self):
-        """Regression test for #14110.
+    def test_retraction_aborts_input_embeds(self):
+        """input_embeds requests are aborted (not retracted) under KV pressure.
 
-        SGLANG_TEST_RETRACT forces retraction every few scheduler iterations.
-        Combined with ignore_eos and a reasonable max_new_tokens, at least one
-        request is retracted mid-decode with non-empty output_ids, then
-        re-prefilled. Pre-#14110 this crashes (cache_k < loc) because fill_ids
-        includes output_ids but input_embeds does not.
+        Retracting an input_embeds request cannot preserve decode progress:
+        re-prefill would need to embed the generated output_ids via the model's
+        embed_tokens (unreachable from the scheduler), and the previous approach
+        (#14110, clearing output_ids) left 10+ per-step accumulators stale —
+        including cross-process detokenizer/tokenizer_manager state. The result
+        was silent corruption: len(output_token_logprobs) != len(output_ids)
+        for RL workloads. Aborting is the only correct outcome.
+
+        SGLANG_TEST_RETRACT forces the retract path every few scheduler
+        iterations; we verify that at least one request gets a clean 503 and
+        the server survives.
         """
         text = "The quick brown fox jumps over the lazy dog. " * 4
         embeds = _embeds_for(text)
 
-        # Batch of requests with enough decode steps that SGLANG_TEST_RETRACT
-        # (interval=3 by default) fires mid-decode.
         n = 4
         resp = _generate(
             self.base_url,
@@ -176,11 +180,27 @@ class TestInputEmbedsChunkedAndRetract(CustomTestCase):
             max_new_tokens=32,
             ignore_eos=True,
         )
+        # Batch endpoint returns 200 with per-request finish_reason. At least
+        # one request should have been aborted via the retract path.
         self.assertEqual(resp.status_code, 200, resp.text[:300])
         results = resp.json()
         self.assertEqual(len(results), n)
-        for r in results:
-            self.assertIn("text", r)
+        aborted = [
+            r
+            for r in results
+            if r.get("meta_info", {}).get("finish_reason", {}).get("type") == "abort"
+        ]
+        self.assertGreater(
+            len(aborted),
+            0,
+            f"expected at least one abort via SGLANG_TEST_RETRACT; "
+            f"finish_reasons: {[r.get('meta_info', {}).get('finish_reason') for r in results]}",
+        )
+        for r in aborted:
+            self.assertIn(
+                "input_embeds",
+                r["meta_info"]["finish_reason"].get("message", ""),
+            )
         self._assert_server_alive()
 
 


### PR DESCRIPTION
## Motivation

Follow-up to #14110. That PR cleared `output_ids = []` in `reset_for_retract` when `input_embeds is not None`, which fixes the KV shape mismatch on re-prefill. But it breaks a subtler invariant: every per-decode-step accumulator on `Req` grows monotonically with `output_ids`. Clearing `output_ids` alone leaves them all stale.

**The failure mode is silent.** For RL workloads (`return_logprob=True`):
- Request generates K tokens, gets retracted, `output_ids` cleared
- Re-prefill regenerates N tokens
- `output_token_logprobs_val` now has **K+N entries for N tokens** — the first K are from a different sampling trajectory
- No crash, no HTTP error. `len(meta_info["output_token_logprobs"]) != len(output_ids)`. Wrong policy gradients.

The bug is model-size-dependent: it only fires when retraction actually happens. We observed it on 27B (KV pressure → retraction) but not 7B (headroom → never retracts).

### Coupled accumulators (all stale after #14110's clear)

| Accumulator | Consumer | Failure |
|---|---|---|
| `output_token_logprobs_val/idx` | tokenizer_manager.py:1785 | K+N logprobs for N tokens |
| `output_top_logprobs_val/idx` | same | same |
| `output_token_ids_logprobs_val/idx` | same | same |
| `hidden_states` | mixin.py:1098 sends full list | duplicate prefill block |
| `send_token_offset`, `send_decode_id_offset` | mixin.py:1004 slice | tokens silently dropped (stream=True) |
| `surr_and_decode_ids`, `cur_decode_ids_len` | schedule_batch.py:949 | detokenized text corrupted |
| `grammar` FSM | mixin.py:222 | expects token K+1, gets token 1 → ValueError → abort |
| `customized_info` | mixin.py:1108 slice by send_token_offset | stale entries included |

### Why the brittle enumerate-and-clear approach is insufficient

`DetokenizerManager.decode_status[rid]` and `TokenizerManager.ReqState` are append-only in **separate processes**. `DEFAULT_FORCE_STREAM_INTERVAL = 50` means even `stream=False` requests flush there after 50 tokens. Any tokens already flushed are permanently in the client-visible stream. Regenerating with `temperature>0` produces *different* tokens appended after the old ones — not duplicates. This cannot be fixed from `reset_for_retract`.

### Other alternatives evaluated and rejected

- **Embed output_ids at the model layer** (`cat(input_embeds, embed_tokens(input_ids[n:]))`): fatal batch-ordering flaw. When a retracted request shares a prefill batch with a fresh one, the input_embeds shortfall is a hole in the *middle* of the concatenated tensor, not at the end. `input_ids[n:]` pulls the wrong tokens.
- **Embed at prepare_for_extend**: ScheduleBatch has no `embed_tokens` access. 42/73 models lack `get_input_embeddings()`. And `grok.py:671`/`minicpm.py:273` apply `hidden_states.mul_(scale)` only in the `input_embeds is None` branch — external embedding would miss per-model scaling.
- **Force chunk boundary at len(input_embeds)**: chunk 2 (zero embed rows) batches with other input_embeds requests → partial coverage again.

## Modifications

Abort input_embeds requests instead of retracting them.

- `retract_decode`: sort input_embeds requests to the front so they pop last; when one does pop, `FINISH_ABORT` with HTTP 503 instead of re-queueing. The `len==1: break` guard is preserved (prevents `new_token_ratio=0` livelock).
- `retract_all` (admin pause): same abort path, with `AbortReq` sent from the scheduler call site.
- Reverts #14110's `output_ids = []` block — dead code now.
- Test updated: `test_retraction_with_output_ids` → `test_retraction_aborts_input_embeds`, asserts at least one clean 503 with a clear finish_reason.

For mixed workloads (some requests use input_embeds, most don't), this is near-free: non-input_embeds requests get retracted first. For all-input_embeds workloads under sustained pressure, tune `--schedule-conservativeness` or `SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR` to keep admission below the retraction threshold — RL rollout lengths are typically predictable so this is tractable.

## Accuracy Tests

- `test/registered/embedding/test_input_embeds_chunked.py` updated to assert clean abort under `SGLANG_TEST_RETRACT`.
- Verified no crash on 27B Gemma under retraction pressure after this change (previously: silent logprob mismatch).

## Benchmarking and Profiling

N/A — no hot-path changes. Retraction is an exception path; the sort key gains one boolean comparison.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests — existing retraction test updated
- [ ] Update documentation as needed — server_arguments.md note about `--schedule-conservativeness` + input_embeds would help; can add if desired