### PR TITLE
feat: add language_only support and EAGLE compat to PixtralForConditionalGeneration

### DIFF
--- a/python/sglang/srt/models/pixtral.py
+++ b/python/sglang/srt/models/pixtral.py
@@ -82,44 +82,66 @@ class PixtralForConditionalGeneration(nn.Module):
     def __init__(self, *, config, prefix: str = "", **kwargs):
         super().__init__()
         self.config = config
-        dataclass_fields = {field.name for field in fields(VisionEncoderArgs)}
-        config_dict = self.config.vision_config.to_dict()
-        if config_dict.get("rope_parameters"):  # transformers v5 compatibility
-            config_dict["rope_theta"] = config_dict["rope_parameters"].get("rope_theta")
-            config_dict["rope_scaling"] = config_dict["rope_parameters"]
-            config_dict.pop("rope_parameters")
-        vision_args = {
-            key: value for key, value in config_dict.items() if key in dataclass_fields
-        }
-
-        self.vision_args = VisionEncoderArgs(**vision_args)
+        self.language_only = getattr(config, "language_only", False)
 
         self.language_model = MistralLarge3ForCausalLM(
             config=self.config.text_config,
             quant_config=kwargs.get("quant_config"),
         )
 
-        self.vision_encoder = VisionTransformer(self.vision_args)
+        if not self.language_only:
+            dataclass_fields = {field.name for field in fields(VisionEncoderArgs)}
+            config_dict = self.config.vision_config.to_dict()
+            if config_dict.get("rope_parameters"):  # transformers v5 compatibility
+                config_dict["rope_theta"] = config_dict["rope_parameters"].get(
+                    "rope_theta"
+                )
+                config_dict["rope_scaling"] = config_dict["rope_parameters"]
+                config_dict.pop("rope_parameters")
+            vision_args = {
+                key: value
+                for key, value in config_dict.items()
+                if key in dataclass_fields
+            }
 
-        if self.vision_args.add_pre_mm_projector_layer_norm:
-            self.pre_mm_projector_norm = RMSNorm(self.vision_args.hidden_size, eps=1e-5)
+            self.vision_args = VisionEncoderArgs(**vision_args)
 
-        if self.vision_args.mm_projector_id == PATCH_MERGE:
-            self.patch_merger = PatchMerger(
-                vision_encoder_dim=self.vision_args.hidden_size,
-                spatial_merge_size=self.vision_args.spatial_merge_size,
-                use_mlp_bias=False,
+            self.vision_encoder = VisionTransformer(self.vision_args)
+
+            if self.vision_args.add_pre_mm_projector_layer_norm:
+                self.pre_mm_projector_norm = RMSNorm(
+                    self.vision_args.hidden_size, eps=1e-5
+                )
+
+            if self.vision_args.mm_projector_id == PATCH_MERGE:
+                self.patch_merger = PatchMerger(
+                    vision_encoder_dim=self.vision_args.hidden_size,
+                    spatial_merge_size=self.vision_args.spatial_merge_size,
+                    use_mlp_bias=False,
+                )
+
+            self.vision_language_adapter = VisionLanguageAdapter(
+                self.vision_args, dim=self.config.text_config.hidden_size
             )
-
-        self.vision_language_adapter = VisionLanguageAdapter(
-            self.vision_args, dim=self.config.text_config.hidden_size
-        )
 
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        if self.language_only:
+            _vision_prefixes = (
+                "vision_encoder",
+                "vision_language_adapter",
+                "patch_merger",
+                "pre_mm_projector_norm",
+            )
+            llm_weights = (
+                (n, w) for n, w in weights if not n.startswith(_vision_prefixes)
+            )
+            self.language_model.load_weights(llm_weights)
+            return
+
         def is_vision_encoder_weights(weight: tuple[str, torch.Tensor]):
             return weight[0].startswith("vision_encoder")
 
@@ -210,6 +232,8 @@ class PixtralForConditionalGeneration(nn.Module):
         return image_embeds
 
     def forward(self, input_ids, positions, forward_batch):
+        if self.language_only:
+            return self.language_model.forward(input_ids, positions, forward_batch)
         return general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,
@@ -226,6 +250,13 @@ class PixtralForConditionalGeneration(nn.Module):
 
     def get_embed_and_head(self):
         return self.language_model.get_embed_and_head()
+
+    @property
+    def lm_head(self):
+        return self.language_model.lm_head
+
+    def set_embed_and_head(self, embed, head):
+        self.language_model.set_embed_and_head(embed, head)
 
 
 class PatchMerger(nn.Module):


### PR DESCRIPTION
## Summary

- Add `language_only` support to `PixtralForConditionalGeneration` — when `config.language_only=True`, skip vision encoder/adapter/merger instantiation and weight loading to save memory for text-only serving (e.g. Mistral-Small-4-119B-NVFP4 with `--disable-multimodal`)
- Add `lm_head` property and `set_embed_and_head()` method to `PixtralForConditionalGeneration` for EAGLE speculative decoding compatibility — the EAGLE worker accesses `model.lm_head` and calls `model.set_embed_and_head()` directly on the top-level model

These changes enable text-only serving of Mistral-Small-4-119B (which uses the Pixtral architecture) without loading the ~1-2 GB vision encoder, and allow EAGLE speculative decoding to function correctly with the Pixtral wrapper.

### Changes

**`python/sglang/srt/models/pixtral.py`**:
- `__init__`: Check `config.language_only`; skip vision component init when True
- `load_weights`: Filter out vision weights when `language_only`; delegate directly to `language_model.load_weights()`
- `forward`: Bypass `general_mm_embed_routine` and call `language_model.forward()` directly when `language_only`
- Add `lm_head` property delegating to `language_model.lm_head`
- Add `set_embed_and_head()` delegating to `language_model.set_embed_and_head()`

### Context

Mistral-Small-4-119B-2603 uses the `PixtralForConditionalGeneration` architecture (MistralLarge3 + vision encoder). For text-only serving (which is common for the NVFP4 quantized variant), the vision encoder wastes memory. The `language_only` pattern is already used by `Qwen3VLMoeForConditionalGeneration`, `DotsVLMForCausalLM`, and others in the codebase.

## Test plan

- [ ] Verify text-only Pixtral serving works with `language_only=True`
- [ ] Verify multimodal Pixtral serving still works (language_only defaults to False)
- [ ] Verify EAGLE speculative decoding can access `model.lm_head` through the Pixtral wrapper