### PR TITLE
fix: use warning_once for speculative sampling kernel unavailable on AMD/HIP

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -304,7 +304,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         # Sample tokens. Force greedy sampling on AMD
         is_all_greedy = sampling_info.is_all_greedy
         if (not is_all_greedy) and (not TREE_SPEC_KERNEL_AVAILABLE):
-            logger.warning(
+            logger.warning_once(
                 "Tree speculative sampling kernel unavailable (likely AMD/HIP build). "
                 "Falling back to greedy verification."
             )

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -422,7 +422,7 @@ class NgramVerifyInput(SpecInput):
             sampling_info.is_all_greedy or envs.SGLANG_NGRAM_FORCE_GREEDY_VERIFY.get()
         )
         if (not is_all_greedy) and (not TREE_SPEC_KERNEL_AVAILABLE):
-            logger.warning(
+            logger.warning_once(
                 "Tree speculative sampling kernel unavailable (likely AMD/HIP build). "
                 "Falling back to greedy verification."
             )


### PR DESCRIPTION
## Motivation

When running speculative decoding on AMD GPUs, the tree speculative sampling kernel is unavailable (it's CUDA-only). This triggers a warning on every scheduler step:

```
Tree speculative sampling kernel unavailable (likely AMD/HIP build). Falling back to greedy verification.
```

This results in massive log spam that:
1. Floods logs making them unusable for debugging
2. Adds unnecessary I/O overhead
3. Is particularly wasteful when `top_k=1`, since greedy and tree-based sampling produce identical results

## Modifications

Changed `logger.warning()` to `logger.warning_once()` in two files:
- `python/sglang/srt/speculative/eagle_info.py`
- `python/sglang/srt/speculative/ngram_info.py`

This ensures the warning is logged only once per process, which is sufficient to inform users about the fallback behavior.

## Accuracy Tests

N/A - This is a logging-only change with no impact on model outputs.

## Benchmarking and Profiling

N/A - This is a logging-only change. The change may slightly improve performance by reducing I/O overhead from log spam.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - *Skipped: This is a trivial one-line logging change with no logic to test.*
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - *Skipped: No documentation changes needed.*
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - *Skipped: Logging-only change.*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).