### PR TITLE
[Fix] Add EPLB rebalance support for Kimi K2.5

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -767,6 +767,10 @@ class KimiK25ForConditionalGeneration(nn.Module):
     def end_layer(self) -> int:
         return self.language_model.end_layer
 
+    @property
+    def routed_experts_weights_of_layer(self):
+        return self.language_model._routed_experts_weights_of_layer.value
+
     def forward(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
## Motivation

Add routed_experts_weights_of_layer property to KimiK25ForConditionalGeneration to enable EPLB (Expert Parallel Load Balancing) rebalance support for Kimi K2.5 models.

EPLB Rebalance error：
```
[2026-03-19 13:32:54] INFO:     10.121.36.12:39116 - "POST /generate HTTP/1.1" 200 OK
[2026-03-19 13:32:54 DP3 PP0 TP3 EP3] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2717, in run_scheduler_process
    scheduler.event_loop_pp_disagg_prefill()
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_pp_mixin.py", line 253, in event_loop_pp_disagg_prefill
    result = self.run_batch(self.cur_batch)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2055, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 452, in forward_batch_generation
    pp_proxy_tensors, can_run_cuda_graph = self.model_runner.forward(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2679, in forward
    self.eplb_manager.on_forward_pass_end()
  File "/sgl-workspace/sglang/python/sglang/srt/eplb/eplb_manager.py", line 62, in on_forward_pass_end
    next(self._main_generator)
  File "/sgl-workspace/sglang/python/sglang/srt/eplb/eplb_manager.py", line 172, in _entrypoint
    yield from self.rebalance()
  File "/sgl-workspace/sglang/python/sglang/srt/eplb/eplb_manager.py", line 220, in rebalance
    yield from self.transfer_parameter()
  File "/sgl-workspace/sglang/python/sglang/srt/eplb/eplb_manager.py", line 347, in transfer_parameter
    update_layer_ids_chunks = self._compute_update_layer_ids_chunks()
  File "/sgl-workspace/sglang/python/sglang/srt/eplb/eplb_manager.py", line 374, in _compute_update_layer_ids_chunks
    list(self._model_runner.model.routed_experts_weights_of_layer.keys())
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1940, in __getattr__
    raise AttributeError(
AttributeError: 'KimiK25ForConditionalGeneration' object has no attribute 'routed_experts_weights_of_layer'
```

## Modifications

Added `routed_experts_weights_of_layer` property in KimiK25ForConditionalGeneration class.

## Accuracy Tests

## Benchmarking and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
