### PR TITLE
[Bugifx] qwen3 rope parameter compatibility

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -566,7 +566,7 @@ class Qwen3MoeAttention(nn.Module):
     def apply_qk_norm_rope(self, qkv, positions, forward_batch):
         use_fused = self.use_fused_qk_norm_rope and qkv.dtype == torch.bfloat16
         if use_fused:
-            theta = self.config.rope_parameters["rope_theta"]
+            theta = self.rope_theta
             positions = (
                 positions.view(-1).to(dtype=torch.int32, device=qkv.device).contiguous()
             )
@@ -691,8 +691,23 @@ class Qwen3MoeDecoderLayer(nn.Module):
         super().__init__()
         self.config = config
         self.hidden_size = config.hidden_size
-        rope_theta = config.rope_parameters["rope_theta"]
-        rope_scaling = config.rope_parameters
+        rope_scaling = getattr(config, "rope_parameters", None)
+        if rope_scaling is None:
+            rope_scaling = getattr(config, "rope_scaling", None)
+
+        if isinstance(rope_scaling, dict):
+            rope_theta = rope_scaling.get(
+                "rope_theta", getattr(config, "rope_theta", None)
+            )
+        else:
+            rope_scaling = None
+            rope_theta = getattr(config, "rope_theta", None)
+
+        if rope_theta is None:
+            raise ValueError(
+                "Missing rope_theta in Qwen3 config. Expected either "
+                "config.rope_parameters['rope_theta'] or config.rope_theta."
+            )
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
         head_dim = getattr(
             config, "head_dim", config.hidden_size // config.num_attention_heads

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -708,6 +708,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
                 "Missing rope_theta in Qwen3 config. Expected either "
                 "config.rope_parameters['rope_theta'] or config.rope_theta."
             )
+        self.rope_theta = rope_theta
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
         head_dim = getattr(
             config, "head_dim", config.hidden_size // config.num_attention_heads

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -78,6 +78,7 @@ from sglang.srt.utils import (
     is_non_idle_and_non_empty,
     is_npu,
 )
+from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_cuda = is_cuda()
 
@@ -691,23 +692,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
         super().__init__()
         self.config = config
         self.hidden_size = config.hidden_size
-        rope_scaling = getattr(config, "rope_parameters", None)
-        if rope_scaling is None:
-            rope_scaling = getattr(config, "rope_scaling", None)
-
-        if isinstance(rope_scaling, dict):
-            rope_theta = rope_scaling.get(
-                "rope_theta", getattr(config, "rope_theta", None)
-            )
-        else:
-            rope_scaling = None
-            rope_theta = getattr(config, "rope_theta", None)
-
-        if rope_theta is None:
-            raise ValueError(
-                "Missing rope_theta in Qwen3 config. Expected either "
-                "config.rope_parameters['rope_theta'] or config.rope_theta."
-            )
+        rope_theta, rope_scaling = get_rope_config(config)
         self.rope_theta = rope_theta
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
         head_dim = getattr(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
To fix #20932
SGLang fails to load some Qwen3 MoE checkpoints whose HF config uses top-level `rope_theta` (v4-style) but does not define
`rope_parameters` (v5-style).

## Modifications

This PR updated qwen3moe.py to make RoPE config parsing compatible across checkpoint formats: it now checks whether RoPE is provided as config.rope_parameters (new style) or as top-level config.rope_theta/config.rope_scaling (old style), and uses the available field accordingly. This prevents load failures caused by different RoPE parameter naming in Qwen3 configs.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
