### PR TITLE
Temporary fix: abort crash on ChunkCache in disagg decode

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -263,6 +263,15 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
 
         Subclasses with prefetch or other async state (e.g., HiRadixCache)
         should override this to terminate in-flight operations.
+
+        TEMPORARY FIX: This no-op exists to prevent an AttributeError crash
+        in disagg decode mode, where the cache is ChunkCache but
+        enable_hicache_storage is True (because --hicache-storage-backend is
+        set for decode offload). The real fix should route abort cleanup
+        through DecodeKVCacheOffloadManager rather than tree_cache, since
+        ChunkCache has no awareness of mooncake storage state and a no-op
+        here may silently leak host memory in mooncake store.
+        See: https://github.com/sgl-project/sglang/pull/20790
         """
         pass
 

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -267,10 +267,10 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
         TEMPORARY FIX: This no-op exists to prevent an AttributeError crash
         in disagg decode mode, where the cache is ChunkCache but
         enable_hicache_storage is True (because --hicache-storage-backend is
-        set for decode offload). The real fix should route abort cleanup
-        through DecodeKVCacheOffloadManager rather than tree_cache, since
-        ChunkCache has no awareness of mooncake storage state and a no-op
-        here may silently leak host memory in mooncake store.
+        set for decode offload). DecodeKVCacheOffloadManager is not a prefix
+        cache subclass, so abort cleanup can't be routed through this
+        interface — a separate code path in the scheduler abort logic is
+        needed. A no-op here may silently leak host memory in mooncake store.
         See: https://github.com/sgl-project/sglang/pull/20790
         """
         pass

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -258,6 +258,14 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def is_tree_cache(self) -> bool:
         return not self.is_chunk_cache()
 
+    def release_aborted_request(self, rid: str):
+        """Clean up any state associated with an aborted request.
+
+        Subclasses with prefetch or other async state (e.g., HiRadixCache)
+        should override this to terminate in-flight operations.
+        """
+        pass
+
     def available_and_evictable_str(self) -> str:
         available_size = self.token_to_kv_pool_allocator.available_size()
         evictable_size = self.evictable_size()


### PR DESCRIPTION
## Summary

**This is a temporary fix.** The proper fix will be handled separately by the decode offload owner.

### The crash
`AttributeError: 'ChunkCache' object has no attribute 'release_aborted_request'` in disagg decode scheduler when a request is aborted.

### Root cause
In disagg decode mode with KV cache offloading:
- `--disaggregation-mode decode` forces `disable_radix_cache = True` → scheduler uses **ChunkCache**
- `--hicache-storage-backend mooncake` (required by decode offload) sets `enable_hicache_storage = True`
- When a request is aborted, the scheduler checks `if self.enable_hicache_storage:` and calls `self.tree_cache.release_aborted_request(rid)` — but `ChunkCache` never had that method

This gap was introduced as the decode offload feature (#17216) created a new valid configuration where `enable_hicache_storage` is True while the cache is ChunkCache, but the abort paths (added in #9874 and #17648) assumed `enable_hicache_storage` implied HiRadixCache.

### What this PR does
Adds a no-op `release_aborted_request` to `BasePrefixCache` so all cache types inherit it, preventing the crash.

### Why this is not a complete fix
The no-op prevents the crash but **may silently leak host memory in mooncake store** when requests are aborted during disagg decode with KV cache offloading. The `release_aborted_request` method on `HiRadixCache` exists specifically to clean up prefetch events and host memory — a no-op skips that cleanup.

The `DecodeKVCacheOffloadManager` is not a prefix cache subclass, so the abort cleanup can't be routed through the `tree_cache.release_aborted_request()` interface. The proper fix requires a separate code path in the scheduler abort logic to handle decode offload cleanup directly — this will be addressed in a follow-up by the decode offload owner.

## Test plan
- [x] Verify disaggregation decode abort requests no longer crash
- [ ] Existing tests pass (no behavioral change for other cache types)
- [ ] **Follow-up needed**: verify no host memory leak in mooncake store on abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)