### PR TITLE
[HiCache] Fix cudaMemcpyBatchAsync segfault with Mooncake host memory allocator

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -61,6 +61,8 @@ def synchronized(func):
 
 
 class HostTensorAllocator(abc.ABC):
+    supports_cuda_batch_memcpy = True
+
     def __init__(self):
         """Initialize the HostTensorAllocator."""
         self.dtype = None
@@ -451,6 +453,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                     dst_indices=device_indices,
                     layer_id=layer_id,
                     page_size=self.page_size,
+                    use_batch_memcpy=self.allocator.supports_cuda_batch_memcpy,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -545,6 +548,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                     src_indices=device_indices,
                     dst_indices=host_indices,
                     page_size=self.page_size,
+                    use_batch_memcpy=self.allocator.supports_cuda_batch_memcpy,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -892,6 +896,7 @@ class MLATokenToKVPoolHost(HostKVCache):
                     dst_indices=device_indices,
                     layer_id=layer_id,
                     page_size=self.page_size,
+                    use_batch_memcpy=self.allocator.supports_cuda_batch_memcpy,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -957,6 +962,7 @@ class MLATokenToKVPoolHost(HostKVCache):
                     src_indices=device_indices,
                     dst_indices=host_indices,
                     page_size=self.page_size,
+                    use_batch_memcpy=self.allocator.supports_cuda_batch_memcpy,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -1226,6 +1232,7 @@ class NSATokenToKVPoolHost(MLATokenToKVPoolHost):
                     dst_indices=device_page_indices,
                     layer_id=layer_id,
                     page_size=1,
+                    use_batch_memcpy=self.allocator.supports_cuda_batch_memcpy,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
@@ -1277,6 +1284,7 @@ class NSATokenToKVPoolHost(MLATokenToKVPoolHost):
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
                     page_size=1,
+                    use_batch_memcpy=self.allocator.supports_cuda_batch_memcpy,
                 )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 class MooncakeHostTensorAllocator(HostTensorAllocator):
+    supports_cuda_batch_memcpy = False
+
     def __init__(self):
         super().__init__()
         from mooncake.store import MooncakeHostMemAllocator

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -336,11 +336,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("transfer_kv_direct", torch::kCUDA, &transfer_kv_direct);
   m.def(
       "transfer_kv_per_layer_direct_pf_lf(Tensor[] src_ptrs, Tensor[] dst_ptrs, Tensor src_indices, "
-      "Tensor dst_indices, int layer_id, int page_size)->() ");
+      "Tensor dst_indices, int layer_id, int page_size, bool use_batch_memcpy=True) -> ()");
   m.impl("transfer_kv_per_layer_direct_pf_lf", torch::kCUDA, &transfer_kv_per_layer_direct_pf_lf);
   m.def(
       "transfer_kv_all_layer_direct_lf_pf(Tensor[] src_ptrs, Tensor[] dst_ptrs, Tensor src_indices, "
-      "Tensor dst_indices, int page_size) ->() ");
+      "Tensor dst_indices, int page_size, bool use_batch_memcpy=True) -> ()");
   m.impl("transfer_kv_all_layer_direct_lf_pf", torch::kCUDA, &transfer_kv_all_layer_direct_lf_pf);
 
   /*

--- a/sgl-kernel/csrc/common_extension_rocm.cc
+++ b/sgl-kernel/csrc/common_extension_rocm.cc
@@ -188,11 +188,11 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.impl("transfer_kv_direct", torch::kCUDA, &transfer_kv_direct);
   m.def(
       "transfer_kv_per_layer_direct_pf_lf(Tensor[] src_ptrs, Tensor[] dst_ptrs, Tensor src_indices, "
-      "Tensor dst_indices, int layer_id, int page_size)->() ");
+      "Tensor dst_indices, int layer_id, int page_size, bool use_batch_memcpy=True) -> ()");
   m.impl("transfer_kv_per_layer_direct_pf_lf", torch::kCUDA, &transfer_kv_per_layer_direct_pf_lf);
   m.def(
       "transfer_kv_all_layer_direct_lf_pf(Tensor[] src_ptrs, Tensor[] dst_ptrs, Tensor src_indices, "
-      "Tensor dst_indices, int page_size) ->() ");
+      "Tensor dst_indices, int page_size, bool use_batch_memcpy=True) -> ()");
   m.impl("transfer_kv_all_layer_direct_lf_pf", torch::kCUDA, &transfer_kv_all_layer_direct_lf_pf);
   m.def(
       "transfer_kv_all_layer_lf_ph(Tensor src_k_layers, Tensor dst_k, Tensor src_v_layers, Tensor dst_v, "

--- a/sgl-kernel/csrc/kvcacheio/transfer.cu
+++ b/sgl-kernel/csrc/kvcacheio/transfer.cu
@@ -739,7 +739,8 @@ inline void transfer_kv_page_first_direct_impl(
     const at::Tensor& src_indices,
     const at::Tensor& dst_indices,
     int64_t start_layer_id,
-    int64_t page_size) {
+    int64_t page_size,
+    bool use_batch_memcpy = true) {
   TORCH_CHECK(src_indices.numel() == dst_indices.numel(), "Source and destination indices must have the same length");
   TORCH_CHECK(page_size > 0, "Page size must be positive");
   TORCH_CHECK(src_indices.numel() % page_size == 0, "Source indices size must be divisible by page size");
@@ -797,6 +798,13 @@ inline void transfer_kv_page_first_direct_impl(
   return;
 
 #else
+  // Caller-requested fallback: some host memory allocators (e.g. Mooncake) are
+  // incompatible with cudaMemcpyBatchAsync due to a CUDA driver bug.
+  if (!use_batch_memcpy) {
+    fallback_to_page_copy();
+    return;
+  }
+
   // Driver capability gate: only use cudaMemcpyBatchAsync on CUDA 12.8+ drivers.
   int driver_version = 0;
   cudaError_t driver_version_err = cudaDriverGetVersion(&driver_version);
@@ -944,8 +952,9 @@ void transfer_kv_per_layer_direct_pf_lf(
     const at::Tensor& src_indices,
     const at::Tensor& dst_indices,
     int64_t layer_id,
-    int64_t page_size) {
-  transfer_kv_page_first_direct_impl<false>(src_ptrs, dst_ptrs, src_indices, dst_indices, layer_id, page_size);
+    int64_t page_size,
+    bool use_batch_memcpy) {
+  transfer_kv_page_first_direct_impl<false>(src_ptrs, dst_ptrs, src_indices, dst_indices, layer_id, page_size, use_batch_memcpy);
 }
 
 void transfer_kv_all_layer_direct_lf_pf(
@@ -953,6 +962,7 @@ void transfer_kv_all_layer_direct_lf_pf(
     std::vector<at::Tensor> dst_ptrs,
     const at::Tensor& src_indices,
     const at::Tensor& dst_indices,
-    int64_t page_size) {
-  transfer_kv_page_first_direct_impl<true>(src_ptrs, dst_ptrs, src_indices, dst_indices, 0, page_size);
+    int64_t page_size,
+    bool use_batch_memcpy) {
+  transfer_kv_page_first_direct_impl<true>(src_ptrs, dst_ptrs, src_indices, dst_indices, 0, page_size, use_batch_memcpy);
 }

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -581,14 +581,16 @@ void transfer_kv_per_layer_direct_pf_lf(
     const at::Tensor& src_indices,
     const at::Tensor& dst_indices,
     int64_t layer_id,
-    int64_t page_size);
+    int64_t page_size,
+    bool use_batch_memcpy);
 
 void transfer_kv_all_layer_direct_lf_pf(
     const std::vector<at::Tensor>& src_ptrs,
     std::vector<at::Tensor> dst_ptrs,
     const at::Tensor& src_indices,
     const at::Tensor& dst_indices,
-    int64_t page_size);
+    int64_t page_size,
+    bool use_batch_memcpy);
 
 /*
  * From csrc/memory

--- a/sgl-kernel/python/sgl_kernel/kvcacheio.py
+++ b/sgl-kernel/python/sgl_kernel/kvcacheio.py
@@ -199,9 +199,10 @@ def transfer_kv_per_layer_direct_pf_lf(
     dst_indices: torch.Tensor,
     layer_id: int,
     page_size: int,
+    use_batch_memcpy: bool = True,
 ):
     torch.ops.sgl_kernel.transfer_kv_per_layer_direct_pf_lf.default(
-        src_ptrs, dst_ptrs, src_indices, dst_indices, layer_id, page_size
+        src_ptrs, dst_ptrs, src_indices, dst_indices, layer_id, page_size, use_batch_memcpy
     )
 
 
@@ -211,9 +212,10 @@ def transfer_kv_all_layer_direct_lf_pf(
     src_indices: torch.Tensor,
     dst_indices: torch.Tensor,
     page_size: int,
+    use_batch_memcpy: bool = True,
 ):
     torch.ops.sgl_kernel.transfer_kv_all_layer_direct_lf_pf.default(
-        src_ptrs, dst_ptrs, src_indices, dst_indices, page_size
+        src_ptrs, dst_ptrs, src_indices, dst_indices, page_size, use_batch_memcpy
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
                                                                                                                                                                                      
                                                                                                                                                                                                           
  When using Mooncake as the HiCache L3 storage backend with `page_first_direct` layout and write-through policy, all TP workers segfault during the first KV backup:                                      
   
```
!!!!!!! Segfault encountered !!!!!!!
  File "<unknown>", line 0, in cuMemcpyBatchAsync_v2
  File "<unknown>", line 0, in cudaMemcpyBatchAsync
  File "<unknown>", line 0, in void transfer_kv_page_first_direct_impl<true>(std::vector<at::Tensor, std::allocator<at::Tensor> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> >, at::Tensor const&, at::Tensor const&, long, long)
  File "<unknown>", line 0, in transfer_kv_all_layer_direct_lf_pf(std::vector<at::Tensor, std::allocator<at::Tensor> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> >, at::Tensor const&, at::Tensor const&, long)
  File "<unknown>", line 0, in c10::impl::make_boxed_from_unboxed_functor<c10::impl::detail::WrapFunctionIntoRuntimeFunctor_<void (*)(std::vector<at::Tensor, std::allocator<at::Tensor> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> >, at::Tensor const&, at::Tensor const&, long), void, c10::guts::typelist::typelist<std::vector<at::Tensor, std::allocator<at::Tensor> > const&, std::vector<at::Tensor, std::allocator<at::Tensor> >, at::Tensor const&, at::Tensor const&, long> >, false>::call(c10::OperatorKernel*, c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
  File "<unknown>", line 0, in torch::autograd::basicAutogradNotImplementedFallbackImpl(c10::OperatorHandle const&, c10::DispatchKeySet, std::vector<c10::IValue, std::allocator<c10::IValue> >*)
  File "<unknown>", line 0, in c10::Dispatcher::callBoxed(c10::OperatorHandle const&, std::vector<c10::IValue, std::allocator<c10::IValue> >*) const [clone .isra.0]
  File "<unknown>", line 0, in torch::jit::invokeOperatorFromPython(c10::ArrayRef<std::shared_ptr<torch::jit::Operator> >, pybind11::args const&, pybind11::kwargs const&, std::optional<c10::DispatchKey>)
  File "<unknown>", line 0, in torch::jit::_get_operation_for_overload_or_packet(c10::ArrayRef<std::shared_ptr<torch::jit::Operator> >, c10::Symbol, pybind11::args const&, pybind11::kwargs const&, bool, std::optional<c10::DispatchKey>)
  File "<unknown>", line 0, in pybind11::cpp_function::initialize<torch::jit::initJITBindings(_object*)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#2}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const::{lambda(pybind11::args const&, pybind11::kwargs const&)#1}, pybind11::object, pybind11::args const&, pybind11::kwargs const&>(torch::jit::initJITBindings(_object*)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#2}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const::{lambda(pybind11::args const&, pybind11::kwargs const&)#1}&&, pybind11::object (*)(pybind11::args const&, pybind11::kwargs const&))::{lambda(pybind11::detail::function_call&)#1}::_FUN(pybind11::detail::function_call&)
  File "<unknown>", line 0, in pybind11::cpp_function::dispatcher(_object*, _object*, _object*)
  File "<unknown>", line 0, in PyObject_Call
  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
  File "<unknown>", line 0, in _PyObject_Call_Prepend
  File "<unknown>", line 0, in _PyObject_MakeTpCall
  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
  File "<unknown>", line 0, in PyEval_EvalCode
  File "<unknown>", line 0, in PyRun_StringFlags
  File "<unknown>", line 0, in PyRun_SimpleStringFlags
  File "<unknown>", line 0, in Py_RunMain
  File "<unknown>", line 0, in Py_BytesMain
  File "<unknown>", line 0, in _start
  File "<unknown>", line 0, in 0xffffffffffffffff

```
                                                                                                                                                                                                           
### Root cause                                                                                                                                                                                           
                                                                                                                                                                                                           
  `cudaMemcpyBatchAsync` (CUDA 12.8+, introduced to sgl-kernel in #18113) segfaults when the destination is host memory allocated by `MooncakeHostMemAllocator` (which is registered as RDMA buffer).      
  Standard `cudaMemcpyAsync` works fine with the same memory. This is a CUDA driver bug (should return an error code, not crash), but sglang needs to work around it.
                                                                                                                                                                                                           
## Solution 

Let the allocator declare its own memory compatibility instead of having callers guess.                                                                                                                  
   
- Add `supports_cuda_batch_memcpy` class attribute to `HostTensorAllocator` (default `True`)                                                                                                             
- Override to `False` in `MooncakeHostTensorAllocator`
- `MHATokenToKVPoolHost` and `MLATokenToKVPoolHost` check this attribute in `backup_from_device_all_layer`; when `False`, fall back to per-page `tensor.copy_()` (which uses `cudaMemcpyAsync` internally)                                                                                                                                                                                              

```                                                                                                                                                                                              
  **Before (segfault with Mooncake)**:                                                                                                                                                                     
  backup_from_device_all_layer()
    → transfer_kv_all_layer_direct_lf_pf()    [C++ kernel]                                                                                                                                                 
    → cudaMemcpyBatchAsync()                  [CUDA 12.8+]
    → cuMemcpyBatchAsync_v2                   [driver: SEGFAULT]                                                                                                                                           
                                                                
  **After (Mooncake path)**:                                                                                                                                                                               
  backup_from_device_all_layer()
    → allocator.supports_cuda_batch_memcpy == False                                                                                                                                                        
    → fallback_backup_page_first_direct()    [Python]
    → tensor.copy()                          [PyTorch → cudaMemcpyAsync: OK]                                                                                                                               
                                                                                                                                                                                                           
  **After (standard allocator, unchanged)**:                                                                                                                                                               
  backup_from_device_all_layer()                                                                                                                                                                           
    → allocator.supports_cuda_batch_memcpy == True                                                                                                                                                         
    → transfer_kv_all_layer_direct_lf_pf()    [C++ kernel, same as before]
```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
