### PR TITLE
[Bugfix] fix qwen3vl hang when --mm-enable-dp-encoder is enable

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -329,6 +329,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                 self.num_position_embeddings,
                 self.hidden_size,
                 quant_config=quant_config,
+                enable_tp=not use_data_parallel,
                 use_attn_tp_group=is_dp_attention_enabled(),
                 enable_tp=False if use_data_parallel else True,
                 prefix=add_prefix("pos_embed", prefix),

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -330,8 +330,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                 self.hidden_size,
                 quant_config=quant_config,
                 enable_tp=not use_data_parallel,
-                use_attn_tp_group=is_dp_attention_enabled(),
-                enable_tp=False if use_data_parallel else True,
+                use_attn_tp_group=is_dp_attention_enabled() and not use_data_parallel,
                 prefix=add_prefix("pos_embed", prefix),
             )
         else:


### PR DESCRIPTION
## Motivation

The Qwen3-VL type model hangs during forward when --mm-enable-dp-encoder is enabled. This is because the VocabParallelEmbedding part remains as TP8 after enabling --mm-enable-dp-encoder, when it should actually be TP1. Therefore, this PR is needed to fix the issue.

## Accuracy Tests
before:
hang

after:
Evaluating...
```
answers saved to: ./answer_sglang.json
{'Accounting': {'acc': 0.467, 'num': 30},
 'Agriculture': {'acc': 0.6, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.267, 'num': 30},
 'Art': {'acc': 0.767, 'num': 30},
 'Art_Theory': {'acc': 0.933, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.833, 'num': 30},
 'Biology': {'acc': 0.6, 'num': 30},
 'Chemistry': {'acc': 0.6, 'num': 30},
 'Clinical_Medicine': {'acc': 0.8, 'num': 30},
 'Computer_Science': {'acc': 0.567, 'num': 30},
 'Design': {'acc': 0.867, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.4, 'num': 30},
 'Economics': {'acc': 0.8, 'num': 30},
 'Electronics': {'acc': 0.3, 'num': 30},
 'Energy_and_Power': {'acc': 0.567, 'num': 30},
 'Finance': {'acc': 0.567, 'num': 30},
 'Geography': {'acc': 0.6, 'num': 30},
 'History': {'acc': 0.833, 'num': 30},
 'Literature': {'acc': 0.833, 'num': 30},
 'Manage': {'acc': 0.567, 'num': 30},
 'Marketing': {'acc': 0.6, 'num': 30},
 'Materials': {'acc': 0.4, 'num': 30},
 'Math': {'acc': 0.367, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.3, 'num': 30},
 'Music': {'acc': 0.4, 'num': 30},
 'Overall': {'acc': 0.619, 'num': 900},
 'Overall-Art and Design': {'acc': 0.742, 'num': 120},
 'Overall-Business': {'acc': 0.6, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.733, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.767, 'num': 120},
 'Overall-Science': {'acc': 0.573, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.429, 'num': 210},
 'Pharmacy': {'acc': 0.9, 'num': 30},
 'Physics': {'acc': 0.7, 'num': 30},
 'Psychology': {'acc': 0.7, 'num': 30},
 'Public_Health': {'acc': 0.733, 'num': 30},
 'Sociology': {'acc': 0.7, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.619
```