### PR TITLE
Fix Qwen3.5 pipeline-parallel layer construction OOM

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -80,7 +80,7 @@ from sglang.srt.utils import (
     make_layers,
     set_weight_attrs,
 )
-from sglang.srt.utils.hf_transformers_utils import get_processor
+from sglang.srt.utils.hf_transformers_utils import get_processor, get_rope_config
 
 logger = logging.getLogger(__name__)
 _is_cuda = is_cuda()
@@ -449,14 +449,13 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
 
-        if hasattr(config, "rope_parameters"):
-            self.rope_scaling = getattr(config, "rope_parameters", None)
-        else:
-            self.rope_scaling = getattr(config, "rope_scaling", None)
-
-        self.rope_theta = self.rope_scaling.get("rope_theta", 10000)
-        self.partial_rotary_factor = self.rope_scaling.get("partial_rotary_factor", 1.0)
+        self.rope_theta, rope_scaling = get_rope_config(config)
+        self.partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
         self.layer_id = layer_id
+
+        # If rope_scaling doesn't specify a scaling type, treat as no scaling
+        if rope_scaling and not ("rope_type" in rope_scaling or "type" in rope_scaling):
+            rope_scaling = None
 
         self.attn_output_gate = getattr(config, "attn_output_gate", True)
         if self.attn_output_gate:
@@ -466,7 +465,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             head_size=self.head_dim,
             rotary_dim=self.head_dim,
             max_position=self.max_position_embeddings,
-            rope_scaling=self.rope_scaling,
+            rope_scaling=rope_scaling,
             base=self.rope_theta,
             partial_rotary_factor=self.partial_rotary_factor,
             is_neox_style=True,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -724,23 +724,12 @@ class Qwen3_5ForCausalLM(nn.Module):
 
         pp_rank = self.pp_group.rank_in_group
         pp_size = self.pp_group.world_size
-        self.layers = make_layers(
+        self.layers, self._start_layer, self._end_layer = make_layers(
             config.num_hidden_layers,
             get_layer,
             pp_rank=pp_rank,
             pp_size=pp_size,
             prefix=f"{prefix}.layers",
-        )
-
-        num_layers = config.num_hidden_layers
-        self._start_layer, self._end_layer = (
-            get_pp_indices(
-                num_layers,
-                pp_rank,
-                pp_size,
-            )
-            if pp_rank is not None and pp_size is not None
-            else (0, num_layers)
         )
 
         # Final normalization

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -80,7 +80,7 @@ from sglang.srt.utils import (
     make_layers,
     set_weight_attrs,
 )
-from sglang.srt.utils.hf_transformers_utils import get_processor, get_rope_config
+from sglang.srt.utils.hf_transformers_utils import get_processor
 
 logger = logging.getLogger(__name__)
 _is_cuda = is_cuda()
@@ -449,13 +449,14 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
 
-        self.rope_theta, rope_scaling = get_rope_config(config)
-        self.partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
-        self.layer_id = layer_id
+        if hasattr(config, "rope_parameters"):
+            self.rope_scaling = getattr(config, "rope_parameters", None)
+        else:
+            self.rope_scaling = getattr(config, "rope_scaling", None)
 
-        # If rope_scaling doesn't specify a scaling type, treat as no scaling
-        if rope_scaling and not ("rope_type" in rope_scaling or "type" in rope_scaling):
-            rope_scaling = None
+        self.rope_theta = self.rope_scaling.get("rope_theta", 10000)
+        self.partial_rotary_factor = self.rope_scaling.get("partial_rotary_factor", 1.0)
+        self.layer_id = layer_id
 
         self.attn_output_gate = getattr(config, "attn_output_gate", True)
         if self.attn_output_gate:
@@ -465,7 +466,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             head_size=self.head_dim,
             rotary_dim=self.head_dim,
             max_position=self.max_position_embeddings,
-            rope_scaling=rope_scaling,
+            rope_scaling=self.rope_scaling,
             base=self.rope_theta,
             partial_rotary_factor=self.partial_rotary_factor,
             is_neox_style=True,
@@ -721,14 +722,16 @@ class Qwen3_5ForCausalLM(nn.Module):
                 is_nextn=is_nextn,
             )
 
+        pp_rank = self.pp_group.rank_in_group
+        pp_size = self.pp_group.world_size
         self.layers = make_layers(
             config.num_hidden_layers,
             get_layer,
+            pp_rank=pp_rank,
+            pp_size=pp_size,
             prefix=f"{prefix}.layers",
         )
 
-        pp_rank = self.pp_group.rank_in_group
-        pp_size = self.pp_group.world_size
         num_layers = config.num_hidden_layers
         self._start_layer, self._end_layer = (
             get_pp_indices(

--- a/test/registered/unit/models/test_qwen35_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen35_pipeline_parallel.py
@@ -5,24 +5,39 @@ from pathlib import Path
 
 class Qwen35PipelineParallelTest(unittest.TestCase):
     def test_make_layers_uses_pp_partitioning(self):
-        source_path = Path(
-            "D:/vbox/repos/sglang-git2/python/sglang/srt/models/qwen3_5.py"
+        source_path = (
+            Path(__file__).resolve().parents[4]
+            / "python"
+            / "sglang"
+            / "srt"
+            / "models"
+            / "qwen3_5.py"
         )
         tree = ast.parse(source_path.read_text(encoding="utf-8"))
 
-        make_layers_call = None
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            if not isinstance(node.func, ast.Name) or node.func.id != "make_layers":
-                continue
-            make_layers_call = node
-            break
+        make_layers_call = self._find_make_layers_call(tree)
 
         self.assertIsNotNone(make_layers_call, "Expected a make_layers() call")
         keywords = {keyword.arg for keyword in make_layers_call.keywords}
         self.assertIn("pp_rank", keywords)
         self.assertIn("pp_size", keywords)
+
+    def _find_make_layers_call(self, tree: ast.AST) -> ast.Call | None:
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef) or node.name != "Qwen3_5ForCausalLM":
+                continue
+            for item in node.body:
+                if not isinstance(item, ast.FunctionDef) or item.name != "__init__":
+                    continue
+                for init_node in ast.walk(item):
+                    if not isinstance(init_node, ast.Call):
+                        continue
+                    if (
+                        isinstance(init_node.func, ast.Name)
+                        and init_node.func.id == "make_layers"
+                    ):
+                        return init_node
+        return None
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_qwen35_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen35_pipeline_parallel.py
@@ -1,0 +1,29 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+class Qwen35PipelineParallelTest(unittest.TestCase):
+    def test_make_layers_uses_pp_partitioning(self):
+        source_path = Path(
+            "D:/vbox/repos/sglang-git2/python/sglang/srt/models/qwen3_5.py"
+        )
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+        make_layers_call = None
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Name) or node.func.id != "make_layers":
+                continue
+            make_layers_call = node
+            break
+
+        self.assertIsNotNone(make_layers_call, "Expected a make_layers() call")
+        keywords = {keyword.arg for keyword in make_layers_call.keywords}
+        self.assertIn("pp_rank", keywords)
+        self.assertIn("pp_size", keywords)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- pass `pp_rank` and `pp_size` into `make_layers()` for `Qwen3_5ForCausalLM`
- ensure each pipeline rank only instantiates its assigned decoder layers
- add a regression test that guards the PP-partitioned `make_layers()` call

## Root Cause
`Qwen3_5ForCausalLM` computed `start_layer/end_layer` for pipeline parallelism, but it still called `make_layers()` without `pp_rank` and `pp_size`. As a result, every PP rank instantiated all decoder layers. For Qwen3.5 MoE models, that meant each rank eagerly allocated all sparse MoE blocks and could OOM during model construction even when the same model fit with tensor parallelism.

## Testing
- `python -m py_compile python/sglang/srt/models/qwen3_5.py test/registered/unit/models/test_qwen35_pipeline_parallel.py`
- `python test/registered/unit/models/test_qwen35_pipeline_parallel.py`

Fixes #20934