### PR TITLE
Bench: add multi-resolution request sizing to exercise diffusion H/W bucketing  

### DIFF
--- a/python/sglang/multimodal_gen/benchmarks/bench_serving.py
+++ b/python/sglang/multimodal_gen/benchmarks/bench_serving.py
@@ -19,9 +19,10 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import time
 from dataclasses import replace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiohttp
 import numpy as np
@@ -61,6 +62,67 @@ def _compute_scale_factor(req: RequestFuncInput, args) -> Optional[float]:
 
     area_units = max((float(width) * float(height)) / float(PATCH_AREA), 1.0)
     return area_units * float(frame_scale) * float(step_scale)
+
+
+def _parse_size_set(size_set: Optional[str]) -> Optional[List[Tuple[int, int]]]:
+    if size_set is None:
+        return None
+    raw = size_set.strip()
+    if not raw:
+        return None
+
+    raw = re.sub(r"[\{\}\[\]\(\)]", " ", raw)
+    parts = [p.strip().strip(",") for p in re.split(r"[\s,]+", raw) if p]
+
+    sizes: List[Tuple[int, int]] = []
+    for p in parts:
+        if not p:
+            continue
+
+        if "x" in p.lower():
+            wh = re.split(r"[xX]", p)
+            if len(wh) != 2:
+                raise ValueError(
+                    f"Invalid --size-set entry '{p}'. Expected 'W' or 'WxH' like '512x768'."
+                )
+            try:
+                w = int(wh[0])
+                h = int(wh[1])
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid --size-set entry '{p}'. Expected 'W' or 'WxH' like '512x768'."
+                ) from e
+        else:
+            try:
+                side = int(p)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid --size-set entry '{p}'. Expected 'W' or 'WxH' like '512x768'."
+                ) from e
+            w = side
+            h = side
+
+        if w <= 0 or h <= 0:
+            raise ValueError(
+                f"Invalid --size-set entry '{p}'. Width/height must be positive."
+            )
+
+        sizes.append((w, h))
+
+    return sizes or None
+
+
+def _parse_weights(weights: Optional[str], n: int) -> Optional[np.ndarray]:
+    if weights is None:
+        return None
+    parts = [p for p in re.split(r"[\s,]+", weights.strip()) if p]
+    if len(parts) != n:
+        raise ValueError(f"--size-weights must have same length as --size-set ({n}).")
+    w = np.array([float(p) for p in parts], dtype=np.float64)
+    if np.any(w < 0) or np.all(w == 0):
+        raise ValueError("--size-weights must be non-negative and not all zero.")
+    w = w / w.sum()
+    return w
 
 
 def _compute_expected_latency_ms_from_base(
@@ -518,6 +580,52 @@ async def benchmark(args):
 
     setattr(args, "task_name", task_name)
 
+    args.size_set_list = _parse_size_set(getattr(args, "size_set", None))
+    if args.size_set_list:
+        args.size_weights = _parse_weights(
+            getattr(args, "size_weights", None), len(args.size_set_list)
+        )
+    else:
+        if getattr(args, "size_weights", None) is not None:
+            raise ValueError("--size-weights requires --size-set")
+        args.size_weights = None
+
+    if args.size_weights is not None and args.size_policy != "random":
+        raise ValueError("--size-weights only supported with --size-policy random.")
+
+    if args.size_policy != "fixed" and not args.size_set_list:
+        raise ValueError(
+            "--size-policy requires --size-set (e.g. --size-set '512,640,768' or '512x768,768x1024')"
+        )
+
+    if args.size_policy != "fixed" and (
+        args.width is not None or args.height is not None
+    ):
+        raise ValueError(
+            "--width/--height are incompatible with --size-policy != fixed. Use --size-set only."
+        )
+
+    if args.size_set_list and args.size_policy == "fixed":
+        if args.width is None and args.height is None:
+            w0, h0 = args.size_set_list[0]
+            args.width = int(w0)
+            args.height = int(h0)
+
+    if args.size_set_list and args.size_policy == "random":
+        if args.size_seed is None:
+            raise ValueError(
+                "--size-policy random requires --size-seed for determinism."
+            )
+        args._size_rng = np.random.default_rng(args.size_seed)
+    else:
+        args._size_rng = None
+
+    if args.square:
+        if args.width is None and args.height is not None:
+            args.width = int(args.height)
+        if args.height is None and args.width is not None:
+            args.height = int(args.width)
+
     if args.dataset == "vbench":
         dataset = VBenchDataset(args, api_url, args.model)
     elif args.dataset == "random":
@@ -600,6 +708,15 @@ async def benchmark(args):
     print_value_formatted("Task:", task_name)
     print_value_formatted("Model:", args.model)
     print_value_formatted("Dataset:", args.dataset)
+    print_value_formatted("Size policy:", args.size_policy)
+    print_value_formatted("Size set:", str(getattr(args, "size_set_list", None)))
+    if getattr(args, "size_weights", None) is not None:
+        print_value_formatted(
+            "Size weights:",
+            np.array2string(getattr(args, "size_weights"), precision=3),
+        )
+    if args.size_seed is not None:
+        print_value_formatted("Size seed:", str(args.size_seed))
 
     # Section 2: Execution & Traffic
     print_divider(50)
@@ -719,6 +836,39 @@ if __name__ == "__main__":
     )
     parser.add_argument("--width", type=int, default=None, help="Image/Video width.")
     parser.add_argument("--height", type=int, default=None, help="Image/Video height.")
+    parser.add_argument(
+        "--size-set",
+        type=str,
+        default=None,
+        help=(
+            "Comma/space-separated sizes. Each entry can be 'W' (square) or 'WxH' (non-square), "
+            "e.g. '512,640,768' or '{512x512 512x768 768x1024}'. Used when --size-policy is not fixed."
+        ),
+    )
+    parser.add_argument(
+        "--size-policy",
+        type=str,
+        choices=["fixed", "round_robin", "random"],
+        default="fixed",
+        help="Size selection policy. fixed uses --width/--height. round_robin/random pick from --size-set.",
+    )
+    parser.add_argument(
+        "--size-weights",
+        type=str,
+        default=None,
+        help='Optional weights aligned to --size-set, e.g. "0.1,0.2,0.7" (same length). Only for random policy.',
+    )
+    parser.add_argument(
+        "--size-seed",
+        type=int,
+        default=None,
+        help="Seed for deterministic --size-policy random (required when --size-policy=random).",
+    )
+    parser.add_argument(
+        "--square",
+        action="store_true",
+        help="Force height=width for each request (applies after size selection).",
+    )
     parser.add_argument(
         "--num-frames", type=int, default=None, help="Number of frames (for video)."
     )

--- a/python/sglang/multimodal_gen/benchmarks/datasets.py
+++ b/python/sglang/multimodal_gen/benchmarks/datasets.py
@@ -6,14 +6,52 @@ import subprocess
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
+import numpy as np
 import requests
 from PIL import Image
 
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
+
+
+def _resolve_request_size(
+    args,
+    idx: int,
+    rng: Optional[np.random.Generator],
+) -> Tuple[Optional[int], Optional[int]]:
+    sizes = getattr(args, "size_set_list", None)
+    policy = getattr(args, "size_policy", "fixed")
+
+    if not sizes or policy == "fixed":
+        width = getattr(args, "width", None)
+        height = getattr(args, "height", None)
+    elif policy == "round_robin":
+        w, h = sizes[idx % len(sizes)]
+        width = int(w)
+        height = int(h)
+    elif policy == "random":
+        if rng is None:
+            raise ValueError(
+                "Internal error: rng is None for random size policy. Did you set args._size_rng?"
+            )
+        weights = getattr(args, "size_weights", None)
+        choice_idx = int(rng.choice(len(sizes), p=weights))
+        w, h = sizes[choice_idx]
+        width = int(w)
+        height = int(h)
+    else:
+        raise ValueError(f"Unknown size policy: {policy}")
+
+    if getattr(args, "square", False):
+        if width is None and height is None:
+            return (None, None)
+        side = int(width if width is not None else height)
+        return (side, side)
+
+    return (width, height)
 
 
 @dataclass
@@ -53,6 +91,7 @@ class BaseDataset(ABC):
         self.api_url = api_url
         self.model = model
         self.items: List[Dict[str, Any]] = []
+        self._size_rng = getattr(args, "_size_rng", None)
 
     @abstractmethod
     def __len__(self) -> int:
@@ -269,12 +308,13 @@ class VBenchDataset(BaseDataset):
 
     def __getitem__(self, idx: int) -> RequestFuncInput:
         item = self.items[idx]
+        width, height = _resolve_request_size(self.args, idx, self._size_rng)
         return RequestFuncInput(
             prompt=item.get("prompt", ""),
             api_url=self.api_url,
             model=self.model,
-            width=self.args.width,
-            height=self.args.height,
+            width=width,
+            height=height,
             num_frames=self.args.num_frames,
             fps=self.args.fps,
             image_paths=[item["image_path"]] if "image_path" in item else None,
@@ -290,12 +330,13 @@ class RandomDataset(BaseDataset):
         return self.num_prompts
 
     def __getitem__(self, idx: int) -> RequestFuncInput:
+        width, height = _resolve_request_size(self.args, idx, self._size_rng)
         return RequestFuncInput(
             prompt=f"Random prompt {idx} for benchmarking diffusion models",
             api_url=self.api_url,
             model=self.model,
-            width=self.args.width,
-            height=self.args.height,
+            width=width,
+            height=height,
             num_frames=self.args.num_frames,
             fps=self.args.fps,
         )

--- a/python/sglang/multimodal_gen/test/test_bench_datasets_size_policy.py
+++ b/python/sglang/multimodal_gen/test/test_bench_datasets_size_policy.py
@@ -1,0 +1,72 @@
+import types
+
+import numpy as np
+import pytest
+
+from sglang.multimodal_gen.benchmarks.datasets import _resolve_request_size
+
+
+def test_resolve_request_size_fixed_uses_width_height():
+    args = types.SimpleNamespace(
+        size_set_list=[(1, 2)],
+        size_policy="fixed",
+        width=512,
+        height=768,
+        square=False,
+    )
+    w, h = _resolve_request_size(args, idx=123, rng=np.random.default_rng(0))
+    assert (w, h) == (512, 768)
+
+
+def test_resolve_request_size_round_robin_picks_by_index():
+    args = types.SimpleNamespace(
+        size_set_list=[(10, 11), (20, 21), (30, 31)],
+        size_policy="round_robin",
+        width=None,
+        height=None,
+        square=False,
+    )
+    assert _resolve_request_size(args, idx=0, rng=None) == (10, 11)
+    assert _resolve_request_size(args, idx=1, rng=None) == (20, 21)
+    assert _resolve_request_size(args, idx=2, rng=None) == (30, 31)
+    assert _resolve_request_size(args, idx=3, rng=None) == (10, 11)
+
+
+def test_resolve_request_size_random_requires_rng():
+    args = types.SimpleNamespace(
+        size_set_list=[(10, 11), (20, 21)],
+        size_policy="random",
+        size_weights=None,
+        width=None,
+        height=None,
+        square=False,
+    )
+    with pytest.raises(ValueError, match=r"rng is None"):
+        _resolve_request_size(args, idx=0, rng=None)
+
+
+def test_resolve_request_size_random_weighted_is_deterministic_for_degenerate_weights():
+    # Degenerate weights (always pick index 1) avoids flakiness.
+    args = types.SimpleNamespace(
+        size_set_list=[(10, 11), (20, 21)],
+        size_policy="random",
+        size_weights=np.array([0.0, 1.0], dtype=np.float64),
+        width=None,
+        height=None,
+        square=False,
+    )
+    rng = np.random.default_rng(0)
+    for idx in range(5):
+        assert _resolve_request_size(args, idx=idx, rng=rng) == (20, 21)
+
+
+def test_resolve_request_size_square_forces_square_after_selection():
+    # From a rectangular entry, square flag should force side=width (if provided).
+    args = types.SimpleNamespace(
+        size_set_list=[(10, 99)],
+        size_policy="round_robin",
+        width=None,
+        height=None,
+        square=True,
+    )
+    assert _resolve_request_size(args, idx=0, rng=None) == (10, 10)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR extends multimodal_gen diffusion benchmarking to support mixed request resolutions within a single benchmark run. Real serving traffic often contains heterogeneous image/video sizes, and a fixed  --width/--height  benchmark cannot capture that distribution. The goal is to make  bench_serving.py  capable of generating controlled multi-resolution workloads (deterministic round-robin or seeded random), while keeping default behavior unchanged. 

## Modifications
- Add new CLI knobs in  python/sglang/multimodal_gen/benchmarks/bench_serving.py :                                                           
    •  --size-set : list of candidate sizes ( W  or  WxH )                                                                                     
    •  --size-policy :  fixed | round_robin | random                                                                                           
    •  --size-weights : optional weights for  random                                                                                           
    •  --size-seed : RNG seed for deterministic  random                                                                                        
    •  --square : force per-request square size after selection                                                                                
- Implement per-request size selection in  python/sglang/multimodal_gen/benchmarks/datasets.py  via _resolve_request_size(...) , so each dataset item carries the intended  (width, height)  into the outgoing request payload.                                                       
 - Add a lightweight unit test for the size-policy logic:                                                                                     
    •  python/sglang/multimodal_gen/test/test_bench_datasets_size_policy.py     

## Accuracy Tests

N/A.  

## Benchmarking and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).