### PR TITLE
Fix NIXL file descriptor leakage during file registration

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -64,6 +64,7 @@ class HiCacheNixl(HiCacheStorage):
         )
 
         self.is_mla_model = storage_config.is_mla_model
+        self.is_zero_copy = False
 
         model_name = "-".join(model_name.split("/")) if model_name else ""
 
@@ -100,7 +101,10 @@ class HiCacheNixl(HiCacheStorage):
     ) -> Optional[Any]:
         """Register files with NIXL."""
         tuples = self.file_manager.files_to_nixl_tuples(file_paths)
-        return self.registration._register_memory(tuples, "FILE")
+        try:
+            return self.registration._register_memory(tuples, "FILE")
+        finally:
+            self.file_manager.close_nixl_tuples(tuples)
 
     def register_objects(
         self, keys: List[str], sizes: Optional[List[int]] = None
@@ -123,90 +127,97 @@ class HiCacheNixl(HiCacheStorage):
 
         # Registering file and object keys per transfer, to be updated when
         # pre-registration for file and object is added to HiCache.
-        if self.backend_selector.mem_type == "FILE":
-            tuples = self.file_manager.files_to_nixl_tuples(keys)
-            if not tuples or not self.registration._register_memory(tuples, "FILE"):
-                logger.error("Failed to prepare files for transfer")
-                return False
-        else:  # mem_type == "OBJ"
-            tuples = [(0, 0, key, "") for key in keys]
-            if not tuples or not self.registration._register_memory(tuples, "OBJ"):
-                logger.error("Failed to register objects")
-                return False
-
-        # Prepare transfer descriptors
-        if isinstance(buffers[0], torch.Tensor):
-            tensor_sizes = [
-                tensor.element_size() * tensor.numel() for tensor in buffers
-            ]
-            storage_tuples = [(x[0], s, x[2]) for x, s in zip(tuples, tensor_sizes)]
-            host_descs = self.agent.get_xfer_descs(buffers)
-
-            if direction in ("READ", "WRITE"):
-                # register buffer to avoid calling initialize_xfer twice due to missing registration
-                self.register_buffers(buffers)
-
-        elif isinstance(buffers[0], tuple):
-            storage_tuples = [(x[0], y[1], x[2]) for x, y in zip(tuples, buffers)]
-            host_descs = self.agent.get_xfer_descs(
-                [(x[0], x[1], 0) for x in buffers], "DRAM"
-            )
-
-            if direction in ("READ", "WRITE"):
-                # register buffer to avoid calling initialize_xfer twice due to missing registration
-                self.register_buffers(buffers)
-
-        else:
-            return False
-
-        storage_descs = self.agent.get_xfer_descs(
-            storage_tuples, self.backend_selector.mem_type
-        )
-
-        if (host_descs is None) or (storage_descs is None):
-            logger.error("Failed to get transfer descriptors")
-            return False
-
-        # Initialize transfer, default assumption that tensor was registered
+        tuples = []
 
         try:
-            xfer_req = self.agent.initialize_xfer(
-                direction, host_descs, storage_descs, self.agent_name
-            )
-        except Exception:
-            # Check if it was due to missing pre-registration
-            if not self.register_buffers(buffers):
-                logger.error("Failed to register tensors/buffers")
+            if self.backend_selector.mem_type == "FILE":
+                tuples = self.file_manager.files_to_nixl_tuples(keys)
+                if not tuples or not self.registration._register_memory(tuples, "FILE"):
+                    logger.error("Failed to prepare files for transfer")
+                    return False
+            else:  # mem_type == "OBJ"
+                tuples = [(0, 0, key, "") for key in keys]
+                if not tuples or not self.registration._register_memory(tuples, "OBJ"):
+                    logger.error("Failed to register objects")
+                    return False
+
+            # Prepare transfer descriptors
+            if isinstance(buffers[0], torch.Tensor):
+                tensor_sizes = [
+                    tensor.element_size() * tensor.numel() for tensor in buffers
+                ]
+                storage_tuples = [(x[0], s, x[2]) for x, s in zip(tuples, tensor_sizes)]
+                host_descs = self.agent.get_xfer_descs(buffers)
+
+                if direction in ("READ", "WRITE"):
+                    # register buffer to avoid calling initialize_xfer twice due to missing registration
+                    self.register_buffers(buffers)
+
+            elif isinstance(buffers[0], tuple):
+                storage_tuples = [(x[0], y[1], x[2]) for x, y in zip(tuples, buffers)]
+                host_descs = self.agent.get_xfer_descs(
+                    [(x[0], x[1], 0) for x in buffers], "DRAM"
+                )
+
+                if direction in ("READ", "WRITE"):
+                    # register buffer to avoid calling initialize_xfer twice due to missing registration
+                    self.register_buffers(buffers)
+
+            else:
                 return False
 
+            storage_descs = self.agent.get_xfer_descs(
+                storage_tuples, self.backend_selector.mem_type
+            )
+
+            if (host_descs is None) or (storage_descs is None):
+                logger.error("Failed to get transfer descriptors")
+                return False
+
+            # Initialize transfer, default assumption that tensor was registered
             try:
                 xfer_req = self.agent.initialize_xfer(
                     direction, host_descs, storage_descs, self.agent_name
                 )
-            except Exception as e:
-                logger.error(f"Failed to create transfer request: {e}")
-                return False
-
-        # Execute transfer and wait for its completion
-        try:
-            state = self.agent.transfer(xfer_req)
-            while state != "DONE":
-                state = self.agent.check_xfer_state(xfer_req)
-                if state == "ERR":
-                    self.agent.release_xfer_handle(xfer_req)
-                    logger.error("Transfer failed")
+            except Exception:
+                # Check if it was due to missing pre-registration
+                if not self.register_buffers(buffers):
+                    logger.error("Failed to register tensors/buffers")
                     return False
-                time.sleep(0.0001)  # Can be changed to os.sched_yield() or parametrized
 
-            self.agent.release_xfer_handle(xfer_req)
-            return True
+                try:
+                    xfer_req = self.agent.initialize_xfer(
+                        direction, host_descs, storage_descs, self.agent_name
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to create transfer request: {e}")
+                    return False
 
-        except Exception as e:
-            logger.error(f"Failed to execute transfer: {e}")
-            import traceback
+            # Execute transfer and wait for its completion
+            try:
+                state = self.agent.transfer(xfer_req)
+                while state != "DONE":
+                    state = self.agent.check_xfer_state(xfer_req)
+                    if state == "ERR":
+                        self.agent.release_xfer_handle(xfer_req)
+                        logger.error("Transfer failed")
+                        return False
+                    time.sleep(
+                        0.0001
+                    )  # Can be changed to os.sched_yield() or parametrized
 
-            logger.error(f"Traceback: {traceback.format_exc()}")
-            return False
+                self.agent.release_xfer_handle(xfer_req)
+                return True
+
+            except Exception as e:
+                logger.error(f"Failed to execute transfer: {e}")
+                import traceback
+
+                logger.error(f"Traceback: {traceback.format_exc()}")
+                return False
+        finally:
+            if self.backend_selector.mem_type == "FILE":
+                self.file_manager.close_nixl_tuples(tuples)
 
     def get(
         self,

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
@@ -284,6 +284,12 @@ class NixlFileManager:
             logger.error(f"Failed to close file descriptor {fd}: {e}")
             return False
 
+    def close_nixl_tuples(self, tuples: List[Tuple[int, int, int, str]]) -> None:
+        """Close file descriptors stored in NIXL FILE tuples."""
+        for _, _, fd, _ in tuples:
+            if fd is not None and fd >= 0:
+                self.close_file(fd)
+
     def files_to_nixl_tuples(
         self, file_paths: List[str]
     ) -> List[Tuple[int, int, int, str]]:
@@ -292,8 +298,7 @@ class NixlFileManager:
         for path in file_paths:
             if (fd := self.open_file(path)) is None:
                 # Clean up on failure
-                for t in tuples:
-                    self.close_file(t[2])
+                self.close_nixl_tuples(tuples)
                 return []
             tuples.append((0, 0, fd, path))
         return tuples

--- a/python/sglang/srt/mem_cache/storage/nixl/test_hicache_nixl_storage.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/test_hicache_nixl_storage.py
@@ -5,6 +5,8 @@ import unittest
 from typing import List
 from unittest.mock import MagicMock
 
+os.environ.setdefault("FLASHINFER_WORKSPACE_BASE", "/tmp")
+
 import torch
 
 from sglang.srt.mem_cache.hicache_storage import HiCacheStorageConfig
@@ -23,6 +25,7 @@ class TestNixlUnified(unittest.TestCase):
         # Create test directories
         self.test_dir = "/tmp/test_nixl_unified"
         os.makedirs(self.test_dir, exist_ok=True)
+        os.environ["SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR"] = self.test_dir
 
         # Mock NIXL agent for registration tests
         self.mock_agent = MagicMock()
@@ -37,17 +40,17 @@ class TestNixlUnified(unittest.TestCase):
         self.storage_config = HiCacheStorageConfig(
             tp_rank=0,
             tp_size=2,
+            pp_rank=0,
+            pp_size=1,
             is_mla_model=False,
+            enable_storage_metrics=False,
             is_page_first_layout=False,
             model_name="test_model",
+            extra_config={"plugin": {"posix": {"active": True}}},
         )
 
         try:
-            self.hicache = HiCacheNixl(
-                storage_config=self.storage_config,
-                file_path=self.test_dir,
-                plugin="POSIX",
-            )
+            self.hicache = HiCacheNixl(storage_config=self.storage_config)
         except ImportError:
             self.skipTest("NIXL not available, skipping NIXL storage tests")
 
@@ -56,7 +59,7 @@ class TestNixlUnified(unittest.TestCase):
         if os.path.exists(self.test_dir):
             import shutil
 
-            shutil.rmtree(self.test_dir)
+            shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def delete_test_file(self, file_path: str) -> bool:
         """Helper method to delete a test file.
@@ -227,6 +230,7 @@ class TestNixlUnified(unittest.TestCase):
         tuples = self.file_manager.files_to_nixl_tuples([test_file])
         self.assertIsNotNone(tuples)
         self.assertTrue(len(tuples) > 0)
+        self.file_manager.close_nixl_tuples(tuples)
 
     def test_error_handling(self):
         """Test error handling in file operations."""
@@ -250,20 +254,37 @@ class TestNixlUnified(unittest.TestCase):
         tensors = [torch.randn(5, 5) for _ in range(3)]
         self.assertIsNotNone(self.hicache.register_buffers(tensors))
 
+    def test_register_files_closes_file_descriptors(self):
+        """Test that register_files closes all opened file descriptors."""
+        files = [os.path.join(self.test_dir, f"fd_test_file_{i}.bin") for i in range(3)]
+        for file in files:
+            self.file_manager.create_file(file)
+
+        captured_fds = []
+
+        def register_and_capture(items, mem_type):
+            self.assertEqual(mem_type, "FILE")
+            captured_fds.extend(item[2] for item in items)
+            for fd in captured_fds:
+                os.fstat(fd)
+            return "mock_registered_memory"
+
+        self.hicache.registration._register_memory = register_and_capture
+
+        self.assertEqual(self.hicache.register_files(files), "mock_registered_memory")
+        self.assertEqual(len(captured_fds), len(files))
+
+        for fd in captured_fds:
+            with self.assertRaises(OSError):
+                os.fstat(fd)
+
     def test_register_files_with_tuples(self):
-        """Test registration of files using NIXL tuples."""
+        """Test registration of files using file paths."""
         files = [os.path.join(self.test_dir, f"test_file_{i}.bin") for i in range(3)]
         for file in files:
             self.file_manager.create_file(file)
 
-        # Create tuples and register
-        tuples = self.file_manager.files_to_nixl_tuples(files)
-        self.hicache.register_files(tuples)
-
-        # Verify tuples
-        self.assertEqual(len(tuples), len(files))
-        for t, f in zip(tuples, files):
-            self.assertEqual(t[3], f)  # Check file path
+        self.assertIsNotNone(self.hicache.register_files(files))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# summary

NIXL backend for HiCache has a bug of file descriptor leakage. Running inference for a long time will lead to depletion of file descriptors.

# Fix
Close files that are opened during data transfers.

# Test

Use a large model to test:

1. Server launch

```bash
export SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR=/raid/hicache_storage
export MODEL_PATH=/models/zai-org/GLM-4.7-FP8

python3 -m sglang.launch_server --model-path $MODEL_PATH --tp 8  --page-size 64 --context-length 202752 --trust-remote-code --dtype float16  --enable-hierarchical-cache     --hicache-write-policy write_through   --hicache-mem-layout page_first --hicache-storage-prefetch-policy wait_complete --hicache-storage-backend nixl  --hicache-storage-backend-extra-config '{"use_posix_aio": "true"}'  --hicache-ratio 1 --hicache-size 0 --log-level debug
```

2. client requests
```bash
export MODEL_PATH=/models/zai-org/GLM-4.7-FP8
python3 ./ttft-estimator.py --model $MODEL_PATH  --host localhost --port 30000 --context-lengths 131072,1196608
```

Before this fix, the system's file descriptors are depleted. After this fix, the system is working properly.