### PR TITLE
[WIP] Support auto-round INT4 model offline inference on CPU

### DIFF
--- a/docs/advanced_features/quantization.md
+++ b/docs/advanced_features/quantization.md
@@ -32,7 +32,7 @@ The following table summarizes quantization method support across NVIDIA and AMD
 | `gptq` | Yes | Yes | Uses Triton or vLLM kernels on AMD |
 | `compressed-tensors` | Yes | Yes | Aiter paths for FP8/MoE on AMD |
 | `quark` | Yes | Yes | AMD Quark quantization; Aiter GEMM paths on AMD |
-| `auto-round` | Yes | Yes | Platform-agnostic (Intel auto-round) |
+| `auto-round` | Yes | Yes | Supports offline INT4 on CPU engine (`SGLANG_USE_CPU_ENGINE=1`): AWQ path uses CPU INT4 kernels, GPTQ path uses CPU fallback dequantization. MoE on CPU is not supported yet. |
 | `quark_int4fp8_moe` | No | Yes | AMD-only; online INT4-to-FP8 MoE quantization (CDNA3/CDNA4) |
 | `awq_marlin` | Yes | No | Marlin kernels are CUDA-only |
 | `gptq_marlin` | Yes | No | Marlin kernels are CUDA-only |
@@ -149,6 +149,19 @@ auto-round \
     --format "auto_round" \
     --output_dir ./tmp_autoround
 ```
+
+- Run AutoRound INT4 model on SGLang CPU engine (offline inference)
+
+```bash
+export SGLANG_USE_CPU_ENGINE=1
+python -m sglang.launch_server \
+    --model-path /path/to/your/autoround-int4-model \
+    --device cpu \
+    --disable-overlap-schedule \
+    --host 0.0.0.0
+```
+
+`--quantization` is not required for offline AutoRound checkpoints, because SGLang reads the quantization method from model config.
 
 - known issues
 

--- a/docs/platforms/cpu_server.md
+++ b/docs/platforms/cpu_server.md
@@ -183,7 +183,11 @@ Notes:
 
 1. For running W8A8 quantized models, please add the flag `--quantization w8a8_int8`.
 
-2. The flag `--tp 6` specifies that tensor parallelism will be applied using 6 ranks (TP6).
+2. For offline AutoRound INT4 checkpoints, do not add `--quantization`; SGLang auto-detects quantization from model config.
+   AutoRound `auto_round:auto_awq` uses CPU INT4 kernels, and `auto_round:auto_gptq` uses CPU fallback dequantization.
+   AutoRound MoE on CPU is not supported yet.
+
+3. The flag `--tp 6` specifies that tensor parallelism will be applied using 6 ranks (TP6).
     The number of TP specified is how many TP ranks will be used during the execution.
     On a CPU platform, a TP rank means a sub-NUMA cluster (SNC).
     Usually we can get the SNC information (How many available) from the Operating System with e.g. `lscpu` command.

--- a/python/sglang/srt/layers/quantization/auto_round.py
+++ b/python/sglang/srt/layers/quantization/auto_round.py
@@ -13,10 +13,190 @@ from sglang.srt.layers.quantization.utils import get_scalar_types
 
 ScalarType, scalar_types = get_scalar_types()
 
-from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.utils import is_npu
+from sglang.srt.layers.quantization.base_config import LinearMethodBase, QuantizationConfig
+from sglang.srt.utils import is_cpu, is_npu
 
+_is_cpu = is_cpu()
 _is_npu = is_npu()
+
+
+def _has_int4_cpu_kernels() -> bool:
+    sgl_kernel_ops = getattr(torch.ops, "sgl_kernel", None)
+    return (
+        sgl_kernel_ops is not None
+        and hasattr(sgl_kernel_ops, "int4_scaled_mm_cpu")
+        and hasattr(sgl_kernel_ops, "convert_weight_packed_scale_zp")
+    )
+
+
+class AutoRoundAWQCPULinearMethod(LinearMethodBase):
+    """CPU fallback for AutoRound AWQ using sgl-kernel int4 GEMM."""
+
+    def __init__(self, quant_config):
+        from sglang.srt.layers.quantization.awq import AWQLinearMethod
+
+        self.quant_config = quant_config
+        self._delegate = AWQLinearMethod(quant_config)
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        self._delegate.create_weights(
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if not _has_int4_cpu_kernels():
+            raise RuntimeError(
+                "AutoRound AWQ CPU requires int4 CPU kernels. "
+                "Please build sgl-kernel CPU backend first."
+            )
+
+        qweight, qzeros, scales = torch.ops.sgl_kernel.convert_weight_packed_scale_zp(
+            layer.qweight.data,
+            layer.qzeros.data,
+            layer.scales.data,
+        )
+        layer.qweight = torch.nn.Parameter(qweight, requires_grad=False)
+        layer.qzeros = torch.nn.Parameter(qzeros, requires_grad=False)
+        layer.scales = torch.nn.Parameter(scales, requires_grad=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        x_2d = x.reshape(-1, x.shape[-1])
+        output = torch.ops.sgl_kernel.int4_scaled_mm_cpu(
+            x_2d,
+            layer.qweight,
+            layer.qzeros,
+            layer.scales,
+            bias,
+        )
+        return output.reshape(x.shape[:-1] + (output.shape[-1],))
+
+
+class AutoRoundGPTQCPULinearMethod(LinearMethodBase):
+    """CPU fallback for AutoRound GPTQ by dequantizing weights on-the-fly."""
+
+    def __init__(self, quant_config):
+        from sglang.srt.layers.quantization.gptq import GPTQLinearMethod
+
+        self.quant_config = quant_config
+        self._delegate = GPTQLinearMethod(quant_config)
+        self.use_v2_format = quant_config.checkpoint_format == "gptq_v2"
+
+    @staticmethod
+    def _unpack_int32(
+        packed: torch.Tensor, num_bits: int, packed_dim: int
+    ) -> torch.Tensor:
+        pack_factor = 32 // num_bits
+        mask = (1 << num_bits) - 1
+        shifts = (
+            torch.arange(pack_factor, device=packed.device, dtype=torch.int32)
+            * num_bits
+        )
+        packed_i32 = packed.to(torch.int32)
+
+        if packed_dim == 0:
+            # [K // pack_factor, N] -> [K, N]
+            return (
+                (packed_i32.unsqueeze(1) >> shifts.view(1, -1, 1)) & mask
+            ).reshape(-1, packed.shape[1])
+        if packed_dim == 1:
+            # [G, N // pack_factor] -> [G, N]
+            return (
+                (packed_i32.unsqueeze(-1) >> shifts.view(1, 1, -1)) & mask
+            ).reshape(packed.shape[0], -1)
+        raise ValueError(f"Unsupported packed_dim={packed_dim}")
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        self._delegate.create_weights(
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Keep tensors in loaded order for CPU fallback dequantization.
+        layer.qzeros = torch.nn.Parameter(layer.qzeros.data, requires_grad=False)
+        layer.qweight = torch.nn.Parameter(layer.qweight.data, requires_grad=False)
+        layer.g_idx = torch.nn.Parameter(layer.g_idx.data, requires_grad=False)
+        layer.scales = torch.nn.Parameter(layer.scales.data, requires_grad=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        x_2d = x.reshape(-1, x.shape[-1])
+        num_bits = self.quant_config.weight_bits
+
+        qweight = self._unpack_int32(layer.qweight, num_bits=num_bits, packed_dim=0).to(
+            layer.scales.dtype
+        )
+        qzeros = self._unpack_int32(layer.qzeros, num_bits=num_bits, packed_dim=1).to(
+            layer.scales.dtype
+        )
+        if not self.use_v2_format:
+            qzeros = qzeros + 1
+
+        use_default_gidx = layer.g_idx.numel() == 0 or (
+            self.quant_config.group_size == -1 and torch.any(layer.g_idx < 0)
+        )
+        if use_default_gidx:
+            if self.quant_config.group_size == -1:
+                g_idx = torch.zeros(
+                    (qweight.shape[0],), dtype=torch.long, device=layer.scales.device
+                )
+            else:
+                g_idx = torch.arange(
+                    qweight.shape[0], dtype=torch.long, device=layer.scales.device
+                ) // self.quant_config.group_size
+        else:
+            g_idx = layer.g_idx.to(dtype=torch.long)
+
+        if g_idx.numel() != qweight.shape[0]:
+            raise ValueError(
+                "AutoRound GPTQ CPU fallback expects g_idx rows to match qweight rows, "
+                f"but got g_idx={g_idx.numel()} and qweight_rows={qweight.shape[0]}."
+            )
+
+        scale_zeros = qzeros * layer.scales
+        dequant_weight = qweight * layer.scales[g_idx] - scale_zeros[g_idx]
+        output = torch.matmul(x_2d, dequant_weight)
+        if bias is not None:
+            output.add_(bias)
+        return output.reshape(x.shape[:-1] + (dequant_weight.shape[-1],))
 
 
 class AutoRoundConfig(QuantizationConfig):
@@ -241,6 +421,22 @@ class AutoRoundConfig(QuantizationConfig):
             group_size,
             sym,
         )
+        if _is_cpu:
+            from sglang.srt.layers.quantization.awq import AWQConfig
+
+            if isinstance(layer, FusedMoE):
+                raise NotImplementedError(
+                    "AutoRound AWQ MoE on CPU is not supported yet."
+                )
+            quant_args = AWQConfig(
+                weight_bits=weight_bits,
+                group_size=group_size,
+                zero_point=not sym,
+            )
+            if isinstance(layer, (LinearBase, ParallelLMHead)):
+                return AutoRoundAWQCPULinearMethod(quant_args)
+            return None
+
         if backend == "auto" or "marlin" in backend:
             AWQ_TYPE_MAP = {
                 4: scalar_types.uint4,
@@ -331,6 +527,22 @@ class AutoRoundConfig(QuantizationConfig):
             group_size,
             sym,
         )
+        if _is_cpu:
+            quant_args = GPTQConfig(
+                weight_bits=weight_bits,
+                group_size=group_size,
+                lm_head_quantized=False,
+                desc_act=False,
+                dynamic={},
+            )
+            if isinstance(layer, FusedMoE):
+                raise NotImplementedError(
+                    "AutoRound GPTQ MoE on CPU is not supported yet."
+                )
+            if isinstance(layer, (LinearBase, ParallelLMHead)):
+                return AutoRoundGPTQCPULinearMethod(quant_args)
+            return None
+
         if _is_npu:
             quant_args = GPTQConfig(
                 weight_bits=weight_bits,
@@ -392,20 +604,17 @@ class AutoRoundConfig(QuantizationConfig):
 
         if isinstance(layer, FusedMoE):
             if use_marlin:
-                from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
+                return GPTQMarlinMoEMethod(quant_args_marlin)
+            from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 
-                config = {
-                    "quant_method": "gptq",
-                    "bits": weight_bits,
-                    "group_size": group_size,
-                    "sym": sym,
-                    "lm_head": False,
-                }
-                return MoeWNA16Config.from_config(config).get_quant_method(
-                    layer, prefix
-                )
-            return GPTQMarlinMoEMethod(quant_args_marlin)
-
+            config = {
+                "quant_method": "gptq",
+                "bits": weight_bits,
+                "group_size": group_size,
+                "sym": sym,
+                "lm_head": False,
+            }
+            return MoeWNA16Config.from_config(config).get_quant_method(layer, prefix)
         if isinstance(layer, (LinearBase, ParallelLMHead)):
             if use_marlin:
                 return GPTQMarlinLinearMethod(quant_args_marlin)
@@ -415,8 +624,8 @@ class AutoRoundConfig(QuantizationConfig):
         return None
 
     def get_quant_method(self, layer: torch.nn.Module, prefix: str):
-        # TODO enable CPU quant method later
         if "gptq" in self.packing_format or "gptq" in self.backend:
             return self.apply_gptq_quant_layer(layer, prefix)
         if "awq" in self.packing_format or "awq" in self.backend:
             return self.apply_awq_quant_layer(layer, prefix)
+        return None

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -370,6 +370,18 @@ def register_fake_ops():
         N = mat2.shape[0]
         return mat1.new_empty(M, N, dtype=out_dtype)
 
+    @torch.library.register_fake("sgl_kernel::int4_scaled_mm_cpu")
+    def _(
+        x,
+        w,
+        w_zeros,
+        w_scales,
+        bias,
+    ):
+        M = x.shape[0]
+        N = w_scales.shape[0] * w_scales.shape[-1]
+        return x.new_empty(M, N, dtype=x.dtype)
+
     @torch.library.register_fake("sgl_kernel::fp8_scaled_mm_cpu")
     def _(
         mat1,

--- a/python/sglang/test/test_auto_round_cpu.py
+++ b/python/sglang/test/test_auto_round_cpu.py
@@ -1,0 +1,173 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _prepare_imports():
+    repo_python = Path(__file__).resolve().parents[2]
+    sglang_root = repo_python / "sglang"
+
+    # Avoid importing sglang/__init__.py (which pulls frontend deps) in this UT.
+    pkg_map = {
+        "sglang": sglang_root,
+        "sglang.srt": sglang_root / "srt",
+        "sglang.srt.layers": sglang_root / "srt" / "layers",
+        "sglang.srt.layers.quantization": sglang_root / "srt" / "layers" / "quantization",
+    }
+    for name, path in pkg_map.items():
+        if name not in sys.modules:
+            mod = types.ModuleType(name)
+            mod.__path__ = [str(path)]
+            sys.modules[name] = mod
+
+    # Keep this UT lightweight by stubbing modules that otherwise pull heavy
+    # runtime dependencies through unrelated import chains.
+    utils_stub = types.ModuleType("sglang.srt.utils")
+    utils_stub.is_cpu = lambda: False
+    utils_stub.is_npu = lambda: False
+    sys.modules["sglang.srt.utils"] = utils_stub
+
+    quant_utils_stub = types.ModuleType("sglang.srt.layers.quantization.utils")
+
+    class _MockScalarTypes:
+        uint4 = "uint4"
+        uint8 = "uint8"
+        uint4b8 = "uint4b8"
+        uint8b128 = "uint8b128"
+
+    quant_utils_stub.get_scalar_types = lambda: (type("MockScalarType", (), {}), _MockScalarTypes())  # type: ignore[arg-type]
+    sys.modules["sglang.srt.layers.quantization.utils"] = quant_utils_stub
+
+    return importlib.import_module("sglang.srt.layers.quantization.auto_round")
+
+
+auto_round_mod = _prepare_imports()
+AutoRoundConfig = auto_round_mod.AutoRoundConfig
+AutoRoundAWQCPULinearMethod = auto_round_mod.AutoRoundAWQCPULinearMethod
+AutoRoundGPTQCPULinearMethod = auto_round_mod.AutoRoundGPTQCPULinearMethod
+
+
+def _pack_rows_dim0_int4(qweight_unpacked: torch.Tensor) -> torch.Tensor:
+    # [K, N] -> [K // 8, N], 8 x int4 packed into one int32 per row-group.
+    assert qweight_unpacked.dtype in (torch.int32, torch.int64, torch.uint8)
+    k, n = qweight_unpacked.shape
+    assert k % 8 == 0
+    out = torch.zeros((k // 8, n), dtype=torch.int32)
+    for i in range(8):
+        out |= (qweight_unpacked[i::8, :].to(torch.int32) & 0xF) << (4 * i)
+    return out
+
+
+def _pack_cols_dim1_int4(qzeros_unpacked: torch.Tensor) -> torch.Tensor:
+    # [G, N] -> [G, N // 8], 8 x int4 packed into one int32 per col-group.
+    assert qzeros_unpacked.dtype in (torch.int32, torch.int64, torch.uint8)
+    g, n = qzeros_unpacked.shape
+    assert n % 8 == 0
+    out = torch.zeros((g, n // 8), dtype=torch.int32)
+    for i in range(8):
+        out |= (qzeros_unpacked[:, i::8].to(torch.int32) & 0xF) << (4 * i)
+    return out
+
+
+def test_auto_round_get_quant_method_routes_awq(monkeypatch):
+    cfg = AutoRoundConfig(
+        weight_bits=4,
+        group_size=128,
+        sym=True,
+        packing_format="auto_round:auto_awq",
+        backend="auto",
+    )
+    sentinel = object()
+    monkeypatch.setattr(
+        cfg,
+        "apply_awq_quant_layer",
+        lambda layer, prefix, backend="auto": sentinel,
+    )
+    assert cfg.get_quant_method(object(), "model.layers.0.mlp.down_proj") is sentinel
+
+
+def test_auto_round_get_quant_method_routes_gptq(monkeypatch):
+    cfg = AutoRoundConfig(
+        weight_bits=4,
+        group_size=128,
+        sym=True,
+        packing_format="auto_round:auto_gptq",
+        backend="auto",
+    )
+    sentinel = object()
+    monkeypatch.setattr(
+        cfg,
+        "apply_gptq_quant_layer",
+        lambda layer, prefix, backend="auto": sentinel,
+    )
+    assert cfg.get_quant_method(object(), "model.layers.0.mlp.down_proj") is sentinel
+
+
+def test_auto_round_gptq_cpu_fallback_matches_reference():
+    method = AutoRoundGPTQCPULinearMethod.__new__(AutoRoundGPTQCPULinearMethod)
+    method.quant_config = types.SimpleNamespace(weight_bits=4, group_size=2)
+    method.use_v2_format = False  # non-v2: qzeros += 1
+
+    # K=8, N=8 so both packed dims align with int4 pack factor (8).
+    k, n, group_size = 8, 8, 2
+    num_groups = k // group_size
+
+    # int4 range [0, 15]
+    qweight_unpacked = (torch.arange(k * n).reshape(k, n) % 16).to(torch.int32)
+    qzeros_unpacked = (torch.arange(num_groups * n).reshape(num_groups, n) % 16).to(
+        torch.int32
+    )
+    scales = torch.linspace(0.1, 1.0, num_groups * n, dtype=torch.float32).reshape(
+        num_groups, n
+    )
+
+    layer = types.SimpleNamespace()
+    layer.qweight = torch.nn.Parameter(
+        _pack_rows_dim0_int4(qweight_unpacked), requires_grad=False
+    )
+    layer.qzeros = torch.nn.Parameter(
+        _pack_cols_dim1_int4(qzeros_unpacked), requires_grad=False
+    )
+    layer.g_idx = torch.nn.Parameter(
+        torch.empty((0,), dtype=torch.int32), requires_grad=False
+    )
+    layer.scales = torch.nn.Parameter(scales, requires_grad=False)
+
+    x = torch.linspace(-1.0, 1.0, 3 * k, dtype=torch.float32).reshape(3, k)
+    bias = torch.linspace(-0.5, 0.5, n, dtype=torch.float32)
+
+    out = method.apply(layer, x, bias=bias)
+
+    g_idx = torch.arange(k, dtype=torch.long) // group_size
+    # non-v2 GPTQ qzeros has +1 offset in dequant
+    qzeros_effective = qzeros_unpacked.to(torch.float32) + 1.0
+    scale_zeros = qzeros_effective * scales
+    dequant_weight = (
+        qweight_unpacked.to(torch.float32) * scales[g_idx] - scale_zeros[g_idx]
+    )
+    ref = x @ dequant_weight + bias
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_auto_round_awq_cpu_requires_int4_kernels(monkeypatch):
+    method = AutoRoundAWQCPULinearMethod.__new__(AutoRoundAWQCPULinearMethod)
+
+    layer = types.SimpleNamespace()
+    layer.qweight = torch.nn.Parameter(
+        torch.zeros((8, 1), dtype=torch.int32), requires_grad=False
+    )
+    layer.qzeros = torch.nn.Parameter(
+        torch.zeros((1, 1), dtype=torch.int32), requires_grad=False
+    )
+    layer.scales = torch.nn.Parameter(
+        torch.ones((1, 8), dtype=torch.float16), requires_grad=False
+    )
+
+    monkeypatch.setattr(auto_round_mod, "_has_int4_cpu_kernels", lambda: False)
+    with pytest.raises(RuntimeError, match="int4 CPU kernels"):
+        method.process_weights_after_loading(layer)


### PR DESCRIPTION
## Summary
This PR implements issue #20914 by adding CPU offline inference support for AutoRound INT4 models.

### What changed
- Add AutoRound CPU AWQ INT4 path in `auto_round.py`:
  - New `AutoRoundAWQCPULinearMethod`
  - Uses `sgl_kernel::convert_weight_packed_scale_zp` for post-load repacking
  - Uses `sgl_kernel::int4_scaled_mm_cpu` for inference
- Add AutoRound CPU GPTQ fallback path:
  - New `AutoRoundGPTQCPULinearMethod`
  - Implements CPU dequantization + matmul fallback (including non-v2 `qzeros + 1` behavior)
- Add CPU graph fake op registration:
  - `sgl_kernel::int4_scaled_mm_cpu` in `cpu_graph_runner.py`
- Fix AutoRound GPTQ MoE branch logic in `auto_round.py`
  - Correct marlin/non-marlin branching to avoid wrong variable usage
- Add CPU unit tests:
  - `python/sglang/test/test_auto_round_cpu.py`
  - Covers routing behavior, GPTQ CPU fallback correctness, and AWQ missing-kernel error behavior
- Update docs:
  - `docs/advanced_features/quantization.md`
  - `docs/platforms/cpu_server.md`

## Validation
### Local checks
- `python3 -m py_compile python/sglang/srt/layers/quantization/auto_round.py python/sglang/srt/model_executor/cpu_graph_runner.py python/sglang/test/test_auto_round_cpu.py`

### Unit tests
- `PYTHONPATH=python .venv/bin/pytest -q python/sglang/test/test_auto_round_cpu.py`
- Result: `4 passed`

## Notes
- AutoRound MoE on CPU is still not supported and now reports explicit `NotImplementedError`.
- AutoRound GPTQ CPU path is a functional fallback; AWQ CPU path uses INT4 CPU kernels.

Fixes #20914
