### PR TITLE
[sgl-model-gateway] Respect configured health endpoint during initial worker detection

### DIFF
--- a/sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs
@@ -144,3 +144,85 @@ impl StepExecutor<LocalWorkerWorkflowData> for DetectConnectionModeStep {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc, time::Duration};
+
+    use axum::{routing::get, Router};
+    use tokio::{net::TcpListener, sync::oneshot, time::sleep};
+    use wfaas::{StepExecutor, WorkflowContext, WorkflowInstanceId};
+
+    use super::DetectConnectionModeStep;
+    use crate::{
+        app_context::AppContext,
+        config::{HealthCheckConfig, RouterConfig},
+        core::{
+            steps::{create_local_worker_workflow_data, workflow_data::WorkerConfigRequest},
+            ConnectionMode,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_detect_connection_uses_configured_health_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new().route("/custom-health", get(|| async { "ok" }));
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        sleep(Duration::from_millis(50)).await;
+
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .random_policy()
+            .health_check_config(HealthCheckConfig {
+                endpoint: "/custom-health".to_string(),
+                ..Default::default()
+            })
+            .build_unchecked();
+        let app_context = Arc::new(AppContext::from_config(config, 30).await.unwrap());
+
+        let worker_config = WorkerConfigRequest {
+            url: format!("http://{}", addr),
+            api_key: None,
+            worker_type: Some("regular".to_string()),
+            labels: HashMap::new(),
+            model_id: None,
+            priority: None,
+            cost: None,
+            runtime: None,
+            tokenizer_path: None,
+            reasoning_parser: None,
+            tool_parser: None,
+            chat_template: None,
+            bootstrap_port: None,
+            health_check_timeout_secs: 1,
+            health_check_interval_secs: 1,
+            health_success_threshold: 1,
+            health_failure_threshold: 1,
+            disable_health_check: false,
+            max_connection_attempts: 1,
+            dp_aware: false,
+        };
+
+        let workflow_data = create_local_worker_workflow_data(worker_config, app_context);
+        let mut context = WorkflowContext::new(WorkflowInstanceId::new(), workflow_data);
+
+        let result = DetectConnectionModeStep.execute(&mut context).await;
+
+        let _ = shutdown_tx.send(());
+        let _ = server.await;
+
+        assert!(result.is_ok());
+        assert_eq!(context.data.connection_mode, Some(ConnectionMode::Http));
+    }
+}

--- a/sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use tracing::debug;
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
@@ -20,13 +20,17 @@ async fn try_http_health_check(
     endpoint: &str,
     client: &Client,
 ) -> Result<(), String> {
-    let is_https = url.starts_with("https://");
-    let protocol = if is_https { "https" } else { "http" };
-    let clean_url = strip_protocol(url);
-    let health_url = format!("{}://{}{}", protocol, clean_url, endpoint);
+    let base_url = if url.starts_with("http://") || url.starts_with("https://") {
+        url.to_string()
+    } else {
+        format!("http://{}", strip_protocol(url))
+    };
+    let health_url = Url::parse(&base_url)
+        .and_then(|base| base.join(endpoint))
+        .map_err(|e| format!("Invalid health check URL: {}", e))?;
 
     client
-        .get(&health_url)
+        .get(health_url)
         .timeout(Duration::from_secs(timeout_secs))
         .send()
         .await
@@ -108,11 +112,11 @@ impl StepExecutor<LocalWorkerWorkflowData> for DetectConnectionModeStep {
         let url = config.url.clone();
         let timeout = config.health_check_timeout_secs;
         let client = &app_context.client;
-        let endpoint = app_context.router_config.health_check.endpoint.clone();
+        let endpoint = &app_context.router_config.health_check.endpoint;
         let runtime_type = config.runtime.as_deref();
 
         let (http_result, grpc_result) = tokio::join!(
-            try_http_health_check(&url, timeout, &endpoint, client),
+            try_http_health_check(&url, timeout, endpoint, client),
             try_grpc_health_check(&url, timeout, runtime_type)
         );
 
@@ -150,7 +154,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use axum::{routing::get, Router};
-    use tokio::{net::TcpListener, sync::oneshot, time::sleep};
+    use tokio::{net::TcpListener, sync::oneshot};
     use wfaas::{StepExecutor, WorkflowContext, WorkflowInstanceId};
 
     use super::DetectConnectionModeStep;
@@ -179,7 +183,19 @@ mod tests {
                 .unwrap();
         });
 
-        sleep(Duration::from_millis(50)).await;
+        let client = reqwest::Client::new();
+        let health_url = format!("http://{}/custom-health", addr);
+        for _ in 0..10 {
+            if let Ok(response) = client.get(&health_url).send().await {
+                if response.status().is_success() {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let response = client.get(&health_url).send().await.unwrap();
+        assert!(response.status().is_success(), "server did not start in time");
 
         let config = RouterConfig::builder()
             .regular_mode(vec![])

--- a/sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs
@@ -17,12 +17,13 @@ use crate::{
 async fn try_http_health_check(
     url: &str,
     timeout_secs: u64,
+    endpoint: &str,
     client: &Client,
 ) -> Result<(), String> {
     let is_https = url.starts_with("https://");
     let protocol = if is_https { "https" } else { "http" };
     let clean_url = strip_protocol(url);
-    let health_url = format!("{}://{}/health", protocol, clean_url);
+    let health_url = format!("{}://{}{}", protocol, clean_url, endpoint);
 
     client
         .get(&health_url)
@@ -107,10 +108,11 @@ impl StepExecutor<LocalWorkerWorkflowData> for DetectConnectionModeStep {
         let url = config.url.clone();
         let timeout = config.health_check_timeout_secs;
         let client = &app_context.client;
+        let endpoint = app_context.router_config.health_check.endpoint.clone();
         let runtime_type = config.runtime.as_deref();
 
         let (http_result, grpc_result) = tokio::join!(
-            try_http_health_check(&url, timeout, client),
+            try_http_health_check(&url, timeout, &endpoint, client),
             try_grpc_health_check(&url, timeout, runtime_type)
         );
 


### PR DESCRIPTION
## Motivation

sgl-model-gateway exposes a configurable --health-check-endpoint, but initial worker detection still hardcoded /health during connection probing. This caused worker registration to fail in deployments where workers expose health on a different path, even though the configured endpoint was honored later by ongoing health checks.

This change makes initial worker detection respect the configured health endpoint so startup behavior matches the documented/runtime health-check configuration.

## Modifications

1. Updated initial HTTP worker detection in sgl-model-gateway/src/core/steps/worker/local/detect_connection.rs to use app_context.router_config.health_check.endpoint instead of hardcoded /health.
2. Added a regression test covering the case where only a custom health endpoint returns 200, and verified that worker detection succeeds.

## Accuracy Tests

Not applicable. This change does not affect model execution or outputs.

## Benchmarking and Profiling

Not applicable. This change does not affect inference kernels or request execution hot paths.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Validations
Tested the change end-to-end by building and running the Rust binary, and verified that a worker exposing a non-/health endpoint can be successfully registered during router startup when health_check_endpoint is configured.

Passed unit test:
cargo test test_detect_connection_uses_configured_health_endpoint -- --nocapture