### PR TITLE
Fix cuda graph max bs capture upper bound

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1299,6 +1299,9 @@ class ServerArgs:
 
         capture_bs = [bs for bs in capture_bs if bs <= self.cuda_graph_max_bs]
 
+        if self.cuda_graph_max_bs not in capture_bs:
+            capture_bs.append(self.cuda_graph_max_bs)
+
         return capture_bs
 
     def _generate_piecewise_cuda_graph_tokens(self):

--- a/test/registered/core/test_server_args.py
+++ b/test/registered/core/test_server_args.py
@@ -48,6 +48,16 @@ class TestLoadBalanceMethod(unittest.TestCase):
         self.assertEqual(server_args.load_balance_method, "round_robin")
 
 
+class TestCudaGraphBatchSizes(unittest.TestCase):
+    def test_generate_cuda_graph_batch_sizes_includes_max_bs(self):
+        server_args = ServerArgs(model_path="dummy", cuda_graph_max_bs=500)
+
+        capture_bs = server_args._generate_cuda_graph_batch_sizes()
+
+        self.assertIn(500, capture_bs)
+        self.assertEqual(capture_bs[-1], 500)
+
+
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")

--- a/test/registered/core/test_server_args.py
+++ b/test/registered/core/test_server_args.py
@@ -48,16 +48,6 @@ class TestLoadBalanceMethod(unittest.TestCase):
         self.assertEqual(server_args.load_balance_method, "round_robin")
 
 
-class TestCudaGraphBatchSizes(unittest.TestCase):
-    def test_generate_cuda_graph_batch_sizes_includes_max_bs(self):
-        server_args = ServerArgs(model_path="dummy", cuda_graph_max_bs=500)
-
-        capture_bs = server_args._generate_cuda_graph_batch_sizes()
-
-        self.assertIn(500, capture_bs)
-        self.assertEqual(capture_bs[-1], 500)
-
-
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")


### PR DESCRIPTION
ensure generated cuda graph batch sizes always include the configured cuda_graph_max_bs
- Typically people set `cuda-graph-max-bs` equal to `max-running-requests`. And the max bs is easy to be run. So we should make sure it run with cuda graph for perf. This also ensure no non-cudagraph fallback in the range. I see huge perf degradation due to fallback.
- This also make the `cuda_graph_"max"_bs` arg make more sense.

