### PR TITLE
fix: populate cache_read_input_tokens in Anthropic /v1/messages responses

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -453,6 +453,9 @@ class AnthropicServing:
 
                 # Emit message_delta with stop_reason and usage
                 stop_reason = STOP_REASON_MAP.get(finish_reason or "stop", "end_turn")
+                cache_read = (
+                    usage_info.get("cache_read_input_tokens", 0) if usage_info else 0
+                )
                 delta_event = AnthropicStreamEvent(
                     type="message_delta",
                     delta=AnthropicDelta(stop_reason=stop_reason),
@@ -463,6 +466,7 @@ class AnthropicServing:
                         output_tokens=(
                             usage_info.get("output_tokens", 0) if usage_info else 0
                         ),
+                        cache_read_input_tokens=cache_read or None,
                     ),
                 )
                 yield _wrap_sse_event(
@@ -522,9 +526,16 @@ class AnthropicServing:
 
             # Usage-only chunk (empty choices with usage info)
             if not chunk.choices and chunk.usage:
+                cache_read = 0
+                if (
+                    chunk.usage.prompt_tokens_details
+                    and chunk.usage.prompt_tokens_details.cached_tokens
+                ):
+                    cache_read = chunk.usage.prompt_tokens_details.cached_tokens
                 usage_info = {
                     "input_tokens": chunk.usage.prompt_tokens,
                     "output_tokens": chunk.usage.completion_tokens or 0,
+                    "cache_read_input_tokens": cache_read,
                 }
                 continue
 
@@ -678,6 +689,17 @@ class AnthropicServing:
         # Map stop reason
         stop_reason = STOP_REASON_MAP.get(choice.finish_reason or "stop", "end_turn")
 
+        # Extract cached tokens from prompt_tokens_details if available
+        cache_read_input_tokens = 0
+        if (
+            response.usage
+            and response.usage.prompt_tokens_details
+            and response.usage.prompt_tokens_details.cached_tokens
+        ):
+            cache_read_input_tokens = (
+                response.usage.prompt_tokens_details.cached_tokens
+            )
+
         return AnthropicMessagesResponse(
             id=f"msg_{uuid.uuid4().hex}",
             content=content,
@@ -686,6 +708,7 @@ class AnthropicServing:
             usage=AnthropicUsage(
                 input_tokens=response.usage.prompt_tokens if response.usage else 0,
                 output_tokens=response.usage.completion_tokens if response.usage else 0,
+                cache_read_input_tokens=cache_read_input_tokens or None,
             ),
         )
 


### PR DESCRIPTION
## Motivation

Addresses part of #20754 — specifically the `cache_read_input_tokens` always being null/missing in the Anthropic-compatible `/v1/messages` usage response.

The `AnthropicUsage` model defines `cache_read_input_tokens` but the serving code never populates it from the underlying OpenAI layer's `prompt_tokens_details.cached_tokens`. This means clients doing cost tracking or cache monitoring against the Anthropic API get incomplete data.

## Changes

Maps `prompt_tokens_details.cached_tokens` from the OpenAI response → `cache_read_input_tokens` in the Anthropic response, for both:

- **Non-streaming** (`_convert_response`): extracts from `response.usage.prompt_tokens_details`
- **Streaming** (`_generate_anthropic_stream`): extracts from the usage-only final chunk and includes it in the `message_delta` event

When there are no cached tokens (the common case), the field remains `None` and is excluded from the JSON response per existing `exclude_none` behavior — so this is fully backwards compatible.

## Test plan

- Deploy with `--enable-cache-report` and send a request that hits the prefix cache
- Verify `cache_read_input_tokens` appears in the Anthropic response usage with the correct count
- Verify without cache hits, the field is omitted (no behavior change)
- Verify both streaming and non-streaming paths