### PR TITLE
ci: remove redundant RUNNER_LABELS from pr-test.yml

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -495,8 +495,6 @@ jobs:
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 1-gpu-runner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -535,8 +533,6 @@ jobs:
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: 1-gpu-runner
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 1-gpu-runner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -577,7 +573,6 @@ jobs:
     timeout-minutes: 240
     env:
       CI: true
-      RUNNER_LABELS: 1-gpu-runner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -628,8 +623,6 @@ jobs:
       needs.check-changes.outputs.sgl_kernel == 'true'
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -701,8 +694,6 @@ jobs:
       needs.check-changes.outputs.jit_kernel == 'true'
     runs-on: 1-gpu-runner
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 1-gpu-runner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -727,7 +718,6 @@ jobs:
     runs-on: 1-gpu-runner
     timeout-minutes: 240
     env:
-      RUNNER_LABELS: 1-gpu-runner
       SGLANG_JIT_KERNEL_RUN_FULL_TESTS: "1"
     steps:
       - uses: actions/checkout@v4
@@ -757,7 +747,6 @@ jobs:
     timeout-minutes: 240
     env:
       CI: true
-      RUNNER_LABELS: 1-gpu-runner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -808,8 +797,6 @@ jobs:
       )
     runs-on: 1-gpu-runner
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 1-gpu-runner
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -905,7 +892,6 @@ jobs:
     runs-on: 1-gpu-5090
     timeout-minutes: 240
     env:
-      RUNNER_LABELS: 1-gpu-5090
       IS_BLACKWELL: "1"
     strategy:
       fail-fast: false
@@ -966,8 +952,6 @@ jobs:
       )
     runs-on: 1-gpu-runner
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 1-gpu-runner
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJson(needs.check-changes.outputs.max_parallel) }}
@@ -1021,8 +1005,6 @@ jobs:
       )
     runs-on: 2-gpu-runner
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 2-gpu-runner
     strategy:
       fail-fast: false
       matrix:
@@ -1078,8 +1060,6 @@ jobs:
       )
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     strategy:
       fail-fast: false
 
@@ -1288,8 +1268,6 @@ jobs:
       )
     runs-on: 4-gpu-h100
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 4-gpu-h100
     strategy:
       fail-fast: false
       matrix:
@@ -1342,8 +1320,6 @@ jobs:
       )
     runs-on: 8-gpu-h200
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 8-gpu-h200
     strategy:
       fail-fast: false
       matrix:
@@ -1412,7 +1388,6 @@ jobs:
     timeout-minutes: 240
     env:
       SGLANG_CI_RDMA_ALL_DEVICES: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
-      RUNNER_LABELS: 8-gpu-h20
     strategy:
       fail-fast: false
       matrix:
@@ -1465,8 +1440,6 @@ jobs:
       )
     runs-on: 4-gpu-h100
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 4-gpu-h100
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1525,8 +1498,6 @@ jobs:
       )
     runs-on: 8-gpu-h200
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: 8-gpu-h200
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1586,8 +1557,6 @@ jobs:
       )
     runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     timeout-minutes: 240
-    env:
-      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -1643,8 +1612,6 @@ jobs:
   #     )
   #   runs-on: 4-gpu-gb200
   #   timeout-minutes: 240
-  #   env:
-  #     RUNNER_LABELS: 4-gpu-gb200
   #   strategy:
   #     fail-fast: false
   #   steps:


### PR DESCRIPTION
## Summary
Remove all `RUNNER_LABELS` job `env` entries from [`.github/workflows/pr-test.yml`](.github/workflows/pr-test.yml). These values duplicated `runs-on` and are not referenced elsewhere in the repo.

## Triggering CI
Per [contribution guide](docs/developer_guide/contribution_guide.md), adding `run-ci` label.

Made with [Cursor](https://cursor.com)