### PR TITLE
Reject HiCache L3 storage backend for NSA models at init time

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -82,6 +82,15 @@ class HiRadixCache(RadixCache):
                 allocator_type=server_args.hicache_storage_backend,
             )
         elif isinstance(self.kv_cache, NSATokenToKVPool):
+            if server_args.hicache_storage_backend is not None:
+                raise ValueError(
+                    "HiCache L3 storage backend (e.g. mooncake) is not yet supported "
+                    "for models with NSA (Native Sparse Attention). The L3 storage "
+                    "layer does not handle the NSA indexer cache "
+                    "(index_k_with_scale_buffer). Please remove "
+                    "--hicache-storage-backend to use L2-only hierarchical cache, "
+                    "which is fully supported."
+                )
             self.token_to_kv_pool_host = NSATokenToKVPoolHost(
                 self.kv_cache,
                 server_args.hicache_ratio,
@@ -100,7 +109,10 @@ class HiRadixCache(RadixCache):
                 allocator_type=server_args.hicache_storage_backend,
             )
         else:
-            raise ValueError(f"HiRadixCache only supports MHA and MLA yet")
+            raise ValueError(
+                f"HiRadixCache only supports MHA, MLA, and NSA KV pools, "
+                f"got {type(self.kv_cache).__name__}"
+            )
 
         self.tp_group = params.tp_cache_group
         self.tp_world_size = torch.distributed.get_world_size(group=self.tp_group)


### PR DESCRIPTION
## Summary

- Raise `ValueError` at startup when `--hicache-storage-backend` is used with NSA (Native Sparse Attention) models (e.g. GLM-5, DeepSeek-V3.2)
- The L3 storage layer (mooncake) only handles MHA K/V and MLA latent-K formats but does not serialize/deserialize the NSA indexer cache (`index_k_with_scale_buffer`), causing silent data corruption and shape mismatch crashes during prefetch
- L2-only hierarchical cache (host memory) is unaffected — it copies raw GPU pages without format awareness
- Also update the fallback error message to reflect that NSA is a supported pool type (for L2) and include the actual type name

🤖 Generated with [Claude Code](https://claude.com/claude-code)