### PR TITLE
feat: enable unified metrics collection in nightly CI with S3 upload

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -123,6 +123,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-h200"
           IS_H200: "1"
+          SGLANG_TEST_METRICS_OUTPUT: test-metrics
         run: |
           cd test
           python3 run_suite.py --hw cuda --suite nightly-8-gpu-common --nightly --timeout-per-file=18000 --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
@@ -172,6 +173,15 @@ jobs:
           name: metrics-8gpu-h200-partition-${{ matrix.partition }}
           path: test/metrics-8gpu-h200-partition-${{ matrix.partition }}.json
           retention-days: 5
+          if-no-files-found: ignore
+
+      - name: Upload test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-8gpu-h200-partition-${{ matrix.partition }}
+          path: test/test-metrics.*.jsonl
+          retention-days: 90
           if-no-files-found: ignore
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -231,6 +241,7 @@ jobs:
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-b200"
+          SGLANG_TEST_METRICS_OUTPUT: test-metrics
         run: |
           cd test
           IS_BLACKWELL=1 python3 run_suite.py --hw cuda --suite nightly-8-gpu-common --nightly --timeout-per-file=12000 --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
@@ -274,6 +285,15 @@ jobs:
           retention-days: 5
           if-no-files-found: ignore
 
+      - name: Upload test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-8gpu-b200-partition-${{ matrix.partition }}
+          path: test/test-metrics.*.jsonl
+          retention-days: 90
+          if-no-files-found: ignore
+
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
         with:
@@ -295,9 +315,20 @@ jobs:
 
       - name: Run eval test for text models
         timeout-minutes: 120
+        env:
+          SGLANG_TEST_METRICS_OUTPUT: test-metrics
         run: |
           cd test
           python3 run_suite.py --hw cuda --suite nightly-eval-text-2-gpu --nightly --continue-on-error --timeout-per-file 4500
+
+      - name: Upload test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-text-accuracy-2gpu
+          path: test/test-metrics.*.jsonl
+          retention-days: 90
+          if-no-files-found: ignore
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -322,10 +353,20 @@ jobs:
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "2-gpu-h100"
+          SGLANG_TEST_METRICS_OUTPUT: test-metrics
         run: |
           cd test
           rm -rf performance_profiles_text_models/
           python3 run_suite.py --hw cuda --suite nightly-perf-text-2-gpu --nightly --continue-on-error --timeout-per-file 3600
+
+      - name: Upload test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-text-perf-2gpu
+          path: test/test-metrics.*.jsonl
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: Publish traces to storage repo
         env:
@@ -354,9 +395,20 @@ jobs:
 
       - name: Run eval test for VLM models (fixed MMMU-100)
         timeout-minutes: 240
+        env:
+          SGLANG_TEST_METRICS_OUTPUT: test-metrics
         run: |
           cd test
           python3 run_suite.py --hw cuda --suite nightly-eval-vlm-2-gpu --nightly --continue-on-error --timeout-per-file 9000
+
+      - name: Upload test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-vlm-accuracy-2gpu
+          path: test/test-metrics.*.jsonl
+          retention-days: 90
+          if-no-files-found: ignore
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: always()
@@ -381,10 +433,20 @@ jobs:
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "2-gpu-h100"
+          SGLANG_TEST_METRICS_OUTPUT: test-metrics
         run: |
           cd test
           rm -rf performance_profiles_vlms/
           python3 run_suite.py --hw cuda --suite nightly-perf-vlm-2-gpu --nightly --continue-on-error --timeout-per-file 3600
+
+      - name: Upload test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-vlm-perf-2gpu
+          path: test/test-metrics.*.jsonl
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: Publish traces to storage repo
         env:
@@ -568,6 +630,10 @@ jobs:
       - nightly-test-general-8-gpu-b200
       - nightly-test-multimodal-server-1-gpu
       - nightly-test-multimodal-server-2-gpu
+      - nightly-test-text-accuracy-2-gpu-h100
+      - nightly-test-text-perf-2-gpu-h100
+      - nightly-test-vlm-accuracy-2-gpu-h100
+      - nightly-test-vlm-perf-2-gpu-h100
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -584,8 +650,11 @@ jobs:
 
       - name: List downloaded metrics
         run: |
-          echo "Downloaded metrics files:"
-          find metrics/ -name "*.json" -type f 2>/dev/null || echo "No metrics files found"
+          echo "=== Benchmark metrics (JSON) ==="
+          find metrics/ -name "*.json" -type f 2>/dev/null || echo "No JSON files found"
+          echo ""
+          echo "=== Test metrics (JSONL from dump_metric) ==="
+          find metrics/ -name "*.jsonl" -type f 2>/dev/null || echo "No JSONL files found"
 
       - name: Merge metrics
         run: |
@@ -596,6 +665,15 @@ jobs:
             --commit-sha ${{ github.sha }} \
             --branch ${{ github.ref_name }}
 
+      - name: Consolidate JSONL test metrics
+        run: |
+          find metrics/ -name "*.jsonl" -type f -exec cat {} + > test-metrics-${{ github.run_id }}.jsonl 2>/dev/null || true
+          if [ -s test-metrics-${{ github.run_id }}.jsonl ]; then
+            echo "Consolidated $(wc -l < test-metrics-${{ github.run_id }}.jsonl) metric lines"
+          else
+            echo "No JSONL test metrics found"
+          fi
+
       - name: Upload consolidated metrics
         uses: actions/upload-artifact@v4
         with:
@@ -603,6 +681,31 @@ jobs:
           path: consolidated-metrics-${{ github.run_id }}.json
           retention-days: 90
           if-no-files-found: warn
+
+      - name: Upload consolidated test metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-metrics-${{ github.run_id }}
+          path: test-metrics-${{ github.run_id }}.jsonl
+          retention-days: 90
+          if-no-files-found: ignore
+
+      - name: Upload all metrics to S3
+        if: always()
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CI_METRICS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_METRICS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-1
+        run: |
+          python3 scripts/ci/utils/upload_metrics_to_s3.py \
+            --consolidated-json consolidated-metrics-${{ github.run_id }}.json \
+            --test-metrics-jsonl test-metrics-${{ github.run_id }}.jsonl \
+            --run-id ${{ github.run_id }} \
+            --commit-sha ${{ github.sha }} \
+            --bucket rdxa-eng-json-logs-05354378 \
+            --prefix ci-metrics/nightly
 
   # Final check job
   check-all-jobs:

--- a/scripts/ci/utils/upload_metrics_to_s3.py
+++ b/scripts/ci/utils/upload_metrics_to_s3.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Upload CI metrics to S3 for long-term storage.
+
+Uploads consolidated benchmark JSON and JSONL test metrics from dump_metric().
+Gracefully no-ops when AWS credentials are not configured.
+
+S3 path structure:
+    s3://{bucket}/{prefix}/{date}/{run_id}/consolidated-metrics.json
+    s3://{bucket}/{prefix}/{date}/{run_id}/test-metrics.jsonl
+
+Usage:
+    python3 scripts/ci/utils/upload_metrics_to_s3.py \
+        --consolidated-json consolidated-metrics-12345.json \
+        --test-metrics-jsonl test-metrics-12345.jsonl \
+        --run-id 12345 \
+        --commit-sha abc123 \
+        --bucket rdxa-eng-json-logs-05354378 \
+        --prefix ci-metrics/nightly
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def aws_credentials_available():
+    return bool(os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"))
+
+
+def upload_file(local_path, s3_uri):
+    if not os.path.exists(local_path):
+        print(f"  Skip (not found): {local_path}")
+        return False
+    if os.path.getsize(local_path) == 0:
+        print(f"  Skip (empty): {local_path}")
+        return False
+
+    try:
+        result = subprocess.run(
+            ["aws", "s3", "cp", local_path, s3_uri],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode == 0:
+            print(f"  Uploaded: {local_path} -> {s3_uri}")
+            return True
+        else:
+            print(f"  Failed: {result.stderr.strip()}")
+            return False
+    except Exception as e:
+        print(f"  Error: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload CI metrics to S3")
+    parser.add_argument("--consolidated-json", help="Path to consolidated JSON")
+    parser.add_argument("--test-metrics-jsonl", help="Path to JSONL test metrics")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--commit-sha", default="unknown")
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--prefix", default="ci-metrics/nightly")
+    args = parser.parse_args()
+
+    if not aws_credentials_available():
+        print("AWS credentials not configured, skipping S3 upload.")
+        print(
+            "To enable, add CI_METRICS_AWS_ACCESS_KEY_ID and "
+            "CI_METRICS_AWS_SECRET_ACCESS_KEY as GitHub repo secrets."
+        )
+        return
+
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    s3_base = f"s3://{args.bucket}/{args.prefix}/{date_str}/{args.run_id}"
+
+    print(f"Uploading metrics to {s3_base}/")
+
+    # Upload a small metadata file for easy querying
+    metadata = {
+        "run_id": args.run_id,
+        "commit_sha": args.commit_sha,
+        "date": date_str,
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    metadata_path = "/tmp/run-metadata.json"
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    uploaded = 0
+    if upload_file(metadata_path, f"{s3_base}/run-metadata.json"):
+        uploaded += 1
+    if args.consolidated_json:
+        if upload_file(args.consolidated_json, f"{s3_base}/consolidated-metrics.json"):
+            uploaded += 1
+    if args.test_metrics_jsonl:
+        if upload_file(args.test_metrics_jsonl, f"{s3_base}/test-metrics.jsonl"):
+            uploaded += 1
+
+    print(f"Done: {uploaded} file(s) uploaded to S3.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Enable `dump_metric()` JSONL output in 6 nightly jobs by setting `SGLANG_TEST_METRICS_OUTPUT` env var
- Collect JSONL metrics as artifacts and consolidate them in the `consolidate-metrics` job
- Add S3 upload script that uploads both consolidated benchmark JSON and test metrics JSONL to `s3://rdxa-eng-json-logs-05354378/ci-metrics/nightly/{date}/{run_id}/`
- S3 upload gracefully no-ops when AWS secrets are not configured

## How it works
The existing `dump_metric()` function (PR #16064) already writes JSONL when `SGLANG_TEST_METRICS_OUTPUT` is set, and `run_eval.py` already calls it for eval scores/latency. This PR simply wires it into the nightly workflow:

1. Each nightly eval/perf job sets `SGLANG_TEST_METRICS_OUTPUT=test-metrics` and uploads the resulting JSONL files as artifacts
2. The `consolidate-metrics` job downloads all artifacts, concatenates JSONL files, and uploads everything to S3
3. S3 path: `ci-metrics/nightly/{date}/{run_id}/` containing `consolidated-metrics.json`, `test-metrics.jsonl`, and `run-metadata.json`

## Blocked on
- **S3 credentials**: Waiting on IT to provision long-lived AWS credentials. Need `CI_METRICS_AWS_ACCESS_KEY_ID` and `CI_METRICS_AWS_SECRET_ACCESS_KEY` added as GitHub repo secrets. Until then, metrics are collected as GitHub artifacts (90-day retention) but not uploaded to S3.

## Jobs affected
- `nightly-test-text-accuracy-2-gpu-h100`
- `nightly-test-text-perf-2-gpu-h100`
- `nightly-test-vlm-accuracy-2-gpu-h100`
- `nightly-test-vlm-perf-2-gpu-h100`
- `nightly-test-general-8-gpu-h200`
- `nightly-test-general-8-gpu-b200`
- `consolidate-metrics`

## Test plan
- [ ] Verify nightly run produces JSONL artifacts (even without S3 credentials)
- [ ] Once AWS secrets are added, verify S3 upload works