### PR TITLE
fix(aiter): use tuned GEMM for unquantized linear with torchao compatibility guard

### DIFF
--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -52,6 +52,7 @@ if _use_aiter:
     from aiter import ActivationType
     from aiter.fused_moe import fused_moe
     from aiter.ops.shuffle import shuffle_weight
+    from aiter.tuned_gemm import tgemm
 
 if _is_npu:
     from sglang.srt.hardware_backend.npu.utils import npu_format_cast
@@ -149,6 +150,9 @@ class UnquantizedLinearMethod(LinearMethodBase):
             if len(x_shapes) == 3:
                 output = output.view(x_shapes[0], x_shapes[1], -1)
             return output
+
+        if _use_aiter and type(layer.weight.data) is torch.Tensor:
+            return tgemm.mm(x, layer.weight, bias, otype=x.dtype)
 
         return F.linear(x, layer.weight, bias)
 


### PR DESCRIPTION
## Motivation

AMD CI sets `SGLANG_USE_AITER=1` globally for all tests. When aiter's `tgemm.mm` (which calls `aiter.gemm_a16w16`) is used for unquantized linear operations, it crashes on models quantized by torchao (e.g. `int4wo-128`, `fp8wo`) because `AffineQuantizedTensor` doesn't support the `aiter.gemm_a16w16` dispatch:

```
NotImplementedError: AffineQuantizedTensor dispatch: attempting to run
  unimplemented operator/function: func=<OpOverload(op='aiter.gemm_a16w16', overload='default')>
```

This was surfaced by [PR #20392](https://github.com/sgl-project/sglang/pull/20392) (shard 10: `test_torchao.py` failure in [CI run](https://github.com/sgl-project/sglang/actions/runs/23233297921/job/67538048347?pr=20392)).

## Modifications

- Import `tgemm` from `aiter.tuned_gemm` when `SGLANG_USE_AITER=1`
- Add a `tgemm.mm` fast path in `UnquantizedLinearMethod.apply` for AMD GPUs, guarded by `type(layer.weight.data) is torch.Tensor` to ensure it only activates on plain tensors
- Torchao-quantized weights (`AffineQuantizedTensor`, a `torch.Tensor` subclass) will fail the strict `type()` check and correctly fall through to `F.linear`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).