### PR TITLE
docs: Metax MACA install (srt_metax extra)

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -2,7 +2,7 @@
 
 You can install SGLang using one of the methods below.
 This page primarily applies to common NVIDIA GPU platforms.
-For other or newer platforms, please refer to the dedicated pages for [AMD GPUs](../platforms/amd_gpu.md), [Intel Xeon CPUs](../platforms/cpu_server.md), [TPU](../platforms/tpu.md), [NVIDIA DGX Spark](https://lmsys.org/blog/2025-11-03-gpt-oss-on-nvidia-dgx-spark/), [NVIDIA Jetson](../platforms/nvidia_jetson.md), [Ascend NPUs](../platforms/ascend_npu.md), and [Intel XPU](../platforms/xpu.md).
+For other or newer platforms, please refer to the dedicated pages for [AMD GPUs](../platforms/amd_gpu.md), [Intel Xeon CPUs](../platforms/cpu_server.md), [TPU](../platforms/tpu.md), [NVIDIA DGX Spark](https://lmsys.org/blog/2025-11-03-gpt-oss-on-nvidia-dgx-spark/), [NVIDIA Jetson](../platforms/nvidia_jetson.md), [Ascend NPUs](../platforms/ascend_npu.md), [Intel XPU](../platforms/xpu.md), and [Metax GPUs (MACA)](../platforms/metax_gpu.md).
 
 ## Method 1: With pip or uv
 

--- a/docs/platforms/metax_gpu.md
+++ b/docs/platforms/metax_gpu.md
@@ -1,0 +1,87 @@
+# Metax GPUs (MACA)
+
+This document describes how to run SGLang on Metax GPUs with the MACA software stack and vendor-provided PyTorch. If you hit issues, please [open an issue](https://github.com/sgl-project/sglang/issues).
+
+## Why a separate `pyproject`
+
+The default `python/pyproject.toml` pins NVIDIA-oriented wheels (`sglang-kernel`, FlashInfer, official CUDA PyTorch, etc.). Installing it on Metax would replace your vendor PyTorch. Use `python/pyproject_other.toml` instead—the same approach as [Moore Threads (MUSA)](mthreads_gpu.md).
+
+## Install from source
+
+1. Install **Metax/MACA PyTorch** (and matching `torchvision` / `torchaudio` if needed) from your vendor instructions. Confirm `python -c "import torch; print(torch.cuda.is_available())"`.
+
+2. Swap the project file (same layout as [Moore Threads](mthreads_gpu.md)):
+
+```bash
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+
+pip install --upgrade pip
+rm -f python/pyproject.toml && cp python/pyproject_other.toml python/pyproject.toml
+```
+
+3. Install SGLang **without letting pip replace your `torch`**.
+
+`outlines`, `transformers`, `timm`, etc. depend on `torch`. A plain `pip install -e "python[srt_metax]"` may download **NVIDIA CUDA** PyTorch from PyPI if pip decides your current build is “insufficient”, which breaks MACA.
+
+**Recommended (keeps vendor PyTorch):** install the editable package without dependencies, then install **all** `srt_metax` requirements in **one** `pip install` so the resolver sees your existing `torch` (avoid `xargs -n1`, which reinstalls dependencies per package and can pull PyPI `torch`).
+
+```bash
+cd python
+pip install -e . --no-deps
+deps=$(python3 <<'PY'
+import tomllib
+from pathlib import Path
+
+data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+optional = data["project"]["optional-dependencies"]
+metax = optional["srt_metax"]
+expanded: list[str] = []
+for item in metax:
+    if item.startswith("sglang[") and item.endswith("]"):
+        extra = item[len("sglang["):-1]
+        expanded.extend(optional[extra])
+    else:
+        expanded.append(item)
+seen: set[str] = set()
+uniq: list[str] = []
+for req in expanded:
+    if req not in seen:
+        seen.add(req)
+        uniq.append(req)
+print(" ".join(uniq))
+PY
+)
+pip install $deps
+```
+
+(After the `cp` step, `python/pyproject.toml` is the former `pyproject_other.toml`, so the snippet reads the correct optional-dependencies table.)
+
+Then verify the PyTorch build string:
+
+```bash
+python -c "import torch; print(torch.__version__)"
+```
+
+You should still see your **Metax/MACA** build (for example a `+metax…` local label). If you see a `+cu12…` PyPI-style build instead, uninstall `torch` / `torchvision` / `torchaudio` and reinstall them from Metax, then repeat the steps above.
+
+**Alternative (single command, higher risk):**
+
+```bash
+pip install -e "python[srt_metax]"
+```
+
+Use only in a **clean** environment where the only `torch` is the vendor wheel and pip resolution keeps it.
+
+4. **Do not** run `pip install -e "python"` using the default `pyproject.toml` in the same environment if you need to keep vendor PyTorch.
+
+## Notes
+
+- `sglang-kernel`, FlashInfer, and FlashAttention wheels from PyPI target NVIDIA CUDA; they are **not** part of `srt_metax`. Attention backends that rely on pure PyTorch / Triton (where supported by MACA) are the practical starting point; expect to tune flags for your stack.
+- `nvidia-ml-py` is listed for tooling compatibility; GPU telemetry may not match NVIDIA NVML on Metax—treat as optional if it causes problems (`pip uninstall nvidia-ml-py`).
+
+## Optional: development extras
+
+```bash
+pip install -e "python[dev_metax]"
+```

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -19,6 +19,7 @@ dependencies = ["aiohttp", "requests", "tqdm", "numpy", "IPython", "setproctitle
 runtime_common = [
   "IPython",
   "aiohttp",
+  "apache-tvm-ffi>=0.1.5,<0.2",
   "anthropic>=0.20.0",
   "blobfile==3.0.0",
   "av",
@@ -61,6 +62,7 @@ runtime_common = [
   "transformers==5.3.0",
   "uvicorn",
   "uvloop",
+  "watchfiles",
   "xgrammar==0.1.27",
   "smg-grpc-servicer>=0.5.0",
 ]
@@ -107,6 +109,13 @@ diffusion_hip = [
 # For Intel Gaudi(device : hpu) follow the installation guide
 # https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html
 srt_hpu = ["sglang[runtime_common]"]
+
+# https://docs.sglang.io/platforms/metax_gpu.md
+# Metax MACA (CUDA API–compatible): use vendor PyTorch; no PyPI torch/sglang-kernel/flashinfer wheels.
+srt_metax = [
+  "sglang[runtime_common]",
+  "nvidia-ml-py",
+]
 
 # https://docs.sglang.io/platforms/mthreads_gpu.md
 srt_musa = [
@@ -159,11 +168,13 @@ test = [
 
 all_hip = ["sglang[srt_hip]", "sglang[diffusion_hip]"]
 all_hpu = ["sglang[srt_hpu]"]
+all_metax = ["sglang[srt_metax]"]
 all_musa = ["sglang[srt_musa]", "sglang[diffusion_musa]"]
 all_mps = ["sglang[srt_mps]", "sglang[diffusion_mps]"]
 
 dev_hip = ["sglang[all_hip]", "sglang[test]"]
 dev_hpu = ["sglang[all_hpu]", "sglang[test]"]
+dev_metax = ["sglang[all_metax]", "sglang[test]"]
 dev_musa = ["sglang[all_musa]", "sglang[test]"]
 dev_mps = ["sglang[all_mps]", "sglang[test]"]
 


### PR DESCRIPTION
## Motivation

Document and wire **Metax (MACA)** installs through `pyproject_other.toml`, without pulling the default NVIDIA stack (`sglang-kernel`, FlashInfer, PyPI CUDA torch). Helps users keep **vendor PyTorch** and avoid accidental `torch` replacement by pip.

## Modifications

- Add **`docs/platforms/metax_gpu.md`**: swap `pyproject_other.toml` → `pyproject.toml`, install paths (`srt_metax` / `dev_metax`), and a **one-shot `pip install`** recipe (inline `tomllib` snippet) to reduce PyPI `torch` hijacking.
- Extend **`python/pyproject_other.toml`**: `runtime_common` adds `apache-tvm-ffi`, `watchfiles`; new **`srt_metax`**, **`all_metax`**, **`dev_metax`**.
- Link from **`docs/get_started/install.md`** to the Metax page.

## Accuracy Tests

N/A (docs + packaging metadata only).

## Benchmarking and Profiling

N/A.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).