### PR TITLE
[MPS] Add StreamContext stub to fix server crash on macOS

### DIFF
--- a/python/sglang/_mps_stub.py
+++ b/python/sglang/_mps_stub.py
@@ -47,6 +47,22 @@ class Stream:
         pass
 
 
+class StreamContext:
+    """Minimal stand-in for ``torch.cuda.StreamContext``.
+
+    MPS has no user-visible streams, so entering / exiting is a no-op.
+    """
+
+    def __init__(self, stream: Any = None) -> None:
+        self.stream = stream
+
+    def __enter__(self) -> "StreamContext":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
 class Event:
     """Minimal stand-in for ``torch.cuda.Event``."""
 
@@ -235,6 +251,7 @@ def install() -> None:
     # Only patch attributes that are actually missing
     for name, obj in [
         ("Stream", Stream),
+        ("StreamContext", StreamContext),
         ("Event", Event),
         ("current_stream", current_stream),
         ("stream", stream),


### PR DESCRIPTION
## Motivation

Fixes #20728

The SGLang server crashes immediately on launch when using `--device mps` on macOS with:

```
AttributeError: module 'torch.mps' has no attribute 'StreamContext'
```

This happens in `scheduler.py` at `self.device_module.StreamContext(self.schedule_stream)` because `torch.mps` does not provide a `StreamContext` API (MPS has no user-visible streams).

## Modifications

Added a no-op `StreamContext` class to `python/sglang/_mps_stub.py` and registered it in the `install()` function so it gets monkey-patched onto `torch.mps` at startup. This follows the exact same pattern already used for `Stream` and `Event` stubs in the same file (introduced by #19549).

The `StreamContext` stub is a simple context manager that does nothing on enter/exit, which is correct because MPS operates on a single command queue with no multi-stream semantics.

## Test plan

- [ ] Verify server launches without crash on macOS with `--device mps`
- [ ] Verify no regression on CUDA (the stub is only patched when `torch.mps` lacks the attribute)