### PR TITLE
ci: run Stage A CUDA tests as stage-a-test-small-1-gpu on 5090

### DIFF
--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -8,7 +8,7 @@ inputs:
   jobs:
     description: |
       JSON array of job specs to wait for. Each element is either:
-        - a string: exact job name (e.g. "stage-a-test-1")
+        - a string: exact job name (e.g. "stage-a-test-small-1-gpu")
         - an object { "prefix": "...", "expected_count": N }: for matrix jobs
     required: true
   max-wait-minutes:

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -35,7 +35,7 @@ on:
           - ''
           - sgl-kernel-unit-test-amd
           - sgl-kernel-unit-test-2-gpu-amd
-          - stage-a-test-small-1-gpu
+          - stage-a-test-small-1-gpu-amd
           - jit-kernel-unit-test-amd
           - stage-b-test-small-1-gpu-amd
           - stage-b-test-small-1-gpu-amd-nondeterministic
@@ -246,12 +246,12 @@ jobs:
 
   # =============================================== primary ====================================================
 
-  stage-a-test-small-1-gpu:
+  stage-a-test-small-1-gpu-amd:
     needs: [check-changes]
     if: |
       always() &&
       (
-        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-small-1-gpu,')) ||
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-small-1-gpu-amd,')) ||
         (
           !(inputs.target_stage || inputs.target_stage_select) &&
           (!failure() && !cancelled()) &&
@@ -283,7 +283,7 @@ jobs:
       - name: Run test
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-small-1-gpu ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-small-1-gpu-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   jit-kernel-unit-test-amd:
     needs: [check-changes]
@@ -984,7 +984,7 @@ jobs:
         multimodal-gen-test-1-gpu-amd,
         multimodal-gen-test-2-gpu-amd,
 
-        stage-a-test-small-1-gpu,
+        stage-a-test-small-1-gpu-amd,
         jit-kernel-unit-test-amd,
         stage-b-test-small-1-gpu-amd,
         stage-b-test-small-1-gpu-amd-nondeterministic,

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -35,7 +35,7 @@ on:
           - ''
           - sgl-kernel-unit-test-amd
           - sgl-kernel-unit-test-2-gpu-amd
-          - stage-a-test-1-amd
+          - stage-a-test-small-1-gpu
           - jit-kernel-unit-test-amd
           - stage-b-test-small-1-gpu-amd
           - stage-b-test-small-1-gpu-amd-nondeterministic
@@ -246,12 +246,12 @@ jobs:
 
   # =============================================== primary ====================================================
 
-  stage-a-test-1-amd:
+  stage-a-test-small-1-gpu:
     needs: [check-changes]
     if: |
       always() &&
       (
-        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-1-amd,')) ||
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-small-1-gpu,')) ||
         (
           !(inputs.target_stage || inputs.target_stage_select) &&
           (!failure() && !cancelled()) &&
@@ -283,7 +283,7 @@ jobs:
       - name: Run test
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-small-1-gpu ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   jit-kernel-unit-test-amd:
     needs: [check-changes]
@@ -984,7 +984,7 @@ jobs:
         multimodal-gen-test-1-gpu-amd,
         multimodal-gen-test-2-gpu-amd,
 
-        stage-a-test-1-amd,
+        stage-a-test-small-1-gpu,
         jit-kernel-unit-test-amd,
         stage-b-test-small-1-gpu-amd,
         stage-b-test-small-1-gpu-amd-nondeterministic,

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -33,7 +33,7 @@ on:
           - ''
           - sgl-kernel-unit-test-amd
           - sgl-kernel-unit-test-2-gpu-amd
-          - stage-a-test-1-amd
+          - stage-a-test-small-1-gpu
           - jit-kernel-unit-test-amd
           - stage-b-test-small-1-gpu-amd
           - stage-b-test-small-1-gpu-amd-nondeterministic
@@ -246,12 +246,12 @@ jobs:
 
   # =============================================== primary ====================================================
 
-  stage-a-test-1-amd:
+  stage-a-test-small-1-gpu:
     needs: [check-changes]
     if: |
       always() &&
       (
-        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-1-amd,')) ||
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-small-1-gpu,')) ||
         (
           !(inputs.target_stage || inputs.target_stage_select) &&
           (!failure() && !cancelled()) &&
@@ -284,7 +284,7 @@ jobs:
       - name: Run test
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-small-1-gpu ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   jit-kernel-unit-test-amd:
     needs: [check-changes]
@@ -326,7 +326,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" python3 -m pytest -q python/sglang/jit_kernel/tests/test_store_cache.py
 
   stage-b-test-small-1-gpu-amd:
-    needs: [check-changes, stage-a-test-1-amd]
+    needs: [check-changes, stage-a-test-small-1-gpu]
     if: |
       always() &&
       (
@@ -366,7 +366,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-small-1-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-small-1-gpu-amd-nondeterministic:
-    needs: [check-changes, stage-a-test-1-amd]
+    needs: [check-changes, stage-a-test-small-1-gpu]
     if: |
       always() &&
       (
@@ -405,7 +405,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-small-1-gpu-amd-nondeterministic --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-small-1-gpu-amd-mi35x:
-    needs: [check-changes, stage-a-test-1-amd]
+    needs: [check-changes, stage-a-test-small-1-gpu]
     if: |
       always() &&
       (
@@ -444,7 +444,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-small-1-gpu-amd-mi35x ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-large-1-gpu-amd:
-    needs: [check-changes, stage-a-test-1-amd]
+    needs: [check-changes, stage-a-test-small-1-gpu]
     if: |
       always() &&
       (
@@ -484,7 +484,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-1-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-large-2-gpu-amd:
-    needs: [check-changes, stage-a-test-1-amd]
+    needs: [check-changes, stage-a-test-small-1-gpu]
     if: |
       always() &&
       (
@@ -868,7 +868,7 @@ jobs:
 
   # =============================================== Disaggregation ====================================================
   stage-b-test-large-8-gpu-35x-disaggregation-amd:
-    needs: [check-changes, stage-a-test-1-amd]
+    needs: [check-changes, stage-a-test-small-1-gpu]
     if: |
       always() &&
       (
@@ -989,7 +989,7 @@ jobs:
         multimodal-gen-test-1-gpu-amd,
         multimodal-gen-test-2-gpu-amd,
 
-        stage-a-test-1-amd,
+        stage-a-test-small-1-gpu,
         jit-kernel-unit-test-amd,
         stage-b-test-small-1-gpu-amd,
         stage-b-test-small-1-gpu-amd-nondeterministic,

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -33,7 +33,7 @@ on:
           - ''
           - sgl-kernel-unit-test-amd
           - sgl-kernel-unit-test-2-gpu-amd
-          - stage-a-test-small-1-gpu
+          - stage-a-test-small-1-gpu-amd
           - jit-kernel-unit-test-amd
           - stage-b-test-small-1-gpu-amd
           - stage-b-test-small-1-gpu-amd-nondeterministic
@@ -246,12 +246,12 @@ jobs:
 
   # =============================================== primary ====================================================
 
-  stage-a-test-small-1-gpu:
+  stage-a-test-small-1-gpu-amd:
     needs: [check-changes]
     if: |
       always() &&
       (
-        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-small-1-gpu,')) ||
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',stage-a-test-small-1-gpu-amd,')) ||
         (
           !(inputs.target_stage || inputs.target_stage_select) &&
           (!failure() && !cancelled()) &&
@@ -284,7 +284,7 @@ jobs:
       - name: Run test
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-small-1-gpu ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-small-1-gpu-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   jit-kernel-unit-test-amd:
     needs: [check-changes]
@@ -326,7 +326,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" python3 -m pytest -q python/sglang/jit_kernel/tests/test_store_cache.py
 
   stage-b-test-small-1-gpu-amd:
-    needs: [check-changes, stage-a-test-small-1-gpu]
+    needs: [check-changes, stage-a-test-small-1-gpu-amd]
     if: |
       always() &&
       (
@@ -366,7 +366,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-small-1-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-small-1-gpu-amd-nondeterministic:
-    needs: [check-changes, stage-a-test-small-1-gpu]
+    needs: [check-changes, stage-a-test-small-1-gpu-amd]
     if: |
       always() &&
       (
@@ -405,7 +405,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-small-1-gpu-amd-nondeterministic --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-small-1-gpu-amd-mi35x:
-    needs: [check-changes, stage-a-test-small-1-gpu]
+    needs: [check-changes, stage-a-test-small-1-gpu-amd]
     if: |
       always() &&
       (
@@ -444,7 +444,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-small-1-gpu-amd-mi35x ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-large-1-gpu-amd:
-    needs: [check-changes, stage-a-test-small-1-gpu]
+    needs: [check-changes, stage-a-test-small-1-gpu-amd]
     if: |
       always() &&
       (
@@ -484,7 +484,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-1-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-large-2-gpu-amd:
-    needs: [check-changes, stage-a-test-small-1-gpu]
+    needs: [check-changes, stage-a-test-small-1-gpu-amd]
     if: |
       always() &&
       (
@@ -868,7 +868,7 @@ jobs:
 
   # =============================================== Disaggregation ====================================================
   stage-b-test-large-8-gpu-35x-disaggregation-amd:
-    needs: [check-changes, stage-a-test-small-1-gpu]
+    needs: [check-changes, stage-a-test-small-1-gpu-amd]
     if: |
       always() &&
       (
@@ -989,7 +989,7 @@ jobs:
         multimodal-gen-test-1-gpu-amd,
         multimodal-gen-test-2-gpu-amd,
 
-        stage-a-test-small-1-gpu,
+        stage-a-test-small-1-gpu-amd,
         jit-kernel-unit-test-amd,
         stage-b-test-small-1-gpu-amd,
         stage-b-test-small-1-gpu-amd-nondeterministic,

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -821,12 +821,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 10
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-a-test-small-1-gpu $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -869,12 +867,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 10
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cpu --suite stage-a-cpu-only $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)
@@ -924,13 +920,11 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           source /etc/profile.d/sglang-ci.sh
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 8 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -979,12 +973,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-b-test-large-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 14 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1034,12 +1026,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-b-test-large-2-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1085,12 +1075,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           IS_BLACKWELL=1 python3 run_suite.py --hw cuda --suite stage-b-test-4-gpu-b200 $CONTINUE_ON_ERROR_FLAG
 
       - name: Run FA4 jit_kernel tests (SM100+)
@@ -1141,12 +1129,9 @@ jobs:
         timeout-minutes: 240
         env:
           RUNAI_STREAMER_MEMORY_LIMIT: 0
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd python
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 sglang/multimodal_gen/test/run_suite.py \
             --suite 1-gpu \
             --partition-id ${{ matrix.part }} \
@@ -1199,12 +1184,9 @@ jobs:
         timeout-minutes: 240
         env:
           RUNAI_STREAMER_MEMORY_LIMIT: 0
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd python
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 sglang/multimodal_gen/test/run_suite.py \
             --suite 2-gpu \
             --partition-id ${{ matrix.part }} \
@@ -1294,12 +1276,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-h100 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1360,12 +1340,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-c-test-8-gpu-h200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1414,12 +1392,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-c-test-8-gpu-h20 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1474,12 +1450,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-c-test-deepep-4-gpu $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1533,12 +1507,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 45
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           python3 run_suite.py --hw cuda --suite stage-c-test-deepep-8-gpu-h200 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1584,12 +1556,10 @@ jobs:
 
       - name: Run test
         timeout-minutes: 30
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
-          CONTINUE_ON_ERROR_FLAG=""
-          if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-            CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-          fi
           IS_BLACKWELL=1 python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-b200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -1636,12 +1606,10 @@ jobs:
   #
   #     - name: Run test
   #       timeout-minutes: 45
+  #       env:
+  #         CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
   #       run: |
   #         cd test
-  #         CONTINUE_ON_ERROR_FLAG=""
-  #         if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
-  #           CONTINUE_ON_ERROR_FLAG="--continue-on-error"
-  #         fi
   #         python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-gb200 --timeout-per-file 3600 $CONTINUE_ON_ERROR_FLAG
   #
   #     - uses: ./.github/actions/upload-cuda-coredumps

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -799,7 +799,6 @@ jobs:
     runs-on: 1-gpu-5090
     timeout-minutes: 240
     env:
-      RUNNER_LABELS: 1-gpu-5090
       IS_BLACKWELL: "1"
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -333,7 +333,7 @@ jobs:
         id: wait
         with:
           stage-name: stage-a
-          jobs: '["stage-a-test-1", "stage-a-cpu-only"]'
+          jobs: '["stage-a-test-small-1-gpu", "stage-a-cpu-only"]'
           max-wait-minutes: '240'
 
   wait-for-stage-b:
@@ -783,20 +783,24 @@ jobs:
 
   # =============================================== primary ====================================================
 
-  stage-a-test-1:
+  # Runs on 5090 (32GB, SM120)
+  stage-a-test-small-1-gpu:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: |
       always() &&
       (
-        (inputs.target_stage == 'stage-a-test-1') ||
+        (inputs.target_stage == 'stage-a-test-small-1-gpu') ||
         (
           !inputs.target_stage &&
           ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: 1-gpu-runner
+    runs-on: 1-gpu-5090
     timeout-minutes: 240
+    env:
+      RUNNER_LABELS: 1-gpu-5090
+      IS_BLACKWELL: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -824,7 +828,9 @@ jobs:
           if [[ "${{ needs.check-changes.outputs.continue_on_error }}" == "true" ]]; then
             CONTINUE_ON_ERROR_FLAG="--continue-on-error"
           fi
-          python3 run_suite.py --hw cuda --suite stage-a-test-1 $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cuda --suite stage-a-test-small-1-gpu $CONTINUE_ON_ERROR_FLAG
+          # temporarily put backend-independent cpu tests here
+          python3 run_suite.py --hw cpu --suite default $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -1667,7 +1673,7 @@ jobs:
         multimodal-gen-test-1-gpu,
         multimodal-gen-test-2-gpu,
 
-        stage-a-test-1,
+        stage-a-test-small-1-gpu,
         stage-a-cpu-only,
         stage-b-test-small-1-gpu,
         stage-b-test-large-1-gpu,

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -829,8 +829,6 @@ jobs:
             CONTINUE_ON_ERROR_FLAG="--continue-on-error"
           fi
           python3 run_suite.py --hw cuda --suite stage-a-test-small-1-gpu $CONTINUE_ON_ERROR_FLAG
-          # temporarily put backend-independent cpu tests here
-          python3 run_suite.py --hw cpu --suite default $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -880,8 +880,6 @@ def popen_launch_server(
         merged.update(env)
         env = merged
 
-    offline_force_disabled = env.get("HF_HUB_OFFLINE") == "0"
-
     # Store per-run marker path for potential invalidation
     per_run_marker_path = None
     try:

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -880,6 +880,8 @@ def popen_launch_server(
         merged.update(env)
         env = merged
 
+    offline_force_disabled = env.get("HF_HUB_OFFLINE") == "0"
+
     # Store per-run marker path for potential invalidation
     per_run_marker_path = None
     try:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -253,7 +253,7 @@ def handle_rerun_stage(
 
     # Valid NVIDIA stage names that support target_stage
     nvidia_stages = [
-        "stage-a-test-1",
+        "stage-a-test-small-1-gpu",
         "stage-a-cpu-only",
         "stage-b-test-small-1-gpu",
         "stage-b-test-large-1-gpu",
@@ -410,7 +410,7 @@ def handle_rerun_stage(
 
 
 CUDA_SUITE_TO_RUNNER = {
-    "stage-a-test-1": "1-gpu-runner",
+    "stage-a-test-small-1-gpu": "1-gpu-5090",
     "stage-a-cpu-only": "ubuntu-latest",
     "stage-b-test-small-1-gpu": "1-gpu-5090",
     "stage-b-test-large-1-gpu": "1-gpu-runner",

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -12,6 +12,12 @@ from github import Auth, Github
 # Configuration
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
 
+# Maps /rerun-stage-only names to workflow_dispatch target_stage for PR Test (AMD).
+# Needed where the suite/job input matches NVIDIA (e.g. stage-a-test-small-1-gpu).
+AMD_RERUN_STAGE_INPUT = {
+    "stage-a-test-small-1-gpu-amd": "stage-a-test-small-1-gpu",
+}
+
 
 def find_workflow_run_url(
     gh_repo,
@@ -274,7 +280,7 @@ def handle_rerun_stage(
     amd_stages = [
         "sgl-kernel-unit-test-amd",
         "sgl-kernel-unit-test-2-gpu-amd",
-        "stage-a-test-1-amd",
+        "stage-a-test-small-1-gpu-amd",
         "stage-b-test-small-1-gpu-amd",
         "stage-b-test-small-1-gpu-amd-nondeterministic",
         "stage-b-test-small-1-gpu-amd-mi35x",
@@ -288,6 +294,12 @@ def handle_rerun_stage(
 
     valid_stages = nvidia_stages + amd_stages
     is_amd_stage = stage_name in amd_stages
+
+    dispatch_target_stage = (
+        AMD_RERUN_STAGE_INPUT.get(stage_name, stage_name)
+        if is_amd_stage
+        else stage_name
+    )
 
     if stage_name not in valid_stages:
         comment.create_reaction("confused")
@@ -334,7 +346,10 @@ def handle_rerun_stage(
                 f"Triggering {workflow_name} workflow on ref: {ref}, PR head SHA: {pr_head_sha}"
             )
             if is_amd_stage:
-                inputs = {"target_stage": stage_name, "pr_head_sha": pr_head_sha}
+                inputs = {
+                    "target_stage": dispatch_target_stage,
+                    "pr_head_sha": pr_head_sha,
+                }
             else:
                 inputs = {
                     "version": "release",
@@ -347,7 +362,7 @@ def handle_rerun_stage(
             ref = pr.head.ref
             print(f"Triggering {workflow_name} workflow on branch: {ref}")
             if is_amd_stage:
-                inputs = {"target_stage": stage_name}
+                inputs = {"target_stage": dispatch_target_stage}
             else:
                 inputs = {"version": "release", "target_stage": stage_name}
 
@@ -381,7 +396,7 @@ def handle_rerun_stage(
                     gh_repo,
                     target_workflow.id,
                     ref,
-                    stage_name,
+                    dispatch_target_stage,
                     token,
                     dispatch_time,
                     pr_head_sha=pr_head_sha,

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -12,12 +12,6 @@ from github import Auth, Github
 # Configuration
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
 
-# Maps /rerun-stage-only names to workflow_dispatch target_stage for PR Test (AMD).
-# Needed where the suite/job input matches NVIDIA (e.g. stage-a-test-small-1-gpu).
-AMD_RERUN_STAGE_INPUT = {
-    "stage-a-test-small-1-gpu-amd": "stage-a-test-small-1-gpu",
-}
-
 
 def find_workflow_run_url(
     gh_repo,
@@ -295,12 +289,6 @@ def handle_rerun_stage(
     valid_stages = nvidia_stages + amd_stages
     is_amd_stage = stage_name in amd_stages
 
-    dispatch_target_stage = (
-        AMD_RERUN_STAGE_INPUT.get(stage_name, stage_name)
-        if is_amd_stage
-        else stage_name
-    )
-
     if stage_name not in valid_stages:
         comment.create_reaction("confused")
         pr.create_issue_comment(
@@ -347,7 +335,7 @@ def handle_rerun_stage(
             )
             if is_amd_stage:
                 inputs = {
-                    "target_stage": dispatch_target_stage,
+                    "target_stage": stage_name,
                     "pr_head_sha": pr_head_sha,
                 }
             else:
@@ -362,7 +350,7 @@ def handle_rerun_stage(
             ref = pr.head.ref
             print(f"Triggering {workflow_name} workflow on branch: {ref}")
             if is_amd_stage:
-                inputs = {"target_stage": dispatch_target_stage}
+                inputs = {"target_stage": stage_name}
             else:
                 inputs = {"version": "release", "target_stage": stage_name}
 
@@ -396,7 +384,7 @@ def handle_rerun_stage(
                     gh_repo,
                     target_workflow.id,
                     ref,
-                    dispatch_target_stage,
+                    stage_name,
                     token,
                     dispatch_time,
                     pr_head_sha=pr_head_sha,

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ register_cuda_ci(est_time=200, suite="nightly-1-gpu", nightly=True)
 
 # Multi-backend test
 register_cuda_ci(est_time=80, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=120, suite="stage-a-test-1")
+register_amd_ci(est_time=120, suite="stage-a-test-1-amd")
 
 # Temporarily disabled test
 register_cuda_ci(est_time=80, suite="stage-b-test-small-1-gpu", disabled="flaky - see #12345")
@@ -72,6 +72,7 @@ When adding 1-GPU tests, choose the appropriate suite based on hardware compatib
 
 | Suite | Runner | GPU | When to Use |
 |-------|--------|-----|-------------|
+| `stage-a-test-small-1-gpu` | `1-gpu-5090` | RTX 5090 (32GB, SM120) | Stage A per-commit smoke on 5090 |
 | `stage-b-test-small-1-gpu` | `1-gpu-5090` | RTX 5090 (32GB, SM120) | 5090-compatible tests (preferred) |
 | `stage-b-test-large-1-gpu` | `1-gpu-runner` | H100 (80GB, SM90) | Large models or 5090-incompatible tests |
 
@@ -98,13 +99,13 @@ If a test cannot run on 5090 due to any of the above, use `stage-b-test-large-1-
 ### Available Suites
 
 **Per-Commit (CUDA)**:
-- Stage A: `stage-a-test-1` (locked), `stage-a-test-2`, `stage-a-test-cpu`
+- Stage A: `stage-a-test-small-1-gpu` (5090), `stage-a-test-2`, `stage-a-test-cpu`
 - Stage B: `stage-b-test-small-1-gpu` (5090), `stage-b-test-large-1-gpu` (H100), `stage-b-test-large-2-gpu`
 - Stage C (4-GPU): `stage-c-test-4-gpu-h100`, `stage-c-test-4-gpu-b200`, `stage-c-test-4-gpu-gb200`, `stage-c-test-deepep-4-gpu`
 - Stage C (8-GPU): `stage-c-test-8-gpu-h20`, `stage-c-test-8-gpu-h200`, `stage-c-test-8-gpu-b200`, `stage-c-test-deepep-8-gpu-h200`
 
 **Per-Commit (AMD)**:
-- `stage-a-test-1`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`
+- `stage-a-test-1-amd`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`
 
 **Nightly**:
 - `nightly-1-gpu`, `nightly-2-gpu`, `nightly-4-gpu`, `nightly-8-gpu`, etc.

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ register_cuda_ci(est_time=200, suite="nightly-1-gpu", nightly=True)
 
 # Multi-backend test
 register_cuda_ci(est_time=80, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=120, suite="stage-a-test-small-1-gpu")
+register_amd_ci(est_time=120, suite="stage-a-test-small-1-gpu-amd")
 
 # Temporarily disabled test
 register_cuda_ci(est_time=80, suite="stage-b-test-small-1-gpu", disabled="flaky - see #12345")
@@ -72,7 +72,8 @@ When adding 1-GPU tests, choose the appropriate suite based on hardware compatib
 
 | Suite | Runner | GPU | When to Use |
 |-------|--------|-----|-------------|
-| `stage-a-test-small-1-gpu` | `1-gpu-5090` | RTX 5090 (32GB, SM120) | Stage A per-commit smoke on 5090 |
+| `stage-a-test-small-1-gpu` | `1-gpu-5090` | RTX 5090 (32GB, SM120) | Stage A per-commit smoke on 5090 (CUDA) |
+| `stage-a-test-small-1-gpu-amd` | AMD CI runners | ROCm | Stage A per-commit smoke (AMD) |
 | `stage-b-test-small-1-gpu` | `1-gpu-5090` | RTX 5090 (32GB, SM120) | 5090-compatible tests (preferred) |
 | `stage-b-test-large-1-gpu` | `1-gpu-runner` | H100 (80GB, SM90) | Large models or 5090-incompatible tests |
 
@@ -105,9 +106,7 @@ If a test cannot run on 5090 due to any of the above, use `stage-b-test-large-1-
 - Stage C (8-GPU): `stage-c-test-8-gpu-h20`, `stage-c-test-8-gpu-h200`, `stage-c-test-8-gpu-b200`, `stage-c-test-deepep-8-gpu-h200`
 
 **Per-Commit (AMD)**:
-- `stage-a-test-small-1-gpu`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`
-
-**Note:** CUDA and AMD both use suite name `stage-a-test-small-1-gpu` (via `--hw cuda` vs `--hw amd`). For `/rerun-stage` on GitHub, AMD Stage A is invoked as `stage-a-test-small-1-gpu-amd` so it is not confused with the NVIDIA job of the same input name.
+- `stage-a-test-small-1-gpu-amd`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`
 
 **Nightly**:
 - `nightly-1-gpu`, `nightly-2-gpu`, `nightly-4-gpu`, `nightly-8-gpu`, etc.

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ register_cuda_ci(est_time=200, suite="nightly-1-gpu", nightly=True)
 
 # Multi-backend test
 register_cuda_ci(est_time=80, suite="stage-b-test-small-1-gpu")
-register_amd_ci(est_time=120, suite="stage-a-test-1-amd")
+register_amd_ci(est_time=120, suite="stage-a-test-small-1-gpu")
 
 # Temporarily disabled test
 register_cuda_ci(est_time=80, suite="stage-b-test-small-1-gpu", disabled="flaky - see #12345")
@@ -105,7 +105,9 @@ If a test cannot run on 5090 due to any of the above, use `stage-b-test-large-1-
 - Stage C (8-GPU): `stage-c-test-8-gpu-h20`, `stage-c-test-8-gpu-h200`, `stage-c-test-8-gpu-b200`, `stage-c-test-deepep-8-gpu-h200`
 
 **Per-Commit (AMD)**:
-- `stage-a-test-1-amd`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`
+- `stage-a-test-small-1-gpu`, `stage-b-test-small-1-gpu-amd`, `stage-b-test-large-2-gpu-amd`
+
+**Note:** CUDA and AMD both use suite name `stage-a-test-small-1-gpu` (via `--hw cuda` vs `--hw amd`). For `/rerun-stage` on GitHub, AMD Stage A is invoked as `stage-a-test-small-1-gpu-amd` so it is not confused with the NVIDIA job of the same input name.
 
 **Nightly**:
 - `nightly-1-gpu`, `nightly-2-gpu`, `nightly-4-gpu`, `nightly-8-gpu`, etc.

--- a/test/registered/attention/test_wave_attention_kernels.py
+++ b/test/registered/attention/test_wave_attention_kernels.py
@@ -25,7 +25,7 @@ from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci
 
 # Wave attention kernel unit tests (AMD only - requires wave_lang)
-register_amd_ci(est_time=60, suite="stage-a-test-1-amd")
+register_amd_ci(est_time=60, suite="stage-a-test-small-1-gpu")
 
 
 class TestWaveAttention(unittest.TestCase):

--- a/test/registered/attention/test_wave_attention_kernels.py
+++ b/test/registered/attention/test_wave_attention_kernels.py
@@ -25,7 +25,7 @@ from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci
 
 # Wave attention kernel unit tests (AMD only - requires wave_lang)
-register_amd_ci(est_time=60, suite="stage-a-test-small-1-gpu")
+register_amd_ci(est_time=60, suite="stage-a-test-small-1-gpu-amd")
 
 
 class TestWaveAttention(unittest.TestCase):

--- a/test/registered/debug_utils/test_cuda_coredump_smoke.py
+++ b/test/registered/debug_utils/test_cuda_coredump_smoke.py
@@ -12,7 +12,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=10,
-    suite="stage-a-test-1",
+    suite="stage-a-test-small-1-gpu",
     disabled="Manual only: triggers intentional CUDA crash for coredump verification",
 )
 

--- a/test/registered/quant/test_awq_dequant.py
+++ b/test/registered/quant/test_awq_dequant.py
@@ -21,7 +21,7 @@ from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_amd_ci(est_time=2, suite="stage-a-test-1-amd")
+register_amd_ci(est_time=2, suite="stage-a-test-small-1-gpu")
 
 device = get_device()
 

--- a/test/registered/quant/test_awq_dequant.py
+++ b/test/registered/quant/test_awq_dequant.py
@@ -21,7 +21,7 @@ from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_amd_ci(est_time=2, suite="stage-a-test-small-1-gpu")
+register_amd_ci(est_time=2, suite="stage-a-test-small-1-gpu-amd")
 
 device = get_device()
 

--- a/test/registered/quant/test_fused_rms_fp8_group_quant.py
+++ b/test/registered/quant/test_fused_rms_fp8_group_quant.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_amd_ci(est_time=10, suite="stage-a-test-small-1-gpu")
+register_amd_ci(est_time=10, suite="stage-a-test-small-1-gpu-amd")
 
 
 def _fp8_available() -> bool:

--- a/test/registered/quant/test_fused_rms_fp8_group_quant.py
+++ b/test/registered/quant/test_fused_rms_fp8_group_quant.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_amd_ci(est_time=10, suite="stage-a-test-1-amd")
+register_amd_ci(est_time=10, suite="stage-a-test-small-1-gpu")
 
 
 def _fp8_available() -> bool:

--- a/test/registered/test_srt_backend.py
+++ b/test/registered/test_srt_backend.py
@@ -19,7 +19,7 @@ from sglang.test.test_programs import (
 )
 from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST, CustomTestCase
 
-register_cuda_ci(est_time=80, suite="stage-a-test-1")
+register_cuda_ci(est_time=80, suite="stage-a-test-small-1-gpu")
 register_amd_ci(est_time=120, suite="stage-a-test-1-amd")
 
 

--- a/test/registered/test_srt_backend.py
+++ b/test/registered/test_srt_backend.py
@@ -20,7 +20,7 @@ from sglang.test.test_programs import (
 from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST, CustomTestCase
 
 register_cuda_ci(est_time=80, suite="stage-a-test-small-1-gpu")
-register_amd_ci(est_time=120, suite="stage-a-test-1-amd")
+register_amd_ci(est_time=120, suite="stage-a-test-small-1-gpu")
 
 
 class TestSRTBackend(CustomTestCase):

--- a/test/registered/test_srt_backend.py
+++ b/test/registered/test_srt_backend.py
@@ -29,7 +29,9 @@ class TestSRTBackend(CustomTestCase):
     @classmethod
     def setUpClass(cls):
         cls.backend = sgl.Runtime(
-            model_path=DEFAULT_MODEL_NAME_FOR_TEST, cuda_graph_max_bs=4
+            model_path=DEFAULT_MODEL_NAME_FOR_TEST,
+            cuda_graph_max_bs=4,
+            mem_fraction_static=0.7,
         )
         sgl.set_default_backend(cls.backend)
 

--- a/test/registered/test_srt_backend.py
+++ b/test/registered/test_srt_backend.py
@@ -20,7 +20,7 @@ from sglang.test.test_programs import (
 from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST, CustomTestCase
 
 register_cuda_ci(est_time=80, suite="stage-a-test-small-1-gpu")
-register_amd_ci(est_time=120, suite="stage-a-test-small-1-gpu")
+register_amd_ci(est_time=120, suite="stage-a-test-small-1-gpu-amd")
 
 
 class TestSRTBackend(CustomTestCase):

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -24,7 +24,7 @@ HW_MAPPING = {
 PER_COMMIT_SUITES = {
     HWBackend.CPU: ["stage-a-cpu-only"],
     HWBackend.AMD: [
-        "stage-a-test-small-1-gpu",
+        "stage-a-test-small-1-gpu-amd",
         "stage-b-test-small-1-gpu-amd",
         "stage-b-test-small-1-gpu-amd-nondeterministic",
         "stage-b-test-small-1-gpu-amd-mi35x",

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -35,7 +35,7 @@ PER_COMMIT_SUITES = {
         "stage-c-test-large-8-gpu-amd-mi35x",
     ],
     HWBackend.CUDA: [
-        "stage-a-test-1",
+        "stage-a-test-small-1-gpu",
         "stage-b-test-small-1-gpu",
         "stage-b-test-large-1-gpu",
         "stage-b-test-large-2-gpu",
@@ -49,7 +49,7 @@ PER_COMMIT_SUITES = {
         "stage-c-test-deepep-8-gpu-h200",
     ],
     HWBackend.NPU: [
-        "stage-a-test-1",
+        "stage-a-test-small-1-gpu",
         "stage-b-test-1-npu-a2",
         "stage-b-test-2-npu-a2",
         "stage-b-test-4-npu-a3",

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -24,7 +24,7 @@ HW_MAPPING = {
 PER_COMMIT_SUITES = {
     HWBackend.CPU: ["stage-a-cpu-only"],
     HWBackend.AMD: [
-        "stage-a-test-1-amd",
+        "stage-a-test-small-1-gpu",
         "stage-b-test-small-1-gpu-amd",
         "stage-b-test-small-1-gpu-amd-nondeterministic",
         "stage-b-test-small-1-gpu-amd-mi35x",


### PR DESCRIPTION
## Summary
Renames the PR Test Stage A CUDA job from `stage-a-test-1` to `stage-a-test-small-1-gpu` and runs it on the `1-gpu-5090` runner (with `IS_BLACKWELL=1`), matching Stage B small 1-GPU 5090 jobs.

## Changes
- Workflow: job id, `target_stage`, `runs-on`, env, `run_suite.py --suite`, `pr-test-finish` needs, `wait-for-stage-a` job list
- Tests: CUDA suite registration for `test_srt_backend`, `test_cuda_coredump_smoke`
- `test/run_suite.py` per-commit suite lists (CUDA + NPU)
- Slash command handler: `/rerun-stage` allowlist + `CUDA_SUITE_TO_RUNNER`
- CI monitor scripts + wait-for-jobs doc example
- `test/README.md`: document new suite; fix AMD example (`stage-a-test-1-amd`)

## CI
After merge, full PR CI unchanged in structure except job name. To trigger CI on this PR per [contribution guide](docs/developer_guide/contribution_guide.md): add the `run-ci` label or comment `/tag-run-ci-label` / `/tag-and-rerun-ci` (if permitted).

Made with [Cursor](https://cursor.com)