### PR TITLE
[Bugfix] Add DeepseekV32ForCausalLM to MTP draft model mapping

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -279,6 +279,7 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] in [
             "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
             "GlmMoeDsaForCausalLM",
         ]:
             self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"


### PR DESCRIPTION
## Motivation

Speculative decoding (EAGLE/NEXTN MTP) does not work with DeepSeek-V3.2 models (`DeepseekV32ForCausalLM`). The `_config_draft_model()` function only maps `DeepseekV3ForCausalLM` to `DeepseekV3ForCausalLMNextN`, but `DeepseekV32ForCausalLM` is a separate architecture class and is not included.

Without this fix, the draft worker silently loads the full 671B model instead of the lightweight NextN (MTP) layer, causing OOM or falling back to non-speculative behaviour.

## Modifications

Add `DeepseekV32ForCausalLM` to the existing architecture list in `_config_draft_model()` that maps to `DeepseekV3ForCausalLMNextN`.

## Checklist
- [x] Format: `pre-commit run --all-files`
- [x] Verified with `nvidia/DeepSeek-V3.2-NVFP4` (TP=8, EAGLE, steps=3, topk=1, draft_tokens=4)
  - Accept length: 2.65 tokens/step
  - +51% throughput at batch-size 1, +26% at concurrency 48
  - Existing CI test `test_deepseek_v32_fp4_mtp_4gpu.py` targets this exact scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)