### PR TITLE
[Fix] Reserve full KV budget for input_embeds requests at admission

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -643,8 +643,13 @@ class PrefillAdder:
             return AddReqResult.NO_TOKEN
 
         def add_req_state(r, insert_sort=False):
+            # ignore_eos cannot finish early; input_embeds cannot be safely
+            # retracted (#14110's output_ids clear leaves per-step accumulators
+            # stale). Reserve the full budget for both to avoid over-admission.
             new_token_ratio = (
-                1.0 if r.sampling_params.ignore_eos else self.new_token_ratio
+                1.0
+                if r.sampling_params.ignore_eos or r.input_embeds is not None
+                else self.new_token_ratio
             )
             tokens_left = r.sampling_params.max_new_tokens * new_token_ratio - len(
                 r.output_ids


### PR DESCRIPTION
## Motivation

#14110 fixes the KV shape mismatch on input_embeds retraction by clearing `output_ids`. But that clear desyncs the per-step accumulators — for RL with `return_logprob=True`, `output_token_logprobs_val` ends up with K+N entries for N output tokens after a retraction (the first K are from the pre-retraction trajectory). Silent, no crash.

The root trigger is `new_token_ratio` decay: it drops from 0.7 toward ~0.1 over 600 decode steps, making admission progressively more optimistic. When the estimate overshoots, retraction fires. This shows up on larger models under sustained load (retraction needs KV pressure to fire).

## Modifications

Treat input_embeds requests like `ignore_eos` at admission: reserve the full `max_new_tokens` budget instead of the decayed estimate. Same line, one additional condition.

This doesn't make retraction impossible — non-input_embeds requests in the same batch can still cause it, and there's still the `len==1: break` last-resort. #20724 (draft) covers that residual by aborting input_embeds requests instead of retracting them. But for workloads that are all input_embeds (RL rollouts), this alone should be sufficient.

## Accuracy Tests

Verified on Gemma-27B under RL rollout load: before, retraction fires every ~600 decode steps (matching the decay constant) and `len(output_token_logprobs)` drifts from `len(output_ids)`; after, no retraction over 10K steps.

The existing `test/registered/embedding/test_input_embeds_chunked.py` covers the chunked-prefill and `SGLANG_TEST_RETRACT` paths.

## Benchmarking and Profiling

N/A — admission-time check, one boolean comparison.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests — existing `test_input_embeds_chunked.py` covers the retraction path
- [ ] Update documentation — could add a note to server_arguments.md about `SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR` for mixed workloads, happy to if wanted