### PR TITLE
fix piecewise cuda graph support for Kimi-K2.5 model

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -716,6 +716,8 @@ class KimiK25ForConditionalGeneration(nn.Module):
             ),
         )
 
+        self.model = self.language_model.model
+
         # Ensure that the dtype of the vision_tower and mm_projector matches that of the language_model.
         # This solves the dtype mismatch issue when using device_map="auto" and torch_dtype.
         if hasattr(self.language_model, "dtype"):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

  - Add `self.model` alias pointing to `self.language_model.model` in `KimiK25ForConditionalGeneration`, following the same pattern as InternVL. This allows the piecewise CUDA graph runner to discover the decoder layers via `hasattr(self.model, "model")`.  

- Since K2.5 is a multimodal model, piecewise CUDA graph is still auto-disabled by default. To enable it, use `--enforce-piecewise-cuda-graph` when launching the server.

Example:                                                        
```bash                                                                                                                                                    
  python3 -m sglang.launch_server \                               
    --model-path moonshotai/Kimi-K2.5 \
    --tp 8 \                                                                                                                                                 
    --enforce-piecewise-cuda-graph \                                                                                                                         
```


```
python3 -m sglang.bench_serving \
--backend sglang-oai-chat  --model moonshotai/Kimi-K2.5 \
--dataset-name random   --num-prompts 128   --random-input-len 1024   \
--random-output-len 200   --random-range-ratio 1.0 --max-concurrency 1 \
--seed 123  --warmup-requests 0  --seed 123123
```


w pcg:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     128       
Benchmark duration (s):                  196.17    
Total input tokens:                      131072    
Total input text tokens:                 131072    
Total generated tokens:                  25600     
Total generated tokens (retokenized):    105       
Request throughput (req/s):              0.65      
Input token throughput (tok/s):          668.16    
Output token throughput (tok/s):         130.50    
Peak output token throughput (tok/s):    50.00     
Peak concurrent requests:                2         
Total token throughput (tok/s):          798.66    
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1532.21   
Median E2E Latency (ms):                 1534.68   
P90 E2E Latency (ms):                    1538.18   
P99 E2E Latency (ms):                    1549.58   
---------------Time to First Token----------------
Mean TTFT (ms):                          30.04     
Median TTFT (ms):                        0.00      
P99 TTFT (ms):                           1277.05   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.55      
Median TPOT (ms):                        7.71      
P99 TPOT (ms):                           7.79      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           7.12      
Median ITL (ms):                         7.13      
P95 ITL (ms):                            7.45      
P99 ITL (ms):                            7.50      
Max ITL (ms):                            7.51      
==================================================
```


w/o pcg:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     128       
Benchmark duration (s):                  194.68    
Total input tokens:                      131072    
Total input text tokens:                 131072    
Total generated tokens:                  25600     
Total generated tokens (retokenized):    94        
Request throughput (req/s):              0.66      
Input token throughput (tok/s):          673.25    
Output token throughput (tok/s):         131.49    
Peak output token throughput (tok/s):    34.00     
Peak concurrent requests:                2         
Total token throughput (tok/s):          804.75    
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1520.63   
Median E2E Latency (ms):                 1520.15   
P90 E2E Latency (ms):                    1523.06   
P99 E2E Latency (ms):                    1527.17   
---------------Time to First Token----------------
Mean TTFT (ms):                          42.32     
Median TTFT (ms):                        0.00      
P99 TTFT (ms):                           1366.54   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.43      
Median TPOT (ms):                        7.64      
P99 TPOT (ms):                           7.67      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           7.12      
Median ITL (ms):                         7.10      
P95 ITL (ms):                            7.46      
P99 ITL (ms):                            7.56      
Max ITL (ms):                            7.72      
==================================================
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
