### PR TITLE
add EVS support for Qwen3-VL

### DIFF
--- a/python/sglang/srt/configs/qwen3_vl.py
+++ b/python/sglang/srt/configs/qwen3_vl.py
@@ -244,6 +244,7 @@ class Qwen3VLConfig(PretrainedConfig):
         video_token_id=151656,
         vision_start_token_id=151652,
         vision_end_token_id=151653,
+        video_pruning_rate=0.0,
         tie_word_embeddings=False,
         **kwargs,
     ):
@@ -261,6 +262,7 @@ class Qwen3VLConfig(PretrainedConfig):
         self.video_token_id = video_token_id
         self.vision_start_token_id = vision_start_token_id
         self.vision_end_token_id = vision_end_token_id
+        self.video_pruning_rate = video_pruning_rate
         super().__init__(**kwargs, tie_word_embeddings=tie_word_embeddings)
 
 

--- a/python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope_rope_index.py
@@ -121,6 +121,7 @@ def get_rope_index(
                         image_grid_thw[image_index][2],
                     )
                     second_per_grid_t = 0
+                    mm_token_id = image_token_id
                     image_index += 1
                     remain_images -= 1
                     ed = ed_image
@@ -134,6 +135,7 @@ def get_rope_index(
                         second_per_grid_t = second_per_grid_ts[video_index]
                     else:
                         second_per_grid_t = 1.0
+                    mm_token_id = video_token_id
                     video_index += 1
                     remain_videos -= 1
                     ed = ed_video
@@ -141,6 +143,14 @@ def get_rope_index(
                 llm_grid_t = t_int
                 llm_grid_h = h_int // spatial_merge_size
                 llm_grid_w = w_int // spatial_merge_size
+                mm_token_count = 0
+                mm_cursor = ed
+                while (
+                    mm_cursor < len(input_tokens)
+                    and input_tokens[mm_cursor] == mm_token_id
+                ):
+                    mm_token_count += 1
+                    mm_cursor += 1
                 text_len = ed - st
                 st_idx = (
                     llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
@@ -180,10 +190,18 @@ def get_rope_index(
                     .expand(llm_grid_t, llm_grid_h, llm_grid_w)
                     .reshape(-1)
                 )
+                vision_pos_ids = torch.stack([t_index, h_index, w_index])
+                expected_mm_token_count = vision_pos_ids.shape[1]
+                if mm_token_count == 0:
+                    mm_token_count = expected_mm_token_count
+                if mm_token_count > expected_mm_token_count:
+                    raise ValueError(
+                        f"Found {mm_token_count} multimodal tokens, expected at most {expected_mm_token_count}."
+                    )
                 llm_pos_ids_list.append(
-                    torch.stack([t_index, h_index, w_index]) + text_len + st_idx
+                    vision_pos_ids[:, :mm_token_count] + text_len + st_idx
                 )
-                st = ed + llm_grid_t * llm_grid_h * llm_grid_w
+                st = ed + mm_token_count
             if st < len(input_tokens):
                 st_idx = (
                     llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1264,7 +1264,7 @@ def general_mm_embed_routine(
             input_embeds = forward_batch.input_embeds
     else:
         input_embeds = None
-
+    # print("DEBUGG input_embeds.shape={}".format(input_embeds.shape))
     hidden_states = language_model(
         input_ids=None,
         forward_batch=forward_batch,

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1264,7 +1264,7 @@ def general_mm_embed_routine(
             input_embeds = forward_batch.input_embeds
     else:
         input_embeds = None
-    # print("DEBUGG input_embeds.shape={}".format(input_embeds.shape))
+
     hidden_states = language_model(
         input_ids=None,
         forward_batch=forward_batch,

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -69,6 +69,7 @@ from sglang.srt.models.utils import (
     WeightsMapper,
     compute_cu_seqlens_from_grid_numpy,
 )
+from sglang.srt.multimodal.evs import EVS, EVSConfig
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
 from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
 from sglang.srt.server_args import get_global_server_args
@@ -1047,7 +1048,7 @@ class Qwen3LLMModel(Qwen3Model):
         return hidden_states, aux_hidden_states
 
 
-class Qwen3VLForConditionalGeneration(nn.Module):
+class Qwen3VLForConditionalGeneration(EVS):
     # To ensure correct weight loading and mapping.
     hf_to_sglang_mapper = WeightsMapper(
         orig_to_new_substr={
@@ -1070,7 +1071,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         prefix: str = "",
         language_model_cls=Qwen3LLMModel,
     ) -> None:
-        super().__init__()
+        super().__init__(config)
         self.pp_group = get_pp_group()
         self.quant_config = quant_config
 
@@ -1128,6 +1129,13 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         self.deepstack_visual_indexes = config.vision_config.deepstack_visual_indexes
         self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
         self.use_deepstack = {Modality.IMAGE: True, Modality.VIDEO: True}
+
+    @staticmethod
+    def create_evs_config(config: Qwen3VLConfig) -> EVSConfig:
+        return EVSConfig(
+            video_pruning_rate=getattr(config, "video_pruning_rate", 0.0),
+            spatial_merge_size=1,
+        )
 
     def separate_deepstack_embeds(self, embedding):
         assert (

--- a/python/sglang/srt/multimodal/evs/evs_processor.py
+++ b/python/sglang/srt/multimodal/evs/evs_processor.py
@@ -66,6 +66,16 @@ class EVSProcessor:
         config_name = hf_config.__class__.__name__
         evs_model = config_to_evs_model.get(hf_config.__class__)
         if evs_model is None:
+            model_type = getattr(hf_config, "model_type", None)
+            compatible_models = [
+                candidate_model
+                for candidate_config, candidate_model in config_to_evs_model.items()
+                if candidate_config.__name__ == config_name
+                or getattr(candidate_config, "model_type", None) == model_type
+            ]
+            if len(compatible_models) == 1:
+                evs_model = compatible_models[0]
+        if evs_model is None:
             logger.info(
                 f"[EVS] no model matches {config_name} in {config_to_evs_model}"
             )

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -10,6 +10,7 @@ import torchvision
 from PIL import Image
 from torchvision.transforms import InterpolationMode
 
+from sglang.srt.configs.qwen3_vl import Qwen3VLConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
@@ -22,6 +23,9 @@ from sglang.srt.models.qwen3_5 import (
 from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeForConditionalGeneration
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
 from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
+from sglang.srt.multimodal.evs import EVSProcessor
+from sglang.srt.multimodal.evs.evs_core import tokens_per_frame
+from sglang.srt.multimodal.evs.evs_module import VideoEVSDataItem
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
@@ -250,6 +254,10 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             hf_config = hf_config.thinker_config
 
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.evs = EVSProcessor(
+            hf_config,
+            {Qwen3VLConfig: Qwen3VLForConditionalGeneration},
+        )
 
         self.IM_START_TOKEN_ID = hf_config.vision_start_token_id
         self.IM_END_TOKEN_ID = hf_config.vision_end_token_id
@@ -274,6 +282,101 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             video_token_id=hf_config.video_token_id,
             audio_token_id=self.audio_token_id,
         ).build(_processor)
+
+    def _maybe_apply_qwen3_evs(
+        self,
+        mm_items: List[MultimodalDataItem],
+        input_ids: torch.Tensor,
+    ) -> tuple[List[MultimodalDataItem], torch.Tensor]:
+        if self.evs.evs_config is None:
+            return mm_items, input_ids
+
+        video_item = next((item for item in mm_items if item.is_video()), None)
+        if video_item is None or not hasattr(video_item, "video_grid_thw"):
+            return mm_items, input_ids
+
+        video_grid_thw = video_item.video_grid_thw
+        if video_grid_thw is None or len(video_grid_thw) == 0:
+            return mm_items, input_ids
+
+        spatial_merge_size = self.hf_config.vision_config.spatial_merge_size
+        merged_video_grid_thw = video_grid_thw.clone()
+        if merged_video_grid_thw[:, 1:].numel() > 0:
+            if torch.any(merged_video_grid_thw[:, 1:] % spatial_merge_size != 0):
+                logger.warning(
+                    "[EVS] skipping Qwen3-VL EVS because video_grid_thw is not divisible by spatial_merge_size"
+                )
+                return mm_items, input_ids
+            merged_video_grid_thw[:, 1:] = (
+                merged_video_grid_thw[:, 1:] // spatial_merge_size
+            )
+
+        estimated_tokens_per_frame = [
+            tokens_per_frame(
+                q=self.evs.evs_config.video_pruning_rate,
+                num_frames=int(grid_t),
+                frame_num_tokens=int(grid_h) * int(grid_w),
+            )
+            for grid_t, grid_h, grid_w in merged_video_grid_thw.tolist()
+        ]
+        flat_estimated_tokens = [
+            token_count
+            for per_video_tokens in estimated_tokens_per_frame
+            for token_count in per_video_tokens
+        ]
+
+        if len(video_item.offsets) != len(flat_estimated_tokens):
+            logger.warning(
+                "[EVS] skipping Qwen3-VL EVS because video offsets do not align with per-frame token groups"
+            )
+            return mm_items, input_ids
+
+        original_input_ids = input_ids.tolist()
+        rewritten_input_ids: list[int] = []
+        cursor = 0
+        for (start, end), token_count in zip(
+            video_item.offsets, flat_estimated_tokens, strict=True
+        ):
+            rewritten_input_ids.extend(original_input_ids[cursor:start])
+            rewritten_input_ids.extend([self.mm_tokens.video_token_id] * token_count)
+            cursor = end + 1
+        rewritten_input_ids.extend(original_input_ids[cursor:])
+
+        rewritten_input_ids_tensor = torch.tensor(
+            rewritten_input_ids,
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        rewritten_video_offsets = self.get_mm_items_offset(
+            rewritten_input_ids_tensor, self.mm_tokens.video_token_id
+        )
+
+        evs_video_item = VideoEVSDataItem(
+            modality=Modality.VIDEO,
+            feature=video_item.feature,
+            offsets=rewritten_video_offsets,
+            thw_grids=[tuple(map(int, grid)) for grid in merged_video_grid_thw.tolist()],
+            pre_chunked_input_ids=rewritten_input_ids,
+            hash=video_item.hash,
+            pad_value=video_item.pad_value,
+            format=video_item.format,
+            precomputed_embeddings=video_item.precomputed_embeddings,
+        )
+        for key, value in video_item.model_specific_data.items():
+            evs_video_item.set(key, value)
+
+        rewritten_items: List[MultimodalDataItem] = []
+        for item in mm_items:
+            if item.is_video():
+                rewritten_items.append(evs_video_item)
+                continue
+
+            token_id = self.mm_tokens.get_token_id_by_modality(item.modality)
+            if token_id is not None:
+                item.offsets = self.get_mm_items_offset(rewritten_input_ids_tensor, token_id)
+            rewritten_items.append(item)
+
+        return rewritten_items, rewritten_input_ids_tensor
 
     def get_mm_data(self, prompt, embeddings, img_grid_thw):
         input_ids, offsets = self.build_input_ids(prompt, img_grid_thw)
@@ -358,6 +461,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 base_output, self.mm_tokens
             )
 
+        mm_items, input_ids = self._maybe_apply_qwen3_evs(mm_items, input_ids)
+        
         audio_feature_lengths = None
 
         if self.model_type == "qwen3_omni_moe":

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -355,7 +355,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             modality=Modality.VIDEO,
             feature=video_item.feature,
             offsets=rewritten_video_offsets,
-            thw_grids=[tuple(map(int, grid)) for grid in merged_video_grid_thw.tolist()],
+            thw_grids=[
+                tuple(map(int, grid)) for grid in merged_video_grid_thw.tolist()
+            ],
             pre_chunked_input_ids=rewritten_input_ids,
             hash=video_item.hash,
             pad_value=video_item.pad_value,
@@ -373,7 +375,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
             token_id = self.mm_tokens.get_token_id_by_modality(item.modality)
             if token_id is not None:
-                item.offsets = self.get_mm_items_offset(rewritten_input_ids_tensor, token_id)
+                item.offsets = self.get_mm_items_offset(
+                    rewritten_input_ids_tensor, token_id
+                )
             rewritten_items.append(item)
 
         return rewritten_items, rewritten_input_ids_tensor
@@ -462,7 +466,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             )
 
         mm_items, input_ids = self._maybe_apply_qwen3_evs(mm_items, input_ids)
-        
+
         audio_feature_lengths = None
 
         if self.model_type == "qwen3_omni_moe":


### PR DESCRIPTION

## Motivation
We support EVS(Efficient Video Sampling) for Qwen3-VL. Long video token can be pruned while keeping accuracy

## Modifications

* add pruning functions in Qwen-VL's processor
* make Qwen3's MROPE embedding compatible with pruned tokens

## Accuracy Tests


dataset | model | accuracy | time-cost | EVS prune rate
-- | -- | -- | -- | --
Video-MME | Qwen3-VL-8B-Instruct | 0.781 | 10:55 | 0.0
Video-MME | Qwen3-VL-8B-Instruct | 0.750 | 7:52 | 0.8
Video-MME | Qwen3-VL-32B-Instruct | 0.803 | 33:57 | 0.0
Video-MME | Qwen3-VL-32B-Instruct | 0.762 | 23:53 | 0.8



## Benchmarking and Profiling

* enable evs
```
export  SGLANG_VLM_CACHE_SIZE_MB=0 
python3 -m sglang.launch_server --model-path /mnt/Qwen3-VL-8B-Instruct/ --json-model-override-args '{"video_pruning_rate": 0.8}' --disable-radix-cache --port 8123
```
* do single query
```
curl http://localhost:8123/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{

    "temperature": 0.0,
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "Describe this video in detail."
          },
          {
            "type": "video_url",
            "video_url": {
              "url": "https://raw.githubusercontent.com/sgl-project/sgl-test-files/refs/heads/main/videos/jobs_presenting_ipod.mp4"
            }
          }
        ]
      }
    ],
    "max_tokens": 30
  }'
```

* example output (prune_rate = 0.8)
```
{"id":"c357d42ab71044a1909912931f87422c","object":"chat.completion","created":1773827999,"model":"default","choices":[{"index":0,"message":{"role":"assistant","content":"The video begins with a man standing on a stage, dressed in a black shirt and dark pants. He is holding a white iPod Nano in his hand","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null}],"usage":{"prompt_tokens":2114,"total_tokens":2144,"completion_tokens":30,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
```
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
