### PR TITLE
[HiCache] Check in-flight async ops in `is_fully_idle()` before attach/detach

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2676,11 +2676,21 @@ class Scheduler(
             )
 
         if not for_health_check:
-            # Grammar queue and prefill inflight queue may not produce batch results
-            # instantly, but they still indicate the server is not fully idle.
+            # Grammar queue and prefill inflight queue may not produce batch
+            # results instantly, but they still indicate the server is not idle.
             idle &= len(self.grammar_manager.grammar_queue) == 0
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 idle &= len(self.disagg_prefill_inflight_queue) == 0
+
+            # HiCache: in-flight async ops (GPU↔Host↔L3) must drain before
+            # destructive operations like attach/detach/flush_cache.
+            if self.enable_hierarchical_cache:
+                tc = self.tree_cache
+                idle &= len(tc.ongoing_write_through) == 0
+                idle &= len(tc.ongoing_load_back) == 0
+                if tc.enable_storage:
+                    idle &= len(tc.ongoing_prefetch) == 0
+                    idle &= len(tc.ongoing_backup) == 0
 
         return idle
 

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -167,6 +167,25 @@ def download_image_with_retry(image_url: str, max_retries: int = 3) -> Image.Ima
             time.sleep(2**i)
 
 
+def flush_cache_with_retry(
+    base_url: str, retries: int = 5, interval: float = 2.0
+) -> bool:
+    """Flush device cache with retry.
+
+    The scheduler may still have in-flight HiCache async ops (GPU↔Host↔L3)
+    that prevent is_fully_idle() from returning True, so we retry.
+    """
+    for _ in range(retries):
+        try:
+            response = requests.post(f"{base_url}/flush_cache", timeout=10)
+            if response.status_code == 200:
+                return True
+        except requests.RequestException:
+            pass
+        time.sleep(interval)
+    return False
+
+
 def is_in_ci():
     """Return whether it is in CI runner."""
     return get_bool_env_var("SGLANG_IS_IN_CI")

--- a/test/manual/hicache/test_disaggregation_hicache.py
+++ b/test/manual/hicache/test_disaggregation_hicache.py
@@ -114,9 +114,16 @@ class DisaggregationHiCacheBase(PDDisaggregationServerBase):
         # Trigger offloading
         self.send_request(self.gen_prompt(1), max_tokens=150)
 
-        # Flush device cache to force remote storage access
-        time.sleep(2)
-        requests.post(self.prefill_url + "/flush_cache")
+        # Flush device cache to force remote storage access.
+        # Retry because in-flight HiCache async ops may block is_fully_idle().
+        for _ in range(5):
+            time.sleep(2)
+            try:
+                resp = requests.post(self.prefill_url + "/flush_cache", timeout=10)
+                if resp.status_code == 200:
+                    break
+            except requests.RequestException:
+                pass
 
 
 class TestDisaggregationPrefillWithHiCache(DisaggregationHiCacheBase):

--- a/test/manual/hicache/test_disaggregation_hicache.py
+++ b/test/manual/hicache/test_disaggregation_hicache.py
@@ -14,6 +14,7 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    flush_cache_with_retry,
     popen_launch_pd_server,
 )
 
@@ -115,15 +116,8 @@ class DisaggregationHiCacheBase(PDDisaggregationServerBase):
         self.send_request(self.gen_prompt(1), max_tokens=150)
 
         # Flush device cache to force remote storage access.
-        # Retry because in-flight HiCache async ops may block is_fully_idle().
-        for _ in range(5):
-            time.sleep(2)
-            try:
-                resp = requests.post(self.prefill_url + "/flush_cache", timeout=10)
-                if resp.status_code == 200:
-                    break
-            except requests.RequestException:
-                pass
+        time.sleep(2)
+        flush_cache_with_retry(self.prefill_url)
 
 
 class TestDisaggregationPrefillWithHiCache(DisaggregationHiCacheBase):

--- a/test/manual/hicache/test_pp_with_hicache.py
+++ b/test/manual/hicache/test_pp_with_hicache.py
@@ -179,12 +179,16 @@ class TestPPWithHiCache(unittest.TestCase):
 
         return False
 
-    def flush_cache(self) -> bool:
-        try:
-            response = requests.post(f"{self.base_url}/flush_cache", timeout=10)
-            return response.status_code == 200
-        except requests.RequestException:
-            return False
+    def flush_cache(self, retries: int = 5, interval: float = 2.0) -> bool:
+        for _ in range(retries):
+            try:
+                response = requests.post(f"{self.base_url}/flush_cache", timeout=10)
+                if response.status_code == 200:
+                    return True
+            except requests.RequestException:
+                pass
+            time.sleep(interval)
+        return False
 
     def test_eval_accuracy(self):
         args = SimpleNamespace(

--- a/test/manual/hicache/test_pp_with_hicache.py
+++ b/test/manual/hicache/test_pp_with_hicache.py
@@ -18,6 +18,7 @@ from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     find_available_port,
+    flush_cache_with_retry,
     popen_launch_server,
 )
 
@@ -179,16 +180,8 @@ class TestPPWithHiCache(unittest.TestCase):
 
         return False
 
-    def flush_cache(self, retries: int = 5, interval: float = 2.0) -> bool:
-        for _ in range(retries):
-            try:
-                response = requests.post(f"{self.base_url}/flush_cache", timeout=10)
-                if response.status_code == 200:
-                    return True
-            except requests.RequestException:
-                pass
-            time.sleep(interval)
-        return False
+    def flush_cache(self) -> bool:
+        return flush_cache_with_retry(self.base_url)
 
     def test_eval_accuracy(self):
         args = SimpleNamespace(

--- a/test/registered/hicache/test_hicache_storage_file_backend.py
+++ b/test/registered/hicache/test_hicache_storage_file_backend.py
@@ -167,13 +167,21 @@ class HiCacheStorageBaseMixin:
         meta = response_json.get("meta_info", {})
         return int(meta.get("cached_tokens", 0))
 
-    def flush_cache(self) -> bool:
-        """Flush device cache to force remote storage access"""
-        try:
-            response = requests.post(f"{self.base_url}/flush_cache", timeout=10)
-            return response.status_code == 200
-        except requests.RequestException:
-            return False
+    def flush_cache(self, retries: int = 5, interval: float = 2.0) -> bool:
+        """Flush device cache to force remote storage access.
+
+        Retries because the scheduler may still have in-flight HiCache async
+        ops (GPU↔Host↔L3) that prevent is_fully_idle() from returning True.
+        """
+        for _ in range(retries):
+            try:
+                response = requests.post(f"{self.base_url}/flush_cache", timeout=10)
+                if response.status_code == 200:
+                    return True
+            except requests.RequestException:
+                pass
+            time.sleep(interval)
+        return False
 
     def gen_prompt(self, token_num: int) -> str:
         """Generate a random prompt of specified token length using tokenizer vocabulary."""

--- a/test/registered/hicache/test_hicache_storage_file_backend.py
+++ b/test/registered/hicache/test_hicache_storage_file_backend.py
@@ -26,6 +26,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    flush_cache_with_retry,
     is_in_ci,
     popen_launch_server,
 )
@@ -167,21 +168,9 @@ class HiCacheStorageBaseMixin:
         meta = response_json.get("meta_info", {})
         return int(meta.get("cached_tokens", 0))
 
-    def flush_cache(self, retries: int = 5, interval: float = 2.0) -> bool:
-        """Flush device cache to force remote storage access.
-
-        Retries because the scheduler may still have in-flight HiCache async
-        ops (GPU↔Host↔L3) that prevent is_fully_idle() from returning True.
-        """
-        for _ in range(retries):
-            try:
-                response = requests.post(f"{self.base_url}/flush_cache", timeout=10)
-                if response.status_code == 200:
-                    return True
-            except requests.RequestException:
-                pass
-            time.sleep(interval)
-        return False
+    def flush_cache(self) -> bool:
+        """Flush device cache to force remote storage access."""
+        return flush_cache_with_retry(self.base_url)
 
     def gen_prompt(self, token_num: int) -> str:
         """Generate a random prompt of specified token length using tokenizer vocabulary."""


### PR DESCRIPTION
- Check `ongoing_write_through`, `ongoing_load_back`, `ongoing_prefetch`, `ongoing_backup` in `is_fully_idle()` so attach/detach/flush_cache wait for all GPU↔Host↔L3 async ops to drain
- Gate behind `not for_health_check` to avoid blocking health check probes with background cache I/O
- Follows up on #20560 — that fix ensures `check_hicache_events()` runs when idle, but `is_fully_idle()` still didn't account for in-flight HiCache ops, allowing unsafe detach while GPU→Host writes are pending