### PR TITLE
feat: add relu2/gelu activation support to Marlin FP4 MoE backend

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
 
 from sglang.srt.utils import is_cuda
 from sglang.srt.utils.custom_op import register_custom_op
@@ -46,6 +47,8 @@ def fused_marlin_moe(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: Optional[float] = None,
+    activation: str = "silu",
+    is_gated: bool = True,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -98,6 +101,10 @@ def fused_marlin_moe(
     N = w2.shape[1] * 16
     topk = topk_ids.shape[1]
 
+    # For gated activations (e.g. SiLU), w1 projects to 2*N (gate + up).
+    # For non-gated activations (e.g. relu2), w1 projects to N directly.
+    w1_out = 2 * N if is_gated else N
+
     # M block size selection logic
     # TODO: tune this further for specific models
     for block_size_m in [8, 16, 32, 48, 64]:
@@ -111,7 +118,7 @@ def fused_marlin_moe(
     )
 
     if workspace is None:
-        max_workspace_size = (max(2 * N, K) // 64) * (
+        max_workspace_size = (max(w1_out, K) // 64) * (
             sorted_token_ids.size(0) // block_size_m
         )
         device = hidden_states.device
@@ -130,12 +137,12 @@ def fused_marlin_moe(
         dtype=hidden_states.dtype,
     )
     intermediate_cache13 = torch.empty(
-        (M * topk_ids.shape[1] * max(2 * N, K),),
+        (M * topk_ids.shape[1] * max(w1_out, K),),
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
-    intermediate_cache1 = intermediate_cache13[: M * topk_ids.shape[1] * 2 * N]
-    intermediate_cache1 = intermediate_cache1.view(-1, 2 * N)
+    intermediate_cache1 = intermediate_cache13[: M * topk_ids.shape[1] * w1_out]
+    intermediate_cache1 = intermediate_cache1.view(-1, w1_out)
     intermediate_cache3 = intermediate_cache13[: M * topk_ids.shape[1] * K]
     intermediate_cache3 = intermediate_cache3.view(-1, K)
 
@@ -165,7 +172,7 @@ def fused_marlin_moe(
         is_ep=expert_map is not None,
         b_q_type=scalar_type1,
         size_m=M,
-        size_n=2 * N,
+        size_n=w1_out,
         size_k=K,
         is_k_full=is_k_full,
         use_atomic_add=use_atomic_add,
@@ -173,7 +180,25 @@ def fused_marlin_moe(
         is_zp_float=False,
     )
 
-    silu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    # Apply activation function
+    if activation == "silu" and is_gated:
+        silu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    elif activation == "silu" and not is_gated:
+        intermediate_cache2 = F.silu(intermediate_cache1.view(-1, N))
+    elif activation == "gelu" and is_gated:
+        from sgl_kernel import gelu_and_mul
+
+        gelu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    elif activation == "gelu" and not is_gated:
+        intermediate_cache2 = F.gelu(intermediate_cache1.view(-1, N))
+    elif activation == "relu2" and not is_gated:
+        intermediate_cache2 = torch.square(
+            F.relu(intermediate_cache1.view(-1, N))
+        )
+    else:
+        raise ValueError(
+            f"Unsupported activation: {activation=}, with {is_gated=}"
+        )
 
     if expert_map is not None:
         intermediate_cache3.zero_()

--- a/python/sglang/srt/layers/moe/moe_runner/marlin.py
+++ b/python/sglang/srt/layers/moe/moe_runner/marlin.py
@@ -87,8 +87,6 @@ def fused_experts_none_to_marlin(
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
 
-    assert runner_config.activation == "silu", "Only SiLU activation is supported."
-
     if (
         MARLIN_MOE_WORKSPACE is None
         or MARLIN_MOE_WORKSPACE.device != hidden_states.device
@@ -118,6 +116,8 @@ def fused_experts_none_to_marlin(
         is_k_full=quant_info.is_k_full,
         inplace=runner_config.inplace,
         routed_scaling_factor=runner_config.routed_scaling_factor,
+        activation=runner_config.activation,
+        is_gated=runner_config.is_gated,
     ).to(hidden_states.dtype)
 
     return StandardCombineInput(

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -402,6 +402,8 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             num_bits=self.num_bits,
             is_k_full=self.is_k_full,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
+            activation=self.moe_runner_config.activation,
+            is_gated=self.moe_runner_config.is_gated,
         )
         return StandardCombineInput(hidden_states=output)
 


### PR DESCRIPTION
## Summary

- Add `activation` and `is_gated` parameters to `fused_marlin_moe()`, matching the activation dispatch already present in the Triton MoE backend (`fused_moe.py`)
- For non-gated activations (e.g. relu2), buffer sizes use `N` instead of `2*N` since there is no gate projection
- Defaults (`activation="silu"`, `is_gated=True`) preserve existing behavior — zero impact on current models
- Thread `activation`/`is_gated` from `MoeRunnerConfig` through both callers (`marlin.py` runner and `compressed_tensors_wNa16_moe.py`)

## Motivation

The Marlin MoE backend is the only working FP4 MoE path on SM121 (GB10 Grace Blackwell), but it hardcoded `silu_and_mul()` as its only activation. This blocks loading **Nemotron-H** (`NVIDIA/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4`), which uses `relu2` (non-gated) activation in its 512 MoE experts.

Closes #20881

## Test plan

- [ ] Existing Marlin MoE tests pass (SiLU gated path unchanged)
- [ ] Nemotron-H NVFP4 loads and runs on SM121 with `--moe-runner-backend marlin`
- [ ] Activation dispatch matches Triton backend behavior for relu2, gelu, silu (gated/non-gated)