### PR TITLE
simplify and improve `pr-test.yml`

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,14 +10,6 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      version:
-        description: "FlashInfer version"
-        required: true
-        type: choice
-        default: "release"
-        options:
-          - "release"
-          - "nightly"
       target_stage:
         description: "Specific stage to run (optional, for quick testing)"
         required: false


### PR DESCRIPTION
## Summary
- remove the unused `version` input from the `workflow_dispatch` section in `pr-test.yml`
- simplify the manual PR test workflow form so it exposes only the remaining relevant inputs

## Test plan
- pre-commit hooks passed during `git commit`
- no runtime tests run (workflow YAML only)

Made with [Cursor](https://cursor.com)