### PR TITLE
ci: move metrics scripts under scripts/ci/utils

### DIFF
--- a/.github/workflows/amd-ci-job-monitor.yml
+++ b/.github/workflows/amd-ci-job-monitor.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/amd-ci-job-monitor.yml'
-      - 'scripts/ci/query_job_status.py'
+      - 'scripts/ci/utils/query_job_status.py'
   workflow_dispatch:
     inputs:
       hours:
@@ -42,7 +42,7 @@ jobs:
       - name: Generate Custom Job Report
         timeout-minutes: 30
         run: |
-          python scripts/ci/query_job_status.py \
+          python scripts/ci/utils/query_job_status.py \
             --repo ${{ github.repository }} \
             --job "${{ inputs.job_filter }}" \
             --workflow "pr-test-amd.yml" \
@@ -107,7 +107,7 @@ jobs:
       - name: Generate Report
         timeout-minutes: 15
         run: |
-          python scripts/ci/query_job_status.py \
+          python scripts/ci/utils/query_job_status.py \
             --repo ${{ github.repository }} \
             --job "${{ matrix.job_name }}" \
             --workflow "pr-test-amd.yml" \
@@ -141,7 +141,7 @@ jobs:
       - name: Generate Nightly Report
         timeout-minutes: 15
         run: |
-          python scripts/ci/query_job_status.py \
+          python scripts/ci/utils/query_job_status.py \
             --repo ${{ github.repository }} \
             --job "${{ matrix.job_name }}" \
             --workflow "nightly-test-amd.yml" \

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Collect performance metrics
         if: always()
         run: |
-          python3 scripts/ci/save_metrics.py \
+          python3 scripts/ci/utils/save_metrics.py \
             --gpu-config 8-gpu-h200 \
             --partition ${{ matrix.partition }} \
             --run-id ${{ github.run_id }} \
@@ -257,7 +257,7 @@ jobs:
       - name: Collect performance metrics
         if: always()
         run: |
-          python3 scripts/ci/save_metrics.py \
+          python3 scripts/ci/utils/save_metrics.py \
             --gpu-config 8-gpu-b200 \
             --partition ${{ matrix.partition }} \
             --run-id ${{ github.run_id }} \
@@ -434,7 +434,7 @@ jobs:
       - name: Collect diffusion performance metrics
         if: always()
         run: |
-          python3 scripts/ci/save_diffusion_metrics.py \
+          python3 scripts/ci/utils/save_diffusion_metrics.py \
             --gpu-config 1-gpu-runner \
             --run-id ${{ github.run_id }} \
             --output python/diffusion-metrics-1gpu-partition-${{ matrix.part }}.json \
@@ -490,7 +490,7 @@ jobs:
       - name: Collect diffusion performance metrics
         if: always()
         run: |
-          python3 scripts/ci/save_diffusion_metrics.py \
+          python3 scripts/ci/utils/save_diffusion_metrics.py \
             --gpu-config 2-gpu-runner \
             --run-id ${{ github.run_id }} \
             --output python/diffusion-metrics-2gpu-partition-${{ matrix.part }}.json \
@@ -589,7 +589,7 @@ jobs:
 
       - name: Merge metrics
         run: |
-          python3 scripts/ci/merge_metrics.py \
+          python3 scripts/ci/utils/merge_metrics.py \
             --input-dir metrics/ \
             --output consolidated-metrics-${{ github.run_id }}.json \
             --run-id ${{ github.run_id }} \

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -114,24 +114,24 @@ jobs:
         with:
           filters: |
             main_package:
-              - "python/sglang/!(multimodal_gen)/**"
+              - ".github/workflows/pr-test.yml"
               - "python/pyproject.toml"
+              - "python/sglang/!(multimodal_gen)/**"
               - "scripts/ci/cuda/*"
               - "scripts/ci/utils/*"
               - "test/**"
-              - ".github/workflows/pr-test.yml"
-            sgl_kernel:
-              - "sgl-kernel/**"
-            jit_kernel:
-              - "python/sglang/jit_kernel/**"
-              - "python/pyproject.toml"
-              - ".github/workflows/pr-test.yml"
             multimodal_gen:
+              - ".github/workflows/pr-test.yml"
+              - "python/pyproject.toml"
               - "python/sglang/multimodal_gen/**"
               - "python/sglang/jit_kernel/**"
               - "python/sglang/cli/**"
-              - "python/pyproject.toml"
+            jit_kernel:
               - ".github/workflows/pr-test.yml"
+              - "python/pyproject.toml"
+              - "python/sglang/jit_kernel/**"
+            sgl_kernel:
+              - "sgl-kernel/**"
 
       # For /rerun-stage (workflow_dispatch with target_stage), dorny/paths-filter doesn't work
       # correctly because it falls back to "last commit" detection which breaks for merge commits.

--- a/python/sglang/test/nightly_utils.py
+++ b/python/sglang/test/nightly_utils.py
@@ -209,7 +209,7 @@ class NightlyBenchmarkRunner:
             )
 
             # Note: JSON files are preserved for metrics collection by CI scripts
-            # They will be collected by scripts/ci/save_metrics.py
+            # They will be collected by scripts/ci/utils/save_metrics.py
 
             return benchmark_results, True
 

--- a/scripts/ci/utils/merge_metrics.py
+++ b/scripts/ci/utils/merge_metrics.py
@@ -5,7 +5,7 @@ This script reads all per-partition metric JSON files and consolidates them
 into a single JSON file with run-level metadata.
 
 Usage:
-    python3 scripts/ci/merge_metrics.py \
+    python3 scripts/ci/utils/merge_metrics.py \
         --input-dir metrics/ \
         --output consolidated-metrics-12345678.json \
         --run-id 12345678 \

--- a/scripts/ci/utils/query_job_status.py
+++ b/scripts/ci/utils/query_job_status.py
@@ -3,9 +3,9 @@
 Query GitHub Actions job status for specific jobs.
 
 Usage:
-    python scripts/ci/query_job_status.py --job "stage-c-test-large-8-gpu-amd-mi35x"
-    python scripts/ci/query_job_status.py --job "stage-c-test-large-8-gpu-amd-mi35x" --hours 48
-    python scripts/ci/query_job_status.py --job "AMD" --workflow pr-test-amd.yml
+    python scripts/ci/utils/query_job_status.py --job "stage-c-test-large-8-gpu-amd-mi35x"
+    python scripts/ci/utils/query_job_status.py --job "stage-c-test-large-8-gpu-amd-mi35x" --hours 48
+    python scripts/ci/utils/query_job_status.py --job "AMD" --workflow pr-test-amd.yml
 
 Requirements:
     pip install tabulate

--- a/scripts/ci/utils/save_diffusion_metrics.py
+++ b/scripts/ci/utils/save_diffusion_metrics.py
@@ -5,7 +5,7 @@ This script reads diffusion test results from the pytest stash and saves them
 with metadata for the performance dashboard.
 
 Usage:
-    python3 scripts/ci/save_diffusion_metrics.py \
+    python3 scripts/ci/utils/save_diffusion_metrics.py \
         --gpu-config 1-gpu-runner \
         --run-id 12345678 \
         --output test/diffusion-metrics-1gpu.json \

--- a/scripts/ci/utils/save_metrics.py
+++ b/scripts/ci/utils/save_metrics.py
@@ -5,7 +5,7 @@ This script reads benchmark result JSON files from performance profile directori
 and saves them with metadata for artifact collection in CI.
 
 Usage:
-    python3 scripts/ci/save_metrics.py \
+    python3 scripts/ci/utils/save_metrics.py \
         --gpu-config 8-gpu-h200 \
         --partition 0 \
         --run-id 12345678 \

--- a/test/show_partitions.py
+++ b/test/show_partitions.py
@@ -22,7 +22,6 @@ _spec = importlib.util.spec_from_file_location("ci_register", _ci_register_path)
 _ci_register = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_ci_register)
 
-CIRegistry = _ci_register.CIRegistry
 HWBackend = _ci_register.HWBackend
 auto_partition = _ci_register.auto_partition
 collect_tests = _ci_register.collect_tests
@@ -110,7 +109,7 @@ def main():
 
         total_time = sum(t.est_time for t in enabled)
         out(
-            f"### {suite} (hw={hw_str}, {partition_count} partition(s), "
+            f"### {suite} (hw={hw_str}, {partition_count} partitions, "
             f"{len(enabled)} enabled, {len(disabled)} disabled, est {total_time:.0f}s total)"
         )
         out()


### PR DESCRIPTION
## Summary
Moves `merge_metrics.py`, `query_job_status.py`, `save_diffusion_metrics.py`, and `save_metrics.py` from `scripts/ci/` to `scripts/ci/utils/` and updates all callers (workflows, `nightly_utils.py`, script usage docs).

## Test plan
- [ ] CI

Made with [Cursor](https://cursor.com)