### PR TITLE
fix: repair remote-instance transfer-engine loading

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -152,6 +152,7 @@ class DataParallelController:
         self.scheduler_procs = []
         self.workers: List[zmq.Socket] = [None] * server_args.dp_size
         self.status: List[bool] = [True] * server_args.dp_size
+        self.scheduler_infos = []
 
         if server_args.enable_dp_attention:
             self.launch_dp_attention_schedulers(server_args, port_args)
@@ -488,6 +489,7 @@ class DataParallelController:
         scheduler_info = []
         for i in range(len(scheduler_pipe_readers)):
             scheduler_info.append(scheduler_pipe_readers[i].recv())
+        self.scheduler_infos.extend(scheduler_info)
 
         self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
@@ -589,6 +591,7 @@ def run_data_parallel_controller_process(
                 "status": "ready",
                 "max_total_num_tokens": controller.max_total_num_tokens,
                 "max_req_input_len": controller.max_req_input_len,
+                "scheduler_infos": controller.scheduler_infos,
             }
         )
         if server_args.node_rank == 0:

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2100,9 +2100,18 @@ class RemoteInstanceModelLoader(BaseModelLoader):
         )
 
         quant_config = _get_quantization_config(model_config, self.load_config)
+        target_device = torch.device(device_config.device)
         with set_default_torch_dtype(model_config.dtype):
-            with torch.device(device_config.device):
+            with target_device:
                 model = _initialize_model(model_config, self.load_config, quant_config)
+
+            # Keep remote-instance model layout consistent with the local load
+            # path before TE metadata registration and weight-info validation.
+            for _, module in model.named_modules():
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is not None:
+                    with device_loading_context(module, target_device):
+                        quant_method.process_weights_after_loading(module)
 
         if (
             load_config.remote_instance_weight_loader_backend
@@ -2242,8 +2251,14 @@ class RemoteInstanceModelLoader(BaseModelLoader):
                     f"got ({tensor.numel()}, {tensor.element_size()})"
                 )
                 return False
-            client_ptr = tensor.data_ptr()
+            # Zero-byte tensors do not need data transfer. Some quantized
+            # post-processing paths intentionally rewrite tensors like g_idx
+            # into empty placeholders, and passing them into Mooncake causes
+            # zero-slice transfer tasks to abort inside the transport layer.
             client_len = tensor.numel() * tensor.element_size()
+            if client_len == 0:
+                continue
+            client_ptr = tensor.data_ptr()
             seed_ptr_list.append(seed_ptr)
             client_ptr_list.append(client_ptr)
             client_len_list.append(client_len)

--- a/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
+++ b/python/sglang/srt/model_loader/remote_instance_weight_loader_utils.py
@@ -107,7 +107,16 @@ def get_remote_instance_transfer_engine_info_per_rank(seed_url: str, rank: int):
 
 def parse_remote_instance_transfer_engine_info_from_scheduler_infos(scheduler_infos):
     remote_instance_transfer_engine_info = {}
-    for data in scheduler_infos:
+
+    def iter_scheduler_infos(items):
+        for data in items:
+            nested_infos = data.get("scheduler_infos")
+            if nested_infos:
+                yield from iter_scheduler_infos(nested_infos)
+            else:
+                yield data
+
+    for data in iter_scheduler_infos(scheduler_infos):
         if (
             "tp_rank" in data
             and "remote_instance_transfer_engine_session_id" in data

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -863,5 +863,13 @@ class KimiK25ForConditionalGeneration(nn.Module):
 
         self.language_model.set_embed_and_head(embed, head)
 
+    def post_load_weights(self, *args, **kwargs):
+        # remote_instance paths may bypass KimiK25.load_weights() and call
+        # post_load_weights() on the top-level model directly. Forward to the
+        # wrapped language model so DeepSeek MLA can derive weights like
+        # w_kc/w_vc from kv_b_proj before graph capture starts.
+        if hasattr(self.language_model, "post_load_weights"):
+            self.language_model.post_load_weights(*args, **kwargs)
+
 
 EntryClass = [KimiK25ForConditionalGeneration]


### PR DESCRIPTION
## Summary
- preserve nested transfer-engine metadata when scheduler info is aggregated through the data parallel controller, so remote-instance seed discovery can still recover per-rank session and weight info
- run quantization post-processing before transfer-engine metadata validation and skip zero-byte tensors during transfer submission, which keeps remote-instance layouts aligned with local seeds and avoids zero-slice transport aborts
- forward `post_load_weights()` from the Kimi wrapper to the underlying language model so MLA-derived tensors such as `w_kc` and `w_vc` are materialized before graph capture

## Test plan
- reproduced the remote-instance loading failures on a Kimi K2.5 deployment and verified the patched branch fixes those startup issues
- not run: upstream unit tests / pre-commit in this repo snapshot