### PR TITLE
fix: warm up cuBLAS and cuBLASLt for BF16/FP32 to fix local-path loading

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1831,13 +1831,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         log_info_on_rank0(logger, f"Using KV cache dtype: {self.kv_cache_dtype}")
 
     def init_cublas(self):
-        """We need to run a small matmul to init cublas. Otherwise, it will raise some errors later."""
-        dtype = torch.float16
-        device = "cuda"
-        a = torch.ones((16, 16), dtype=dtype, device=device)
-        b = torch.ones((16, 16), dtype=dtype, device=device)
-        c = a @ b
-        return c
+        """Warm up cuBLAS/cuBLASLt to avoid lazy-init errors during CUDA graph capture.
+
+        On Blackwell (SM120) + cuBLAS < 13.2, FP32 cublasSgemm is broken for
+        matrices > 16x16, so we only warm up FP16/BF16.  Both the legacy cublas
+        (matmul operator) and the cuBLASLt (F.linear) paths are exercised.
+        """
+        device = self.device if hasattr(self, 'device') and self.device else 'cuda'
+        for dtype in [torch.float16, torch.bfloat16]:
+            for size in [(16, 16), (128, 256)]:
+                a = torch.ones(size, dtype=dtype, device=device)
+                b = torch.ones((size[1], size[0]), dtype=dtype, device=device)
+                c = a @ b
+                torch.nn.functional.linear(
+                    a, torch.ones((size[0], size[1]), dtype=dtype, device=device)
+                )
+                del a, b, c
 
     def init_attention_backend(self):
         """Init attention kernel backend."""


### PR DESCRIPTION
## Fix: warm up cuBLAS/cuBLASLt handles for FP16/BF16

### Problem

`init_cublas()` only runs a single FP16 16x16 `torch.matmul`, which leaves the BF16 and cuBLASLt code-paths un-initialised.  When those paths are first hit inside a CUDA-graph capture region (or during the automatic VLM server warmup), the lazy cuBLAS init fails with `CUBLAS_STATUS_NOT_INITIALIZED`.

The bug is masked when loading a model from a HuggingFace repo ID because the Hub client triggers enough CUDA work to warm cuBLAS as a side effect.  Loading from a **local path** skips the Hub client and hits the uninitialised handle on the first BF16 op.

### Changes

- Exercise both `@` (cuBLAS `cublasGemmEx`) **and** `F.linear` (cuBLASLt `cublasLtMatmulAlgoGetHeuristic`) paths
- Warm up **FP16 and BF16** at two representative matrix sizes `(16,16)` and `(128,256)`
- Use `self.device` instead of hard-coded `"cuda"` so each TP worker warms cuBLAS on its own GPU
- Clean up temporary tensors with `del`

### Why FP32 is excluded

On **Blackwell (SM120) + cuBLAS 13.1.0.3** (shipped with CUDA 13.0 / PyTorch nightly), `cublasSgemm` returns `CUBLAS_STATUS_NOT_INITIALIZED` for any matrix larger than 16x16.  This is a cuBLAS regression — not an SGLang bug — and it also causes a separate `cublasLtMatmulAlgoGetHeuristic` crash during NCCL multi-GPU init.

**Workaround**: upgrading the `nvidia-cublas` pip package to **>= 13.2** resolves both the FP32 cublasSgemm and the multi-GPU cublasLt/NCCL crash.  Until 13.2 is the default, this PR intentionally omits FP32 warmup to keep SGLang working on stock CUDA 13.0 builds.

### Testing

Tested on 8× RTX 6000 Pro Blackwell (SM120) with CUDA 13.0 + PyTorch 2.10.0+cu130:

- Verified `cublasSgemm` FP32 is broken for matrices > 16×16 with cuBLAS 13.1.0.3 (system CUDA 13.0)
- Verified FP16+BF16 warmup at (16,16) and (128,256) succeeds and prevents `CUBLAS_STATUS_NOT_INITIALIZED` during CUDA graph capture
- Verified upgrading `nvidia-cublas` pip package to 13.3.0.5 (via `LD_LIBRARY_PATH`) fixes both FP32 `cublasSgemm` and `cublasLtMatmulAlgoGetHeuristic` NCCL multi-GPU crash
- Confirmed cuBLAS 13.2.1.1 (CUDA 13.2 / cu132) has no issues — both FP32 and cublasLt work without warmup