### PR TITLE
[AMD] fix CI: workspace buffer OOM and tuned GEMM torchao compatibility

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -186,8 +186,15 @@ class AiterAttnBackend(AttentionBackend):
                 )
 
         # aiter kernel related initialization
+        # Cap effective sequence length by actual KV cache capacity to avoid
+        # over-allocating the workspace buffer on memory-constrained GPUs.
+        # No single sequence can exceed max_total_num_tokens.
+        effective_max_seq_len = min(
+            self.max_context_len,
+            getattr(model_runner, "max_total_num_tokens", self.max_context_len),
+        )
         self.max_num_partitions = (
-            self.max_context_len + _AITER_PARTITION_SIZE_ROCM - 1
+            effective_max_seq_len + _AITER_PARTITION_SIZE_ROCM - 1
         ) // _AITER_PARTITION_SIZE_ROCM
 
         nbyes_per_qo_elem = torch.finfo(torch.float32).bits // 8

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -52,6 +52,7 @@ if _use_aiter:
     from aiter import ActivationType
     from aiter.fused_moe import fused_moe
     from aiter.ops.shuffle import shuffle_weight
+    from aiter.tuned_gemm import tgemm
 
 if _is_npu:
     from sglang.srt.hardware_backend.npu.utils import npu_format_cast
@@ -149,6 +150,9 @@ class UnquantizedLinearMethod(LinearMethodBase):
             if len(x_shapes) == 3:
                 output = output.view(x_shapes[0], x_shapes[1], -1)
             return output
+
+        if _use_aiter and type(layer.weight.data) is torch.Tensor:
+            return tgemm.mm(x, layer.weight, bias, otype=x.dtype)
 
         return F.linear(x, layer.weight, bias)
 


### PR DESCRIPTION
## Motivation

Two aiter backend failures surfaced by [PR #20392](https://github.com/sgl-project/sglang/pull/20392) which defaults AMD HIP GPUs to the aiter backend:

**Shard 8** ([CI log](https://github.com/sgl-project/sglang/actions/runs/23233297921/job/67538048340?pr=20392)): `test_no_overlap_scheduler.py` OOM during `AiterAttnBackend.__init__`:
```
torch.OutOfMemoryError: HIP out of memory. Tried to allocate 16.25 GiB.
GPU 0 has a total capacity of 255.98 GiB of which 4.23 GiB is free.
```

**Shard 10** ([CI log](https://github.com/sgl-project/sglang/actions/runs/23233297921/job/67538048347?pr=20392)): `test_torchao.py` crash on quantized weights:
```
NotImplementedError: AffineQuantizedTensor dispatch: attempting to run
  unimplemented operator/function: func=<OpOverload(op='aiter.gemm_a16w16')>
```

## Modifications

### 1. `aiter_backend.py` — workspace buffer OOM

The workspace buffer for `paged_attention_ragged` was sized using `max_context_len` (e.g. 131K for Llama 3.1 → 512 partitions → 16.25 GiB), but the CI GPU's KV cache only held 25K tokens. Since no single sequence can exceed `max_total_num_tokens`, we cap `max_num_partitions` accordingly:

- Before: `max_num_partitions = ceil(131072 / 256) = 512` → workspace ~16.25 GiB
- After: `max_num_partitions = ceil(25432 / 256) = 100` → workspace ~3.2 GiB

### 2. `unquant.py` — tuned GEMM with torchao guard

Add aiter's `tgemm.mm` fast path for unquantized linear ops on AMD, guarded by `type(layer.weight.data) is torch.Tensor`. Torchao-quantized weights (`AffineQuantizedTensor`, a `torch.Tensor` subclass) fail the strict `type()` check and correctly fall through to `F.linear`.

## Additional Note for PR #20392

The PR also has a logic bug in its workspace buffer guard condition:
```python
# Current (incorrect): skips allocation only when BOTH are true
if not (self.use_mla and self.use_triton_unified_attention):

# Should be: skips allocation when EITHER is true
if not (self.use_mla or self.use_triton_unified_attention):
```
`workspace_buffer` is only used by `paged_attention_ragged`, which is only called when both `use_mla=False` AND `use_triton_unified_attention=False`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).