### PR TITLE
[Benchmark] Add option to record power usage in bench_serving with `--record-power`

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -38,7 +38,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets import DatasetRow, get_dataset
 from sglang.benchmark.datasets.mooncake import get_mooncake_request_over_time
-from sglang.benchmark.power import get_power_recorder
+from sglang.benchmark.power import get_power_recorder, print_power_summary
 from sglang.benchmark.utils import (
     get_tokenizer,
     parse_custom_headers,
@@ -1548,84 +1548,11 @@ async def benchmark(
         print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
         print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
         print("{:<40} {:<10.2f}".format("Max ITL (ms):", metrics.max_itl_ms))
+
     if power_stats is not None:
-        print("{s:{c}^{n}}".format(s="GPU Power (all devices)", n=50, c="-"))
-        print(
-            "{:<40} {:<10.2f}".format(
-                "P25 Total Power (total W):", power_stats["p25_power_w"]
-            )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                "Mean Total Power (total W):", power_stats["mean_power_w"]
-            )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                "Median Total Power (total W):", power_stats["median_power_w"]
-            )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                "Median Power (per-GPU W):",
-                power_stats["median_power_per_accelerator_w"],
-            )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                "P75 Total Power (total W):", power_stats["p75_power_w"]
-            )
-        )
-        print("{:<40} {:<10}".format("Power samples:", power_stats["num_samples"]))
-
-        print("{s:{c}^{n}}".format(s="CPU Power (all sockets)", n=50, c="-"))
-
-        def _fmt(val) -> str:
-            return f"{val:<10.2f}" if val is not None else "None"
-
-        print(
-            "{:<40} {}".format(
-                "CPU P25 Total Power (W):", _fmt(power_stats["cpu_p25_power_w"])
-            )
-        )
-        print(
-            "{:<40} {}".format(
-                "CPU Mean Total Power (W):", _fmt(power_stats["cpu_mean_power_w"])
-            )
-        )
-        print(
-            "{:<40} {}".format(
-                "CPU Median Total Power (W):", _fmt(power_stats["cpu_median_power_w"])
-            )
-        )
-        print(
-            "{:<40} {}".format(
-                "CPU Median Power (per-socket W):",
-                _fmt(power_stats["cpu_median_power_per_socket_w"]),
-            )
-        )
-        print(
-            "{:<40} {}".format(
-                "CPU P75 Total Power (W):", _fmt(power_stats["cpu_p75_power_w"])
-            )
-        )
-        print(
-            "{:<40} {}".format(
-                "CPU Power samples:",
-                (
-                    power_stats["cpu_num_samples"]
-                    if power_stats["cpu_num_samples"] is not None
-                    else "None"
-                ),
-            )
-        )
-
         median_power = power_stats["median_power_w"]
-
-        description = "GPU"
         if power_stats["cpu_median_power_w"] is not None:
             median_power += power_stats["cpu_median_power_w"]
-            description = "CPU + GPU"
 
         input_toks_per_watt = metrics.total_input / median_power
         output_toks_per_watt = metrics.total_output / median_power
@@ -1634,25 +1561,11 @@ async def benchmark(
         ) / median_power
 
         power_stats["input_toks_per_watt"] = input_toks_per_watt
-        power_stats["input_toks_per_watt"] = output_toks_per_watt
-        power_stats["input_toks_per_watt"] = total_toks_per_watt
+        power_stats["output_toks_per_watt"] = output_toks_per_watt
+        power_stats["total_toks_per_watt"] = total_toks_per_watt
 
-        print("{s:{c}^{n}}".format(s="Power summary", n=50, c="-"))
-        print(
-            "{:<40} {:<10.2f}".format(
-                f"Input tokens/({description} median W):", input_toks_per_watt
-            )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                f"Output tokens/({description} median W):", output_toks_per_watt
-            )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                f"Total tokens/({description} median W):", total_toks_per_watt
-            )
-        )
+        print_power_summary(power_stats)
+
     print("=" * 50)
 
     resp = requests.get(base_url + "/get_server_info", headers=get_auth_headers())

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2278,7 +2278,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--record-power",
         action="store_true",
-        help="Record GPU power usage during benchmark (excluding warmup). Available only on AMD Instinct GPUs at the moment."
+        help="Record GPU power usage during benchmark (excluding warmup). The environment variable `CUDA_VISIBLE_DEVICES` must be set to record the power from the used devices only (e.g. for TP=4 on an 8 devices node)."
         "Samples every 5s and reports P25/mean/median/P75 stats.",
     )
     parser.add_argument(

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -38,6 +38,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets import DatasetRow, get_dataset
 from sglang.benchmark.datasets.mooncake import get_mooncake_request_over_time
+from sglang.benchmark.power import get_power_recorder
 from sglang.benchmark.utils import (
     get_tokenizer,
     parse_custom_headers,
@@ -1183,6 +1184,7 @@ async def benchmark(
     mooncake_num_rounds=1,
     profile_prefill_url: Optional[List[str]] = None,
     profile_decode_url: Optional[List[str]] = None,
+    record_power: bool = False,
 ):
     if backend in ASYNC_REQUEST_FUNCS:
         request_func = ASYNC_REQUEST_FUNCS[backend]
@@ -1309,6 +1311,11 @@ async def benchmark(
             if profile_output.success:
                 print("Profiler started")
 
+    # Start power recording (after warmup)
+    power_recorder = get_power_recorder() if record_power else None
+    if power_recorder is not None:
+        power_recorder.start()
+
     # Run all requests
     benchmark_start_time = time.perf_counter()
     tasks: List[asyncio.Task] = []
@@ -1379,6 +1386,12 @@ async def benchmark(
     outputs: List[RequestFuncOutput] = await asyncio.gather(*tasks)
     if is_multi_turn:
         outputs = [x for output in outputs for x in output]
+
+    # Stop power recording
+    power_stats = None
+    if power_recorder is not None:
+        power_recorder.stop()
+        power_stats = power_recorder.get_stats()
 
     # Stop profiler (only if profile_steps was not provided, as it auto-stops)
     if profile and not (
@@ -1535,6 +1548,111 @@ async def benchmark(
         print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
         print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
         print("{:<40} {:<10.2f}".format("Max ITL (ms):", metrics.max_itl_ms))
+    if power_stats is not None:
+        print("{s:{c}^{n}}".format(s="GPU Power (all devices)", n=50, c="-"))
+        print(
+            "{:<40} {:<10.2f}".format(
+                "P25 Total Power (total W):", power_stats["p25_power_w"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Mean Total Power (total W):", power_stats["mean_power_w"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Median Total Power (total W):", power_stats["median_power_w"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Median Power (per-GPU W):",
+                power_stats["median_power_per_accelerator_w"],
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "P75 Total Power (total W):", power_stats["p75_power_w"]
+            )
+        )
+        print("{:<40} {:<10}".format("Power samples:", power_stats["num_samples"]))
+
+        print("{s:{c}^{n}}".format(s="CPU Power (all sockets)", n=50, c="-"))
+
+        def _fmt(val) -> str:
+            return f"{val:<10.2f}" if val is not None else "None"
+
+        print(
+            "{:<40} {}".format(
+                "CPU P25 Total Power (W):", _fmt(power_stats["cpu_p25_power_w"])
+            )
+        )
+        print(
+            "{:<40} {}".format(
+                "CPU Mean Total Power (W):", _fmt(power_stats["cpu_mean_power_w"])
+            )
+        )
+        print(
+            "{:<40} {}".format(
+                "CPU Median Total Power (W):", _fmt(power_stats["cpu_median_power_w"])
+            )
+        )
+        print(
+            "{:<40} {}".format(
+                "CPU Median Power (per-socket W):",
+                _fmt(power_stats["cpu_median_power_per_socket_w"]),
+            )
+        )
+        print(
+            "{:<40} {}".format(
+                "CPU P75 Total Power (W):", _fmt(power_stats["cpu_p75_power_w"])
+            )
+        )
+        print(
+            "{:<40} {}".format(
+                "CPU Power samples:",
+                (
+                    power_stats["cpu_num_samples"]
+                    if power_stats["cpu_num_samples"] is not None
+                    else "None"
+                ),
+            )
+        )
+
+        median_power = power_stats["median_power_w"]
+
+        description = "GPU"
+        if power_stats["cpu_median_power_w"] is not None:
+            median_power += power_stats["cpu_median_power_w"]
+            description = "CPU + GPU"
+
+        input_toks_per_watt = metrics.total_input / median_power
+        output_toks_per_watt = metrics.total_output / median_power
+        total_toks_per_watt = (
+            metrics.total_input + metrics.total_output
+        ) / median_power
+
+        power_stats["input_toks_per_watt"] = input_toks_per_watt
+        power_stats["input_toks_per_watt"] = output_toks_per_watt
+        power_stats["input_toks_per_watt"] = total_toks_per_watt
+
+        print("{s:{c}^{n}}".format(s="Power summary", n=50, c="-"))
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Input tokens/({description} median W):", input_toks_per_watt
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Output tokens/({description} median W):", output_toks_per_watt
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Total tokens/({description} median W):", total_toks_per_watt
+            )
+        )
     print("=" * 50)
 
     resp = requests.get(base_url + "/get_server_info", headers=get_auth_headers())
@@ -1593,6 +1711,8 @@ async def benchmark(
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
             "max_concurrent_requests": metrics.max_concurrent_requests,
         }
+        if power_stats is not None:
+            result.update(power_stats)
     else:
         print(f"Error running benchmark for request rate: {request_rate}")
         print("-" * 30)
@@ -1883,6 +2003,7 @@ def run_benchmark(args_: argparse.Namespace):
             mooncake_num_rounds=args.mooncake_num_rounds,
             profile_prefill_url=getattr(args, "profile_prefill_url", None),
             profile_decode_url=getattr(args, "profile_decode_url", None),
+            record_power=args.record_power,
         )
     )
 
@@ -2240,6 +2361,12 @@ if __name__ == "__main__":
         type=int,
         default=1,
         help="Number of warmup requests to run before the benchmark",
+    )
+    parser.add_argument(
+        "--record-power",
+        action="store_true",
+        help="Record GPU power usage during benchmark (excluding warmup). Available only on AMD Instinct GPUs at the moment."
+        "Samples every 5s and reports P25/mean/median/P75 stats.",
     )
     parser.add_argument(
         "--tokenize-prompt",

--- a/python/sglang/benchmark/power.py
+++ b/python/sglang/benchmark/power.py
@@ -11,9 +11,11 @@ import torch
 if torch.version.hip:
     try:
         import amdsmi
+
         amdsmi.amdsmi_init(amdsmi.AmdSmiInitFlags.INIT_ALL_PROCESSORS)
     except Exception as e:
         amdsmi.amdsmi_init(amdsmi.AmdSmiInitFlags.INIT_AMD_GPUS)
+
 
 class PowerRecorderMixin(ABC):
     """Abstract base class for power recorders."""
@@ -109,6 +111,7 @@ class PowerRecorderMixin(ABC):
             )
         return stats
 
+
 class PowerRecorderAMD(PowerRecorderMixin):
     """Records GPU and CPU power usage in a background thread using amdsmi."""
 
@@ -117,10 +120,11 @@ class PowerRecorderAMD(PowerRecorderMixin):
         self._accelerator_handles = amdsmi.amdsmi_get_processor_handles()
         # Will be an empty list if amdsmi CPU dependencies are not met.
         self._cpu_handles = amdsmi.amdsmi_get_cpusocket_handles()
-        
-        if len(self._cpu_handles) == 0:
-            print("WARNING: could not find CPU handles for power recording, amdsmi dependencies are likely not met. Recording GPU power only.")
 
+        if len(self._cpu_handles) == 0:
+            print(
+                "WARNING: could not find CPU handles for power recording, amdsmi dependencies are likely not met. Recording GPU power only."
+            )
 
     def _record_accelerator(self) -> float:
         """Sample total GPU power across all devices. Returns watts."""
@@ -141,6 +145,102 @@ class PowerRecorderAMD(PowerRecorderMixin):
         return total_power_mw / 1000.0
 
 
+def print_power_summary(power_stats: dict) -> None:
+    def _fmt(val) -> str:
+        return f"{val:<10.2f}" if val is not None else "None"
+
+    print("{s:{c}^{n}}".format(s="GPU Power (all devices)", n=50, c="-"))
+    print(
+        "{:<40} {:<10.2f}".format(
+            "P25 Total Power (total W):", power_stats["p25_power_w"]
+        )
+    )
+    print(
+        "{:<40} {:<10.2f}".format(
+            "Mean Total Power (total W):", power_stats["mean_power_w"]
+        )
+    )
+    print(
+        "{:<40} {:<10.2f}".format(
+            "Median Total Power (total W):", power_stats["median_power_w"]
+        )
+    )
+    print(
+        "{:<40} {:<10.2f}".format(
+            "Median Power (per-GPU W):",
+            power_stats["median_power_per_accelerator_w"],
+        )
+    )
+    print(
+        "{:<40} {:<10.2f}".format(
+            "P75 Total Power (total W):", power_stats["p75_power_w"]
+        )
+    )
+    print("{:<40} {:<10}".format("Power samples:", power_stats["num_samples"]))
+
+    print("{s:{c}^{n}}".format(s="CPU Power (all sockets)", n=50, c="-"))
+    print(
+        "{:<40} {}".format(
+            "CPU P25 Total Power (W):", _fmt(power_stats["cpu_p25_power_w"])
+        )
+    )
+    print(
+        "{:<40} {}".format(
+            "CPU Mean Total Power (W):", _fmt(power_stats["cpu_mean_power_w"])
+        )
+    )
+    print(
+        "{:<40} {}".format(
+            "CPU Median Total Power (W):", _fmt(power_stats["cpu_median_power_w"])
+        )
+    )
+    print(
+        "{:<40} {}".format(
+            "CPU Median Power (per-socket W):",
+            _fmt(power_stats["cpu_median_power_per_socket_w"]),
+        )
+    )
+    print(
+        "{:<40} {}".format(
+            "CPU P75 Total Power (W):", _fmt(power_stats["cpu_p75_power_w"])
+        )
+    )
+    print(
+        "{:<40} {}".format(
+            "CPU Power samples:",
+            (
+                power_stats["cpu_num_samples"]
+                if power_stats["cpu_num_samples"] is not None
+                else "None"
+            ),
+        )
+    )
+
+    description = "GPU"
+    if power_stats["cpu_median_power_w"] is not None:
+        description = "CPU + GPU"
+
+    print("{s:{c}^{n}}".format(s="Power summary", n=50, c="-"))
+    print(
+        "{:<40} {:<10.2f}".format(
+            f"Input tokens/({description} median W):",
+            power_stats["input_toks_per_watt"],
+        )
+    )
+    print(
+        "{:<40} {:<10.2f}".format(
+            f"Output tokens/({description} median W):",
+            power_stats["output_toks_per_watt"],
+        )
+    )
+    print(
+        "{:<40} {:<10.2f}".format(
+            f"Total tokens/({description} median W):",
+            power_stats["total_toks_per_watt"],
+        )
+    )
+
+
 def get_power_recorder(interval: float = 5.0) -> PowerRecorderMixin:
     """Return the appropriate PowerRecorder for the current hardware."""
     from sglang.srt.utils import is_hip
@@ -150,4 +250,3 @@ def get_power_recorder(interval: float = 5.0) -> PowerRecorderMixin:
     raise NotImplementedError(
         "Power recording is only implemented on AMD GPUs (is_hip()=False)."
     )
-

--- a/python/sglang/benchmark/power.py
+++ b/python/sglang/benchmark/power.py
@@ -1,5 +1,6 @@
 """Power recording utilities for benchmarking."""
 
+import os
 import threading
 from abc import ABC, abstractmethod
 from typing import List, Optional
@@ -117,7 +118,45 @@ class PowerRecorderAMD(PowerRecorderMixin):
 
     def init_accelerator(self) -> None:
         self.amdsmi = amdsmi
-        self._accelerator_handles = amdsmi.amdsmi_get_processor_handles()
+        all_handles = amdsmi.amdsmi_get_processor_handles()
+
+        self.all_handles = all_handles
+
+        # CUDA_VISIBLE_DEVICES order is not the same as amdsmi handles order, even when setting `CUDA_DEVICE_ORDER=PCI_BUS_ID`, thus we rely on the bus IDs to monitor the correct devices.
+        cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if cuda_visible is None:
+            raise ValueError(
+                "The power measurement utility requires the environment variable `CUDA_VISIBLE_DEVICES` to be set "
+                "in the benchmark similarly to the sglang server."
+            )
+        assert torch.cuda.device_count() > 0
+
+        bus_id_to_handle = {}
+        for handle in all_handles:
+            # amdsmi_get_gpu_device_bdf returns e.g. "0000:e5:00.0"; the bus field is hex.
+            bdf = amdsmi.amdsmi_get_gpu_device_bdf(handle)
+            bus_id = int(bdf.split(":")[1], 16)
+            bus_id_to_handle[bus_id] = handle
+
+        # For each visible CUDA device, look up its PCI bus ID via torch, and match it to amdsmi correct handles.
+        self._accelerator_handles = []
+
+        bus_ids = []
+        for idx in range(torch.cuda.device_count()):
+            pci_bus_id = torch.cuda.get_device_properties(idx).pci_bus_id
+            bus_ids.append(pci_bus_id)
+            if pci_bus_id not in bus_id_to_handle:
+                raise ValueError(
+                    f"Could not find amdsmi handle for CUDA device {idx} (PCI bus ID {pci_bus_id}). "
+                    f"Available bus IDs: {list(bus_id_to_handle.keys())}"
+                )
+            self._accelerator_handles.append(bus_id_to_handle[pci_bus_id])
+
+        print(
+            f"Power recorder: monitoring {len(self._accelerator_handles)} GPU(s) "
+            f"(CUDA_VISIBLE_DEVICES={cuda_visible!r}, bus IDs: {bus_ids})"
+        )
+
         # Will be an empty list if amdsmi CPU dependencies are not met.
         self._cpu_handles = amdsmi.amdsmi_get_cpusocket_handles()
 

--- a/python/sglang/benchmark/power.py
+++ b/python/sglang/benchmark/power.py
@@ -1,0 +1,153 @@
+"""Power recording utilities for benchmarking."""
+
+import threading
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+import numpy as np
+import torch
+
+# NOTE: If using `from sglang.srt.utils import is_hip`, we later always get empty cpu socket handles.
+if torch.version.hip:
+    try:
+        import amdsmi
+        amdsmi.amdsmi_init(amdsmi.AmdSmiInitFlags.INIT_ALL_PROCESSORS)
+    except Exception as e:
+        amdsmi.amdsmi_init(amdsmi.AmdSmiInitFlags.INIT_AMD_GPUS)
+
+class PowerRecorderMixin(ABC):
+    """Abstract base class for power recorders."""
+
+    def __init__(self, interval: float = 5.0):
+        self.interval = interval
+        self.accelerator_samples: List[float] = []
+        self.cpu_samples: List[float] = []
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._accelerator_handles = None
+        self._cpu_handles = None
+        self.init_accelerator()
+
+    @abstractmethod
+    def init_accelerator(self) -> None:
+        """Initialize accelerator handles into self._accelerator_handles."""
+
+    @abstractmethod
+    def _record_accelerator(self) -> float:
+        """Sample and return total accelerator power in watts."""
+
+    @abstractmethod
+    def _record_cpu(self) -> float:
+        """Sample and return total CPU power in watts."""
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self.accelerator_samples = []
+        self.cpu_samples = []
+        self._thread = threading.Thread(target=self._record_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._thread is None:
+            return
+        self._stop_event.set()
+        self._thread.join()
+        self._thread = None
+
+    def _record_loop(self) -> None:
+        while not self._stop_event.is_set():
+            if self._accelerator_handles:
+                self.accelerator_samples.append(self._record_accelerator())
+            if self._cpu_handles:
+                self.cpu_samples.append(self._record_cpu())
+            self._stop_event.wait(timeout=self.interval)
+
+    def get_stats(self) -> dict:
+        """Return a dict of power statistics collected since start()."""
+        assert self._accelerator_handles is not None
+        assert self._cpu_handles is not None
+
+        if not self.accelerator_samples:
+            raise RuntimeError("No accelerator power samples collected.")
+
+        arr = np.array(self.accelerator_samples)
+        num_devices = len(self._accelerator_handles)
+        stats = {
+            "p25_power_w": float(np.percentile(arr, 25)),
+            "mean_power_w": float(np.mean(arr)),
+            "median_power_w": float(np.median(arr)),
+            "median_power_per_accelerator_w": float(np.median(arr) / num_devices),
+            "p75_power_w": float(np.percentile(arr, 75)),
+            "num_samples": len(self.accelerator_samples),
+        }
+
+        if self.cpu_samples and len(self._cpu_handles) > 0:
+            cpu_arr = np.array(self.cpu_samples)
+            num_sockets = len(self._cpu_handles)
+            stats.update(
+                {
+                    "cpu_p25_power_w": float(np.percentile(cpu_arr, 25)),
+                    "cpu_mean_power_w": float(np.mean(cpu_arr)),
+                    "cpu_median_power_w": float(np.median(cpu_arr)),
+                    "cpu_median_power_per_socket_w": float(
+                        np.median(cpu_arr) / num_sockets
+                    ),
+                    "cpu_p75_power_w": float(np.percentile(cpu_arr, 75)),
+                    "cpu_num_samples": len(self.cpu_samples),
+                }
+            )
+        else:
+            stats.update(
+                {
+                    "cpu_p25_power_w": None,
+                    "cpu_mean_power_w": None,
+                    "cpu_median_power_w": None,
+                    "cpu_median_power_per_socket_w": None,
+                    "cpu_p75_power_w": None,
+                    "cpu_num_samples": None,
+                }
+            )
+        return stats
+
+class PowerRecorderAMD(PowerRecorderMixin):
+    """Records GPU and CPU power usage in a background thread using amdsmi."""
+
+    def init_accelerator(self) -> None:
+        self.amdsmi = amdsmi
+        self._accelerator_handles = amdsmi.amdsmi_get_processor_handles()
+        # Will be an empty list if amdsmi CPU dependencies are not met.
+        self._cpu_handles = amdsmi.amdsmi_get_cpusocket_handles()
+        
+        if len(self._cpu_handles) == 0:
+            print("WARNING: could not find CPU handles for power recording, amdsmi dependencies are likely not met. Recording GPU power only.")
+
+
+    def _record_accelerator(self) -> float:
+        """Sample total GPU power across all devices. Returns watts."""
+        total_power = 0.0
+        for handle in self._accelerator_handles:
+            power_info = self.amdsmi.amdsmi_get_power_info(handle)
+            total_power += power_info["socket_power"]
+        return total_power
+
+    def _record_cpu(self) -> float:
+        """Sample total CPU socket power across all sockets. Returns watts."""
+        total_power_mw = 0.0
+        for handle in self._cpu_handles:
+            # amdsmi_get_cpu_socket_power returns a string like "121650 mW"
+            power_str = self.amdsmi.amdsmi_get_cpu_socket_power(handle)
+            mw_value = float(power_str.split()[0])
+            total_power_mw += mw_value
+        return total_power_mw / 1000.0
+
+
+def get_power_recorder(interval: float = 5.0) -> PowerRecorderMixin:
+    """Return the appropriate PowerRecorder for the current hardware."""
+    from sglang.srt.utils import is_hip
+
+    if is_hip():
+        return PowerRecorderAMD(interval=interval)
+    raise NotImplementedError(
+        "Power recording is only implemented on AMD GPUs (is_hip()=False)."
+    )
+


### PR DESCRIPTION
This PR adds the ability to record CPU and GPU power usage in `sglang.bench_serving`, using the option `--record-power`.

At the moment, only AMD GPUs/CPUs are supported, but support for other hardware could be added later.

For AMD devices, we rely on `amdsmi`'s `amdsmi_get_power_info` and `amdsmi_get_cpu_socket_power` for power recording.

Example result:
```
-------------GPU Power (all devices)--------------
P25 Total Power (total W):               2108.75
Mean Total Power (total W):              2236.50
Median Total Power (total W):            2236.50
Median Power (per-GPU W):                279.56
P75 Total Power (total W):               2364.25
Power samples:                           2
-------------CPU Power (all sockets)--------------
CPU P25 Total Power (W):                 251.86
CPU Mean Total Power (W):                254.40
CPU Median Total Power (W):              254.40
CPU Median Power (per-socket W):         127.20
CPU P75 Total Power (W):                 256.93
CPU Power samples:                       2
------------------Power summary-------------------
Input tokens/(CPU + GPU median W):       89.56
Output tokens/(CPU + GPU median W):      13.70
Total tokens/(CPU + GPU median W):       103.25
```