### PR TITLE
[AMD] CI: stop installing transformers from git main in Qwen 3.5 and GLM-5 nightly tests

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -608,7 +608,7 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build --skip-test-time-deps
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git mistral-common "lm-eval[api]" --upgrade
+          bash scripts/ci/amd/amd_ci_exec.sh pip install mistral-common "lm-eval[api]"
 
       - name: Accuracy Test ROCm 7.2 (8-GPU Qwen 3.5)
         timeout-minutes: 120
@@ -640,8 +640,6 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
-          # GLM-5 requires latest transformers for glm_moe_dsa architecture
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git
 
       - name: Accuracy Test ROCm 7.2 (8-GPU GLM-5 NSA)
         timeout-minutes: 120
@@ -1196,7 +1194,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-aiter-build --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git mistral-common "lm-eval[api]" --upgrade
+          bash scripts/ci/amd/amd_ci_exec.sh pip install mistral-common "lm-eval[api]"
 
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU Qwen 3.5)
         timeout-minutes: 120
@@ -1229,8 +1227,6 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          # GLM-5 requires latest transformers for glm_moe_dsa architecture
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git
 
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU GLM-5 NSA)
         timeout-minutes: 180

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -612,7 +612,7 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git mistral-common "lm-eval[api]" --upgrade
+          bash scripts/ci/amd/amd_ci_exec.sh pip install mistral-common "lm-eval[api]"
 
       - name: Accuracy Test (8-GPU Qwen 3.5)
         timeout-minutes: 120
@@ -643,8 +643,6 @@ jobs:
       - name: Install dependencies
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
-          # GLM-5 requires latest transformers for glm_moe_dsa architecture
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git
 
       - name: Accuracy Test (8-GPU GLM-5 NSA)
         timeout-minutes: 120
@@ -1202,7 +1200,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git mistral-common "lm-eval[api]" --upgrade
+          bash scripts/ci/amd/amd_ci_exec.sh pip install mistral-common "lm-eval[api]"
 
       - name: Accuracy Test MI35x (8-GPU Qwen 3.5)
         timeout-minutes: 120
@@ -1235,8 +1233,6 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
           # Install tabulate for run_suite.py (missing in MI35x container)
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-          # GLM-5 requires latest transformers for glm_moe_dsa architecture
-          bash scripts/ci/amd/amd_ci_exec.sh pip install git+https://github.com/huggingface/transformers.git
 
       - name: Accuracy Test MI35x (8-GPU GLM-5 NSA)
         timeout-minutes: 180


### PR DESCRIPTION
## Summary

- Remove `pip install git+https://github.com/huggingface/transformers.git` from all Qwen 3.5 and GLM-5 CI jobs across both `nightly-test-amd.yml` and `nightly-test-amd-rocm720.yml`
- Use the stable transformers shipped in the docker image instead, matching all other passing nightly jobs (Grok2, DeepSeek-V3.2, etc.)
- Keep `mistral-common` and `lm-eval[api]` for Qwen 3.5 tests that need them

## Motivation

Transformers PR [huggingface/transformers#41250](https://github.com/huggingface/transformers/pull/41250) (merged Mar 16) converts `PretrainedConfig` subclasses to `@dataclass` via `__init_subclass__`, which breaks sglang's `DeepseekVL2Config` (non-default field `vision_config` follows default arguments). This crashes the server on import and prevents **any** test from running:

```
TypeError: non-default argument 'vision_config' follows default argument
```

Both the [Qwen 3.5 MI35x](https://github.com/sgl-project/sglang/actions/runs/23172097640/job/67326067541) and [GLM-5 MI35x](https://github.com/sgl-project/sglang/actions/runs/23172097640/job/67326067539) jobs failed in Nightly #633 for this reason, while Grok2 and DeepSeek-V3.2 (which don't install from git main) passed fine.

Installing bleeding-edge transformers from `main` is fragile — upstream breaking changes can silently break CI at any time. The stable version in the docker image is sufficient.

## Test plan

- [ ] Verify Qwen 3.5 nightly accuracy tests pass on MI30x and MI35x
- [ ] Verify GLM-5 nightly accuracy tests pass on MI30x and MI35x
- [ ] Verify ROCm 7.2 variants also pass