### PR TITLE
[Observability] Add Prometheus metrics endpoint for gRPC mode

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -20,10 +20,12 @@ async def _start_metrics_server(host: str, port: int):
     from aiohttp import web
     from prometheus_client import (
         CollectorRegistry,
-        generate_latest,
         multiprocess,
     )
-    from prometheus_client.exposition import CONTENT_TYPE_LATEST
+    from prometheus_client.openmetrics.exposition import (
+        CONTENT_TYPE_LATEST,
+        generate_latest,
+    )
 
     async def metrics_handler(request):
         try:
@@ -31,6 +33,11 @@ async def _start_metrics_server(host: str, port: int):
             # MultiProcessCollector re-reads the .db files from
             # PROMETHEUS_MULTIPROC_DIR.  This is necessary when not using
             # make_wsgi_app/make_asgi_app, which handle this internally.
+            #
+            # Use OpenMetrics format (same as make_asgi_app) so that metric
+            # names with colons (e.g. sglang:prompt_tokens_total) are
+            # converted to underscores, matching the HTTP-mode output that
+            # Grafana dashboards expect.
             registry = CollectorRegistry()
             multiprocess.MultiProcessCollector(registry)
             data = generate_latest(registry)

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -1,6 +1,56 @@
 """
 Thin gRPC server wrapper — delegates to smg-grpc-servicer package.
+
+When --enable-metrics is set, a lightweight HTTP server is started on
+a separate port (gRPC port + 1) to expose Prometheus /metrics.
 """
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def _start_metrics_server(host: str, port: int):
+    """Start an HTTP server exposing Prometheus /metrics.
+
+    The caller is responsible for calling ``runner.cleanup()`` on the returned
+    AppRunner when shutting down.  The server begins accepting requests before
+    this function returns.
+    """
+    from aiohttp import web
+    from prometheus_client import (
+        CollectorRegistry,
+        generate_latest,
+        multiprocess,
+    )
+    from prometheus_client.exposition import CONTENT_TYPE_LATEST
+
+    async def metrics_handler(request):
+        try:
+            # Create a fresh registry on each request so that
+            # MultiProcessCollector re-reads the .db files from
+            # PROMETHEUS_MULTIPROC_DIR.  This is necessary when not using
+            # make_wsgi_app/make_asgi_app, which handle this internally.
+            registry = CollectorRegistry()
+            multiprocess.MultiProcessCollector(registry)
+            data = generate_latest(registry)
+            return web.Response(
+                body=data,
+                headers={"Content-Type": CONTENT_TYPE_LATEST},
+            )
+        except Exception:
+            logger.exception("Failed to generate Prometheus metrics")
+            return web.Response(status=500, text="Failed to generate metrics")
+
+    app = web.Application()
+    app.router.add_get("/metrics", metrics_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port)
+    await site.start()
+    logger.info("Prometheus metrics server started on http://%s:%d/metrics", host, port)
+    return runner
 
 
 async def serve_grpc(server_args, model_info=None):
@@ -14,4 +64,36 @@ async def serve_grpc(server_args, model_info=None):
             "If already installed, there may be a broken import due to a "
             "version mismatch — see the chained exception above for details."
         ) from e
-    await _serve_grpc(server_args, model_info)
+
+    metrics_runner = None
+    if server_args.enable_metrics:
+        from sglang.srt.observability.func_timer import enable_func_timer
+        from sglang.srt.utils import set_prometheus_multiproc_dir
+
+        # Must set PROMETHEUS_MULTIPROC_DIR before any prometheus_client import
+        # -- both in this process (the metrics server imports it) and in child
+        # processes (schedulers).
+        set_prometheus_multiproc_dir()
+        enable_func_timer()
+
+        metrics_port = server_args.port + 1
+        try:
+            metrics_runner = await _start_metrics_server(server_args.host, metrics_port)
+        except OSError as e:
+            logger.error(
+                "Failed to start metrics server on port %d: %s. "
+                "Continuing without metrics.",
+                metrics_port,
+                e,
+            )
+
+    try:
+        await _serve_grpc(server_args, model_info)
+    finally:
+        if metrics_runner is not None:
+            try:
+                await metrics_runner.cleanup()
+            except Exception:
+                logger.exception(
+                    "Failed to cleanly shut down Prometheus metrics server"
+                )

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -2,7 +2,7 @@
 Thin gRPC server wrapper — delegates to smg-grpc-servicer package.
 
 When --enable-metrics is set, a lightweight HTTP server is started on
-a separate port (gRPC port + 1) to expose Prometheus /metrics.
+--metrics-http-port (default: --port + 1) to expose Prometheus /metrics.
 """
 
 import logging
@@ -29,15 +29,14 @@ async def _start_metrics_server(host: str, port: int):
 
     async def metrics_handler(request):
         try:
-            # Create a fresh registry on each request so that
-            # MultiProcessCollector re-reads the .db files from
-            # PROMETHEUS_MULTIPROC_DIR.  This is necessary when not using
-            # make_wsgi_app/make_asgi_app, which handle this internally.
+            # Create a fresh registry and attach a MultiProcessCollector
+            # on each request.  This is the recommended pattern from the
+            # prometheus_client multiprocess docs to ensure up-to-date
+            # data from PROMETHEUS_MULTIPROC_DIR.
             #
-            # Use OpenMetrics format (same as make_asgi_app) so that metric
-            # names with colons (e.g. sglang:prompt_tokens_total) are
-            # converted to underscores, matching the HTTP-mode output that
-            # Grafana dashboards expect.
+            # Use OpenMetrics format to match what the HTTP-mode endpoint
+            # returns when Prometheus scrapes it with an OpenMetrics Accept
+            # header (make_asgi_app performs content negotiation).
             registry = CollectorRegistry()
             multiprocess.MultiProcessCollector(registry)
             data = generate_latest(registry)
@@ -54,8 +53,12 @@ async def _start_metrics_server(host: str, port: int):
 
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, host, port)
-    await site.start()
+    try:
+        site = web.TCPSite(runner, host, port)
+        await site.start()
+    except BaseException:
+        await runner.cleanup()
+        raise
     logger.info("Prometheus metrics server started on http://%s:%d/metrics", host, port)
     return runner
 
@@ -74,24 +77,34 @@ async def serve_grpc(server_args, model_info=None):
 
     metrics_runner = None
     if server_args.enable_metrics:
-        from sglang.srt.observability.func_timer import enable_func_timer
-        from sglang.srt.utils import set_prometheus_multiproc_dir
-
-        # Must set PROMETHEUS_MULTIPROC_DIR before any prometheus_client import
-        # -- both in this process (the metrics server imports it) and in child
-        # processes (schedulers).
-        set_prometheus_multiproc_dir()
-        enable_func_timer()
-
-        metrics_port = server_args.port + 1
         try:
+            from sglang.srt.observability.func_timer import enable_func_timer
+            from sglang.srt.utils import set_prometheus_multiproc_dir
+
+            # Must set PROMETHEUS_MULTIPROC_DIR env var before any
+            # prometheus_client import.  The env var is inherited by child
+            # processes (schedulers) that import prometheus_client later.
+            set_prometheus_multiproc_dir()
+            enable_func_timer()
+
+            metrics_port = (
+                server_args.metrics_http_port
+                if server_args.metrics_http_port is not None
+                else server_args.port + 1
+            )
             metrics_runner = await _start_metrics_server(server_args.host, metrics_port)
         except OSError as e:
             logger.error(
-                "Failed to start metrics server on port %d: %s. "
-                "Continuing without metrics.",
-                metrics_port,
+                "Failed to start metrics server: %s. " "Continuing without metrics.",
                 e,
+                exc_info=True,
+            )
+        except Exception as e:
+            logger.error(
+                "Unexpected error starting metrics server: %s. "
+                "Continuing without metrics.",
+                e,
+                exc_info=True,
             )
 
     try:
@@ -100,7 +113,8 @@ async def serve_grpc(server_args, model_info=None):
         if metrics_runner is not None:
             try:
                 await metrics_runner.cleanup()
-            except Exception:
+            except Exception as e:
                 logger.exception(
-                    "Failed to cleanly shut down Prometheus metrics server"
+                    "Failed to cleanly shut down Prometheus metrics server: %s",
+                    e,
                 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -405,6 +405,7 @@ class ServerArgs:
     crash_dump_folder: Optional[str] = None
     show_time_cost: bool = False
     enable_metrics: bool = False
+    metrics_http_port: Optional[int] = None
     enable_mfu_metrics: bool = False
     enable_metrics_for_all_schedulers: bool = False
     tokenizer_metrics_custom_labels_header: str = "x-custom-labels"
@@ -4512,6 +4513,14 @@ class ServerArgs:
             "--enable-metrics",
             action="store_true",
             help="Enable log prometheus metrics.",
+        )
+        parser.add_argument(
+            "--metrics-http-port",
+            type=int,
+            default=ServerArgs.metrics_http_port,
+            help="Port for the Prometheus metrics HTTP server. "
+            "Only used in gRPC mode (--grpc-mode); in HTTP mode, metrics are served on the main --port. "
+            "Defaults to --port + 1 when --enable-metrics is set.",
         )
         parser.add_argument(
             "--enable-mfu-metrics",


### PR DESCRIPTION
## Summary
- When `--enable-metrics` is set in gRPC mode, starts a lightweight aiohttp HTTP server to expose Prometheus `/metrics` endpoint
- New `--metrics-http-port` arg to configure the metrics port (defaults to `--port + 1`)
- Uses OpenMetrics format with multiprocess-safe Prometheus collection, matching HTTP-mode output when scraped by Prometheus
- Entire metrics initialization is wrapped in try/except — failures never crash the gRPC server
- Properly cleans up the metrics server on shutdown (including AppRunner leak fix on bind failure)

## Changes
- `python/sglang/srt/entrypoints/grpc_server.py` — new `_start_metrics_server()` and metrics lifecycle in `serve_grpc()`
- `python/sglang/srt/server_args.py` — new `metrics_http_port: Optional[int]` field and `--metrics-http-port` CLI arg

## Test plan
- [x] Start gRPC server with `--enable-metrics` and verify `/metrics` is accessible on `port+1`
- [x] Verify metrics output is valid OpenMetrics format with `# EOF` terminator
- [x] Verified on remote H200 machine (ac-h200-gpu04) with Qwen2.5-0.5B-Instruct — all scheduler metrics present
- [ ] Test `--metrics-http-port 9090` to verify custom port works
- [ ] Test port conflict scenario — server should start without metrics and log a warning
- [ ] Test without `--enable-metrics` — no metrics server should start

🤖 Generated with [Claude Code](https://claude.com/claude-code)