### PR TITLE
fix: /health_generate always routes to RouterManager in single-router mode

### DIFF
--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1220,6 +1220,10 @@ impl RouterTrait for PDRouter {
         }
     }
 
+    fn use_router_health_generate(&self) -> bool {
+        true
+    }
+
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
         // Get info from the first decode server to match sglang's server info format
         // Note: We use decode workers for server info to match expected format

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -723,6 +723,10 @@ impl RouterTrait for Router {
         self.proxy_get_request(req, "health_generate").await
     }
 
+    fn use_router_health_generate(&self) -> bool {
+        true
+    }
+
     async fn get_server_info(&self, req: Request<Body>) -> Response {
         self.proxy_get_request(req, "get_server_info").await
     }

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -56,6 +56,10 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
+    fn use_router_health_generate(&self) -> bool {
+        false
+    }
+
     /// Get server information
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
         (StatusCode::NOT_IMPLEMENTED, "Server info not implemented").into_response()

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -398,6 +398,10 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         }
     }
 
+    fn use_router_health_generate(&self) -> bool {
+        true
+    }
+
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
         let stats = self.worker_registry.stats();
         let external_workers = self.external_workers();

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -407,7 +407,7 @@ impl RouterTrait for RouterManager {
     async fn health_generate(&self, req: Request<Body>) -> Response {
         if !self.enable_igw {
             let router = {
-                let deafult_router = self
+                let default_router = self
                     .default_router
                     .read()
                     .unwrap_or_else(|e| e.into_inner());

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -404,7 +404,24 @@ impl RouterTrait for RouterManager {
         self
     }
 
-    async fn health_generate(&self, _req: Request<Body>) -> Response {
+    async fn health_generate(&self, req: Request<Body>) -> Response {
+        if !self.enable_igw {
+            let router = {
+                let default_id = self
+                    .default_router
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone();
+
+                default_id.and_then(|id| self.routers.get(&id).map(|r| r.clone()))
+            };
+
+            if let Some(router) = router {
+                if router.use_router_health_generate() {
+                    return router.health_generate(req).await;
+                }
+            }
+        }
         // IGW readiness: return 200 if at least one router has healthy workers
         let has_healthy_workers = self
             .worker_registry

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -407,13 +407,14 @@ impl RouterTrait for RouterManager {
     async fn health_generate(&self, req: Request<Body>) -> Response {
         if !self.enable_igw {
             let router = {
-                let default_id = self
+                let deafult_router = self
                     .default_router
                     .read()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .clone();
+                    .unwrap_or_else(|e| e.into_inner());
 
-                default_id.and_then(|id| self.routers.get(&id).map(|r| r.clone()))
+                default_router
+                    .as_ref()
+                    .and_then(|id| self.routers.get(&id).map(|r| r.clone()))
             };
 
             if let Some(router) = router {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In HTTP PD deployments, I observed that the gateway `/health_generate` endpoint returned directly from `RouterManager::health_generate()` and did not reach `PDRouter::health_generate()`.

Because of this, the endpoint did not reflect the stricter PD router health check semantics that were already implemented in `PDRouter`.

## Modifications

<!-- Detail the changes made in this pull request. -->
- add `use_router_health_generate()` so routers can indicate whether they want to handle `health_generate()` themselves
``` rust
fn use_router_health_generate(&self) -> bool {
        true
}
```
- update `RouterManager::health_generate()` to route to the default router's `health_generate()` in single-router mode when `use_router_health_generate()` returns `true`
```rust
    async fn health_generate(&self, req: Request<Body>) -> Response {
        if !self.enable_igw {
            let router = {
                let default_router = self
                    .default_router
                    .read()
                    .unwrap_or_else(|e| e.into_inner());

                default_router
                    .as_ref()
                    .and_then(|id| self.routers.get(&id).map(|r| r.clone()))
            };

            if let Some(router) = router {
                if router.use_router_health_generate() {
                    return router.health_generate(req).await;
                }
            }
        }
```
- fall back to the current behavior otherwise

## Testing
Local verification: `cargo build --features vendored-openssl` and `cargo test --features vendored-openssl` both passed.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.