### PR TITLE
[Tiny Fix] Fix IS_BLACKWELL env var empty string warning in rerun-ut workflow

### DIFF
--- a/.github/workflows/rerun-ut.yml
+++ b/.github/workflows/rerun-ut.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 120
     env:
       RUNNER_LABELS: ${{ inputs.runner_label }}
-      IS_BLACKWELL: ${{ (inputs.runner_label == '1-gpu-5090' || contains(inputs.runner_label, 'b200')) && '1' || '' }}
+      IS_BLACKWELL: ${{ (inputs.runner_label == '1-gpu-5090' || contains(inputs.runner_label, 'b200')) && '1' || '0' }}
       SGLANG_CI_RDMA_ALL_DEVICES: ${{ inputs.runner_label == '8-gpu-h20' && 'mlx5_1,mlx5_2,mlx5_3,mlx5_4' || '' }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Fix `IS_BLACKWELL` env var in `rerun-ut.yml` producing empty string `""` when runner is not Blackwell, which triggers an `EnvBool` parse warning
- Changed fallback from `''` to `'0'` so it's a valid boolean value

## Test plan
- [ ] Verify `rerun-ut` workflow no longer emits `UserWarning: Invalid value for IS_BLACKWELL` on non-Blackwell runners