### PR TITLE
[Test] Add unit tests for srt/sampling

### DIFF
--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -12,6 +12,7 @@ import torch
 
 from sglang.srt.sampling.custom_logit_processor import (
     CustomLogitProcessor,
+    DeepSeekR1ThinkingBudgetLogitProcessor,
     DeepseekOCRNoRepeatNGramLogitProcessor,
     DisallowedTokensLogitsProcessor,
     Qwen3ThinkingBudgetLogitProcessor,
@@ -54,7 +55,6 @@ class TestCustomLogitProcessorSerialization(unittest.TestCase):
         s = DisallowedTokensLogitsProcessor.to_str()
         cls1 = _cache_from_str(s)
         cls2 = _cache_from_str(s)
-        # The cached function returns the CLASS, not an instance
         self.assertIs(cls1, cls2)
 
 
@@ -224,6 +224,37 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         # Batch 1 should have been modified (budget exceeded)
         self.assertEqual(result[1, self.NL].item(), 0.0)
         self.assertTrue(torch.isinf(result[1, 0]) and result[1, 0] < 0)
+
+    def test_multiple_thinking_start_counts_from_first(self):
+        """When multiple THINKING_START tokens exist, .index() finds the first.
+        Budget is counted from the *first* START, not the last."""
+        req = _make_req(
+            origin_input_ids=[self.START, 100, 101],
+            output_ids=[self.START, 200, 201],  # second START in output
+        )
+        # cur_ids = [START, 100, 101, START, 200, 201]
+        # First START at index 0, tokens_after_start = 5
+        # Budget=10 → 5 < 10 → no modification
+        params = [{"thinking_budget": 10, "__req__": req}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_deepseek_r1_variant_forces_end(self):
+        """Verify DeepSeekR1 variant works with its own token IDs."""
+        proc = DeepSeekR1ThinkingBudgetLogitProcessor()
+        START = proc.THINKING_START_TOKEN_ID  # 128798
+        NL = proc.NEW_LINE_TOKEN_ID  # 201
+        VOCAB = 200000
+
+        req = _make_req(origin_input_ids=[START], output_ids=[100] * 5)
+        params = [{"thinking_budget": 5, "__req__": req}]
+        logits = torch.zeros(1, VOCAB)
+        result = proc(logits, params)
+        # Budget exceeded, last token (100) is not newline → force newline
+        self.assertEqual(result[0, NL].item(), 0.0)
+        self.assertTrue(torch.isinf(result[0, 0]) and result[0, 0] < 0)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -18,11 +18,10 @@ from sglang.srt.sampling.custom_logit_processor import (
     Qwen3ThinkingBudgetLogitProcessor,
     _cache_from_str,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
-# ---------------------------------------------------------------------------
 # Helper: mock a Req object (used by ThinkingBudget and NGram processors)
-# ---------------------------------------------------------------------------
 def _make_req(origin_input_ids=None, output_ids=None):
     req = MagicMock()
     req.origin_input_ids = origin_input_ids or []
@@ -30,11 +29,8 @@ def _make_req(origin_input_ids=None, output_ids=None):
     return req
 
 
-# ---------------------------------------------------------------------------
 # Serialization round-trip
-# ---------------------------------------------------------------------------
-class TestCustomLogitProcessorSerialization(unittest.TestCase):
-    """Test dill-based serialization used to send processors over the network."""
+class TestCustomLogitProcessorSerialization(CustomTestCase):
 
     def test_to_str_produces_valid_json(self):
         s = DisallowedTokensLogitsProcessor.to_str()
@@ -43,14 +39,13 @@ class TestCustomLogitProcessorSerialization(unittest.TestCase):
         self.assertIsInstance(data["callable"], str)
 
     def test_round_trip_serialization(self):
-        """Serialize then deserialize — result should be a usable processor."""
+        """Test serialize then deserialize produces a usable processor."""
         s = DisallowedTokensLogitsProcessor.to_str()
         processor = CustomLogitProcessor.from_str(s)
         self.assertIsInstance(processor, DisallowedTokensLogitsProcessor)
 
     def test_from_str_is_cached(self):
-        """Calling from_str twice with the same string should return the same class
-        (from LRU cache), but different instances (because from_str calls cls())."""
+        """Test that from_str uses LRU cache for repeated calls."""
         _cache_from_str.cache_clear()
         s = DisallowedTokensLogitsProcessor.to_str()
         cls1 = _cache_from_str(s)
@@ -58,10 +53,8 @@ class TestCustomLogitProcessorSerialization(unittest.TestCase):
         self.assertIs(cls1, cls2)
 
 
-# ---------------------------------------------------------------------------
 # DisallowedTokensLogitsProcessor
-# ---------------------------------------------------------------------------
-class TestDisallowedTokensLogitsProcessor(unittest.TestCase):
+class TestDisallowedTokensLogitsProcessor(CustomTestCase):
     def setUp(self):
         self.processor = DisallowedTokensLogitsProcessor()
 
@@ -82,17 +75,15 @@ class TestDisallowedTokensLogitsProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
 
     def test_mismatched_params_raises(self):
-        """All batch items must have the same disallowed token_ids."""
+        """Test that mismatched token_ids across batch items raises AssertionError."""
         logits = torch.zeros(2, 10)
         params = [{"token_ids": [1, 2]}, {"token_ids": [3, 4]}]
         with self.assertRaises(AssertionError):
             self.processor(logits, params)
 
 
-# ---------------------------------------------------------------------------
 # ThinkingBudgetLogitProcessor (using Qwen3 variant)
-# ---------------------------------------------------------------------------
-class TestThinkingBudgetLogitProcessor(unittest.TestCase):
+class TestThinkingBudgetLogitProcessor(CustomTestCase):
     """Test thinking budget enforcement using Qwen3 token IDs.
 
     Qwen3 tokens:
@@ -113,7 +104,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         return torch.zeros(batch_size, self.VOCAB)
 
     def test_budget_not_exceeded_no_change(self):
-        """If thinking tokens < budget, logits should not be modified."""
+        """Test no modification when thinking tokens are within budget."""
         req = _make_req(
             origin_input_ids=[self.START],
             output_ids=[100, 101],  # 2 tokens after start
@@ -124,8 +115,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertEqual(result[0, 0].item(), 0.0)  # unchanged
 
     def test_budget_exceeded_forces_newline_first(self):
-        """When budget is exceeded and last token is NOT newline,
-        force the model to emit a newline."""
+        """Test forcing newline when budget exceeded and last token is not newline."""
         req = _make_req(
             origin_input_ids=[self.START],
             output_ids=[100] * 5,  # 5 tokens, budget=5 → exceeded
@@ -138,7 +128,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[0, 0]) and result[0, 0] < 0)
 
     def test_budget_exceeded_with_newline_forces_end_token(self):
-        """When budget exceeded and last token IS newline, force thinking end."""
+        """Test forcing end token when budget exceeded and last token is newline."""
         req = _make_req(
             origin_input_ids=[self.START],
             output_ids=[100] * 5 + [self.NL],  # 6 tokens, last is newline
@@ -150,7 +140,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[0, 0]) and result[0, 0] < 0)
 
     def test_skips_when_not_in_thinking(self):
-        """If THINKING_START not in token ids, skip (no thinking phase)."""
+        """Test skip when THINKING_START is absent (no thinking phase)."""
         req = _make_req(origin_input_ids=[100, 101], output_ids=[102])
         params = [{"thinking_budget": 0, "__req__": req}]
         logits = self._logits()
@@ -159,7 +149,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_skips_when_thinking_already_ended(self):
-        """If THINKING_END already in token ids, skip."""
+        """Test skip when THINKING_END already appeared."""
         req = _make_req(
             origin_input_ids=[self.START],
             output_ids=[100, self.END, 200],
@@ -199,7 +189,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_budget_zero_forces_immediate_end(self):
-        """Budget=0 means end thinking immediately (0 tokens allowed)."""
+        """Test that budget=0 forces thinking to end immediately."""
         req = _make_req(
             origin_input_ids=[self.START],
             output_ids=[100],  # 1 token after start > budget=0
@@ -211,7 +201,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertEqual(result[0, self.NL].item(), 0.0)
 
     def test_none_param_dict_in_list_skipped(self):
-        """A None entry in the param list should be skipped gracefully."""
+        """Test that None entry in param list is skipped gracefully."""
         req = _make_req(
             origin_input_ids=[self.START],
             output_ids=[100] * 10,
@@ -226,8 +216,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[1, 0]) and result[1, 0] < 0)
 
     def test_multiple_thinking_start_counts_from_first(self):
-        """When multiple THINKING_START tokens exist, .index() finds the first.
-        Budget is counted from the *first* START, not the last."""
+        """Test that budget counts from the first THINKING_START occurrence."""
         req = _make_req(
             origin_input_ids=[self.START, 100, 101],
             output_ids=[self.START, 200, 201],  # second START in output
@@ -242,7 +231,7 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_deepseek_r1_variant_forces_end(self):
-        """Verify DeepSeekR1 variant works with its own token IDs."""
+        """Test DeepSeekR1 variant with its own token IDs."""
         proc = DeepSeekR1ThinkingBudgetLogitProcessor()
         START = proc.THINKING_START_TOKEN_ID  # 128798
         NL = proc.NEW_LINE_TOKEN_ID  # 201
@@ -257,10 +246,8 @@ class TestThinkingBudgetLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[0, 0]) and result[0, 0] < 0)
 
 
-# ---------------------------------------------------------------------------
 # DeepseekOCRNoRepeatNGramLogitProcessor
-# ---------------------------------------------------------------------------
-class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
+class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
     VOCAB = 100
 
     def setUp(self):
@@ -270,8 +257,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         return torch.zeros(batch_size, self.VOCAB)
 
     def test_bans_repeated_bigrams(self):
-        """Sequence [1,2,3,1,2] with ngram_size=2 — last bigram prefix is (2),
-        which appeared at index 1 followed by 3. So token 3 should be banned."""
+        """Test banning token that completes a repeated bigram."""
         req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
         params = [
             {
@@ -285,7 +271,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
 
     def test_non_repeated_tokens_unchanged(self):
-        """Tokens that DON'T complete a repeated ngram should remain at 0."""
+        """Test that tokens not completing a repeated ngram are unchanged."""
         req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
         params = [{"__req__": req, "ngram_size": 2, "window_size": 100}]
         logits = self._logits()
@@ -294,7 +280,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         self.assertEqual(result[0, 1].item(), 0.0)
 
     def test_window_size_limits_search(self):
-        """With a small window, older ngrams should NOT cause banning."""
+        """Test that ngrams outside the window are not considered."""
         # Sequence: [1,2,3,...,1,2] but window only covers the last 3 tokens
         req = _make_req(origin_input_ids=[1, 2, 3, 4, 5, 1, 2])
         params = [{"__req__": req, "ngram_size": 2, "window_size": 3}]
@@ -306,7 +292,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         self.assertEqual(result[0, 3].item(), 0.0)
 
     def test_whitelist_protects_tokens(self):
-        """Whitelisted tokens should not be banned even if they form repeated ngrams."""
+        """Test that whitelisted tokens are not banned despite repeated ngrams."""
         req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
         params = [
             {
@@ -395,8 +381,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[1, 1]) and result[1, 1] < 0)
 
     def test_search_end_leq_search_start_skips(self):
-        """When window_size is small relative to ngram_size, search_end <= search_start
-        and the item should be skipped."""
+        """Test skip when window is too small for the ngram_size."""
         # sequence length=4, ngram_size=3, window_size=2
         # search_start = max(0, 4-2) = 2
         # search_end = 4 - 3 + 1 = 2
@@ -409,7 +394,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_invalid_whitelist_type_handled(self):
-        """Non-iterable whitelist_token_ids should be handled gracefully (TypeError)."""
+        """Test graceful handling of non-iterable whitelist_token_ids."""
         req = _make_req(origin_input_ids=[1, 2, 1, 2])
         params = [
             {
@@ -425,7 +410,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
         self.assertTrue(torch.isinf(result[0, 1]) and result[0, 1] < 0)
 
     def test_batch_processing(self):
-        """Multiple batch items should be processed independently."""
+        """Test that multiple batch items are processed independently."""
         req1 = _make_req(
             origin_input_ids=[1, 2, 1, 2]
         )  # will ban token 2 (bigram repeat)

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -1,0 +1,420 @@
+"""Unit tests for srt/sampling/custom_logit_processor.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import json
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.sampling.custom_logit_processor import (
+    CustomLogitProcessor,
+    DeepseekOCRNoRepeatNGramLogitProcessor,
+    DisallowedTokensLogitsProcessor,
+    Qwen3ThinkingBudgetLogitProcessor,
+    _cache_from_str,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock a Req object (used by ThinkingBudget and NGram processors)
+# ---------------------------------------------------------------------------
+def _make_req(origin_input_ids=None, output_ids=None):
+    req = MagicMock()
+    req.origin_input_ids = origin_input_ids or []
+    req.output_ids = output_ids or []
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+class TestCustomLogitProcessorSerialization(unittest.TestCase):
+    """Test dill-based serialization used to send processors over the network."""
+
+    def test_to_str_produces_valid_json(self):
+        s = DisallowedTokensLogitsProcessor.to_str()
+        data = json.loads(s)
+        self.assertIn("callable", data)
+        self.assertIsInstance(data["callable"], str)
+
+    def test_round_trip_serialization(self):
+        """Serialize then deserialize — result should be a usable processor."""
+        s = DisallowedTokensLogitsProcessor.to_str()
+        processor = CustomLogitProcessor.from_str(s)
+        self.assertIsInstance(processor, DisallowedTokensLogitsProcessor)
+
+    def test_from_str_is_cached(self):
+        """Calling from_str twice with the same string should return the same class
+        (from LRU cache), but different instances (because from_str calls cls())."""
+        _cache_from_str.cache_clear()
+        s = DisallowedTokensLogitsProcessor.to_str()
+        cls1 = _cache_from_str(s)
+        cls2 = _cache_from_str(s)
+        # The cached function returns the CLASS, not an instance
+        self.assertIs(cls1, cls2)
+
+
+# ---------------------------------------------------------------------------
+# DisallowedTokensLogitsProcessor
+# ---------------------------------------------------------------------------
+class TestDisallowedTokensLogitsProcessor(unittest.TestCase):
+    def setUp(self):
+        self.processor = DisallowedTokensLogitsProcessor()
+
+    def test_disallowed_tokens_set_to_neg_inf(self):
+        logits = torch.zeros(2, 10)
+        params = [{"token_ids": [2, 5]}, {"token_ids": [2, 5]}]
+        result = self.processor(logits, params)
+        self.assertTrue(torch.isinf(result[0, 2]) and result[0, 2] < 0)
+        self.assertTrue(torch.isinf(result[0, 5]) and result[0, 5] < 0)
+        self.assertTrue(torch.isinf(result[1, 2]) and result[1, 2] < 0)
+
+    def test_allowed_tokens_unchanged(self):
+        logits = torch.ones(1, 10)
+        params = [{"token_ids": [3]}]
+        result = self.processor(logits, params)
+        self.assertEqual(result[0, 0].item(), 1.0)
+        self.assertEqual(result[0, 4].item(), 1.0)
+        self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
+
+    def test_mismatched_params_raises(self):
+        """All batch items must have the same disallowed token_ids."""
+        logits = torch.zeros(2, 10)
+        params = [{"token_ids": [1, 2]}, {"token_ids": [3, 4]}]
+        with self.assertRaises(AssertionError):
+            self.processor(logits, params)
+
+
+# ---------------------------------------------------------------------------
+# ThinkingBudgetLogitProcessor (using Qwen3 variant)
+# ---------------------------------------------------------------------------
+class TestThinkingBudgetLogitProcessor(unittest.TestCase):
+    """Test thinking budget enforcement using Qwen3 token IDs.
+
+    Qwen3 tokens:
+        THINKING_START = 151667
+        THINKING_END   = 151668
+        NEW_LINE       = 198
+    """
+
+    START = Qwen3ThinkingBudgetLogitProcessor.THINKING_START_TOKEN_ID
+    END = Qwen3ThinkingBudgetLogitProcessor.THINKING_END_TOKEN_ID
+    NL = Qwen3ThinkingBudgetLogitProcessor.NEW_LINE_TOKEN_ID
+    VOCAB = 200000
+
+    def setUp(self):
+        self.processor = Qwen3ThinkingBudgetLogitProcessor()
+
+    def _logits(self, batch_size=1):
+        return torch.zeros(batch_size, self.VOCAB)
+
+    def test_budget_not_exceeded_no_change(self):
+        """If thinking tokens < budget, logits should not be modified."""
+        req = _make_req(
+            origin_input_ids=[self.START],
+            output_ids=[100, 101],  # 2 tokens after start
+        )
+        params = [{"thinking_budget": 10, "__req__": req}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        self.assertEqual(result[0, 0].item(), 0.0)  # unchanged
+
+    def test_budget_exceeded_forces_newline_first(self):
+        """When budget is exceeded and last token is NOT newline,
+        force the model to emit a newline."""
+        req = _make_req(
+            origin_input_ids=[self.START],
+            output_ids=[100] * 5,  # 5 tokens, budget=5 → exceeded
+        )
+        params = [{"thinking_budget": 5, "__req__": req}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # newline should be the only non-neg-inf token
+        self.assertEqual(result[0, self.NL].item(), 0.0)
+        self.assertTrue(torch.isinf(result[0, 0]) and result[0, 0] < 0)
+
+    def test_budget_exceeded_with_newline_forces_end_token(self):
+        """When budget exceeded and last token IS newline, force thinking end."""
+        req = _make_req(
+            origin_input_ids=[self.START],
+            output_ids=[100] * 5 + [self.NL],  # 6 tokens, last is newline
+        )
+        params = [{"thinking_budget": 5, "__req__": req}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        self.assertEqual(result[0, self.END].item(), 0.0)
+        self.assertTrue(torch.isinf(result[0, 0]) and result[0, 0] < 0)
+
+    def test_skips_when_not_in_thinking(self):
+        """If THINKING_START not in token ids, skip (no thinking phase)."""
+        req = _make_req(origin_input_ids=[100, 101], output_ids=[102])
+        params = [{"thinking_budget": 0, "__req__": req}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_skips_when_thinking_already_ended(self):
+        """If THINKING_END already in token ids, skip."""
+        req = _make_req(
+            origin_input_ids=[self.START],
+            output_ids=[100, self.END, 200],
+        )
+        params = [{"thinking_budget": 0, "__req__": req}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_skips_when_budget_is_none(self):
+        req = _make_req(origin_input_ids=[self.START], output_ids=[100] * 10)
+        params = [{"thinking_budget": None, "__req__": req}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_skips_when_budget_is_negative(self):
+        req = _make_req(origin_input_ids=[self.START], output_ids=[100] * 10)
+        params = [{"thinking_budget": -1, "__req__": req}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_none_params_returns_unchanged(self):
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, None)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_empty_params_returns_unchanged(self):
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, [])
+        self.assertTrue(torch.equal(result, original))
+
+    def test_budget_zero_forces_immediate_end(self):
+        """Budget=0 means end thinking immediately (0 tokens allowed)."""
+        req = _make_req(
+            origin_input_ids=[self.START],
+            output_ids=[100],  # 1 token after start > budget=0
+        )
+        params = [{"thinking_budget": 0, "__req__": req}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # Should force newline since last token (100) is not newline
+        self.assertEqual(result[0, self.NL].item(), 0.0)
+
+    def test_none_param_dict_in_list_skipped(self):
+        """A None entry in the param list should be skipped gracefully."""
+        req = _make_req(
+            origin_input_ids=[self.START],
+            output_ids=[100] * 10,
+        )
+        params = [None, {"thinking_budget": 0, "__req__": req}]
+        logits = self._logits(batch_size=2)
+        result = self.processor(logits, params)
+        # Batch 0 (None param) should be unchanged
+        self.assertEqual(result[0, 0].item(), 0.0)
+        # Batch 1 should have been modified (budget exceeded)
+        self.assertEqual(result[1, self.NL].item(), 0.0)
+        self.assertTrue(torch.isinf(result[1, 0]) and result[1, 0] < 0)
+
+
+# ---------------------------------------------------------------------------
+# DeepseekOCRNoRepeatNGramLogitProcessor
+# ---------------------------------------------------------------------------
+class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
+    VOCAB = 100
+
+    def setUp(self):
+        self.processor = DeepseekOCRNoRepeatNGramLogitProcessor()
+
+    def _logits(self, batch_size=1):
+        return torch.zeros(batch_size, self.VOCAB)
+
+    def test_bans_repeated_bigrams(self):
+        """Sequence [1,2,3,1,2] with ngram_size=2 — last bigram prefix is (2),
+        which appeared at index 1 followed by 3. So token 3 should be banned."""
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        params = [
+            {
+                "__req__": req,
+                "ngram_size": 2,
+                "window_size": 100,
+            }
+        ]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.isinf(result[0, 3]) and result[0, 3] < 0)
+
+    def test_non_repeated_tokens_unchanged(self):
+        """Tokens that DON'T complete a repeated ngram should remain at 0."""
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": 100}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # Token 1 is not banned (prefix (2) was followed by 3, not 1)
+        self.assertEqual(result[0, 1].item(), 0.0)
+
+    def test_window_size_limits_search(self):
+        """With a small window, older ngrams should NOT cause banning."""
+        # Sequence: [1,2,3,...,1,2] but window only covers the last 3 tokens
+        req = _make_req(origin_input_ids=[1, 2, 3, 4, 5, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": 3}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # Window covers [5, 1, 2]. The bigram (1,2) from index 0-1 is outside.
+        # Within window: bigrams are (5,1), (1,2). Current prefix is (2).
+        # No bigram starting with prefix (2) in window → nothing banned.
+        self.assertEqual(result[0, 3].item(), 0.0)
+
+    def test_whitelist_protects_tokens(self):
+        """Whitelisted tokens should not be banned even if they form repeated ngrams."""
+        req = _make_req(origin_input_ids=[1, 2, 3, 1, 2])
+        params = [
+            {
+                "__req__": req,
+                "ngram_size": 2,
+                "window_size": 100,
+                "whitelist_token_ids": [3],
+            }
+        ]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # Token 3 would be banned but is whitelisted
+        self.assertEqual(result[0, 3].item(), 0.0)
+
+    def test_ngram_size_zero_skips(self):
+        """ngram_size=0 is invalid and should be skipped (no modification)."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": 0, "window_size": 100}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_window_size_zero_skips(self):
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": 0}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_empty_params_returns_unchanged(self):
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, None)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_short_sequence_skips(self):
+        """Sequence shorter than ngram_size should be skipped."""
+        req = _make_req(origin_input_ids=[1])
+        params = [{"__req__": req, "ngram_size": 3, "window_size": 100}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_unigram_mode(self):
+        """ngram_size=1 bans any token already seen in the window."""
+        req = _make_req(origin_input_ids=[5, 10, 15])
+        params = [{"__req__": req, "ngram_size": 1, "window_size": 100}]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # All tokens in [5, 10, 15] should be banned
+        self.assertTrue(torch.isinf(result[0, 5]) and result[0, 5] < 0)
+        self.assertTrue(torch.isinf(result[0, 10]) and result[0, 10] < 0)
+        self.assertTrue(torch.isinf(result[0, 15]) and result[0, 15] < 0)
+        # Other tokens should be fine
+        self.assertEqual(result[0, 0].item(), 0.0)
+
+    def test_none_req_skips(self):
+        """If __req__ is missing, the batch item should be skipped."""
+        params = [{"ngram_size": 2, "window_size": 100}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_invalid_ngram_size_type_skips(self):
+        """Non-numeric ngram_size should be handled gracefully."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [
+            {"__req__": req, "ngram_size": "invalid", "window_size": 100}
+        ]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_falsy_params_in_list_skipped(self):
+        """A falsy entry (None, {}, 0) in param list should be skipped."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [None, {"__req__": req, "ngram_size": 2, "window_size": 100}]
+        logits = self._logits(batch_size=2)
+        result = self.processor(logits, params)
+        # Batch 0 (None) unchanged
+        self.assertEqual(result[0, 0].item(), 0.0)
+        # Batch 1 has ban applied
+        self.assertTrue(torch.isinf(result[1, 1]) and result[1, 1] < 0)
+
+    def test_search_end_leq_search_start_skips(self):
+        """When window_size is small relative to ngram_size, search_end <= search_start
+        and the item should be skipped."""
+        # sequence length=4, ngram_size=3, window_size=2
+        # search_start = max(0, 4-2) = 2
+        # search_end = 4 - 3 + 1 = 2
+        # search_end (2) <= search_start (2) → skip
+        req = _make_req(origin_input_ids=[1, 2, 3, 4])
+        params = [{"__req__": req, "ngram_size": 3, "window_size": 2}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_invalid_whitelist_type_handled(self):
+        """Non-iterable whitelist_token_ids should be handled gracefully (TypeError)."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [
+            {
+                "__req__": req,
+                "ngram_size": 2,
+                "window_size": 100,
+                "whitelist_token_ids": 999,  # int, not iterable
+            }
+        ]
+        logits = self._logits()
+        result = self.processor(logits, params)
+        # Should still ban token 1 (whitelist parse fails, falls back to empty set)
+        self.assertTrue(torch.isinf(result[0, 1]) and result[0, 1] < 0)
+
+    def test_batch_processing(self):
+        """Multiple batch items should be processed independently."""
+        req1 = _make_req(origin_input_ids=[1, 2, 1, 2])  # will ban token 2 (bigram repeat)
+        req2 = _make_req(origin_input_ids=[3, 4, 5])  # no repeat
+        params = [
+            {"__req__": req1, "ngram_size": 2, "window_size": 100},
+            {"__req__": req2, "ngram_size": 2, "window_size": 100},
+        ]
+        logits = self._logits(batch_size=2)
+        result = self.processor(logits, params)
+        # Batch 0: bigram (1,2) appeared, prefix is (2) → ban token that followed (2) = 1
+        # Also (2,1) appeared, prefix is (2) → already covered
+        # Actually: sequence is [1,2,1,2], prefix is last (ngram_size-1)=1 token = (2)
+        # Scanning: index 0: (1,2) prefix=(1); index 1: (2,1) prefix=(2)→bans 1; index 2: (1,2) prefix=(1)
+        # So prefix (2) appeared at index 1, followed by token 1. Ban token 1.
+        self.assertTrue(torch.isinf(result[0, 1]) and result[0, 1] < 0)
+        # Batch 1: prefix is (5), no matching prefix in window → no bans
+        self.assertEqual(result[1, 3].item(), 0.0)
+        self.assertEqual(result[1, 4].item(), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -12,8 +12,8 @@ import torch
 
 from sglang.srt.sampling.custom_logit_processor import (
     CustomLogitProcessor,
-    DeepSeekR1ThinkingBudgetLogitProcessor,
     DeepseekOCRNoRepeatNGramLogitProcessor,
+    DeepSeekR1ThinkingBudgetLogitProcessor,
     DisallowedTokensLogitsProcessor,
     Qwen3ThinkingBudgetLogitProcessor,
     _cache_from_str,
@@ -377,9 +377,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
     def test_invalid_ngram_size_type_skips(self):
         """Non-numeric ngram_size should be handled gracefully."""
         req = _make_req(origin_input_ids=[1, 2, 1, 2])
-        params = [
-            {"__req__": req, "ngram_size": "invalid", "window_size": 100}
-        ]
+        params = [{"__req__": req, "ngram_size": "invalid", "window_size": 100}]
         logits = self._logits()
         original = logits.clone()
         result = self.processor(logits, params)
@@ -428,7 +426,9 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(unittest.TestCase):
 
     def test_batch_processing(self):
         """Multiple batch items should be processed independently."""
-        req1 = _make_req(origin_input_ids=[1, 2, 1, 2])  # will ban token 2 (bigram repeat)
+        req1 = _make_req(
+            origin_input_ids=[1, 2, 1, 2]
+        )  # will ban token 2 (bigram repeat)
         req2 = _make_req(origin_input_ids=[3, 4, 5])  # no repeat
         params = [
             {"__req__": req1, "ngram_size": 2, "window_size": 100},

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -33,6 +33,7 @@ def _make_req(origin_input_ids=None, output_ids=None):
 class TestCustomLogitProcessorSerialization(CustomTestCase):
 
     def test_to_str_produces_valid_json(self):
+        """Test that to_str() produces valid JSON with a 'callable' field."""
         s = DisallowedTokensLogitsProcessor.to_str()
         data = json.loads(s)
         self.assertIn("callable", data)
@@ -59,6 +60,7 @@ class TestDisallowedTokensLogitsProcessor(CustomTestCase):
         self.processor = DisallowedTokensLogitsProcessor()
 
     def test_disallowed_tokens_set_to_neg_inf(self):
+        """Test that disallowed token positions are set to -inf for all batch items."""
         logits = torch.zeros(2, 10)
         params = [{"token_ids": [2, 5]}, {"token_ids": [2, 5]}]
         result = self.processor(logits, params)
@@ -67,6 +69,7 @@ class TestDisallowedTokensLogitsProcessor(CustomTestCase):
         self.assertTrue(torch.isinf(result[1, 2]) and result[1, 2] < 0)
 
     def test_allowed_tokens_unchanged(self):
+        """Test that non-disallowed tokens keep their original logit values."""
         logits = torch.ones(1, 10)
         params = [{"token_ids": [3]}]
         result = self.processor(logits, params)
@@ -161,6 +164,7 @@ class TestThinkingBudgetLogitProcessor(CustomTestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_skips_when_budget_is_none(self):
+        """Test that thinking_budget=None is ignored even during thinking phase."""
         req = _make_req(origin_input_ids=[self.START], output_ids=[100] * 10)
         params = [{"thinking_budget": None, "__req__": req}]
         logits = self._logits()
@@ -169,6 +173,7 @@ class TestThinkingBudgetLogitProcessor(CustomTestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_skips_when_budget_is_negative(self):
+        """Test that negative thinking_budget is treated as disabled (no enforcement)."""
         req = _make_req(origin_input_ids=[self.START], output_ids=[100] * 10)
         params = [{"thinking_budget": -1, "__req__": req}]
         logits = self._logits()
@@ -177,12 +182,14 @@ class TestThinkingBudgetLogitProcessor(CustomTestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_none_params_returns_unchanged(self):
+        """Test that passing None as param list returns logits unchanged."""
         logits = self._logits()
         original = logits.clone()
         result = self.processor(logits, None)
         self.assertTrue(torch.equal(result, original))
 
     def test_empty_params_returns_unchanged(self):
+        """Test that passing empty param list returns logits unchanged."""
         logits = self._logits()
         original = logits.clone()
         result = self.processor(logits, [])
@@ -317,6 +324,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_window_size_zero_skips(self):
+        """Test that window_size=0 disables ngram checking (no modification)."""
         req = _make_req(origin_input_ids=[1, 2, 1, 2])
         params = [{"__req__": req, "ngram_size": 2, "window_size": 0}]
         logits = self._logits()
@@ -325,6 +333,7 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         self.assertTrue(torch.equal(result, original))
 
     def test_empty_params_returns_unchanged(self):
+        """Test that None param list returns logits unchanged (early return)."""
         logits = self._logits()
         original = logits.clone()
         result = self.processor(logits, None)

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -297,6 +297,27 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
         self.assertTrue(torch.isinf(logits[0, 5]) and logits[0, 5] < 0)
         self.assertTrue(torch.isinf(logits[0, 10]) and logits[0, 10] < 0)
 
+    def test_blocks_additional_stop_tokens(self):
+        """additional_stop_token_ids from tokenizer should also be blocked."""
+        req = _make_req(min_tokens=3, stop_ids=None, eos_id=2)
+        req.tokenizer.additional_stop_token_ids = {7, 8}
+        batch = _make_batch([req])
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedMinNewTokensPenalizer}
+        )
+        pen = orch.penalizers[BatchedMinNewTokensPenalizer]
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        # EOS (2) + additional stops (7, 8) should all be blocked
+        for tok in [2, 7, 8]:
+            self.assertTrue(
+                torch.isinf(logits[0, tok]) and logits[0, tok] < 0,
+                f"token {tok} should be blocked before min_new_tokens",
+            )
+        # Non-stop tokens should be fine
+        self.assertEqual(logits[0, 0].item(), 0.0)
+
     def test_filter_keeps_subset(self):
         orch, pen = self._setup([(3, None, 2), (5, None, 2)])
         keep = torch.tensor([1])

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -1,0 +1,445 @@
+"""Unit tests for srt/sampling/penaltylib/ — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.sampling.penaltylib.frequency_penalty import (
+    BatchedFrequencyPenalizer,
+)
+from sglang.srt.sampling.penaltylib.min_new_tokens import (
+    BatchedMinNewTokensPenalizer,
+)
+from sglang.srt.sampling.penaltylib.orchestrator import (
+    BatchedPenalizerOrchestrator,
+    _BatchedPenalizer,
+)
+from sglang.srt.sampling.penaltylib.presence_penalty import (
+    BatchedPresencePenalizer,
+)
+
+VOCAB_SIZE = 32
+DEVICE = "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: mock Req and ScheduleBatch
+# ---------------------------------------------------------------------------
+def _make_req(freq=0.0, pres=0.0, min_tokens=0, stop_ids=None, eos_id=2):
+    """Create a mock request with sampling params."""
+    req = MagicMock()
+    req.sampling_params.frequency_penalty = freq
+    req.sampling_params.presence_penalty = pres
+    req.sampling_params.min_new_tokens = min_tokens
+    req.sampling_params.stop_token_ids = stop_ids
+    req.tokenizer.additional_stop_token_ids = None
+    req.tokenizer.eos_token_id = eos_id
+    return req
+
+
+def _make_batch(reqs):
+    """Create a mock ScheduleBatch.
+    Note: orchestrator accesses batch.reqs as an attribute (not a method call)."""
+    batch = MagicMock()
+    batch.reqs = reqs
+    batch.device = DEVICE
+    return batch
+
+
+# ---------------------------------------------------------------------------
+# BatchedPenalizerOrchestrator
+# ---------------------------------------------------------------------------
+class TestBatchedPenalizerOrchestrator(unittest.TestCase):
+
+    def test_init_detects_required_penalizers(self):
+        reqs = [_make_req(freq=1.0)]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        self.assertTrue(orch.is_required)
+
+    def test_init_not_required_when_no_penalties(self):
+        reqs = [_make_req()]  # all defaults (0.0)
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        self.assertFalse(orch.is_required)
+
+    def test_batch_property_via_weakref(self):
+        reqs = [_make_req()]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, set())
+        self.assertIs(orch.batch, batch)
+
+    def test_batch_setter_none(self):
+        reqs = [_make_req()]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, set())
+        orch.batch = None
+        self.assertIsNone(orch.batch)
+
+    def test_batch_setter_new_batch(self):
+        reqs = [_make_req()]
+        batch1 = _make_batch(reqs)
+        batch2 = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch1, set())
+        orch.batch = batch2
+        self.assertIs(orch.batch, batch2)
+
+    def test_context_manager_releases(self):
+        reqs = [_make_req(freq=1.0)]
+        batch = _make_batch(reqs)
+        with BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}) as orch:
+            self.assertTrue(orch.is_required)
+        self.assertFalse(orch.is_required)
+        self.assertEqual(len(orch.penalizers), 0)
+
+    def test_filter_empty_indices_releases(self):
+        reqs = [_make_req(freq=1.0)]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch.filter(torch.tensor([], dtype=torch.long))
+        self.assertFalse(orch.is_required)
+
+    def test_filter_not_required_is_noop(self):
+        reqs = [_make_req()]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        self.assertFalse(orch.is_required)
+        orch.filter(torch.tensor([0]))  # should not raise
+
+    def test_merge_both_not_required_is_noop(self):
+        reqs = [_make_req()]
+        batch = _make_batch(reqs)
+        orch1 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch2 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch1.merge(orch2)  # should not raise
+        self.assertFalse(orch1.is_required)
+
+
+# ---------------------------------------------------------------------------
+# BatchedFrequencyPenalizer
+# ---------------------------------------------------------------------------
+class TestBatchedFrequencyPenalizer(unittest.TestCase):
+
+    def _setup(self, freq_values):
+        reqs = [_make_req(freq=f) for f in freq_values]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        pen = orch.penalizers[BatchedFrequencyPenalizer]
+        return orch, pen
+
+    def test_is_required_with_nonzero_penalty(self):
+        _, pen = self._setup([1.5])
+        self.assertTrue(pen.is_required())
+
+    def test_is_not_required_with_zero_penalty(self):
+        _, pen = self._setup([0.0])
+        self.assertFalse(pen.is_required())
+
+    def test_cumulate_and_apply(self):
+        """After cumulating token 5 once, logits[5] should decrease by freq_penalty."""
+        orch, pen = self._setup([2.0])
+        output_ids = torch.tensor([5])
+        pen.cumulate_output_tokens(output_ids)
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        self.assertAlmostEqual(logits[0, 5].item(), -2.0, places=5)
+        # Other tokens unaffected
+        self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
+
+    def test_cumulate_twice_doubles_penalty(self):
+        """Frequency penalty scales linearly with count."""
+        orch, pen = self._setup([1.0])
+        pen.cumulate_output_tokens(torch.tensor([3]))
+        pen.cumulate_output_tokens(torch.tensor([3]))
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        self.assertAlmostEqual(logits[0, 3].item(), -2.0, places=5)
+
+    def test_filter_keeps_subset(self):
+        orch, pen = self._setup([1.0, 2.0])
+        keep = torch.tensor([1])
+        pen.filter(keep)
+        self.assertEqual(pen.frequency_penalties.shape[0], 1)
+        self.assertAlmostEqual(pen.frequency_penalties[0, 0].item(), 2.0, places=5)
+
+    def test_merge_concatenates(self):
+        _, pen1 = self._setup([1.0])
+        _, pen2 = self._setup([2.0])
+        pen1.merge(pen2)
+        self.assertEqual(pen1.frequency_penalties.shape[0], 2)
+
+    def test_teardown_cleans_attributes(self):
+        _, pen = self._setup([1.0])
+        pen.teardown()
+        self.assertFalse(hasattr(pen, "frequency_penalties"))
+        self.assertFalse(hasattr(pen, "cumulated_frequency_penalties"))
+        self.assertFalse(pen.is_prepared())
+
+    def test_cumulate_when_not_prepared_is_noop(self):
+        """Calling cumulate before prepare should not crash."""
+        _, pen = self._setup([0.0])
+        # pen is not prepared (is_required=False)
+        pen.cumulate_output_tokens(torch.tensor([1]))  # should not raise
+
+    def test_apply_when_not_prepared_is_noop(self):
+        _, pen = self._setup([0.0])
+        logits = torch.zeros(1, VOCAB_SIZE)
+        original = logits.clone()
+        pen.apply(logits)
+        self.assertTrue(torch.equal(logits, original))
+
+
+# ---------------------------------------------------------------------------
+# BatchedPresencePenalizer
+# ---------------------------------------------------------------------------
+class TestBatchedPresencePenalizer(unittest.TestCase):
+
+    def _setup(self, pres_values):
+        reqs = [_make_req(pres=p) for p in pres_values]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedPresencePenalizer})
+        pen = orch.penalizers[BatchedPresencePenalizer]
+        return orch, pen
+
+    def test_is_required_with_nonzero_penalty(self):
+        _, pen = self._setup([0.5])
+        self.assertTrue(pen.is_required())
+
+    def test_presence_penalty_does_not_scale(self):
+        """Unlike frequency, presence penalty is flat — same regardless of count."""
+        orch, pen = self._setup([1.0])
+        pen.cumulate_output_tokens(torch.tensor([7]))
+        pen.cumulate_output_tokens(torch.tensor([7]))  # same token again
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        # scatter_ overwrites (not adds), so penalty should be 1.0, not 2.0
+        self.assertAlmostEqual(logits[0, 7].item(), -1.0, places=5)
+
+    def test_filter_keeps_subset(self):
+        orch, pen = self._setup([1.0, 2.0])
+        keep = torch.tensor([0])
+        pen.filter(keep)
+        self.assertEqual(pen.presence_penalties.shape[0], 1)
+        self.assertAlmostEqual(pen.presence_penalties[0, 0].item(), 1.0, places=5)
+
+    def test_merge_concatenates(self):
+        _, pen1 = self._setup([1.0])
+        _, pen2 = self._setup([2.0])
+        pen1.merge(pen2)
+        self.assertEqual(pen1.presence_penalties.shape[0], 2)
+
+    def test_teardown_cleans_attributes(self):
+        _, pen = self._setup([1.0])
+        pen.teardown()
+        self.assertFalse(hasattr(pen, "presence_penalties"))
+
+
+# ---------------------------------------------------------------------------
+# BatchedMinNewTokensPenalizer
+# ---------------------------------------------------------------------------
+class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
+
+    def _setup(self, configs):
+        """configs: list of (min_tokens, stop_ids, eos_id)."""
+        reqs = [
+            _make_req(min_tokens=c[0], stop_ids=c[1], eos_id=c[2])
+            for c in configs
+        ]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedMinNewTokensPenalizer})
+        pen = orch.penalizers[BatchedMinNewTokensPenalizer]
+        return orch, pen
+
+    def test_is_required_with_positive_min_tokens(self):
+        _, pen = self._setup([(5, None, 2)])
+        self.assertTrue(pen.is_required())
+
+    def test_is_not_required_with_zero_min_tokens(self):
+        _, pen = self._setup([(0, None, 2)])
+        self.assertFalse(pen.is_required())
+
+    def test_blocks_eos_before_min_tokens(self):
+        """EOS token should get -inf penalty before min_new_tokens is reached."""
+        orch, pen = self._setup([(3, None, 2)])
+        # Before any output: len=0 < min=3 → block EOS (token 2)
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        self.assertTrue(torch.isinf(logits[0, 2]) and logits[0, 2] < 0)
+        # Non-stop tokens should be fine
+        self.assertEqual(logits[0, 0].item(), 0.0)
+
+    def test_allows_eos_after_min_tokens(self):
+        """After generating min_new_tokens, EOS should no longer be blocked."""
+        orch, pen = self._setup([(2, None, 2)])
+        # Generate 2 tokens
+        pen.cumulate_output_tokens(torch.tensor([10]))
+        pen.cumulate_output_tokens(torch.tensor([11]))
+        # Now len=2 >= min=2 → EOS should NOT be blocked
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        self.assertEqual(logits[0, 2].item(), 0.0)
+
+    def test_blocks_custom_stop_tokens(self):
+        """Custom stop_token_ids should also be blocked before min_new_tokens."""
+        orch, pen = self._setup([(3, {5, 10}, 2)])
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        # EOS (2), stop token 5, stop token 10 should all be blocked
+        self.assertTrue(torch.isinf(logits[0, 2]) and logits[0, 2] < 0)
+        self.assertTrue(torch.isinf(logits[0, 5]) and logits[0, 5] < 0)
+        self.assertTrue(torch.isinf(logits[0, 10]) and logits[0, 10] < 0)
+
+    def test_filter_keeps_subset(self):
+        orch, pen = self._setup([(3, None, 2), (5, None, 2)])
+        keep = torch.tensor([1])
+        pen.filter(keep)
+        self.assertEqual(pen.min_new_tokens.shape[0], 1)
+        self.assertEqual(pen.min_new_tokens[0, 0].item(), 5)
+
+    def test_merge_concatenates(self):
+        _, pen1 = self._setup([(3, None, 2)])
+        _, pen2 = self._setup([(5, None, 2)])
+        pen1.merge(pen2)
+        self.assertEqual(pen1.min_new_tokens.shape[0], 2)
+
+    def test_teardown_cleans_attributes(self):
+        _, pen = self._setup([(3, None, 2)])
+        pen.teardown()
+        self.assertFalse(hasattr(pen, "min_new_tokens"))
+        self.assertFalse(hasattr(pen, "stop_token_penalties"))
+        self.assertFalse(hasattr(pen, "len_output_tokens"))
+
+
+# ---------------------------------------------------------------------------
+# _BatchedPenalizer base class edge cases
+# ---------------------------------------------------------------------------
+class TestBatchedPenalizerBase(unittest.TestCase):
+
+    def test_filter_when_not_prepared_is_noop(self):
+        reqs = [_make_req()]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        pen = orch.penalizers[BatchedFrequencyPenalizer]
+        # pen is not prepared (frequency_penalty=0 → not required)
+        pen.filter(torch.tensor([0]))  # should not raise
+
+    def test_merge_prepares_both_if_needed(self):
+        """When merging, if one side is not prepared, it should get prepared first."""
+        reqs_a = [_make_req(freq=0.0)]  # not required
+        reqs_b = [_make_req(freq=1.0)]  # required
+        batch_a = _make_batch(reqs_a)
+        batch_b = _make_batch(reqs_b)
+        orch_a = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_a, {BatchedFrequencyPenalizer})
+        orch_b = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_b, {BatchedFrequencyPenalizer})
+        pen_a = orch_a.penalizers[BatchedFrequencyPenalizer]
+        pen_b = orch_b.penalizers[BatchedFrequencyPenalizer]
+        self.assertFalse(pen_a.is_prepared())
+        self.assertTrue(pen_b.is_prepared())
+        # Merge should prepare pen_a first
+        pen_a.merge(pen_b)
+        self.assertTrue(pen_a.is_prepared())
+        self.assertEqual(pen_a.frequency_penalties.shape[0], 2)
+
+    def test_merge_both_unprepared_is_noop(self):
+        reqs = [_make_req()]
+        batch = _make_batch(reqs)
+        orch1 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch2 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        pen1 = orch1.penalizers[BatchedFrequencyPenalizer]
+        pen2 = orch2.penalizers[BatchedFrequencyPenalizer]
+        pen1.merge(pen2)  # both not prepared → noop
+        self.assertFalse(pen1.is_prepared())
+
+    def test_prepare_is_idempotent(self):
+        """Calling prepare() multiple times should only prepare once."""
+        reqs = [_make_req(freq=1.0)]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        pen = orch.penalizers[BatchedFrequencyPenalizer]
+        self.assertTrue(pen.is_prepared())
+        # Calling prepare again should not crash or reinitialize
+        pen.prepare()
+        self.assertTrue(pen.is_prepared())
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator with multiple penalizer types
+# ---------------------------------------------------------------------------
+class TestOrchestratorMultiplePenalizers(unittest.TestCase):
+
+    def test_all_three_penalizers(self):
+        """Test orchestrator managing frequency, presence, and min_new_tokens together."""
+        reqs = [_make_req(freq=1.0, pres=0.5, min_tokens=2, eos_id=2)]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch,
+            {BatchedFrequencyPenalizer, BatchedPresencePenalizer, BatchedMinNewTokensPenalizer},
+        )
+        self.assertTrue(orch.is_required)
+
+        # Cumulate one token
+        output_ids = torch.tensor([5])
+        orch.cumulate_output_tokens(output_ids)
+
+        # Apply all penalties
+        logits = torch.zeros(1, VOCAB_SIZE)
+        orch.apply(logits)
+
+        # Token 5: freq_penalty=1.0 (cumulated once) + pres_penalty=0.5
+        self.assertAlmostEqual(logits[0, 5].item(), -1.5, places=4)
+        # EOS (token 2): blocked by min_new_tokens (len=1 < min=2)
+        self.assertTrue(torch.isinf(logits[0, 2]) and logits[0, 2] < 0)
+
+    def test_filter_with_penalizer_no_longer_required(self):
+        """After filtering, if a penalizer is no longer required, it should be torn down."""
+        reqs = [_make_req(freq=0.0), _make_req(freq=1.0)]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        self.assertTrue(orch.is_required)
+
+        # Keep only the request with freq=0 (index 0)
+        batch.reqs = [reqs[0]]
+        orch.filter(torch.tensor([0]))
+
+        pen = orch.penalizers[BatchedFrequencyPenalizer]
+        # After filter, only req with freq=0 remains → penalizer not required
+        self.assertFalse(pen.is_required())
+
+    def test_filter_keeps_required_penalizer(self):
+        """Filter should keep penalizer active if it's still required."""
+        reqs = [_make_req(freq=1.0), _make_req(freq=2.0)]
+        batch = _make_batch(reqs)
+        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        self.assertTrue(orch.is_required)
+
+        batch.reqs = [reqs[1]]
+        orch.filter(torch.tensor([1]))
+        self.assertTrue(orch.is_required)
+
+    def test_merge_one_required(self):
+        """Merging when only one side is required should still mark as required."""
+        reqs_a = [_make_req(freq=0.0)]
+        reqs_b = [_make_req(freq=1.0)]
+        batch_a = _make_batch(reqs_a)
+        batch_b = _make_batch(reqs_b)
+        orch_a = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_a, {BatchedFrequencyPenalizer})
+        orch_b = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_b, {BatchedFrequencyPenalizer})
+        self.assertFalse(orch_a.is_required)
+        self.assertTrue(orch_b.is_required)
+
+        orch_a.merge(orch_b)
+        self.assertTrue(orch_a.is_required)
+        pen = orch_a.penalizers[BatchedFrequencyPenalizer]
+        self.assertEqual(pen.frequency_penalties.shape[0], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -21,14 +21,13 @@ from sglang.srt.sampling.penaltylib.orchestrator import (
 from sglang.srt.sampling.penaltylib.presence_penalty import (
     BatchedPresencePenalizer,
 )
+from sglang.test.test_utils import CustomTestCase
 
 VOCAB_SIZE = 32
 DEVICE = "cpu"
 
 
-# ---------------------------------------------------------------------------
 # Helpers: mock Req and ScheduleBatch
-# ---------------------------------------------------------------------------
 def _make_req(freq=0.0, presence=0.0, min_tokens=0, stop_ids=None, eos_id=2):
     """Create a mock request with sampling params."""
     req = MagicMock()
@@ -50,10 +49,8 @@ def _make_batch(reqs):
     return batch
 
 
-# ---------------------------------------------------------------------------
 # BatchedPenalizerOrchestrator
-# ---------------------------------------------------------------------------
-class TestBatchedPenalizerOrchestrator(unittest.TestCase):
+class TestBatchedPenalizerOrchestrator(CustomTestCase):
 
     def test_init_detects_required_penalizers(self):
         reqs = [_make_req(freq=1.0)]
@@ -133,10 +130,8 @@ class TestBatchedPenalizerOrchestrator(unittest.TestCase):
         self.assertFalse(orch1.is_required)
 
 
-# ---------------------------------------------------------------------------
 # BatchedFrequencyPenalizer
-# ---------------------------------------------------------------------------
-class TestBatchedFrequencyPenalizer(unittest.TestCase):
+class TestBatchedFrequencyPenalizer(CustomTestCase):
 
     def _setup(self, freq_values):
         reqs = [_make_req(freq=f) for f in freq_values]
@@ -156,7 +151,7 @@ class TestBatchedFrequencyPenalizer(unittest.TestCase):
         self.assertFalse(pen.is_required())
 
     def test_cumulate_and_apply(self):
-        """After cumulating token 5 once, logits[5] should decrease by freq_penalty."""
+        """Test that cumulating a token applies frequency penalty to its logit."""
         orch, pen = self._setup([2.0])
         output_ids = torch.tensor([5])
         pen.cumulate_output_tokens(output_ids)
@@ -168,7 +163,7 @@ class TestBatchedFrequencyPenalizer(unittest.TestCase):
         self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
 
     def test_cumulate_twice_doubles_penalty(self):
-        """Frequency penalty scales linearly with count."""
+        """Test that frequency penalty scales linearly with occurrence count."""
         orch, pen = self._setup([1.0])
         pen.cumulate_output_tokens(torch.tensor([3]))
         pen.cumulate_output_tokens(torch.tensor([3]))
@@ -198,7 +193,7 @@ class TestBatchedFrequencyPenalizer(unittest.TestCase):
         self.assertFalse(pen.is_prepared())
 
     def test_cumulate_when_not_prepared_is_noop(self):
-        """Calling cumulate before prepare should not crash."""
+        """Test that cumulate before prepare does not crash."""
         _, pen = self._setup([0.0])
         # pen is not prepared (is_required=False)
         pen.cumulate_output_tokens(torch.tensor([1]))  # should not raise
@@ -211,10 +206,8 @@ class TestBatchedFrequencyPenalizer(unittest.TestCase):
         self.assertTrue(torch.equal(logits, original))
 
 
-# ---------------------------------------------------------------------------
 # BatchedPresencePenalizer
-# ---------------------------------------------------------------------------
-class TestBatchedPresencePenalizer(unittest.TestCase):
+class TestBatchedPresencePenalizer(CustomTestCase):
 
     def _setup(self, presence_values):
         reqs = [_make_req(presence=p) for p in presence_values]
@@ -230,7 +223,7 @@ class TestBatchedPresencePenalizer(unittest.TestCase):
         self.assertTrue(pen.is_required())
 
     def test_presence_penalty_does_not_scale(self):
-        """Unlike frequency, presence penalty is flat — same regardless of count."""
+        """Test that presence penalty is flat (same value regardless of count)."""
         orch, pen = self._setup([1.0])
         pen.cumulate_output_tokens(torch.tensor([7]))
         pen.cumulate_output_tokens(torch.tensor([7]))  # same token again
@@ -259,10 +252,8 @@ class TestBatchedPresencePenalizer(unittest.TestCase):
         self.assertFalse(hasattr(pen, "presence_penalties"))
 
 
-# ---------------------------------------------------------------------------
 # BatchedMinNewTokensPenalizer
-# ---------------------------------------------------------------------------
-class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
+class TestBatchedMinNewTokensPenalizer(CustomTestCase):
 
     def _setup(self, configs):
         """configs: list of (min_tokens, stop_ids, eos_id)."""
@@ -283,7 +274,7 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
         self.assertFalse(pen.is_required())
 
     def test_blocks_eos_before_min_tokens(self):
-        """EOS token should get -inf penalty before min_new_tokens is reached."""
+        """Test that EOS token is blocked before min_new_tokens is reached."""
         orch, pen = self._setup([(3, None, 2)])
         # Before any output: len=0 < min=3 → block EOS (token 2)
         logits = torch.zeros(1, VOCAB_SIZE)
@@ -293,7 +284,7 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
         self.assertEqual(logits[0, 0].item(), 0.0)
 
     def test_allows_eos_after_min_tokens(self):
-        """After generating min_new_tokens, EOS should no longer be blocked."""
+        """Test that EOS is allowed after generating min_new_tokens."""
         orch, pen = self._setup([(2, None, 2)])
         # Generate 2 tokens
         pen.cumulate_output_tokens(torch.tensor([10]))
@@ -304,7 +295,7 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
         self.assertEqual(logits[0, 2].item(), 0.0)
 
     def test_blocks_custom_stop_tokens(self):
-        """Custom stop_token_ids should also be blocked before min_new_tokens."""
+        """Test that custom stop_token_ids are also blocked before min_new_tokens."""
         orch, pen = self._setup([(3, {5, 10}, 2)])
         logits = torch.zeros(1, VOCAB_SIZE)
         pen.apply(logits)
@@ -314,7 +305,7 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
         self.assertTrue(torch.isinf(logits[0, 10]) and logits[0, 10] < 0)
 
     def test_blocks_additional_stop_tokens(self):
-        """additional_stop_token_ids from tokenizer should also be blocked."""
+        """Test that tokenizer's additional_stop_token_ids are also blocked."""
         req = _make_req(min_tokens=3, stop_ids=None, eos_id=2)
         req.tokenizer.additional_stop_token_ids = {7, 8}
         batch = _make_batch([req])
@@ -355,10 +346,8 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
         self.assertFalse(hasattr(pen, "len_output_tokens"))
 
 
-# ---------------------------------------------------------------------------
 # _BatchedPenalizer base class edge cases
-# ---------------------------------------------------------------------------
-class TestBatchedPenalizerBase(unittest.TestCase):
+class TestBatchedPenalizerBase(CustomTestCase):
 
     def test_filter_when_not_prepared_is_noop(self):
         reqs = [_make_req()]
@@ -371,7 +360,7 @@ class TestBatchedPenalizerBase(unittest.TestCase):
         pen.filter(torch.tensor([0]))  # should not raise
 
     def test_merge_prepares_both_if_needed(self):
-        """When merging, if one side is not prepared, it should get prepared first."""
+        """Test that merge prepares unprepared side before concatenating."""
         reqs_a = [_make_req(freq=0.0)]  # not required
         reqs_b = [_make_req(freq=1.0)]  # required
         batch_a = _make_batch(reqs_a)
@@ -406,7 +395,7 @@ class TestBatchedPenalizerBase(unittest.TestCase):
         self.assertFalse(pen1.is_prepared())
 
     def test_prepare_is_idempotent(self):
-        """Calling prepare() multiple times should only prepare once."""
+        """Test that calling prepare() multiple times does not crash."""
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -419,10 +408,8 @@ class TestBatchedPenalizerBase(unittest.TestCase):
         self.assertTrue(pen.is_prepared())
 
 
-# ---------------------------------------------------------------------------
 # Orchestrator with multiple penalizer types
-# ---------------------------------------------------------------------------
-class TestOrchestratorMultiplePenalizers(unittest.TestCase):
+class TestOrchestratorMultiplePenalizers(CustomTestCase):
 
     def test_all_three_penalizers(self):
         """Test orchestrator managing frequency, presence, and min_new_tokens together."""
@@ -453,7 +440,7 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
         self.assertTrue(torch.isinf(logits[0, 2]) and logits[0, 2] < 0)
 
     def test_filter_with_penalizer_no_longer_required(self):
-        """After filtering, if a penalizer is no longer required, it should be torn down."""
+        """Test that penalizer is torn down when no longer required after filter."""
         reqs = [_make_req(freq=0.0), _make_req(freq=1.0)]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -470,7 +457,7 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
         self.assertFalse(pen.is_required())
 
     def test_filter_keeps_required_penalizer(self):
-        """Filter should keep penalizer active if it's still required."""
+        """Test that filter keeps penalizer active when still required."""
         reqs = [_make_req(freq=1.0), _make_req(freq=2.0)]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -483,7 +470,7 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
         self.assertTrue(orch.is_required)
 
     def test_merge_one_required(self):
-        """Merging when only one side is required should still mark as required."""
+        """Test that merge marks orchestrator as required when one side is."""
         reqs_a = [_make_req(freq=0.0)]
         reqs_b = [_make_req(freq=1.0)]
         batch_a = _make_batch(reqs_a)

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -17,7 +17,6 @@ from sglang.srt.sampling.penaltylib.min_new_tokens import (
 )
 from sglang.srt.sampling.penaltylib.orchestrator import (
     BatchedPenalizerOrchestrator,
-    _BatchedPenalizer,
 )
 from sglang.srt.sampling.penaltylib.presence_penalty import (
     BatchedPresencePenalizer,
@@ -30,11 +29,11 @@ DEVICE = "cpu"
 # ---------------------------------------------------------------------------
 # Helpers: mock Req and ScheduleBatch
 # ---------------------------------------------------------------------------
-def _make_req(freq=0.0, pres=0.0, min_tokens=0, stop_ids=None, eos_id=2):
+def _make_req(freq=0.0, presence=0.0, min_tokens=0, stop_ids=None, eos_id=2):
     """Create a mock request with sampling params."""
     req = MagicMock()
     req.sampling_params.frequency_penalty = freq
-    req.sampling_params.presence_penalty = pres
+    req.sampling_params.presence_penalty = presence
     req.sampling_params.min_new_tokens = min_tokens
     req.sampling_params.stop_token_ids = stop_ids
     req.tokenizer.additional_stop_token_ids = None
@@ -59,13 +58,17 @@ class TestBatchedPenalizerOrchestrator(unittest.TestCase):
     def test_init_detects_required_penalizers(self):
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         self.assertTrue(orch.is_required)
 
     def test_init_not_required_when_no_penalties(self):
         reqs = [_make_req()]  # all defaults (0.0)
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         self.assertFalse(orch.is_required)
 
     def test_batch_property_via_weakref(self):
@@ -92,7 +95,9 @@ class TestBatchedPenalizerOrchestrator(unittest.TestCase):
     def test_context_manager_releases(self):
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
-        with BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}) as orch:
+        with BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        ) as orch:
             self.assertTrue(orch.is_required)
         self.assertFalse(orch.is_required)
         self.assertEqual(len(orch.penalizers), 0)
@@ -100,22 +105,30 @@ class TestBatchedPenalizerOrchestrator(unittest.TestCase):
     def test_filter_empty_indices_releases(self):
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         orch.filter(torch.tensor([], dtype=torch.long))
         self.assertFalse(orch.is_required)
 
     def test_filter_not_required_is_noop(self):
         reqs = [_make_req()]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         self.assertFalse(orch.is_required)
         orch.filter(torch.tensor([0]))  # should not raise
 
     def test_merge_both_not_required_is_noop(self):
         reqs = [_make_req()]
         batch = _make_batch(reqs)
-        orch1 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
-        orch2 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch1 = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
+        orch2 = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         orch1.merge(orch2)  # should not raise
         self.assertFalse(orch1.is_required)
 
@@ -128,7 +141,9 @@ class TestBatchedFrequencyPenalizer(unittest.TestCase):
     def _setup(self, freq_values):
         reqs = [_make_req(freq=f) for f in freq_values]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         pen = orch.penalizers[BatchedFrequencyPenalizer]
         return orch, pen
 
@@ -201,10 +216,12 @@ class TestBatchedFrequencyPenalizer(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestBatchedPresencePenalizer(unittest.TestCase):
 
-    def _setup(self, pres_values):
-        reqs = [_make_req(pres=p) for p in pres_values]
+    def _setup(self, presence_values):
+        reqs = [_make_req(presence=p) for p in presence_values]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedPresencePenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedPresencePenalizer}
+        )
         pen = orch.penalizers[BatchedPresencePenalizer]
         return orch, pen
 
@@ -249,12 +266,11 @@ class TestBatchedMinNewTokensPenalizer(unittest.TestCase):
 
     def _setup(self, configs):
         """configs: list of (min_tokens, stop_ids, eos_id)."""
-        reqs = [
-            _make_req(min_tokens=c[0], stop_ids=c[1], eos_id=c[2])
-            for c in configs
-        ]
+        reqs = [_make_req(min_tokens=c[0], stop_ids=c[1], eos_id=c[2]) for c in configs]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedMinNewTokensPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedMinNewTokensPenalizer}
+        )
         pen = orch.penalizers[BatchedMinNewTokensPenalizer]
         return orch, pen
 
@@ -347,7 +363,9 @@ class TestBatchedPenalizerBase(unittest.TestCase):
     def test_filter_when_not_prepared_is_noop(self):
         reqs = [_make_req()]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         pen = orch.penalizers[BatchedFrequencyPenalizer]
         # pen is not prepared (frequency_penalty=0 → not required)
         pen.filter(torch.tensor([0]))  # should not raise
@@ -358,8 +376,12 @@ class TestBatchedPenalizerBase(unittest.TestCase):
         reqs_b = [_make_req(freq=1.0)]  # required
         batch_a = _make_batch(reqs_a)
         batch_b = _make_batch(reqs_b)
-        orch_a = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_a, {BatchedFrequencyPenalizer})
-        orch_b = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_b, {BatchedFrequencyPenalizer})
+        orch_a = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch_a, {BatchedFrequencyPenalizer}
+        )
+        orch_b = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch_b, {BatchedFrequencyPenalizer}
+        )
         pen_a = orch_a.penalizers[BatchedFrequencyPenalizer]
         pen_b = orch_b.penalizers[BatchedFrequencyPenalizer]
         self.assertFalse(pen_a.is_prepared())
@@ -372,8 +394,12 @@ class TestBatchedPenalizerBase(unittest.TestCase):
     def test_merge_both_unprepared_is_noop(self):
         reqs = [_make_req()]
         batch = _make_batch(reqs)
-        orch1 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
-        orch2 = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch1 = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
+        orch2 = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         pen1 = orch1.penalizers[BatchedFrequencyPenalizer]
         pen2 = orch2.penalizers[BatchedFrequencyPenalizer]
         pen1.merge(pen2)  # both not prepared → noop
@@ -383,7 +409,9 @@ class TestBatchedPenalizerBase(unittest.TestCase):
         """Calling prepare() multiple times should only prepare once."""
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         pen = orch.penalizers[BatchedFrequencyPenalizer]
         self.assertTrue(pen.is_prepared())
         # Calling prepare again should not crash or reinitialize
@@ -398,11 +426,16 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
 
     def test_all_three_penalizers(self):
         """Test orchestrator managing frequency, presence, and min_new_tokens together."""
-        reqs = [_make_req(freq=1.0, pres=0.5, min_tokens=2, eos_id=2)]
+        reqs = [_make_req(freq=1.0, presence=0.5, min_tokens=2, eos_id=2)]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
-            VOCAB_SIZE, batch,
-            {BatchedFrequencyPenalizer, BatchedPresencePenalizer, BatchedMinNewTokensPenalizer},
+            VOCAB_SIZE,
+            batch,
+            {
+                BatchedFrequencyPenalizer,
+                BatchedPresencePenalizer,
+                BatchedMinNewTokensPenalizer,
+            },
         )
         self.assertTrue(orch.is_required)
 
@@ -423,7 +456,9 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
         """After filtering, if a penalizer is no longer required, it should be torn down."""
         reqs = [_make_req(freq=0.0), _make_req(freq=1.0)]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         self.assertTrue(orch.is_required)
 
         # Keep only the request with freq=0 (index 0)
@@ -438,7 +473,9 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
         """Filter should keep penalizer active if it's still required."""
         reqs = [_make_req(freq=1.0), _make_req(freq=2.0)]
         batch = _make_batch(reqs)
-        orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, {BatchedFrequencyPenalizer})
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch, {BatchedFrequencyPenalizer}
+        )
         self.assertTrue(orch.is_required)
 
         batch.reqs = [reqs[1]]
@@ -451,8 +488,12 @@ class TestOrchestratorMultiplePenalizers(unittest.TestCase):
         reqs_b = [_make_req(freq=1.0)]
         batch_a = _make_batch(reqs_a)
         batch_b = _make_batch(reqs_b)
-        orch_a = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_a, {BatchedFrequencyPenalizer})
-        orch_b = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch_b, {BatchedFrequencyPenalizer})
+        orch_a = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch_a, {BatchedFrequencyPenalizer}
+        )
+        orch_b = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, batch_b, {BatchedFrequencyPenalizer}
+        )
         self.assertFalse(orch_a.is_required)
         self.assertTrue(orch_b.is_required)
 

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -53,6 +53,7 @@ def _make_batch(reqs):
 class TestBatchedPenalizerOrchestrator(CustomTestCase):
 
     def test_init_detects_required_penalizers(self):
+        """Test that orchestrator marks is_required=True when any request has nonzero penalty."""
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -61,6 +62,7 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         self.assertTrue(orch.is_required)
 
     def test_init_not_required_when_no_penalties(self):
+        """Test that orchestrator marks is_required=False when all penalties are zero."""
         reqs = [_make_req()]  # all defaults (0.0)
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -69,12 +71,14 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         self.assertFalse(orch.is_required)
 
     def test_batch_property_via_weakref(self):
+        """Test that batch property returns the original batch via weakref."""
         reqs = [_make_req()]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, set())
         self.assertIs(orch.batch, batch)
 
     def test_batch_setter_none(self):
+        """Test that setting batch to None breaks the weakref cleanly."""
         reqs = [_make_req()]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(VOCAB_SIZE, batch, set())
@@ -82,6 +86,7 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         self.assertIsNone(orch.batch)
 
     def test_batch_setter_new_batch(self):
+        """Test that batch can be reassigned to a different ScheduleBatch."""
         reqs = [_make_req()]
         batch1 = _make_batch(reqs)
         batch2 = _make_batch(reqs)
@@ -90,6 +95,7 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         self.assertIs(orch.batch, batch2)
 
     def test_context_manager_releases(self):
+        """Test that exiting the context manager releases all penalizers."""
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
         with BatchedPenalizerOrchestrator(
@@ -100,6 +106,7 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         self.assertEqual(len(orch.penalizers), 0)
 
     def test_filter_empty_indices_releases(self):
+        """Test that filtering with no indices left fully releases the orchestrator."""
         reqs = [_make_req(freq=1.0)]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -109,6 +116,7 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         self.assertFalse(orch.is_required)
 
     def test_filter_not_required_is_noop(self):
+        """Test that filter on a not-required orchestrator does nothing."""
         reqs = [_make_req()]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -118,6 +126,7 @@ class TestBatchedPenalizerOrchestrator(CustomTestCase):
         orch.filter(torch.tensor([0]))  # should not raise
 
     def test_merge_both_not_required_is_noop(self):
+        """Test that merging two not-required orchestrators stays not-required."""
         reqs = [_make_req()]
         batch = _make_batch(reqs)
         orch1 = BatchedPenalizerOrchestrator(
@@ -143,10 +152,12 @@ class TestBatchedFrequencyPenalizer(CustomTestCase):
         return orch, pen
 
     def test_is_required_with_nonzero_penalty(self):
+        """Test that nonzero frequency_penalty makes the penalizer required."""
         _, pen = self._setup([1.5])
         self.assertTrue(pen.is_required())
 
     def test_is_not_required_with_zero_penalty(self):
+        """Test that zero frequency_penalty makes the penalizer not required."""
         _, pen = self._setup([0.0])
         self.assertFalse(pen.is_required())
 
@@ -173,6 +184,7 @@ class TestBatchedFrequencyPenalizer(CustomTestCase):
         self.assertAlmostEqual(logits[0, 3].item(), -2.0, places=5)
 
     def test_filter_keeps_subset(self):
+        """Test that filter retains only the selected batch indices."""
         orch, pen = self._setup([1.0, 2.0])
         keep = torch.tensor([1])
         pen.filter(keep)
@@ -180,12 +192,14 @@ class TestBatchedFrequencyPenalizer(CustomTestCase):
         self.assertAlmostEqual(pen.frequency_penalties[0, 0].item(), 2.0, places=5)
 
     def test_merge_concatenates(self):
+        """Test that merge concatenates penalty tensors from two penalizers."""
         _, pen1 = self._setup([1.0])
         _, pen2 = self._setup([2.0])
         pen1.merge(pen2)
         self.assertEqual(pen1.frequency_penalties.shape[0], 2)
 
     def test_teardown_cleans_attributes(self):
+        """Test that teardown deletes internal tensors and resets prepared state."""
         _, pen = self._setup([1.0])
         pen.teardown()
         self.assertFalse(hasattr(pen, "frequency_penalties"))
@@ -199,6 +213,7 @@ class TestBatchedFrequencyPenalizer(CustomTestCase):
         pen.cumulate_output_tokens(torch.tensor([1]))  # should not raise
 
     def test_apply_when_not_prepared_is_noop(self):
+        """Test that apply on an unprepared penalizer leaves logits unchanged."""
         _, pen = self._setup([0.0])
         logits = torch.zeros(1, VOCAB_SIZE)
         original = logits.clone()
@@ -219,6 +234,7 @@ class TestBatchedPresencePenalizer(CustomTestCase):
         return orch, pen
 
     def test_is_required_with_nonzero_penalty(self):
+        """Test that nonzero presence_penalty makes the penalizer required."""
         _, pen = self._setup([0.5])
         self.assertTrue(pen.is_required())
 
@@ -234,6 +250,7 @@ class TestBatchedPresencePenalizer(CustomTestCase):
         self.assertAlmostEqual(logits[0, 7].item(), -1.0, places=5)
 
     def test_filter_keeps_subset(self):
+        """Test that filter retains the first request's presence penalty."""
         orch, pen = self._setup([1.0, 2.0])
         keep = torch.tensor([0])
         pen.filter(keep)
@@ -241,12 +258,14 @@ class TestBatchedPresencePenalizer(CustomTestCase):
         self.assertAlmostEqual(pen.presence_penalties[0, 0].item(), 1.0, places=5)
 
     def test_merge_concatenates(self):
+        """Test that merge concatenates presence penalty tensors."""
         _, pen1 = self._setup([1.0])
         _, pen2 = self._setup([2.0])
         pen1.merge(pen2)
         self.assertEqual(pen1.presence_penalties.shape[0], 2)
 
     def test_teardown_cleans_attributes(self):
+        """Test that teardown removes the presence_penalties tensor."""
         _, pen = self._setup([1.0])
         pen.teardown()
         self.assertFalse(hasattr(pen, "presence_penalties"))
@@ -266,10 +285,12 @@ class TestBatchedMinNewTokensPenalizer(CustomTestCase):
         return orch, pen
 
     def test_is_required_with_positive_min_tokens(self):
+        """Test that positive min_new_tokens makes the penalizer required."""
         _, pen = self._setup([(5, None, 2)])
         self.assertTrue(pen.is_required())
 
     def test_is_not_required_with_zero_min_tokens(self):
+        """Test that min_new_tokens=0 makes the penalizer not required."""
         _, pen = self._setup([(0, None, 2)])
         self.assertFalse(pen.is_required())
 
@@ -326,6 +347,7 @@ class TestBatchedMinNewTokensPenalizer(CustomTestCase):
         self.assertEqual(logits[0, 0].item(), 0.0)
 
     def test_filter_keeps_subset(self):
+        """Test that filter keeps the second request (min_tokens=5) and drops the first."""
         orch, pen = self._setup([(3, None, 2), (5, None, 2)])
         keep = torch.tensor([1])
         pen.filter(keep)
@@ -333,12 +355,14 @@ class TestBatchedMinNewTokensPenalizer(CustomTestCase):
         self.assertEqual(pen.min_new_tokens[0, 0].item(), 5)
 
     def test_merge_concatenates(self):
+        """Test that merge combines min_new_tokens tensors from two penalizers."""
         _, pen1 = self._setup([(3, None, 2)])
         _, pen2 = self._setup([(5, None, 2)])
         pen1.merge(pen2)
         self.assertEqual(pen1.min_new_tokens.shape[0], 2)
 
     def test_teardown_cleans_attributes(self):
+        """Test that teardown removes min_new_tokens, stop_token_penalties, and len_output_tokens."""
         _, pen = self._setup([(3, None, 2)])
         pen.teardown()
         self.assertFalse(hasattr(pen, "min_new_tokens"))
@@ -350,6 +374,7 @@ class TestBatchedMinNewTokensPenalizer(CustomTestCase):
 class TestBatchedPenalizerBase(CustomTestCase):
 
     def test_filter_when_not_prepared_is_noop(self):
+        """Test that filter on an unprepared penalizer does not crash."""
         reqs = [_make_req()]
         batch = _make_batch(reqs)
         orch = BatchedPenalizerOrchestrator(
@@ -381,6 +406,7 @@ class TestBatchedPenalizerBase(CustomTestCase):
         self.assertEqual(pen_a.frequency_penalties.shape[0], 2)
 
     def test_merge_both_unprepared_is_noop(self):
+        """Test that merging two unprepared penalizers keeps them unprepared."""
         reqs = [_make_req()]
         batch = _make_batch(reqs)
         orch1 = BatchedPenalizerOrchestrator(

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -14,14 +14,13 @@ from sglang.srt.sampling.sampling_batch_info import (
     merge_bias_tensor,
 )
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.test.test_utils import CustomTestCase
 
 VOCAB_SIZE = 32
 DEVICE = "cpu"
 
 
-# ---------------------------------------------------------------------------
 # Helper: construct a minimal SamplingBatchInfo
-# ---------------------------------------------------------------------------
 def _make_info(batch_size=2, **overrides):
     """Create a SamplingBatchInfo with sane defaults for testing."""
     defaults = dict(
@@ -41,10 +40,7 @@ def _make_info(batch_size=2, **overrides):
     return SamplingBatchInfo(**defaults)
 
 
-# ---------------------------------------------------------------------------
-# merge_bias_tensor — standalone utility
-# ---------------------------------------------------------------------------
-class TestMergeBiasTensor(unittest.TestCase):
+class TestMergeBiasTensor(CustomTestCase):
 
     def test_both_none_returns_none(self):
         result = merge_bias_tensor(None, None, 2, 3, DEVICE, 0.0)
@@ -83,20 +79,15 @@ class TestMergeBiasTensor(unittest.TestCase):
         self.assertEqual(result[2, 0].item(), 1.0)
 
 
-# ---------------------------------------------------------------------------
 # SamplingBatchInfo.__len__
-# ---------------------------------------------------------------------------
-class TestSamplingBatchInfoLen(unittest.TestCase):
+class TestSamplingBatchInfoLen(CustomTestCase):
 
     def test_len_matches_batch_size(self):
         info = _make_info(batch_size=5)
         self.assertEqual(len(info), 5)
 
 
-# ---------------------------------------------------------------------------
-# merge_custom_logit_processor — static method
-# ---------------------------------------------------------------------------
-class TestMergeCustomLogitProcessor(unittest.TestCase):
+class TestMergeCustomLogitProcessor(CustomTestCase):
 
     def test_both_none_returns_none(self):
         result = SamplingBatchInfo.merge_custom_logit_processor(
@@ -138,10 +129,8 @@ class TestMergeCustomLogitProcessor(unittest.TestCase):
         self.assertEqual(result[10][1].shape[0], 3)
 
 
-# ---------------------------------------------------------------------------
 # apply_logits_bias
-# ---------------------------------------------------------------------------
-class TestApplyLogitsBias(unittest.TestCase):
+class TestApplyLogitsBias(CustomTestCase):
 
     def test_applies_linear_penalties(self):
         info = _make_info(batch_size=1)
@@ -186,10 +175,8 @@ class TestApplyLogitsBias(unittest.TestCase):
         self.assertTrue(torch.equal(logits, original))
 
 
-# ---------------------------------------------------------------------------
 # update_penalties
-# ---------------------------------------------------------------------------
-class TestUpdatePenalties(unittest.TestCase):
+class TestUpdatePenalties(CustomTestCase):
 
     def test_required_creates_penalties_tensor(self):
         orch = MagicMock(is_required=True)
@@ -206,10 +193,8 @@ class TestUpdatePenalties(unittest.TestCase):
         self.assertIsNone(info.acc_linear_penalties)
 
 
-# ---------------------------------------------------------------------------
 # update_regex_vocab_mask
-# ---------------------------------------------------------------------------
-class TestUpdateRegexVocabMask(unittest.TestCase):
+class TestUpdateRegexVocabMask(CustomTestCase):
 
     def test_no_grammars_clears_mask(self):
         info = _make_info(batch_size=1)
@@ -238,7 +223,7 @@ class TestUpdateRegexVocabMask(unittest.TestCase):
         grammar.move_vocab_mask.assert_called_once()
 
     def test_mixed_grammars_only_active_fills(self):
-        """Finished/terminated/None grammars should be skipped by fill loop."""
+        """Test that finished, terminated, and None grammars are skipped."""
         active = MagicMock()
         active.finished = False
         active.is_terminated.return_value = False
@@ -261,10 +246,8 @@ class TestUpdateRegexVocabMask(unittest.TestCase):
         terminated.fill_vocab_mask.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
 # filter_batch
-# ---------------------------------------------------------------------------
-class TestFilterBatch(unittest.TestCase):
+class TestFilterBatch(CustomTestCase):
 
     def test_filter_keeps_correct_indices(self):
         info = _make_info(batch_size=3)
@@ -295,7 +278,7 @@ class TestFilterBatch(unittest.TestCase):
         self.assertEqual(mask.shape[0], 2)
 
     def test_filter_removes_all_custom_processors(self):
-        """When filter removes all requests using a processor, it should be cleaned up."""
+        """Test cleanup when filter removes all requests using a processor."""
         proc = MagicMock()
         info = _make_info(batch_size=3)
         info.has_custom_logit_processor = True
@@ -315,10 +298,8 @@ class TestFilterBatch(unittest.TestCase):
         self.assertIsNone(info.sampling_seed)
 
 
-# ---------------------------------------------------------------------------
 # merge_batch
-# ---------------------------------------------------------------------------
-class TestMergeBatch(unittest.TestCase):
+class TestMergeBatch(CustomTestCase):
 
     def test_merge_concatenates_tensors(self):
         info1 = _make_info(batch_size=2)
@@ -371,7 +352,7 @@ class TestMergeBatch(unittest.TestCase):
         self.assertEqual(len(info1.custom_params), 2)
 
     def test_merge_with_none_sampling_seed(self):
-        """When sampling_seed is None on both sides, it stays None."""
+        """Test that merge preserves None when both sampling_seeds are None."""
         info1 = _make_info(batch_size=1)
         info1.sampling_seed = None
         info2 = _make_info(batch_size=1)
@@ -380,7 +361,7 @@ class TestMergeBatch(unittest.TestCase):
         self.assertIsNone(info1.sampling_seed)
 
     def test_merge_with_both_sampling_seeds(self):
-        """When both sides have sampling_seed tensors, they should be concatenated."""
+        """Test that merge concatenates both sampling_seed tensors."""
         info1 = _make_info(batch_size=2)
         info1.sampling_seed = torch.tensor([10, 20], dtype=torch.int64)
         info2 = _make_info(batch_size=1)
@@ -392,10 +373,8 @@ class TestMergeBatch(unittest.TestCase):
         self.assertEqual(info1.sampling_seed[2].item(), 30)
 
 
-# ---------------------------------------------------------------------------
 # copy_for_forward
-# ---------------------------------------------------------------------------
-class TestCopyForForward(unittest.TestCase):
+class TestCopyForForward(CustomTestCase):
 
     def test_returns_copy_without_orchestrator(self):
         orch = MagicMock(is_required=False)
@@ -406,10 +385,8 @@ class TestCopyForForward(unittest.TestCase):
         self.assertIsNotNone(info.penalizer_orchestrator)
 
 
-# ---------------------------------------------------------------------------
 # from_schedule_batch
-# ---------------------------------------------------------------------------
-class TestFromScheduleBatch(unittest.TestCase):
+class TestFromScheduleBatch(CustomTestCase):
 
     def _make_req(
         self,
@@ -501,7 +478,7 @@ class TestFromScheduleBatch(unittest.TestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_from_schedule_batch_sampling_flags(self, mock_server_args):
-        """Verify need_top_p/top_k/min_p flags are computed correctly."""
+        """Test that sampling flags (need_top_p/top_k/min_p) are set correctly."""
         mock_server_args.return_value.enable_deterministic_inference = False
         mock_server_args.return_value.enable_custom_logit_processor = False
 
@@ -529,8 +506,7 @@ class TestFromScheduleBatch(unittest.TestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_custom_logit_processor_merging(self, mock_server_args):
-        """When enable_custom_logit_processor=True and reqs have processors,
-        they should be deserialized and merged by type."""
+        """Test deserialization and merging of custom logit processors."""
         from sglang.srt.sampling.custom_logit_processor import (
             DisallowedTokensLogitsProcessor,
         )

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -108,23 +108,19 @@ class TestMergeCustomLogitProcessor(unittest.TestCase):
         proc = MagicMock()
         lhs = {42: (proc, torch.tensor([True, False]))}
         rhs = {42: (proc, torch.tensor([False, True, True]))}
-        result = SamplingBatchInfo.merge_custom_logit_processor(
-            lhs, rhs, 2, 3, DEVICE
-        )
+        result = SamplingBatchInfo.merge_custom_logit_processor(lhs, rhs, 2, 3, DEVICE)
         self.assertIn(42, result)
         self.assertEqual(result[42][1].shape[0], 5)
-        self.assertTrue(result[42][1][0].item())   # from lhs
-        self.assertFalse(result[42][1][1].item())   # from lhs
-        self.assertTrue(result[42][1][3].item())    # from rhs
+        self.assertTrue(result[42][1][0].item())  # from lhs
+        self.assertFalse(result[42][1][1].item())  # from lhs
+        self.assertTrue(result[42][1][3].item())  # from rhs
 
     def test_disjoint_keys(self):
         proc_a = MagicMock()
         proc_b = MagicMock()
         lhs = {1: (proc_a, torch.tensor([True, False]))}
         rhs = {2: (proc_b, torch.tensor([True]))}
-        result = SamplingBatchInfo.merge_custom_logit_processor(
-            lhs, rhs, 2, 1, DEVICE
-        )
+        result = SamplingBatchInfo.merge_custom_logit_processor(lhs, rhs, 2, 1, DEVICE)
         # Key 1: lhs mask [True, False] + zero-filled rhs [False]
         self.assertEqual(result[1][1].shape[0], 3)
         self.assertTrue(result[1][1][0].item())
@@ -137,9 +133,7 @@ class TestMergeCustomLogitProcessor(unittest.TestCase):
     def test_lhs_none_rhs_present(self):
         proc = MagicMock()
         rhs = {10: (proc, torch.tensor([True]))}
-        result = SamplingBatchInfo.merge_custom_logit_processor(
-            None, rhs, 2, 1, DEVICE
-        )
+        result = SamplingBatchInfo.merge_custom_logit_processor(None, rhs, 2, 1, DEVICE)
         self.assertIn(10, result)
         self.assertEqual(result[10][1].shape[0], 3)
 
@@ -292,9 +286,7 @@ class TestFilterBatch(unittest.TestCase):
         proc = MagicMock()
         info = _make_info(batch_size=3)
         info.has_custom_logit_processor = True
-        info.custom_logit_processor = {
-            42: (proc, torch.tensor([True, False, True]))
-        }
+        info.custom_logit_processor = {42: (proc, torch.tensor([True, False, True]))}
         info.custom_params = [{"a": 1}, {"b": 2}, {"c": 3}]
         keep = torch.tensor([0, 2])
         info.filter_batch([0, 2], keep)
@@ -307,9 +299,7 @@ class TestFilterBatch(unittest.TestCase):
         proc = MagicMock()
         info = _make_info(batch_size=3)
         info.has_custom_logit_processor = True
-        info.custom_logit_processor = {
-            42: (proc, torch.tensor([False, True, False]))
-        }
+        info.custom_logit_processor = {42: (proc, torch.tensor([False, True, False]))}
         info.custom_params = [None, {"x": 1}, None]
         # Keep only index 0 and 2 — processor 42's mask becomes [False, False]
         keep = torch.tensor([0, 2])
@@ -353,10 +343,10 @@ class TestMergeBatch(unittest.TestCase):
             need_min_p_sampling=True,
         )
         info1.merge_batch(info2)
-        self.assertFalse(info1.is_all_greedy)       # AND semantics
-        self.assertTrue(info1.need_top_p_sampling)   # OR semantics
-        self.assertTrue(info1.need_top_k_sampling)   # OR semantics
-        self.assertTrue(info1.need_min_p_sampling)   # OR semantics
+        self.assertFalse(info1.is_all_greedy)  # AND semantics
+        self.assertTrue(info1.need_top_p_sampling)  # OR semantics
+        self.assertTrue(info1.need_top_k_sampling)  # OR semantics
+        self.assertTrue(info1.need_min_p_sampling)  # OR semantics
 
     def test_merge_with_logit_bias(self):
         info1 = _make_info(batch_size=1)
@@ -421,16 +411,27 @@ class TestCopyForForward(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestFromScheduleBatch(unittest.TestCase):
 
-    def _make_req(self, temp=1.0, top_p=1.0, top_k=-1, min_p=0.0,
-                  freq=0.0, pres=0.0, min_tokens=0, logit_bias=None,
-                  seed=None, stop_ids=None, eos_id=2):
+    def _make_req(
+        self,
+        temp=1.0,
+        top_p=1.0,
+        top_k=-1,
+        min_p=0.0,
+        freq=0.0,
+        presence=0.0,
+        min_tokens=0,
+        logit_bias=None,
+        seed=None,
+        stop_ids=None,
+        eos_id=2,
+    ):
         req = MagicMock()
         req.sampling_params.temperature = temp
         req.sampling_params.top_p = top_p
         req.sampling_params.top_k = top_k
         req.sampling_params.min_p = min_p
         req.sampling_params.frequency_penalty = freq
-        req.sampling_params.presence_penalty = pres
+        req.sampling_params.presence_penalty = presence
         req.sampling_params.min_new_tokens = min_tokens
         req.sampling_params.logit_bias = logit_bias
         req.sampling_params.sampling_seed = seed
@@ -509,10 +510,10 @@ class TestFromScheduleBatch(unittest.TestCase):
         batch.reqs = reqs
         batch.device = DEVICE
         info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
-        self.assertTrue(info.need_top_p_sampling)   # 0.9 != 1.0
-        self.assertTrue(info.need_top_k_sampling)   # 50 != TOP_K_ALL
-        self.assertTrue(info.need_min_p_sampling)   # 0.1 > 0
-        self.assertFalse(info.is_all_greedy)        # top_k=50 > 1
+        self.assertTrue(info.need_top_p_sampling)  # 0.9 != 1.0
+        self.assertTrue(info.need_top_k_sampling)  # 50 != TOP_K_ALL
+        self.assertTrue(info.need_min_p_sampling)  # 0.1 > 0
+        self.assertFalse(info.is_all_greedy)  # top_k=50 > 1
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_no_logit_bias_when_all_none(self, mock_server_args):

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -1,0 +1,502 @@
+"""Unit tests for srt/sampling/sampling_batch_info.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.sampling.sampling_batch_info import (
+    SamplingBatchInfo,
+    merge_bias_tensor,
+)
+from sglang.srt.sampling.sampling_params import TOP_K_ALL
+
+VOCAB_SIZE = 32
+DEVICE = "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Helper: construct a minimal SamplingBatchInfo
+# ---------------------------------------------------------------------------
+def _make_info(batch_size=2, **overrides):
+    """Create a SamplingBatchInfo with sane defaults for testing."""
+    defaults = dict(
+        temperatures=torch.ones(batch_size, 1),
+        top_ps=torch.ones(batch_size),
+        top_ks=torch.full((batch_size,), TOP_K_ALL, dtype=torch.int32),
+        min_ps=torch.zeros(batch_size),
+        is_all_greedy=False,
+        need_top_p_sampling=False,
+        need_top_k_sampling=False,
+        need_min_p_sampling=False,
+        vocab_size=VOCAB_SIZE,
+        device=DEVICE,
+        penalizer_orchestrator=MagicMock(is_required=False),
+    )
+    defaults.update(overrides)
+    return SamplingBatchInfo(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# merge_bias_tensor — standalone utility
+# ---------------------------------------------------------------------------
+class TestMergeBiasTensor(unittest.TestCase):
+
+    def test_both_none_returns_none(self):
+        result = merge_bias_tensor(None, None, 2, 3, DEVICE, 0.0)
+        self.assertIsNone(result)
+
+    def test_both_present_concatenates(self):
+        lhs = torch.ones(2, VOCAB_SIZE)
+        rhs = torch.zeros(3, VOCAB_SIZE)
+        result = merge_bias_tensor(lhs, rhs, 2, 3, DEVICE, 0.0)
+        self.assertEqual(result.shape, (5, VOCAB_SIZE))
+        self.assertEqual(result[0, 0].item(), 1.0)
+        self.assertEqual(result[3, 0].item(), 0.0)
+
+    def test_lhs_none_fills_default(self):
+        rhs = torch.ones(3, VOCAB_SIZE)
+        result = merge_bias_tensor(None, rhs, 2, 3, DEVICE, 0.0)
+        self.assertEqual(result.shape, (5, VOCAB_SIZE))
+        # First 2 rows filled with default (0.0)
+        self.assertEqual(result[0, 0].item(), 0.0)
+        # Last 3 rows from rhs
+        self.assertEqual(result[2, 0].item(), 1.0)
+
+    def test_rhs_none_fills_default(self):
+        lhs = torch.ones(2, VOCAB_SIZE)
+        result = merge_bias_tensor(lhs, None, 2, 3, DEVICE, 0.0)
+        self.assertEqual(result.shape, (5, VOCAB_SIZE))
+        self.assertEqual(result[0, 0].item(), 1.0)
+        # Last 3 rows filled with default (0.0)
+        self.assertEqual(result[3, 0].item(), 0.0)
+
+    def test_custom_default_value(self):
+        rhs = torch.ones(1, VOCAB_SIZE)
+        result = merge_bias_tensor(None, rhs, 2, 1, DEVICE, -1.0)
+        self.assertEqual(result[0, 0].item(), -1.0)
+        self.assertEqual(result[1, 0].item(), -1.0)
+        self.assertEqual(result[2, 0].item(), 1.0)
+
+
+# ---------------------------------------------------------------------------
+# SamplingBatchInfo.__len__
+# ---------------------------------------------------------------------------
+class TestSamplingBatchInfoLen(unittest.TestCase):
+
+    def test_len_matches_batch_size(self):
+        info = _make_info(batch_size=5)
+        self.assertEqual(len(info), 5)
+
+
+# ---------------------------------------------------------------------------
+# merge_custom_logit_processor — static method
+# ---------------------------------------------------------------------------
+class TestMergeCustomLogitProcessor(unittest.TestCase):
+
+    def test_both_none_returns_none(self):
+        result = SamplingBatchInfo.merge_custom_logit_processor(
+            None, None, 2, 3, DEVICE
+        )
+        self.assertIsNone(result)
+
+    def test_same_key_merges_masks(self):
+        proc = MagicMock()
+        lhs = {42: (proc, torch.tensor([True, False]))}
+        rhs = {42: (proc, torch.tensor([False, True, True]))}
+        result = SamplingBatchInfo.merge_custom_logit_processor(
+            lhs, rhs, 2, 3, DEVICE
+        )
+        self.assertIn(42, result)
+        self.assertEqual(result[42][1].shape[0], 5)
+        self.assertTrue(result[42][1][0].item())   # from lhs
+        self.assertFalse(result[42][1][1].item())   # from lhs
+        self.assertTrue(result[42][1][3].item())    # from rhs
+
+    def test_disjoint_keys(self):
+        proc_a = MagicMock()
+        proc_b = MagicMock()
+        lhs = {1: (proc_a, torch.tensor([True, False]))}
+        rhs = {2: (proc_b, torch.tensor([True]))}
+        result = SamplingBatchInfo.merge_custom_logit_processor(
+            lhs, rhs, 2, 1, DEVICE
+        )
+        # Key 1: lhs mask [True, False] + zero-filled rhs [False]
+        self.assertEqual(result[1][1].shape[0], 3)
+        self.assertTrue(result[1][1][0].item())
+        self.assertFalse(result[1][1][2].item())
+        # Key 2: zero-filled lhs [False, False] + rhs mask [True]
+        self.assertEqual(result[2][1].shape[0], 3)
+        self.assertFalse(result[2][1][0].item())
+        self.assertTrue(result[2][1][2].item())
+
+    def test_lhs_none_rhs_present(self):
+        proc = MagicMock()
+        rhs = {10: (proc, torch.tensor([True]))}
+        result = SamplingBatchInfo.merge_custom_logit_processor(
+            None, rhs, 2, 1, DEVICE
+        )
+        self.assertIn(10, result)
+        self.assertEqual(result[10][1].shape[0], 3)
+
+
+# ---------------------------------------------------------------------------
+# apply_logits_bias
+# ---------------------------------------------------------------------------
+class TestApplyLogitsBias(unittest.TestCase):
+
+    def test_applies_linear_penalties(self):
+        info = _make_info(batch_size=1)
+        info.acc_linear_penalties = torch.tensor([[-1.0] * VOCAB_SIZE])
+        logits = torch.zeros(1, VOCAB_SIZE)
+        info.apply_logits_bias(logits)
+        self.assertAlmostEqual(logits[0, 0].item(), -1.0, places=5)
+
+    def test_applies_logit_bias(self):
+        info = _make_info(batch_size=1)
+        bias = torch.zeros(1, VOCAB_SIZE)
+        bias[0, 5] = 10.0
+        info.logit_bias = bias
+        logits = torch.zeros(1, VOCAB_SIZE)
+        info.apply_logits_bias(logits)
+        self.assertAlmostEqual(logits[0, 5].item(), 10.0, places=5)
+        self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
+
+    def test_applies_vocab_mask(self):
+        info = _make_info(batch_size=1)
+        info.vocab_mask = torch.ones(1, VOCAB_SIZE)
+        info.apply_mask_func = MagicMock()
+        logits = torch.zeros(1, VOCAB_SIZE)
+        info.apply_logits_bias(logits)
+        info.apply_mask_func.assert_called_once()
+
+    def test_applies_penalizer_orchestrator(self):
+        orch = MagicMock(is_required=True)
+        info = _make_info(batch_size=1, penalizer_orchestrator=orch)
+        logits = torch.zeros(1, VOCAB_SIZE)
+        info.apply_logits_bias(logits)
+        orch.apply.assert_called_once_with(logits)
+
+    def test_no_bias_no_change(self):
+        info = _make_info(batch_size=1)
+        info.acc_linear_penalties = None
+        info.logit_bias = None
+        info.vocab_mask = None
+        logits = torch.zeros(1, VOCAB_SIZE)
+        original = logits.clone()
+        info.apply_logits_bias(logits)
+        self.assertTrue(torch.equal(logits, original))
+
+
+# ---------------------------------------------------------------------------
+# update_penalties
+# ---------------------------------------------------------------------------
+class TestUpdatePenalties(unittest.TestCase):
+
+    def test_required_creates_penalties_tensor(self):
+        orch = MagicMock(is_required=True)
+        info = _make_info(batch_size=2, penalizer_orchestrator=orch)
+        info.update_penalties()
+        self.assertIsNotNone(info.acc_linear_penalties)
+        self.assertEqual(info.acc_linear_penalties.shape, (2, VOCAB_SIZE))
+        orch.apply.assert_called_once()
+
+    def test_not_required_sets_none(self):
+        orch = MagicMock(is_required=False)
+        info = _make_info(batch_size=2, penalizer_orchestrator=orch)
+        info.update_penalties()
+        self.assertIsNone(info.acc_linear_penalties)
+
+
+# ---------------------------------------------------------------------------
+# update_regex_vocab_mask
+# ---------------------------------------------------------------------------
+class TestUpdateRegexVocabMask(unittest.TestCase):
+
+    def test_no_grammars_clears_mask(self):
+        info = _make_info(batch_size=1)
+        info.grammars = None
+        info.update_regex_vocab_mask()
+        self.assertIsNone(info.vocab_mask)
+        self.assertIsNone(info.apply_mask_func)
+
+    def test_empty_grammars_clears_mask(self):
+        info = _make_info(batch_size=1)
+        info.grammars = []
+        info.update_regex_vocab_mask()
+        self.assertIsNone(info.vocab_mask)
+
+    def test_with_grammars_allocates_and_fills(self):
+        grammar = MagicMock()
+        grammar.finished = False
+        grammar.is_terminated.return_value = False
+        grammar.allocate_vocab_mask.return_value = torch.zeros(1, VOCAB_SIZE)
+        grammar.move_vocab_mask.return_value = torch.zeros(1, VOCAB_SIZE)
+        info = _make_info(batch_size=1)
+        info.grammars = [grammar]
+        info.update_regex_vocab_mask()
+        grammar.allocate_vocab_mask.assert_called_once()
+        grammar.fill_vocab_mask.assert_called_once()
+        grammar.move_vocab_mask.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# filter_batch
+# ---------------------------------------------------------------------------
+class TestFilterBatch(unittest.TestCase):
+
+    def test_filter_keeps_correct_indices(self):
+        info = _make_info(batch_size=3)
+        info.temperatures = torch.tensor([[1.0], [2.0], [3.0]])
+        info.top_ps = torch.tensor([0.9, 0.8, 0.7])
+        info.top_ks = torch.tensor([10, 20, 30], dtype=torch.int32)
+        info.min_ps = torch.tensor([0.0, 0.1, 0.2])
+        info.logit_bias = torch.ones(3, VOCAB_SIZE)
+        keep = torch.tensor([0, 2])
+        info.filter_batch([0, 2], keep)
+        self.assertEqual(len(info), 2)
+        self.assertAlmostEqual(info.temperatures[0, 0].item(), 1.0)
+        self.assertAlmostEqual(info.temperatures[1, 0].item(), 3.0)
+        self.assertAlmostEqual(info.top_ps[1].item(), 0.7)
+
+    def test_filter_with_custom_logit_processor(self):
+        proc = MagicMock()
+        info = _make_info(batch_size=3)
+        info.has_custom_logit_processor = True
+        info.custom_logit_processor = {
+            42: (proc, torch.tensor([True, False, True]))
+        }
+        info.custom_params = [{"a": 1}, {"b": 2}, {"c": 3}]
+        keep = torch.tensor([0, 2])
+        info.filter_batch([0, 2], keep)
+        self.assertEqual(info.custom_params, [{"a": 1}, {"c": 3}])
+        mask = info.custom_logit_processor[42][1]
+        self.assertEqual(mask.shape[0], 2)
+
+    def test_filter_removes_all_custom_processors(self):
+        """When filter removes all requests using a processor, it should be cleaned up."""
+        proc = MagicMock()
+        info = _make_info(batch_size=3)
+        info.has_custom_logit_processor = True
+        info.custom_logit_processor = {
+            42: (proc, torch.tensor([False, True, False]))
+        }
+        info.custom_params = [None, {"x": 1}, None]
+        # Keep only index 0 and 2 — processor 42's mask becomes [False, False]
+        keep = torch.tensor([0, 2])
+        info.filter_batch([0, 2], keep)
+        self.assertFalse(info.has_custom_logit_processor)
+        self.assertIsNone(info.custom_logit_processor)
+
+    def test_filter_with_none_sampling_seed(self):
+        info = _make_info(batch_size=3)
+        info.sampling_seed = None
+        keep = torch.tensor([1])
+        info.filter_batch([1], keep)
+        self.assertIsNone(info.sampling_seed)
+
+
+# ---------------------------------------------------------------------------
+# merge_batch
+# ---------------------------------------------------------------------------
+class TestMergeBatch(unittest.TestCase):
+
+    def test_merge_concatenates_tensors(self):
+        info1 = _make_info(batch_size=2)
+        info1.temperatures = torch.tensor([[1.0], [2.0]])
+        info2 = _make_info(batch_size=1)
+        info2.temperatures = torch.tensor([[3.0]])
+        info1.merge_batch(info2)
+        self.assertEqual(len(info1), 3)
+        self.assertAlmostEqual(info1.temperatures[2, 0].item(), 3.0)
+
+    def test_merge_combines_flags(self):
+        info1 = _make_info(is_all_greedy=True, need_top_p_sampling=False)
+        info2 = _make_info(is_all_greedy=False, need_top_p_sampling=True)
+        info1.merge_batch(info2)
+        self.assertFalse(info1.is_all_greedy)
+        self.assertTrue(info1.need_top_p_sampling)
+
+    def test_merge_with_logit_bias(self):
+        info1 = _make_info(batch_size=1)
+        info1.logit_bias = torch.ones(1, VOCAB_SIZE)
+        info2 = _make_info(batch_size=1)
+        info2.logit_bias = None
+        info1.merge_batch(info2)
+        self.assertEqual(info1.logit_bias.shape, (2, VOCAB_SIZE))
+
+    def test_merge_with_custom_logit_processor(self):
+        proc = MagicMock()
+        info1 = _make_info(batch_size=1)
+        info1.has_custom_logit_processor = True
+        info1.custom_logit_processor = {1: (proc, torch.tensor([True]))}
+        info1.custom_params = [{"a": 1}]
+        info2 = _make_info(batch_size=1)
+        info2.has_custom_logit_processor = False
+        info2.custom_logit_processor = None
+        info2.custom_params = None
+        info1.merge_batch(info2)
+        self.assertTrue(info1.has_custom_logit_processor)
+        self.assertEqual(len(info1.custom_params), 2)
+
+    def test_merge_with_none_sampling_seed(self):
+        """When sampling_seed is None on both sides, it stays None."""
+        info1 = _make_info(batch_size=1)
+        info1.sampling_seed = None
+        info2 = _make_info(batch_size=1)
+        info2.sampling_seed = None
+        info1.merge_batch(info2)
+        self.assertIsNone(info1.sampling_seed)
+
+
+# ---------------------------------------------------------------------------
+# copy_for_forward
+# ---------------------------------------------------------------------------
+class TestCopyForForward(unittest.TestCase):
+
+    def test_returns_copy_without_orchestrator(self):
+        orch = MagicMock(is_required=False)
+        info = _make_info(batch_size=1, penalizer_orchestrator=orch)
+        copied = info.copy_for_forward()
+        self.assertIsNone(copied.penalizer_orchestrator)
+        # Original should still have orchestrator
+        self.assertIsNotNone(info.penalizer_orchestrator)
+
+
+# ---------------------------------------------------------------------------
+# from_schedule_batch
+# ---------------------------------------------------------------------------
+class TestFromScheduleBatch(unittest.TestCase):
+
+    def _make_req(self, temp=1.0, top_p=1.0, top_k=-1, min_p=0.0,
+                  freq=0.0, pres=0.0, min_tokens=0, logit_bias=None,
+                  seed=None, stop_ids=None, eos_id=2):
+        req = MagicMock()
+        req.sampling_params.temperature = temp
+        req.sampling_params.top_p = top_p
+        req.sampling_params.top_k = top_k
+        req.sampling_params.min_p = min_p
+        req.sampling_params.frequency_penalty = freq
+        req.sampling_params.presence_penalty = pres
+        req.sampling_params.min_new_tokens = min_tokens
+        req.sampling_params.logit_bias = logit_bias
+        req.sampling_params.sampling_seed = seed
+        req.sampling_params.stop_token_ids = stop_ids
+        req.sampling_params.custom_params = None
+        req.custom_logit_processor = None
+        req.tokenizer.additional_stop_token_ids = None
+        req.tokenizer.eos_token_id = eos_id
+        return req
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_basic_construction(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+
+        reqs = [self._make_req(temp=0.8, top_p=0.9, top_k=50, min_p=0.1)]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertEqual(len(info), 1)
+        self.assertAlmostEqual(info.temperatures[0, 0].item(), 0.8, places=5)
+        self.assertAlmostEqual(info.top_ps[0].item(), 0.9, places=5)
+        self.assertEqual(info.top_ks[0].item(), 50)
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_greedy_detection(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+
+        reqs = [self._make_req(top_k=1)]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertTrue(info.is_all_greedy)
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_logit_bias_construction(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+
+        reqs = [self._make_req(logit_bias={"5": 2.0, "10": -1.0})]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertIsNotNone(info.logit_bias)
+        self.assertAlmostEqual(info.logit_bias[0, 5].item(), 2.0)
+        self.assertAlmostEqual(info.logit_bias[0, 10].item(), -1.0)
+        self.assertAlmostEqual(info.logit_bias[0, 0].item(), 0.0)
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_deterministic_seed(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = True
+        mock_server_args.return_value.enable_custom_logit_processor = False
+
+        reqs = [self._make_req(seed=123), self._make_req(seed=None)]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertIsNotNone(info.sampling_seed)
+        self.assertEqual(info.sampling_seed[0].item(), 123)
+        self.assertEqual(info.sampling_seed[1].item(), 42)  # default
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_no_logit_bias_when_all_none(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+
+        reqs = [self._make_req(), self._make_req()]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertIsNone(info.logit_bias)
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_custom_logit_processor_merging(self, mock_server_args):
+        """When enable_custom_logit_processor=True and reqs have processors,
+        they should be deserialized and merged by type."""
+        from sglang.srt.sampling.custom_logit_processor import (
+            DisallowedTokensLogitsProcessor,
+        )
+
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = True
+
+        proc_str = DisallowedTokensLogitsProcessor.to_str()
+        req1 = self._make_req()
+        req1.custom_logit_processor = proc_str
+        req1.sampling_params.custom_params = {"token_ids": [1]}
+        req2 = self._make_req()
+        req2.custom_logit_processor = None  # no processor
+        req2.sampling_params.custom_params = None
+
+        batch = MagicMock()
+        batch.reqs = [req1, req2]
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+
+        self.assertTrue(info.has_custom_logit_processor)
+        self.assertIsNotNone(info.custom_logit_processor)
+        self.assertEqual(len(info.custom_logit_processor), 1)
+        # Check the mask: req1 has processor (True), req2 doesn't (False)
+        key = list(info.custom_logit_processor.keys())[0]
+        proc, mask = info.custom_logit_processor[key]
+        self.assertIsInstance(proc, DisallowedTokensLogitsProcessor)
+        self.assertTrue(mask[0].item())
+        self.assertFalse(mask[1].item())
+        # custom_params should be collected for all reqs
+        self.assertEqual(len(info.custom_params), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -243,6 +243,29 @@ class TestUpdateRegexVocabMask(unittest.TestCase):
         grammar.fill_vocab_mask.assert_called_once()
         grammar.move_vocab_mask.assert_called_once()
 
+    def test_mixed_grammars_only_active_fills(self):
+        """Finished/terminated/None grammars should be skipped by fill loop."""
+        active = MagicMock()
+        active.finished = False
+        active.is_terminated.return_value = False
+        active.allocate_vocab_mask.return_value = torch.zeros(3, VOCAB_SIZE)
+        active.move_vocab_mask.return_value = torch.zeros(3, VOCAB_SIZE)
+
+        finished = MagicMock()
+        finished.finished = True
+
+        terminated = MagicMock()
+        terminated.finished = False
+        terminated.is_terminated.return_value = True
+
+        info = _make_info(batch_size=3)
+        info.grammars = [active, finished, terminated]
+        info.update_regex_vocab_mask()
+
+        active.fill_vocab_mask.assert_called_once()
+        finished.fill_vocab_mask.assert_not_called()
+        terminated.fill_vocab_mask.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # filter_batch
@@ -262,6 +285,8 @@ class TestFilterBatch(unittest.TestCase):
         self.assertAlmostEqual(info.temperatures[0, 0].item(), 1.0)
         self.assertAlmostEqual(info.temperatures[1, 0].item(), 3.0)
         self.assertAlmostEqual(info.top_ps[1].item(), 0.7)
+        # logit_bias should also be filtered
+        self.assertEqual(info.logit_bias.shape, (2, VOCAB_SIZE))
 
     def test_filter_with_custom_logit_processor(self):
         proc = MagicMock()
@@ -315,11 +340,23 @@ class TestMergeBatch(unittest.TestCase):
         self.assertAlmostEqual(info1.temperatures[2, 0].item(), 3.0)
 
     def test_merge_combines_flags(self):
-        info1 = _make_info(is_all_greedy=True, need_top_p_sampling=False)
-        info2 = _make_info(is_all_greedy=False, need_top_p_sampling=True)
+        info1 = _make_info(
+            is_all_greedy=True,
+            need_top_p_sampling=False,
+            need_top_k_sampling=False,
+            need_min_p_sampling=False,
+        )
+        info2 = _make_info(
+            is_all_greedy=False,
+            need_top_p_sampling=True,
+            need_top_k_sampling=True,
+            need_min_p_sampling=True,
+        )
         info1.merge_batch(info2)
-        self.assertFalse(info1.is_all_greedy)
-        self.assertTrue(info1.need_top_p_sampling)
+        self.assertFalse(info1.is_all_greedy)       # AND semantics
+        self.assertTrue(info1.need_top_p_sampling)   # OR semantics
+        self.assertTrue(info1.need_top_k_sampling)   # OR semantics
+        self.assertTrue(info1.need_min_p_sampling)   # OR semantics
 
     def test_merge_with_logit_bias(self):
         info1 = _make_info(batch_size=1)
@@ -351,6 +388,18 @@ class TestMergeBatch(unittest.TestCase):
         info2.sampling_seed = None
         info1.merge_batch(info2)
         self.assertIsNone(info1.sampling_seed)
+
+    def test_merge_with_both_sampling_seeds(self):
+        """When both sides have sampling_seed tensors, they should be concatenated."""
+        info1 = _make_info(batch_size=2)
+        info1.sampling_seed = torch.tensor([10, 20], dtype=torch.int64)
+        info2 = _make_info(batch_size=1)
+        info2.sampling_seed = torch.tensor([30], dtype=torch.int64)
+        info1.merge_batch(info2)
+        self.assertEqual(info1.sampling_seed.shape[0], 3)
+        self.assertEqual(info1.sampling_seed[0].item(), 10)
+        self.assertEqual(info1.sampling_seed[1].item(), 20)
+        self.assertEqual(info1.sampling_seed[2].item(), 30)
 
 
 # ---------------------------------------------------------------------------
@@ -448,6 +497,22 @@ class TestFromScheduleBatch(unittest.TestCase):
         self.assertIsNotNone(info.sampling_seed)
         self.assertEqual(info.sampling_seed[0].item(), 123)
         self.assertEqual(info.sampling_seed[1].item(), 42)  # default
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
+    def test_from_schedule_batch_sampling_flags(self, mock_server_args):
+        """Verify need_top_p/top_k/min_p flags are computed correctly."""
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+
+        reqs = [self._make_req(top_p=0.9, top_k=50, min_p=0.1)]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertTrue(info.need_top_p_sampling)   # 0.9 != 1.0
+        self.assertTrue(info.need_top_k_sampling)   # 50 != TOP_K_ALL
+        self.assertTrue(info.need_min_p_sampling)   # 0.1 > 0
+        self.assertFalse(info.is_all_greedy)        # top_k=50 > 1
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_no_logit_bias_when_all_none(self, mock_server_args):

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -43,10 +43,12 @@ def _make_info(batch_size=2, **overrides):
 class TestMergeBiasTensor(CustomTestCase):
 
     def test_both_none_returns_none(self):
+        """Test that merging two None tensors returns None."""
         result = merge_bias_tensor(None, None, 2, 3, DEVICE, 0.0)
         self.assertIsNone(result)
 
     def test_both_present_concatenates(self):
+        """Test that two present tensors are concatenated along batch dim."""
         lhs = torch.ones(2, VOCAB_SIZE)
         rhs = torch.zeros(3, VOCAB_SIZE)
         result = merge_bias_tensor(lhs, rhs, 2, 3, DEVICE, 0.0)
@@ -55,6 +57,7 @@ class TestMergeBiasTensor(CustomTestCase):
         self.assertEqual(result[3, 0].item(), 0.0)
 
     def test_lhs_none_fills_default(self):
+        """Test that missing lhs is filled with default value before concatenation."""
         rhs = torch.ones(3, VOCAB_SIZE)
         result = merge_bias_tensor(None, rhs, 2, 3, DEVICE, 0.0)
         self.assertEqual(result.shape, (5, VOCAB_SIZE))
@@ -64,6 +67,7 @@ class TestMergeBiasTensor(CustomTestCase):
         self.assertEqual(result[2, 0].item(), 1.0)
 
     def test_rhs_none_fills_default(self):
+        """Test that missing rhs is filled with default value before concatenation."""
         lhs = torch.ones(2, VOCAB_SIZE)
         result = merge_bias_tensor(lhs, None, 2, 3, DEVICE, 0.0)
         self.assertEqual(result.shape, (5, VOCAB_SIZE))
@@ -72,6 +76,7 @@ class TestMergeBiasTensor(CustomTestCase):
         self.assertEqual(result[3, 0].item(), 0.0)
 
     def test_custom_default_value(self):
+        """Test that a custom default (-1.0) fills the missing lhs rows."""
         rhs = torch.ones(1, VOCAB_SIZE)
         result = merge_bias_tensor(None, rhs, 2, 1, DEVICE, -1.0)
         self.assertEqual(result[0, 0].item(), -1.0)
@@ -83,6 +88,7 @@ class TestMergeBiasTensor(CustomTestCase):
 class TestSamplingBatchInfoLen(CustomTestCase):
 
     def test_len_matches_batch_size(self):
+        """Test that __len__ returns batch size (number of temperature rows)."""
         info = _make_info(batch_size=5)
         self.assertEqual(len(info), 5)
 
@@ -90,12 +96,14 @@ class TestSamplingBatchInfoLen(CustomTestCase):
 class TestMergeCustomLogitProcessor(CustomTestCase):
 
     def test_both_none_returns_none(self):
+        """Test that merging two None processor dicts returns None."""
         result = SamplingBatchInfo.merge_custom_logit_processor(
             None, None, 2, 3, DEVICE
         )
         self.assertIsNone(result)
 
     def test_same_key_merges_masks(self):
+        """Test that same processor key concatenates the boolean masks."""
         proc = MagicMock()
         lhs = {42: (proc, torch.tensor([True, False]))}
         rhs = {42: (proc, torch.tensor([False, True, True]))}
@@ -107,6 +115,7 @@ class TestMergeCustomLogitProcessor(CustomTestCase):
         self.assertTrue(result[42][1][3].item())  # from rhs
 
     def test_disjoint_keys(self):
+        """Test that disjoint processor keys are merged with zero-filled padding."""
         proc_a = MagicMock()
         proc_b = MagicMock()
         lhs = {1: (proc_a, torch.tensor([True, False]))}
@@ -122,6 +131,7 @@ class TestMergeCustomLogitProcessor(CustomTestCase):
         self.assertTrue(result[2][1][2].item())
 
     def test_lhs_none_rhs_present(self):
+        """Test that None lhs is treated as empty dict and rhs mask is padded."""
         proc = MagicMock()
         rhs = {10: (proc, torch.tensor([True]))}
         result = SamplingBatchInfo.merge_custom_logit_processor(None, rhs, 2, 1, DEVICE)
@@ -133,6 +143,7 @@ class TestMergeCustomLogitProcessor(CustomTestCase):
 class TestApplyLogitsBias(CustomTestCase):
 
     def test_applies_linear_penalties(self):
+        """Test that pre-accumulated linear penalties are added to logits."""
         info = _make_info(batch_size=1)
         info.acc_linear_penalties = torch.tensor([[-1.0] * VOCAB_SIZE])
         logits = torch.zeros(1, VOCAB_SIZE)
@@ -140,6 +151,7 @@ class TestApplyLogitsBias(CustomTestCase):
         self.assertAlmostEqual(logits[0, 0].item(), -1.0, places=5)
 
     def test_applies_logit_bias(self):
+        """Test that per-token logit_bias is added to logits."""
         info = _make_info(batch_size=1)
         bias = torch.zeros(1, VOCAB_SIZE)
         bias[0, 5] = 10.0
@@ -150,6 +162,7 @@ class TestApplyLogitsBias(CustomTestCase):
         self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
 
     def test_applies_vocab_mask(self):
+        """Test that vocab_mask triggers the apply_mask_func callback."""
         info = _make_info(batch_size=1)
         info.vocab_mask = torch.ones(1, VOCAB_SIZE)
         info.apply_mask_func = MagicMock()
@@ -158,6 +171,7 @@ class TestApplyLogitsBias(CustomTestCase):
         info.apply_mask_func.assert_called_once()
 
     def test_applies_penalizer_orchestrator(self):
+        """Test that a required orchestrator's apply() is called on logits."""
         orch = MagicMock(is_required=True)
         info = _make_info(batch_size=1, penalizer_orchestrator=orch)
         logits = torch.zeros(1, VOCAB_SIZE)
@@ -165,6 +179,7 @@ class TestApplyLogitsBias(CustomTestCase):
         orch.apply.assert_called_once_with(logits)
 
     def test_no_bias_no_change(self):
+        """Test that logits stay unchanged when no bias sources are set."""
         info = _make_info(batch_size=1)
         info.acc_linear_penalties = None
         info.logit_bias = None
@@ -179,6 +194,7 @@ class TestApplyLogitsBias(CustomTestCase):
 class TestUpdatePenalties(CustomTestCase):
 
     def test_required_creates_penalties_tensor(self):
+        """Test that update_penalties allocates a zero tensor and calls orchestrator.apply."""
         orch = MagicMock(is_required=True)
         info = _make_info(batch_size=2, penalizer_orchestrator=orch)
         info.update_penalties()
@@ -187,6 +203,7 @@ class TestUpdatePenalties(CustomTestCase):
         orch.apply.assert_called_once()
 
     def test_not_required_sets_none(self):
+        """Test that update_penalties sets acc_linear_penalties to None when not required."""
         orch = MagicMock(is_required=False)
         info = _make_info(batch_size=2, penalizer_orchestrator=orch)
         info.update_penalties()
@@ -197,6 +214,7 @@ class TestUpdatePenalties(CustomTestCase):
 class TestUpdateRegexVocabMask(CustomTestCase):
 
     def test_no_grammars_clears_mask(self):
+        """Test that None grammars clears both vocab_mask and apply_mask_func."""
         info = _make_info(batch_size=1)
         info.grammars = None
         info.update_regex_vocab_mask()
@@ -204,12 +222,14 @@ class TestUpdateRegexVocabMask(CustomTestCase):
         self.assertIsNone(info.apply_mask_func)
 
     def test_empty_grammars_clears_mask(self):
+        """Test that empty grammars list clears vocab_mask."""
         info = _make_info(batch_size=1)
         info.grammars = []
         info.update_regex_vocab_mask()
         self.assertIsNone(info.vocab_mask)
 
     def test_with_grammars_allocates_and_fills(self):
+        """Test that an active grammar gets allocate, fill, and move called."""
         grammar = MagicMock()
         grammar.finished = False
         grammar.is_terminated.return_value = False
@@ -250,6 +270,7 @@ class TestUpdateRegexVocabMask(CustomTestCase):
 class TestFilterBatch(CustomTestCase):
 
     def test_filter_keeps_correct_indices(self):
+        """Test that filter retains rows at indices 0 and 2, dropping index 1."""
         info = _make_info(batch_size=3)
         info.temperatures = torch.tensor([[1.0], [2.0], [3.0]])
         info.top_ps = torch.tensor([0.9, 0.8, 0.7])
@@ -266,6 +287,7 @@ class TestFilterBatch(CustomTestCase):
         self.assertEqual(info.logit_bias.shape, (2, VOCAB_SIZE))
 
     def test_filter_with_custom_logit_processor(self):
+        """Test that filter updates both custom_params list and processor mask."""
         proc = MagicMock()
         info = _make_info(batch_size=3)
         info.has_custom_logit_processor = True
@@ -291,6 +313,7 @@ class TestFilterBatch(CustomTestCase):
         self.assertIsNone(info.custom_logit_processor)
 
     def test_filter_with_none_sampling_seed(self):
+        """Test that filter preserves None sampling_seed without error."""
         info = _make_info(batch_size=3)
         info.sampling_seed = None
         keep = torch.tensor([1])
@@ -302,6 +325,7 @@ class TestFilterBatch(CustomTestCase):
 class TestMergeBatch(CustomTestCase):
 
     def test_merge_concatenates_tensors(self):
+        """Test that merge concatenates temperature tensors from both batches."""
         info1 = _make_info(batch_size=2)
         info1.temperatures = torch.tensor([[1.0], [2.0]])
         info2 = _make_info(batch_size=1)
@@ -311,6 +335,7 @@ class TestMergeBatch(CustomTestCase):
         self.assertAlmostEqual(info1.temperatures[2, 0].item(), 3.0)
 
     def test_merge_combines_flags(self):
+        """Test that merge ANDs is_all_greedy and ORs need_*_sampling flags."""
         info1 = _make_info(
             is_all_greedy=True,
             need_top_p_sampling=False,
@@ -330,6 +355,7 @@ class TestMergeBatch(CustomTestCase):
         self.assertTrue(info1.need_min_p_sampling)  # OR semantics
 
     def test_merge_with_logit_bias(self):
+        """Test that merge pads missing logit_bias with zeros before concatenation."""
         info1 = _make_info(batch_size=1)
         info1.logit_bias = torch.ones(1, VOCAB_SIZE)
         info2 = _make_info(batch_size=1)
@@ -338,6 +364,7 @@ class TestMergeBatch(CustomTestCase):
         self.assertEqual(info1.logit_bias.shape, (2, VOCAB_SIZE))
 
     def test_merge_with_custom_logit_processor(self):
+        """Test that merge combines processors when only one side has them."""
         proc = MagicMock()
         info1 = _make_info(batch_size=1)
         info1.has_custom_logit_processor = True
@@ -377,6 +404,7 @@ class TestMergeBatch(CustomTestCase):
 class TestCopyForForward(CustomTestCase):
 
     def test_returns_copy_without_orchestrator(self):
+        """Test that copy_for_forward returns a copy with orchestrator set to None."""
         orch = MagicMock(is_required=False)
         info = _make_info(batch_size=1, penalizer_orchestrator=orch)
         copied = info.copy_for_forward()
@@ -421,6 +449,7 @@ class TestFromScheduleBatch(CustomTestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_basic_construction(self, mock_server_args):
+        """Test that from_schedule_batch correctly extracts sampling params from requests."""
         mock_server_args.return_value.enable_deterministic_inference = False
         mock_server_args.return_value.enable_custom_logit_processor = False
 
@@ -437,6 +466,7 @@ class TestFromScheduleBatch(CustomTestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_greedy_detection(self, mock_server_args):
+        """Test that top_k=1 sets is_all_greedy=True."""
         mock_server_args.return_value.enable_deterministic_inference = False
         mock_server_args.return_value.enable_custom_logit_processor = False
 
@@ -449,6 +479,7 @@ class TestFromScheduleBatch(CustomTestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_logit_bias_construction(self, mock_server_args):
+        """Test that logit_bias dict is converted to a tensor with correct values."""
         mock_server_args.return_value.enable_deterministic_inference = False
         mock_server_args.return_value.enable_custom_logit_processor = False
 
@@ -464,6 +495,7 @@ class TestFromScheduleBatch(CustomTestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_deterministic_seed(self, mock_server_args):
+        """Test that explicit seed=123 is kept and missing seed defaults to 42."""
         mock_server_args.return_value.enable_deterministic_inference = True
         mock_server_args.return_value.enable_custom_logit_processor = False
 
@@ -494,6 +526,7 @@ class TestFromScheduleBatch(CustomTestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_global_server_args")
     def test_no_logit_bias_when_all_none(self, mock_server_args):
+        """Test that logit_bias stays None when no request has logit_bias set."""
         mock_server_args.return_value.enable_deterministic_inference = False
         mock_server_args.return_value.enable_custom_logit_processor = False
 

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -13,70 +13,63 @@ from sglang.srt.sampling.sampling_params import (
     SamplingParams,
     get_max_seq_length,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
-# ---------------------------------------------------------------------------
-# SamplingParams.__init__ — implicit conversions
-# ---------------------------------------------------------------------------
-class TestSamplingParamsInit(unittest.TestCase):
-    """Test the two implicit conversions that happen in __init__."""
+class TestSamplingParamsInit(CustomTestCase):
 
     def test_zero_temperature_becomes_greedy(self):
-        """temperature=0 should trigger greedy mode: top_k=1, temperature=1.0."""
+        """Test greedy conversion when temperature is 0."""
         sp = SamplingParams(temperature=0.0)
         self.assertEqual(sp.top_k, 1)
         self.assertEqual(sp.temperature, 1.0)
 
     def test_near_zero_temperature_becomes_greedy(self):
-        """temperature just below 1e-6 should also trigger greedy."""
+        """Test greedy conversion when temperature is near zero (1e-7)."""
         sp = SamplingParams(temperature=1e-7)
         self.assertEqual(sp.top_k, 1)
         self.assertEqual(sp.temperature, 1.0)
 
     def test_temperature_at_eps_boundary_not_greedy(self):
-        """temperature exactly at 1e-6 should NOT trigger greedy (< not <=)."""
+        """Test that temperature exactly at 1e-6 does not trigger greedy (strict <)."""
         sp = SamplingParams(temperature=1e-6)
         self.assertEqual(sp.temperature, 1e-6)
         # top_k should remain at TOP_K_ALL (from -1 default)
         self.assertEqual(sp.top_k, TOP_K_ALL)
 
     def test_negative_temperature_not_modified(self):
-        """Negative temperature is invalid but __init__ doesn't reject it —
-        that's verify()'s job. Confirm __init__ leaves it unchanged."""
+        """Test that __init__ preserves negative temperature (rejected by verify instead)."""
         sp = SamplingParams(temperature=-1.0)
         self.assertEqual(sp.temperature, -1.0)
 
     def test_top_k_minus_one_becomes_top_k_all(self):
-        """top_k=-1 means 'whole vocabulary', converted to TOP_K_ALL."""
+        """Test that top_k=-1 is converted to TOP_K_ALL (whole vocabulary)."""
         sp = SamplingParams(top_k=-1)
         self.assertEqual(sp.top_k, TOP_K_ALL)
 
     def test_positive_top_k_preserved(self):
-        """An explicit positive top_k should be kept as-is."""
+        """Test that explicit positive top_k is kept as-is."""
         sp = SamplingParams(top_k=50)
         self.assertEqual(sp.top_k, 50)
 
     def test_stop_token_ids_stored_as_set(self):
-        """stop_token_ids list should be converted to a set for O(1) lookup."""
+        """Test that stop_token_ids list is converted to set."""
         sp = SamplingParams(stop_token_ids=[1, 2, 3])
         self.assertIsInstance(sp.stop_token_ids, set)
         self.assertEqual(sp.stop_token_ids, {1, 2, 3})
 
     def test_stop_token_ids_none_stays_none(self):
+        """Test that None stop_token_ids stays None."""
         sp = SamplingParams(stop_token_ids=None)
         self.assertIsNone(sp.stop_token_ids)
 
     def test_empty_stop_token_ids_becomes_none(self):
-        """Empty list is falsy in Python — treated same as None, not as empty set."""
+        """Test that empty list is treated as None (falsy in Python)."""
         sp = SamplingParams(stop_token_ids=[])
         self.assertIsNone(sp.stop_token_ids)
 
 
-# ---------------------------------------------------------------------------
-# SamplingParams.verify — parameter validation
-# ---------------------------------------------------------------------------
-class TestSamplingParamsVerify(unittest.TestCase):
-    """Test that verify() rejects invalid values and accepts valid ones."""
+class TestSamplingParamsVerify(CustomTestCase):
 
     VOCAB_SIZE = 32000
 
@@ -88,8 +81,9 @@ class TestSamplingParamsVerify(unittest.TestCase):
 
     # --- happy path ---
     def test_valid_params_pass(self):
+        """Default valid params should pass verify() without raising."""
         sp = self._make()
-        sp.verify(self.VOCAB_SIZE)  # should not raise
+        sp.verify(self.VOCAB_SIZE)
 
     # --- temperature ---
     def test_negative_temperature_raises(self):
@@ -147,8 +141,7 @@ class TestSamplingParamsVerify(unittest.TestCase):
             sp.verify(self.VOCAB_SIZE)
 
     def test_top_k_negative_raises(self):
-        """top_k=-2 stays as-is (__init__ only converts -1 to TOP_K_ALL),
-        and verify() should reject it."""
+        """Test that top_k=-2 is rejected (__init__ only converts -1)."""
         sp = self._make()
         sp.top_k = -2  # bypass __init__ conversion
         with self.assertRaises(ValueError):
@@ -166,6 +159,7 @@ class TestSamplingParamsVerify(unittest.TestCase):
             sp.verify(self.VOCAB_SIZE)
 
     def test_frequency_penalty_boundaries_valid(self):
+        """Boundary values -2.0 and 2.0 should both be accepted."""
         self._make(frequency_penalty=-2.0).verify(self.VOCAB_SIZE)
         self._make(frequency_penalty=2.0).verify(self.VOCAB_SIZE)
 
@@ -211,7 +205,7 @@ class TestSamplingParamsVerify(unittest.TestCase):
         sp.verify(self.VOCAB_SIZE)
 
     def test_max_new_tokens_none_skips_validation(self):
-        """When max_new_tokens is None, the min<=max check is skipped entirely."""
+        """Test that max_new_tokens=None skips the min<=max check."""
         sp = self._make(min_new_tokens=9999, max_new_tokens=None)
         sp.verify(self.VOCAB_SIZE)  # should not raise
 
@@ -246,11 +240,7 @@ class TestSamplingParamsVerify(unittest.TestCase):
             sp.verify(self.VOCAB_SIZE)
 
 
-# ---------------------------------------------------------------------------
-# SamplingParams.normalize — stop string processing
-# ---------------------------------------------------------------------------
-class TestSamplingParamsNormalize(unittest.TestCase):
-    """Test that normalize() correctly processes stop strings and regex."""
+class TestSamplingParamsNormalize(CustomTestCase):
 
     def test_none_stop_strs_becomes_empty_list(self):
         sp = SamplingParams(stop=None)
@@ -304,11 +294,7 @@ class TestSamplingParamsNormalize(unittest.TestCase):
         self.assertEqual(sp.stop_regex_max_len, 3)
 
 
-# ---------------------------------------------------------------------------
-# get_max_seq_length / _max_length_from_subpattern — regex analysis
-# ---------------------------------------------------------------------------
-class TestRegexMaxLength(unittest.TestCase):
-    """Test the recursive regex AST length calculator."""
+class TestRegexMaxLength(CustomTestCase):
 
     def test_literal_string(self):
         """'abc' → 3 literals."""
@@ -365,8 +351,7 @@ class TestRegexMaxLength(unittest.TestCase):
         self.assertEqual(get_max_seq_length("a?"), 1)
 
     def test_mixed_unbounded_and_bounded(self):
-        """'ab+c{3}' → 1 + MAX_LEN + 3. Since MAX_LEN dominates,
-        the total includes it."""
+        """'ab+c{3}' → 1 + MAX_LEN + 3 (unbounded dominates)."""
         result = get_max_seq_length("ab+c{3}")
         self.assertGreaterEqual(result, MAX_LEN)
 
@@ -375,8 +360,7 @@ class TestRegexMaxLength(unittest.TestCase):
         self.assertEqual(get_max_seq_length(""), 0)
 
     def test_lookahead_triggers_unhandled_token(self):
-        """Lookahead (?=...) produces an ASSERT token which is not handled —
-        the else branch should log a warning and add MAX_LEN."""
+        """Test that lookahead (?=...) hits the unhandled ASSERT branch."""
         result = get_max_seq_length("(?=a)b")
         # ASSERT (lookahead) → MAX_LEN, LITERAL 'b' → 1
         self.assertGreaterEqual(result, MAX_LEN)

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -11,7 +11,6 @@ from sglang.srt.sampling.sampling_params import (
     MAX_LEN,
     TOP_K_ALL,
     SamplingParams,
-    _max_length_from_subpattern,
     get_max_seq_length,
 )
 
@@ -242,7 +241,7 @@ class TestSamplingParamsVerify(unittest.TestCase):
         sp.verify(self.VOCAB_SIZE)
 
     def test_all_three_grammars_set_raises(self):
-        sp = self._make(json_schema='{}', regex="a", ebnf="rule")
+        sp = self._make(json_schema="{}", regex="a", ebnf="rule")
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -79,62 +79,66 @@ class TestSamplingParamsVerify(CustomTestCase):
         defaults.update(kwargs)
         return SamplingParams(**defaults)
 
-    # --- happy path ---
     def test_valid_params_pass(self):
         """Default valid params should pass verify() without raising."""
         sp = self._make()
         sp.verify(self.VOCAB_SIZE)
 
-    # --- temperature ---
     def test_negative_temperature_raises(self):
+        """Test that verify() rejects negative temperature (must be >= 0)."""
         sp = self._make(temperature=-0.5)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     # --- top_p ---
     def test_top_p_negative_raises(self):
+        """Test that verify() rejects negative top_p (valid range is (0, 1])."""
         sp = self._make(top_p=-0.5)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_top_p_zero_raises(self):
-        """top_p=0 is not in (0, 1]."""
+        """Test that verify() rejects top_p=0 (not in (0, 1])."""
         sp = self._make(top_p=0.0)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_top_p_above_one_raises(self):
+        """Test that verify() rejects top_p > 1.0."""
         sp = self._make(top_p=1.1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_top_p_exactly_one_is_valid(self):
+        """Test that top_p=1.0 is accepted (inclusive upper bound)."""
         sp = self._make(top_p=1.0)
-        sp.verify(self.VOCAB_SIZE)  # should not raise
+        sp.verify(self.VOCAB_SIZE)
 
     def test_top_p_small_positive_is_valid(self):
+        """Test that a small positive top_p (0.01) is accepted."""
         sp = self._make(top_p=0.01)
         sp.verify(self.VOCAB_SIZE)
 
     # --- min_p ---
     def test_min_p_negative_raises(self):
+        """Test that verify() rejects negative min_p (valid range is [0, 1])."""
         sp = self._make(min_p=-0.1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_min_p_above_one_raises(self):
+        """Test that verify() rejects min_p > 1.0."""
         sp = self._make(min_p=1.01)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_min_p_boundaries_valid(self):
-        """Both 0.0 and 1.0 are valid."""
+        """Test that both 0.0 and 1.0 are accepted."""
         self._make(min_p=0.0).verify(self.VOCAB_SIZE)
         self._make(min_p=1.0).verify(self.VOCAB_SIZE)
 
-    # --- top_k ---
     def test_top_k_zero_raises(self):
-        """top_k=0 is invalid (must be >=1 or -1 for all)."""
+        """Test that verify() rejects top_k=0 (must be >=1 or -1 for all)."""
         sp = self._make()
         sp.top_k = 0  # bypass __init__ conversion
         with self.assertRaises(ValueError):
@@ -149,58 +153,68 @@ class TestSamplingParamsVerify(CustomTestCase):
 
     # --- frequency_penalty ---
     def test_frequency_penalty_below_minus_two_raises(self):
+        """Test that verify() rejects frequency_penalty < -2.0."""
         sp = self._make(frequency_penalty=-2.1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_frequency_penalty_above_two_raises(self):
+        """Test that verify() rejects frequency_penalty > 2.0."""
         sp = self._make(frequency_penalty=2.1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_frequency_penalty_boundaries_valid(self):
-        """Boundary values -2.0 and 2.0 should both be accepted."""
+        """Test that both -2.0 and 2.0 are accepted."""
         self._make(frequency_penalty=-2.0).verify(self.VOCAB_SIZE)
         self._make(frequency_penalty=2.0).verify(self.VOCAB_SIZE)
 
     # --- presence_penalty ---
     def test_presence_penalty_out_of_range_raises(self):
+        """Test that verify() rejects presence_penalty outside [-2, 2]."""
         sp = self._make(presence_penalty=2.5)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     # --- repetition_penalty ---
     def test_repetition_penalty_negative_raises(self):
+        """Test that verify() rejects negative repetition_penalty (valid range is [0, 2])."""
         sp = self._make(repetition_penalty=-0.1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_repetition_penalty_above_two_raises(self):
+        """Test that verify() rejects repetition_penalty > 2.0."""
         sp = self._make(repetition_penalty=2.1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_repetition_penalty_boundaries_valid(self):
+        """Test that boundary values 0.0 and 2.0 are both accepted."""
         self._make(repetition_penalty=0.0).verify(self.VOCAB_SIZE)
         self._make(repetition_penalty=2.0).verify(self.VOCAB_SIZE)
 
     # --- min_new_tokens / max_new_tokens ---
     def test_negative_min_new_tokens_raises(self):
+        """Test that verify() rejects negative min_new_tokens."""
         sp = self._make(min_new_tokens=-1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_negative_max_new_tokens_raises(self):
+        """Test that verify() rejects negative max_new_tokens."""
         sp = self._make(max_new_tokens=-1)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_min_exceeds_max_new_tokens_raises(self):
+        """Test that verify() rejects min_new_tokens > max_new_tokens."""
         sp = self._make(min_new_tokens=100, max_new_tokens=50)
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_min_equals_max_new_tokens_valid(self):
+        """Test that min_new_tokens == max_new_tokens is accepted."""
         sp = self._make(min_new_tokens=10, max_new_tokens=10)
         sp.verify(self.VOCAB_SIZE)
 
@@ -211,30 +225,35 @@ class TestSamplingParamsVerify(CustomTestCase):
 
     # --- logit_bias ---
     def test_logit_bias_token_exceeds_vocab_raises(self):
+        """Test that verify() rejects logit_bias with token_id >= vocab_size."""
         sp = self._make(logit_bias={"99999": 1.0})
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_logit_bias_negative_token_raises(self):
+        """Test that verify() rejects logit_bias with negative token_id."""
         sp = self._make(logit_bias={"-1": 1.0})
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_logit_bias_valid_tokens(self):
+        """Test that logit_bias with token_ids within [0, vocab_size) is accepted."""
         sp = self._make(logit_bias={"0": 1.0, "31999": -0.5})
         sp.verify(self.VOCAB_SIZE)
 
-    # --- grammar mutual exclusion ---
     def test_multiple_grammars_raises(self):
+        """Test that verify() rejects setting both json_schema and regex (mutually exclusive)."""
         sp = self._make(json_schema='{"type":"object"}', regex="abc")
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
     def test_single_grammar_valid(self):
+        """Test that setting only one grammar type is accepted."""
         sp = self._make(json_schema='{"type":"object"}')
         sp.verify(self.VOCAB_SIZE)
 
     def test_all_three_grammars_set_raises(self):
+        """Test that verify() rejects setting json_schema, regex, and ebnf together."""
         sp = self._make(json_schema="{}", regex="a", ebnf="rule")
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
@@ -243,29 +262,32 @@ class TestSamplingParamsVerify(CustomTestCase):
 class TestSamplingParamsNormalize(CustomTestCase):
 
     def test_none_stop_strs_becomes_empty_list(self):
+        """Test that normalize() converts None stop to empty list with max_len=0."""
         sp = SamplingParams(stop=None)
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_strs, [])
         self.assertEqual(sp.stop_str_max_len, 0)
 
     def test_string_stop_str_wrapped_in_list(self):
+        """Test that normalize() wraps a single stop string into a list."""
         sp = SamplingParams(stop="<|end|>")
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_strs, ["<|end|>"])
 
     def test_list_stop_strs_unchanged(self):
+        """Test that normalize() preserves a list of stop strings as-is."""
         sp = SamplingParams(stop=["stop1", "stop2"])
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_strs, ["stop1", "stop2"])
 
     def test_stop_str_max_len_without_tokenizer(self):
-        """Without a tokenizer, max_len is the raw string character count."""
+        """Test that without a tokenizer, max_len is the raw string character count."""
         sp = SamplingParams(stop=["ab", "cdef"])
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_str_max_len, 4)  # len("cdef")
 
     def test_stop_str_max_len_with_tokenizer(self):
-        """With a tokenizer, max_len counts encoded token IDs."""
+        """Test that with a tokenizer, max_len counts encoded token IDs."""
         tokenizer = MagicMock()
         # "hello" encodes to 2 tokens, "world!!" to 3 tokens
         tokenizer.encode.side_effect = lambda s, add_special_tokens=False: {
@@ -277,18 +299,20 @@ class TestSamplingParamsNormalize(CustomTestCase):
         self.assertEqual(sp.stop_str_max_len, 3)
 
     def test_none_stop_regex_becomes_empty_list(self):
+        """Test that normalize() converts None stop_regex to empty list with max_len=0."""
         sp = SamplingParams(stop_regex=None)
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_regex_strs, [])
         self.assertEqual(sp.stop_regex_max_len, 0)
 
     def test_string_stop_regex_wrapped_in_list(self):
+        """Test that normalize() wraps a single stop_regex string into a list."""
         sp = SamplingParams(stop_regex=r"\d+")
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_regex_strs, [r"\d+"])
 
     def test_stop_regex_max_len_computed(self):
-        """Bounded regex should compute a finite max length."""
+        """Test that bounded regex computes a finite max length."""
         sp = SamplingParams(stop_regex=r"[a-z]{3}")
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_regex_max_len, 3)
@@ -297,76 +321,75 @@ class TestSamplingParamsNormalize(CustomTestCase):
 class TestRegexMaxLength(CustomTestCase):
 
     def test_literal_string(self):
-        """'abc' → 3 literals."""
+        """Test that plain string 'abc' gives max length 3."""
         self.assertEqual(get_max_seq_length("abc"), 3)
 
     def test_character_class(self):
-        """'[a-z]' → 1 (one character from set)."""
+        """Test that character class '[a-z]' gives max length 1."""
         self.assertEqual(get_max_seq_length("[a-z]"), 1)
 
     def test_dot_any(self):
-        """'.' matches any one character → 1."""
+        """Test that dot wildcard '.' gives max length 1."""
         self.assertEqual(get_max_seq_length("."), 1)
 
     def test_unbounded_star(self):
-        """'a*' → unbounded repeat → MAX_LEN."""
+        """Test that 'a*' (zero or more, no upper bound) returns MAX_LEN."""
         result = get_max_seq_length("a*")
         self.assertEqual(result, MAX_LEN)
 
     def test_unbounded_plus(self):
-        """'a+' → at least 1, unbounded → MAX_LEN."""
+        """Test that 'a+' (one or more, no upper bound) returns MAX_LEN."""
         result = get_max_seq_length("a+")
         self.assertEqual(result, MAX_LEN)
 
     def test_bounded_repeat(self):
-        """'a{5}' → exactly 5 × 1 = 5."""
+        """Test that exact repeat 'a{5}' gives max length 5."""
         self.assertEqual(get_max_seq_length("a{5}"), 5)
 
     def test_bounded_range_repeat(self):
-        """'a{2,4}' → upper bound is 4 × 1 = 4."""
+        """Test that range repeat 'a{2,4}' uses upper bound, giving max length 4."""
         self.assertEqual(get_max_seq_length("a{2,4}"), 4)
 
     def test_branch_takes_max(self):
-        """'abc|de' → max(3, 2) = 3."""
+        """Test that alternation 'abc|de' takes the longer branch: max(3, 2) = 3."""
         self.assertEqual(get_max_seq_length("abc|de"), 3)
 
     def test_subpattern_group(self):
-        """'(abc)' → 3 from the group content."""
+        """Test that capturing group '(abc)' gives max length 3 from inner content."""
         self.assertEqual(get_max_seq_length("(abc)"), 3)
 
     def test_zero_width_assertions_ignored(self):
-        """'^abc$' → anchors contribute 0, result = 3."""
+        """Test that anchors ^ and $ in '^abc$' add 0, giving max length 3."""
         self.assertEqual(get_max_seq_length("^abc$"), 3)
 
     def test_complex_pattern(self):
-        """'(foo|bar)\\d{2}' → max(3,3) + 2 = 5."""
+        """Test combined pattern '(foo|bar)\\d{2}': branch(3) + repeat(2) = 5."""
         self.assertEqual(get_max_seq_length(r"(foo|bar)\d{2}"), 5)
 
     def test_nested_groups(self):
-        """'((ab))' → nested subpatterns still = 2."""
+        """Test that nested groups '((ab))' correctly recurse to give max length 2."""
         self.assertEqual(get_max_seq_length("((ab))"), 2)
 
     def test_question_mark_optional(self):
-        """'a?' → {0,1} repeat → 1 × 1 = 1."""
+        """Test that optional 'a?' (equivalent to a{0,1}) gives max length 1."""
         self.assertEqual(get_max_seq_length("a?"), 1)
 
     def test_mixed_unbounded_and_bounded(self):
-        """'ab+c{3}' → 1 + MAX_LEN + 3 (unbounded dominates)."""
+        """Test that 'ab+c{3}' gives >= MAX_LEN because b+ is unbounded."""
         result = get_max_seq_length("ab+c{3}")
         self.assertGreaterEqual(result, MAX_LEN)
 
     def test_empty_regex(self):
-        """Empty regex matches empty string → length 0."""
+        """Test that empty regex gives max length 0 (no tokens to match)."""
         self.assertEqual(get_max_seq_length(""), 0)
 
     def test_lookahead_triggers_unhandled_token(self):
-        """Test that lookahead (?=...) hits the unhandled ASSERT branch."""
+        """Test that lookahead (?=a) hits the unhandled-token fallback (MAX_LEN)."""
         result = get_max_seq_length("(?=a)b")
-        # ASSERT (lookahead) → MAX_LEN, LITERAL 'b' → 1
         self.assertGreaterEqual(result, MAX_LEN)
 
     def test_lookbehind_triggers_unhandled_token(self):
-        """Lookbehind (?<=...) also produces an unhandled ASSERT token."""
+        """Test that lookbehind (?<=x) hits the unhandled-token fallback (MAX_LEN)."""
         result = get_max_seq_length("(?<=x)y")
         self.assertGreaterEqual(result, MAX_LEN)
 

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -67,6 +67,11 @@ class TestSamplingParamsInit(unittest.TestCase):
         sp = SamplingParams(stop_token_ids=None)
         self.assertIsNone(sp.stop_token_ids)
 
+    def test_empty_stop_token_ids_becomes_none(self):
+        """Empty list is falsy in Python — treated same as None, not as empty set."""
+        sp = SamplingParams(stop_token_ids=[])
+        self.assertIsNone(sp.stop_token_ids)
+
 
 # ---------------------------------------------------------------------------
 # SamplingParams.verify — parameter validation
@@ -94,6 +99,11 @@ class TestSamplingParamsVerify(unittest.TestCase):
             sp.verify(self.VOCAB_SIZE)
 
     # --- top_p ---
+    def test_top_p_negative_raises(self):
+        sp = self._make(top_p=-0.5)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
     def test_top_p_zero_raises(self):
         """top_p=0 is not in (0, 1]."""
         sp = self._make(top_p=0.0)
@@ -134,6 +144,14 @@ class TestSamplingParamsVerify(unittest.TestCase):
         """top_k=0 is invalid (must be >=1 or -1 for all)."""
         sp = self._make()
         sp.top_k = 0  # bypass __init__ conversion
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_top_k_negative_raises(self):
+        """top_k=-2 stays as-is (__init__ only converts -1 to TOP_K_ALL),
+        and verify() should reject it."""
+        sp = self._make()
+        sp.top_k = -2  # bypass __init__ conversion
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
@@ -192,6 +210,11 @@ class TestSamplingParamsVerify(unittest.TestCase):
     def test_min_equals_max_new_tokens_valid(self):
         sp = self._make(min_new_tokens=10, max_new_tokens=10)
         sp.verify(self.VOCAB_SIZE)
+
+    def test_max_new_tokens_none_skips_validation(self):
+        """When max_new_tokens is None, the min<=max check is skipped entirely."""
+        sp = self._make(min_new_tokens=9999, max_new_tokens=None)
+        sp.verify(self.VOCAB_SIZE)  # should not raise
 
     # --- logit_bias ---
     def test_logit_bias_token_exceeds_vocab_raises(self):

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -1,0 +1,369 @@
+"""Unit tests for srt/sampling/sampling_params.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.sampling.sampling_params import (
+    MAX_LEN,
+    TOP_K_ALL,
+    SamplingParams,
+    _max_length_from_subpattern,
+    get_max_seq_length,
+)
+
+
+# ---------------------------------------------------------------------------
+# SamplingParams.__init__ — implicit conversions
+# ---------------------------------------------------------------------------
+class TestSamplingParamsInit(unittest.TestCase):
+    """Test the two implicit conversions that happen in __init__."""
+
+    def test_zero_temperature_becomes_greedy(self):
+        """temperature=0 should trigger greedy mode: top_k=1, temperature=1.0."""
+        sp = SamplingParams(temperature=0.0)
+        self.assertEqual(sp.top_k, 1)
+        self.assertEqual(sp.temperature, 1.0)
+
+    def test_near_zero_temperature_becomes_greedy(self):
+        """temperature just below 1e-6 should also trigger greedy."""
+        sp = SamplingParams(temperature=1e-7)
+        self.assertEqual(sp.top_k, 1)
+        self.assertEqual(sp.temperature, 1.0)
+
+    def test_temperature_at_eps_boundary_not_greedy(self):
+        """temperature exactly at 1e-6 should NOT trigger greedy (< not <=)."""
+        sp = SamplingParams(temperature=1e-6)
+        self.assertEqual(sp.temperature, 1e-6)
+        # top_k should remain at TOP_K_ALL (from -1 default)
+        self.assertEqual(sp.top_k, TOP_K_ALL)
+
+    def test_negative_temperature_not_modified(self):
+        """Negative temperature is invalid but __init__ doesn't reject it —
+        that's verify()'s job. Confirm __init__ leaves it unchanged."""
+        sp = SamplingParams(temperature=-1.0)
+        self.assertEqual(sp.temperature, -1.0)
+
+    def test_top_k_minus_one_becomes_top_k_all(self):
+        """top_k=-1 means 'whole vocabulary', converted to TOP_K_ALL."""
+        sp = SamplingParams(top_k=-1)
+        self.assertEqual(sp.top_k, TOP_K_ALL)
+
+    def test_positive_top_k_preserved(self):
+        """An explicit positive top_k should be kept as-is."""
+        sp = SamplingParams(top_k=50)
+        self.assertEqual(sp.top_k, 50)
+
+    def test_stop_token_ids_stored_as_set(self):
+        """stop_token_ids list should be converted to a set for O(1) lookup."""
+        sp = SamplingParams(stop_token_ids=[1, 2, 3])
+        self.assertIsInstance(sp.stop_token_ids, set)
+        self.assertEqual(sp.stop_token_ids, {1, 2, 3})
+
+    def test_stop_token_ids_none_stays_none(self):
+        sp = SamplingParams(stop_token_ids=None)
+        self.assertIsNone(sp.stop_token_ids)
+
+
+# ---------------------------------------------------------------------------
+# SamplingParams.verify — parameter validation
+# ---------------------------------------------------------------------------
+class TestSamplingParamsVerify(unittest.TestCase):
+    """Test that verify() rejects invalid values and accepts valid ones."""
+
+    VOCAB_SIZE = 32000
+
+    def _make(self, **kwargs):
+        """Helper: create SamplingParams with safe defaults, override with kwargs."""
+        defaults = dict(temperature=1.0, top_p=1.0, top_k=10, min_p=0.0)
+        defaults.update(kwargs)
+        return SamplingParams(**defaults)
+
+    # --- happy path ---
+    def test_valid_params_pass(self):
+        sp = self._make()
+        sp.verify(self.VOCAB_SIZE)  # should not raise
+
+    # --- temperature ---
+    def test_negative_temperature_raises(self):
+        sp = self._make(temperature=-0.5)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    # --- top_p ---
+    def test_top_p_zero_raises(self):
+        """top_p=0 is not in (0, 1]."""
+        sp = self._make(top_p=0.0)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_top_p_above_one_raises(self):
+        sp = self._make(top_p=1.1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_top_p_exactly_one_is_valid(self):
+        sp = self._make(top_p=1.0)
+        sp.verify(self.VOCAB_SIZE)  # should not raise
+
+    def test_top_p_small_positive_is_valid(self):
+        sp = self._make(top_p=0.01)
+        sp.verify(self.VOCAB_SIZE)
+
+    # --- min_p ---
+    def test_min_p_negative_raises(self):
+        sp = self._make(min_p=-0.1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_min_p_above_one_raises(self):
+        sp = self._make(min_p=1.01)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_min_p_boundaries_valid(self):
+        """Both 0.0 and 1.0 are valid."""
+        self._make(min_p=0.0).verify(self.VOCAB_SIZE)
+        self._make(min_p=1.0).verify(self.VOCAB_SIZE)
+
+    # --- top_k ---
+    def test_top_k_zero_raises(self):
+        """top_k=0 is invalid (must be >=1 or -1 for all)."""
+        sp = self._make()
+        sp.top_k = 0  # bypass __init__ conversion
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    # --- frequency_penalty ---
+    def test_frequency_penalty_below_minus_two_raises(self):
+        sp = self._make(frequency_penalty=-2.1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_frequency_penalty_above_two_raises(self):
+        sp = self._make(frequency_penalty=2.1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_frequency_penalty_boundaries_valid(self):
+        self._make(frequency_penalty=-2.0).verify(self.VOCAB_SIZE)
+        self._make(frequency_penalty=2.0).verify(self.VOCAB_SIZE)
+
+    # --- presence_penalty ---
+    def test_presence_penalty_out_of_range_raises(self):
+        sp = self._make(presence_penalty=2.5)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    # --- repetition_penalty ---
+    def test_repetition_penalty_negative_raises(self):
+        sp = self._make(repetition_penalty=-0.1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_repetition_penalty_above_two_raises(self):
+        sp = self._make(repetition_penalty=2.1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_repetition_penalty_boundaries_valid(self):
+        self._make(repetition_penalty=0.0).verify(self.VOCAB_SIZE)
+        self._make(repetition_penalty=2.0).verify(self.VOCAB_SIZE)
+
+    # --- min_new_tokens / max_new_tokens ---
+    def test_negative_min_new_tokens_raises(self):
+        sp = self._make(min_new_tokens=-1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_negative_max_new_tokens_raises(self):
+        sp = self._make(max_new_tokens=-1)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_min_exceeds_max_new_tokens_raises(self):
+        sp = self._make(min_new_tokens=100, max_new_tokens=50)
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_min_equals_max_new_tokens_valid(self):
+        sp = self._make(min_new_tokens=10, max_new_tokens=10)
+        sp.verify(self.VOCAB_SIZE)
+
+    # --- logit_bias ---
+    def test_logit_bias_token_exceeds_vocab_raises(self):
+        sp = self._make(logit_bias={"99999": 1.0})
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_negative_token_raises(self):
+        sp = self._make(logit_bias={"-1": 1.0})
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_valid_tokens(self):
+        sp = self._make(logit_bias={"0": 1.0, "31999": -0.5})
+        sp.verify(self.VOCAB_SIZE)
+
+    # --- grammar mutual exclusion ---
+    def test_multiple_grammars_raises(self):
+        sp = self._make(json_schema='{"type":"object"}', regex="abc")
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_single_grammar_valid(self):
+        sp = self._make(json_schema='{"type":"object"}')
+        sp.verify(self.VOCAB_SIZE)
+
+    def test_all_three_grammars_set_raises(self):
+        sp = self._make(json_schema='{}', regex="a", ebnf="rule")
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+
+# ---------------------------------------------------------------------------
+# SamplingParams.normalize — stop string processing
+# ---------------------------------------------------------------------------
+class TestSamplingParamsNormalize(unittest.TestCase):
+    """Test that normalize() correctly processes stop strings and regex."""
+
+    def test_none_stop_strs_becomes_empty_list(self):
+        sp = SamplingParams(stop=None)
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_strs, [])
+        self.assertEqual(sp.stop_str_max_len, 0)
+
+    def test_string_stop_str_wrapped_in_list(self):
+        sp = SamplingParams(stop="<|end|>")
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_strs, ["<|end|>"])
+
+    def test_list_stop_strs_unchanged(self):
+        sp = SamplingParams(stop=["stop1", "stop2"])
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_strs, ["stop1", "stop2"])
+
+    def test_stop_str_max_len_without_tokenizer(self):
+        """Without a tokenizer, max_len is the raw string character count."""
+        sp = SamplingParams(stop=["ab", "cdef"])
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_str_max_len, 4)  # len("cdef")
+
+    def test_stop_str_max_len_with_tokenizer(self):
+        """With a tokenizer, max_len counts encoded token IDs."""
+        tokenizer = MagicMock()
+        # "hello" encodes to 2 tokens, "world!!" to 3 tokens
+        tokenizer.encode.side_effect = lambda s, add_special_tokens=False: {
+            "hello": [101, 102],
+            "world!!": [201, 202, 203],
+        }[s]
+        sp = SamplingParams(stop=["hello", "world!!"])
+        sp.normalize(tokenizer=tokenizer)
+        self.assertEqual(sp.stop_str_max_len, 3)
+
+    def test_none_stop_regex_becomes_empty_list(self):
+        sp = SamplingParams(stop_regex=None)
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_regex_strs, [])
+        self.assertEqual(sp.stop_regex_max_len, 0)
+
+    def test_string_stop_regex_wrapped_in_list(self):
+        sp = SamplingParams(stop_regex=r"\d+")
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_regex_strs, [r"\d+"])
+
+    def test_stop_regex_max_len_computed(self):
+        """Bounded regex should compute a finite max length."""
+        sp = SamplingParams(stop_regex=r"[a-z]{3}")
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_regex_max_len, 3)
+
+
+# ---------------------------------------------------------------------------
+# get_max_seq_length / _max_length_from_subpattern — regex analysis
+# ---------------------------------------------------------------------------
+class TestRegexMaxLength(unittest.TestCase):
+    """Test the recursive regex AST length calculator."""
+
+    def test_literal_string(self):
+        """'abc' → 3 literals."""
+        self.assertEqual(get_max_seq_length("abc"), 3)
+
+    def test_character_class(self):
+        """'[a-z]' → 1 (one character from set)."""
+        self.assertEqual(get_max_seq_length("[a-z]"), 1)
+
+    def test_dot_any(self):
+        """'.' matches any one character → 1."""
+        self.assertEqual(get_max_seq_length("."), 1)
+
+    def test_unbounded_star(self):
+        """'a*' → unbounded repeat → MAX_LEN."""
+        result = get_max_seq_length("a*")
+        self.assertEqual(result, MAX_LEN)
+
+    def test_unbounded_plus(self):
+        """'a+' → at least 1, unbounded → MAX_LEN."""
+        result = get_max_seq_length("a+")
+        self.assertEqual(result, MAX_LEN)
+
+    def test_bounded_repeat(self):
+        """'a{5}' → exactly 5 × 1 = 5."""
+        self.assertEqual(get_max_seq_length("a{5}"), 5)
+
+    def test_bounded_range_repeat(self):
+        """'a{2,4}' → upper bound is 4 × 1 = 4."""
+        self.assertEqual(get_max_seq_length("a{2,4}"), 4)
+
+    def test_branch_takes_max(self):
+        """'abc|de' → max(3, 2) = 3."""
+        self.assertEqual(get_max_seq_length("abc|de"), 3)
+
+    def test_subpattern_group(self):
+        """'(abc)' → 3 from the group content."""
+        self.assertEqual(get_max_seq_length("(abc)"), 3)
+
+    def test_zero_width_assertions_ignored(self):
+        """'^abc$' → anchors contribute 0, result = 3."""
+        self.assertEqual(get_max_seq_length("^abc$"), 3)
+
+    def test_complex_pattern(self):
+        """'(foo|bar)\\d{2}' → max(3,3) + 2 = 5."""
+        self.assertEqual(get_max_seq_length(r"(foo|bar)\d{2}"), 5)
+
+    def test_nested_groups(self):
+        """'((ab))' → nested subpatterns still = 2."""
+        self.assertEqual(get_max_seq_length("((ab))"), 2)
+
+    def test_question_mark_optional(self):
+        """'a?' → {0,1} repeat → 1 × 1 = 1."""
+        self.assertEqual(get_max_seq_length("a?"), 1)
+
+    def test_mixed_unbounded_and_bounded(self):
+        """'ab+c{3}' → 1 + MAX_LEN + 3. Since MAX_LEN dominates,
+        the total includes it."""
+        result = get_max_seq_length("ab+c{3}")
+        self.assertGreaterEqual(result, MAX_LEN)
+
+    def test_empty_regex(self):
+        """Empty regex matches empty string → length 0."""
+        self.assertEqual(get_max_seq_length(""), 0)
+
+    def test_lookahead_triggers_unhandled_token(self):
+        """Lookahead (?=...) produces an ASSERT token which is not handled —
+        the else branch should log a warning and add MAX_LEN."""
+        result = get_max_seq_length("(?=a)b")
+        # ASSERT (lookahead) → MAX_LEN, LITERAL 'b' → 1
+        self.assertGreaterEqual(result, MAX_LEN)
+
+    def test_lookbehind_triggers_unhandled_token(self):
+        """Lookbehind (?<=...) also produces an unhandled ASSERT token."""
+        result = get_max_seq_length("(?<=x)y")
+        self.assertGreaterEqual(result, MAX_LEN)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Part of #20865 (srt/sampling portion).

The `srt/sampling/` module previously had no unit test coverage. This PR adds 177 tests in 4 test files, covering all 8 source files under `srt/sampling/`. No server launch, no model weight loading.

## Coverage

```
Name                                                         Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------
python/sglang/srt/sampling/custom_logit_processor.py           109      0   100%
python/sglang/srt/sampling/penaltylib/__init__.py                5      0   100%
python/sglang/srt/sampling/penaltylib/frequency_penalty.py      22      0   100%
python/sglang/srt/sampling/penaltylib/min_new_tokens.py         27      0   100%
python/sglang/srt/sampling/penaltylib/orchestrator.py          127      8    94%   146, 204, 212, 220, 228, 235, 242, 249
python/sglang/srt/sampling/penaltylib/presence_penalty.py       22      0   100%
python/sglang/srt/sampling/sampling_batch_info.py              166      0   100%
python/sglang/srt/sampling/sampling_params.py                  118      2    98%   22-23
------------------------------------------------------------------------------------------
TOTAL                                                          596     10    98%
```

The 10 uncovered lines are unreachable at runtime: Python 3.10 compat import fallback (lines 22-23 in sampling_params.py) and abstract method bodies / defensive exception in orchestrator.py.

## Test plan

```bash
# command
pytest test/registered/unit/sampling/test_sampling_params.py -v
# output
================================================================== test session starts ==================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /scratch/zijunga1/conda_envs/sglang/bin/python3
cachedir: .pytest_cache
rootdir: /scratch/zijunga1/sglang/test
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.0.0
collected 64 items                                                                                                                                      

test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_empty_stop_token_ids_becomes_none PASSED                      [  1%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_near_zero_temperature_becomes_greedy PASSED                   [  3%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_negative_temperature_not_modified PASSED                      [  4%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_positive_top_k_preserved PASSED                               [  6%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_stop_token_ids_none_stays_none PASSED                         [  7%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_stop_token_ids_stored_as_set PASSED                           [  9%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_temperature_at_eps_boundary_not_greedy PASSED                 [ 10%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_top_k_minus_one_becomes_top_k_all PASSED                      [ 12%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsInit::test_zero_temperature_becomes_greedy PASSED                        [ 14%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_all_three_grammars_set_raises PASSED                        [ 15%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_frequency_penalty_above_two_raises PASSED                   [ 17%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_frequency_penalty_below_minus_two_raises PASSED             [ 18%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_frequency_penalty_boundaries_valid PASSED                   [ 20%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_logit_bias_negative_token_raises PASSED                     [ 21%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_logit_bias_token_exceeds_vocab_raises PASSED                [ 23%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_logit_bias_valid_tokens PASSED                              [ 25%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_max_new_tokens_none_skips_validation PASSED                 [ 26%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_min_equals_max_new_tokens_valid PASSED                      [ 28%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_min_exceeds_max_new_tokens_raises PASSED                    [ 29%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_min_p_above_one_raises PASSED                               [ 31%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_min_p_boundaries_valid PASSED                               [ 32%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_min_p_negative_raises PASSED                                [ 34%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_multiple_grammars_raises PASSED                             [ 35%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_negative_max_new_tokens_raises PASSED                       [ 37%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_negative_min_new_tokens_raises PASSED                       [ 39%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_negative_temperature_raises PASSED                          [ 40%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_presence_penalty_out_of_range_raises PASSED                 [ 42%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_repetition_penalty_above_two_raises PASSED                  [ 43%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_repetition_penalty_boundaries_valid PASSED                  [ 45%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_repetition_penalty_negative_raises PASSED                   [ 46%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_single_grammar_valid PASSED                                 [ 48%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_k_negative_raises PASSED                                [ 50%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_k_zero_raises PASSED                                    [ 51%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_p_above_one_raises PASSED                               [ 53%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_p_exactly_one_is_valid PASSED                           [ 54%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_p_negative_raises PASSED                                [ 56%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_p_small_positive_is_valid PASSED                        [ 57%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_top_p_zero_raises PASSED                                    [ 59%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsVerify::test_valid_params_pass PASSED                                    [ 60%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_list_stop_strs_unchanged PASSED                          [ 62%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_none_stop_regex_becomes_empty_list PASSED                [ 64%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_none_stop_strs_becomes_empty_list PASSED                 [ 65%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_stop_regex_max_len_computed PASSED                       [ 67%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_stop_str_max_len_with_tokenizer PASSED                   [ 68%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_stop_str_max_len_without_tokenizer PASSED                [ 70%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_string_stop_regex_wrapped_in_list PASSED                 [ 71%]
test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsNormalize::test_string_stop_str_wrapped_in_list PASSED                   [ 73%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_bounded_range_repeat PASSED                                       [ 75%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_bounded_repeat PASSED                                             [ 76%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_branch_takes_max PASSED                                           [ 78%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_character_class PASSED                                            [ 79%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_complex_pattern PASSED                                            [ 81%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_dot_any PASSED                                                    [ 82%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_empty_regex PASSED                                                [ 84%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_literal_string PASSED                                             [ 85%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_lookahead_triggers_unhandled_token PASSED                         [ 87%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_lookbehind_triggers_unhandled_token PASSED                        [ 89%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_mixed_unbounded_and_bounded PASSED                                [ 90%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_nested_groups PASSED                                              [ 92%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_question_mark_optional PASSED                                     [ 93%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_subpattern_group PASSED                                           [ 95%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_unbounded_plus PASSED                                             [ 96%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_unbounded_star PASSED                                             [ 98%]
test/registered/unit/sampling/test_sampling_params.py::TestRegexMaxLength::test_zero_width_assertions_ignored PASSED                              [100%]

=================================================================== warnings summary ====================================================================
../conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /scratch/zijunga1/conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 64 passed, 1 warning in 95.30s (0:01:35) ========================================================
```

```bash
# command
pytest test/registered/unit/sampling/test_custom_logit_processor.py -v
# output
================================================================== test session starts ==================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /scratch/zijunga1/conda_envs/sglang/bin/python3
cachedir: .pytest_cache
rootdir: /scratch/zijunga1/sglang/test
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.0.0
collected 34 items                                                                                                                                      

test/registered/unit/sampling/test_custom_logit_processor.py::TestCustomLogitProcessorSerialization::test_from_str_is_cached PASSED               [  2%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestCustomLogitProcessorSerialization::test_round_trip_serialization PASSED         [  5%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestCustomLogitProcessorSerialization::test_to_str_produces_valid_json PASSED       [  8%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDisallowedTokensLogitsProcessor::test_allowed_tokens_unchanged PASSED           [ 11%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDisallowedTokensLogitsProcessor::test_disallowed_tokens_set_to_neg_inf PASSED   [ 14%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDisallowedTokensLogitsProcessor::test_mismatched_params_raises PASSED           [ 17%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_budget_exceeded_forces_newline_first PASSED  [ 20%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_budget_exceeded_with_newline_forces_end_token PASSED [ 23%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_budget_not_exceeded_no_change PASSED         [ 26%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_budget_zero_forces_immediate_end PASSED      [ 29%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_deepseek_r1_variant_forces_end PASSED        [ 32%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_empty_params_returns_unchanged PASSED        [ 35%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_multiple_thinking_start_counts_from_first PASSED [ 38%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_none_param_dict_in_list_skipped PASSED       [ 41%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_none_params_returns_unchanged PASSED         [ 44%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_skips_when_budget_is_negative PASSED         [ 47%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_skips_when_budget_is_none PASSED             [ 50%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_skips_when_not_in_thinking PASSED            [ 52%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestThinkingBudgetLogitProcessor::test_skips_when_thinking_already_ended PASSED     [ 55%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_bans_repeated_bigrams PASSED       [ 58%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_batch_processing PASSED            [ 61%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_empty_params_returns_unchanged PASSED [ 64%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_falsy_params_in_list_skipped PASSED [ 67%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_invalid_ngram_size_type_skips PASSED [ 70%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_invalid_whitelist_type_handled PASSED [ 73%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_ngram_size_zero_skips PASSED       [ 76%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_non_repeated_tokens_unchanged PASSED [ 79%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_none_req_skips PASSED              [ 82%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_search_end_leq_search_start_skips PASSED [ 85%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_short_sequence_skips PASSED        [ 88%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_unigram_mode PASSED                [ 91%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_whitelist_protects_tokens PASSED   [ 94%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_window_size_limits_search PASSED   [ 97%]
test/registered/unit/sampling/test_custom_logit_processor.py::TestDeepseekOCRNoRepeatNGramLogitProcessor::test_window_size_zero_skips PASSED      [100%]

=================================================================== warnings summary ====================================================================
../conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /scratch/zijunga1/conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 34 passed, 1 warning in 110.01s (0:01:50) =======================================================
```

```bash
# command
pytest test/registered/unit/sampling/test_penaltylib.py -v
# output
================================================================== test session starts ==================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /scratch/zijunga1/conda_envs/sglang/bin/python3
cachedir: .pytest_cache
rootdir: /scratch/zijunga1/sglang/test
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.0.0
collected 40 items                                                                                                                                      

test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_batch_property_via_weakref PASSED                        [  2%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_batch_setter_new_batch PASSED                            [  5%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_batch_setter_none PASSED                                 [  7%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_context_manager_releases PASSED                          [ 10%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_filter_empty_indices_releases PASSED                     [ 12%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_filter_not_required_is_noop PASSED                       [ 15%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_init_detects_required_penalizers PASSED                  [ 17%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_init_not_required_when_no_penalties PASSED               [ 20%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerOrchestrator::test_merge_both_not_required_is_noop PASSED                   [ 22%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_apply_when_not_prepared_is_noop PASSED                      [ 25%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_cumulate_and_apply PASSED                                   [ 27%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_cumulate_twice_doubles_penalty PASSED                       [ 30%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_cumulate_when_not_prepared_is_noop PASSED                   [ 32%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_filter_keeps_subset PASSED                                  [ 35%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_is_not_required_with_zero_penalty PASSED                    [ 37%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_is_required_with_nonzero_penalty PASSED                     [ 40%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_merge_concatenates PASSED                                   [ 42%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedFrequencyPenalizer::test_teardown_cleans_attributes PASSED                           [ 45%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPresencePenalizer::test_filter_keeps_subset PASSED                                   [ 47%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPresencePenalizer::test_is_required_with_nonzero_penalty PASSED                      [ 50%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPresencePenalizer::test_merge_concatenates PASSED                                    [ 52%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPresencePenalizer::test_presence_penalty_does_not_scale PASSED                       [ 55%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPresencePenalizer::test_teardown_cleans_attributes PASSED                            [ 57%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_allows_eos_after_min_tokens PASSED                       [ 60%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_blocks_additional_stop_tokens PASSED                     [ 62%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_blocks_custom_stop_tokens PASSED                         [ 65%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_blocks_eos_before_min_tokens PASSED                      [ 67%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_filter_keeps_subset PASSED                               [ 70%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_is_not_required_with_zero_min_tokens PASSED              [ 72%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_is_required_with_positive_min_tokens PASSED              [ 75%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_merge_concatenates PASSED                                [ 77%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedMinNewTokensPenalizer::test_teardown_cleans_attributes PASSED                        [ 80%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerBase::test_filter_when_not_prepared_is_noop PASSED                          [ 82%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerBase::test_merge_both_unprepared_is_noop PASSED                             [ 85%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerBase::test_merge_prepares_both_if_needed PASSED                             [ 87%]
test/registered/unit/sampling/test_penaltylib.py::TestBatchedPenalizerBase::test_prepare_is_idempotent PASSED                                     [ 90%]
test/registered/unit/sampling/test_penaltylib.py::TestOrchestratorMultiplePenalizers::test_all_three_penalizers PASSED                            [ 92%]
test/registered/unit/sampling/test_penaltylib.py::TestOrchestratorMultiplePenalizers::test_filter_keeps_required_penalizer PASSED                 [ 95%]
test/registered/unit/sampling/test_penaltylib.py::TestOrchestratorMultiplePenalizers::test_filter_with_penalizer_no_longer_required PASSED        [ 97%]
test/registered/unit/sampling/test_penaltylib.py::TestOrchestratorMultiplePenalizers::test_merge_one_required PASSED                              [100%]

=================================================================== warnings summary ====================================================================
../conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /scratch/zijunga1/conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 40 passed, 1 warning in 97.22s (0:01:37) ========================================================
```

```bash
# command
pytest test/registered/unit/sampling/test_sampling_batch_info.py -v
# output
================================================================== test session starts ==================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /scratch/zijunga1/conda_envs/sglang/bin/python3
cachedir: .pytest_cache
rootdir: /scratch/zijunga1/sglang/test
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.0.0
collected 39 items                                                                                                                                      

test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBiasTensor::test_both_none_returns_none PASSED                                [  2%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBiasTensor::test_both_present_concatenates PASSED                             [  5%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBiasTensor::test_custom_default_value PASSED                                  [  7%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBiasTensor::test_lhs_none_fills_default PASSED                                [ 10%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBiasTensor::test_rhs_none_fills_default PASSED                                [ 12%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestSamplingBatchInfoLen::test_len_matches_batch_size PASSED                           [ 15%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeCustomLogitProcessor::test_both_none_returns_none PASSED                      [ 17%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeCustomLogitProcessor::test_disjoint_keys PASSED                               [ 20%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeCustomLogitProcessor::test_lhs_none_rhs_present PASSED                        [ 23%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeCustomLogitProcessor::test_same_key_merges_masks PASSED                       [ 25%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestApplyLogitsBias::test_applies_linear_penalties PASSED                              [ 28%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestApplyLogitsBias::test_applies_logit_bias PASSED                                    [ 30%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestApplyLogitsBias::test_applies_penalizer_orchestrator PASSED                        [ 33%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestApplyLogitsBias::test_applies_vocab_mask PASSED                                    [ 35%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestApplyLogitsBias::test_no_bias_no_change PASSED                                     [ 38%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestUpdatePenalties::test_not_required_sets_none PASSED                                [ 41%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestUpdatePenalties::test_required_creates_penalties_tensor PASSED                     [ 43%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestUpdateRegexVocabMask::test_empty_grammars_clears_mask PASSED                       [ 46%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestUpdateRegexVocabMask::test_mixed_grammars_only_active_fills PASSED                 [ 48%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestUpdateRegexVocabMask::test_no_grammars_clears_mask PASSED                          [ 51%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestUpdateRegexVocabMask::test_with_grammars_allocates_and_fills PASSED                [ 53%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFilterBatch::test_filter_keeps_correct_indices PASSED                              [ 56%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFilterBatch::test_filter_removes_all_custom_processors PASSED                      [ 58%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFilterBatch::test_filter_with_custom_logit_processor PASSED                        [ 61%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFilterBatch::test_filter_with_none_sampling_seed PASSED                            [ 64%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBatch::test_merge_combines_flags PASSED                                       [ 66%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBatch::test_merge_concatenates_tensors PASSED                                 [ 69%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBatch::test_merge_with_both_sampling_seeds PASSED                             [ 71%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBatch::test_merge_with_custom_logit_processor PASSED                          [ 74%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBatch::test_merge_with_logit_bias PASSED                                      [ 76%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestMergeBatch::test_merge_with_none_sampling_seed PASSED                              [ 79%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestCopyForForward::test_returns_copy_without_orchestrator PASSED                      [ 82%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_basic_construction PASSED                                  [ 84%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_custom_logit_processor_merging PASSED                      [ 87%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_deterministic_seed PASSED                                  [ 89%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_from_schedule_batch_sampling_flags PASSED                  [ 92%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_greedy_detection PASSED                                    [ 94%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_logit_bias_construction PASSED                             [ 97%]
test/registered/unit/sampling/test_sampling_batch_info.py::TestFromScheduleBatch::test_no_logit_bias_when_all_none PASSED                         [100%]

=================================================================== warnings summary ====================================================================
../conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /scratch/zijunga1/conda_envs/sglang/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 39 passed, 3 warnings in 100.14s (0:01:40) =======================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```