### PR TITLE
Fix scale_step_k computation in the fp8_kernel

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -759,7 +759,7 @@ def _w8a8_block_fp8_matmul(
     As_ptrs = As + offs_am * stride_As_m
     offs_bsn = offs_bn // group_n
     Bs_ptrs = Bs + offs_bsn * stride_Bs_n
-    scale_step_k = BLOCK_SIZE_K // group_k
+    n_tiles_k_per_group_k = group_k // BLOCK_SIZE_K
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -773,6 +773,7 @@ def _w8a8_block_fp8_matmul(
         a_s = tl.load(As_ptrs)
         b_s = tl.load(Bs_ptrs)
 
+        scale_step_k = tl.where((k + 1) % n_tiles_k_per_group_k == 0, 1, 0)
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk


### PR DESCRIPTION
## Motivation
According to the kernel design, `group_k` is expected to be divisible by `BLOCK_SIZE_K`. However, when `BLOCK_SIZE_K` is smaller than `group_k`, `scale_step_k` is always computed as `0`, which prevents the scaling pointer from advancing. 

For example, with `BLOCK_SIZE_K = 64` and `group_k = 128`, the current implementation results in `scale_step_k = 0`. 

This fix ensures the kernel correctly handles such cases by properly updating the scaling pointer. 

## Modifications
1. Compute the number of blocks within each `group_k` (i.e., how many blocks share the same scaling parameters).
2. Update `scale_step_k` to `1` only after the last block in the group has consumed the shared scaling parameters, ensuring the pointer advances correctly.


## Accuracy Tests

Server Launching Scripts:
```py

# before using default fp8 config, which mean BLOCK_SIZE_K is always equal to group_k
python -m sglang.launch_server --model-path /models/Qwen3.5-35B-A3B-FP8/0b2752837483aa34b3db6e83e151b150c0e00e49 --tp-size 1 --reasoning-parser qwen3 --tool-call-parser qwen3_coder --port 8888 --mem-fraction-static 0.9


# after using tuned fp8 config
python -m sglang.launch_server --model-path /models/Qwen3.5-35B-A3B-FP8/0b2752837483aa34b3db6e83e151b150c0e00e49 --tp-size 1 --reasoning-parser qwen3 --tool-call-parser qwen3_coder --port 8889 --mem-fraction-static 0.9
```

**E2E Accuracy Tests**
### MMLU
```py
# before
python3 -m sglang.test.run_eval --port 8888 --eval-name mmlu --num-examples 200 --repeat 3  --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0 --max-tokens 4096
```
<img width="1274" height="539" alt="image" src="https://github.com/user-attachments/assets/460ffd3d-8801-4243-b095-308b40d33cb1" />

```py
# after
python3 -m sglang.test.run_eval --port 8889 --eval-name mmlu --num-examples 200 --repeat 3 --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0 --max-tokens 4096
```
<img width="1274" height="537" alt="image" src="https://github.com/user-attachments/assets/b83a0ea8-06f7-4973-a54b-c04e46964353" />


### GSM8k
<img width="1712" height="912" alt="image" src="https://github.com/user-attachments/assets/d68890ef-4733-4806-8977-7aa2c15d0e72" />

**Kernel Accuracy Tests**
<img width="1575" height="1203" alt="image" src="https://github.com/user-attachments/assets/83d6d26d-b075-433b-93e8-09499f3492c1" />

The maximum element-wise difference of 1 can be attributed to accumulated numerical errors when using BLOCK_SIZE_K = 64. However in this configuration, the current kernel is more prone to error accumulation, which can lead to noticeable inaccuracies.

## Benchmarking and Profiling

**Kernel Performance Comparison**
<img width="494" height="304" alt="image" src="https://github.com/user-attachments/assets/1828cc3b-21d5-4f2b-84f5-f9227d27ce39" />
The tiny *us* overhead towards this PR, but this can be fine to make the computation logic correct

**E2E Benchmark**
Before:

| random_input_len | random_output_len | request_rate | max_concurrency |  -  | mean_ttft_ms | p99_ttft_ms | mean_tpot_ms | p99_tpot_ms | mean_itl_ms | p99_itl_ms | mean_e2e_latency_ms | p99_e2e_latency_ms | output_throughput |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1200.00 | 800.00 | 1.00 | 1.00 | - | 117.80 | 144.34 | 10.36 | 10.45 | 10.37 | 10.77 | 8394.76 | 8463.76 | 95.29 |
| 1200.00 | 800.00 | 2.00 | 2.00 | - | 118.03 | 130.97 | 12.50 | 12.55 | 12.50 | 12.73 | 10102.16 | 10148.59 | 158.29 |
| 1200.00 | 800.00 | 4.00 | 4.00 | - | 141.86 | 167.82 | 15.57 | 15.76 | 15.58 | 15.91 | 12585.41 | 12714.18 | 253.86 |
| 1200.00 | 800.00 | 8.00 | 8.00 | - | 439.05 | 716.62 | 21.40 | 22.05 | 21.44 | 21.94 | 17538.00 | 17783.10 | 364.42 |
| 1200.00 | 800.00 | 16.00 | 16.00 | - | 5689.39 | 23048.81 | 27.21 | 28.40 | 27.24 | 28.15 | 27433.15 | 45576.83 | 450.99 |


After:
| random_input_len | random_output_len | request_rate | max_concurrency |  -  | mean_ttft_ms | p99_ttft_ms | mean_tpot_ms | p99_tpot_ms | mean_itl_ms | p99_itl_ms | mean_e2e_latency_ms | p99_e2e_latency_ms | output_throughput |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1200.00 | 800.00 | 1.00 | 1.00 | - | 116.68 | 140.34 | 8.84 | 8.90 | 8.87 | 9.20 | 7176.15 | 7237.19 | 111.47 |
| 1200.00 | 800.00 | 2.00 | 2.00 | - | 114.51 | 124.02 | 11.54 | 11.63 | 11.55 | 11.89 | 9334.51 | 9405.63 | 171.30 |
| 1200.00 | 800.00 | 4.00 | 4.00 | - | 142.74 | 220.35 | 14.48 | 14.70 | 14.49 | 14.99 | 11713.21 | 11863.03 | 272.73 |
| 1200.00 | 800.00 | 8.00 | 8.00 | - | 454.02 | 733.78 | 20.75 | 21.51 | 20.94 | 23.94 | 17035.50 | 17333.18 | 375.16 |
| 1200.00 | 800.00 | 16.00 | 16.00 | - | 5575.56 | 22461.90 | 26.45 | 27.59 | 26.52 | 27.48 | 26711.13 | 44461.92 | 463.62 |

The correctness check and performance benchmark about kernel can be seen in https://github.com/Muqi1029/Awesome-LLM-Training-Serving/blob/main/tutorial/triton/benchmark/fp8_kernel.py

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
6. After green CI and required approvals, ask Merge Oncalls to merge.
