### PR TITLE
[HiCache] Reduce per-request backup log noise

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -256,7 +256,7 @@ class DecodeKVCacheOffloadManager:
             # Release host memory
             self.decode_host_mem_pool.free(host_indices)
 
-            logger.info(
+            logger.debug(
                 f"Finished backup request {req_id}, free host memory, len:{len(host_indices)}, cost time:{time.time() - start_time:.2f} seconds."
             )
 


### PR DESCRIPTION
## Summary
- Downgrade the per-request "Finished backup request" log from `info` to `debug` in `decode_kvcache_offload_manager.py`
- This log fires for every page backup on every DP rank. With HiCache ratio=1 and 8 DP ranks, a single request generating 2048 tokens produces ~256 log lines (32 pages × 8 ranks), drowning out useful operational logs.

## Test plan
- [ ] Deploy with `--log-level info` (default) and verify the backup log no longer appears
- [ ] Deploy with `--log-level debug` and verify the backup log still appears
- [ ] Verify HiCache backup functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)