### PR TITLE
[Refactor] honor chat-template defaults in reasoning-mode resolution

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1256,7 +1256,11 @@ class OpenAIServingChat(OpenAIServingBase):
 
         # Explicit request parameter has the highest priority.
         if request.chat_template_kwargs and param_name in request.chat_template_kwargs:
-            return request.chat_template_kwargs.get(param_name) is not False
+            value = request.chat_template_kwargs.get(param_name)
+            if not parser_default:
+                # Off-by-default parsers require an explicit True signal.
+                return value is True
+            return value is not False
 
         # If omitted, use the default inferred from chat template when available.
         get_template_default = getattr(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1090,7 +1090,7 @@ class OpenAIServingChat(OpenAIServingBase):
             # Align with Kimi-K2 format: functions.{name}:{index}
             # Kimi-K2 allows multiple tool_calls in one message; SGLang sets call_item.tool_index to the *local* position inside that message.
             # Therefore, the index must be corrected by using `history_tool_calls_cnt + call_item.tool_index` to ensure globally unique and properly ordered.
-            tool_call_id = f"functions.{call_item.name}:{history_tool_calls_cnt+call_item.tool_index}"
+            tool_call_id = f"functions.{call_item.name}:{history_tool_calls_cnt + call_item.tool_index}"
             logger.debug(
                 f"Process tool call idx, parser: {self.tool_call_parser}, tool_call_id: {tool_call_id}, history_cnt: {history_tool_calls_cnt}"
             )
@@ -1238,25 +1238,37 @@ class OpenAIServingChat(OpenAIServingBase):
         """Judge whether the request needs reasoning"""
         if not self.reasoning_parser:
             return False
-        if self.reasoning_parser in ["deepseek-v3"]:
-            # Models that require explicit enable thinking (thinking=True)
-            return (
-                request.chat_template_kwargs is not None
-                and request.chat_template_kwargs.get("thinking") is True
-            )
-        if self.reasoning_parser in ["kimi_k2"]:
-            # Models that thinking by default, and can be disabled by setting thinking=False
-            return (
-                not request.chat_template_kwargs
-                or request.chat_template_kwargs.get("thinking") is not False
-            )
-        if self.reasoning_parser in ["qwen3", "glm45", "nemotron_3", "interns1"]:
-            # Models that thinking by default, and can be disabled by setting enable_thinking=False
-            return (
-                not request.chat_template_kwargs
-                or request.chat_template_kwargs.get("enable_thinking") is not False
-            )
-        return True  # default
+
+        parser_control_config = {
+            # parser: (chat_template bool key, parser-level fallback default)
+            "deepseek-v3": ("thinking", False),
+            "kimi_k2": ("thinking", True),
+            "qwen3": ("enable_thinking", True),
+            "glm45": ("enable_thinking", True),
+            "nemotron_3": ("enable_thinking", True),
+            "interns1": ("enable_thinking", True),
+        }
+        control_config = parser_control_config.get(self.reasoning_parser)
+        if control_config is None:
+            return True
+
+        param_name, parser_default = control_config
+
+        # Explicit request parameter has the highest priority.
+        if request.chat_template_kwargs and param_name in request.chat_template_kwargs:
+            return request.chat_template_kwargs.get(param_name) is not False
+
+        # If omitted, use the default inferred from chat template when available.
+        get_template_default = getattr(
+            self.template_manager, "get_chat_template_bool_default", None
+        )
+        if callable(get_template_default):
+            template_default = get_template_default(param_name)
+            if template_default is not None:
+                return template_default
+
+        # Fallback to parser-level historical behavior.
+        return parser_default
 
     async def _process_tool_call_stream(
         self,

--- a/python/sglang/srt/managers/template_manager.py
+++ b/python/sglang/srt/managers/template_manager.py
@@ -58,6 +58,7 @@ class TemplateManager:
         self._completion_template_name: Optional[str] = None
         self._jinja_template_content_format: Optional[str] = "openai"
         self._force_reasoning: bool = False
+        self._chat_template_bool_defaults: Dict[str, bool] = {}
 
     @property
     def chat_template_name(self) -> Optional[str]:
@@ -84,6 +85,10 @@ class TemplateManager:
         """
         return self._force_reasoning
 
+    def get_chat_template_bool_default(self, param_name: str) -> Optional[bool]:
+        """Get detected default for a bool chat-template parameter."""
+        return self._chat_template_bool_defaults.get(param_name)
+
     def _detect_reasoning_pattern(self, template: str) -> bool:
         """
         Detect if the chat template contains reasoning/thinking patterns.
@@ -99,6 +104,48 @@ class TemplateManager:
             logger.info("Detected the force reasoning pattern in chat template.")
 
         return has_reasoning
+
+    def _detect_chat_template_bool_default(
+        self,
+        tokenizer_manager: TokenizerManager,
+        param_name: str,
+    ) -> Optional[bool]:
+        """
+        Detect whether a bool chat-template parameter defaults to True/False.
+
+        Returns:
+            True if template default behavior matches {param_name}=True,
+            False if it matches {param_name}=False,
+            None if unknown or cannot be detected.
+        """
+        tokenizer = tokenizer_manager.tokenizer
+        if tokenizer is None or getattr(tokenizer, "chat_template", None) is None:
+            return None
+        if not hasattr(tokenizer, "apply_chat_template"):
+            return None
+
+        messages = [{"role": "user", "content": "."}]
+        common_kwargs = {"tokenize": False, "add_generation_prompt": True}
+
+        try:
+            prompt_default = tokenizer.apply_chat_template(messages, **common_kwargs)
+            prompt_true = tokenizer.apply_chat_template(
+                messages, **{**common_kwargs, param_name: True}
+            )
+            prompt_false = tokenizer.apply_chat_template(
+                messages, **{**common_kwargs, param_name: False}
+            )
+        except Exception as e:
+            logger.debug(
+                f"Failed to detect default for chat template param '{param_name}': {e}"
+            )
+            return None
+
+        if prompt_default == prompt_true and prompt_default != prompt_false:
+            return True
+        if prompt_default == prompt_false and prompt_default != prompt_true:
+            return False
+        return None
 
     def load_chat_template(
         self,
@@ -141,11 +188,21 @@ class TemplateManager:
                         "No chat template found, defaulting to 'string' content format"
                     )
 
-        # Detect reasoning pattern from chat template
+        # Detect reasoning pattern and bool parameter defaults from chat template
+        self._chat_template_bool_defaults = {}
         if tokenizer_manager.tokenizer:
             self._force_reasoning = self._detect_reasoning_pattern(
                 tokenizer_manager.tokenizer.chat_template
             )
+            # Bool chat-template parameter defaults are only meaningful for HF/Jinja
+            # templates. Built-in conversation templates are handled elsewhere.
+            if self._chat_template_name is None:
+                for param_name in ("enable_thinking", "thinking"):
+                    detected = self._detect_chat_template_bool_default(
+                        tokenizer_manager, param_name
+                    )
+                    if detected is not None:
+                        self._chat_template_bool_defaults[param_name] = detected
 
     def _load_explicit_chat_template(
         self, tokenizer_manager: TokenizerManager, chat_template_arg: str

--- a/test/registered/openai_server/basic/test_serving_chat.py
+++ b/test/registered/openai_server/basic/test_serving_chat.py
@@ -79,6 +79,10 @@ class _MockTemplateManager:
         self.chat_template_name: Optional[str] = "llama-3"
         self.jinja_template_content_format: Optional[str] = None
         self.completion_template_name: Optional[str] = None
+        self.chat_template_bool_defaults = {}
+
+    def get_chat_template_bool_default(self, param_name: str) -> Optional[bool]:
+        return self.chat_template_bool_defaults.get(param_name)
 
 
 class ServingChatTestCase(unittest.TestCase):
@@ -133,6 +137,75 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertIsInstance(adapted, GenerateReqInput)
             self.assertFalse(adapted.stream)
             self.assertEqual(processed, self.basic_req)
+
+    def test_on_by_default_parser_reasoning_resolution_precedence(self):
+        self.chat.reasoning_parser = "qwen3"
+        cases = [
+            (
+                "explicit_true_overrides_template_false",
+                {"enable_thinking": False},
+                {"enable_thinking": True},
+                True,
+            ),
+            (
+                "explicit_false_overrides_template_false",
+                {"enable_thinking": False},
+                {"enable_thinking": False},
+                False,
+            ),
+            (
+                "explicit_none_treated_as_enabled",
+                {"enable_thinking": False},
+                {"enable_thinking": None},
+                True,
+            ),
+            (
+                "template_default_used_when_param_missing",
+                {"enable_thinking": False},
+                None,
+                False,
+            ),
+            ("parser_fallback_used_when_no_template_default", {}, None, True),
+        ]
+
+        for _, template_defaults, kwargs, expected in cases:
+            with self.subTest(
+                template_defaults=template_defaults, kwargs=kwargs, expected=expected
+            ):
+                self.template_manager.chat_template_bool_defaults = template_defaults
+                req = ChatCompletionRequest(
+                    model="test",
+                    messages=[{"role": "user", "content": "Hi?"}],
+                    chat_template_kwargs=kwargs,
+                )
+                self.assertEqual(self.chat._get_reasoning_from_request(req), expected)
+
+    def test_off_by_default_parser_reasoning_resolution_precedence(self):
+        self.chat.reasoning_parser = "deepseek-v3"
+        cases = [
+            ("explicit_true_required", {}, {"thinking": True}, True),
+            ("explicit_false_stays_disabled", {}, {"thinking": False}, False),
+            ("explicit_none_stays_disabled", {}, {"thinking": None}, False),
+            (
+                "template_default_used_when_param_missing",
+                {"thinking": True},
+                None,
+                True,
+            ),
+            ("parser_fallback_used_when_no_template_default", {}, None, False),
+        ]
+
+        for _, template_defaults, kwargs, expected in cases:
+            with self.subTest(
+                template_defaults=template_defaults, kwargs=kwargs, expected=expected
+            ):
+                self.template_manager.chat_template_bool_defaults = template_defaults
+                req = ChatCompletionRequest(
+                    model="test",
+                    messages=[{"role": "user", "content": "Hi?"}],
+                    chat_template_kwargs=kwargs,
+                )
+                self.assertEqual(self.chat._get_reasoning_from_request(req), expected)
 
     def test_jinja_uses_openai_tool_schema_first(self):
         """Ensure Jinja chat templates receive OpenAI-shaped tools by default."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR is a robustness hardening change.

The previous reasoning-mode decision path depended heavily on parser-level fallback assumptions. That made behavior sensitive to template/model differences and configuration variance over time.  
Instead of treating this as a model-specific fix, this change improves the default-resolution mechanism so it is more stable, predictable, and maintainable as new templates/parsers are added.

Residual risk: for non-thinking models without a detectable chat-template boolean default, reasoning-mode resolution still falls back to parser defaults if `--reasoning-parser` is provided.

## Modifications

1. Refactored reasoning flag resolution in `serving_chat.py`:
   - Introduced parser-specific control mapping (`param_name`, fallback default).
   - Unified precedence:
     - explicit request param (`chat_template_kwargs`) >
     - detected chat-template default >
     - parser fallback default.

2. Extended `TemplateManager` to detect and expose template boolean defaults:
   - Added storage for detected bool defaults.
   - Added helper API to query them.
   - Added detection logic by comparing rendered prompts for default/True/False cases.

## Accuracy Tests
Issue #20786  is a concrete example showing that reasoning-mode resolution can become brittle when parser fallback assumptions and chat-template defaults diverge.  
We use #20786 as a representative case, not as a model-specific patch target. In that case, `Qwen/Qwen3.5-0.8B` is a non-thinking model, while its chat template explicitly sets `enable_thinking=false`.

``` bash
sglang serve \
  --model-path Qwen/Qwen3.5-0.8B \
  --port 8000 \
  --reasoning-parser qwen3 \
  --trust-remote-code \
  --attention-backend triton
```

``` bash
curl -s http://127.0.0.1:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model":"Qwen3.5-0.8B",
    "messages":[{"role":"user","content":"What is 2+2?"}],
    "max_tokens":64
  }'
```

``` json
{
  "id": "98e562a83ab3479b8586295d0f3c2870",
  "object": "chat.completion",
  "created": 1773817126,
  "model": "Qwen3.5-0.8B",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Mathematically, the answer to \"What is 2+2?\" is **4**.\n\nThis follows Albert马克思's foolproof demonstration, known as the Einstein paradox (usually attributed to a long-time errant student of Einstein), which proves that addition can always be regrouped. The calculation is:\n$$ ",
        "reasoning_content": null,
        "tool_calls": null
      },
      "logprobs": null,
      "finish_reason": "length",
      "matched_stop": null
    }
  ],
  "usage": {
    "prompt_tokens": 19,
    "total_tokens": 83,
    "completion_tokens": 64,
    "prompt_tokens_details": null,
    "reasoning_tokens": 0
  },
  "metadata": {
    "weight_version": "default"
  }
}
```

Residual risk: for non-thinking models without a detectable chat-template boolean default, reasoning-mode resolution still falls back to parser defaults if `--reasoning-parser` is provided.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
