### PR TITLE
[Bugifx] qwen3vl rope parameter compatibility

### DIFF
--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -32,6 +32,7 @@ from sglang.srt.models.qwen2 import Qwen2Model
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, get_bool_env_var, is_cuda, is_hip, is_npu
+from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 Qwen3Config = None
 
@@ -316,8 +317,7 @@ class Qwen3DecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        rope_theta = config.rope_parameters["rope_theta"]
-        rope_scaling = config.rope_parameters
+        rope_theta, rope_scaling = get_rope_config(config)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
         head_dim = getattr(config, "head_dim", None)
         self.self_attn = Qwen3Attention(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Follow the [PR20931](https://github.com/sgl-project/sglang/pull/20931)

We still meet this error when running Qwen3VL even if using main branch after that PR.

> [2026-03-20 07:07:49] Scheduler hit an exception: Traceback (most recent call last):
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/managers/scheduler.py", line 3403, in run_scheduler_process
> scheduler = Scheduler(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/managers/scheduler.py", line 376, in init
> self.init_model_worker()
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/managers/scheduler.py", line 593, in init_model_worker
> self.init_tp_model_worker()
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/managers/scheduler.py", line 551, in init_tp_model_worker
> self.tp_worker = TpModelWorker(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/managers/tp_worker.py", line 261, in init
> self._init_model_runner()
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/managers/tp_worker.py", line 344, in _init_model_runner
> self._model_runner = ModelRunner(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/model_executor/model_runner.py", line 422, in init
> self.initialize(pre_model_load_memory)
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/model_executor/model_runner.py", line 502, in initialize
> self.load_model()
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/model_executor/model_runner.py", line 1079, in load_model
> self.model = self.loader.load_model(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/model_loader/loader.py", line 683, in load_model
> model = _initialize_model(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/model_loader/loader.py", line 277, in _initialize_model
> return model_class(**kwargs)
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/models/qwen3_vl.py", line 1100, in init
> self.model = language_model_cls(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/models/qwen3_vl.py", line 955, in init
> super().init(config=config, quant_config=quant_config, prefix=prefix)
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/models/qwen3.py", line 331, in init
> super().init(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/models/qwen2.py", line 293, in init
> self.layers, self.start_layer, self.end_layer = make_layers(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/utils/common.py", line 654, in make_layers
> get_offloader().wrap_modules(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/utils/offloader.py", line 36, in wrap_modules
> return list(all_modules_generator)
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/utils/common.py", line 656, in
> layer_fn(idx=idx, prefix=add_prefix(idx, prefix))
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/models/qwen2.py", line 295, in
> lambda idx, prefix: decoder_layer_type(
> File "/work/qwen3-vl/third_party/sglang/python/sglang/srt/models/qwen3.py", line 219, in init
> rope_theta = config.rope_parameters["rope_theta"]
> File "/usr/local/lib/python3.10/dist-packages/transformers/configuration_utils.py", line 207, in getattribute
> return super().getattribute(key)
> AttributeError: 'Qwen3VLConfig' object has no attribute 'rope_parameters'
> 
> [2026-03-20 07:07:49] Received sigquit from a child process. It usually means the child failed.

## Modifications

This PR fixes the bug as the same way as that PR. After the fix, Qwen3VL works smoothly in my local tests.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
