### PR TITLE
Add CI maintenance mode gate to nightly-test-nvidia.yml

### DIFF
--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -39,6 +39,8 @@ runs:
           "## ⚠️ CI Maintenance Mode is Active" \
           "The CI infrastructure is currently under maintenance." \
           "All PR CI runs are paused until maintenance is complete." \
+          "You might also experience unexpected failures during this period." \
+          "The team is working on the issue and will update the status as soon as possible." \
           "" \
           "What should you do?" \
           "- Check back later (~12 hours)" \

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh
@@ -81,6 +85,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -110,6 +118,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -191,6 +203,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh
@@ -219,6 +235,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -289,6 +309,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh
@@ -311,6 +335,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -348,6 +376,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh
@@ -370,6 +402,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -411,6 +447,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -468,6 +508,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh diffusion
@@ -520,6 +564,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
+
       - name: Install dependencies
         run: |
           IS_BLACKWELL=1 bash scripts/ci/cuda/ci_install_dependency.sh
@@ -544,6 +592,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Run `./.github/actions/check-maintenance` after checkout on all GPU jobs in `nightly-test-nvidia.yml`, matching the pattern used in `pr-test.yml`.
- Skips `ubuntu-latest` jobs (`consolidate-metrics`, `check-all-jobs`) which do not need the gate.

## Test plan
- [ ] CI: workflow YAML valid

Made with [Cursor](https://cursor.com)