### PR TITLE
[Fix] Patch is_flash_attn_2_available for flash-attn-4 in VLM input format test

### DIFF
--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -28,6 +28,24 @@ from huggingface_hub import snapshot_download
 
 from sglang.srt.utils import get_bool_env_var
 
+# Compatibility shim: flash-attn-4 registers a bare ``flash_attn`` namespace
+# that makes ``is_flash_attn_2_available()`` return True, but lacks the v2 API
+# (``flash_attn_func``, etc.).  HuggingFace remote model code (e.g. Kimi-VL)
+# guarded by that check will crash with ImportError at module load time.
+# Force it to False when the real v2 API is absent.
+try:
+    import flash_attn as _flash_attn_mod
+
+    if not hasattr(_flash_attn_mod, "flash_attn_func"):
+        import transformers.utils as _hf_utils
+        import transformers.utils.import_utils as _hf_import_utils
+
+        _hf_import_utils.is_flash_attn_2_available = lambda: False
+        _hf_utils.is_flash_attn_2_available = lambda: False
+    del _flash_attn_mod
+except ImportError:
+    pass
+
 # Conditional import based on SGLANG_USE_MODELSCOPE environment variable
 if get_bool_env_var("SGLANG_USE_MODELSCOPE"):
     from modelscope import AutoConfig, GenerationConfig

--- a/test/registered/vlm/test_vlm_input_format.py
+++ b/test/registered/vlm/test_vlm_input_format.py
@@ -6,6 +6,16 @@ from typing import Optional
 import requests
 import torch
 
+# Compatibility shim: flash-attn-4 registers a bare ``flash_attn`` namespace
+# that makes ``is_flash_attn_2_available()`` return True, but lacks the v2 API
+# (``flash_attn_func``, etc.).  Force it to False so HF remote model code
+# (e.g. Kimi-VL) skips the flash-attn v2 import path.
+import transformers.utils as _hf_utils
+import transformers.utils.import_utils as _hf_import_utils
+
+_hf_import_utils.is_flash_attn_2_available = lambda: False
+_hf_utils.is_flash_attn_2_available = lambda: False
+
 # Compatibility shim: Kimi-VL dynamic module expects PytorchGELUTanh which may
 # be missing in transformers==4.57.1. Inject a lightweight implementation so
 # the model can import successfully without downgrading transformers.

--- a/test/registered/vlm/test_vlm_input_format.py
+++ b/test/registered/vlm/test_vlm_input_format.py
@@ -6,16 +6,6 @@ from typing import Optional
 import requests
 import torch
 
-# Compatibility shim: flash-attn-4 registers a bare ``flash_attn`` namespace
-# that makes ``is_flash_attn_2_available()`` return True, but lacks the v2 API
-# (``flash_attn_func``, etc.).  Force it to False so HF remote model code
-# (e.g. Kimi-VL) skips the flash-attn v2 import path.
-import transformers.utils as _hf_utils
-import transformers.utils.import_utils as _hf_import_utils
-
-_hf_import_utils.is_flash_attn_2_available = lambda: False
-_hf_utils.is_flash_attn_2_available = lambda: False
-
 # Compatibility shim: Kimi-VL dynamic module expects PytorchGELUTanh which may
 # be missing in transformers==4.57.1. Inject a lightweight implementation so
 # the model can import successfully without downgrading transformers.


### PR DESCRIPTION
## Motivation

sglang now depends on `flash-attn-4` (>= 4.0.0b4) introduced in https://github.com/sgl-project/sglang/pull/20303 . Unlike `flash-attn` v2, `flash-attn-4` registers a bare `flash_attn` **namespace package** with no actual content — no `flash_attn_func`, no `flash_attn_varlen_func`, and no `flash_attn.bert_padding` submodule.

This causes `transformers.utils.is_flash_attn_2_available()` to return `True` (it can `find_spec("flash_attn")`), so HuggingFace remote model code that guards flash-attn v2 imports behind that check still attempts the import and crashes:

```
ImportError: cannot import name 'flash_attn_func' from 'flash_attn' (unknown location)
```

This breaks `TestKimiVLImageUnderstandsImage` in `test_vlm_input_format.py`, because the Kimi-VL remote `modeling_kimi_vl.py` does:

```python
if is_flash_attn_2_available():
    from flash_attn import flash_attn_func, flash_attn_varlen_func
    from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input
```

at module level during `get_class_from_dynamic_module()`.

## Fix

Patch `is_flash_attn_2_available` to return `False` at both `transformers.utils.import_utils` and `transformers.utils` (since different code paths import from either location) before any HF dynamic module loading happens. The test only exercises the vision tower and does not need flash attention.

## Test plan
- [x] Verify `TestKimiVLImageUnderstandsImage` passes on CI with `flash-attn-4` installed