### PR TITLE
[UX] Suppress noisy `httpx`/`httpcore` INFO logs

### DIFF
--- a/python/sglang/cli/serve.py
+++ b/python/sglang/cli/serve.py
@@ -6,6 +6,9 @@ import os
 
 from sglang.cli.utils import get_is_diffusion_model, get_model_path
 from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils.common import suppress_noisy_warnings
+
+suppress_noisy_warnings()
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1022,6 +1022,11 @@ def suppress_noisy_warnings():
         category=FutureWarning,
     )
 
+    # Suppress noisy third-party HTTP loggers.
+    # huggingface_hub uses httpx which logs every HTTP request at INFO level.
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
 
 def suppress_other_loggers():
     suppress_noisy_warnings()
@@ -1180,6 +1185,12 @@ def configure_logger(server_args, prefix: str = ""):
         datefmt="%Y-%m-%d %H:%M:%S",
         force=True,
     )
+
+    # Suppress noisy httpx/httpcore loggers in every process that calls
+    # configure_logger (main, scheduler, detokenizer). Spawned subprocesses
+    # don't inherit the parent's logger state, so this must run here too.
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 # source: https://github.com/vllm-project/vllm/blob/93b38bea5dd03e1b140ca997dfaadef86f8f1855/vllm/lora/utils.py#L9


### PR DESCRIPTION
## Summary

Transformers v5 depends on a newer `huggingface_hub` which switched from `requests` to `httpx` as its HTTP backend. `httpx` logs every HTTP request at INFO level, flooding server output since SGLang sets the root logger to INFO.

Suppress `httpx` and `httpcore` loggers to WARNING at all server entry points and spawned subprocesses.

Before:
```
[2026-03-19 17:03:53] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/Qwen/Qwen3.5-27B-FP8/resolve/main/model_index.json "HTTP/1.1 404 Not Found"
[2026-03-19 17:03:54] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/Qwen/Qwen3.5-27B-FP8/resolve/main/config.json "HTTP/1.1 307 Temporary Redirect"
[2026-03-19 17:03:54] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/Qwen/Qwen3.5-27B-FP8/... "HTTP/1.1 200 OK"
... (repeated 50+ times during startup)
```

After: all `httpx` HTTP Request lines are removed from startup output.