### PR TITLE
[Fix] retract decode offload kvcache check

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -445,7 +445,10 @@ class DecodePreallocQueue:
             allocatable_tokens -= required_tokens_for_request
 
             # load from cpu, release the cpu copy
-            req.load_kv_cache(self.req_to_token_pool, self.token_to_kv_pool_allocator)
+            if self.scheduler.server_args.disaggregation_decode_enable_offload_kvcache:
+                req.load_kv_cache(
+                    self.req_to_token_pool, self.token_to_kv_pool_allocator
+                )
 
         self.retracted_queue = [
             entry

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1935,7 +1935,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
         req = self.reqs[idx]
 
-        if server_args.disaggregation_mode == "decode":
+        if (
+            server_args.disaggregation_mode == "decode"
+            and server_args.disaggregation_decode_enable_offload_kvcache
+        ):
             req.offload_kv_cache(
                 self.req_to_token_pool, self.token_to_kv_pool_allocator
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
> Thread 0x00007f81bf32a300 (most recent call first):
  File "/usr/lib/python3.12/multiprocessing/popen_fork.py", line 27 in poll
  File "/usr/lib/python3.12/multiprocessing/popen_fork.py", line 43 in wait
  File "/usr/lib/python3.12/multiprocessing/process.py", line 149 in join
  File "/sgl-workspace/sglang/python/sglang/srt/managers/data_parallel_controller.py", line 598 in run_data_parallel_controller_process
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108 in run
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314 in _bootstrap
  File "/usr/lib/python3.12/multiprocessing/spawn.py", line 135 in _main
  File "/usr/lib/python3.12/multiprocessing/spawn.py"[2026-03-15 22:08:28 DP4 TP17 EP17] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3375, in run_scheduler_process
    scheduler.run_event_loop()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1241, in run_event_loop
    dispatch_event_loop(self)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 3265, in dispatch_event_loop
    scheduler.event_loop_overlap_disagg_decode()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/decode.py", line 996, in event_loop_overlap_disagg_decode
    batch = self.get_next_disagg_decode_batch_to_run()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/decode.py", line 1051, in get_next_disagg_decode_batch_to_run
    self.running_batch = self.update_running_batch(self.running_batch)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2380, in update_running_batch
    retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(
                                                     ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/schedule_batch.py", line 1884, in retract_decode
    self.release_req(idx, len(sorted_indices), server_args)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/schedule_batch.py", line 1914, in release_req
    req.offload_kv_cache(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/schedule_batch.py", line 1128, in offload_kv_cache
    self.kv_cache_cpu = token_to_kv_pool_allocator.get_cpu_copy(token_indices)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/allocator.py", line 168, in get_cpu_copy
    return self._kvcache.get_cpu_copy(indices)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 715, in get_cpu_copy
    raise NotImplementedError()
NotImplementedError

When disaggregation_decode_enable_offload_kvcache is False (default), release_req() was unconditionally calling req.offload_kv_cache(), which on HybridLinearKVPool (Mamba+attention hybrid models) hits a NotImplementedError since get_cpu_copy() is not implemented.
    
Symmetrically, resume_retracted_reqs() was unconditionally calling req.load_kv_cache() even though no offload had occurred.
    
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Guard both calls behind the disaggregation_decode_enable_offload_kvcache flag.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
