### PR TITLE
[Speculative] Fix EAGLE draft KV cache over-allocation by one step

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2885,6 +2885,9 @@ class ServerArgs:
                     self.speculative_num_draft_tokens,
                 ) = auto_choose_speculative_params(self)
 
+            if self.speculative_num_steps < 1:
+                raise ValueError("speculative_num_steps must be at least 1")
+
             if (
                 self.attention_backend == "trtllm_mha"
                 or self.decode_attention_backend == "trtllm_mha"

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -73,6 +73,7 @@ class EAGLEDraftCudaGraphRunner:
         self.tp_size = self.model_runner.tp_size
         self.dp_size = self.model_runner.dp_size
         self.speculative_num_steps = model_runner.server_args.speculative_num_steps
+        self.draft_kv_num_steps = self.speculative_num_steps - 1
         self.topk = model_runner.server_args.speculative_eagle_topk
         self.enable_profile_cuda_graph = (
             model_runner.server_args.enable_profile_cuda_graph
@@ -107,7 +108,7 @@ class EAGLEDraftCudaGraphRunner:
             input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
             req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int64)
             out_cache_loc = torch.zeros(
-                (self.max_num_token * self.speculative_num_steps,),
+                (self.max_num_token * self.draft_kv_num_steps,),
                 dtype=self._cache_loc_dtype(),
             )
             positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
@@ -226,7 +227,7 @@ class EAGLEDraftCudaGraphRunner:
         seq_lens_cpu = buffers.seq_lens_cpu[:num_seqs]
         extend_seq_lens = buffers.extend_seq_lens[:num_seqs]
         extend_seq_lens_cpu = self.extend_seq_lens_cpu[:num_seqs]
-        out_cache_loc = buffers.out_cache_loc[: num_tokens * self.speculative_num_steps]
+        out_cache_loc = buffers.out_cache_loc[: num_tokens * self.draft_kv_num_steps]
         positions = buffers.positions[:num_tokens]
         mrope_positions = buffers.mrope_positions[:, :num_tokens]
         hidden_states = buffers.hidden_states[:num_seqs]
@@ -382,7 +383,7 @@ class EAGLEDraftCudaGraphRunner:
 
         # Common inputs
         buffers.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
-        buffers.out_cache_loc[: raw_num_token * self.speculative_num_steps].copy_(
+        buffers.out_cache_loc[: raw_num_token * self.draft_kv_num_steps].copy_(
             forward_batch.out_cache_loc
         )
         buffers.positions[:raw_num_token].copy_(forward_batch.positions)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -94,6 +94,7 @@ class EAGLEWorker(TpModelWorker):
         self.server_args = server_args
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
+        self.draft_kv_num_steps = self.speculative_num_steps - 1
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
         self.gpu_id = gpu_id
         self.device = server_args.device
@@ -409,8 +410,7 @@ class EAGLEWorker(TpModelWorker):
         # [       topk 0         ] [       topk 1         ]
         # [iter=0, iter=1, iter=2] [iter=0, iter=1, iter=2]
         if self.page_size == 1:
-            alloc_len_per_decode = self.speculative_num_steps * self.topk
-            # TODO: We only need self.speculative_num_steps - 1 * topk cache loc
+            alloc_len_per_decode = self.draft_kv_num_steps * self.topk
             out_cache_loc, token_to_kv_pool_state_backup = alloc_token_slots(
                 batch.tree_cache,
                 num_seqs * alloc_len_per_decode,
@@ -422,11 +422,11 @@ class EAGLEWorker(TpModelWorker):
                     batch.req_to_token_pool.req_to_token,
                     batch.req_pool_indices,
                     batch.seq_lens,
-                    self.speculative_num_steps,
+                    self.draft_kv_num_steps,
                 )
                 prefix_lens_cpu = batch.seq_lens_cpu
-                seq_lens_cpu = batch.seq_lens_cpu + self.speculative_num_steps
-                extend_num_tokens = num_seqs * self.speculative_num_steps
+                seq_lens_cpu = batch.seq_lens_cpu + self.draft_kv_num_steps
+                extend_num_tokens = num_seqs * self.draft_kv_num_steps
             else:
                 # In this case, the last partial page needs to be duplicated.
                 # KV cache layout in batch.req_to_token_pool.req_to_token:
@@ -449,14 +449,14 @@ class EAGLEWorker(TpModelWorker):
                     batch.req_to_token_pool.req_to_token,
                     batch.req_pool_indices,
                     batch.seq_lens,
-                    self.speculative_num_steps,
+                    self.draft_kv_num_steps,
                     self.topk,
                     self.page_size,
                 )
                 prefix_lens_cpu = batch.seq_lens_cpu
                 last_page_lens_cpu = prefix_lens_cpu % self.page_size
                 num_new_pages_per_topk = (
-                    last_page_lens_cpu + self.speculative_num_steps + self.page_size - 1
+                    last_page_lens_cpu + self.draft_kv_num_steps + self.page_size - 1
                 ) // self.page_size
                 seq_lens_cpu = (
                     prefix_lens_cpu // self.page_size * self.page_size
@@ -504,10 +504,10 @@ class EAGLEWorker(TpModelWorker):
             duplicate_cache_len,
             batch.req_to_token_pool.req_to_token.shape[1],
             self.topk,
-            self.speculative_num_steps,
+            self.draft_kv_num_steps,
             self.page_size,
             next_power_of_2(num_seqs),
-            next_power_of_2(self.speculative_num_steps + self.page_size),
+            next_power_of_2(self.draft_kv_num_steps + self.page_size),
         )
 
         if self.page_size > 1 and self.topk > 1:
@@ -516,9 +516,8 @@ class EAGLEWorker(TpModelWorker):
                     target_cache_loc, source_cache_loc
                 )
             # Remove padded slots
-            # TODO: We only need self.speculative_num_steps - 1 cache loc
             out_cache_loc = out_cache_loc[
-                : num_seqs * self.topk * self.speculative_num_steps
+                : num_seqs * self.topk * self.draft_kv_num_steps
             ]
 
         batch.out_cache_loc = out_cache_loc
@@ -634,12 +633,11 @@ class EAGLEWorker(TpModelWorker):
 
         if self.hot_token_id is not None:
             topk_index = self.hot_token_id[topk_index]
-        # TODO: We only need self.speculative_num_steps - 1 cache loc
         out_cache_loc = out_cache_loc.reshape(
-            forward_batch.batch_size, self.topk, self.speculative_num_steps
+            forward_batch.batch_size, self.topk, self.draft_kv_num_steps
         )
         out_cache_loc = out_cache_loc.permute((2, 0, 1)).reshape(
-            self.speculative_num_steps, -1
+            self.draft_kv_num_steps, -1
         )
 
         # Return values

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -111,6 +111,7 @@ class EagleDraftWorker(BaseDraftWorker):
         self.device = server_args.device
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
+        self.draft_kv_num_steps = self.speculative_num_steps - 1
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
@@ -325,7 +326,7 @@ class EagleDraftWorker(BaseDraftWorker):
             self.cuda_graph_runner,
             self.draft_runner,
             self.topk,
-            self.speculative_num_steps,
+            self.draft_kv_num_steps,
         )
 
         # Run draft
@@ -412,10 +413,10 @@ class EagleDraftWorker(BaseDraftWorker):
             topk_index = self.hot_token_id[topk_index]
 
         out_cache_loc = out_cache_loc.reshape(
-            forward_batch.batch_size, self.topk, self.speculative_num_steps
+            forward_batch.batch_size, self.topk, self.draft_kv_num_steps
         )
         out_cache_loc = out_cache_loc.permute((2, 0, 1)).reshape(
-            self.speculative_num_steps, -1
+            self.draft_kv_num_steps, -1
         )
 
         # Return values

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -85,6 +85,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         self.server_args = server_args
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
+        self.draft_kv_num_steps = self.speculative_num_steps - 1
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
         self.gpu_id = gpu_id
         self.device = server_args.device

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -91,6 +91,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         self.device = server_args.device
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
+        self.draft_kv_num_steps = self.speculative_num_steps - 1
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
@@ -98,7 +99,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
 
         # Set constant
         EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
-            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
+            self.draft_kv_num_steps * self.topk, self.speculative_num_draft_tokens
         )
 
         # Do not capture cuda graph in `TpModelWorker` init,
@@ -223,7 +224,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
             self.cuda_graph_runner,
             self.draft_runner_list[0],
             self.topk,
-            self.speculative_num_steps,
+            self.draft_kv_num_steps,
         )
 
         # Run draft


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The original code allocated `speculative_num_steps * topk` KV cache slots per request, but only `(speculative_num_steps - 1) * topk` slots were actually written during draft forward. The extra slots were wasted, reducing effective KV cache capacity. 

## Modifications

<!-- Detail the changes made in this pull request. -->
 All changes are in `python/sglang/srt/speculative/eagle_worker.py`:

  - Introduce `self.draft_kv_num_steps = self.speculative_num_steps - 1` for KV
    cache allocation calculations.
  - Update allocation size for `page_size == 1` path.
  - Update `get_last_loc_large_page_size_top_k_1` and
    `get_last_loc_large_page_size_large_top_k` parameters.
  - Update `assign_draft_cache_locs` kernel parameters.
  - Update `out_cache_loc` reshape in `draft_forward`.
  - Remove resolved TODO comments.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
