### PR TITLE
Fix unbounded Prometheus label cardinality in priority scheduling

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -80,6 +80,7 @@ from sglang.srt.managers.tokenizer_manager_multiitem_mixin import (
     TokenizerManagerMultiItemMixin,
 )
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
+from sglang.srt.observability.label_transform import transform_priority
 from sglang.srt.observability.metrics_collector import TokenizerMetricsCollector
 from sglang.srt.observability.req_time_stats import (
     APIServerReqTimeStats,
@@ -1926,8 +1927,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             labels.update(custom_labels)
         if self.enable_priority_scheduling:
             priority = getattr(state.obj, "priority", None)
-            if priority is not None:
-                labels["priority"] = str(priority)
+            labels["priority"] = transform_priority(priority)
         if (
             not state.ttft_observed
             and self.disaggregation_mode != DisaggregationMode.PREFILL

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.observability.label_transform import transform_priority
 from sglang.srt.observability.utils import exponential_buckets, generate_buckets
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_bool_env_var
@@ -59,15 +60,14 @@ class QueueCount:
     """Holds both the total count and optional per-priority breakdown for a queue."""
 
     total: int = 0
-    by_priority: Optional[Dict[int, int]] = None
+    by_priority: Optional[Dict[str, int]] = None
 
     @classmethod
     def from_reqs(cls, reqs: List[Req], enable_priority_scheduling: bool = False):
-        # NOTE: If requests have priority=None (no --default-priority-value set),
-        # Counter will produce {None: N}, resulting in priority="None" Prometheus labels.
-        # Set --default-priority-value when enabling priority scheduling to avoid this.
+        # Bucket raw priority integers via transform_priority() so that
+        # the number of distinct Prometheus label values is bounded.
         by_priority = (
-            dict(Counter(req.priority for req in reqs))
+            dict(Counter(transform_priority(req.priority) for req in reqs))
             if enable_priority_scheduling
             else None
         )
@@ -183,7 +183,7 @@ class SchedulerMetricsCollector:
         self.enable_lora = enable_lora
         self.enable_hierarchical_cache = enable_hierarchical_cache
         self.last_log_time = time.perf_counter()
-        self._known_priorities: Set[int] = set()
+        self._known_priorities: Set[str] = set()
 
         self.num_running_reqs = Gauge(
             name="sglang:num_running_reqs",
@@ -788,7 +788,7 @@ class SchedulerMetricsCollector:
             for priority in self._known_priorities:
                 value = data.by_priority.get(priority, 0)
                 labels = dict(self.labels)
-                labels["priority"] = str(priority)
+                labels["priority"] = priority
                 gauge.labels(**labels).set(value)
 
     def _log_histogram(self, histogram, data: Union[int, float]) -> None:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -778,10 +778,10 @@ class SchedulerMetricsCollector:
         gauge.labels(**self.labels).set(data)
 
     def _log_gauge_queue_count(self, gauge: Gauge, data: QueueCount) -> None:
-        # Log a QueueCount to gauge: total under default labels, per-priority breakdown under priority="<int>".
+        # Log a QueueCount to gauge: total under default labels, per-priority breakdown under priority="<bucket>".
         # NOTE: When priority scheduling is enabled, the total is recorded under
         # priority="" (the default label value). Per-priority breakdowns are recorded
-        # with priority="<int>". Grafana queries should use priority="" for totals.
+        # with priority="<bucket>". Grafana queries should use priority="" for totals.
         gauge.labels(**self.labels).set(data.total)
         if data.by_priority is not None:
             self._known_priorities.update(data.by_priority.keys())

--- a/test/registered/metrics/test_priority_metrics.py
+++ b/test/registered/metrics/test_priority_metrics.py
@@ -50,7 +50,7 @@ class TestQueueCount(CustomTestCase):
     """Unit tests for QueueCount (no server needed)."""
 
     def test_queue_count_from_reqs(self):
-        """QueueCount correctly counts per-priority breakdown."""
+        """QueueCount correctly counts per-priority breakdown (bucketed to strings)."""
         reqs = [
             Mock(priority=1),
             Mock(priority=1),
@@ -60,7 +60,8 @@ class TestQueueCount(CustomTestCase):
         ]
         qc = QueueCount.from_reqs(reqs, enable_priority_scheduling=True)
         self.assertEqual(qc.total, 5)
-        self.assertEqual(qc.by_priority, {1: 2, 5: 2, 10: 1})
+        # Keys are now strings produced by transform_priority()
+        self.assertEqual(qc.by_priority, {"1": 2, "5": 2, "10": 1})
 
     def test_queue_count_from_reqs_disabled(self):
         """Priority scheduling disabled → no breakdown."""
@@ -74,6 +75,22 @@ class TestQueueCount(CustomTestCase):
         qc = QueueCount.from_reqs([], enable_priority_scheduling=True)
         self.assertEqual(qc.total, 0)
         self.assertEqual(qc.by_priority, {})
+
+    def test_queue_count_out_of_range_priorities_are_bucketed(self):
+        """Out-of-range priorities are bucketed to prevent unbounded cardinality."""
+        reqs = [
+            Mock(priority=-5),
+            Mock(priority=-100),
+            Mock(priority=99999),
+            Mock(priority=31),
+            Mock(priority=0),
+            Mock(priority=None),
+        ]
+        qc = QueueCount.from_reqs(reqs, enable_priority_scheduling=True)
+        self.assertEqual(qc.total, 6)
+        # -5 and -100 both map to "LOW", 99999 and 31 both map to "HIGH",
+        # 0 maps to "0", None maps to "UNKNOWN"
+        self.assertEqual(qc.by_priority, {"LOW": 2, "HIGH": 2, "0": 1, "UNKNOWN": 1})
 
 
 class TestPriorityMetrics(CustomTestCase):


### PR DESCRIPTION
## Summary
- **Fixes #20814** - When `--enable-priority-scheduling` is active, raw priority integers were used directly as Prometheus labels with no range limit. Each unique priority value registered a new time series, causing `_known_priorities` to grow indefinitely and leading to memory leaks and DoS.
- Applied the existing `transform_priority()` function from `label_transform.py` to bucket raw priority integers into a bounded set of string labels (`0`-`30` as-is, `<0` -> `LOW`, `>=31` -> `HIGH`, `None` -> `UNKNOWN`) before using them as Prometheus label values.
- This bounds the maximum number of distinct priority label values to 34 (31 numeric + LOW + HIGH + UNKNOWN), preventing cardinality explosion.

## Changes
- **`python/sglang/srt/observability/metrics_collector.py`**: `QueueCount.from_reqs()` now applies `transform_priority()` to bucket raw priority values. `_known_priorities` and `by_priority` types updated from `int` to `str` keys. Removed unnecessary `str()` wrapper in `_log_gauge_queue_count()`.
- **`python/sglang/srt/managers/tokenizer_manager.py`**: Per-request histogram labels now use `transform_priority()` instead of raw `str(priority)`, and always set the priority label (using `UNKNOWN` for `None`).
- **`test/registered/metrics/test_priority_metrics.py`**: Updated unit tests to expect string-keyed `by_priority` dicts. Added test for out-of-range priority bucketing.

## Test plan
- [x] Existing `TestQueueCount` unit tests updated and passing
- [x] New `test_queue_count_out_of_range_priorities_are_bucketed` test covers edge cases (negative, very large, None)
- [ ] `TestPriorityMetrics` integration tests (require GPU) - priorities 1, 5, 10, 0 are all within the 0-30 range, so expected label values remain unchanged
- [x] Pre-commit checks all pass