### PR TITLE
[MPS] Add MPSEnv to check_env for macOS support

### DIFF
--- a/python/sglang/check_env.py
+++ b/python/sglang/check_env.py
@@ -514,7 +514,6 @@ class MUSAEnv(BaseEnv):
             return {}
 
 
-
 class MPSEnv(BaseEnv):
     """Environment checker for Apple MPS (Metal Performance Shaders)"""
 
@@ -588,6 +587,7 @@ class MPSEnv(BaseEnv):
         # Apple Silicon uses a unified memory architecture with a single GPU
         # device, so there is no multi-device topology to report.
         return {}
+
 
 if __name__ == "__main__":
     if is_cuda_v2():

--- a/python/sglang/check_env.py
+++ b/python/sglang/check_env.py
@@ -523,6 +523,7 @@ class MPSEnv(BaseEnv):
 
     def __init__(self):
         super().__init__()
+        self.package_list = list(self.package_list)
         self.package_list.extend(MPSEnv.EXTRA_PACKAGE_LIST)
 
     def get_info(self):
@@ -543,6 +544,8 @@ class MPSEnv(BaseEnv):
             output = subprocess.check_output(
                 ["system_profiler", "SPDisplaysDataType"],
                 text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=30,
             )
             for line in output.splitlines():
                 line = line.strip()
@@ -555,7 +558,7 @@ class MPSEnv(BaseEnv):
                     gpu_info[key] = line.split(":", 1)[1].strip()
                 elif line.startswith("Total Number of Cores:"):
                     gpu_info["GPU Cores"] = line.split(":", 1)[1].strip()
-        except (subprocess.SubprocessError, FileNotFoundError):
+        except (subprocess.SubprocessError, OSError):
             gpu_info["GPU"] = "Not Available"
         return gpu_info
 
@@ -571,11 +574,11 @@ class MPSEnv(BaseEnv):
         # Apple Silicon uses unified memory shared between CPU and GPU
         try:
             output = subprocess.check_output(
-                ["sysctl", "-n", "hw.memsize"], text=True
+                ["sysctl", "-n", "hw.memsize"], text=True, timeout=10
             ).strip()
             mem_bytes = int(output)
             mac_info["Unified Memory"] = f"{mem_bytes / (1024 ** 3):.1f} GB"
-        except (subprocess.SubprocessError, FileNotFoundError, ValueError):
+        except (subprocess.SubprocessError, OSError, ValueError):
             pass
         return mac_info
 

--- a/python/sglang/check_env.py
+++ b/python/sglang/check_env.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import os
+import platform
 import resource
 import subprocess
 import sys
@@ -10,7 +11,7 @@ from collections import OrderedDict, defaultdict
 
 import torch
 
-from sglang.srt.utils import is_hip, is_musa, is_npu
+from sglang.srt.utils import is_hip, is_mps, is_musa, is_npu
 
 
 def is_cuda_v2():
@@ -513,6 +514,81 @@ class MUSAEnv(BaseEnv):
             return {}
 
 
+
+class MPSEnv(BaseEnv):
+    """Environment checker for Apple MPS (Metal Performance Shaders)"""
+
+    EXTRA_PACKAGE_LIST = [
+        "mlx",
+    ]
+
+    def __init__(self):
+        super().__init__()
+        self.package_list.extend(MPSEnv.EXTRA_PACKAGE_LIST)
+
+    def get_info(self):
+        mps_info = {"MPS available": torch.backends.mps.is_available()}
+        if mps_info["MPS available"]:
+            mps_info.update(self.get_device_info())
+            mps_info.update(self._get_macos_info())
+        return mps_info
+
+    def get_device_info(self):
+        """
+        Get information about the Apple GPU via system_profiler.
+        torch.mps does not expose device name or count APIs, so we
+        fall back to macOS system_profiler.
+        """
+        gpu_info = {}
+        try:
+            output = subprocess.check_output(
+                ["system_profiler", "SPDisplaysDataType"],
+                text=True,
+            )
+            for line in output.splitlines():
+                line = line.strip()
+                if line.startswith("Chipset Model:"):
+                    gpu_info["GPU"] = line.split(":", 1)[1].strip()
+                elif line.startswith("Metal Support:") or line.startswith(
+                    "Metal Family:"
+                ):
+                    key = line.split(":", 1)[0].strip()
+                    gpu_info[key] = line.split(":", 1)[1].strip()
+                elif line.startswith("Total Number of Cores:"):
+                    gpu_info["GPU Cores"] = line.split(":", 1)[1].strip()
+        except (subprocess.SubprocessError, FileNotFoundError):
+            gpu_info["GPU"] = "Not Available"
+        return gpu_info
+
+    def _get_macos_info(self):
+        """
+        Get macOS and hardware version information.
+        """
+        mac_info = {}
+        mac_ver = platform.mac_ver()[0]
+        if mac_ver:
+            mac_info["macOS Version"] = mac_ver
+        mac_info["Machine"] = platform.machine()
+        # Apple Silicon uses unified memory shared between CPU and GPU
+        try:
+            output = subprocess.check_output(
+                ["sysctl", "-n", "hw.memsize"], text=True
+            ).strip()
+            mem_bytes = int(output)
+            mac_info["Unified Memory"] = f"{mem_bytes / (1024 ** 3):.1f} GB"
+        except (subprocess.SubprocessError, FileNotFoundError, ValueError):
+            pass
+        return mac_info
+
+    def get_hypervisor_vendor(self) -> dict:
+        # lscpu is not available on macOS
+        return {}
+
+    def get_topology(self):
+        # Apple Silicon uses a unified memory architecture with a single GPU
+        # device, so there is no multi-device topology to report.
+        return {}
+
 if __name__ == "__main__":
     if is_cuda_v2():
         env = GPUEnv()
@@ -522,4 +598,9 @@ if __name__ == "__main__":
         env = NPUEnv()
     elif is_musa():
         env = MUSAEnv()
+    elif is_mps():
+        env = MPSEnv()
+    else:
+        print("No supported device found (CUDA, ROCm, NPU, MUSA, or MPS).")
+        sys.exit(1)
     env.check_env()


### PR DESCRIPTION
## Summary

- Add an `MPSEnv` class to `check_env.py` so that `python -m sglang.check_env` works on macOS with Apple MPS devices
- Report MPS availability, GPU model / Metal support / GPU cores (via `system_profiler`), macOS version, machine architecture, and unified memory size
- Check the `mlx` package version (used for optional MPS kernel acceleration)
- Add a fallback `else` branch so the script exits cleanly when no supported device is detected, instead of crashing with `UnboundLocalError`

Fixes #20727

## Modifications

`python/sglang/check_env.py`:
- Added `import platform` and `is_mps` import from `sglang.srt.utils`
- Added `MPSEnv(BaseEnv)` class that overrides `get_info()`, `get_device_info()`, `get_hypervisor_vendor()`, and `get_topology()` for macOS
- Updated `__main__` block to include `elif is_mps(): env = MPSEnv()` and a fallback `else` branch
- Added subprocess timeouts (30s for `system_profiler`, 10s for `sysctl`) to prevent hangs
- Added `stderr=subprocess.DEVNULL` to `system_profiler` call to suppress noise
- Widened exception handling from `FileNotFoundError` to `OSError` to also catch `PermissionError` and other OS-level failures
- Copy `package_list` before extending in `__init__` to avoid mutating the global `PACKAGE_LIST`

## Test plan

- [ ] Run `python -m sglang.check_env` on a macOS machine with Apple Silicon (MPS available) and verify the output includes MPS availability, GPU info, macOS version, unified memory, and mlx package version
- [ ] Run `python -m sglang.check_env` on a Linux machine with CUDA and verify no regressions (existing paths still work)
- [ ] Verify the fallback `else` branch prints a clear message on unsupported platforms