### PR TITLE
fix(internvl): resolve return_dict=None before bool check in CUDA graph path

### DIFF
--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -347,6 +347,13 @@ class InternVisionEncoder(nn.Module):
                 Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
         """
         if self.enable_cg and (not output_hidden_states):
+            # Resolve return_dict=None to config default, same as the non-graph
+            # path below.  Without this, `not None` evaluates to True and the
+            # CUDA-graph path always returns a plain tuple, breaking callers
+            # (e.g. RadioInternVisionModel) that expect a BaseModelOutput.
+            return_dict = (
+                return_dict if return_dict is not None else self.config.use_return_dict
+            )
             # graph path only returns last_hidden_state
             hidden_states = inputs_embeds.to(device=inputs_embeds.device).contiguous()
             hidden_states = self.cuda_graph_runner.run(hidden_states)


### PR DESCRIPTION
## Summary

- Fix `InternVisionEncoder.forward()` CUDA graph path returning `tuple` instead of `BaseModelOutput` when `return_dict=None` (the default)
- Resolve `return_dict=None` to `self.config.use_return_dict` **before** using it as a boolean, matching the behavior of the non-CUDA-graph code path
- Prevents `AssertionError` in `RadioInternVisionModel` (and other callers that expect `BaseModelOutput`) when processing image requests with `SGLANG_VIT_ENABLE_CUDA_GRAPH=1`

## Root Cause

`not None` evaluates to `True` in Python, so `if not return_dict:` always took the tuple-return branch when `return_dict` was not explicitly passed. The non-CUDA-graph path already resolves this correctly; this fix applies the same resolution to the fast path.

Fixes #20638

## Test Plan

- [ ] Serve a RADIO-based VLM (e.g. `NVIDIA-Nemotron-Nano-12B-v2-VL`) with `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` and `--mm-attention-backend triton_attn`
- [ ] Send a request with an image and verify no `AssertionError` occurs
- [ ] Text-only requests continue to work as before