### PR TITLE
CUTLASS FP8 Blockwise GEMM improvement of SM120

### DIFF
--- a/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
+++ b/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
@@ -256,7 +256,66 @@ void launch_sm120_fp8_blockwise_scaled_mm(
   using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());  // Layout type for SFA matrix operand
   using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());  // Layout type for SFB matrix operand
 
-  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+  constexpr bool kCanUsePingpong = (64 % ScaleGranularityM == 0);
+
+  int m = a.size(0);
+  int k = a.size(1);
+  int n = b.size(1);
+
+  auto a_ptr = static_cast<ElementA*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementB*>(b.data_ptr());
+  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+
+  auto scales_a_ptr = static_cast<ElementBlockScale*>(scales_a.data_ptr());
+  auto scales_b_ptr = static_cast<ElementBlockScale*>(scales_b.data_ptr());
+
+  LayoutSFA layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));
+  LayoutSFB layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
+
+  auto run_gemm = [&](auto tag) -> cutlass::Status {
+    using GemmKernel = decltype(tag);
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+    Gemm gemm_op;
+
+    using StrideA = typename GemmKernel::StrideA;
+    using StrideB = typename GemmKernel::StrideB;
+    using StrideC = typename GemmKernel::StrideD;
+
+    StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, 1));
+    StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, 1));
+    StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, 1));
+
+    typename GemmKernel::MainloopArguments mainloop_args{
+        a_ptr, stride_a, b_ptr, stride_b, scales_a_ptr, layout_SFA, scales_b_ptr, layout_SFB};
+
+    typename GemmKernel::EpilogueArguments epilogue_args{{}, c_ptr, stride_c, c_ptr, stride_c};
+    epilogue_args.thread.alpha = 1.0f;
+
+    typename Gemm::Arguments args = {
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {m, n, k, 1},
+        mainloop_args,
+        epilogue_args,
+    };
+
+    auto can_implement = gemm_op.can_implement(args);
+    if (can_implement != cutlass::Status::kSuccess) {
+      return can_implement;
+    }
+
+    size_t workspace_size = gemm_op.get_workspace_size(args);
+    cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+    auto init_status = gemm_op.initialize(args, workspace.get());
+    if (init_status != cutlass::Status::kSuccess) {
+      return init_status;
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+    return gemm_op.run(stream);
+  };
+
+  using CooperativeCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
       ArchTag,
       OperatorClass,
       PerSmTileShape,
@@ -270,10 +329,12 @@ void launch_sm120_fp8_blockwise_scaled_mm(
       ElementD,
       LayoutDTag,
       AlignmentD,
-      cutlass::epilogue::collective::EpilogueScheduleAuto  // Epilogue schedule policy
-      >::CollectiveOp;
+      cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
 
-  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+  using CooperativeStageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+      sizeof(typename CooperativeCollectiveEpilogue::SharedStorage))>;
+
+  using CooperativeCollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
       ArchTag,
       OperatorClass,
       ElementA,
@@ -285,69 +346,65 @@ void launch_sm120_fp8_blockwise_scaled_mm(
       ElementAccumulator,
       MmaTileShape,
       ClusterShape,
-      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-          sizeof(typename CollectiveEpilogue::SharedStorage))>,
-      cutlass::gemm::collective::KernelScheduleAuto  // Kernel schedule policy. Auto defaults to cooperative kernel
-                                                     // schedule
-      >::CollectiveOp;
+      CooperativeStageCount,
+      cutlass::gemm::KernelScheduleSm120Blockwise>::CollectiveOp;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      Shape<int, int, int, int>,  // Indicates ProblemShape
-      CollectiveMainloop,
-      CollectiveEpilogue,
-      void>;
+  using CooperativeGemmKernel = cutlass::gemm::kernel::
+      GemmUniversal<Shape<int, int, int, int>, CooperativeCollectiveMainloop, CooperativeCollectiveEpilogue, void>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  cutlass::Status status = cutlass::Status::kSuccess;
+  if constexpr (kCanUsePingpong) {
+    using PingpongMmaTileShape_MNK = Shape<_64, _128, _128>;
+    using PingpongCollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        ArchTag,
+        OperatorClass,
+        PerSmTileShape,
+        ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator,
+        ElementAccumulator,
+        ElementC,
+        LayoutCTag,
+        AlignmentC,
+        ElementD,
+        LayoutDTag,
+        AlignmentD,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
 
-  Gemm gemm_op;
+    using PingpongStageCount = cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+        sizeof(typename PingpongCollectiveEpilogue::SharedStorage))>;
 
-  int m = a.size(0);
-  int k = a.size(1);
-  int n = b.size(1);
+    using PingpongCollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        ArchTag,
+        OperatorClass,
+        ElementA,
+        cute::tuple<LayoutATag, LayoutSFA>,
+        AlignmentA,
+        ElementB,
+        cute::tuple<LayoutBTag, LayoutSFB>,
+        AlignmentB,
+        ElementAccumulator,
+        PingpongMmaTileShape_MNK,
+        ClusterShape,
+        PingpongStageCount,
+        cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120>::CollectiveOp;
 
-  auto a_ptr = static_cast<ElementA*>(a.data_ptr());
-  auto b_ptr = static_cast<ElementB*>(b.data_ptr());
-  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+    using PingpongGemmKernel = cutlass::gemm::kernel::
+        GemmUniversal<Shape<int, int, int, int>, PingpongCollectiveMainloop, PingpongCollectiveEpilogue, void>;
 
-  auto scales_a_ptr = static_cast<ElementBlockScale*>(scales_a.data_ptr());
-  auto scales_b_ptr = static_cast<ElementBlockScale*>(scales_b.data_ptr());
+    if (m <= 64) {
+      status = run_gemm(PingpongGemmKernel{});
+      if (status != cutlass::Status::kSuccess) {
+        status = run_gemm(CooperativeGemmKernel{});
+      }
+    } else {
+      status = run_gemm(CooperativeGemmKernel{});
+    }
+  } else {
+    status = run_gemm(CooperativeGemmKernel{});
+  }
 
-  using StrideA = typename Gemm::GemmKernel::StrideA;
-  using StrideB = typename Gemm::GemmKernel::StrideB;
-  using StrideD = typename Gemm::GemmKernel::StrideD;
-  using StrideC = typename Gemm::GemmKernel::StrideD;
-
-  StrideA stride_a = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(m, k, 1));
-  StrideB stride_b = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(n, k, 1));
-  StrideC stride_c = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(m, n, 1));
-  LayoutSFA layout_SFA = ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));
-  LayoutSFB layout_SFB = ScaleConfig::tile_atom_to_shape_SFB(make_shape(m, n, k, 1));
-
-  typename GemmKernel::MainloopArguments mainloop_args{
-      a_ptr, stride_a, b_ptr, stride_b, scales_a_ptr, layout_SFA, scales_b_ptr, layout_SFB};
-
-  typename GemmKernel::EpilogueArguments epilogue_args{{}, c_ptr, stride_c, c_ptr, stride_c};
-  epilogue_args.thread.alpha = 1.0f;
-
-  typename Gemm::Arguments args = {
-      cutlass::gemm::GemmUniversalMode::kGemm,
-      {m, n, k, 1},
-      mainloop_args,
-      epilogue_args,
-  };
-
-  auto can_implement = gemm_op.can_implement(args);
-  TORCH_CHECK(can_implement == cutlass::Status::kSuccess, cutlassGetStatusString(can_implement))
-
-  size_t workspace_size = gemm_op.get_workspace_size(args);
-  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
-
-  auto init_status = gemm_op.initialize(args, workspace.get());
-  TORCH_CHECK(init_status == cutlass::Status::kSuccess, cutlassGetStatusString(init_status));
-
-  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
-  auto status = gemm_op.run(stream);
-  TORCH_CHECK(status == cutlass::Status::kSuccess, cutlassGetStatusString(status))
+  TORCH_CHECK(status == cutlass::Status::kSuccess, cutlassGetStatusString(status));
 }
 
 template <typename OutType>


### PR DESCRIPTION
### Motivation

The SM120 fp8 blockwise GEMM kernel was using `KernelScheduleAuto` as the schedule, which on SM120 happens to select the cooperative kernel only. The single-kernel approach misses a performance opportunity, the pingpong schedule is about 2x faster than cooperative for small M. I adapted the example from the CUTLASS repo.

### Modifications

`sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu`:

- Replaced `KernelScheduleAuto` with `KernelScheduleSm120Blockwise` for the cooperative path, when M > 64, to avoid
the specific CUTLASS issue (the refcheck output will explode in relative error, I'm not sure of the cause exactly, but it appears to be potentially a CUTLASS library issue)
- Added a pingpong path using `KernelTmaWarpSpecializedBlockwisePingpongSm120` with a 64x128x128 tile shape for M ≤ 64.
- Added a `m <= 64` runtime check to pick between the two paths.
- Refactor the kernel setup a bit.

### Accuracy and UT

<img width="1898" height="249" alt="Screenshot 2026-03-18 at 6 51 54 PM" src="https://github.com/user-attachments/assets/2cfca10c-cdad-4b2e-99c8-bb9cf6423410" />

RTX 5090 (SM120) against Flashinfer across Qwen/Qwen3.5-27B-FP8 shapes at M from 1 to 512:

### Performance (RTX 5090, N=1536, K=5120)

<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/6abc9dc9-f53d-4253-8dd2-a1921b2171f1" />
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/a57cf64c-5ecf-4fbb-984e-4a93389d090f" />


| M | this PR | FlashInfer | Triton |
|---|---|---|---|
| 8 | 0.034 ms | 0.063 ms | 0.041 ms |
| 64 | 0.034 ms | 0.063 ms | 0.041 ms |
| 128 | 0.063 ms | 0.063 ms | 0.042 ms |
| 512 | 0.063 ms | 0.063 ms | 0.043 ms |

Profiles:

E2E Accuracy:

```
python -m sglang.test.run_eval --base-url http://localhost:30000 --eval-name gsm8k --num-examples 200 --max-tokens 16000 --repeat 5 --num-threads 48 --num-shots 5 --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --chat-template-kwargs '{"enable_thinking": true}'
```

Before:
`{'score:std': np.float64(0.07053367989832945), 'scores': ['0.995', '0.975', '0.980', '0.990', '0.995'], 'mean_score': np.float64(0.9870000000000001)}`

After:
`{'score:std': np.float64(0.12155245781143219), 'scores': ['0.990', '0.985', '0.995', '0.995', '0.985'], 'mean_score': np.float64(0.99)}`

BS = 1 speed:

Before:
(It will use the cooperative schedule)
<img width="1694" height="222" alt="Screenshot 2026-03-18 at 6 59 50 PM" src="https://github.com/user-attachments/assets/9d4b23c4-94fd-49c5-94be-1e6317c55ffb" />

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   29.996    |  1024  |   1.000    |      34.14      |
+-------------+--------+------------+-----------------+
```

After:
<img width="1508" height="298" alt="Screenshot 2026-03-18 at 6 54 45 PM" src="https://github.com/user-attachments/assets/e9324778-3a74-4e0b-b2a0-ac3c54451218" />
(I only zoom in really far, to show the ping-pong schedule name)
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   19.652    |  1024  |   1.000    |      52.11      |
+-------------+--------+------------+-----------------+
```

I think we can change the default GEMM backend on SM120 later.

### Checklist
- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [x] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.