### PR TITLE
[MiniMax M2] Fix KV cache scale loading

### DIFF
--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -1132,7 +1132,6 @@ class MiniMaxM2ForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
-
         return loaded_params
 
     @classmethod

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -1063,9 +1063,17 @@ class MiniMaxM2ForCausalLM(nn.Module):
             if spec_layer is not None:
                 continue  # skip spec decode layers for main model
 
+            _is_kv_scale = name.endswith(".k_scale") or name.endswith(".v_scale")
+
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
+                    continue
+                # Skip kv cache scales - maybe_remap_kv_scale_name expects the
+                # original checkpoint name (e.g. self_attn.k_proj.k_scale) to
+                # remap it to self_attn.attn.k_scale. Renaming k_proj -> qkv_proj
+                # here would break that pattern match.
+                if _is_kv_scale:
                     continue
                 # We have mlp.experts[0].gate_proj in the checkpoint.
                 # Since we handle the experts below in expert_params_mapping,
@@ -1124,6 +1132,7 @@ class MiniMaxM2ForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
         return loaded_params
 
     @classmethod


### PR DESCRIPTION
## Motivation

When KV cache quantization is enabled in Model-Optimizer, the quantized checkpoint include kv scales as:
```
model.layers.N.self_attn.k_proj.k_scale
model.layers.N.self_attn.v_proj.v_scale
```

During the MiniMax loading, the qkv weights are mapped from shards as
```
SGLang param name: model.layers.N.self_attn.qkv_proj.weight
(Unfused) weight shard: k
(Unfused) weight name: model.layers.N.self_attn.k_proj.weight
```
by renaming the weight
```
model.layers.N.self_attn.k_proj.weight -> model.layers.N.self_attn.qkv_proj.weight
```

However, this qkv weight renaming also applies to the kv scales, which results in:
```
model.layers.N.self_attn.k_proj.k_scale -> model.layers.N.self_attn.qkv_proj.k_scale
model.layers.N.self_attn.v_proj.v_scale -> model.layers.N.self_attn.qkv_proj.v_scale
```

And so the `maybe_remap_kv_scale_name` fails to remap since it expects the original weight name.

## Modifications

This PR skips the renaming if the weight is a kv scale, so we fall through to `maybe_remap_kv_scale_name` which correctly remaps the name.

## Accuracy Tests

Verified that the `k_scale` is remapped correctly: `KV scale remap: 'model.layers.0.self_attn.k_proj.k_scale' -> 'model.layers.0.self_attn.attn.k_scale'`

## Benchmarking and Profiling

No speed impact

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
