### PR TITLE
Fix /rerun-stage dispatch failure for non-AMD stages

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -340,7 +340,6 @@ def handle_rerun_stage(
                 }
             else:
                 inputs = {
-                    "version": "release",
                     "target_stage": stage_name,
                     "pr_head_sha": pr_head_sha,
                 }
@@ -352,7 +351,7 @@ def handle_rerun_stage(
             if is_amd_stage:
                 inputs = {"target_stage": stage_name}
             else:
-                inputs = {"version": "release", "target_stage": stage_name}
+                inputs = {"target_stage": stage_name}
 
         # Record dispatch time before triggering
         dispatch_time = time.time()


### PR DESCRIPTION
## Summary
- `/rerun-stage` fails for non-AMD stages with `422: Unexpected inputs provided: ["version"]`
- Caused by #20911 removing the `version` input from `pr-test.yml` without updating the slash command handler
- Fix: remove `"version": "release"` from dispatch inputs in `slash_command_handler.py`