### PR TITLE
Replace _resolve_future_token_ids with JIT kernel + platform dispatch

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py
@@ -10,6 +10,7 @@ from sglang.jit_kernel.benchmark.utils import (
     run_benchmark,
 )
 from sglang.jit_kernel.resolve_future_token_ids import resolve_future_token_ids_cuda
+from sglang.srt.utils import get_compiler_backend
 
 SIZE_LIST = get_benchmark_range(
     full_range=[2**n for n in range(4, 16)],  # 16 … 32K elements
@@ -27,14 +28,19 @@ def _torch_resolve(input_ids, future_map):
     )
 
 
+_compiled_resolve = torch.compile(
+    _torch_resolve, dynamic=True, backend=get_compiler_backend()
+)
+
+
 @triton.testing.perf_report(
     triton.testing.Benchmark(
         x_names=["size"],
         x_vals=configs,
         line_arg="provider",
-        line_vals=["jit", "torch"],
-        line_names=["SGL JIT Kernel", "PyTorch"],
-        styles=[("blue", "-"), ("red", "--")],
+        line_vals=["jit", "torch_compile", "torch"],
+        line_names=["SGL JIT Kernel", "torch.compile", "PyTorch"],
+        styles=[("blue", "-"), ("green", "-."), ("red", "--")],
         ylabel="us",
         plot_name="resolve-future-token-ids-performance",
         args={},
@@ -51,6 +57,8 @@ def benchmark(size: int, provider: str):
 
     if provider == "jit":
         fn = lambda: resolve_future_token_ids_cuda(input_ids.clone(), future_map)
+    elif provider == "torch_compile":
+        fn = lambda: _compiled_resolve(input_ids.clone(), future_map)
     else:
         fn = lambda: _torch_resolve(input_ids.clone(), future_map)
 

--- a/python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py
@@ -1,0 +1,61 @@
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.jit_kernel.benchmark.utils import (
+    DEFAULT_DEVICE,
+    get_benchmark_range,
+    run_benchmark,
+)
+from sglang.jit_kernel.resolve_future_token_ids import resolve_future_token_ids_cuda
+
+SIZE_LIST = get_benchmark_range(
+    full_range=[2**n for n in range(4, 16)],  # 16 … 32K elements
+    ci_range=[256, 4096],
+)
+
+configs = list(itertools.product(SIZE_LIST))
+
+
+def _torch_resolve(input_ids, future_map):
+    input_ids[:] = torch.where(
+        input_ids < 0,
+        future_map[torch.clamp(-input_ids, min=0)],
+        input_ids,
+    )
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["size"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["jit", "torch"],
+        line_names=["SGL JIT Kernel", "PyTorch"],
+        styles=[("blue", "-"), ("red", "--")],
+        ylabel="us",
+        plot_name="resolve-future-token-ids-performance",
+        args={},
+    )
+)
+def benchmark(size: int, provider: str):
+    map_size = 8192
+    future_map = torch.randint(
+        0, 50000, (map_size,), dtype=torch.int64, device=DEFAULT_DEVICE
+    )
+    input_ids = torch.randint(
+        -map_size + 1, 50000, (size,), dtype=torch.int64, device=DEFAULT_DEVICE
+    )
+
+    if provider == "jit":
+        fn = lambda: resolve_future_token_ids_cuda(input_ids.clone(), future_map)
+    else:
+        fn = lambda: _torch_resolve(input_ids.clone(), future_map)
+
+    return run_benchmark(fn)
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
@@ -2,7 +2,6 @@
 #include <sgl_kernel/utils.h>   // For RuntimeCheck, div_ceil
 
 #include <sgl_kernel/utils.cuh>  // For LaunchKernel
-#include <sgl_kernel/vec.cuh>    // For AlignedVector
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -12,53 +11,21 @@
 
 namespace {
 
-// ----------------------------------------------------------------
-// Kernel: resolve future token IDs in-place using vectorized 128-bit
-// loads/stores with branchless per-element logic.
-//
-// Semantics: for each element in input_ids,
-//   if val < 0: input_ids[i] = future_map[clamp(-val, 0)]
-//   else:       input_ids[i] = val  (unchanged)
-//
-// T     = int32_t | int64_t
-// kVecN = number of elements per 128-bit vector (4 for int32, 2 for int64)
-// ----------------------------------------------------------------
-template <typename T, int kVecN>
-__global__ void
-resolve_future_token_ids_kernel(T* __restrict__ input_ids, const T* __restrict__ future_map, uint32_t n_total) {
-  using vec_t = device::AlignedVector<T, kVecN>;
-  const uint32_t n_vecs = n_total / kVecN;
-
-  // --- vectorised body ---
-  const uint32_t vec_stride = blockDim.x * gridDim.x;
-  for (uint32_t vi = blockIdx.x * blockDim.x + threadIdx.x; vi < n_vecs; vi += vec_stride) {
-    vec_t v;
-    v.load(input_ids, vi);
-#pragma unroll
-    for (int i = 0; i < kVecN; ++i) {
-      T val = v[i];
+template <typename T>
+__global__ void resolve_future_token_ids_kernel(T* __restrict__ input_ids, const T* __restrict__ future_map, size_t n) {
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    T val = input_ids[idx];
+    if (val < 0) {
       T key = -val;
-      if (key < 0) key = 0;  // clamp for signed overflow
-      // Branchless: always gather, select via predicate (compiles to SELP)
-      v[i] = (val < 0) ? future_map[key] : val;
+      if (key < 0) key = 0;  // clamp for overflow
+      input_ids[idx] = future_map[key];
     }
-    v.store(input_ids, vi);
-  }
-
-  // --- scalar tail ---
-  const uint32_t base = n_vecs * kVecN;
-  const uint32_t scalar_stride = blockDim.x * gridDim.x;
-  for (uint32_t i = blockIdx.x * blockDim.x + threadIdx.x; base + i < n_total; i += scalar_stride) {
-    T val = input_ids[base + i];
-    T key = -val;
-    if (key < 0) key = 0;
-    input_ids[base + i] = (val < 0) ? future_map[key] : val;
   }
 }
 
-// ----------------------------------------------------------------
-// Launcher: validates tensors, selects vector width, launches kernel
-// ----------------------------------------------------------------
+constexpr size_t kBlockSize = 256;
+
 template <typename T>
 struct ResolveFutureTokenIds {
   static void run(tvm::ffi::TensorView input_ids, tvm::ffi::TensorView future_map) {
@@ -69,30 +36,18 @@ struct ResolveFutureTokenIds {
     SymbolicDevice device_;
     device_.set_options<kDLCUDA>();
 
-    TensorMatcher({N})  //
-        .with_dtype<T>()
-        .with_device(device_)
-        .verify(input_ids);
+    TensorMatcher({N}).with_dtype<T>().with_device(device_).verify(input_ids);
 
-    TensorMatcher({M})  //
-        .with_dtype<T>()
-        .with_device(device_)
-        .verify(future_map);
+    TensorMatcher({M}).with_dtype<T>().with_device(device_).verify(future_map);
 
-    const uint32_t num_tokens = static_cast<uint32_t>(N.unwrap());
+    const size_t num_tokens = N.unwrap();
     if (num_tokens == 0) return;
 
+    const size_t grid_size = div_ceil(num_tokens, kBlockSize);
     const DLDevice device = device_.unwrap();
 
-    // 128-bit vector width: int32 -> 4 elements, int64 -> 2 elements
-    constexpr int kVecN = 16 / sizeof(T);
-    const uint32_t n_work_items = div_ceil(num_tokens, static_cast<uint32_t>(kVecN));
-
-    constexpr uint32_t kBlockSize = 256;
-    const uint32_t grid = div_ceil(n_work_items, kBlockSize);
-
-    LaunchKernel(grid, kBlockSize, device)(
-        resolve_future_token_ids_kernel<T, kVecN>,
+    LaunchKernel(grid_size, kBlockSize, device)(
+        resolve_future_token_ids_kernel<T>,
         static_cast<T*>(input_ids.data_ptr()),
         static_cast<const T*>(future_map.data_ptr()),
         num_tokens);

--- a/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
@@ -1,0 +1,57 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+template <typename T>
+__global__ void resolve_future_token_ids_kernel(T* __restrict__ input_ids, const T* __restrict__ future_map, size_t n) {
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    T val = input_ids[idx];
+    if (val < 0) {
+      T key = -val;
+      if (key < 0) key = 0;  // clamp for overflow
+      input_ids[idx] = future_map[key];
+    }
+  }
+}
+
+constexpr size_t kBlockSize = 256;
+
+template <typename T>
+struct ResolveFutureTokenIds {
+  static void run(tvm::ffi::TensorView input_ids, tvm::ffi::TensorView future_map) {
+    using namespace host;
+
+    SymbolicSize N = {"num_tokens"};
+    SymbolicSize M = {"map_size"};
+    SymbolicDevice device_;
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N}).with_dtype<T>().with_device(device_).verify(input_ids);
+
+    TensorMatcher({M}).with_dtype<T>().with_device(device_).verify(future_map);
+
+    const size_t num_tokens = N.unwrap();
+    if (num_tokens == 0) return;
+
+    const size_t grid_size = div_ceil(num_tokens, kBlockSize);
+    const DLDevice device = device_.unwrap();
+
+    LaunchKernel(grid_size, kBlockSize, device)(
+        resolve_future_token_ids_kernel<T>,
+        static_cast<T*>(input_ids.data_ptr()),
+        static_cast<const T*>(future_map.data_ptr()),
+        num_tokens);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
@@ -1,7 +1,8 @@
-#include <sgl_kernel/tensor.h>
-#include <sgl_kernel/utils.h>
+#include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDevice
+#include <sgl_kernel/utils.h>   // For RuntimeCheck, div_ceil
 
-#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel
+#include <sgl_kernel/vec.cuh>    // For AlignedVector
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -11,21 +12,53 @@
 
 namespace {
 
-template <typename T>
-__global__ void resolve_future_token_ids_kernel(T* __restrict__ input_ids, const T* __restrict__ future_map, size_t n) {
-  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx < n) {
-    T val = input_ids[idx];
-    if (val < 0) {
+// ----------------------------------------------------------------
+// Kernel: resolve future token IDs in-place using vectorized 128-bit
+// loads/stores with branchless per-element logic.
+//
+// Semantics: for each element in input_ids,
+//   if val < 0: input_ids[i] = future_map[clamp(-val, 0)]
+//   else:       input_ids[i] = val  (unchanged)
+//
+// T     = int32_t | int64_t
+// kVecN = number of elements per 128-bit vector (4 for int32, 2 for int64)
+// ----------------------------------------------------------------
+template <typename T, int kVecN>
+__global__ void
+resolve_future_token_ids_kernel(T* __restrict__ input_ids, const T* __restrict__ future_map, uint32_t n_total) {
+  using vec_t = device::AlignedVector<T, kVecN>;
+  const uint32_t n_vecs = n_total / kVecN;
+
+  // --- vectorised body ---
+  const uint32_t vec_stride = blockDim.x * gridDim.x;
+  for (uint32_t vi = blockIdx.x * blockDim.x + threadIdx.x; vi < n_vecs; vi += vec_stride) {
+    vec_t v;
+    v.load(input_ids, vi);
+#pragma unroll
+    for (int i = 0; i < kVecN; ++i) {
+      T val = v[i];
       T key = -val;
-      if (key < 0) key = 0;  // clamp for overflow
-      input_ids[idx] = future_map[key];
+      if (key < 0) key = 0;  // clamp for signed overflow
+      // Branchless: always gather, select via predicate (compiles to SELP)
+      v[i] = (val < 0) ? future_map[key] : val;
     }
+    v.store(input_ids, vi);
+  }
+
+  // --- scalar tail ---
+  const uint32_t base = n_vecs * kVecN;
+  const uint32_t scalar_stride = blockDim.x * gridDim.x;
+  for (uint32_t i = blockIdx.x * blockDim.x + threadIdx.x; base + i < n_total; i += scalar_stride) {
+    T val = input_ids[base + i];
+    T key = -val;
+    if (key < 0) key = 0;
+    input_ids[base + i] = (val < 0) ? future_map[key] : val;
   }
 }
 
-constexpr size_t kBlockSize = 256;
-
+// ----------------------------------------------------------------
+// Launcher: validates tensors, selects vector width, launches kernel
+// ----------------------------------------------------------------
 template <typename T>
 struct ResolveFutureTokenIds {
   static void run(tvm::ffi::TensorView input_ids, tvm::ffi::TensorView future_map) {
@@ -36,18 +69,30 @@ struct ResolveFutureTokenIds {
     SymbolicDevice device_;
     device_.set_options<kDLCUDA>();
 
-    TensorMatcher({N}).with_dtype<T>().with_device(device_).verify(input_ids);
+    TensorMatcher({N})  //
+        .with_dtype<T>()
+        .with_device(device_)
+        .verify(input_ids);
 
-    TensorMatcher({M}).with_dtype<T>().with_device(device_).verify(future_map);
+    TensorMatcher({M})  //
+        .with_dtype<T>()
+        .with_device(device_)
+        .verify(future_map);
 
-    const size_t num_tokens = N.unwrap();
+    const uint32_t num_tokens = static_cast<uint32_t>(N.unwrap());
     if (num_tokens == 0) return;
 
-    const size_t grid_size = div_ceil(num_tokens, kBlockSize);
     const DLDevice device = device_.unwrap();
 
-    LaunchKernel(grid_size, kBlockSize, device)(
-        resolve_future_token_ids_kernel<T>,
+    // 128-bit vector width: int32 -> 4 elements, int64 -> 2 elements
+    constexpr int kVecN = 16 / sizeof(T);
+    const uint32_t n_work_items = div_ceil(num_tokens, static_cast<uint32_t>(kVecN));
+
+    constexpr uint32_t kBlockSize = 256;
+    const uint32_t grid = div_ceil(n_work_items, kBlockSize);
+
+    LaunchKernel(grid, kBlockSize, device)(
+        resolve_future_token_ids_kernel<T, kVecN>,
         static_cast<T*>(input_ids.data_ptr()),
         static_cast<const T*>(future_map.data_ptr()),
         num_tokens);

--- a/python/sglang/jit_kernel/resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/resolve_future_token_ids.py
@@ -9,9 +9,12 @@ from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
+_SUPPORTED_DTYPES = (torch.int32, torch.int64)
+
 
 @cache_once
 def _jit_resolve_future_token_ids_module(dtype: torch.dtype) -> Module:
+    """Compile and cache the JIT module for a given dtype."""
     args = make_cpp_args(dtype)
     return load_jit(
         "resolve_future_token_ids",
@@ -29,5 +32,18 @@ def _jit_resolve_future_token_ids_module(dtype: torch.dtype) -> Module:
 def resolve_future_token_ids_cuda(
     input_ids: torch.Tensor, future_token_ids_map: torch.Tensor
 ) -> None:
+    """Resolve future token IDs in-place on CUDA.
+
+    For each negative value in input_ids, replaces it with
+    future_token_ids_map[-value]. Non-negative values are unchanged.
+
+    Supported dtypes: torch.int32, torch.int64.
+    """
+    if not input_ids.is_cuda:
+        raise RuntimeError("input_ids must be a CUDA tensor")
+    if input_ids.dtype not in _SUPPORTED_DTYPES:
+        raise RuntimeError(
+            f"Unsupported dtype {input_ids.dtype}. Supported: {_SUPPORTED_DTYPES}"
+        )
     module = _jit_resolve_future_token_ids_module(input_ids.dtype)
     module.resolve_future_token_ids(input_ids, future_token_ids_map)

--- a/python/sglang/jit_kernel/resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/resolve_future_token_ids.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_resolve_future_token_ids_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "resolve_future_token_ids",
+        *args,
+        cuda_files=["elementwise/resolve_future_token_ids.cuh"],
+        cuda_wrappers=[
+            (
+                "resolve_future_token_ids",
+                f"ResolveFutureTokenIds<{args}>::run",
+            )
+        ],
+    )
+
+
+def resolve_future_token_ids_cuda(
+    input_ids: torch.Tensor, future_token_ids_map: torch.Tensor
+) -> None:
+    module = _jit_resolve_future_token_ids_module(input_ids.dtype)
+    module.resolve_future_token_ids(input_ids, future_token_ids_map)

--- a/python/sglang/jit_kernel/resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/resolve_future_token_ids.py
@@ -9,8 +9,6 @@ from sglang.jit_kernel.utils import cache_once, load_jit, make_cpp_args
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
-_SUPPORTED_DTYPES = (torch.int32, torch.int64)
-
 
 @cache_once
 def _jit_resolve_future_token_ids_module(dtype: torch.dtype) -> Module:
@@ -39,11 +37,5 @@ def resolve_future_token_ids_cuda(
 
     Supported dtypes: torch.int32, torch.int64.
     """
-    if not input_ids.is_cuda:
-        raise RuntimeError("input_ids must be a CUDA tensor")
-    if input_ids.dtype not in _SUPPORTED_DTYPES:
-        raise RuntimeError(
-            f"Unsupported dtype {input_ids.dtype}. Supported: {_SUPPORTED_DTYPES}"
-        )
     module = _jit_resolve_future_token_ids_module(input_ids.dtype)
     module.resolve_future_token_ids(input_ids, future_token_ids_map)

--- a/python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py
@@ -1,0 +1,63 @@
+import pytest
+import torch
+
+from sglang.jit_kernel.resolve_future_token_ids import resolve_future_token_ids_cuda
+
+
+def _reference_resolve(input_ids, future_map):
+    """Reference implementation using plain torch."""
+    result = input_ids.clone()
+    result[:] = torch.where(
+        result < 0,
+        future_map[torch.clamp(-result, min=0)],
+        result,
+    )
+    return result
+
+
+@pytest.mark.parametrize("size", [1, 2, 127, 128, 255, 256, 1024, 4097])
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+class TestResolveFutureTokenIds:
+    def test_all_negative(self, size: int, dtype: torch.dtype) -> None:
+        map_size = 8192
+        future_map = torch.randint(0, 50000, (map_size,), dtype=dtype, device="cuda")
+        # Negative indices in range [-map_size+1, -1]
+        input_ids = -torch.randint(1, map_size, (size,), dtype=dtype, device="cuda")
+
+        expected = _reference_resolve(input_ids, future_map)
+        resolve_future_token_ids_cuda(input_ids, future_map)
+        assert torch.equal(input_ids, expected)
+
+    def test_all_non_negative(self, size: int, dtype: torch.dtype) -> None:
+        map_size = 16
+        future_map = torch.randint(0, 50000, (map_size,), dtype=dtype, device="cuda")
+        input_ids = torch.randint(0, 50000, (size,), dtype=dtype, device="cuda")
+
+        expected = input_ids.clone()
+        resolve_future_token_ids_cuda(input_ids, future_map)
+        assert torch.equal(input_ids, expected)
+
+    def test_mixed(self, size: int, dtype: torch.dtype) -> None:
+        map_size = 8192
+        future_map = torch.randint(0, 50000, (map_size,), dtype=dtype, device="cuda")
+        # Mix of negative and non-negative
+        input_ids = torch.randint(
+            -map_size + 1, 50000, (size,), dtype=dtype, device="cuda"
+        )
+
+        expected = _reference_resolve(input_ids, future_map)
+        resolve_future_token_ids_cuda(input_ids, future_map)
+        assert torch.equal(input_ids, expected)
+
+    def test_zeros(self, size: int, dtype: torch.dtype) -> None:
+        map_size = 16
+        future_map = torch.randint(0, 50000, (map_size,), dtype=dtype, device="cuda")
+        input_ids = torch.zeros(size, dtype=dtype, device="cuda")
+
+        expected = input_ids.clone()
+        resolve_future_token_ids_cuda(input_ids, future_map)
+        assert torch.equal(input_ids, expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from sglang.srt.speculative.spec_utils import spec_need_hidden_states
-from sglang.srt.utils import get_compiler_backend, is_npu
+from sglang.srt.utils import get_compiler_backend, is_cuda, is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import ModelWorkerBatch
@@ -14,16 +14,32 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_info import EagleDraftInput
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
-_is_npu = is_npu()
+_is_cuda = is_cuda()
+_is_hip = is_hip()
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
-def _resolve_future_token_ids(input_ids, future_token_ids_map):
+def _resolve_future_token_ids_native(input_ids, future_token_ids_map):
     input_ids[:] = torch.where(
         input_ids < 0,
         future_token_ids_map[torch.clamp(-input_ids, min=0)],
         input_ids,
     )
+
+
+if _is_cuda:
+    from sglang.jit_kernel.resolve_future_token_ids import (
+        resolve_future_token_ids_cuda,
+    )
+
+    _resolve_future_token_ids = resolve_future_token_ids_cuda
+elif _is_hip:
+    _resolve_future_token_ids = torch.compile(
+        _resolve_future_token_ids_native,
+        dynamic=True,
+        backend=get_compiler_backend(),
+    )
+else:
+    _resolve_future_token_ids = _resolve_future_token_ids_native
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add a CUDA JIT kernel (`resolve_future_token_ids.cuh`) that resolves future token IDs in-place, templated on dtype (int32/int64)
- Add Python JIT wrapper with `@cache_once` for module caching
- Replace the single `@torch.compile` implementation with platform dispatch: CUDA JIT kernel on CUDA, `torch.compile` on HIP/AMD, plain torch on other platforms (NPU, CPU, etc.)
- Add comprehensive unit tests covering multiple sizes, dtypes, and input patterns
- Add benchmark comparing JIT kernel vs torch.compile vs PyTorch

## Benchmark (NVIDIA H100)

| Size | SGL JIT Kernel (us) | torch.compile (us) | PyTorch (us) | JIT vs torch.compile |
|------|--------------------:|--------------------:|------------:|---------------------:|
| 16 | 2.82 | 3.25 | 12.31 | 1.15x faster |
| 128 | 3.23 | 3.27 | 12.30 | 1.01x faster |
| 1024 | 3.31 | 3.47 | 14.16 | 1.05x faster |
| 4096 | 3.37 | 3.51 | 14.79 | 1.04x faster |
| 16384 | 3.57 | 4.02 | 15.22 | 1.13x faster |
| 32768 | 3.68 | 4.79 | 15.57 | 1.30x faster |

## Test plan
- [x] Run unit tests: `python -m pytest python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py -v -s` (64/64 passed)
- [x] Run e2e tests: `python -m pytest test/registered/core/test_srt_engine.py -x -v` (8/8 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)