### PR TITLE
Fix Qwen3.5-0.8B model returning content=null with --reasoning-parser qwen3 (#20786)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1251,7 +1251,12 @@ class OpenAIServingChat(OpenAIServingBase):
                 or request.chat_template_kwargs.get("thinking") is not False
             )
         if self.reasoning_parser in ["qwen3", "glm45", "nemotron_3", "interns1"]:
-            # Models that thinking by default, and can be disabled by setting enable_thinking=False
+            # Only enable thinking when the chat template actually supports it
+            # (i.e., has <think> in assistant preamble). Models like Qwen3.5-0.8B
+            # don't support thinking, so their output should go to content, not
+            # reasoning_content. See #20786.
+            if not self.template_manager.force_reasoning:
+                return False
             return (
                 not request.chat_template_kwargs
                 or request.chat_template_kwargs.get("enable_thinking") is not False


### PR DESCRIPTION
Fix Qwen3.5 small models returning content=null with --reasoning-parser qwen3 (#20786)

When using --reasoning-parser qwen3 with Qwen3.5 small models (e.g., 0.8B), all output was incorrectly placed into reasoning_content while content became null.

Root cause: _get_reasoning_from_request() unconditionally defaulted to thinking=True for the qwen3 parser when enable_thinking was not explicitly set. However, Qwen3.5 small models do not support thinking mode — their chat template does not contain the <think> preamble, so the model never emits <think>...</think> tags. With force_reasoning=True, the parser treated all output as reasoning_content and never switched back to normal content.

Fix: Check template_manager.force_reasoning (which inspects the model's chat template for the <think> pattern) before enabling thinking mode. If the chat template does not support thinking, return False regardless of the enable_thinking parameter. This ensures:
- Qwen3.5-0.8B (no <think> in template): output goes to content as expected
- Qwen3-4B (has <think> in template): thinking mode works as before
- Explicit enable_thinking=False still disables thinking for supported models

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #20786

When using `--reasoning-parser qwen3` with Qwen3.5 small models (e.g., Qwen3.5-0.8B), SGLang incorrectly treats them as thinking mode by default. This causes all output to be placed in `reasoning_content` while `content` becomes `null`.

```json
{
  "message": {
    "role": "assistant",
    "content": null,
    "reasoning_content": "The result of 2 + 2 is **4**."
  }
}
```

The root cause is that _get_reasoning_from_request() unconditionally defaults to thinking=True for the qwen3 parser when enable_thinking is not explicitly set. However, Qwen3.5 small models do not support thinking mode, their chat template does not contain the <think> preamble, so the model never emits <think>...</think> tags. With force_reasoning=True, the parser treats all output as reasoning_content and never switches back to normal content.

## Modifications

In _get_reasoning_from_request() (serving_chat.py), added a template_manager.force_reasoning check before enabling thinking mode for qwen3, glm45, nemotron_3, and interns1 parsers. template_manager.force_reasoning inspects the model's chat template for the <|im_start|>assistant\n<think>\n pattern, which is the reliable signal for whether a model actually supports thinking.

If the chat template does not support thinking, return False regardless of the enable_thinking parameter. This ensures:

Qwen3.5-0.8B (no <think> in template): output goes to content as expected
Qwen3-4B (has <think> in template): thinking mode works as before, controlled by enable_thinking

## Accuracy Tests

Verified with Qwen3.5-0.8B + --reasoning-parser qwen3. After the fix, content correctly contains the model output instead of being null.

```python
"""
Start server:
  python -m sglang.launch_server --model-path Qwen/Qwen3.5-0.8B --port 8000 --reasoning-parser qwen3 --trust-remote-code

Run:
  python test_issue_20786.py
"""

import requests

BASE_URL = "http://localhost:8000"
MODEL = "Qwen3.5-0.8B"
PAYLOAD = {
    "model": MODEL,
    "messages": [{"role": "user", "content": "What is 2 + 2?"}],
    "max_tokens": 64,
}


def chat(**kwargs):
    resp = requests.post(f"{BASE_URL}/v1/chat/completions", json={**PAYLOAD, **kwargs})
    resp.raise_for_status()
    msg = resp.json()["choices"][0]["message"]
    return msg.get("content"), msg.get("reasoning_content")


# Test 1: default (no enable_thinking) — was the bug
content, reasoning = chat()
assert content is not None, f"FAIL: content is null, reasoning={reasoning!r}"
print(f"[PASS] default: content={content!r}")

# Test 2: enable_thinking=False
content, reasoning = chat(chat_template_kwargs={"enable_thinking": False})
assert content is not None, "FAIL: content is null with enable_thinking=False"
print(f"[PASS] enable_thinking=False: content={content!r}")

# Test 3: enable_thinking=True (model doesn't support it, should still work)
content, reasoning = chat(chat_template_kwargs={"enable_thinking": True})
assert content is not None, f"FAIL: content is null with enable_thinking=True, reasoning={reasoning!r}"
print(f"[PASS] enable_thinking=True: content={content!r}")

print("\nAll tests passed.")

```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
