### PR TITLE
fix(dp-attn): consistent overlap disable decision across DP ranks

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1330,15 +1330,12 @@ class Scheduler(
         # so all DP ranks make the same overlap decision (avoiding deadlock).
         # In non-DP mode, use the local forward_mode directly.
         if self.require_mlp_sync:
-            batch_is_extend = batch and batch.is_extend_in_batch
-            last_batch_is_extend = (
-                self.last_batch and self.last_batch.is_extend_in_batch
-            )
+            is_extend = lambda b: b and b.is_extend_in_batch
         else:
-            batch_is_extend = batch and batch.forward_mode.is_extend()
-            last_batch_is_extend = (
-                self.last_batch and self.last_batch.forward_mode.is_extend()
-            )
+            is_extend = lambda b: b and b.forward_mode.is_extend()
+
+        batch_is_extend = is_extend(batch)
+        last_batch_is_extend = is_extend(self.last_batch)
 
         disable_overlap_for_batch = (
             envs.SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP.get()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1326,12 +1326,24 @@ class Scheduler(
     def is_disable_overlap_for_batch(self, batch: ScheduleBatch) -> bool:
         # For two consecutive prefill batches, we disable overlap to improve the TTFT of the first batch.
         # This might slightly hurt the throughput, so we use an environment variable to control it.
+        # In DP attention mode, use the globally synchronized is_extend_in_batch
+        # so all DP ranks make the same overlap decision (avoiding deadlock).
+        # In non-DP mode, use the local forward_mode directly.
+        if self.require_mlp_sync:
+            batch_is_extend = batch and batch.is_extend_in_batch
+            last_batch_is_extend = (
+                self.last_batch and self.last_batch.is_extend_in_batch
+            )
+        else:
+            batch_is_extend = batch and batch.forward_mode.is_extend()
+            last_batch_is_extend = (
+                self.last_batch and self.last_batch.forward_mode.is_extend()
+            )
+
         disable_overlap_for_batch = (
             envs.SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP.get()
-            and batch
-            and batch.forward_mode.is_extend()
-            and self.last_batch
-            and self.last_batch.forward_mode.is_extend()
+            and batch_is_extend
+            and last_batch_is_extend
         )
 
         # We do not support overlap + spec + grammar yet,

--- a/test/registered/distributed/test_dp_attention.py
+++ b/test/registered/distributed/test_dp_attention.py
@@ -38,6 +38,10 @@ class TestDPAttentionDP2TP2(
     def setUpClass(cls):
         cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
+        cls._env_override = envs.SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP.override(
+            True
+        )
+        cls._env_override.__enter__()
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -58,6 +62,7 @@ class TestDPAttentionDP2TP2(
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
+        cls._env_override.__exit__(None, None, None)
 
     def test_mgsm_en(self):
         args = SimpleNamespace(

--- a/test/registered/distributed/test_dp_attention.py
+++ b/test/registered/distributed/test_dp_attention.py
@@ -1,3 +1,5 @@
+import concurrent.futures
+import time
 import unittest
 from types import SimpleNamespace
 
@@ -76,6 +78,64 @@ class TestDPAttentionDP2TP2(
         metrics = run_eval(args)
         print(f"{metrics=}")
         self.assertGreater(metrics["score"], 0.8)
+
+    def test_overlap_disable_with_asymmetric_dp_load(self):
+        """Trigger extend vs decode across DP ranks to test overlap disable consistency.
+
+        Sends long-prompt requests only to rank 0 (consecutive extends) while
+        rank 1 is in decode from earlier requests. If the overlap disable
+        decision is not globally synchronized, ranks will deadlock.
+        """
+        long_prompt = "Write a very long story. " * 100
+        short_prompt = "Hi"
+
+        # Step 1: Send short requests to rank 1 so it enters decode
+        short_futures = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            for _ in range(4):
+                short_futures.append(
+                    executor.submit(
+                        requests.post,
+                        self.base_url + "/generate",
+                        json={
+                            "text": short_prompt,
+                            "sampling_params": {
+                                "max_new_tokens": 32,
+                                "temperature": 0,
+                            },
+                            "routed_dp_rank": 1,
+                        },
+                    )
+                )
+            # Brief pause to let rank 1 finish prefill and enter decode
+            time.sleep(0.5)
+
+            # Step 2: Send long-prompt requests to rank 0 (consecutive extends)
+            # while rank 1 is still generating (decode)
+            long_futures = []
+            for _ in range(4):
+                long_futures.append(
+                    executor.submit(
+                        requests.post,
+                        self.base_url + "/generate",
+                        json={
+                            "text": long_prompt,
+                            "sampling_params": {
+                                "max_new_tokens": 8,
+                                "temperature": 0,
+                            },
+                            "routed_dp_rank": 0,
+                        },
+                    )
+                )
+
+            # All requests should complete without deadlock
+            for f in short_futures + long_futures:
+                resp = f.result(timeout=60)
+                resp.raise_for_status()
+
+        # Verify server is still alive
+        self.assertIsNone(self.process.poll())
 
 
 class TestDPRetract(

--- a/test/registered/distributed/test_dp_attention.py
+++ b/test/registered/distributed/test_dp_attention.py
@@ -1,5 +1,3 @@
-import concurrent.futures
-import time
 import unittest
 from types import SimpleNamespace
 
@@ -78,64 +76,6 @@ class TestDPAttentionDP2TP2(
         metrics = run_eval(args)
         print(f"{metrics=}")
         self.assertGreater(metrics["score"], 0.8)
-
-    def test_overlap_disable_with_asymmetric_dp_load(self):
-        """Trigger extend vs decode across DP ranks to test overlap disable consistency.
-
-        Sends long-prompt requests only to rank 0 (consecutive extends) while
-        rank 1 is in decode from earlier requests. If the overlap disable
-        decision is not globally synchronized, ranks will deadlock.
-        """
-        long_prompt = "Write a very long story. " * 100
-        short_prompt = "Hi"
-
-        # Step 1: Send short requests to rank 1 so it enters decode
-        short_futures = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            for _ in range(4):
-                short_futures.append(
-                    executor.submit(
-                        requests.post,
-                        self.base_url + "/generate",
-                        json={
-                            "text": short_prompt,
-                            "sampling_params": {
-                                "max_new_tokens": 32,
-                                "temperature": 0,
-                            },
-                            "routed_dp_rank": 1,
-                        },
-                    )
-                )
-            # Brief pause to let rank 1 finish prefill and enter decode
-            time.sleep(0.5)
-
-            # Step 2: Send long-prompt requests to rank 0 (consecutive extends)
-            # while rank 1 is still generating (decode)
-            long_futures = []
-            for _ in range(4):
-                long_futures.append(
-                    executor.submit(
-                        requests.post,
-                        self.base_url + "/generate",
-                        json={
-                            "text": long_prompt,
-                            "sampling_params": {
-                                "max_new_tokens": 8,
-                                "temperature": 0,
-                            },
-                            "routed_dp_rank": 0,
-                        },
-                    )
-                )
-
-            # All requests should complete without deadlock
-            for f in short_futures + long_futures:
-                resp = f.result(timeout=60)
-                resp.raise_for_status()
-
-        # Verify server is still alive
-        self.assertIsNone(self.process.poll())
 
 
 class TestDPRetract(


### PR DESCRIPTION
## Summary
- In DP attention mode, use globally synchronized `is_extend_in_batch` for overlap disable check so all ranks agree (preventing deadlock)
- In non-DP mode, use local `forward_mode.is_extend()` to preserve existing behavior
- Enable `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP` in DP attention CI test

## Test plan
- [x] Existing `TestDPAttentionDP2TP2` now runs with `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP=1`