### PR TITLE
ci: bypass maintenance gate for PR Test on main

### DIFF
--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -1,5 +1,5 @@
 name: Check Maintenance Mode
-description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label.
+description: Blocks CI when maintenance mode is active (issue #21065 is open), unless the PR has the bypass-maintenance label, or env SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN=true (PR Test workflow on main only).
 
 inputs:
   github-token:
@@ -17,6 +17,12 @@ runs:
         MAINTENANCE_ISSUE=21065
         REPO="${{ github.repository }}"
         PR_NUMBER="${{ github.event.pull_request.number }}"
+
+        # PR Test workflow only: scheduled runs and runs on main (dispatch / workflow_call) set this env
+        if [[ "${SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN:-}" == "true" ]]; then
+          echo "✅ PR Test on main branch; bypassing maintenance gate."
+          exit 0
+        fi
 
         # Check if maintenance issue is open (fail-open: if API errors, allow CI to proceed)
         ISSUE_STATE=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,6 +57,8 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
+  # Schedule / main-branch dispatch / workflow_call from main use refs/heads/main; PR events use refs/pull/*/merge
+  SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
 permissions:
   actions: write


### PR DESCRIPTION
## Summary
When [CI maintenance mode](https://github.com/sgl-project/sglang/issues/21065) is active, `check-maintenance` blocks runs that are not PRs with the `bypass-maintenance` label. **PR Test** scheduled runs and manual runs from `main` were incorrectly blocked (e.g. [failed check-changes](https://github.com/sgl-project/sglang/actions/runs/23373003291/job/68000261314)).

## Changes
- **`pr-test.yml`**: set workflow env `SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN` when `github.ref == refs/heads/main` (schedule, dispatch from main, `workflow_call` from main).
- **`check-maintenance`**: if that env is `true`, skip the maintenance gate.

Pull requests still use `refs/pull/*/merge`, so they remain gated unless labeled. **`nightly-test-nvidia.yml`** does not set the env, so behavior there is unchanged.

Made with [Cursor](https://cursor.com)