### PR TITLE
fix: non-streaming abort broken when --enable-metrics is used

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1499,33 +1499,54 @@ def add_prometheus_track_response_middleware(app):
         )
     )
 
-    @app.middleware("http")
-    async def track_http_status_code(request, call_next):
-        # With recording all requests, we have the risk of high cardinality if requests have arbitrary unhandled paths.
-        # But given that SGLang engines with metrics enabled are usually behind routers this looks safe.
-        path, is_handled_path = _get_fastapi_request_path(request)
-        method = request.method
-        routing_key = request.headers.get("x-smg-routing-key")
+    from starlette.requests import Request
 
-        http_request_counter.labels(endpoint=path, method=method).inc()
-        http_requests_active.labels(endpoint=path, method=method).inc()
-        if routing_key:
-            routing_keys_active.inc(routing_key)
+    class _PrometheusASGIMiddleware:
+        """ASGI-native middleware to preserve client disconnect events."""
 
-        try:
-            response = await call_next(request)
+        def __init__(self, app):
+            self.app = app
 
-            http_response_counter.labels(
-                endpoint=path,
-                method=method,
-                status_code=str(response.status_code),
-            ).inc()
+        async def __call__(self, scope, receive, send):
+            if scope["type"] != "http":
+                await self.app(scope, receive, send)
+                return
 
-            return response
-        finally:
-            http_requests_active.labels(endpoint=path, method=method).dec()
+            request = Request(scope, receive=receive)
+            # With recording all requests, we have the risk of high cardinality
+            # if requests have arbitrary unhandled paths. But given that SGLang
+            # engines with metrics enabled are usually behind routers this
+            # looks safe.
+            path, is_handled_path = _get_fastapi_request_path(request)
+            method = request.method
+            routing_key = request.headers.get("x-smg-routing-key")
+
+            http_request_counter.labels(endpoint=path, method=method).inc()
+            http_requests_active.labels(endpoint=path, method=method).inc()
             if routing_key:
-                routing_keys_active.dec(routing_key)
+                routing_keys_active.inc(routing_key)
+
+            status_code = "500"
+
+            async def send_wrapper(message):
+                nonlocal status_code
+                if message["type"] == "http.response.start":
+                    status_code = str(message["status"])
+                await send(message)
+
+            try:
+                await self.app(scope, receive, send_wrapper)
+            finally:
+                http_response_counter.labels(
+                    endpoint=path,
+                    method=method,
+                    status_code=status_code,
+                ).inc()
+                http_requests_active.labels(endpoint=path, method=method).dec()
+                if routing_key:
+                    routing_keys_active.dec(routing_key)
+
+    app.add_middleware(_PrometheusASGIMiddleware)
 
 
 # https://github.com/blueswen/fastapi-observability/blob/132a3c576f8b09e5311c68bd553215013bc75685/fastapi_app/utils.py#L98

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -1688,6 +1688,7 @@ def run_and_check_memory_leak(
     chunked_prefill_size,
     assert_has_abort,
     api_key: Optional[str] = None,
+    enable_metrics: bool = False,
 ):
     other_args = [
         "--chunked-prefill-size",
@@ -1701,6 +1702,8 @@ def run_and_check_memory_leak(
         other_args += ["--enable-mixed-chunk"]
     if disable_overlap:
         other_args += ["--disable-overlap-schedule"]
+    if enable_metrics:
+        other_args += ["--enable-metrics"]
 
     model = DEFAULT_MODEL_NAME_FOR_TEST
     port = random.randint(4000, 5000)

--- a/test/registered/scheduler/test_abort.py
+++ b/test/registered/scheduler/test_abort.py
@@ -110,6 +110,49 @@ class TestAbortWithApiKey(CustomTestCase):
         )
 
 
+class TestAbortWithMetrics(CustomTestCase):
+    def workload_func(self, base_url, model):
+        def process_func():
+            def run_one(_):
+                prompt = """
+                System: You are a helpful assistant.
+                User: What is the capital of France?
+                Assistant: The capital of France is
+                """
+
+                response = requests.post(
+                    f"{base_url}/generate",
+                    json={
+                        "text": prompt,
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 2048,
+                        },
+                    },
+                )
+                response.json()
+
+            with ThreadPoolExecutor(16) as executor:
+                list(executor.map(run_one, list(range(16))))
+
+        p = multiprocessing.Process(target=process_func)
+        p.start()
+        time.sleep(0.5)
+        p.terminate()
+        time.sleep(10)
+
+    def test_memory_leak_with_metrics(self):
+        run_and_check_memory_leak(
+            self.workload_func,
+            disable_radix_cache=False,
+            enable_mixed_chunk=False,
+            disable_overlap=False,
+            chunked_prefill_size=8192,
+            assert_has_abort=True,
+            enable_metrics=True,
+        )
+
+
 class TestAbortAll(AbortAllMixin, CustomTestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Motivation

When `--enable-metrics` is used, `add_prometheus_track_response_middleware()` registers a middleware via `@app.middleware("http")`. This decorator internally wraps the handler with Starlette's `BaseHTTPMiddleware`, which replaces the ASGI `receive` callable with its own `receive_or_disconnect` wrapper.

This breaks `Request.is_disconnected()`: the method uses a pre-cancelled `anyio.CancelScope` to probe `_receive()`, expecting it to return synchronously. Uvicorn's raw `receive()` does exactly that — it checks its `disconnected` flag and instantly returns `{"type": "http.disconnect"}`. But `BaseHTTPMiddleware`'s wrapper enters `anyio.create_task_group()`, which gets killed by the pre-cancelled scope, returning `{}` instead. The disconnect is never detected.

**Impact**: With `--enable-metrics`, after a client disconnects from a non-streaming request, `_wait_one_response()` in `tokenizer_manager.py` keeps polling `is_disconnected()` every 50 tokens but always gets `False`. The server continues generating tokens indefinitely, wasting GPU resources. In our production environment, we observed tokens growing from ~7k to 23k+ over 2 minutes after client disconnect, with no abort.

Streaming requests are less affected because they have a separate disconnect detection path (SSE `send()` raises on broken pipe).

This is the **same class of bug** fixed in https://github.com/sgl-project/sglang/pull/17253 for the API-key middleware.

## Changes

### `python/sglang/srt/utils/common.py`
Replace `@app.middleware("http")` + `track_http_status_code()` with `_PrometheusASGIMiddleware`, a pure ASGI middleware class (consistent with `_ApiKeyASGIMiddleware` from #17253). Key differences:
- `receive` is passed through untouched → `is_disconnected()` reaches uvicorn's raw `receive()`
- Status code is captured via a `send_wrapper` that intercepts `http.response.start` (replaces `call_next()` + `response.status_code`)
- All metrics behavior is preserved: request/response counters, active request gauge, routing key tracking

### `python/sglang/test/test_utils.py`
Add `enable_metrics: bool = False` parameter to `run_and_check_memory_leak()`.

### `test/registered/scheduler/test_abort.py`
Add `TestAbortWithMetrics` (mirrors `TestAbortWithApiKey` from #17253) to verify abort works correctly when metrics middleware is enabled.

## Verification

A/B tested on H20 × 4 with MiniMax-M2.5 (TP4). Launched the server with `--enable-metrics`, sent a non-streaming request (`max_tokens=100000`), waited for decode to start, then killed the client.

**Before fix** (`@app.middleware("http")`): server kept generating after client disconnect — tokens grew from 8483 to 9643+ in 10s with zero abort logs, and would continue all the way to `max_tokens` (100000), wasting GPU for ~15 minutes per request.

**After fix** (`_PrometheusASGIMiddleware`): all 4 TP ranks logged `Abort running request` within 1s, decode stopped immediately. `/metrics` endpoint still works.

| | Before fix | After fix |
|---|---|---|
| `request._receive` | `BaseHTTPMiddleware...receive_or_disconnect` | `RequestResponseCycle.receive` |
| `is_disconnected()` after kill | Always `False` | `True` within 1s |
| Server behavior after kill | Keeps generating (8483→9643+) | Abort immediately, 0 running req |
| Abort log entries | 0 | 4 (all TP ranks) |
| `/metrics` endpoint | Works | Works |

## Test plan

- [x] Manual A/B test: bug confirmed on `main`, fix confirmed on same setup
