### PR TITLE
ci: merge CPU default and stage-a-cpu-only suites

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -838,8 +838,6 @@ jobs:
             CONTINUE_ON_ERROR_FLAG="--continue-on-error"
           fi
           python3 run_suite.py --hw cuda --suite stage-a-test-1 $CONTINUE_ON_ERROR_FLAG
-          # temporarily put backend-independent cpu tests here
-          python3 run_suite.py --hw cpu --suite default $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()

--- a/test/registered/debug_utils/comparator/aligner/entrypoint/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/entrypoint/test_executor.py
@@ -28,7 +28,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import ParallelAxis, TokenLayou
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestExecuteSubPlans:

--- a/test/registered/debug_utils/comparator/aligner/entrypoint/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/entrypoint/test_planner.py
@@ -25,7 +25,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import TokenLayout
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 def _make_meta(

--- a/test/registered/debug_utils/comparator/aligner/reorderer/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/reorderer/test_executor.py
@@ -22,7 +22,7 @@ from sglang.srt.debug_utils.comparator.aligner.unsharder.types import (
 from sglang.srt.debug_utils.comparator.dims_spec import ParallelAxis
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _zigzag_order(cp_size: int) -> list[int]:

--- a/test/registered/debug_utils/comparator/aligner/reorderer/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/reorderer/test_planner.py
@@ -24,7 +24,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestComputeReordererPlans:

--- a/test/registered/debug_utils/comparator/aligner/test_axis_aligner.py
+++ b/test/registered/debug_utils/comparator/aligner/test_axis_aligner.py
@@ -13,7 +13,7 @@ from sglang.srt.debug_utils.comparator.log_sink import log_sink
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestComputeAxisAlignerPlan:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_aux_loader.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_aux_loader.py
@@ -19,7 +19,7 @@ from sglang.srt.debug_utils.comparator.log_sink import LogSink
 from sglang.srt.debug_utils.comparator.output_types import ErrorLog, InfoLog
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 _sglang_plugin = _SGLangPlugin()
 _megatron_plugin = _MegatronPlugin()

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_aux_plugins.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_aux_plugins.py
@@ -16,7 +16,7 @@ from sglang.srt.debug_utils.comparator.aligner.token_aligner.smart.types import 
 from sglang.srt.debug_utils.comparator.dims_spec import TokenLayout
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 _sglang_plugin = _SGLangPlugin()
 _megatron_plugin = _MegatronPlugin()

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_concat_steps.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_concat_steps.py
@@ -9,7 +9,7 @@ from sglang.srt.debug_utils.comparator.aligner.token_aligner.concat_steps import
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestExecuteConcat:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_executor.py
@@ -25,7 +25,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import TokenLayout
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 def _named(tensor: torch.Tensor, names: list[str]) -> torch.Tensor:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_planner.py
@@ -23,7 +23,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import TokenLayout
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestBuildTokenIndexSGLangThd:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_thd_seq_lens_loader.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_thd_seq_lens_loader.py
@@ -14,7 +14,7 @@ from sglang.srt.debug_utils.comparator.aligner.token_aligner.smart.aux_plugins i
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 def _save_pt(

--- a/test/registered/debug_utils/comparator/aligner/unsharder/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/unsharder/test_executor.py
@@ -27,7 +27,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.srt.debug_utils.comparator.output_types import ReplicatedCheckResult
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _name_tensors(

--- a/test/registered/debug_utils/comparator/aligner/unsharder/test_parallel_info.py
+++ b/test/registered/debug_utils/comparator/aligner/unsharder/test_parallel_info.py
@@ -9,7 +9,7 @@ from sglang.srt.debug_utils.comparator.aligner.unsharder.types import AxisInfo
 from sglang.srt.debug_utils.comparator.dims_spec import ParallelAxis
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestNormalizeParallelInfo:

--- a/test/registered/debug_utils/comparator/aligner/unsharder/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/unsharder/test_planner.py
@@ -14,7 +14,7 @@ from sglang.srt.debug_utils.comparator.aligner.unsharder.types import (
 from sglang.srt.debug_utils.comparator.dims_spec import ParallelAxis, parse_dims
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestComputeUnsharderPlan:

--- a/test/registered/debug_utils/comparator/dims_spec/test_dim_parser.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_dim_parser.py
@@ -12,7 +12,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="default", nightly=True)
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestParseDim:

--- a/test/registered/debug_utils/comparator/dims_spec/test_dims_parser.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_dims_parser.py
@@ -15,7 +15,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="default", nightly=True)
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestSingletonDimUtilFilterOut:

--- a/test/registered/debug_utils/comparator/dims_spec/test_tensor_naming.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_tensor_naming.py
@@ -13,7 +13,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="default", nightly=True)
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestFindDimIndex:

--- a/test/registered/debug_utils/comparator/dims_spec/test_types.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_types.py
@@ -9,7 +9,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="default", nightly=True)
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestDimConstants:

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_comparator.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_comparator.py
@@ -13,7 +13,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.comparator import (
 from sglang.srt.debug_utils.comparator.tensor_comparator.types import DiffInfo
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=20, suite="default", nightly=True)
+register_cpu_ci(est_time=20, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestComputeTensorStats:

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_formatter.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_formatter.py
@@ -55,7 +55,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.types import (
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 # Snapshot strings below are intentionally spelled out in full per test.

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_types.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_types.py
@@ -21,7 +21,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.types import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _make_stats(**overrides) -> TensorStats:

--- a/test/registered/debug_utils/comparator/test_bundle_comparator.py
+++ b/test/registered/debug_utils/comparator/test_bundle_comparator.py
@@ -10,7 +10,7 @@ from sglang.srt.debug_utils.comparator.log_sink import LogSink
 from sglang.srt.debug_utils.comparator.output_types import ErrorLog
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 def _save_tensor(

--- a/test/registered/debug_utils/comparator/test_bundle_matcher.py
+++ b/test/registered/debug_utils/comparator/test_bundle_matcher.py
@@ -13,7 +13,7 @@ from sglang.srt.debug_utils.comparator.bundle_matcher import (
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 def _make_row(

--- a/test/registered/debug_utils/comparator/test_display.py
+++ b/test/registered/debug_utils/comparator/test_display.py
@@ -20,7 +20,7 @@ from sglang.srt.debug_utils.comparator.output_types import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _render_rich(renderable: object) -> str:

--- a/test/registered/debug_utils/comparator/test_dp_utils.py
+++ b/test/registered/debug_utils/comparator/test_dp_utils.py
@@ -11,7 +11,7 @@ from sglang.srt.debug_utils.comparator.dp_utils import (
 from sglang.srt.debug_utils.dump_loader import ValueWithMeta
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="default", nightly=True)
+register_cpu_ci(est_time=15, suite="stage-a-cpu-only", nightly=True)
 
 
 def _make_sglang_meta(

--- a/test/registered/debug_utils/comparator/test_dump_loader.py
+++ b/test/registered/debug_utils/comparator/test_dump_loader.py
@@ -7,7 +7,7 @@ import torch
 from sglang.srt.debug_utils.dump_loader import read_tokenizer_path
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _save_pt(

--- a/test/registered/debug_utils/comparator/test_entrypoint.py
+++ b/test/registered/debug_utils/comparator/test_entrypoint.py
@@ -30,7 +30,7 @@ from sglang.srt.debug_utils.comparator.output_types import (
 from sglang.srt.debug_utils.dumper import DumperConfig, _Dumper, _RecomputeStatus
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 _FIXED_EXP_NAME = "my_exp_name"
 

--- a/test/registered/debug_utils/comparator/test_log_sink.py
+++ b/test/registered/debug_utils/comparator/test_log_sink.py
@@ -11,7 +11,7 @@ from sglang.srt.debug_utils.comparator.output_types import (
 from sglang.srt.debug_utils.comparator.report_sink import report_sink
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _make_error_log(**overrides) -> ErrorLog:

--- a/test/registered/debug_utils/comparator/test_manually_verify.py
+++ b/test/registered/debug_utils/comparator/test_manually_verify.py
@@ -23,7 +23,7 @@ import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=60, suite="default", nightly=True)
+register_cpu_ci(est_time=60, suite="stage-a-cpu-only", nightly=True)
 
 _PUBLISH_DIR: Path = Path("/tmp/comparator_manual_verify")
 _PNG_MAGIC: bytes = b"\x89PNG"

--- a/test/registered/debug_utils/comparator/test_meta_overrider.py
+++ b/test/registered/debug_utils/comparator/test_meta_overrider.py
@@ -16,7 +16,7 @@ from sglang.srt.debug_utils.comparator.meta_overrider import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 # ───────────────────── Unit: MetaOverrideRule ─────────────────────

--- a/test/registered/debug_utils/comparator/test_model_validation.py
+++ b/test/registered/debug_utils/comparator/test_model_validation.py
@@ -44,7 +44,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.types import (
 from sglang.srt.debug_utils.comparator.utils import Pair, _check_equal_lengths
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestCheckEqualLengths:

--- a/test/registered/debug_utils/comparator/test_output_types.py
+++ b/test/registered/debug_utils/comparator/test_output_types.py
@@ -49,7 +49,7 @@ from sglang.srt.debug_utils.comparator.output_types import (
 from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 def _render_rich(renderable: object) -> str:

--- a/test/registered/debug_utils/comparator/test_per_token_visualizer.py
+++ b/test/registered/debug_utils/comparator/test_per_token_visualizer.py
@@ -15,7 +15,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.comparator import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 _PNG_MAGIC: bytes = b"\x89PNG"
 

--- a/test/registered/debug_utils/comparator/test_preset.py
+++ b/test/registered/debug_utils/comparator/test_preset.py
@@ -3,7 +3,7 @@ import pytest
 from sglang.srt.debug_utils.comparator.preset import PRESETS, expand_preset
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="default", nightly=True)
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestExpandPreset:

--- a/test/registered/debug_utils/comparator/test_utils.py
+++ b/test/registered/debug_utils/comparator/test_utils.py
@@ -17,7 +17,7 @@ from sglang.srt.debug_utils.comparator.utils import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestCalcRelDiff:

--- a/test/registered/debug_utils/comparator/test_visualizer.py
+++ b/test/registered/debug_utils/comparator/test_visualizer.py
@@ -10,7 +10,7 @@ from sglang.srt.debug_utils.comparator.visualizer.preprocessing import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestPreprocessTensor:

--- a/test/registered/debug_utils/comparator/testing_helpers.py
+++ b/test/registered/debug_utils/comparator/testing_helpers.py
@@ -7,7 +7,10 @@ from typing import Optional
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(
-    est_time=0, suite="default", nightly=True, disabled="helper module, no tests"
+    est_time=0,
+    suite="stage-a-cpu-only",
+    nightly=True,
+    disabled="helper module, no tests",
 )
 
 from sglang.srt.debug_utils.comparator.tensor_comparator.types import (

--- a/test/registered/debug_utils/source_patcher/test_code_patcher.py
+++ b/test/registered/debug_utils/source_patcher/test_code_patcher.py
@@ -10,7 +10,7 @@ from sglang.srt.debug_utils.source_patcher.code_patcher import (
 from sglang.srt.debug_utils.source_patcher.types import EditSpec, PatchSpec
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 SAMPLE_MODULE_NAME = "_source_patcher_test_fixtures.sample_module"
 

--- a/test/registered/debug_utils/source_patcher/test_dumper_integration.py
+++ b/test/registered/debug_utils/source_patcher/test_dumper_integration.py
@@ -8,7 +8,7 @@ import yaml
 from sglang.srt.debug_utils.dumper import DumperConfig, _Dumper
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 SAMPLE_MODULE_NAME = "_source_patcher_test_fixtures.sample_module"
 

--- a/test/registered/debug_utils/source_patcher/test_source_editor.py
+++ b/test/registered/debug_utils/source_patcher/test_source_editor.py
@@ -5,7 +5,7 @@ from sglang.srt.debug_utils.source_patcher.source_editor import apply_edits
 from sglang.srt.debug_utils.source_patcher.types import EditSpec, PatchApplicationError
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=10, suite="default", nightly=True)
+register_cpu_ci(est_time=10, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestApplyEdits:

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -14,7 +14,7 @@ from sglang.srt.debug_utils.dump_comparator import (
 from sglang.srt.debug_utils.dumper import DumperConfig, _Dumper
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 
 # ----------------------------- Unit tests -----------------------------

--- a/test/registered/debug_utils/test_dump_loader.py
+++ b/test/registered/debug_utils/test_dump_loader.py
@@ -15,7 +15,7 @@ from sglang.srt.debug_utils.dump_loader import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestReadMeta:

--- a/test/registered/debug_utils/test_schedule_simulator.py
+++ b/test/registered/debug_utils/test_schedule_simulator.py
@@ -25,7 +25,7 @@ from sglang.srt.debug_utils.schedule_simulator import (
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=120, suite="default", nightly=True)
+register_cpu_ci(est_time=120, suite="stage-a-cpu-only", nightly=True)
 
 
 # ==================== Non-E2E Tests ====================

--- a/test/registered/function_call/test_kimik2_detector.py
+++ b/test/registered/function_call/test_kimik2_detector.py
@@ -11,7 +11,7 @@ from sglang.srt.function_call.kimik2_detector import (
 from sglang.srt.parser.reasoning_parser import KimiK2Detector as KimiK2ReasoningDetector
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(1.0, "default")
+register_cpu_ci(1.0, "stage-a-cpu-only")
 
 
 def _make_tool(name, parameters=None):

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -18,7 +18,7 @@ from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(1.0, "default")
+register_cpu_ci(1.0, "stage-a-cpu-only")
 
 
 class TestPythonicDetector(unittest.TestCase):

--- a/test/registered/unit/function_call/test_glm47_moe_detector.py
+++ b/test/registered/unit/function_call/test_glm47_moe_detector.py
@@ -10,7 +10,7 @@ from sglang.srt.function_call.glm47_moe_detector import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(1.0, "default")
+register_cpu_ci(1.0, "stage-a-cpu-only")
 
 
 class TestGlm47MoeDetector(unittest.TestCase):

--- a/test/registered/unit/function_call/test_json_schema_constraint.py
+++ b/test/registered/unit/function_call/test_json_schema_constraint.py
@@ -18,7 +18,7 @@ from sglang.srt.function_call.utils import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(1.0, "default")
+register_cpu_ci(1.0, "stage-a-cpu-only")
 
 
 class TestJsonSchemaConstraint(unittest.TestCase):

--- a/test/registered/unit/function_call/test_parallel_tool_calls.py
+++ b/test/registered/unit/function_call/test_parallel_tool_calls.py
@@ -23,7 +23,7 @@ from sglang.srt.entrypoints.openai.protocol import Function, Tool
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(1.0, "default")
+register_cpu_ci(1.0, "stage-a-cpu-only")
 
 
 class TestParallelToolCalls(unittest.TestCase):

--- a/test/registered/unit/function_call/test_unknown_tool_name.py
+++ b/test/registered/unit/function_call/test_unknown_tool_name.py
@@ -9,7 +9,7 @@ from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(1.0, "default")
+register_cpu_ci(1.0, "stage-a-cpu-only")
 
 
 class DummyDetector(BaseFormatDetector):

--- a/test/registered/unit/observability/test_cpu_monitor.py
+++ b/test/registered/unit/observability/test_cpu_monitor.py
@@ -3,7 +3,7 @@ import unittest
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=60, suite="default", nightly=True)
+register_cpu_ci(est_time=60, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestCpuMonitor(unittest.TestCase):

--- a/test/registered/unit/utils/test_patch_tokenizer.py
+++ b/test/registered/unit/utils/test_patch_tokenizer.py
@@ -10,7 +10,7 @@ from sglang.srt.utils.patch_tokenizer import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=30, suite="default", nightly=True)
+register_cpu_ci(est_time=30, suite="stage-a-cpu-only", nightly=True)
 
 
 class TestPatchTokenizerEndToEndTest(unittest.TestCase):

--- a/test/registered/utils/test_log_utils.py
+++ b/test/registered/utils/test_log_utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from sglang.srt.utils.log_utils import create_log_targets, log_json
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=1, suite="default")
+register_cpu_ci(est_time=1, suite="stage-a-cpu-only")
 
 
 class TestLogUtils(unittest.TestCase):

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -22,7 +22,7 @@ HW_MAPPING = {
 
 # Per-commit test suites (run on every PR)
 PER_COMMIT_SUITES = {
-    HWBackend.CPU: ["default", "stage-a-cpu-only"],
+    HWBackend.CPU: ["stage-a-cpu-only"],
     HWBackend.AMD: [
         "stage-a-test-1-amd",
         "stage-b-test-small-1-gpu-amd",


### PR DESCRIPTION
## Summary
- Consolidate per-commit CPU tests into a single suite name (`stage-a-cpu-only`).
- Retag all `register_cpu_ci(..., suite="default")` entries to `stage-a-cpu-only` (including `nightly=True` registrations for consistency).
- Remove the redundant `run_suite.py --hw cpu --suite default` step from the `stage-a-test-1` GPU job; those tests now run only in `stage-a-cpu-only` on `ubuntu-latest`.
- `PER_COMMIT_SUITES` for CPU now lists only `stage-a-cpu-only`.

## CI
Per [contribution guide](docs/developer_guide/contribution_guide.md), maintainers can add the `run-ci` label or use slash commands (e.g. `/tag-and-rerun-ci`) to trigger workflows.

Made with [Cursor](https://cursor.com)