### PR TITLE
fix: wrap _import_static_state in inference_mode to fix resume on Blackwell

### DIFF
--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -220,6 +220,7 @@ def _export_static_state(model):
 
 
 def _import_static_state(model, static_params):
-    self_named_buffers = dict(model.named_buffers())
-    for name, tensor in static_params["buffers"]:
-        self_named_buffers[name][...] = tensor
+    with torch.inference_mode():
+        self_named_buffers = dict(model.named_buffers())
+        for name, tensor in static_params["buffers"]:
+            self_named_buffers[name][...] = tensor


### PR DESCRIPTION
## Summary
- Wrap inplace buffer writes in `_import_static_state` with `torch.inference_mode()` to fix `resume_memory_occupation` crash on Blackwell GPUs

## Problem
On Blackwell (sm100), the warmup forward pass runs under `torch.inference_mode()`, which causes `RotaryEmbedding.cos_sin_cache` to be replaced with an inference tensor via a `.to()` dtype conversion. When `resume_memory_occupation` later calls `_import_static_state`, the inplace write to this buffer fails:

```
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.
```

## Fix
Wrap the body of `_import_static_state` in `torch.inference_mode()`.

## Test plan
- Tested sleep/wake cycle on B200 with Qwen3.5-4B — inference works correctly after resume + `update_weights_from_disk`