### PR TITLE
[DP] disable dp controller watchdog for node_rank > 0 in multi-node deployment

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -170,12 +170,18 @@ class DataParallelController:
 
         self.init_dispatcher()
 
-        self.soft_watchdog = Watchdog.create(
-            debug_name="DataParallelController",
-            watchdog_timeout=server_args.soft_watchdog_timeout,
-            soft=True,
-            test_stuck_time=envs.SGLANG_TEST_STUCK_DP_CONTROLLER.get(),
-        )
+        if server_args.node_rank == 0:
+            self.soft_watchdog = Watchdog.create(
+                debug_name="DataParallelController",
+                watchdog_timeout=server_args.soft_watchdog_timeout,
+                soft=True,
+                test_stuck_time=envs.SGLANG_TEST_STUCK_DP_CONTROLLER.get(),
+            )
+        else:
+            self.soft_watchdog = Watchdog.create(
+                debug_name="DataParallelController",
+                watchdog_timeout=None,
+            )
 
         if server_args.enable_metrics:
             start_cpu_monitor_thread("data_parallel_controller")


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In a multi-node deployment, nodes with `node_rank > 0` continuously output useless soft watchdog dump messages.

## Modifications

Use noop watchdog for node_rank != 0. 

Because in [https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/data_parallel_controller.py#L551](url) and [https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/data_parallel_controller.py#L595](url), only the controller with node_rank == 0 runs the event loop and will be fed, while the other controllers end up watchdog timeout.


## Server Logs

deploying by
```
python3 -m sglang.launch_server \
    --model-path /mnt/data/models/GLM-4.5-Air-FP8/ \
    --tp-size 16 \
    --dp-size 16 \
    --enable-dp-attention \
    --enable-metrics \
    --enable-dp-lm-head \
    --dist-init-addr $MASTER_ADDR:5000 --nnodes 2 --node-rank $RANK \
    --moe-dense-tp-size 1 \
    --enable-metrics \
    --mem-fraction-static 0.70 \
    --kv-cache-dtype fp8_e4m3 \
    --soft-watchdog-timeout 10 \
    --host 0.0.0.0 \
    --page-size 64 \
    --port 30000
```


1. w/o this PR

RANK1:
```
[2026-03-17 17:31:50 DP12 TP12] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.28, #queue-req: 0
[2026-03-17 17:31:50 DP14 TP14] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.27, #queue-req: 0
[2026-03-17 17:31:53] Pyspy dump for PID 10366:
Process 10366: sglang::data_parallel_controller
Python v3.12.3 (/usr/bin/python3.12)

Thread 10366 (idle): "MainThread"
    wait4 (libc.so.6)
    poll (multiprocessing/popen_fork.py:27)
    wait (multiprocessing/popen_fork.py:43)
    join (multiprocessing/process.py:149)
    run_data_parallel_controller_process (data_parallel_controller.py:614)
    run (multiprocessing/process.py:108)
    _bootstrap (multiprocessing/process.py:314)
    _main (multiprocessing/spawn.py:135)
    spawn_main (multiprocessing/spawn.py:122)
    <module> (<string>:1)
    0x7f983b82a1ca (libc.so.6)
Thread 13170 (idle): "Thread-1 (_watchdog_thread)"
    poll (libc.so.6)
    select (selectors.py:415)
    _communicate (subprocess.py:2115)
    communicate (subprocess.py:1209)
    run (subprocess.py:550)
    pyspy_dump_schedulers (utils/common.py:2432)
    _watchdog_once (utils/watchdog.py:150)
    _watchdog_thread (utils/watchdog.py:125)
    run (threading.py:1010)
    _bootstrap_inner (threading.py:1073)
    _bootstrap (threading.py:1030)
    0x7f983b89caa4 (libc.so.6)
    0x7f983b929c6c (libc.so.6)
Thread 13172 (idle): "Thread-2 (monitor)"
    clock_nanosleep (libc.so.6)
    monitor (cpu_monitor.py:21)
    run (threading.py:1010)
    _bootstrap_inner (threading.py:1073)
    _bootstrap (threading.py:1030)
    0x7f983b89caa4 (libc.so.6)
    0x7f983b929c6c (libc.so.6)

[2026-03-17 17:31:53] DataParallelController watchdog timeout (self.watchdog_timeout=10.0, self.soft=True)


[2026-03-17 17:31:54 DP15 TP15] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.61, #queue-req: 0
[2026-03-17 17:31:54 DP11 TP11] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.61, #queue-req: 0
[2026-03-17 17:31:54 DP13 TP13] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.61, #queue-req: 0
[2026-03-17 17:31:54 DP9 TP9] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.61, #queue-req: 0
[2026-03-17 17:31:54 DP8 TP8] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.61, #queue-req: 0
[2026-03-17 17:31:54 DP12 TP12] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.61, #queue-req: 0
[2026-03-17 17:31:54 DP10 TP10] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.59, #queue-req: 0
[2026-03-17 17:31:54 DP14 TP14] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 129.58, #queue-req: 0
[2026-03-17 17:31:58 DP12 TP12] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.36, #queue-req: 0
[2026-03-17 17:31:58 DP13 TP13] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.36, #queue-req: 0
[2026-03-17 17:31:58 DP9 TP9] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.35, #queue-req: 0
[2026-03-17 17:31:58 DP11 TP11] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.36, #queue-req: 0
[2026-03-17 17:31:58 DP15 TP15] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.36, #queue-req: 0
[2026-03-17 17:31:58 DP8 TP8] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.36, #queue-req: 0
[2026-03-17 17:31:58 DP10 TP10] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.37, #queue-req: 0
[2026-03-17 17:31:58 DP14 TP14] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.38, #queue-req: 0
[2026-03-17 17:32:02 DP10 TP10] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP11 TP11] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP8 TP8] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP9 TP9] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP13 TP13] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP12 TP12] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP14 TP14] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:02 DP15 TP15] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.15, #queue-req: 0
[2026-03-17 17:32:04] Pyspy dump for PID 10366:
Process 10366: sglang::data_parallel_controller
Python v3.12.3 (/usr/bin/python3.12)

Thread 10366 (idle): "MainThread"
    wait4 (libc.so.6)
    poll (multiprocessing/popen_fork.py:27)
    wait (multiprocessing/popen_fork.py:43)
    join (multiprocessing/process.py:149)
    run_data_parallel_controller_process (data_parallel_controller.py:614)
    run (multiprocessing/process.py:108)
    _bootstrap (multiprocessing/process.py:314)
    _main (multiprocessing/spawn.py:135)
    spawn_main (multiprocessing/spawn.py:122)
    <module> (<string>:1)
    0x7f983b82a1ca (libc.so.6)
Thread 13170 (idle): "Thread-1 (_watchdog_thread)"
    poll (libc.so.6)
    select (selectors.py:415)
    _communicate (subprocess.py:2115)
    communicate (subprocess.py:1209)
    run (subprocess.py:550)
    pyspy_dump_schedulers (utils/common.py:2432)
    _watchdog_once (utils/watchdog.py:150)
    _watchdog_thread (utils/watchdog.py:125)
    run (threading.py:1010)
    _bootstrap_inner (threading.py:1073)
    _bootstrap (threading.py:1030)
    0x7f983b89caa4 (libc.so.6)
    0x7f983b929c6c (libc.so.6)
Thread 13172 (idle): "Thread-2 (monitor)"
    clock_nanosleep (libc.so.6)
    monitor (cpu_monitor.py:21)
    run (threading.py:1010)
    _bootstrap_inner (threading.py:1073)
    _bootstrap (threading.py:1030)
    0x7f983b89caa4 (libc.so.6)
    0x7f983b929c6c (libc.so.6)

[2026-03-17 17:32:04] DataParallelController watchdog timeout (self.watchdog_timeout=10.0, self.soft=True)


[2026-03-17 17:32:06 DP8 TP8] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 118.38, #queue-req: 0
```
2. w/ this PR

RANK1
```
[2026-03-17 17:34:18 DP11 TP11] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, cuda graph: False
[2026-03-17 17:34:18 DP12 TP12] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, cuda graph: False
[2026-03-17 17:34:18 DP15 TP15] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, cuda graph: False
[2026-03-17 17:34:18 DP14 TP14] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, cuda graph: False
[2026-03-17 17:34:18 DP13 TP13] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, input throughput (token/s): 0.00, cuda graph: False
[2026-03-17 17:35:05 DP15 TP15] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.37, cuda graph: False
[2026-03-17 17:35:05 DP9 TP9] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.36, cuda graph: False
[2026-03-17 17:35:05 DP10 TP10] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.36, cuda graph: False
[2026-03-17 17:35:05 DP13 TP13] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.37, cuda graph: False
[2026-03-17 17:35:05 DP12 TP12] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.37, cuda graph: False
[2026-03-17 17:35:05 DP11 TP11] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.36, cuda graph: False
[2026-03-17 17:35:05 DP14 TP14] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.37, cuda graph: False
[2026-03-17 17:35:05 DP8 TP8] Prefill batch, #new-seq: 3, #new-token: 192, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1, input throughput (token/s): 1.36, cuda graph: False
[2026-03-17 17:35:05 DP9 TP9] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1182.68, cuda graph: False
[2026-03-17 17:35:05 DP10 TP10] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1185.81, cuda graph: False
[2026-03-17 17:35:05 DP15 TP15] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1176.59, cuda graph: False
[2026-03-17 17:35:05 DP13 TP13] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1179.63, cuda graph: False
[2026-03-17 17:35:05 DP8 TP8] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1271.20, cuda graph: False
[2026-03-17 17:35:05 DP12 TP12] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1175.24, cuda graph: False
[2026-03-17 17:35:05 DP14 TP14] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1179.04, cuda graph: False
[2026-03-17 17:35:05 DP11 TP11] Prefill batch, #new-seq: 8, #new-token: 512, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, input throughput (token/s): 1166.25, cuda graph: False
[2026-03-17 17:35:05 DP9 TP9] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 7205.60, cuda graph: False
[2026-03-17 17:35:05 DP15 TP15] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 7074.13, cuda graph: False
[2026-03-17 17:35:05 DP10 TP10] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 7012.64, cuda graph: False
[2026-03-17 17:35:05 DP13 TP13] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 7117.07, cuda graph: False
[2026-03-17 17:35:05 DP12 TP12] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 7191.33, cuda graph: False
[2026-03-17 17:35:05 DP14 TP14] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 6752.61, cuda graph: False
[2026-03-17 17:35:05 DP11 TP11] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 6393.39, cuda graph: False
[2026-03-17 17:35:05 DP8 TP8] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 11, #queue-req: 0, input throughput (token/s): 5711.31, cuda graph: False
[2026-03-17 17:35:07 DP9 TP9] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.83, #queue-req: 0
[2026-03-17 17:35:07 DP13 TP13] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.83, #queue-req: 0
[2026-03-17 17:35:07 DP15 TP15] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.82, #queue-req: 0
[2026-03-17 17:35:07 DP10 TP10] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.84, #queue-req: 0
[2026-03-17 17:35:07 DP14 TP14] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.83, #queue-req: 0
[2026-03-17 17:35:07 DP11 TP11] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.83, #queue-req: 0
[2026-03-17 17:35:07 DP12 TP12] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.83, #queue-req: 0
[2026-03-17 17:35:07 DP8 TP8] Decode batch, #running-req: 12, #token: 768, token usage: 0.00, cuda graph: True, gen throughput (token/s): 3.83, #queue-req: 0
[2026-03-17 17:35:11 DP13 TP13] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.90, #queue-req: 0
[2026-03-17 17:35:11 DP15 TP15] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.90, #queue-req: 0
[2026-03-17 17:35:11 DP12 TP12] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.91, #queue-req: 0
[2026-03-17 17:35:11 DP10 TP10] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.90, #queue-req: 0
[2026-03-17 17:35:11 DP9 TP9] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.90, #queue-req: 0
[2026-03-17 17:35:11 DP14 TP14] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.90, #queue-req: 0
[2026-03-17 17:35:11 DP11 TP11] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.90, #queue-req: 0
[2026-03-17 17:35:11 DP8 TP8] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 130.91, #queue-req: 0
[2026-03-17 17:35:15 DP13 TP13] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.13, #queue-req: 0
[2026-03-17 17:35:15 DP12 TP12] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.13, #queue-req: 0
[2026-03-17 17:35:15 DP10 TP10] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.13, #queue-req: 0
[2026-03-17 17:35:15 DP15 TP15] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.13, #queue-req: 0
[2026-03-17 17:35:15 DP14 TP14] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.13, #queue-req: 0
[2026-03-17 17:35:15 DP11 TP11] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.14, #queue-req: 0
[2026-03-17 17:35:15 DP9 TP9] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.13, #queue-req: 0
[2026-03-17 17:35:15 DP8 TP8] Decode batch, #running-req: 12, #token: 1536, token usage: 0.00, cuda graph: True, gen throughput (token/s): 124.14, #queue-req: 0
[2026-03-17 17:35:19 DP11 TP11] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP13 TP13] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP9 TP9] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP15 TP15] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP10 TP10] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP12 TP12] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP14 TP14] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:19 DP8 TP8] Decode batch, #running-req: 12, #token: 2304, token usage: 0.00, cuda graph: True, gen throughput (token/s): 120.40, #queue-req: 0
[2026-03-17 17:35:23 DP14 TP14] Decode batch, #running-req: 11, #token: 2816, token usage: 0.00, cuda graph: True, gen throughput (token/s): 112.62, #queue-req: 0
[2026-03-17 17:35:23 DP12 TP12] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.77, #queue-req: 0
[2026-03-17 17:35:23 DP11 TP11] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.76, #queue-req: 0
[2026-03-17 17:35:23 DP15 TP15] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.76, #queue-req: 0
[2026-03-17 17:35:23 DP13 TP13] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.77, #queue-req: 0
[2026-03-17 17:35:23 DP10 TP10] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.76, #queue-req: 0
[2026-03-17 17:35:23 DP9 TP9] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.76, #queue-req: 0
[2026-03-17 17:35:23 DP8 TP8] Decode batch, #running-req: 12, #token: 3072, token usage: 0.00, cuda graph: True, gen throughput (token/s): 117.77, #queue-req: 0

```

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
5. After green CI and required approvals, ask Merge Oncalls to merge.
