### PR TITLE
[Perf] Support Flashinfer trtllm tinygemm router gemm for GPT-OSS

### DIFF
--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -75,10 +75,20 @@ from sglang.srt.models.utils import (
     enable_fused_set_kv_buffer,
 )
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import LazyValue, add_prefix, is_npu, make_layers
+from sglang.srt.utils import (
+    LazyValue,
+    add_prefix,
+    get_device_sm,
+    is_cuda,
+    is_flashinfer_available,
+    is_npu,
+    make_layers,
+)
 from sglang.srt.utils.custom_op import register_custom_op
 
 _is_npu = is_npu()
+_is_cuda = is_cuda()
+_device_sm = get_device_sm()
 
 
 class GptOssConfig(PretrainedConfig):
@@ -95,6 +105,43 @@ logger = logging.getLogger(__name__)
 # SGLang assumes exclusive
 def get_attention_sliding_window_size(config):
     return config.sliding_window - 1
+
+
+class MoEGate(ReplicatedLinear):
+    """
+    Router gate that uses flashinfer tinygemm_bf16 when input batch size is <= 128,
+    otherwise falls back to the standard ReplicatedLinear path.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.use_flashinfer_tinygemm = False
+        if (
+            _is_cuda
+            and _device_sm >= 90
+            and is_flashinfer_available()
+            and self.params_dtype == torch.bfloat16
+            and self.input_size % 64 == 0
+            and self.output_size % 16 == 0
+        ):
+            from flashinfer.gemm.routergemm import tinygemm_bf16
+
+            self.use_flashinfer_tinygemm = True
+            self.flashinfer_tinygemm_bf16 = tinygemm_bf16
+
+    def forward(self, x: torch.Tensor):
+        if (
+            self.use_flashinfer_tinygemm
+            and x.dtype == torch.bfloat16
+            and x.shape[0] <= 128
+        ):
+            output = torch.empty(
+                x.shape[0], self.output_size, dtype=torch.bfloat16, device=x.device
+            )
+            self.flashinfer_tinygemm_bf16(x, self.weight, output, bias=self.bias)
+            return output, None
+        return super().forward(x)
 
 
 class GptOssSparseMoeBlock(nn.Module):
@@ -147,7 +194,7 @@ class GptOssSparseMoeBlock(nn.Module):
             **extra_kwargs,
         )
 
-        self.router = ReplicatedLinear(
+        self.router = MoEGate(
             config.hidden_size,
             config.num_local_experts,
             bias=True,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Support Flashinfer trtllm tinygemm router gemm for GPT-OSS, only enable when bs<=128.

## Accuracy Tests
PR:
```
[{'eval_name': 'aime25', 'model_name': 'gpt-oss-120b-low_temp1.0_20260318_083440', 'metric': 0.5291666666666667}]
```
main:
```
[{'eval_name': 'aime25', 'model_name': 'gpt-oss-120b-low_temp1.0_20260318_084625', 'metric': 0.5416666666666666}]
```

## Benchmarking and Profiling
### Kernel:
GPU: NVIDIA B200
```
gpt-oss-120b: hidden_size=2880, num_experts=128, bias=True
 batch  F.linear(us)  tinygemm(us)   speedup
------------------------------------------
     1      0.0057        0.0034     1.66x
     2      0.0059        0.0034     1.72x
     4      0.0059        0.0034     1.72x
     8      0.0059        0.0034     1.72x
    16      0.0061        0.0034     1.78x
    32      0.0061        0.0034     1.78x
    64      0.0059        0.0036     1.62x
   128      0.0061        0.0036     1.68x
   256      0.0061        0.0059     1.03x
   512      0.0061        0.0104     0.59x
```
GPU: NVIDIA H100 PCIe
```
gpt-oss-120b: hidden_size=2880, num_experts=128, bias=True
 batch  F.linear(us)  tinygemm(us)   speedup
------------------------------------------
     1      0.0066        0.0037     1.79x
     2      0.0066        0.0037     1.80x
     4      0.0066        0.0037     1.79x
     8      0.0066        0.0037     1.80x
    16      0.0069        0.0038     1.84x
    32      0.0070        0.0038     1.85x
    64      0.0071        0.0041     1.74x
   128      0.0073        0.0067     1.08x
   256      0.0074        0.0104     0.71x
   512      0.0073        0.0165     0.44x
```

### E2E model perf(GPT-OSS-120b TP2 con8):
PR: **6.9% perf gain**
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     40
Benchmark duration (s):                  20.06
Total input tokens:                      40960
Total input text tokens:                 40960
Total generated tokens:                  40960
Total generated tokens (retokenized):    38856
Request throughput (req/s):              1.99
Input token throughput (tok/s):          2041.78
Output token throughput (tok/s):         2041.78
Peak output token throughput (tok/s):    2304.00
Peak concurrent requests:                16
Total token throughput (tok/s):          4083.56
Concurrency:                             7.99
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4009.39
Median E2E Latency (ms):                 3993.83
P90 E2E Latency (ms):                    4575.41
P99 E2E Latency (ms):                    4576.16
---------------Time to First Token----------------
Mean TTFT (ms):                          239.55
Median TTFT (ms):                        276.98
P99 TTFT (ms):                           678.37
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.69
Median TPOT (ms):                        3.60
P99 TPOT (ms):                           4.10
---------------Inter-Token Latency----------------
Mean ITL (ms):                           3.69
Median ITL (ms):                         3.63
P95 ITL (ms):                            3.79
P99 ITL (ms):                            4.17
Max ITL (ms):                            30.88
==================================================
```
main:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     40
Benchmark duration (s):                  20.14
Total input tokens:                      40960
Total input text tokens:                 40960
Total generated tokens:                  40960
Total generated tokens (retokenized):    40439
Request throughput (req/s):              1.99
Input token throughput (tok/s):          2033.83
Output token throughput (tok/s):         2033.83
Peak output token throughput (tok/s):    2152.00
Peak concurrent requests:                16
Total token throughput (tok/s):          4067.67
Concurrency:                             7.99
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4025.01
Median E2E Latency (ms):                 3999.50
P90 E2E Latency (ms):                    4187.85
P99 E2E Latency (ms):                    4188.21
---------------Time to First Token----------------
Mean TTFT (ms):                          85.05
Median TTFT (ms):                        61.97
P99 TTFT (ms):                           205.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.85
Median TPOT (ms):                        3.85
P99 TPOT (ms):                           3.94
---------------Inter-Token Latency----------------
Mean ITL (ms):                           3.85
Median ITL (ms):                         3.85
P95 ITL (ms):                            3.93
P99 ITL (ms):                            4.32
Max ITL (ms):                            8.59
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
