### PR TITLE
fix: ProfileMerger support profile_prefix for trace discovery (#20933)

### DIFF
--- a/python/sglang/srt/managers/scheduler_profiler_mixin.py
+++ b/python/sglang/srt/managers/scheduler_profiler_mixin.py
@@ -231,7 +231,7 @@ class SchedulerProfilerMixin:
 
         try:
             logger.info("Starting profile merge...")
-            merger = ProfileMerger(self.torch_profiler_output_dir, self.profile_id)
+            merger = ProfileMerger(self.torch_profiler_output_dir, self.profile_id, self.profile_prefix)
             merged_path = merger.merge_chrome_traces()
 
             summary = merger.get_merge_summary()

--- a/python/sglang/srt/utils/profile_merger.py
+++ b/python/sglang/srt/utils/profile_merger.py
@@ -14,9 +14,10 @@ logger = logging.getLogger(__name__)
 class ProfileMerger:
     """Merge profile traces from all parallelism types: TP, DP, PP, EP."""
 
-    def __init__(self, output_dir: str, profile_id: str):
+    def __init__(self, output_dir: str, profile_id: str, profile_prefix: str = ""):
         self.output_dir = output_dir
         self.profile_id = profile_id
+        self.profile_prefix = profile_prefix
         self.merged_trace_path = os.path.join(
             output_dir, f"merged-{profile_id}.trace.json.gz"
         )
@@ -83,7 +84,10 @@ class ProfileMerger:
 
     def _discover_trace_files(self) -> List[str]:
         """Discover trace files matching profile_id (supports TP/DP/PP/EP formats)."""
-        patterns = [f"{self.profile_id}*.trace.json.gz"]
+        if self.profile_prefix:
+            patterns = [f"{self.profile_prefix}-{self.profile_id}*.trace.json.gz"]
+        else:
+            patterns = [f"{self.profile_id}*.trace.json.gz"]
 
         trace_files = []
         for pattern in patterns:

--- a/python/sglang/srt/utils/profile_merger.py
+++ b/python/sglang/srt/utils/profile_merger.py
@@ -84,10 +84,8 @@ class ProfileMerger:
 
     def _discover_trace_files(self) -> List[str]:
         """Discover trace files matching profile_id (supports TP/DP/PP/EP formats)."""
-        if self.profile_prefix:
-            patterns = [f"{self.profile_prefix}-{self.profile_id}*.trace.json.gz"]
-        else:
-            patterns = [f"{self.profile_id}*.trace.json.gz"]
+        prefix_part = f"{self.profile_prefix}-" if self.profile_prefix else ""
+        patterns = [f"{prefix_part}{self.profile_id}*.trace.json.gz"]
 
         trace_files = []
         for pattern in patterns:


### PR DESCRIPTION
## Summary

Fixes #20933 - ProfileMerger fails to discover trace files when `profile_prefix` is set (e.g., `DECODE`, `EXTEND` suffixes).

## Changes

1. **profile_merger.py**: Added `profile_prefix` parameter to `__init__()` with default `""` (backward compatible)
2. **profile_merger.py**: Updated `_discover_trace_files()` to include prefix in glob pattern: `"{profile_prefix}-{profile_id}*.trace.json.gz"`
3. **scheduler_profiler_mixin.py**: Pass `self.profile_prefix` when creating `ProfileMerger` instance

## Root Cause

The original `_discover_trace_files()` only searched for `{profile_id}*.trace.json.gz`, which missed files with prefixes like `DECODE-{profile_id}*.trace.json.gz` or `EXTEND-{profile_id}*.trace.json.gz`.

## Testing

- Backward compatible: Default `profile_prefix=""` keeps original behavior
- Forward compatible: When `profile_prefix` is set, correctly discovers prefixed traces

Closes #20933
