### PR TITLE
[Bugfix] Fix whitespace stripping in GLM detector tool call arguments

### DIFF
--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -759,7 +759,6 @@ class Glm47MoeDetector(BaseFormatDetector):
         arguments = {}
         for arg_key, arg_value in pairs:
             arg_key = arg_key.strip()
-            arg_value = arg_value.strip()
             arg_type = get_argument_type(func_name, arg_key, tools)
             parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
 

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -613,7 +613,6 @@ class Glm4MoeDetector(BaseFormatDetector):
         arguments = {}
         for arg_key, arg_value in pairs:
             arg_key = arg_key.strip()
-            arg_value = arg_value.strip()
             arg_type = get_argument_type(func_name, arg_key, tools)
             parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
 

--- a/test/registered/unit/function_call/test_glm47_moe_detector.py
+++ b/test/registered/unit/function_call/test_glm47_moe_detector.py
@@ -1287,6 +1287,77 @@ class TestGlm47MoeDetector(unittest.TestCase):
         self.assertEqual(params["old_string"], "    def foo():")
         self.assertEqual(params["new_string"], "        def bar():")
 
+    def test_whitespace_preserved_streaming_glm4(self):
+        """Regression test for issue #20542: whitespace preservation in GLM4 streaming."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="apply_diff",
+                    description="Apply a diff to a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "old_string": {"type": "string"},
+                            "new_string": {"type": "string"},
+                        },
+                        "required": ["old_string", "new_string"],
+                    },
+                ),
+            ),
+        ]
+        nl = chr(10)
+        chunks = [
+            "<tool_call>apply_diff" + nl,
+            "<arg_key>old_string</arg_key>" + nl,
+            "<arg_value>    def foo():</arg_value>" + nl,
+            "<arg_key>new_string</arg_key>" + nl,
+            "<arg_value>        def bar():</arg_value>" + nl,
+            "</tool_call>",
+        ]
+        detector = Glm4MoeDetector()
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, tools)
+            all_calls.extend(result.calls)
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "apply_diff")
+        full_params = "".join([c.parameters for c in all_calls if c.parameters])
+        params = json.loads(full_params)
+        self.assertEqual(params["old_string"], "    def foo():")
+        self.assertEqual(params["new_string"], "        def bar():")
+
+    def test_whitespace_trailing_preserved(self):
+        """Test that trailing whitespace in string values is also preserved."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="apply_diff",
+                    description="Apply a diff to a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "old_string": {"type": "string"},
+                        },
+                        "required": ["old_string"],
+                    },
+                ),
+            ),
+        ]
+        text = (
+            "<tool_call>apply_diff"
+            "<arg_key>old_string</arg_key>"
+            "<arg_value>hello world   </arg_value>"
+            "</tool_call>"
+        )
+        detector = Glm47MoeDetector()
+        result = detector.detect_and_parse(text, tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["old_string"], "hello world   ")
+
 
 class TestGlm4ComplexJsonSchema(unittest.TestCase):
     """Test complex JSON Schema type inference for GLM function call parsers."""

--- a/test/registered/unit/function_call/test_glm47_moe_detector.py
+++ b/test/registered/unit/function_call/test_glm47_moe_detector.py
@@ -1171,6 +1171,122 @@ class TestGlm47MoeDetector(unittest.TestCase):
             f"'value' appears {value_count} times - indicates reprocessing bug",
         )
 
+    # ==================== Whitespace Preservation Tests ====================
+
+    def test_whitespace_preserved_in_string_args_glm47(self):
+        """Regression test for issue #20542: whitespace preservation in GLM47."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="apply_diff",
+                    description="Apply a diff to a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "old_string": {"type": "string"},
+                            "new_string": {"type": "string"},
+                        },
+                        "required": ["old_string", "new_string"],
+                    },
+                ),
+            ),
+        ]
+        text = (
+            "<tool_call>apply_diff"
+            "<arg_key>old_string</arg_key>"
+            "<arg_value>    def foo():</arg_value>"
+            "<arg_key>new_string</arg_key>"
+            "<arg_value>        def bar():</arg_value>"
+            "</tool_call>"
+        )
+        detector = Glm47MoeDetector()
+        result = detector.detect_and_parse(text, tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["old_string"], "    def foo():")
+        self.assertEqual(params["new_string"], "        def bar():")
+
+    def test_whitespace_preserved_in_string_args_glm4(self):
+        """Regression test for issue #20542: whitespace preservation in GLM4."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="apply_diff",
+                    description="Apply a diff to a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "old_string": {"type": "string"},
+                            "new_string": {"type": "string"},
+                        },
+                        "required": ["old_string", "new_string"],
+                    },
+                ),
+            ),
+        ]
+        nl = chr(10)
+        text = (
+            "<tool_call>apply_diff"
+            + nl
+            + "<arg_key>old_string</arg_key>"
+            + nl
+            + "<arg_value>    def foo():</arg_value>"
+            + nl
+            + "<arg_key>new_string</arg_key>"
+            + nl
+            + "<arg_value>        def bar():</arg_value>"
+            + nl
+            + "</tool_call>"
+        )
+        detector = Glm4MoeDetector()
+        result = detector.detect_and_parse(text, tools)
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["old_string"], "    def foo():")
+        self.assertEqual(params["new_string"], "        def bar():")
+
+    def test_whitespace_preserved_streaming_glm47(self):
+        """Regression test for issue #20542: whitespace preservation in streaming."""
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="apply_diff",
+                    description="Apply a diff to a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "old_string": {"type": "string"},
+                            "new_string": {"type": "string"},
+                        },
+                        "required": ["old_string", "new_string"],
+                    },
+                ),
+            ),
+        ]
+        chunks = [
+            "<tool_call>apply_diff",
+            "<arg_key>old_string</arg_key>",
+            "<arg_value>    def foo():</arg_value>",
+            "<arg_key>new_string</arg_key>",
+            "<arg_value>        def bar():</arg_value>",
+            "</tool_call>",
+        ]
+        detector = Glm47MoeDetector()
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, tools)
+            all_calls.extend(result.calls)
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "apply_diff")
+        full_params = "".join([c.parameters for c in all_calls if c.parameters])
+        params = json.loads(full_params)
+        self.assertEqual(params["old_string"], "    def foo():")
+        self.assertEqual(params["new_string"], "        def bar():")
+
 
 class TestGlm4ComplexJsonSchema(unittest.TestCase):
     """Test complex JSON Schema type inference for GLM function call parsers."""


### PR DESCRIPTION
## Motivation

`Glm4MoeDetector._parse_argument_pairs` and `Glm47MoeDetector._parse_argument_pairs` both call `arg_value.strip()` on extracted argument values before parsing them. This strips leading and trailing whitespace from string-typed arguments, which is lossy when whitespace is significant (e.g., source code with meaningful indentation in code-editing tool calls).

## Solution

Remove the `arg_value.strip()` call from both detectors. The `arg_key.strip()` is retained since keys are identifiers where whitespace is never significant. The downstream `parse_arguments()` function already handles the raw value correctly:
- For string types it uses the value as-is (preserving whitespace)
- For structured types (objects, arrays, numbers) it parses via `json.loads()` which is inherently whitespace-insensitive

## Changes

- `python/sglang/srt/function_call/glm4_moe_detector.py`: Remove `arg_value = arg_value.strip()` (line 616)
- `python/sglang/srt/function_call/glm47_moe_detector.py`: Remove `arg_value = arg_value.strip()` (line 762)

Fixes #20542

## Test plan

- Existing GLM detector tests continue to pass (whitespace in existing test values is not leading/trailing)
- Five new regression tests added:
  - GLM47 non-streaming: leading whitespace preserved in string args
  - GLM4 non-streaming: leading whitespace preserved in string args
  - GLM47 streaming: leading whitespace preserved during incremental parsing
  - GLM4 streaming: leading whitespace preserved during incremental parsing
  - Trailing whitespace preservation: trailing spaces kept intact in string args