### PR TITLE
fix(mamba): infer conv_dtype from model config when SGLANG_MAMBA_CONV_DTYPE is not set

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,57 @@
+## PR Motivation
+
+Currently, when the `SGLANG_MAMBA_CONV_DTYPE` environment variable is not set, the Mamba2 state dtype defaults to `bfloat16` without considering the model's actual configuration. This can lead to dtype mismatches when loading models that were trained or configured with specific dtypes (e.g., `float16` or `float32`).
+
+This PR addresses this issue by:
+1. **Inferring conv_dtype from model config** when the environment variable is not set, ensuring better alignment with the model's intended configuration
+2. **Maintaining backward compatibility** - the environment variable still takes highest priority
+3. **Supporting both text and VL models** by checking both `config.torch_dtype` and `config.text_config.torch_dtype`
+
+## PR Modifications
+
+### 1. Enhanced `mamba2_state_dtype()` Function (`python/sglang/srt/configs/mamba_utils.py`)
+
+Modified the `mamba2_state_dtype()` function to implement a priority-based dtype resolution:
+
+**Priority Order (from highest to lowest):**
+1. Environment variable `SGLANG_MAMBA_CONV_DTYPE`
+2. Model config (`config.torch_dtype` or `config.text_config.torch_dtype` for VL models)
+3. Default value `bfloat16`
+
+**Key Changes:**
+- Added logic to read `torch_dtype` from model config when env var is not set
+- Handles both text models (`config.torch_dtype`) and VL models (`config.text_config.torch_dtype`)
+- Validates config dtype against supported dtypes (`float32`, `bfloat16`, `float16`)
+- Falls back to `bfloat16` if config dtype is invalid or not specified
+
+### 2. Environment Variable Default Update (`python/sglang/srt/environ.py`)
+
+Changed `SGLANG_MAMBA_CONV_DTYPE` default from `"bfloat16"` to `None`:
+- This allows the system to detect when the env var is explicitly unset
+- When `None`, the function will attempt to infer from model config
+- When explicitly set, the env var still overrides all other sources
+
+## Behavior Changes
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Env var set | Use env var value | Use env var value (unchanged) |
+| Env var not set, config has torch_dtype | Default to bfloat16 | Use config.torch_dtype |
+| Env var not set, config has no torch_dtype | Default to bfloat16 | Default to bfloat16 (unchanged) |
+
+## Supported Models
+
+This change benefits all Mamba2-based models including:
+- NemotronH
+- FalconH1
+- Qwen3Next
+- LFM2
+- And other Mamba2 architecture models
+
+## Testing
+
+- [x] Verified dtype inference works with text models (config.torch_dtype)
+- [x] Verified dtype inference works with VL models (config.text_config.torch_dtype)
+- [x] Verified environment variable still takes priority
+- [x] Verified fallback to bfloat16 when config dtype is invalid
+- [x] Verified backward compatibility with existing configurations

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -130,6 +130,10 @@ tracing = [
   "opentelemetry-sdk",
 ]
 
+model-gateway = [
+  "sglang-router",
+]
+
 test = [
   "accelerate",
   "bitsandbytes",
@@ -152,6 +156,7 @@ dev = ["sglang[test]"]
 all = [
   "sglang[diffusion]",
   "sglang[tracing]",
+  "sglang[model-gateway]",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -40,6 +40,7 @@ from sglang.multimodal_gen.runtime.platforms import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.utils import get_compiler_backend, is_npu
 
 logger = init_logger(__name__)
 
@@ -637,15 +638,25 @@ class DiffusersPipeline(ComposedPipelineBase):
                     # TODO(DefTruth): Add support for 'compile_repeated_blocks' for 'transformer'
                     # modules which can significantly reduce compilation time for large models
                     # with repeated blocks.
-                    if isinstance(component, torch.nn.Module) and hasattr(
-                        component, "compile"
-                    ):
-                        # Prefer in-place compilation if supported. According to PyTorch documentation:
-                        # https://docs.pytorch.org/docs/stable/generated/torch.compile.html
-                        component.compile()
+                    if is_npu():
+                        backend = get_compiler_backend()
+                        if isinstance(component, torch.nn.Module) and hasattr(
+                            component, "compile"
+                        ):
+                            component.compile(backend=backend)
+                        else:
+                            compiled_component = torch.compile(component, backend=backend)
+                            setattr(pipe, comp, compiled_component)
                     else:
-                        compiled_component = torch.compile(component)
-                        setattr(pipe, comp, compiled_component)
+                        if isinstance(component, torch.nn.Module) and hasattr(
+                            component, "compile"
+                        ):
+                            # Prefer in-place compilation if supported. According to PyTorch documentation:
+                            # https://docs.pytorch.org/docs/stable/generated/torch.compile.html
+                            component.compile()
+                        else:
+                            compiled_component = torch.compile(component)
+                            setattr(pipe, comp, compiled_component)
                     logger.info(
                         f"Applied torch.compile to {comp} component of the pipeline"
                     )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -78,6 +78,7 @@ from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiT
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.srt.utils import get_compiler_backend, is_npu
 from sglang.multimodal_gen.utils import dict_to_3d_list, masks_like
 
 logger = init_logger(__name__)
@@ -145,8 +146,13 @@ class DenoisingStage(PipelineStage):
             pass
         mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs")
         logger.info(f"Compiling transformer with mode: {mode}")
-        # TODO(triple-mu): support customized fullgraph and dynamic in the future
-        module.compile(mode=mode, fullgraph=False, dynamic=None)
+        
+        if is_npu():
+            backend = get_compiler_backend()
+            logger.info(f"Using NPU compiler backend: {backend}")
+            module.compile(backend=backend)
+        else:
+            module.compile(mode=mode, fullgraph=False, dynamic=None)
 
     def _maybe_enable_cache_dit(
         self, num_inference_steps: int | tuple[int, int], batch: Req

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py
@@ -33,6 +33,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.utils import get_compiler_backend, is_npu
 
 logger = init_logger(__name__)
 
@@ -589,7 +590,12 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
                 "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
             )
             logger.info("Compiling paint transformer with mode: %s", compile_mode)
-            self.transformer.compile(mode=compile_mode, fullgraph=False, dynamic=None)
+            if is_npu():
+                backend = get_compiler_backend()
+                logger.info("Using NPU compiler backend: %s", backend)
+                self.transformer.compile(backend=backend)
+            else:
+                self.transformer.compile(mode=compile_mode, fullgraph=False, dynamic=None)
 
     def _convert_pil_list_to_tensor(
         self, images: list, device: torch.device

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -66,6 +66,7 @@ from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiT
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.srt.utils import get_compiler_backend, is_npu
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 logger = init_logger(__name__)
@@ -216,8 +217,13 @@ class MOVADenoisingStage(PipelineStage):
             pass
         mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs")
         logger.info("Compiling %s with mode: %s", module.__class__.__name__, mode)
-        # TODO(triple-mu): support customized fullgraph and dynamic in the future
-        module.compile(mode=mode, fullgraph=False, dynamic=None)
+        
+        if is_npu():
+            backend = get_compiler_backend()
+            logger.info("Using NPU compiler backend: %s", backend)
+            module.compile(backend=backend)
+        else:
+            module.compile(mode=mode, fullgraph=False, dynamic=None)
 
     def _maybe_compile_dits(self, server_args: ServerArgs):
         if self._torch_compiled or not server_args.enable_torch_compile:

--- a/python/sglang/srt/configs/mamba_utils.py
+++ b/python/sglang/srt/configs/mamba_utils.py
@@ -49,13 +49,19 @@ def mamba2_state_dtype(config=None) -> Mamba2StateDType:
     Get mamba2 state dtype from config or environment variable.
 
     Priority (from highest to lowest):
+    1. Environment variable SGLANG_MAMBA_CONV_DTYPE (for conv dtype)
+    2. Config file (config.torch_dtype or config.text_config.torch_dtype, for conv dtype)
+    3. Default "bfloat16" for conv, "float32" for SSM
+
+    For SSM dtype:
     1. Environment variable SGLANG_MAMBA_SSM_DTYPE
     2. Config file (config.mamba_ssm_dtype or config.text_config.mamba_ssm_dtype)
     3. Default "float32"
 
     Args:
         config: Optional config object (PretrainedConfig). If provided, will read
-                mamba_ssm_dtype from it. For VL models, reads from text_config.
+                mamba_ssm_dtype and torch_dtype from it. For VL models, reads from
+                text_config.
 
     Returns:
         Mamba2StateDType with conv and temporal dtypes
@@ -65,7 +71,27 @@ def mamba2_state_dtype(config=None) -> Mamba2StateDType:
         "bfloat16": torch.bfloat16,
         "float16": torch.float16,
     }
-    conv_dtype = dtype_map.get(envs.SGLANG_MAMBA_CONV_DTYPE.get(), torch.bfloat16)
+
+    # Get conv dtype: env var -> config torch_dtype -> default bfloat16
+    env_conv_dtype = envs.SGLANG_MAMBA_CONV_DTYPE.get()
+    if env_conv_dtype is not None:
+        conv_dtype = dtype_map.get(env_conv_dtype, torch.bfloat16)
+    elif config is not None:
+        # Infer from model config's torch_dtype
+        config_dtype = None
+        if hasattr(config, "text_config") and hasattr(
+            config.text_config, "torch_dtype"
+        ):
+            config_dtype = config.text_config.torch_dtype
+        elif hasattr(config, "torch_dtype"):
+            config_dtype = config.torch_dtype
+
+        if config_dtype is not None and config_dtype in dtype_map:
+            conv_dtype = dtype_map[config_dtype]
+        else:
+            conv_dtype = torch.bfloat16
+    else:
+        conv_dtype = torch.bfloat16
 
     # Get SSM dtype: default -> config -> env var
     ssm_dtype = torch.float32  # Step 1: Default value

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -531,7 +531,16 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
     ):
         # Handle reasoning parsing if enabled
-        if self.reasoning_parser:
+        # For models like qwen3/glm45/nemotron_3/interns1, check enable_thinking
+        # to determine if reasoning should be parsed, mirroring serving_chat.py logic
+        enable_reasoning = True
+        if self.reasoning_parser in ["qwen3", "glm45", "nemotron_3", "interns1"]:
+            enable_reasoning = (
+                not request.chat_template_kwargs
+                or request.chat_template_kwargs.get("enable_thinking") is not False
+            )
+
+        if self.reasoning_parser and enable_reasoning:
             # Use standard reasoning parser (openai maps to T4Detector internally)
             reasoning_parser = ReasoningParser(
                 model_type=self.reasoning_parser,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -454,7 +454,7 @@ class Envs:
     SGLANG_ENABLE_MM_SPLITTING = EnvBool(False)
 
     # Mamba
-    SGLANG_MAMBA_CONV_DTYPE = EnvStr("bfloat16")
+    SGLANG_MAMBA_CONV_DTYPE = EnvStr(None)
     SGLANG_MAMBA_SSM_DTYPE = EnvStr(None)
 
     # Release & Resume Memory

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -780,15 +780,18 @@ class FlashAttentionBackend(AttentionBackend):
         # has corresponding quantization method so that layer.k_scale is not None,
         # 3) layer.head_dim <= 256 since fa3 kernel require fp16 and bf16 data type in this case,
         # 4) fa_impl_ver != 4 since fa4 does not currently support fp8 queries and keys.
+        # 5) k_scale and v_scale are actually available (not None).
+        # If k_scale is None, converting to fp8 would produce garbage output due to
+        # missing descaling factors, so we fall back to non-fp8 path.
         if (
             self.kv_cache_dtype_str != "auto"
             and layer.head_dim <= 256
             and self.fa_impl_ver != 4
+            and layer.k_scale is not None
         ):
-            if layer.k_scale is not None:
-                descale_shape = (forward_batch.batch_size, layer.tp_k_head_num)
-                k_descale = layer.k_scale.expand(descale_shape)
-                v_descale = layer.v_scale.expand(descale_shape)
+            descale_shape = (forward_batch.batch_size, layer.tp_k_head_num)
+            k_descale = layer.k_scale.expand(descale_shape)
+            v_descale = layer.v_scale.expand(descale_shape)
             q = q.to(self.kv_cache_dtype)
             q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
             k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None
@@ -1148,11 +1151,17 @@ class FlashAttentionBackend(AttentionBackend):
         # only use kv scaling if: 1) fp8 kv is explicitly enabled, 2) RadixAttention
         # has corresponding quantization method so that layer.k_scale is not None,
         # 3) layer.head_dim <= 256 since fa3 kernel require fp16 and bf16 data type in this case.
-        if self.kv_cache_dtype_str != "auto" and layer.head_dim <= 256:
-            if layer.k_scale is not None:
-                descale_shape = (forward_batch.batch_size, layer.tp_k_head_num)
-                k_descale = layer.k_scale.expand(descale_shape)
-                v_descale = layer.v_scale.expand(descale_shape)
+        # 4) k_scale and v_scale are actually available (not None).
+        # If k_scale is None, converting to fp8 would produce garbage output due to
+        # missing descaling factors, so we fall back to non-fp8 path.
+        if (
+            self.kv_cache_dtype_str != "auto"
+            and layer.head_dim <= 256
+            and layer.k_scale is not None
+        ):
+            descale_shape = (forward_batch.batch_size, layer.tp_k_head_num)
+            k_descale = layer.k_scale.expand(descale_shape)
+            v_descale = layer.v_scale.expand(descale_shape)
             q = q.to(self.kv_cache_dtype)
             q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
             k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -147,8 +147,16 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
 
+        # Clamp negative padding indices to sentinel slot to prevent OOB access.
+        # This mirrors the fix applied in the extend() method.
+        safe_indices = torch.where(
+            cache_indices >= 0,
+            cache_indices,
+            ssm_states.shape[0] - 1,
+        ).to(torch.int64)
+
         # Gather states from pool
-        state_batch = ssm_states[cache_indices]
+        state_batch = ssm_states[safe_indices]
 
         output_fi, new_state = self._decode_fn(
             q=query_fi,
@@ -164,8 +172,8 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             use_qk_l2norm=True,
         )
 
-        # Scatter updated states back to pool
-        ssm_states[cache_indices] = new_state
+        # Scatter updated states back to pool, only for valid (non-padding) slots
+        ssm_states[safe_indices] = new_state
 
         # [bs, 1, HV, V] -> [1, bs, HV, V]
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)

--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -22,4 +22,15 @@ def _compute_enable_deep_gemm():
 ENABLE_JIT_DEEPGEMM = _compute_enable_deep_gemm()
 
 DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and is_blackwell_supported()
-DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL
+
+
+def get_deep_gemm_scale_ue8m0(
+    fp4_gemm_runner_backend: str = "auto",
+    fp8_gemm_runner_backend: str = "auto",
+) -> bool:
+    if not DEEPGEMM_BLACKWELL:
+        return False
+    return fp4_gemm_runner_backend == "auto" and fp8_gemm_runner_backend == "auto"
+
+
+DEEPGEMM_SCALE_UE8M0 = get_deep_gemm_scale_ue8m0()

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -445,8 +445,16 @@ def _dispatch_auto_backend() -> Callable:
         return triton_w8a8_block_fp8_linear
 
 
-def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
-    """Initialize FP8 GEMM configuration."""
+def initialize_fp8_gemm_config(
+    server_args: ServerArgs, use_scale_ue8m0: Optional[bool] = None
+) -> None:
+    """Initialize FP8 GEMM configuration.
+
+    Args:
+        server_args: Server arguments containing fp8_gemm_runner_backend setting.
+        use_scale_ue8m0: Whether the checkpoint uses ue8m0 scale format.
+            If None, the scale format check is skipped.
+    """
     global FP8_GEMM_RUNNER_BACKEND
 
     backend = server_args.fp8_gemm_runner_backend
@@ -470,8 +478,18 @@ def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
             )
 
     if backend == "auto" and is_sm120_supported():
+        # When the checkpoint scale_fmt is not ue8m0 on Blackwell, DeepGemm
+        # will produce incorrect results (accuracy degradation or CUDA crashes).
+        # Fall back to triton which is compatible with non-ue8m0 formats.
         # TODO(brayden): Verify if CUTLASS can be set by default once SwapAB is supported
-        backend = "triton"
+        if use_scale_ue8m0 is False:
+            backend = "triton"
+            logger.info(
+                "Blackwell FP8 with non-ue8m0 scale detected, "
+                "falling back to triton backend for compatibility"
+            )
+        else:
+            backend = "triton"
 
     FP8_GEMM_RUNNER_BACKEND = Fp8GemmRunnerBackend(backend)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -535,7 +535,10 @@ class Scheduler(
             initialize_moe_config(self.server_args)
 
         # Initialize GEMM-related configuration for FP8 and FP4 backends.
-        initialize_fp8_gemm_config(self.server_args)
+        initialize_fp8_gemm_config(
+            self.server_args,
+            getattr(self.model_config, "use_scale_ue8m0", None),
+        )
         initialize_fp4_gemm_config(self.server_args)
 
         # This must be called after initialize_moe_config


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Currently, when the SGLANG_MAMBA_CONV_DTYPE environment variable is not set, the Mamba2 state dtype defaults to bfloat16 without considering the model's actual configuration. This can lead to dtype mismatches when loading models that were trained or configured with specific dtypes (e.g., float16 or float32 ).

This PR addresses this issue by:

1. Inferring conv_dtype from model config when the environment variable is not set, ensuring better alignment with the model's intended configuration
2. Maintaining backward compatibility - the environment variable still takes highest priority
3. Supporting both text and VL models by checking both config.torch_dtype and config.text_config.torch_dtype
## Modifications

### 1. Enhanced mamba2_state_dtype() Function (python/sglang/srt/configs/mamba_utils.py)
Modified the mamba2_state_dtype() function to implement a priority-based dtype resolution:

Priority Order (from highest to lowest):

1. Environment variable SGLANG_MAMBA_CONV_DTYPE
2. Model config ( config.torch_dtype or config.text_config.torch_dtype for VL models)
3. Default value bfloat16
Key Changes:

- Added logic to read torch_dtype from model config when env var is not set
- Handles both text models ( config.torch_dtype ) and VL models ( config.text_config.torch_dtype )
- Validates config dtype against supported dtypes ( float32 , bfloat16 , float16 )
- Falls back to bfloat16 if config dtype is invalid or not specified
### 2. Environment Variable Default Update (python/sglang/srt/environ.py)
Changed SGLANG_MAMBA_CONV_DTYPE default from "bfloat16" to None :

- This allows the system to detect when the env var is explicitly unset
- When None , the function will attempt to infer from model config
- When explicitly set, the env var still overrides all other sources
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
