### PR TITLE
Implement per-token w4afp8 moe gemm, improve performance with w4afp8 moe gemm

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -2055,6 +2055,82 @@ def triton_scaled_mm(
     return result.to(out_dtype)
 
 
+@triton.jit
+def interleave_int4xfp8_Hopper_kernel(
+    ptr_4b,
+    ptr_4b_interleaved,
+    rows,
+    cols,
+    grid_0: tl.constexpr,
+    BLOCK_TX: tl.constexpr,
+    BLOCK_TY: tl.constexpr,
+):
+    blockIdx_x = tl.program_id(0)
+    lane_x = tl.arange(0, BLOCK_TX)
+    lane_y = tl.arange(0, BLOCK_TY)
+
+    rows_half = rows // 2
+    cols_div4 = cols // 4
+
+    block_id = blockIdx_x
+    while block_id < rows_half:
+        partition_id = lane_y
+        mask_partition = partition_id < (cols // 64)
+        while tl.max(mask_partition.to(tl.int32)) > 0:
+            lane_id = lane_x[None, :]
+            partition = partition_id[:, None]
+            row_id = (block_id // 8) * 16 + (block_id % 8)
+            dst_row_id = row_id + ((lane_id % 8) // 4) * 8
+            mma_id = lane_id // 8
+            interleaved_lane_id = mma_id * 8 + (lane_id % 4) * 2
+            col_id = partition * 16 + lane_id
+            dst_col_id = partition * 16 + interleaved_lane_id
+
+            src_id_a = row_id * cols_div4 + col_id
+            src_id_b = (row_id + 8) * cols_div4 + col_id
+
+            dst_id = dst_row_id * cols_div4 + dst_col_id
+
+            valid = (
+                (col_id < cols_div4)
+                & (dst_row_id < rows)
+                & (row_id + 8 < rows)
+                & mask_partition[:, None]
+            )
+
+            fp4x2_a = tl.load(ptr_4b + src_id_a, mask=valid, other=0).to(tl.uint16)
+            fp4x2_b = tl.load(ptr_4b + src_id_b, mask=valid, other=0).to(tl.uint16)
+
+            tl.store(ptr_4b_interleaved + dst_id, fp4x2_a, mask=valid)
+            tl.store(ptr_4b_interleaved + (dst_id + 1), fp4x2_b, mask=valid)
+
+            partition_id = partition_id + BLOCK_TY
+            mask_partition = partition_id < (cols // 64)
+
+        block_id += grid_0
+
+
+def interleave_int4(int4_ptr, int4_interleaved_ptr, rows, cols):
+    BLOCK_TX = 16
+    BLOCK_TY = 32
+    grid_0 = 1024
+
+    int16_ptr = int4_ptr.view(torch.int16)  # reinterpret_cast<const uint16_t*>
+    int16_interleaved_ptr = int4_interleaved_ptr.view(
+        torch.int16
+    )  # reinterpret_cast<uint16_t*>
+
+    interleave_int4xfp8_Hopper_kernel[(grid_0,)](
+        int16_ptr,
+        int16_interleaved_ptr,
+        rows,
+        cols,
+        grid_0=grid_0,
+        BLOCK_TX=BLOCK_TX,
+        BLOCK_TY=BLOCK_TY,
+    )
+
+
 if _is_cuda:
     if enable_sgl_per_token_group_quant_8bit:
 

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -244,7 +244,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "cutlass_w4a8_moe_mm(Tensor! d, Tensor a, Tensor b, "
       "               Tensor a_scales, Tensor b_scales, Tensor expert_offsets, "
       "               Tensor problem_sizes, Tensor a_strides, "
-      "               Tensor b_strides, Tensor d_strides, Tensor s_strides,"
+      "               Tensor b_strides, Tensor d_strides, Tensor sa_strides, Tensor sb_strides, "
       "               int chunk_size, int topk) -> ()");
   m.impl("cutlass_w4a8_moe_mm", torch::kCUDA, &cutlass_w4a8_moe_mm);
 

--- a/sgl-kernel/csrc/cutlass_extensions/detail/collective/mixed_input_utils.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/detail/collective/mixed_input_utils.hpp
@@ -25,6 +25,66 @@
 
 namespace cutlass::gemm::collective::detail {
 
+typedef uint32_t __nv_int4x8_storage_t;
+typedef uint64_t __nv_fp8x8_storage_t;
+
+// [ 0,  1,  2,  3] encoded as FP8
+__constant__ static uint32_t POS_E4M3s_REG1_[2] = {0x44403800, 0x44403800};
+// [ 4,  5,  6,  7] encoded as FP8
+__constant__ static uint32_t POS_E4M3s_REG2_[2] = {0x4E4C4A48, 0x4E4C4A48};
+// [-8, -7, -6, -5] encoded as FP8
+__constant__ static uint32_t NEG_E4M3s_REG1_[2] = {0xCACCCED0, 0xCACCCED0};
+// [-4, -3, -2, -1] encoded as FP8
+__constant__ static uint32_t NEG_E4M3s_REG2_[2] = {0xB8C0C4C8, 0xB8C0C4C8};
+
+__device__ __inline__ __nv_fp8x8_storage_t psx_cvt_lut_prmt_int4x8_to_fp8x8(const __nv_int4x8_storage_t int4x8) {
+  __nv_fp8x8_storage_t fp8x8_raw;
+  __nv_fp8x4_storage_t* fp8x4_raw = reinterpret_cast<__nv_fp8x4_storage_t*>(&fp8x8_raw);
+
+  // View the input as reg
+  uint32_t reg = reinterpret_cast<const uint32_t&>(int4x8);
+
+  // Determines if to get from the signed or unsigned candidates
+  uint32_t sign = (reg & 0x88888888) >> 1;
+
+  // Ignore sign bit when indexing into LUT
+  uint32_t lut_idx = (reg & 0x77777777);
+
+  // Signed is OR'd with 0x32103210 to find the correct value in the LUT
+  const uint32_t final_prmt_base = 0x32103210;
+
+  auto lane_id = threadIdx.x & 0x1;
+  uint32_t POS_E4M3s_REG1 = POS_E4M3s_REG1_[lane_id];
+  uint32_t POS_E4M3s_REG2 = POS_E4M3s_REG2_[lane_id];
+  uint32_t NEG_E4M3s_REG1 = NEG_E4M3s_REG1_[lane_id];
+  uint32_t NEG_E4M3s_REG2 = NEG_E4M3s_REG2_[lane_id];
+
+  asm volatile(
+      "{\n"
+      "  .reg .b32 pos_f8s, neg_f8s;\n"
+      "  .reg .b32 lut1, sign1, prmt0, prmt1;\n"
+      "  or.b32 prmt0, %4, %3;\n"
+      "  prmt.b32 pos_f8s, %5, %6, %2;\n"
+      "  prmt.b32 neg_f8s, %7, %8, %2;\n"
+      "  prmt.b32 %0, pos_f8s, neg_f8s, prmt0;\n"
+      "  shr.u32 lut1, %2, 16;\n"
+      "  shr.u32 sign1, %3, 16;\n"
+      "  or.b32 prmt1, %4, sign1;\n"
+      "  prmt.b32 pos_f8s, %5, %6, lut1;\n"
+      "  prmt.b32 neg_f8s, %7, %8, lut1;\n"
+      "  prmt.b32 %1, pos_f8s, neg_f8s, prmt1;\n"
+      "}\n"
+      : "=r"(fp8x4_raw[0]), "=r"(fp8x4_raw[1])
+      : "r"(lut_idx),
+        "r"(sign),
+        "r"(final_prmt_base),
+        "r"(POS_E4M3s_REG1),
+        "r"(POS_E4M3s_REG2),
+        "r"(NEG_E4M3s_REG1),
+        "r"(NEG_E4M3s_REG2));
+  return fp8x8_raw;
+}
+
 template <class Collective>
 struct MixedGroupedGemmInputUtils {
  private:
@@ -32,26 +92,42 @@ struct MixedGroupedGemmInputUtils {
   using ConversionMode = typename Collective::ConversionMode;
   using SmemLayoutA = typename Collective::SmemLayoutA;
   using SmemLayoutB = typename Collective::SmemLayoutB;
-  using SmemLayoutScale = typename Collective::SmemLayoutScale;
+  using SmemLayoutScaleA = typename Collective::SmemLayoutScaleA;
+  using SmemLayoutScaleB = typename Collective::SmemLayoutScaleB;
   using SwappedElementA = typename Collective::SwappedElementA;
   using SwappedElementB = typename Collective::SwappedElementB;
   using RealSwappedElementA = typename Collective::RealSwappedElementA;
   using RealSwappedElementB = typename Collective::RealSwappedElementB;
-  using ElementScale = typename Collective::ElementScale;
+  using ScaleA = typename Collective::ScaleA;
+  using ScaleB = typename Collective::ScaleB;
+  using ElementScale = typename Collective::ScaleA;
+
   using ElementZero = typename Collective::ElementZero;
-  using SmemCopyAtomScale = typename Collective::SmemCopyAtomScale;
+  using SmemCopyAtomScaleA = typename Collective::SmemCopyAtomScaleA;
+  using SmemCopyAtomScaleB = typename Collective::SmemCopyAtomScaleB;
   static constexpr auto KernelConversionMode = Collective::KernelConversionMode;
   static constexpr auto ModeHasScales = Collective::ModeHasScales;
   static constexpr auto UseScaleLookupTable = Collective::UseScaleLookupTable;
+  static constexpr auto UseInt4ToFP8LookupTable = Collective::UseInt4ToFP8LookupTable;
 
  public:
-  static constexpr auto elements_per_smem_scale() {
+  static constexpr auto elements_per_smem_scaleA() {
     if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
       return 0;
     } else if constexpr (ModeHasScales) {
-      return cute::cosize_v<SmemLayoutScale>;
+      return cute::cosize_v<SmemLayoutScaleA>;
     } else {
-      static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Type not handled in scale smem allocation.");
+      static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Type not handled in scaleA smem allocation.");
+    }
+  }
+
+  static constexpr auto elements_per_smem_scaleB() {
+    if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
+      return 0;
+    } else if constexpr (ModeHasScales) {
+      return cute::cosize_v<SmemLayoutScaleB>;
+    } else {
+      static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Type not handled in scaleB smem allocation.");
     }
   }
 
@@ -61,9 +137,10 @@ struct MixedGroupedGemmInputUtils {
         KernelConversionMode == ConversionMode::ConvertAndScale) {
       return 0;
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
-      return cute::cosize_v<SmemLayoutScale>;
+      return cute::cosize_v<SmemLayoutScaleA>;
     } else {
-      static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Type not handled in scale smem allocation.");
+      static_assert(
+          cutlass::detail::dependent_false<KernelSchedule>, "Type not handled in zero_point smem allocation.");
     }
   }
 
@@ -82,19 +159,25 @@ struct MixedGroupedGemmInputUtils {
     if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
       return 0;
     } else if constexpr (ModeHasScales) {
-      constexpr uint32_t scale_tx_bytes = cutlass::bits_to_bytes(
-          size<0>(SmemLayoutScale{}) * size<1>(SmemLayoutScale{}) *
-          static_cast<uint32_t>(cute::sizeof_bits_v<ElementScale>));
-      static_assert(scale_tx_bytes % 128 == 0, "Each scale stage must be 128B aligned.");  // required by TMA
+      constexpr uint32_t scaleA_tx_bytes = cutlass::bits_to_bytes(
+          size<0>(SmemLayoutScaleA{}) * size<1>(SmemLayoutScaleA{}) *
+          static_cast<uint32_t>(cute::sizeof_bits_v<ScaleA>));
+      static_assert(scaleA_tx_bytes % 128 == 0, "Each scaleA stage must be 128B aligned.");  // required by TMA
+
+      constexpr uint32_t scaleB_tx_bytes = cutlass::bits_to_bytes(
+          size<0>(SmemLayoutScaleB{}) * size<1>(SmemLayoutScaleB{}) *
+          static_cast<uint32_t>(cute::sizeof_bits_v<ScaleB>));
+      static_assert(scaleB_tx_bytes % 128 == 0, "Each scaleB stage must be 128B aligned.");  // required by TMA
+
       if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-        return scale_tx_bytes;
+        return scaleA_tx_bytes + scaleB_tx_bytes;
       } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
         // Scale and zero share smem layout
         constexpr uint32_t zero_tx_bytes = cutlass::bits_to_bytes(
-            size<0>(SmemLayoutScale{}) * size<1>(SmemLayoutScale{}) *
+            size<0>(SmemLayoutScaleA{}) * size<1>(SmemLayoutScaleA{}) *
             static_cast<uint32_t>(cute::sizeof_bits_v<ElementZero>));
         static_assert(zero_tx_bytes % 128 == 0, "Each zero stage must be 128B aligned.");  // required by TMA
-        return scale_tx_bytes + zero_tx_bytes;
+        return scaleA_tx_bytes + scaleB_tx_bytes + zero_tx_bytes;
       } else {
         static_assert(
             cutlass::detail::dependent_false<KernelSchedule>, "Type not handled in tma transaction bytes computation.");
@@ -105,40 +188,46 @@ struct MixedGroupedGemmInputUtils {
     }
   }
 
-  /// Utilities to copy A and extra inputs from smem to RF
-  template <class SmemTiledCopyA, class TensorASmemView, class TensorACopyView, class... Ts, class... Us>
-  CUTLASS_DEVICE static void copy_tensors_MK(
+  // Utilities to copy A from smem to RF
+  template <class SmemTiledCopyA, class TensorASmemView, class TensorACopyView>
+  CUTLASS_DEVICE static void copy_tensors_A(
       SmemTiledCopyA const& smem_tiled_copy_A,
       TensorASmemView const& tCsA,
       TensorACopyView& tCrA_copy_view,
+      int k_block,
+      int read_stage) {
+    if (k_block < size<2>(tCsA.shape())) {
+      copy(smem_tiled_copy_A, tCsA(_, _, k_block, read_stage), tCrA_copy_view(_, _, k_block));
+    }
+  }
+
+  /// Utilities to copy Scales for A from smem to RF
+  template <class... Ts, class... Us>
+  CUTLASS_DEVICE static void copy_tensors_SFA(
       cute::tuple<Ts...> const& partitioned_mma_extra_info,
       cute::tuple<Us...> const& tiled_copy_and_views,
       int k_block,
       int read_stage) {
-    copy(smem_tiled_copy_A, tCsA(_, _, k_block, read_stage), tCrA_copy_view(_, _, k_block));
+    // We are starting a new k-tile so copy the scale
+    if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
+      // nothing to do
+    } else if constexpr (ModeHasScales) {
+      auto smem_tiled_copy_S = cute::get<0>(tiled_copy_and_views);
+      auto tCrS_copy_view = cute::get<1>(tiled_copy_and_views);
+      auto tCsS = cute::get<0>(partitioned_mma_extra_info);
 
-    if (k_block == 0) {
-      // We are starting a new k-tile so copy the scale
-      if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
-        // nothing to do
-      } else if constexpr (ModeHasScales) {
-        auto smem_tiled_copy_S = cute::get<0>(tiled_copy_and_views);
-        auto tCrS_copy_view = cute::get<1>(tiled_copy_and_views);
-        auto tCsS = cute::get<0>(partitioned_mma_extra_info);
-        copy(smem_tiled_copy_S, tCsS(_, _, k_block, read_stage), tCrS_copy_view(_, _, k_block));
-        if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-          // Nothing extra to do
-        } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
-          auto tCsZ = cute::get<2>(partitioned_mma_extra_info);
-          auto tCrZ_copy_view = cute::get<2>(tiled_copy_and_views);
-          copy(smem_tiled_copy_S, tCsZ(_, _, k_block, read_stage), tCrZ_copy_view(_, _, k_block));
-        } else {
-          static_assert(
-              cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in A -> RF path.");
-        }
+      copy(smem_tiled_copy_S, tCsS(_, _, k_block, read_stage), tCrS_copy_view(_, _, k_block));
+      if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
+        // Nothing extra to do
+      } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
+        auto tCsZ = cute::get<2>(partitioned_mma_extra_info);
+        auto tCrZ_copy_view = cute::get<2>(tiled_copy_and_views);
+        copy(smem_tiled_copy_S, tCsZ(_, _, k_block, read_stage), tCrZ_copy_view(_, _, k_block));
       } else {
         static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in A -> RF path.");
       }
+    } else {
+      static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in A -> RF path.");
     }
   }
 
@@ -203,6 +292,27 @@ struct MixedGroupedGemmInputUtils {
           : "=r"(r[i])
           : "r"(lut_idx), "r"(sign), "r"(scale_neg_[0]), "r"(scale_neg_[1]), "r"(scale_pos_[0]), "r"(scale_pos_[1]));
     }
+  }
+
+  template <
+      class EngineIn,
+      class LayoutIn,
+      class EngineOut,
+      class LayoutOut>
+  CUTLASS_DEVICE static void int4tofp8_lookup_table_convert(  // Accept mutable temporaries
+      Tensor<EngineIn, LayoutIn> const& src,
+      Tensor<EngineOut, LayoutOut>&& dst) {
+    int4tofp8_lookup_table_convert(src, dst);
+  }
+
+  template <class EngineIn, class LayoutIn, class EngineOut, class LayoutOut>
+  CUTLASS_DEVICE static void
+  int4tofp8_lookup_table_convert(Tensor<EngineIn, LayoutIn> const& src, Tensor<EngineOut, LayoutOut>& dst) {
+    // View the input as reg
+    auto&& src_ = cute::recast<__nv_int4x8_storage_t>(src)(0);
+    auto&& dst_ = cute::recast<__nv_fp8x8_storage_t>(dst)(0);
+
+    dst_ = psx_cvt_lut_prmt_int4x8_to_fp8x8(src_);
   }
 
   /// Utilities to dequantize A.
@@ -371,7 +481,11 @@ struct MixedGroupedGemmInputUtils {
     // KernelConversionMode == ConversionMode::DirectConvert
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < size<1>(dst_vm); ++i) {
-      LayoutAwareConvert(src_vm(_, i), dst_vm(_, i));
+      if constexpr (UseInt4ToFP8LookupTable) {
+        int4tofp8_lookup_table_convert(src_vm(_, i), dst_vm(_, i));
+      } else {
+        LayoutAwareConvert(src_vm(_, i), dst_vm(_, i));
+      }
     }
   }
 
@@ -383,30 +497,44 @@ struct MixedGroupedGemmInputUtils {
       TensorStorage& shared_tensors,
       uint2 const& cluster_local_block_id,
       int const m_coord,
+      int const n_coord,
       int const l_coord) {
     if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
       return cute::make_tuple();
     } else if constexpr (ModeHasScales) {
-      Tensor sS =
-          make_tensor(make_smem_ptr(shared_tensors.smem_scale.begin()), SmemLayoutScale{});  // (BLK_M,BLK_K,PIPE)
-      Tensor gS_mkl = get<2>(load_inputs);
-      auto block_tma_s = mainloop_params.tma_load_scale.get_slice(cluster_local_block_id.y);
-      Tensor gS = gS_mkl(_, _, m_coord, _, l_coord);  // (BLK_M,BLK_K,k)
+      Tensor sSA =
+          make_tensor(make_smem_ptr(shared_tensors.smem_scaleA.begin()), SmemLayoutScaleA{});  // (BLK_M,BLK_K,PIPE)
+      Tensor gSA_mkl = get<2>(load_inputs);
+      auto block_tma_sA = mainloop_params.tma_load_scaleA.get_slice(cluster_local_block_id.y);
+      Tensor gSA = gSA_mkl(_, _, m_coord, _, l_coord);  // (BLK_M,BLK_K,k)
 
-      Tensor tSgS = block_tma_s.partition_S(gS);  // (TMA,TMA_M,TMA_K,k)
-      Tensor tSsS = block_tma_s.partition_D(sS);  // (TMA,TMA_M,TMA_K,PIPE)
+      Tensor tSgSA = block_tma_sA.partition_S(gSA);  // (TMA,TMA_M,TMA_K,k)
+      Tensor tSsSA = block_tma_sA.partition_D(sSA);  // (TMA,TMA_M,TMA_K,PIPE)
+
+      Tensor sSB =
+          make_tensor(make_smem_ptr(shared_tensors.smem_scaleB.begin()), SmemLayoutScaleB{});  // (BLK_N,BLK_K,PIPE)
+      Tensor gSB_mkl = get<3>(load_inputs);
+      auto block_tma_sB = mainloop_params.tma_load_scaleB.get_slice(cluster_local_block_id.x);
+      Tensor gSB = gSB_mkl(_, _, n_coord, _, l_coord);  // (BLK_N,BLK_K,k)
+
+      Tensor tSgSB = block_tma_sB.partition_S(gSB);  // (TMA,TMA_N,TMA_K,k)
+      Tensor tSsSB = block_tma_sB.partition_D(sSB);  // (TMA,TMA_N,TMA_K,PIPE)
+
+      CUTE_STATIC_ASSERT_V(size<1>(tSgSA(_, _, 0, 0)) == size<1>(tSsSA(_, _, 0, 0)));
+      CUTE_STATIC_ASSERT_V(size<1>(tSgSB(_, _, 0, 0)) == size<1>(tSsSB(_, _, 0, 0)));
+
       if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-        return cute::make_tuple(tSgS, tSsS);
+        return cute::make_tuple(tSgSA, tSsSA, tSgSB, tSsSB);
       } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
         Tensor sZ =
-            make_tensor(make_smem_ptr(shared_tensors.smem_zero.begin()), SmemLayoutScale{});  // (BLK_M,BLK_K,PIPE)
-        Tensor gZ_mkl = get<3>(load_inputs);
+            make_tensor(make_smem_ptr(shared_tensors.smem_zero.begin()), SmemLayoutScaleA{});  // (BLK_M,BLK_K,PIPE)
+        Tensor gZ_mkl = get<4>(load_inputs);
         auto block_tma_z = mainloop_params.tma_load_zero.get_slice(cluster_local_block_id.y);
         Tensor gZ = gZ_mkl(_, _, m_coord, _, l_coord);  // (BLK_M,BLK_K,k)
 
         Tensor tZgZ = block_tma_z.partition_S(gZ);  // (TMA,TMA_M,TMA_K,k)
         Tensor tZsZ = block_tma_z.partition_D(sZ);  // (TMA,TMA_M,TMA_K,PIPE)
-        return cute::make_tuple(tSgS, tSsS, tZgZ, tZsZ);
+        return cute::make_tuple(tSgSA, tSsSA, tSgSB, tSsSB, tZgZ, tZsZ);
       } else {
         static_assert(
             cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled for input partitioning.");
@@ -425,15 +553,15 @@ struct MixedGroupedGemmInputUtils {
       // nothing to do
       return cute::make_tuple();
     } else if constexpr (UseScaleLookupTable) {
-      Tensor sS =
-          make_tensor(make_smem_ptr(shared_tensors.smem_scale.begin()), SmemLayoutScale{});  // (BLK_M,BLK_SCALE_K,PIPE)
+      Tensor sS = make_tensor(
+          make_smem_ptr(shared_tensors.smem_scaleA.begin()), SmemLayoutScaleA{});  // (BLK_M,BLK_SCALE_K,PIPE)
       Tensor tCsS = mma_thread_slice.partition_A(sS);
       Tensor tCrS = make_tensor<ElementScale>(mma_thread_slice.partition_fragment_A(sS(_, _, Int<0>{})).layout());
 
       return cute::make_tuple(tCsS, tCrS);
     } else if constexpr (ModeHasScales) {
-      Tensor sS =
-          make_tensor(make_smem_ptr(shared_tensors.smem_scale.begin()), SmemLayoutScale{});  // (BLK_M,BLK_SCALE_K,PIPE)
+      Tensor sS = make_tensor(
+          make_smem_ptr(shared_tensors.smem_scaleA.begin()), SmemLayoutScaleA{});  // (BLK_M,BLK_SCALE_K,PIPE)
       Tensor tCsS = mma_thread_slice.partition_A(sS);
       Tensor tCrS = make_tensor<ElementScale>(mma_thread_slice.partition_fragment_A(sS(_, _, Int<0>{})).layout());
 
@@ -441,7 +569,7 @@ struct MixedGroupedGemmInputUtils {
         return cute::make_tuple(tCsS, tCrS);
       } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
         Tensor sZ = make_tensor(
-            make_smem_ptr(shared_tensors.smem_zero.begin()), SmemLayoutScale{});  // (BLK_M,BLK_SCALE_K,PIPE)
+            make_smem_ptr(shared_tensors.smem_zero.begin()), SmemLayoutScaleA{});  // (BLK_M,BLK_SCALE_K,PIPE)
         Tensor tCsZ = mma_thread_slice.partition_A(sZ);
         Tensor tCrZ = make_tensor<ElementZero>(mma_thread_slice.partition_fragment_A(sZ(_, _, Int<0>{})).layout());
         return cute::make_tuple(tCsS, tCrS, tCsZ, tCrZ);
@@ -461,14 +589,14 @@ struct MixedGroupedGemmInputUtils {
       // nothing to do
       return cute::make_tuple();
     } else if constexpr (ModeHasScales) {
-      auto smem_tiled_copy_S = make_tiled_copy_A(SmemCopyAtomScale{}, tiled_mma);
+      auto smem_tiled_copy_S = make_tiled_copy_A(SmemCopyAtomScaleA{}, tiled_mma);
       auto smem_thr_copy_S = smem_tiled_copy_S.get_thread_slice(warp_group_thread_idx);
       Tensor tCrS_copy_view = smem_thr_copy_S.retile_D(cute::get<1>(partitioned_extra_info));  // (CPY,CPY_M,CPY_K)
 
       if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
         return cute::make_tuple(smem_tiled_copy_S, tCrS_copy_view);
       } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
-        Tensor tCrZ_copy_view = smem_thr_copy_S.retile_D(cute::get<3>(partitioned_extra_info));  // (CPY,CPY_M,CPY_K)
+        Tensor tCrZ_copy_view = smem_thr_copy_S.retile_D(cute::get<5>(partitioned_extra_info));  // (CPY,CPY_M,CPY_K)
         return cute::make_tuple(smem_tiled_copy_S, tCrS_copy_view, tCrZ_copy_view);
       } else {
         static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in A -> RF path.");

--- a/sgl-kernel/csrc/cutlass_extensions/gemm/collective/builders/sm90_gmma_builder_.inl
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/collective/builders/sm90_gmma_builder_.inl
@@ -1,0 +1,67 @@
+// Support scale B from cutlass
+#pragma once
+
+#include "cute/arch/cluster_sm90.hpp"
+#include "cute/tensor.hpp"
+#include "cutlass/gemm/collective/builders/sm90_common.inl"
+#include "cutlass/gemm/collective/collective_builder_decl.hpp"
+#include "cutlass/gemm/collective/collective_mma_decl.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/pipeline/sm90_pipeline.hpp"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::collective {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+// Returns the maximum number of smem tiles that can be used with a given smem capacity (with an optional scale matrix),
+// or overrides with manual count.
+template <
+    int capacity_bytes_,
+    class ElementA,
+    class ElementB,
+    class ElementScaleA,
+    class ElementScaleB,
+    class ElementZero,
+    class TileShapeMNK,
+    int carveout_bytes_,
+    int alignment = 128>
+constexpr int
+compute_stage_count_or_override_single_affine_transformed_input_(StageCountAutoCarveout<carveout_bytes_> stage_count) {
+  // 32 bytes to account for barriers etc.
+  constexpr auto mainloop_pipeline_bytes = sizeof(typename cutlass::PipelineTmaAsync<1>::SharedStorage);
+  constexpr int scale_zero_k_tile = 1;
+  constexpr auto a_bits = cute::sizeof_bits_v<ElementA>;
+  constexpr auto b_bits = cute::sizeof_bits_v<ElementB>;
+  constexpr auto sA_bits = get_bits_for_possibly_void_element<ElementScaleA>();
+  constexpr auto sB_bits = get_bits_for_possibly_void_element<ElementScaleB>();
+  constexpr auto z_bits = get_bits_for_possibly_void_element<ElementZero>();
+
+  constexpr auto scaleA_bytes = cutlass::bits_to_bytes(sA_bits * size<0>(TileShapeMNK{}) * scale_zero_k_tile);
+  constexpr auto scaleB_bytes =
+      cutlass::bits_to_bytes(sB_bits * size<1>(TileShapeMNK{}) * 4 * scale_zero_k_tile);  // K need padding to 4
+  constexpr auto zero_bytes = cutlass::bits_to_bytes(z_bits * size<0>(TileShapeMNK{}) * scale_zero_k_tile);
+
+  static_assert(scaleA_bytes % 128 == 0, "Scale A bytes must be a multiple of 128");
+  static_assert(scaleB_bytes % 128 == 0, "Scale B bytes must be a multiple of 128");
+  static_assert(zero_bytes % 128 == 0, "Zero bytes must be a multiple of 128");
+
+  // When scales are void, s_bits will be 0 so no smem will be allocated for scales.
+  constexpr int stage_bytes_ = cutlass::bits_to_bytes(a_bits * size<0>(TileShapeMNK{}) * size<2>(TileShapeMNK{})) +
+                               cutlass::bits_to_bytes(b_bits * size<1>(TileShapeMNK{}) * size<2>(TileShapeMNK{})) +
+                               scaleA_bytes + scaleB_bytes + zero_bytes;
+
+  constexpr int stage_bytes = cutlass::round_up(stage_bytes_, alignment) + static_cast<int>(mainloop_pipeline_bytes);
+  constexpr int carveout_bytes = cutlass::round_up(carveout_bytes_, alignment);
+  constexpr int capacity_bytes = capacity_bytes_ / alignment * alignment;
+
+  return (capacity_bytes - carveout_bytes) / stage_bytes;
+}
+
+}  // namespace detail
+}  // namespace cutlass::gemm::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sgl-kernel/csrc/cutlass_extensions/gemm/collective/collective_mma_decl_.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/collective/collective_mma_decl_.hpp
@@ -1,0 +1,33 @@
+// Support scale B from cutlass
+#pragma once
+
+#include <cute/numeric/integral_constant.hpp>
+#include <cutlass/detail/dependent_false.hpp>
+
+namespace cutlass::gemm::collective {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+    class DispatchPolicy,
+    class TileShape,
+    class ElementA,
+    class StrideA,
+    class ElementB,
+    class StrideB,
+    class TiledMma,
+    class GmemTiledCopyA,
+    class SmemLayoutAtomA,
+    class SmemCopyAtomA,
+    class TransformA,
+    class GmemTiledCopyB,
+    class SmemLayoutAtomB,
+    class SmemCopyAtomB,
+    class TransformB>
+struct CollectiveMma_ {
+  static_assert(cutlass::detail::dependent_false<ElementA>, "Could not find a mainloop specialization.");
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::gemm::collective

--- a/sgl-kernel/csrc/cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_2scales.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_2scales.hpp
@@ -1,0 +1,301 @@
+// Support scale B from cutlass
+#pragma once
+
+#include "cute/algorithm/functional.hpp"
+#include "cute/algorithm/gemm.hpp"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cute/arch/copy_sm90.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/numeric/arithmetic_tuple.hpp"
+#include "cutlass/cuda_host_adapter.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/collective/mixed_input_utils.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/numeric_types.h"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/trace.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::collective {
+using namespace cute;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// WarpSpecialized Mainloop
+template <
+    int Stages,
+    class ClusterShape,
+    class KernelSchedule_,
+    class TileShape_,
+    class ElementAOptionalTuple,
+    class StrideA_,
+    class ElementBOptionalTuple,
+    class StrideB_,
+    class TiledMma_,
+    class GmemTiledCopyA_,
+    class SmemLayoutAtomA_,
+    class SmemCopyAtomA_,
+    class TransformA_,
+    class GmemTiledCopyB_,
+    class SmemLayoutAtomB_,
+    class SmemCopyAtomB_,
+    class TransformB_>
+struct CollectiveMma_<
+    MainloopSm90ArrayTmaGmmaWarpSpecializedMixedInput<Stages, ClusterShape, KernelSchedule_>,
+    TileShape_,
+    ElementAOptionalTuple,
+    StrideA_,
+    ElementBOptionalTuple,
+    StrideB_,
+    TiledMma_,
+    GmemTiledCopyA_,
+    SmemLayoutAtomA_,
+    SmemCopyAtomA_,
+    TransformA_,
+    GmemTiledCopyB_,
+    SmemLayoutAtomB_,
+    SmemCopyAtomB_,
+    TransformB_> {
+ public:
+  //
+  // Type Aliases
+  //
+  using ConversionMode = cutlass::detail::ConversionMode;
+  using DispatchPolicy = MainloopSm90ArrayTmaGmmaWarpSpecializedMixedInput<Stages, ClusterShape, KernelSchedule_>;
+  using TileShape = TileShape_;
+  using KernelSchedule = KernelSchedule_;
+
+ private:
+  template <class T>
+  friend struct detail::MixedInputUtils;
+  using CollectiveType = CollectiveMma<
+      DispatchPolicy,
+      TileShape_,
+      ElementAOptionalTuple,
+      StrideA_,
+      ElementBOptionalTuple,
+      StrideB_,
+      TiledMma_,
+      GmemTiledCopyA_,
+      SmemLayoutAtomA_,
+      SmemCopyAtomA_,
+      TransformA_,
+      GmemTiledCopyB_,
+      SmemLayoutAtomB_,
+      SmemCopyAtomB_,
+      TransformB_>;
+  using Utils = detail::MixedInputUtils<CollectiveType>;
+
+  //
+  // Type Aliases
+  //
+  using ZeroA = detail::deduce_mixed_width_dtype_t<2, ElementAOptionalTuple>;
+  using ZeroB = detail::deduce_mixed_width_dtype_t<2, ElementBOptionalTuple>;
+
+ public:
+  static_assert(
+      cute::is_tuple<ElementAOptionalTuple>::value && cute::is_tuple<ElementBOptionalTuple>::value,
+      "ElementA and ElementB must be tuples.");
+  using ElementA = detail::deduce_mixed_width_dtype_t<0, ElementAOptionalTuple>;
+  using ElementB = detail::deduce_mixed_width_dtype_t<0, ElementBOptionalTuple>;
+  static constexpr bool IsATransformed = cute::is_tuple<ElementAOptionalTuple>::value;
+
+  using ScaleA = detail::deduce_mixed_width_dtype_t<1, ElementAOptionalTuple>;
+  using ScaleB = detail::deduce_mixed_width_dtype_t<1, ElementBOptionalTuple>;
+
+  using ElementZero = cute::conditional_t<IsATransformed, ZeroA, ZeroB>;
+  // For cases where we can't have a void type, we can use this to allow the code to compile when the scale / zero is
+  // void.
+  using NonVoidElementScaleA = cute::conditional_t<cute::is_void_v<ScaleA>, float, ScaleA>;
+  using NonVoidElementScaleB = cute::conditional_t<cute::is_void_v<ScaleB>, float, ScaleB>;
+  using NonVoidElementZero = cute::conditional_t<cute::is_void_v<ElementZero>, float, ElementZero>;
+
+  using StrideA = StrideA_;
+  using InternalStrideA = cute::remove_pointer_t<StrideA>;
+  using StrideB = StrideB_;
+  using InternalStrideB = cute::remove_pointer_t<StrideB>;
+
+  using StrideScaleA = cute::Stride<cute::Int<1>, int64_t, int64_t>;
+  using StrideScaleB = cute::Stride<int64_t, cute::Int<1>, int64_t>;
+  using NonVoidStrideScaleA =
+      cute::conditional_t<cute::is_void_v<StrideScaleA>, cute::Stride<_1, int64_t, int64_t>, StrideScaleA>;
+  using NonVoidStrideScaleB =
+      cute::conditional_t<cute::is_void_v<StrideScaleB>, cute::Stride<int64_t, _1, int64_t>, StrideScaleB>;
+
+  static_assert(
+      (IsATransformed && (cutlass::gemm::detail::is_k_major<StrideA>() || is_layout<StrideA>::value ||
+                          is_layout<InternalStrideA>::value)) ||
+          (!IsATransformed && (cutlass::gemm::detail::is_k_major<StrideB>() || is_layout<StrideB>::value ||
+                               is_layout<InternalStrideB>::value)),
+      "The transformed type must be K-major.");
+
+  static_assert(
+      (IsATransformed && (sizeof(ElementB) == 2)) || (!IsATransformed && (sizeof(ElementA) == 2)) ||
+          ((cutlass::gemm::detail::is_k_major<StrideA>() || is_layout<StrideA>::value ||
+            is_layout<InternalStrideA>::value) &&
+           (cutlass::gemm::detail::is_k_major<StrideB>() || is_layout<StrideB>::value ||
+            is_layout<InternalStrideB>::value)),
+      "The unscaled element must be 2 bytes OR both inputs must be K-major");
+
+  static_assert(
+      cutlass::gemm::detail::is_mn_major<NonVoidStrideScaleA>() &&
+          cutlass::gemm::detail::is_k_major<NonVoidStrideScaleB>(),
+      "ScaleA must be MN major [Col Major if A is scaled]. ScaleB must be K major.");
+
+  using CtaShape_MNK = decltype(shape_div(TileShape{}, ClusterShape{}));
+  using TiledMma = TiledMma_;
+  using ElementAccumulator = typename TiledMma::ValTypeC;
+  using GmemTiledCopyA = GmemTiledCopyA_;
+  using GmemTiledCopyB = GmemTiledCopyB_;
+  using GmemTiledCopyScale = cute::SM90_TMA_LOAD;
+  using SmemLayoutAtomA = SmemLayoutAtomA_;
+  using SmemLayoutAtomB = SmemLayoutAtomB_;
+  using SmemCopyAtomA = SmemCopyAtomA_;
+  using SmemCopyAtomB = SmemCopyAtomB_;
+  using SmemCopyAtomScaleA = Copy_Atom<cute::AutoVectorizingCopy, NonVoidElementScaleA>;
+  using SmemCopyAtomScaleB = Copy_Atom<cute::DefaultCopy, NonVoidElementScaleB>;
+
+  // We must ensure the type to be scaled goes to RF
+  static constexpr bool SwapAB = !IsATransformed;
+  using SwappedStrideA = cute::conditional_t<!SwapAB, StrideA, StrideB>;
+  using SwappedStrideB = cute::conditional_t<!SwapAB, StrideB, StrideA>;
+  using InternalSwappedStrideA = cute::conditional_t<!SwapAB, InternalStrideA, InternalStrideB>;
+  using InternalSwappedStrideB = cute::conditional_t<!SwapAB, InternalStrideB, InternalStrideA>;
+  using SwappedSmemLayoutAtomA = cute::conditional_t<!SwapAB, SmemLayoutAtomA, SmemLayoutAtomB>;
+  using SwappedSmemLayoutAtomB = cute::conditional_t<!SwapAB, SmemLayoutAtomB, SmemLayoutAtomA>;
+  using SwappedSmemCopyAtomA = cute::conditional_t<!SwapAB, SmemCopyAtomA, SmemCopyAtomB>;
+  using SwappedSmemCopyAtomB = cute::conditional_t<!SwapAB, SmemCopyAtomB, SmemCopyAtomA>;
+  // TMA converts f32 input to tf32 when copying from GMEM to SMEM
+  // For all other types, cast to size equivalent uint type to avoid any rounding by TMA.
+  static constexpr bool ConvertF32toTF32A = cute::is_same_v<float, ElementA>;
+  static constexpr bool ConvertF32toTF32B = cute::is_same_v<float, ElementB>;
+  using ConvertedElementA = cute::conditional_t<ConvertF32toTF32A, tfloat32_t, uint_bit_t<sizeof_bits_v<ElementA>>>;
+  using ConvertedElementB = cute::conditional_t<ConvertF32toTF32B, tfloat32_t, uint_bit_t<sizeof_bits_v<ElementB>>>;
+  using RealSwappedElementA = cute::conditional_t<!SwapAB, ElementA, ElementB>;
+  using RealSwappedElementB = cute::conditional_t<!SwapAB, ElementB, ElementA>;
+  using SwappedElementA = cute::conditional_t<!SwapAB, ConvertedElementA, ConvertedElementB>;
+  using SwappedElementB = cute::conditional_t<!SwapAB, ConvertedElementB, ConvertedElementA>;
+
+  using TransformA = TransformA_;
+  using TransformB = TransformB_;
+  using SwappedTransformA = cute::conditional_t<!SwapAB, TransformA, TransformB>;
+  using SwappedTransformB = cute::conditional_t<!SwapAB, TransformB, TransformA>;
+  using ArchTag = typename DispatchPolicy::ArchTag;
+
+  using MainloopPipeline = cutlass::PipelineTmaAsync<DispatchPolicy::Stages>;
+  using PipelineState = cutlass::PipelineState<DispatchPolicy::Stages>;
+  using PipelineParams = typename MainloopPipeline::Params;
+
+  static constexpr int NumProducerThreadEvents = 1;
+  static constexpr int GroupSize = 128;
+  using SmemLayoutAtomScaleA = Layout<Shape<decltype(cute::shape<0>(SwappedSmemLayoutAtomA{})), cute::Int<1>>>;
+
+  static constexpr int TileK = cute::get<2>(TileShape{});
+
+  // static constexpr int TileKGroup = TileK / GroupSize;
+  static constexpr int TileKGroup = 4;  // K need padding to 4
+
+  using SmemLayoutAtomScaleB = Layout<
+      Shape<decltype(cute::shape<0>(SwappedSmemLayoutAtomB{})), cute::Int<TileKGroup>>,
+      cute::Stride<cute::Int<TileKGroup>, cute::Int<1>>>;
+
+  using ScaleATileShape = decltype(make_shape(shape<0>(TileShape{}), shape<1>(SmemLayoutAtomScaleA{})));
+  using ScaleBTileShape = decltype(make_shape(shape<1>(TileShape{}), cute::Int<TileKGroup>{}));
+
+  static_assert(cute::rank(SwappedSmemLayoutAtomA{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert(cute::rank(SwappedSmemLayoutAtomB{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+
+  static_assert(
+      (size<0>(TileShape{}) % size<0>(SwappedSmemLayoutAtomA{})) == 0, "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert(
+      (size<2>(TileShape{}) % size<1>(SwappedSmemLayoutAtomA{})) == 0, "SmemLayoutAtom must evenly divide tile shape.");
+
+  static_assert(cute::rank(SwappedSmemLayoutAtomB{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert(
+      (size<1>(TileShape{}) % size<0>(SwappedSmemLayoutAtomB{})) == 0, "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert(
+      (size<2>(TileShape{}) % size<1>(SwappedSmemLayoutAtomB{})) == 0, "SmemLayoutAtom must evenly divide tile shape.");
+
+  static_assert(rank(SmemLayoutAtomScaleA{}) == 2, "SmemLayoutAtomScaleA must be rank 2");
+  static_assert(rank(SmemLayoutAtomScaleB{}) == 2, "SmemLayoutAtomScaleB must be rank 2");
+
+  static_assert(
+      (size<0>(TileShape{}) % size<0>(SmemLayoutAtomScaleA{})) == 0, "SmemLayoutAtomScaleA must equal the tile shape.");
+  static_assert(
+      (size<2>(TileShape{}) % size<1>(SmemLayoutAtomScaleA{})) == 0,
+      "SmemLayoutAtomScaleA must evenly divide tile k shape.");
+
+  static_assert(
+      (size<1>(TileShape{}) % size<0>(SmemLayoutAtomScaleB{})) == 0, "SmemLayoutAtomScaleB must equal the tile shape.");
+  static_assert(
+      (size<2>(TileShape{}) % size<1>(SmemLayoutAtomScaleB{})) == 0,
+      "SmemLayoutAtomScaleB must evenly divide tile k shape.");
+
+  /// Tile along modes in a way that maximizes the TMA box size.
+  using SmemLayoutA = decltype(detail::get_smem_layout<DispatchPolicy::Stages>(
+      SwappedSmemLayoutAtomA{}, select<0, 2>(TileShape{}), InternalSwappedStrideA{}));
+  using SmemLayoutB = decltype(detail::get_smem_layout<DispatchPolicy::Stages>(
+      SwappedSmemLayoutAtomB{}, select<1, 2>(TileShape{}), InternalSwappedStrideB{}));
+
+  // It is assumed that the scales and zero-points share the same smem layout
+  using SmemLayoutScaleA = decltype(tile_to_shape(
+      SmemLayoutAtomScaleA{},
+      make_shape(shape<0>(ScaleATileShape{}), shape<1>(ScaleATileShape{}), Int<Stages>{}),
+      cute::conditional_t<
+          ::cutlass::gemm::detail::is_major<0, NonVoidStrideScaleA>(),
+          Step<_2, _1, _3>,
+          Step<_1, _2, _3>>{}));
+
+  using SmemLayoutScaleB = decltype(tile_to_shape(
+      SmemLayoutAtomScaleB{},
+      make_shape(shape<0>(ScaleBTileShape{}), shape<1>(ScaleBTileShape{}), Int<Stages>{}),
+      cute::conditional_t<
+          ::cutlass::gemm::detail::is_major<0, NonVoidStrideScaleB>(),
+          Step<_2, _1, _3>,
+          Step<_1, _2, _3>>{}));
+
+  static_assert(DispatchPolicy::Stages >= 2, "Specialization requires Stages set to value 2 or more.");
+  static_assert(
+      not cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value &&
+          cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeB>::value,
+      "MMA atom must source A from rmem and B operand from smem_desc for this mainloop.");
+  static_assert(
+      cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD> || cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD_MULTICAST>,
+      "GmemTiledCopy - invalid SM90 TMA copy atom specified.");
+  static_assert(
+      cute::is_same_v<GmemTiledCopyB, SM90_TMA_LOAD> || cute::is_same_v<GmemTiledCopyB, SM90_TMA_LOAD_MULTICAST>,
+      "GmemTiledCopy - invalid SM90 TMA copy atom specified.");
+
+  // To relax them, we need to handle loading more than 1 row of scales for every main loop iteration.
+  // We must also handle updating the pipeline transaction bytes on the fly.
+  static_assert(size<1>(SmemLayoutAtomScaleA{}) == 1, "size<1>(SmemLayoutAtomScaleA) must be 1.");
+
+ private:
+  static constexpr ConversionMode get_conversion_mode() {
+    if constexpr (cute::is_void_v<ScaleA>) {
+      return ConversionMode::DirectConvert;
+    } else if constexpr (cute::is_void_v<ElementZero>) {
+      return ConversionMode::ConvertAndScale;
+    } else {
+      return ConversionMode::ConvertAndScaleWithZero;
+    }
+  }
+
+ public:
+  static constexpr ConversionMode KernelConversionMode = get_conversion_mode();
+  static constexpr bool ModeHasScales = KernelConversionMode == ConversionMode::ConvertAndScale ||
+                                        KernelConversionMode == ConversionMode::ConvertAndScaleWithZero;
+  static constexpr bool UseScaleLookupTable =
+      KernelConversionMode == ConversionMode::ConvertAndScale && cutlass::detail::is_Array_v<ScaleA>;
+  static constexpr bool UseInt4ToFP8LookupTable = KernelConversionMode == ConversionMode::ConvertAndScale &&
+                                                  cute::is_same_v<ElementA, cutlass::int4_t> &&
+                                                  cute::is_same_v<ElementB, cutlass::float_e4m3_t>;
+  static_assert(UseScaleLookupTable && UseInt4ToFP8LookupTable, " Only support lookup table for int4 * fp8.");
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::gemm::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sgl-kernel/csrc/cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_mixed_input_.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_mixed_input_.hpp
@@ -43,6 +43,8 @@
 #include "cutlass/pipeline/pipeline.hpp"
 #include "cutlass/trace.h"
 #include "cutlass_extensions/detail/collective/mixed_input_utils.hpp"
+#include "cutlass_extensions/gemm/collective/collective_mma_decl_.hpp"
+#include "cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_2scales.hpp"
 
 #define GROUP_SIZE 128
 
@@ -101,7 +103,7 @@ struct CollectiveMmaArrayMixedInput<
  private:
   template <class T>
   friend struct detail::MixedGroupedGemmInputUtils;
-  using CollectiveType = CollectiveMma<
+  using CollectiveType = CollectiveMma_<
       DispatchPolicy,
       TileShape_,
       ElementAOptionalTuple,
@@ -129,18 +131,18 @@ struct CollectiveMmaArrayMixedInput<
 
  public:
   static_assert(
-      cute::is_tuple<ElementAOptionalTuple>::value ^ cute::is_tuple<ElementBOptionalTuple>::value,
-      "Either A OR B must be a tuple. It must take the from {ElementOperand, [ElementScale], [ElementZero]}. Inputs in "
-      "[] are optional.");
+      cute::is_tuple<ElementAOptionalTuple>::value && cute::is_tuple<ElementBOptionalTuple>::value,
+      "ElementA and ElementB must be tuples.");
 
   using ElementA = detail::deduce_mixed_width_dtype_t<0, ElementAOptionalTuple>;
   using ElementB = detail::deduce_mixed_width_dtype_t<0, ElementBOptionalTuple>;
-  static constexpr bool IsATransformed = cute::is_tuple<ElementAOptionalTuple>::value;
-  using ElementScale = cute::conditional_t<IsATransformed, ScaleA, ScaleB>;
+  static constexpr bool IsATransformed = cutlass::sizeof_bits<ElementA>::value == 4;  // cutlass::int4b_t
+
   using ElementZero = cute::conditional_t<IsATransformed, ZeroA, ZeroB>;
   // For cases where we can't have a void type, we can use this to allow the code to compile when the scale / zero is
   // void.
-  using NonVoidElementScale = cute::conditional_t<cute::is_void_v<ElementScale>, float, ElementScale>;
+  using NonVoidElementScaleA = cute::conditional_t<cute::is_void_v<ScaleA>, float, ScaleA>;
+  using NonVoidElementScaleB = cute::conditional_t<cute::is_void_v<ScaleB>, float, ScaleB>;
   using NonVoidElementZero = cute::conditional_t<cute::is_void_v<ElementZero>, float, ElementZero>;
 
   using StrideA = StrideA_;
@@ -148,9 +150,12 @@ struct CollectiveMmaArrayMixedInput<
   using StrideB = StrideB_;
   using InternalStrideB = cute::remove_pointer_t<StrideB>;
 
-  using StrideScale = cute::Stride<cute::Int<1>, int64_t, int64_t>;
-  using NonVoidStrideScale =
-      cute::conditional_t<cute::is_void_v<StrideScale>, cute::Stride<_1, int64_t, int64_t>, StrideScale>;
+  using StrideScaleA = cute::Stride<cute::Int<1>, int64_t, int64_t>;
+  using StrideScaleB = cute::Stride<int64_t, cute::Int<1>, int64_t>;
+  using NonVoidStrideScaleA =
+      cute::conditional_t<cute::is_void_v<StrideScaleA>, cute::Stride<_1, int64_t, int64_t>, StrideScaleA>;
+  using NonVoidStrideScaleB =
+      cute::conditional_t<cute::is_void_v<StrideScaleB>, cute::Stride<int64_t, _1, int64_t>, StrideScaleB>;
 
   static_assert(
       (IsATransformed && (cutlass::gemm::detail::is_k_major<StrideA>() || is_layout<StrideA>::value ||
@@ -168,8 +173,9 @@ struct CollectiveMmaArrayMixedInput<
       "The unscaled element must be 2 bytes OR both inputs must be K-major");
 
   static_assert(
-      cutlass::gemm::detail::is_mn_major<NonVoidStrideScale>(),
-      "Scale must be MN major [Col Major if A is scaled, Row Major if B is scaled].");
+      cutlass::gemm::detail::is_mn_major<NonVoidStrideScaleA>() &&
+          cutlass::gemm::detail::is_k_major<NonVoidStrideScaleB>(),
+      "ScaleA must be MN major [Col Major if A is scaled]. ScaleB must be K major.");
 
   using CtaShape_MNK = decltype(shape_div(TileShape{}, ClusterShape{}));
   using TiledMma = TiledMma_;
@@ -181,10 +187,9 @@ struct CollectiveMmaArrayMixedInput<
   using SmemLayoutAtomB = SmemLayoutAtomB_;
   using SmemCopyAtomA = SmemCopyAtomA_;
   using SmemCopyAtomB = SmemCopyAtomB_;
-  using SmemCopyAtomScale = Copy_Atom<cute::AutoVectorizingCopy, NonVoidElementScale>;
 
   // We must ensure the type to be scaled goes to RF
-  static constexpr bool SwapAB = !IsATransformed;
+  static constexpr bool SwapAB = !IsATransformed;  // "false" for this case, since A is scaled
   using SwappedStrideA = cute::conditional_t<!SwapAB, StrideA, StrideB>;
   using SwappedStrideB = cute::conditional_t<!SwapAB, StrideB, StrideA>;
   using InternalSwappedStrideA = cute::conditional_t<!SwapAB, InternalStrideA, InternalStrideB>;
@@ -212,19 +217,33 @@ struct CollectiveMmaArrayMixedInput<
 
   static constexpr int IsSubbyteA = cute::sizeof_bits_v<SwappedElementA> < 8;
   using TmaElementA = cute::conditional_t<IsSubbyteA, uint8_t, SwappedElementA>;
-  using TmaElementScale = uint_bit_t<sizeof_bits_v<NonVoidElementScale>>;  // in case we have array. translating to uint
-                                                                           // to satisfy tma descriptor's specialization
+  using TmaElementScaleA =
+      uint_bit_t<sizeof_bits_v<NonVoidElementScaleA>>;  // in case we have array. translating to uint
+                                                        // to satisfy tma descriptor's specialization
 
   using MainloopPipeline = cutlass::PipelineTmaAsync<DispatchPolicy::Stages>;
   using PipelineState = cutlass::PipelineState<DispatchPolicy::Stages>;
   using PipelineParams = typename MainloopPipeline::Params;
 
   static constexpr int NumProducerThreadEvents = 1;
+  static constexpr int GroupSize = 128;
+  using SmemLayoutAtomScaleA = Layout<Shape<decltype(cute::shape<0>(SwappedSmemLayoutAtomA{})), cute::Int<1>>>;
 
-  using SmemLayoutAtomScale = Layout<Shape<decltype(cute::shape<0>(SwappedSmemLayoutAtomA{})), cute::Int<1>>>;
-  using ScaleTileShape = decltype(make_shape(shape<0>(TileShape{}), shape<1>(SmemLayoutAtomScale{})));
+  static constexpr int TileK = cute::get<2>(TileShape{});
+
+  // static constexpr int TileKGroup = TileK / GroupSize;
+  static constexpr int TileKGroup = 4;  // K need padding to 4
+
+  using SmemLayoutAtomScaleB = Layout<
+      Shape<decltype(cute::shape<0>(SwappedSmemLayoutAtomB{})), cute::Int<TileKGroup>>,
+      cute::Stride<cute::Int<TileKGroup>, cute::Int<1>>>;
+
+  using ScaleATileShape = decltype(make_shape(shape<0>(TileShape{}), shape<1>(SmemLayoutAtomScaleA{})));
+  using ScaleBTileShape = decltype(make_shape(shape<1>(TileShape{}), cute::Int<TileKGroup>{}));
 
   static_assert(cute::rank(SwappedSmemLayoutAtomA{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert(cute::rank(SwappedSmemLayoutAtomB{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+
   static_assert(
       (size<0>(TileShape{}) % size<0>(SwappedSmemLayoutAtomA{})) == 0, "SmemLayoutAtom must evenly divide tile shape.");
   static_assert(
@@ -236,12 +255,20 @@ struct CollectiveMmaArrayMixedInput<
   static_assert(
       (size<2>(TileShape{}) % size<1>(SwappedSmemLayoutAtomB{})) == 0, "SmemLayoutAtom must evenly divide tile shape.");
 
-  static_assert(rank(SmemLayoutAtomScale{}) == 2, "SmemLayoutAtomScale must be rank 2");
+  static_assert(rank(SmemLayoutAtomScaleA{}) == 2, "SmemLayoutAtomScale must be rank 2");
+  static_assert(rank(SmemLayoutAtomScaleB{}) == 2, "SmemLayoutBtomScale must be rank 2");
+
   static_assert(
-      (size<0>(TileShape{}) % size<0>(SmemLayoutAtomScale{})) == 0, "SmemLayoutAtomScale must equal the tile shape.");
+      (size<0>(TileShape{}) % size<0>(SmemLayoutAtomScaleA{})) == 0, "SmemLayoutAtomScaleA must equal the tile shape.");
   static_assert(
-      (size<2>(TileShape{}) % size<1>(SmemLayoutAtomScale{})) == 0,
-      "SmemLayoutAtomScale must evenly divide tile k shape.");
+      (size<2>(TileShape{}) % size<1>(SmemLayoutAtomScaleA{})) == 0,
+      "SmemLayoutAtomScaleA must evenly divide tile k shape.");
+
+  static_assert(
+      (size<1>(TileShape{}) % size<0>(SmemLayoutAtomScaleB{})) == 0, "SmemLayoutAtomScaleB must equal the tile shape.");
+  static_assert(
+      (size<2>(TileShape{}) % size<1>(SmemLayoutAtomScaleB{})) == 0,
+      "SmemLayoutAtomScaleB must evenly divide tile k shape.");
 
   /// Tile along modes in a way that maximizes the TMA box size.
   using SmemLayoutA = decltype(detail::get_smem_layout<DispatchPolicy::Stages>(
@@ -250,11 +277,19 @@ struct CollectiveMmaArrayMixedInput<
       SwappedSmemLayoutAtomB{}, select<1, 2>(TileShape{}), InternalSwappedStrideB{}));
 
   // It is assumed that the scales and zero-points share the same smem layout
-  using SmemLayoutScale = decltype(tile_to_shape(
-      SmemLayoutAtomScale{},
-      make_shape(shape<0>(ScaleTileShape{}), shape<1>(ScaleTileShape{}), Int<Stages>{}),
+  using SmemLayoutScaleA = decltype(tile_to_shape(
+      SmemLayoutAtomScaleA{},
+      make_shape(shape<0>(ScaleATileShape{}), shape<1>(ScaleATileShape{}), Int<Stages>{}),
       cute::conditional_t<
-          ::cutlass::gemm::detail::is_major<0, NonVoidStrideScale>(),
+          ::cutlass::gemm::detail::is_major<0, NonVoidStrideScaleA>(),
+          Step<_2, _1, _3>,
+          Step<_1, _2, _3>>{}));
+
+  using SmemLayoutScaleB = decltype(tile_to_shape(
+      SmemLayoutAtomScaleB{},
+      make_shape(shape<0>(ScaleBTileShape{}), shape<1>(ScaleBTileShape{}), Int<Stages>{}),
+      cute::conditional_t<
+          ::cutlass::gemm::detail::is_major<0, NonVoidStrideScaleB>(),
           Step<_2, _1, _3>,
           Step<_1, _2, _3>>{}));
 
@@ -272,11 +307,10 @@ struct CollectiveMmaArrayMixedInput<
 
   // To relax them, we need to handle loading more than 1 row of scales for every main loop iteration.
   // We must also handle updating the pipeline transaction bytes on the fly.
-  static_assert(size<1>(SmemLayoutAtomScale{}) == 1, "size<1>(SmemLayoutAtomScale) must be 1.");
 
  private:
   static constexpr ConversionMode get_conversion_mode() {
-    if constexpr (cute::is_void_v<ElementScale>) {
+    if constexpr (cute::is_void_v<ScaleA>) {
       return ConversionMode::DirectConvert;
     } else if constexpr (cute::is_void_v<ElementZero>) {
       return ConversionMode::ConvertAndScale;
@@ -289,28 +323,28 @@ struct CollectiveMmaArrayMixedInput<
   static constexpr ConversionMode KernelConversionMode = get_conversion_mode();
   static constexpr bool ModeHasScales = KernelConversionMode == ConversionMode::ConvertAndScale ||
                                         KernelConversionMode == ConversionMode::ConvertAndScaleWithZero;
-  static constexpr bool UseScaleLookupTable =
-      KernelConversionMode == ConversionMode::ConvertAndScale && cutlass::detail::is_Array_v<ElementScale>;
+
   static constexpr size_t SmemAlignmentA = cutlass::detail::alignment_for_swizzle(SmemLayoutA{});
   static constexpr size_t SmemAlignmentB = cutlass::detail::alignment_for_swizzle(SmemLayoutB{});
-  static constexpr size_t SmemAlignmentScale = cute::max(SmemAlignmentA, SmemAlignmentB);
-
   static_assert(SmemAlignmentA >= 128 and SmemAlignmentB >= 128, "Require at least 128B alignment");
 
   struct SharedStorage {
-    static constexpr int scale_elements = Utils::elements_per_smem_scale();
+    static constexpr int scaleA_elements = Utils::elements_per_smem_scaleA();
+    static constexpr int scaleB_elements = Utils::elements_per_smem_scaleB();
     static constexpr int zero_elements = Utils::elements_per_smem_zero();
     struct TensorStorage {
       CUTE_ALIGNAS(SmemAlignmentA) cute::ArrayEngine<RealSwappedElementA, cute::cosize_v<SmemLayoutA>> smem_A;
       CUTE_ALIGNAS(SmemAlignmentB) cute::ArrayEngine<typename TiledMma::ValTypeB, cute::cosize_v<SmemLayoutB>> smem_B;
-      cute::ArrayEngine<NonVoidElementScale, scale_elements> smem_scale;
+      cute::ArrayEngine<NonVoidElementScaleA, scaleA_elements> smem_scaleA;
+      cute::ArrayEngine<NonVoidElementScaleB, scaleB_elements> smem_scaleB;
       cute::ArrayEngine<NonVoidElementZero, zero_elements> smem_zero;
     } tensors;
 
     struct TensorMapStorage {
       cute::TmaDescriptor smem_tensormap_A;
       cute::TmaDescriptor smem_tensormap_B;
-      cute::TmaDescriptor smem_tensormap_scale;
+      cute::TmaDescriptor smem_tensormap_scaleA;
+      cute::TmaDescriptor smem_tensormap_scaleB;
       cute::TmaDescriptor smem_tensormap_zero;
     };
 
@@ -330,8 +364,10 @@ struct CollectiveMmaArrayMixedInput<
     StrideA dA;
     ElementB const** ptr_B;
     StrideB dB;
-    ElementScale const** ptr_S = nullptr;
-    NonVoidStrideScale const* dS{};
+    ScaleA const** ptr_SA = nullptr;
+    NonVoidStrideScaleA const* dSA{};
+    ScaleB const** ptr_SB = nullptr;
+    NonVoidStrideScaleB const* dSB{};
     int chunk_size = 0;
     ElementZero const** ptr_Z = nullptr;
   };
@@ -350,6 +386,7 @@ struct CollectiveMmaArrayMixedInput<
         SmemLayoutA{}(_, _, cute::Int<0>{}),
         make_shape(shape<0>(TileShape{}), shape<2>(TileShape{})),
         size<1>(ClusterShape{})));  // mcast along N mode for this M load, if any
+
     // Assumption: StrideB is congruent with Problem_NK
     using TMA_B = decltype(make_tma_copy(
         GmemTiledCopyB{},
@@ -358,38 +395,53 @@ struct CollectiveMmaArrayMixedInput<
         make_shape(shape<1>(TileShape{}), shape<2>(TileShape{})),
         size<0>(ClusterShape{})));  // mcast along M mode for this N load, if any
 
-    using TMA_Scale = decltype(make_tma_copy<TmaElementScale>(
+    // using TMA_B = TMA_A;
+
+    using TMA_ScaleA = decltype(make_tma_copy<TmaElementScaleA>(
         GmemTiledCopyScale{},
         make_tensor(
-            detail::get_logical_ptr(static_cast<NonVoidElementScale const*>(nullptr)),
-            repeat_like(NonVoidStrideScale{}, int32_t(0)),
-            NonVoidStrideScale{}),
-        SmemLayoutScale{}(_, _, cute::Int<0>{}),
-        ScaleTileShape{},
+            detail::get_logical_ptr(static_cast<NonVoidElementScaleA const*>(nullptr)),
+            repeat_like(NonVoidStrideScaleA{}, int32_t(0)),
+            NonVoidStrideScaleA{}),
+        SmemLayoutScaleA{}(_, _, cute::Int<0>{}),
+        ScaleATileShape{},
         _1{}));  // mcast along N mode for this M load, if any. Scale is ALWAYS loaded with A for RF kernel
+
+    using TMA_ScaleB = decltype(make_tma_copy(
+        GmemTiledCopyScale{},
+        make_tensor(
+            detail::get_logical_ptr(static_cast<NonVoidElementScaleB const*>(nullptr)),
+            repeat_like(NonVoidStrideScaleB{}, int32_t(0)),
+            NonVoidStrideScaleB{}),
+        SmemLayoutScaleB{}(_, _, cute::Int<0>{}),
+        ScaleBTileShape{},
+        _1{}));  // mcast along M mode for this N load, if any. Scale is ALWAYS loaded with B for RF kernel
 
     using TMA_Zero = decltype(make_tma_copy(
         GmemTiledCopyScale{},
         make_tensor(
             detail::get_logical_ptr(static_cast<NonVoidElementZero const*>(nullptr)),
-            repeat_like(NonVoidStrideScale{}, int32_t(0)),
-            NonVoidStrideScale{}),
-        SmemLayoutScale{}(_, _, cute::Int<0>{}),
-        ScaleTileShape{},
+            repeat_like(NonVoidStrideScaleA{}, int32_t(0)),
+            NonVoidStrideScaleA{}),
+        SmemLayoutScaleA{}(_, _, cute::Int<0>{}),
+        ScaleATileShape{},
         _1{}));  // mcast along N mode for this M load, if any. Scale is ALWAYS loaded with A for RF kernel
 
     TMA_A tma_load_a;
     TMA_B tma_load_b;
     uint32_t tma_transaction_bytes = TmaTransactionBytes;
-    TMA_Scale tma_load_scale;
+    TMA_ScaleA tma_load_scaleA;
+    TMA_ScaleB tma_load_scaleB;
     TMA_Zero tma_load_zero;
     void* tensormaps;
     SwappedElementA const** ptr_A;
     SwappedStrideA ptr_dA;
     SwappedElementB const** ptr_B;
     SwappedStrideB ptr_dB;
-    NonVoidElementScale const** ptr_S;
-    NonVoidStrideScale const* dS;
+    NonVoidElementScaleA const** ptr_SA;
+    NonVoidStrideScaleA const* dSA;
+    NonVoidElementScaleB const** ptr_SB;
+    NonVoidStrideScaleB const* dSB;
     NonVoidElementZero const** ptr_Z;
     int64_t scale_k;
     int chunk_size;
@@ -488,7 +540,9 @@ struct CollectiveMmaArrayMixedInput<
         SmemLayoutB{}(_, _, cute::Int<0>{}),
         make_shape(shape<1>(TileShape{}), shape<2>(TileShape{})),
         size<0>(ClusterShape{}));  // mcast along M mode for this N load, if any
-    typename Params::TMA_Scale tma_load_scale{};
+    typename Params::TMA_ScaleA tma_load_scaleA{};
+    typename Params::TMA_ScaleB tma_load_scaleB{};
+
     typename Params::TMA_Zero tma_load_zero{};
 
     void* tensormaps = workspace;
@@ -498,15 +552,18 @@ struct CollectiveMmaArrayMixedInput<
           tma_load_a,
           tma_load_b,
           TmaTransactionBytes,
-          tma_load_scale,
+          tma_load_scaleA,
+          tma_load_scaleB,
           tma_load_zero,
           tensormaps,
           reinterpret_cast<SwappedElementA const**>(ptr_A),
           ptr_dA,
           reinterpret_cast<SwappedElementB const**>(ptr_B),
           ptr_dB,
-          reinterpret_cast<NonVoidElementScale const**>(args.ptr_S),
-          args.dS,
+          reinterpret_cast<NonVoidElementScaleA const**>(args.ptr_SA),
+          args.dSA,
+          reinterpret_cast<NonVoidElementScaleB const**>(args.ptr_SB),
+          args.dSB,
           reinterpret_cast<NonVoidElementZero const**>(args.ptr_Z),
           scale_k,
           chunk_size,
@@ -519,17 +576,28 @@ struct CollectiveMmaArrayMixedInput<
       return SwapAB ? args_setup(args.ptr_B, args.ptr_A) : args_setup(args.ptr_A, args.ptr_B);
     } else if constexpr (ModeHasScales) {
       auto fake_scale_k = 1;
-      ElementScale const* ptr_S = reinterpret_cast<ElementScale const*>(args.ptr_S);
-      StrideScale dS{};
-      Tensor tensor_scale =
-          make_tensor(detail::get_logical_ptr(ptr_S), make_layout(make_shape(init_M, fake_scale_k, mock_L), dS));
-      tma_load_scale = make_tma_copy<TmaElementScale>(
+      ScaleA const* ptr_SA = reinterpret_cast<ScaleA const*>(args.ptr_SA);
+      ScaleB const* ptr_SB = reinterpret_cast<ScaleB const*>(args.ptr_SB);
+      StrideScaleA dSA{};
+      Tensor tensor_scaleA =
+          make_tensor(detail::get_logical_ptr(ptr_SA), make_layout(make_shape(init_M, fake_scale_k, mock_L), dSA));
+      StrideScaleB dSB{};
+      Tensor tensor_scaleB =
+          make_tensor(detail::get_logical_ptr(ptr_SB), make_layout(make_shape(init_N, fake_scale_k, mock_L), dSB));
+
+      tma_load_scaleA = make_tma_copy<TmaElementScaleA>(
           GmemTiledCopyScale{},
-          tensor_scale,
-          SmemLayoutScale{}(_, _, cute::Int<0>{}),
-          ScaleTileShape{},
+          tensor_scaleA,
+          SmemLayoutScaleA{}(_, _, cute::Int<0>{}),
+          ScaleATileShape{},
           _1{});  // mcast along N mode for this M load, if any
 
+      tma_load_scaleB = make_tma_copy(
+          GmemTiledCopyScale{},
+          tensor_scaleB,
+          SmemLayoutScaleB{}(_, _, cute::Int<0>{}),
+          ScaleBTileShape{},
+          _1{});  // mcast along M mode for this N load, if any
       if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
         return SwapAB ? args_setup(
                             args.ptr_B,
@@ -546,12 +614,12 @@ struct CollectiveMmaArrayMixedInput<
       } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
         ElementZero const* ptr_Z = reinterpret_cast<ElementZero const*>(args.ptr_Z);
         Tensor tensor_zero =
-            make_tensor(detail::get_logical_ptr(ptr_Z), make_layout(make_shape(init_M, fake_scale_k, mock_L), dS));
+            make_tensor(detail::get_logical_ptr(ptr_Z), make_layout(make_shape(init_M, fake_scale_k, mock_L), dSA));
         tma_load_zero = make_tma_copy(
             GmemTiledCopyScale{},
             tensor_zero,
-            SmemLayoutScale{}(_, _, cute::Int<0>{}),
-            ScaleTileShape{},
+            SmemLayoutScaleA{}(_, _, cute::Int<0>{}),
+            ScaleATileShape{},
             _1{});  // mcast along N mode for this M load, if any
         return SwapAB ? args_setup(
                             args.ptr_B,
@@ -591,12 +659,12 @@ struct CollectiveMmaArrayMixedInput<
       return calculate_workspace_size(2);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       // Allocate gmem space for input tensormaps per each SM, A tensormap copies followed by B tensormap copies,
-      // followed by scale tensormap copies
-      return calculate_workspace_size(3);
+      // followed by scaleA and scaleB tensormap copies
+      return calculate_workspace_size(4);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       // Allocate gmem space for input tensormaps per each SM, A tensormap copies followed by B tensormap copies,
-      // followed by scale and zeros tensormap copies
-      return calculate_workspace_size(4);
+      // followed by scaleA and scaleB and zeros tensormap copies
+      return calculate_workspace_size(5);
     } else {
       static_assert(
           cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in get_workspace_size.");
@@ -639,23 +707,28 @@ struct CollectiveMmaArrayMixedInput<
         implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_B>(
                                              detail::get_gmem_layout(cute::make_shape(N, K, L), dB));
         if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
-          implementable = implementable && (args.ptr_S == nullptr);
+          implementable = implementable && (args.ptr_SA == nullptr);
+          implementable = implementable && (args.ptr_SB == nullptr);
           implementable = implementable && (args.ptr_Z == nullptr);
         } else if constexpr (ModeHasScales) {
-          const int scale_mn = SwapAB ? N : M;
           const int scale_k = (K + args.chunk_size - 1) / args.chunk_size;
-          constexpr int min_tma_aligned_elements_scale = tma_alignment_bits / cutlass::sizeof_bits<ElementScale>::value;
-          implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_scale>(
-                                               cute::make_shape(scale_mn, scale_k, L), StrideScale{});
+          constexpr int min_tma_aligned_elements_scaleA = tma_alignment_bits / cutlass::sizeof_bits<ScaleA>::value;
+          constexpr int min_tma_aligned_elements_scaleB = tma_alignment_bits / cutlass::sizeof_bits<ScaleB>::value;
+          implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_scaleA>(
+                                               cute::make_shape(M, scale_k, L), StrideScaleA{});
+          implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_scaleB>(
+                                               cute::make_shape(N, scale_k % 4 == 0 ? scale_k : scale_k * 4, L),
+                                               StrideScaleB{});  // scale_k need padding to 4
           implementable = implementable && (args.chunk_size == K || ((args.chunk_size % size<2>(TileShape{})) == 0));
           implementable = implementable && args.chunk_size != 0;
-          implementable = implementable && (args.ptr_S != nullptr);
+          implementable = implementable && (args.ptr_SA != nullptr);
+          implementable = implementable && (args.ptr_SB != nullptr);
           if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
             implementable = implementable && (args.ptr_Z == nullptr);
           } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
             constexpr int min_tma_aligned_elements_zero = tma_alignment_bits / cutlass::sizeof_bits<ElementZero>::value;
             implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_zero>(
-                                                 cute::make_shape(scale_mn, scale_k, L), StrideScale{});
+                                                 cute::make_shape(M, scale_k, L), StrideScaleA{});
             implementable = implementable && (args.ptr_Z != nullptr);
           } else {
             static_assert(
@@ -713,14 +786,22 @@ struct CollectiveMmaArrayMixedInput<
       // auto scale_k = K / mainloop_params.chunk_size;
       auto scale_k = K / GROUP_SIZE;
 
-      Tensor mS_mkl = mainloop_params.tma_load_scale.get_tma_tensor(make_shape(M, scale_k, L));  // (m,scale_k,l)
-      Tensor gS_mkl = local_tile(mS_mkl, ScaleTileShape{}, make_coord(_, _));  // (BLK_M,BLK_Scale_K,m,scale_k,l)
+      Tensor mSA_mkl = mainloop_params.tma_load_scaleA.get_tma_tensor(make_shape(M, scale_k, L));  // (m,scale_k,l)
+      Tensor gSA_mkl = local_tile(mSA_mkl, ScaleATileShape{}, make_coord(_, _));  // (BLK_M,BLK_Scale_K,m,scale_k,l)
+
+      // Tensor mSB_nkl = mainloop_params.tma_load_scaleB.get_tma_tensor(make_shape(N, scale_k, L));  // (n,scale_k,l)
+      Tensor mSB_nkl = mainloop_params.tma_load_scaleB.get_tma_tensor(shape(
+          detail::get_gmem_layout(
+              make_shape(N, scale_k % 4 == 0 ? scale_k : scale_k * 4, L),
+              mainloop_params.dSB[0])));  // (m,k,l) scale_k need padding to 4 for B scale
+
+      Tensor gSB_nkl = local_tile(mSB_nkl, ScaleBTileShape{}, make_coord(_, _));  // (BLK_N,BLK_Scale_K,n,scale_k,l)
       if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-        return cute::make_tuple(gA_mkl, gB_nkl, gS_mkl);
+        return cute::make_tuple(gA_mkl, gB_nkl, gSA_mkl, gSB_nkl);
       } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
         Tensor mZ_mkl = mainloop_params.tma_load_zero.get_tma_tensor(make_shape(M, scale_k, L));  // (m,scale_k,l)
-        Tensor gZ_mkl = local_tile(mZ_mkl, ScaleTileShape{}, make_coord(_, _));  // (BLK_M,BLK_Scale_K,m,scale_k,l)
-        return cute::make_tuple(gA_mkl, gB_nkl, gS_mkl, gZ_mkl);
+        Tensor gZ_mkl = local_tile(mZ_mkl, ScaleATileShape{}, make_coord(_, _));  // (BLK_M,BLK_Scale_K,m,scale_k,l)
+        return cute::make_tuple(gA_mkl, gB_nkl, gSA_mkl, gSB_nkl, gZ_mkl);
       } else {
         static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in load_init.");
       }
@@ -749,11 +830,11 @@ struct CollectiveMmaArrayMixedInput<
       static_assert(sizeof...(Ts) == 2, "Direct convert needs two inputs");
       static_assert(sizeof...(TMs) == 2, "Direct convert needs two tensormaps");
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      static_assert(sizeof...(Ts) == 3, "Scaled convert needs three inputs");
-      static_assert(sizeof...(TMs) == 3, "Scaled convert needs three tensormaps");
+      static_assert(sizeof...(Ts) == 4, "Scaled convert needs four inputs");
+      static_assert(sizeof...(TMs) == 4, "Scaled convert needs four tensormaps");
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
-      static_assert(sizeof...(Ts) == 4, "Scaled and zero convert needs four inputs");
-      static_assert(sizeof...(TMs) == 4, "Scaled and zero convert needs four tensormaps");
+      static_assert(sizeof...(Ts) == 5, "Scaled and zero convert needs five inputs");
+      static_assert(sizeof...(TMs) == 5, "Scaled and zero convert needs five tensormaps");
     } else {
       static_assert(cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in TMA load.");
     }
@@ -790,7 +871,8 @@ struct CollectiveMmaArrayMixedInput<
 
     uint16_t mcast_mask_a = 0;
     uint16_t mcast_mask_b = 0;
-    uint16_t mcast_mask_s = 0;
+    uint16_t mcast_mask_sA = 0;
+    uint16_t mcast_mask_sB = 0;
 
     // Issue TmaLoads
     // Maps the tile -> block, value
@@ -809,7 +891,7 @@ struct CollectiveMmaArrayMixedInput<
     }
 
     auto extra_input_partitions = Utils::partition_extra_tma_inputs(
-        mainloop_params, load_inputs, shared_tensors, cluster_local_block_id, m_coord, l_coord);
+        mainloop_params, load_inputs, shared_tensors, cluster_local_block_id, m_coord, n_coord, l_coord);
 
     // Mainloop
     CUTLASS_PRAGMA_NO_UNROLL
@@ -839,8 +921,11 @@ struct CollectiveMmaArrayMixedInput<
         // Nothing extra to do.
       } else if constexpr (ModeHasScales) {
         // scale copy
-        auto tSgS = get<0>(extra_input_partitions);
-        auto tSsS = get<1>(extra_input_partitions);
+        auto tSgSA = get<0>(extra_input_partitions);
+        auto tSsSA = get<1>(extra_input_partitions);
+
+        auto tSgSB = get<2>(extra_input_partitions);
+        auto tSsSB = get<3>(extra_input_partitions);
 
         // Temporary factor which will determine which k tile to reload from gmem. Needed so we don't modify tma
         // transaction bytes on the fly. We must do a ceiling divide here to correctly handle with chunk_size == K. In
@@ -850,20 +935,24 @@ struct CollectiveMmaArrayMixedInput<
         // chunk_size == K.
         if (cute::elect_one_sync()) {
           copy(
-              mainloop_params.tma_load_scale.with(get<2>(input_tensormaps), *tma_barrier, mcast_mask_s),
-              tSgS(_, _, _, scale_load_k),
-              tSsS(_, _, _, write_stage));
+              mainloop_params.tma_load_scaleA.with(get<2>(input_tensormaps), *tma_barrier, mcast_mask_sA),
+              tSgSA(_, _, _, scale_load_k),
+              tSsSA(_, _, _, write_stage));
+          copy(
+              mainloop_params.tma_load_scaleB.with(get<3>(input_tensormaps), *tma_barrier, mcast_mask_sB),
+              tSgSB(_, _, _, *k_tile_iter),
+              tSsSB(_, _, _, write_stage));
         }
 
         if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
           // Nothing extra to do
         } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
           // zero copy
-          auto tZgZ = get<2>(extra_input_partitions);
-          auto tZsZ = get<3>(extra_input_partitions);
+          auto tZgZ = get<4>(extra_input_partitions);
+          auto tZsZ = get<5>(extra_input_partitions);
           if (cute::elect_one_sync()) {
             copy(
-                mainloop_params.tma_load_zero.with(get<3>(input_tensormaps), *tma_barrier, mcast_mask_s),
+                mainloop_params.tma_load_zero.with(get<4>(input_tensormaps), *tma_barrier, mcast_mask_sA),
                 tZgZ(_, _, _, scale_load_k),
                 tZsZ(_, _, _, write_stage));
           }
@@ -928,6 +1017,9 @@ struct CollectiveMmaArrayMixedInput<
 
     Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()), SmemLayoutB{});  // (BLK_N,BLK_K,PIPE)
 
+    constexpr int BLK_N = size<0>(SmemLayoutScaleB{});
+    constexpr int BLK_scaleK = size<1>(SmemLayoutScaleB{});
+
     //
     // Define C accumulators and A/B partitioning
     //
@@ -985,6 +1077,23 @@ struct CollectiveMmaArrayMixedInput<
     CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<2>(sA));  // PIPE
     CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<2>(sB));  // PIPE
 
+    using SmemCopyAtomA_LDSM = Copy_Atom<SM75_U32x4_LDSM_N, ElementB>;
+    auto smem_tiled_copy_A_LDSM = make_tiled_copy_A(SmemCopyAtomA_LDSM{}, tiled_mma);
+    auto smem_thr_copy_A_LDSM = smem_tiled_copy_A_LDSM.get_thread_slice(thread_idx);
+
+    Tensor sA_LDSM = recast<ElementB>(sA);
+    auto tCsA_LDSM = smem_thr_copy_A_LDSM.partition_S(sA_LDSM);
+
+    using ABBitWidthRatio = Int<sizeof_bits_v<ElementB> / sizeof_bits_v<ElementA>>;
+    auto tCrA_load_LDSM_shape = replace<2>(tCrA_mma.shape(), size(get<2>(tCrA_mma.shape())) / ABBitWidthRatio{});
+    Tensor tCrA_load_LDSM = make_fragment_like<ElementB>(tCrA_load_LDSM_shape);
+    Tensor tCrA_copy_view_LDSM = smem_thr_copy_A_LDSM.retile_D(tCrA_load_LDSM);  // (CPY,CPY_M,CPY_K)
+
+    auto ptr = recast_ptr<RealSwappedElementA>(tCrA_load_LDSM.data());
+    auto old_shape = tCrA_load_LDSM.shape();
+    auto new_shape = make_shape(size<0>(old_shape), get<1>(old_shape), size<2>(old_shape) * ABBitWidthRatio{});
+    Tensor tCrA_load_4b_packed = make_tensor(ptr, make_layout(new_shape));
+
     //
     // PIPELINED MAIN LOOP
     //
@@ -1015,15 +1124,14 @@ struct CollectiveMmaArrayMixedInput<
 
       // copy smem->rmem for A operand
 
-      Utils::copy_tensors_MK(
-          smem_tiled_copy_A, tCsA, tCrA_copy_view, partitioned_extra_info, copy_partitions_extra_info, 0, read_stage);
+      Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, 0, read_stage);
+
       if (K_BLOCK_MAX > 1) {
-        Utils::copy_tensors_MK(
-            smem_tiled_copy_A, tCsA, tCrA_copy_view, partitioned_extra_info, copy_partitions_extra_info, 1, read_stage);
+        Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, 1, read_stage);
       }
 
       // src: tCrA_load, dst: tCrA_mma
-      Utils::convert_A_kblock(tCrA_load, tCrA_mma, 0);
+      Utils::convert_A_kblock(tCrA_load_4b_packed, tCrA_mma, 0);
 
       // Unroll the K mode manually to set scale D to 1
       CUTLASS_PRAGMA_UNROLL
@@ -1042,22 +1150,44 @@ struct CollectiveMmaArrayMixedInput<
 
           warpgroup_commit_batch();
 
+          if (k_block == 0) {
+            Utils::copy_tensors_SFA(partitioned_extra_info, copy_partitions_extra_info, 0, read_stage);
+          }
+
           if (k_block < K_BLOCK_MAX - 2) {
-            Utils::copy_tensors_MK(
-                smem_tiled_copy_A,
-                tCsA,
-                tCrA_copy_view,
-                partitioned_extra_info,
-                copy_partitions_extra_info,
-                k_block + 2,
-                read_stage);
+            Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, k_block + 2, read_stage);
           }
           if (k_block < K_BLOCK_MAX - 1) {
-            Utils::convert_A_kblock(tCrA_load, tCrA_mma, k_block + 1);
+            Utils::convert_A_kblock(tCrA_load_4b_packed, tCrA_mma, k_block + 1);
           }
         }
       }
 
+      constexpr int n_mma = cute::size<0>(sB.shape())() / 8;
+      float4 scale_b_per_n_e0[n_mma];
+      float4 scale_b_per_n_e1[n_mma];
+      uint32_t lane_id;
+      asm("mov.u32 %0, %laneid;" : "=r"(lane_id));
+      int in_blk_c = (lane_id & 3) * 2;
+      auto smem_scaleB_stage = shared_tensors.smem_scaleB.begin() + read_stage * BLK_N * BLK_scaleK;
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int n = 0; n < size<0, 2>(accum); ++n) {
+        int col_base = (n << 3) + in_blk_c;
+        asm volatile("ld.shared.v4.f32 {%0,%1,%2,%3}, [%4];"
+                     : "=f"(scale_b_per_n_e0[n].x),
+                       "=f"(scale_b_per_n_e0[n].y),
+                       "=f"(scale_b_per_n_e0[n].z),
+                       "=f"(scale_b_per_n_e0[n].w)
+                     : "l"(smem_scaleB_stage + 4 * col_base));
+        asm volatile("ld.shared.v4.f32 {%0,%1,%2,%3}, [%4];"
+                     : "=f"(scale_b_per_n_e1[n].x),
+                       "=f"(scale_b_per_n_e1[n].y),
+                       "=f"(scale_b_per_n_e1[n].z),
+                       "=f"(scale_b_per_n_e1[n].w)
+                     : "l"(smem_scaleB_stage + 4 * (col_base + 1))  // +1
+        );
+      }
       warpgroup_wait<0>();
 
       CUTLASS_PRAGMA_UNROLL
@@ -1066,23 +1196,31 @@ struct CollectiveMmaArrayMixedInput<
 
         // Apply the group-wise scaling
         // tCrS  ((4, _2, _2), MMA_M, _1)
-        // accum ((2, _2, _2), MMA_M, _1)
+        // accum ((_2, _2, n), MMA_M, _1)
         auto tCrS = cute::get<1>(partitioned_extra_info);
         for (int mma_m = 0; mma_m < size<1>(accum); mma_m++) {
+          CUTLASS_PRAGMA_UNROLL
           for (int m = 0; m < size<0, 1>(accum); m++) {
-            for (int n = 0; n < size<0, 2>(accum); n++) {
-              for (int e = 0; e < size<0, 0>(accum); e++) {
-                auto accum_coord = make_coord(make_tuple(e, m, n), mma_m, 0);
-                auto scale_coord = make_coord(make_tuple(0, m, 0), mma_m, 0);
+            float sA = static_cast<float>(tCrS(make_coord(make_tuple(0, m, 0), mma_m, 0))[chunk_id_]);
 
+            CUTLASS_PRAGMA_UNROLL
+            for (int n = 0; n < size<0, 2>(accum); n++) {
+              float sb_e0 = ((float*)&(scale_b_per_n_e0[n]))[chunk_id_];
+              float sb_e1 = ((float*)&(scale_b_per_n_e1[n]))[chunk_id_];
+              {
+                auto accum_coord = make_coord(make_tuple(0, m, n), mma_m, 0);
                 if (chunk_id_ == 0) {
-                  accum(accum_coord) =
-                      intermediate_array[chunk_id_](accum_coord) * static_cast<float>(tCrS(scale_coord)[0]);
+                  accum(accum_coord) = intermediate_array[chunk_id_](accum_coord) * sA * sb_e0;
                 } else {
-                  accum(accum_coord) =
-                      fma(intermediate_array[chunk_id_](accum_coord),
-                          static_cast<float>(tCrS(scale_coord)[chunk_id_]),
-                          accum(accum_coord));
+                  accum(accum_coord) = fma(intermediate_array[chunk_id_](accum_coord), sA * sb_e0, accum(accum_coord));
+                }
+              }
+              {
+                auto accum_coord = make_coord(make_tuple(1, m, n), mma_m, 0);
+                if (chunk_id_ == 0) {
+                  accum(accum_coord) = intermediate_array[chunk_id_](accum_coord) * sA * sb_e1;
+                } else {
+                  accum(accum_coord) = fma(intermediate_array[chunk_id_](accum_coord), sA * sb_e1, accum(accum_coord));
                 }
               }
             }
@@ -1096,25 +1234,10 @@ struct CollectiveMmaArrayMixedInput<
         // mma.
         pipeline.consumer_wait(smem_pipe_read, barrier_token);
 
-        Utils::copy_tensors_MK(
-            smem_tiled_copy_A,
-            tCsA,
-            tCrA_copy_view,
-            partitioned_extra_info,
-            copy_partitions_extra_info,
-            0,
-            smem_pipe_read.index());
+        Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, 0, smem_pipe_read.index());
+        Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, 1, smem_pipe_read.index());
 
-        Utils::copy_tensors_MK(
-            smem_tiled_copy_A,
-            tCsA,
-            tCrA_copy_view,
-            partitioned_extra_info,
-            copy_partitions_extra_info,
-            1,
-            smem_pipe_read.index());
-
-        Utils::convert_A_kblock(tCrA_load, tCrA_mma, 0);
+        Utils::convert_A_kblock(tCrA_load_4b_packed, tCrA_mma, 0);
       }
     }
 
@@ -1131,6 +1254,35 @@ struct CollectiveMmaArrayMixedInput<
 
       int read_stage = smem_pipe_read.index();
       ++smem_pipe_read;
+
+      constexpr int n_mma = cute::size<0>(sB.shape())() / 8;
+      float4 scale_b_per_n_e0[n_mma];
+      float4 scale_b_per_n_e1[n_mma];
+
+      uint32_t lane_id;
+      asm("mov.u32 %0, %laneid;" : "=r"(lane_id));
+      int in_blk_c = (lane_id & 3) * 2;
+      auto smem_scaleB_stage = shared_tensors.smem_scaleB.begin() + read_stage * BLK_N * BLK_scaleK;
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int n = 0; n < size<0, 2>(accum); ++n) {
+        int col_base = (n << 3) + in_blk_c;
+        asm volatile("ld.shared.v4.f32 {%0,%1,%2,%3}, [%4];"
+                     : "=f"(scale_b_per_n_e0[n].x),
+                       "=f"(scale_b_per_n_e0[n].y),
+                       "=f"(scale_b_per_n_e0[n].z),
+                       "=f"(scale_b_per_n_e0[n].w)
+                     : "l"(smem_scaleB_stage + 4 * col_base)  // +0
+        );
+
+        asm volatile("ld.shared.v4.f32 {%0,%1,%2,%3}, [%4];"
+                     : "=f"(scale_b_per_n_e1[n].x),
+                       "=f"(scale_b_per_n_e1[n].y),
+                       "=f"(scale_b_per_n_e1[n].z),
+                       "=f"(scale_b_per_n_e1[n].w)
+                     : "l"(smem_scaleB_stage + 4 * (col_base + 1))  // +1
+        );
+      }
 
       // Unroll the K mode manually to set scale D to 1
       CUTLASS_PRAGMA_UNROLL
@@ -1154,10 +1306,15 @@ struct CollectiveMmaArrayMixedInput<
 
           if (k_block == 0) {
             barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
+            Utils::copy_tensors_SFA(partitioned_extra_info, copy_partitions_extra_info, 0, read_stage);
           }
 
           if (k_block == K_BLOCK_MAX - 1) {
             // The last k_block
+
+            pipeline.consumer_wait(smem_pipe_read, barrier_token);
+            Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, 0, smem_pipe_read.index());
+            Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, 1, smem_pipe_read.index());
 
             warpgroup_wait<0>();
 
@@ -1168,54 +1325,36 @@ struct CollectiveMmaArrayMixedInput<
               // Apply the group-wise scaling
               auto tCrS = cute::get<1>(partitioned_extra_info);
               for (int mma_m = 0; mma_m < size<1>(accum); mma_m++) {
+                CUTLASS_PRAGMA_UNROLL
                 for (int m = 0; m < size<0, 1>(accum); m++) {
-                  for (int n = 0; n < size<0, 2>(accum); n++) {
-                    for (int e = 0; e < size<0, 0>(accum); e++) {
-                      auto accum_coord = make_coord(make_tuple(e, m, n), mma_m, 0);
-                      auto scale_coord = make_coord(make_tuple(0, m, 0), mma_m, 0);
+                  float sA = static_cast<float>(tCrS(make_coord(make_tuple(0, m, 0), mma_m, 0))[chunk_id_]);
 
+                  CUTLASS_PRAGMA_UNROLL
+                  for (int n = 0; n < size<0, 2>(accum); n++) {
+                    float sb_e0 = ((float*)&(scale_b_per_n_e0[n]))[chunk_id_];
+                    float sb_e1 = ((float*)&(scale_b_per_n_e1[n]))[chunk_id_];
+                    {
+                      auto accum_coord = make_coord(make_tuple(0, m, n), mma_m, 0);
                       accum(accum_coord) =
-                          fma(intermediate_array[chunk_id_](accum_coord),
-                              static_cast<float>(tCrS(scale_coord)[chunk_id_]),
-                              accum(accum_coord));
+                          fma(intermediate_array[chunk_id_](accum_coord), sA * sb_e0, accum(accum_coord));
+                    }
+                    {
+                      auto accum_coord = make_coord(make_tuple(1, m, n), mma_m, 0);
+                      accum(accum_coord) =
+                          fma(intermediate_array[chunk_id_](accum_coord), sA * sb_e1, accum(accum_coord));
                     }
                   }
                 }
               }
             }
 
-            pipeline.consumer_wait(smem_pipe_read, barrier_token);
-
             // copy scales when passing k_block=0
-            Utils::copy_tensors_MK(
-                smem_tiled_copy_A,
-                tCsA,
-                tCrA_copy_view,
-                partitioned_extra_info,
-                copy_partitions_extra_info,
-                0,
-                smem_pipe_read.index());
-            Utils::copy_tensors_MK(
-                smem_tiled_copy_A,
-                tCsA,
-                tCrA_copy_view,
-                partitioned_extra_info,
-                copy_partitions_extra_info,
-                1,
-                smem_pipe_read.index());
-            Utils::convert_A_kblock(tCrA_load, tCrA_mma, 0);
+            Utils::convert_A_kblock(tCrA_load_4b_packed, tCrA_mma, 0);
           } else {
             if (k_block < K_BLOCK_MAX - 2) {
-              Utils::copy_tensors_MK(
-                  smem_tiled_copy_A,
-                  tCsA,
-                  tCrA_copy_view,
-                  partitioned_extra_info,
-                  copy_partitions_extra_info,
-                  k_block + 2,
-                  read_stage);
+              Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, k_block + 2, read_stage);
             }
-            Utils::convert_A_kblock(tCrA_load, tCrA_mma, k_block + 1);
+            Utils::convert_A_kblock(tCrA_load_4b_packed, tCrA_mma, k_block + 1);
           }
         }
       }
@@ -1229,6 +1368,35 @@ struct CollectiveMmaArrayMixedInput<
 
       int read_stage = smem_pipe_read.index();
 
+      constexpr int n_mma = cute::size<0>(sB.shape())() / 8;
+      float4 scale_b_per_n_e0[n_mma];
+      float4 scale_b_per_n_e1[n_mma];
+
+      uint32_t lane_id;
+      asm("mov.u32 %0, %laneid;" : "=r"(lane_id));
+      int in_blk_c = (lane_id & 3) * 2;
+      auto smem_scaleB_stage = shared_tensors.smem_scaleB.begin() + read_stage * BLK_N * BLK_scaleK;
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int n = 0; n < size<0, 2>(accum); ++n) {
+        int col_base = (n << 3) + in_blk_c;
+        asm volatile("ld.shared.v4.f32 {%0,%1,%2,%3}, [%4];"
+                     : "=f"(scale_b_per_n_e0[n].x),
+                       "=f"(scale_b_per_n_e0[n].y),
+                       "=f"(scale_b_per_n_e0[n].z),
+                       "=f"(scale_b_per_n_e0[n].w)
+                     : "l"(smem_scaleB_stage + 4 * col_base)  // +0
+        );
+
+        asm volatile("ld.shared.v4.f32 {%0,%1,%2,%3}, [%4];"
+                     : "=f"(scale_b_per_n_e1[n].x),
+                       "=f"(scale_b_per_n_e1[n].y),
+                       "=f"(scale_b_per_n_e1[n].z),
+                       "=f"(scale_b_per_n_e1[n].w)
+                     : "l"(smem_scaleB_stage + 4 * (col_base + 1))  // +1
+        );
+      }
+
       tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
 
       // Unroll the K mode manually to set scale D to 1
@@ -1240,6 +1408,10 @@ struct CollectiveMmaArrayMixedInput<
         tiled_mma.accumulate_ = GMMA::ScaleOut::One;
         warpgroup_commit_batch();
 
+        if (k_block == 0) {
+          Utils::copy_tensors_SFA(partitioned_extra_info, copy_partitions_extra_info, 0, read_stage);
+        }
+
         if (k_block == K_BLOCK_MAX - 1) {
           // release prior barrier
           pipeline.consumer_release(smem_pipe_release);  // UNLOCK smem_pipe_release, done _computing_ on it
@@ -1247,17 +1419,10 @@ struct CollectiveMmaArrayMixedInput<
         }
 
         if (k_block < K_BLOCK_MAX - 2) {
-          Utils::copy_tensors_MK(
-              smem_tiled_copy_A,
-              tCsA,
-              tCrA_copy_view,
-              partitioned_extra_info,
-              copy_partitions_extra_info,
-              k_block + 2,
-              read_stage);
+          Utils::copy_tensors_A(smem_tiled_copy_A_LDSM, tCsA_LDSM, tCrA_copy_view_LDSM, k_block + 2, read_stage);
         }
         if (k_block < K_BLOCK_MAX - 1) {
-          Utils::convert_A_kblock(tCrA_load, tCrA_mma, k_block + 1);
+          Utils::convert_A_kblock(tCrA_load_4b_packed, tCrA_mma, k_block + 1);
         }
 
         if ((k_block + 1) % NumMMAsPerChunk == 0) {
@@ -1269,15 +1434,22 @@ struct CollectiveMmaArrayMixedInput<
           // Apply the group-wise scaling
           auto tCrS = cute::get<1>(partitioned_extra_info);
           for (int mma_m = 0; mma_m < size<1>(accum); mma_m++) {
+            CUTLASS_PRAGMA_UNROLL
             for (int m = 0; m < size<0, 1>(accum); m++) {
-              for (int n = 0; n < size<0, 2>(accum); n++) {
-                for (int e = 0; e < size<0, 0>(accum); e++) {
-                  auto accum_coord = make_coord(make_tuple(e, m, n), mma_m, 0);
-                  auto scale_coord = make_coord(make_tuple(0, m, 0), mma_m, 0);
-                  int scale_idx = k_block / NumMMAsPerChunk;
+              int scale_idx = k_block / NumMMAsPerChunk;
+              float sA = static_cast<float>(tCrS(make_coord(make_tuple(0, m, 0), mma_m, 0))[scale_idx]);
 
-                  accum(accum_coord) = fma(
-                      intermediate(accum_coord), static_cast<float>(tCrS(scale_coord)[scale_idx]), accum(accum_coord));
+              CUTLASS_PRAGMA_UNROLL
+              for (int n = 0; n < size<0, 2>(accum); n++) {
+                float sb_e0 = ((float*)&(scale_b_per_n_e0[n]))[scale_idx];
+                float sb_e1 = ((float*)&(scale_b_per_n_e1[n]))[scale_idx];
+                {
+                  auto accum_coord = make_coord(make_tuple(0, m, n), mma_m, 0);
+                  accum(accum_coord) = fma(intermediate(accum_coord), sA * sb_e0, accum(accum_coord));
+                }
+                {
+                  auto accum_coord = make_coord(make_tuple(1, m, n), mma_m, 0);
+                  accum(accum_coord) = fma(intermediate(accum_coord), sA * sb_e1, accum(accum_coord));
                 }
               }
             }
@@ -1295,9 +1467,6 @@ struct CollectiveMmaArrayMixedInput<
 
     smem_pipe_release.advance(k_tile_count);
 
-    // Wait on all GMMAs to complete
-    // warpgroup_wait<0>();
-
     for (int count = 0; count < prologue_mma_count; ++count) {
       pipeline.consumer_release(smem_pipe_release);  // UNLOCK smem_pipe_release, done _computing_ on it
       ++smem_pipe_release;
@@ -1313,8 +1482,9 @@ struct CollectiveMmaArrayMixedInput<
 
     cute::TmaDescriptor* tma_desc_a = &gmem_tensormap[sm_idx];
     cute::TmaDescriptor* tma_desc_b = &gmem_tensormap[sm_idx + sm_count];
-    cute::TmaDescriptor* tma_desc_scale = &gmem_tensormap[sm_idx + 2 * sm_count];
-    cute::TmaDescriptor* tma_desc_zero = &gmem_tensormap[sm_idx + 3 * sm_count];
+    cute::TmaDescriptor* tma_desc_scaleA = &gmem_tensormap[sm_idx + 2 * sm_count];
+    cute::TmaDescriptor* tma_desc_scaleB = &gmem_tensormap[sm_idx + 3 * sm_count];
+    cute::TmaDescriptor* tma_desc_zero = &gmem_tensormap[sm_idx + 4 * sm_count];
 
     // Bringing tensormaps from params to smem for modification later
     Tensor pA_tensormap = make_tensor(mainloop_params.tma_load_a.get_tma_descriptor(), Int<1>{}, Int<1>{});
@@ -1328,10 +1498,14 @@ struct CollectiveMmaArrayMixedInput<
     }
 
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      Tensor pS_tensormap = make_tensor(mainloop_params.tma_load_scale.get_tma_descriptor(), Int<1>{}, Int<1>{});
-      Tensor sS_tensormap = make_tensor(make_smem_ptr(&shared_tensormaps.smem_tensormap_scale), Int<1>{}, Int<1>{});
+      Tensor pSA_tensormap = make_tensor(mainloop_params.tma_load_scaleA.get_tma_descriptor(), Int<1>{}, Int<1>{});
+      Tensor sSA_tensormap = make_tensor(make_smem_ptr(&shared_tensormaps.smem_tensormap_scaleA), Int<1>{}, Int<1>{});
+
+      Tensor pSB_tensormap = make_tensor(mainloop_params.tma_load_scaleB.get_tma_descriptor(), Int<1>{}, Int<1>{});
+      Tensor sSB_tensormap = make_tensor(make_smem_ptr(&shared_tensormaps.smem_tensormap_scaleB), Int<1>{}, Int<1>{});
       if (cute::elect_one_sync()) {
-        copy(recast<uint128_t>(pS_tensormap), recast<uint128_t>(sS_tensormap));
+        copy(recast<uint128_t>(pSA_tensormap), recast<uint128_t>(sSA_tensormap));
+        copy(recast<uint128_t>(pSB_tensormap), recast<uint128_t>(sSB_tensormap));
       }
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       Tensor pZ_tensormap = make_tensor(mainloop_params.tma_load_zero.get_tma_descriptor(), Int<1>{}, Int<1>{});
@@ -1349,9 +1523,9 @@ struct CollectiveMmaArrayMixedInput<
     if constexpr (KernelConversionMode == ConversionMode::DirectConvert) {
       return cute::make_tuple(tma_desc_a, tma_desc_b);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scale);
+      return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scaleA, tma_desc_scaleB);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
-      return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scale, tma_desc_zero);
+      return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scaleA, tma_desc_scaleB, tma_desc_zero);
     } else {
       static_assert(
           cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in tensormaps_init.");
@@ -1369,7 +1543,9 @@ struct CollectiveMmaArrayMixedInput<
         shared_tensormaps.smem_tensormap_B, mainloop_params.ptr_B[next_batch]);
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       cute::tma_descriptor_replace_addr_in_shared_mem(
-          shared_tensormaps.smem_tensormap_scale, mainloop_params.ptr_S[next_batch]);
+          shared_tensormaps.smem_tensormap_scaleA, mainloop_params.ptr_SA[next_batch]);
+      cute::tma_descriptor_replace_addr_in_shared_mem(
+          shared_tensormaps.smem_tensormap_scaleB, mainloop_params.ptr_SB[next_batch]);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       cute::tma_descriptor_replace_addr_in_shared_mem(
           shared_tensormaps.smem_tensormap_zero, mainloop_params.ptr_Z[next_batch]);
@@ -1397,8 +1573,10 @@ struct CollectiveMmaArrayMixedInput<
     cute::array<uint64_t, MaxTensorRank> prob_stride_A = {0, 0, 0, 0, 0};
     cute::array<uint32_t, MaxTensorRank> prob_shape_B = {1, 1, 1, 1, 1};
     cute::array<uint64_t, MaxTensorRank> prob_stride_B = {0, 0, 0, 0, 0};
-    cute::array<uint32_t, MaxTensorRank> prob_shape_scale = {1, 1, 1, 1, 1};
-    cute::array<uint64_t, MaxTensorRank> prob_stride_scale = {0, 0, 0, 0, 0};
+    cute::array<uint32_t, MaxTensorRank> prob_shape_scaleA = {1, 1, 1, 1, 1};
+    cute::array<uint64_t, MaxTensorRank> prob_stride_scaleA = {0, 0, 0, 0, 0};
+    cute::array<uint32_t, MaxTensorRank> prob_shape_scaleB = {1, 1, 1, 1, 1};
+    cute::array<uint64_t, MaxTensorRank> prob_stride_scaleB = {0, 0, 0, 0, 0};
     cute::array<uint32_t, MaxTensorRank> prob_shape_zero = {1, 1, 1, 1, 1};
     cute::array<uint64_t, MaxTensorRank> prob_stride_zero = {0, 0, 0, 0, 0};
 
@@ -1414,19 +1592,28 @@ struct CollectiveMmaArrayMixedInput<
     cute::detail::fill_tma_gmem_shape_stride(mainloop_params.tma_load_b, tensor_b, prob_shape_B, prob_stride_B);
 
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      NonVoidElementScale const* ptr_S = nullptr;
+      NonVoidElementScaleA const* ptr_SA = nullptr;
       // auto scale_k = K / mainloop_params.chunk_size;
       auto scale_k = K / GROUP_SIZE;
-      Tensor tensor_scale =
-          make_tensor(detail::get_logical_ptr(ptr_S), make_shape(M, scale_k, Int<1>{}), mainloop_params.dS[next_group]);
+      Tensor tensor_scaleA = make_tensor(
+          detail::get_logical_ptr(ptr_SA), make_shape(M, scale_k, Int<1>{}), mainloop_params.dSA[next_group]);
+
+      NonVoidElementScaleB const* ptr_SB = nullptr;
+      Tensor tensor_scaleB = make_tensor(
+          detail::get_logical_ptr(ptr_SB),
+          make_shape(N, scale_k % 4 == 0 ? scale_k : scale_k * 4, Int<1>{}),
+          mainloop_params.dSB[next_group]);  // scale_k need padding to 4 for B scale
+
       cute::detail::fill_tma_gmem_shape_stride(
-          mainloop_params.tma_load_scale, tensor_scale, prob_shape_scale, prob_stride_scale);
+          mainloop_params.tma_load_scaleA, tensor_scaleA, prob_shape_scaleA, prob_stride_scaleA);
+      cute::detail::fill_tma_gmem_shape_stride(
+          mainloop_params.tma_load_scaleB, tensor_scaleB, prob_shape_scaleB, prob_stride_scaleB);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       ElementZero const* ptr_Z = nullptr;
       // auto scale_k = K / mainloop_params.chunk_size;
       auto scale_k = K / GROUP_SIZE;
-      Tensor tensor_zero =
-          make_tensor(detail::get_logical_ptr(ptr_Z), make_shape(M, scale_k, Int<1>{}), mainloop_params.dS[next_group]);
+      Tensor tensor_zero = make_tensor(
+          detail::get_logical_ptr(ptr_Z), make_shape(M, scale_k, Int<1>{}), mainloop_params.dSA[next_group]);
       cute::detail::fill_tma_gmem_shape_stride(
           mainloop_params.tma_load_zero, tensor_zero, prob_shape_zero, prob_stride_zero);
     } else if constexpr (KernelConversionMode != ConversionMode::DirectConvert) {
@@ -1442,11 +1629,14 @@ struct CollectiveMmaArrayMixedInput<
     for (uint64_t& stride : prob_stride_B) {
       stride = (stride * sizeof_bits_v<SwappedElementB>) / 8;
     }
-    for (uint64_t& stride : prob_stride_scale) {
-      stride = (stride * sizeof_bits_v<NonVoidElementScale>) / 8;
+    for (uint64_t& stride : prob_stride_scaleA) {
+      stride = (stride * sizeof_bits_v<NonVoidElementScaleA>) / 8;
+    }
+    for (uint64_t& stride : prob_stride_scaleB) {
+      stride = (stride * sizeof_bits_v<NonVoidElementScaleB>) / 8;
     }
     for (uint64_t& stride : prob_stride_zero) {
-      stride = (stride * sizeof_bits_v<NonVoidElementScale>) / 8;
+      stride = (stride * sizeof_bits_v<NonVoidElementScaleA>) / 8;
     }
 
     cute::tma_descriptor_replace_dims_strides_in_shared_mem(
@@ -1456,7 +1646,9 @@ struct CollectiveMmaArrayMixedInput<
 
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       cute::tma_descriptor_replace_dims_strides_in_shared_mem(
-          shared_tensormaps.smem_tensormap_scale, prob_shape_scale, prob_stride_scale);
+          shared_tensormaps.smem_tensormap_scaleA, prob_shape_scaleA, prob_stride_scaleA);
+      cute::tma_descriptor_replace_dims_strides_in_shared_mem(
+          shared_tensormaps.smem_tensormap_scaleB, prob_shape_scaleB, prob_stride_scaleB);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       cute::tma_descriptor_replace_dims_strides_in_shared_mem(
           shared_tensormaps.smem_tensormap_zero, prob_shape_zero, prob_stride_zero);
@@ -1496,9 +1688,10 @@ struct CollectiveMmaArrayMixedInput<
     tma_descriptor_cp_fence_release(get<0>(input_tensormaps), shared_tensormaps.smem_tensormap_A);
     tma_descriptor_cp_fence_release(get<1>(input_tensormaps), shared_tensormaps.smem_tensormap_B);
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      tma_descriptor_cp_fence_release(get<2>(input_tensormaps), shared_tensormaps.smem_tensormap_scale);
+      tma_descriptor_cp_fence_release(get<2>(input_tensormaps), shared_tensormaps.smem_tensormap_scaleA);
+      tma_descriptor_cp_fence_release(get<3>(input_tensormaps), shared_tensormaps.smem_tensormap_scaleB);
     } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
-      tma_descriptor_cp_fence_release(get<3>(input_tensormaps), shared_tensormaps.smem_tensormap_zero);
+      tma_descriptor_cp_fence_release(get<4>(input_tensormaps), shared_tensormaps.smem_tensormap_zero);
     } else if constexpr (KernelConversionMode != ConversionMode::DirectConvert) {
       static_assert(
           cutlass::detail::dependent_false<KernelSchedule>,
@@ -1513,8 +1706,9 @@ struct CollectiveMmaArrayMixedInput<
     cute::tma_descriptor_fence_acquire(get<1>(input_tensormaps));
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       cute::tma_descriptor_fence_acquire(get<2>(input_tensormaps));
-    } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       cute::tma_descriptor_fence_acquire(get<3>(input_tensormaps));
+    } else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
+      cute::tma_descriptor_fence_acquire(get<4>(input_tensormaps));
     } else if constexpr (KernelConversionMode != ConversionMode::DirectConvert) {
       static_assert(
           cutlass::detail::dependent_false<KernelSchedule>, "Conversion mode not handled in tensormaps_fence_acquire.");

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/scaled_mm_entry.cu
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/scaled_mm_entry.cu
@@ -21,7 +21,8 @@ void cutlass_w4a8_moe_mm_sm90(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size,
     int64_t topk);
 
@@ -47,7 +48,8 @@ void cutlass_w4a8_moe_mm(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size,
     int64_t topk) {
   cutlass_w4a8_moe_mm_sm90(
@@ -61,7 +63,8 @@ void cutlass_w4a8_moe_mm(
       a_strides,
       b_strides,
       d_strides,
-      s_strides,
+      sa_strides,
+      sb_strides,
       chunk_size,
       topk);
   return;

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_get_group_starts.cuh
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_get_group_starts.cuh
@@ -30,8 +30,10 @@ __global__ void int4_fp8_get_group_gemm_starts(
   a_offsets[expert_id] = a_base_as_int + expert_offset * k;
   b_offsets[expert_id] = b_base_as_int + expert_id * k * n / 2;
   out_offsets[expert_id] = out_base_as_int + expert_offset * n;
-  a_scales_offsets[expert_id] = a_scales_base_as_int + (per_act_token ? expert_offset : 0);
-  b_scales_offsets[expert_id] = b_scales_base_as_int + (per_out_ch ? expert_id * n * k / 128 : expert_id);
+  int64_t scale_k = k / 128;
+  b_scales_offsets[expert_id] = b_scales_base_as_int + (per_out_ch ? expert_id * n * scale_k : expert_id);
+  a_scales_offsets[expert_id] =
+      a_scales_base_as_int + (per_act_token ? expert_offset * (scale_k % 4 == 0 ? scale_k : scale_k * 4) : 0);
 }
 
 template <typename ElementA, typename ElementB, typename ElementC, typename ElementAccumulator>
@@ -58,8 +60,9 @@ __global__ void int4_fp8_get_group_gemm_starts_3d(
   int64_t a_offset = expert_id * m * k;
   int64_t b_offset = expert_id * k * n / 2;
   int64_t out_offset = expert_id * m * n;
-  int64_t a_scales_offset = 0;
-  int64_t b_scales_offset = per_out_ch ? expert_id * n * 4 * k / 512 : expert_id;
+  int64_t scale_k = k / 128;
+  int64_t a_scales_offset = expert_id * m * (scale_k % 4 == 0 ? scale_k : scale_k * 4);
+  int64_t b_scales_offset = per_out_ch ? expert_id * n * scale_k : expert_id;
 
   a_offsets[expert_id] = a_base_as_int + a_offset;
   b_offsets[expert_id] = b_base_as_int + b_offset;

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu
@@ -48,7 +48,8 @@ inline void invoke_gemm(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size) {
   using GemmT = typename Config::Cutlass3xW4A8Gemm;
   cutlass_w4a8_group_gemm_caller<GemmT>(
@@ -62,7 +63,8 @@ inline void invoke_gemm(
       a_strides,
       b_strides,
       d_strides,
-      s_strides,
+      sa_strides,
+      sb_strides,
       chunk_size);
 }
 
@@ -81,7 +83,8 @@ inline void invoke_gemm(
       a_strides,                            \
       b_strides,                            \
       d_strides,                            \
-      s_strides,                            \
+      sa_strides,                           \
+      sb_strides,                           \
       chunk_size)
 #define INVOKE_GEMM_WITH_CONFIG(Config) INVOKE_GEMM_WITH_CONFIG_HELPER Config
 
@@ -96,86 +99,74 @@ void dispatch_w4a8_moe_mm_sm90(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size,
     int64_t topk) {
-  uint32_t const m = a_tensors.size(0) / topk;
-  uint32_t const n = d_tensors.size(1);
-  uint32_t const k = a_tensors.size(1);
+  uint32_t m;
+  if (a_tensors.dim() == 3) {  // for decode with ep
+    m = 16;
+  } else {
+    m = a_tensors.size(0);  // The number of experts = b_tensors.size(0) * ep-size
+                            // for prefill with ep, and for tp
+  }
+
+  uint32_t const n = d_tensors.size(-1);
+  uint32_t const k = a_tensors.size(-1);
 
   if (n == 4096 && k == 7168) {
-    // group gemm 1
-    if (m <= 4) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<64, 32, 512, 2, 1, 1>));
-    } else if (m <= 32) {
+    // group gemm 1 for ep
+    if (m <= 16) {  // for decode
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 2, 1, 1>));
-    } else if (m <= 256) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 1, 1, 1>));
     } else if (m <= 1024) {
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 512, 2, 1, 1>));
-    } else if (m <= 4096) {
-      // Optimized for prefill: seq_len up to 4096 (m=4096 with topk=1)
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 2, 1, 1>));
     } else {
-      // Optimized for prefill: seq_len up to 8192 (m=8192 with topk=1)
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 1, 1, 1>));
     }
   } else if (n == 7168 && k == 2048) {
-    // group gemm 2
-    if (m <= 8) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<64, 16, 512, 1, 1, 1>));
-    } else if (m <= 512) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 512, 1, 1, 1>));
-    } else if (m <= 4096) {
-      // Optimized for prefill: larger cluster for better throughput
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 2, 1, 1>));
+    // group gemm 2 for ep
+    if (m <= 16) {  // for decode
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 2, 1, 1>));
+    } else if (m <= 1024) {
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 512, 2, 1, 1>));
     } else {
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 1, 1, 1>));
     }
   } else if (n == 512 && k == 7168) {
     // group gemm 1 for tp
-    if (m <= 4) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<64, 32, 512, 2, 1, 1>));
-    } else if (m <= 32) {
+    if (m <= 512) {
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 2, 1, 1>));
-    } else if (m <= 256) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 1, 1, 1>));
-    } else if (m <= 1024) {
+    } else if (m <= 4096) {
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 512, 2, 1, 1>));
     } else {
       INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 1, 1, 1>));
     }
   } else if (n == 7168 && k == 256) {
     // group gemm 2 for tp
-    if (m <= 8) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<64, 16, 128, 1, 1, 1>));
-    } else if (m <= 32) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 32, 128, 1, 1, 1>));
-    } else if (m <= 512) {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 32, 128, 2, 1, 1>));
+    if (m <= 512) {
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 128, 1, 1, 1>));
+    } else if (m <= 4096) {
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 128, 1, 1, 1>));
     } else {
-      INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 64, 128, 1, 1, 1>));
+      INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 128, 1, 1, 1>));
     }
   } else {
     if (k % 512 == 0) {
       // For large m (prefill), prefer larger cluster
-      if (m <= 32) {
-        // Decode: target batch size (16-32) - use cluster size 1 for better latency
-        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 1, 1, 1>));
-      } else if (m <= 1024) {
-        // Decode: large batch or small prefill
-        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 512, 1, 1, 1>));
+      if (m <= 1024) {
+        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 512, 2, 1, 1>));
+      } else if (m <= 4096) {
+        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 512, 2, 1, 1>));
       } else {
-        // Prefill: large sequence length - prefer larger cluster
         INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 512, 1, 1, 1>));
       }
     } else {
-      if (m <= 32) {
-        // Decode: target batch size (16-32) - use larger tile for better throughput
-        INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 32, 128, 1, 1, 1>));
+      if (m <= 1024) {
+        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 16, 128, 1, 1, 1>));  // PP has some bug when k = 128
+      } else if (m <= 4096) {
+        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 32, 128, 1, 1, 1>));
       } else {
-        // Prefill: larger sequence length
-        INVOKE_GEMM_WITH_CONFIG((SM90_PP<128, 64, 128, 1, 1, 1>));
+        INVOKE_GEMM_WITH_CONFIG((SM90_CO<128, 64, 128, 1, 1, 1>));
       }
     }
   }
@@ -194,7 +185,8 @@ void cutlass_w4a8_moe_mm_sm90(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size,
     int64_t topk) {
   dispatch_w4a8_moe_mm_sm90(
@@ -208,7 +200,8 @@ void cutlass_w4a8_moe_mm_sm90(
       a_strides,
       b_strides,
       d_strides,
-      s_strides,
+      sa_strides,
+      sb_strides,
       chunk_size,
       topk);
 }

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cuh
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cuh
@@ -73,7 +73,8 @@ static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
 template <typename TileShape, typename ClusterShape, typename KernelSchedule, typename EpilogueSchedule>
 struct cutlass_3x_w4a8_group_gemm {
   static constexpr int GroupSize = 128;
-  static constexpr int PackedScalesNum = get<2>(TileShape{}) / GroupSize;
+  static constexpr int PackedScalesNum =
+      get<2>(TileShape{}) / GroupSize;  // get<2>(TileShape{}) :K only support 128/512
   using ElementScalePacked = cutlass::Array<ElementScale, PackedScalesNum>;
 
   using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
@@ -98,7 +99,7 @@ struct cutlass_3x_w4a8_group_gemm {
       cute::tuple<QuantType, ElementScalePacked>,
       LayoutB_Transpose*,
       AlignmentB,
-      MmaType,
+      cute::tuple<MmaType, float>,
       LayoutA_Transpose*,
       AlignmentA,
       ElementAccumulator,
@@ -118,7 +119,8 @@ struct cutlass_3x_w4a8_group_gemm {
   using StrideB = cute::remove_pointer_t<cutlass::detail::TagToStrideB_t<LayoutB*>>;
   using StrideC = typename GemmKernelScaleOnly::InternalStrideC;
   using StrideD = typename GemmKernelScaleOnly::InternalStrideD;
-  using StrideS = typename CollectiveMainloopScaleOnly::StrideScale;
+  using StrideSA = typename CollectiveMainloopScaleOnly::StrideScaleA;
+  using StrideSB = typename CollectiveMainloopScaleOnly::StrideScaleB;
 };
 
 /**
@@ -148,7 +150,8 @@ struct cutlass_3x_w4a8_group_gemm {
  * @param a_strides Stride information for A tensors
  * @param b_strides Stride information for B tensors
  * @param d_strides Stride information for D tensors
- * @param s_strides Stride information for scale tensors
+ * @param sa_strides Stride information for A scale tensors
+ * @param sb_strides Stride information for B scale tensors
  * @param chunk_size Size of each chunk for scales (K / number of scale chunks)
  */
 // template <typename TileShape, typename ClusterShape, typename KernelSchedule, typename EpilogueSchedule>
@@ -164,7 +167,8 @@ void cutlass_w4a8_group_gemm_caller(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size) {
   //   using Gemm = cutlass_3x_w4a8_group_gemm<TileShape, ClusterShape, KernelSchedule, EpilogueSchedule>;
   using Args = typename Gemm::GemmScaleOnly::Arguments;
@@ -176,8 +180,8 @@ void cutlass_w4a8_group_gemm_caller(
   // Check inputs
   TORCH_CHECK(a_tensors.dim() == 2 or a_tensors.dim() == 3, "A tensor must be 2D/3D");
   TORCH_CHECK(b_tensors.dim() == 3, "B tensor must be 3D [E, N, K/2]");
+  TORCH_CHECK(a_scales.dim() == 2 or a_tensors.dim() == 3, "A Scale tensor must be 2D/3D");
   TORCH_CHECK(b_scales.dim() == 3, "Scale tensor must be 3D [E, K//512, N*4]");
-  TORCH_CHECK(a_scales.dim() == 1, "A Scale tensor must be 1D [1]");
   TORCH_CHECK(expert_offsets.dim() == 1, "expert_offsets must be a 1D tensor");
   TORCH_CHECK(problem_sizes.dim() == 2, "problem_sizes must be 2D tensor");
 
@@ -211,9 +215,9 @@ void cutlass_w4a8_group_gemm_caller(
 
   Args arguments;
   decltype(arguments.epilogue.thread) fusion_args;
-  fusion_args.alpha = 0;
+  fusion_args.alpha = 1;  // not use scalar scale
   fusion_args.beta = 0;
-  fusion_args.alpha_ptr = a_scales.data_ptr<float>();
+  fusion_args.alpha_ptr = nullptr;
   ;
   fusion_args.beta_ptr = nullptr;
   fusion_args.alpha_ptr_array = nullptr;
@@ -245,7 +249,9 @@ void cutlass_w4a8_group_gemm_caller(
        static_cast<const MmaType**>(a_ptrs.data_ptr()),
        static_cast<typename Gemm::StrideA*>(a_strides.data_ptr()),
        static_cast<const typename Gemm::ElementScalePacked**>(b_scales_ptrs.data_ptr()),
-       static_cast<typename Gemm::StrideS*>(s_strides.data_ptr()),
+       static_cast<typename Gemm::StrideSA*>(sb_strides.data_ptr()),
+       static_cast<const float**>(a_scales_ptrs.data_ptr()),
+       static_cast<typename Gemm::StrideSB*>(sa_strides.data_ptr()),
        static_cast<int>(chunk_size)},
       {fusion_args,
        nullptr,

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -381,7 +381,8 @@ void cutlass_w4a8_moe_mm(
     torch::Tensor const& a_strides,
     torch::Tensor const& b_strides,
     torch::Tensor const& d_strides,
-    torch::Tensor const& s_strides,
+    torch::Tensor const& sa_strides,
+    torch::Tensor const& sb_strides,
     int64_t chunk_size,
     int64_t topk);
 /*

--- a/sgl-kernel/python/sgl_kernel/cutlass_moe.py
+++ b/sgl-kernel/python/sgl_kernel/cutlass_moe.py
@@ -54,7 +54,8 @@ def cutlass_w4a8_moe_mm(
     a_strides: torch.tensor,
     b_strides: torch.tensor,
     d_strides: torch.tensor,
-    s_strides: torch.tensor,
+    sa_strides: torch.tensor,
+    sb_strides: torch.tensor,
     chunk_size: int = 128,
     topk: int = 8,
 ):
@@ -81,7 +82,8 @@ def cutlass_w4a8_moe_mm(
         a_strides: Strides information for A matrices
         b_strides: Strides information for B matrices
         d_strides: Strides information for D matrices
-        s_strides: Strides information for b_scales matrices
+        sa_strides: Strides information for a_scales matrices
+        sb_strides: Strides information for b_scales matrices
         chunk_size: Number of elements each scale value applies to (K//512), default to 128
 
     Requirements:
@@ -106,7 +108,8 @@ def cutlass_w4a8_moe_mm(
         a_strides,
         b_strides,
         d_strides,
-        s_strides,
+        sa_strides,
+        sb_strides,
         chunk_size,
         topk,
     )

--- a/sgl-kernel/tests/test_cutlass_w4a8_moe_mm.py
+++ b/sgl-kernel/tests/test_cutlass_w4a8_moe_mm.py
@@ -4,6 +4,12 @@ from sgl_kernel import cutlass_w4a8_moe_mm
 from utils import is_hopper
 
 from sglang.jit_kernel.per_tensor_quant_fp8 import per_tensor_quant_fp8
+from sglang.srt.layers.moe.ep_moe.kernels import deepep_ll_get_cutlass_w4a8_moe_mm_data
+from sglang.srt.layers.quantization.fp8_kernel import (
+    interleave_int4,
+    sglang_per_token_group_quant_8bit,
+    sglang_per_token_group_quant_fp8,
+)
 
 
 def pack_int4_values_to_int8(int4_values_interleaved: torch.Tensor) -> torch.Tensor:
@@ -51,27 +57,22 @@ def pack_interleave(num_experts, ref_weight, ref_scale):
     not is_hopper(),
     reason="cutlass_w4a8_moe_mm is only supported on sm90",
 )
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
-def test_int4_fp8_grouped_gemm_single_expert(batch_size):
+@pytest.mark.parametrize("num_experts", [8, 16, 32])
+@pytest.mark.parametrize("m", [32, 128, 512])
+@pytest.mark.parametrize("k", [128, 256, 512, 768, 7168])
+@pytest.mark.parametrize("n", [512, 1024, 7168])
+def test_int4_fp8_grouped_gemm3d_expert(num_experts, m, k, n):  # low-latency 3d input
     # Test parameters
-    num_experts = 1
-    m = batch_size  # batch size
-    k = 512  # input dimension
-    n = 1024  # output dimension
     torch.manual_seed(0)
     dtype = torch.bfloat16
     device = "cuda"
     debug = False
 
-    print(f"\nTesting with batch_size={batch_size}")
-
     # Create input tensors with ones
     if debug:
-        a = torch.ones(m, k, dtype=torch.bfloat16, device=device)
         ref_w = torch.ones(num_experts, n, k, dtype=torch.int8, device=device)
         ref_w_scale = torch.ones(num_experts, n, k // 128, dtype=dtype, device=device)
     else:
-        a = torch.randn(m, k, dtype=dtype, device=device)
         ref_w = torch.randint(
             -8, 8, (num_experts, n, k), dtype=torch.int8, device=device
         )
@@ -82,42 +83,98 @@ def test_int4_fp8_grouped_gemm_single_expert(batch_size):
         )
 
     w, w_scale = pack_interleave(num_experts, ref_w, ref_w_scale)
+    w_interleaved = torch.empty_like(w)
+    interleave_int4(w, w_interleaved, num_experts * n, k)
 
+    a = torch.zeros((num_experts, m, k), dtype=dtype, device=device)
     # Create expert offsets and problem sizes
-    expert_offsets = torch.tensor([0, m], dtype=torch.int32, device=device)
-    problem_sizes = torch.tensor([[n, m, k]], dtype=torch.int32, device=device)
+    expert_offsets = []
+    offset = 0
+    masked_m_list = []
+    for i in range(num_experts):
+        m_i = torch.randint(0, m + 1, (1,)).item()
+        masked_m_list.append(m_i)
+        if debug:
+            a_i = torch.ones(m_i, k, dtype=dtype, device=device)
+        else:
+            a_i = torch.randn(m_i, k, dtype=dtype, device=device)
+        a[i, :m_i, :] = a_i
+
+        expert_offsets.append(offset)
+        offset += m_i
+
+    expert_offsets = torch.tensor(expert_offsets, dtype=torch.int32, device=device)
+    masked_m = torch.tensor(masked_m_list, dtype=torch.int32, device=device)
+
+    problem_sizes1 = torch.empty((num_experts, 3), dtype=torch.int32, device=device)
+    problem_sizes2 = torch.empty((num_experts, 3), dtype=torch.int32, device=device)
+    problem_sizes1, problem_sizes2 = deepep_ll_get_cutlass_w4a8_moe_mm_data(
+        masked_m,
+        problem_sizes1,
+        problem_sizes2,
+        num_experts,
+        n / 2,
+        k,
+    )
 
     a_strides = torch.full((num_experts, 3), k, device=device, dtype=torch.int64)
     c_strides = torch.full((num_experts, 3), n, device=device, dtype=torch.int64)
     b_strides = a_strides
-    s_strides = c_strides
+    sb_strides = c_strides
 
     # Quantize input
-    a_q, a_scale = _per_tensor_quant_fp8(a)
+    # a_q, a_scale = sglang_per_token_group_quant_fp8(a, 128)
+
+    a_q, a_scale = sglang_per_token_group_quant_8bit(
+        x=a,
+        dst_dtype=torch.float8_e4m3fn,
+        group_size=128,
+        masked_m=masked_m,
+        column_major_scales=False,
+        scale_tma_aligned=False,
+        fuse_silu_and_mul=False,
+        enable_v2=True,
+    )
+
+    if k % 512 != 0:  # K need padding to 4 for B scale
+        assert k % 128 == 0, "k must be multiple of 128 or 512"
+        a_scale_padded = a_scale.repeat_interleave(4, dim=-1)
+        sa_strides = torch.full(
+            (num_experts, 3), k // 128 * 4, device=device, dtype=torch.int64
+        )
+    else:
+        a_scale_padded = a_scale
+        sa_strides = torch.full(
+            (num_experts, 3), k // 128, device=device, dtype=torch.int64
+        )
 
     # Create output tensor
-    c = torch.empty((m, n), dtype=torch.bfloat16, device=device)
+    c = torch.zeros((num_experts, m, n), dtype=torch.bfloat16, device=device)
     cutlass_w4a8_moe_mm(
         c,
         a_q,
-        w,
-        a_scale,
+        w_interleaved,
+        a_scale_padded,
         w_scale,
-        expert_offsets[:-1],
-        problem_sizes,
+        expert_offsets,
+        problem_sizes1,
         a_strides,
         b_strides,
         c_strides,
-        s_strides,
+        sa_strides,
+        sb_strides,
         128,
         8,
     )
-    c = c.to(dtype)
 
     # Reference implementation
-    experts_selection_result = torch.full((m,), 0)
-    c_ref = ref_grouped_gemm(
-        c, a_q, a_scale, ref_w, ref_w_scale, num_experts, experts_selection_result
+    c_ref = ref_grouped_gemm3d(
+        c,
+        a_q,
+        a_scale,
+        ref_w,
+        ref_w_scale,
+        num_experts,
     )
 
     # Compare results
@@ -150,7 +207,7 @@ def _per_tensor_quant_fp8(
         device=x.device,
         dtype=torch.float32,
     )
-    per_tensor_quant_fp8(x, x_q, x_s, is_static=False)
+    sgl_per_tensor_quant_fp8(x, x_q, x_s, is_static=False)
     return x_q, x_s
 
 
@@ -158,11 +215,13 @@ def _per_tensor_quant_fp8(
     not is_hopper(),
     reason="cutlass_w4a8_moe_mm is only supported on sm90",
 )
-@pytest.mark.parametrize("batch_size", [2, 4, 8, 16, 32])
-@pytest.mark.parametrize("k", [256, 512, 1024, 2048, 4096, 7168])
-@pytest.mark.parametrize("n", [256, 512, 1024, 2048, 7168])
+@pytest.mark.parametrize("batch_size", [2, 4, 16, 32, 10240])
+@pytest.mark.parametrize("k", [128, 256, 512, 1024, 2048, 4096, 7168])
+@pytest.mark.parametrize("n", [128, 256, 512, 1024, 2048, 7168])
 @pytest.mark.parametrize("num_experts", [2, 4, 6, 8])
-def test_int4_fp8_grouped_gemm_multi_experts(batch_size, k, n, num_experts):
+def test_int4_fp8_grouped_gemm_multi_experts(
+    batch_size, k, n, num_experts
+):  # normal 2d input
     torch.manual_seed(0)
     dtype = torch.bfloat16
     device = "cuda"
@@ -171,7 +230,7 @@ def test_int4_fp8_grouped_gemm_multi_experts(batch_size, k, n, num_experts):
     print(
         f"\nTesting with batch_size={batch_size}, k={k}, n={n}, num_experts={num_experts}"
     )
-
+    batch_size = batch_size * 8  # topk = 8
     if debug:
         a = torch.ones(batch_size, k, dtype=torch.bfloat16, device=device)
         ref_w = torch.ones(num_experts, n, k, dtype=torch.int8, device=device)
@@ -188,6 +247,8 @@ def test_int4_fp8_grouped_gemm_multi_experts(batch_size, k, n, num_experts):
         )
 
     w, w_scale = pack_interleave(num_experts, ref_w, ref_w_scale)
+    w_interleaved = torch.empty_like(w)
+    interleave_int4(w, w_interleaved, num_experts * n, k)
 
     # random select experts
     experts_selection_result = torch.randint(
@@ -212,28 +273,43 @@ def test_int4_fp8_grouped_gemm_multi_experts(batch_size, k, n, num_experts):
     expert_offsets = torch.tensor(expert_offsets, dtype=torch.int32, device=device)
 
     # Permute input and quantize
-    a_q, a_scale = _per_tensor_quant_fp8(a)
+    a_q, a_scale = sglang_per_token_group_quant_fp8(a, 128)
+
+    if k % 512 != 0:  # K need padding to 4 for B scale
+        assert k % 128 == 0, "k must be multiple of 128 or 512"
+        a_scale_padded = a_scale.repeat_interleave(4, dim=-1)
+        sa_strides = torch.full(
+            (num_experts, 3), k // 128 * 4, device=device, dtype=torch.int64
+        )
+    else:
+        a_scale_padded = a_scale
+        sa_strides = torch.full(
+            (num_experts, 3), k // 128, device=device, dtype=torch.int64
+        )
+
     a_q_perm = a_q[permutation]
+    a_scale_perm = a_scale_padded[permutation]
 
     # Create stride tensors
     a_strides = torch.full((num_experts, 3), k, device=device, dtype=torch.int64)
     c_strides = torch.full((num_experts, 3), n, device=device, dtype=torch.int64)
     b_strides = a_strides
-    s_strides = c_strides
+    sb_strides = c_strides
 
     c_perm = torch.empty((batch_size, n), dtype=torch.bfloat16, device=device)
     cutlass_w4a8_moe_mm(
         c_perm,
         a_q_perm,
-        w,
-        a_scale,
+        w_interleaved,
+        a_scale_perm,
         w_scale,
         expert_offsets,
         problem_sizes,
         a_strides,
         b_strides,
         c_strides,
-        s_strides,
+        sa_strides,
+        sb_strides,
         128,
         8,
     )
@@ -267,6 +343,9 @@ def ref_grouped_gemm(
 ):
     dtype = torch.bfloat16
     c_ref = torch.zeros_like(c)
+    a_q = a_q.to(torch.float32) * a_scale.repeat_interleave(128, dim=1).to(
+        torch.float32
+    )
     for i in range(num_experts):
         token_idx = torch.where(experts_selection_result == i)[0]
         if len(token_idx) == 0:
@@ -275,9 +354,23 @@ def ref_grouped_gemm(
 
         ref_w_scale_repeat = w_scale[i].repeat_interleave(128, dim=1).to(torch.float32)
         ref_w = w[i].to(torch.float32) * ref_w_scale_repeat
-        c = torch.matmul(a.to(torch.float32), ref_w.t()) * a_scale
+        c = torch.matmul(a.to(torch.float32), ref_w.t())
         c_ref[token_idx] = c.to(dtype)
 
+    return c_ref
+
+
+def ref_grouped_gemm3d(c, a_q, a_scale, w, w_scale, num_experts):
+    dtype = torch.bfloat16
+    c_ref = torch.zeros_like(c)
+    for i in range(num_experts):
+        a = a_q[i].to(torch.float32) * a_scale[i].repeat_interleave(128, dim=-1).to(
+            torch.float32
+        )
+        ref_w_scale_repeat = w_scale[i].repeat_interleave(128, dim=1).to(torch.float32)
+        ref_w = w[i].to(torch.float32) * ref_w_scale_repeat
+        c = torch.matmul(a, ref_w.t())
+        c_ref[i] = c.to(dtype)
     return c_ref
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
**[1/2] Enhance w4afp8 performance: The kernel part of the complete code functionality**

This pull request (PR) refactors the functionality of [PR-7762](https://github.com/sgl-project/sglang/pull/7762)  Significantly enhance performance：
1. Resolved the question w4afp8 deepep is that it can only use bf16

- Reimplemented the gemm pipeline with per-token quantization granularity, enabling dispatch for fp8 tokens

2. Improve performance with w4afp8 moe gemm

- Add a pipeline for A scale (per-token)

- Optimize the pipeline

- Replace LDS with LDSM for W4 weight

- Estimate the shape of the actual activation in MOE, to optimize block tile shape

<!-- Describe the purpose and goals of this pull request. -->

## How to use w4afp8

1. merge PR

- to sglang develop

2. use w4afp8 model

- Use open-source models：
  - https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8

- You can quantize the model by yourself
  - https://github.com/vllm-project/llm-compressor/pull/2027

## Modifications

- w4afp8 moe gemm kernel
- moe layer
- test

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
model: https://huggingface.co/deepseek-ai/DeepSeek-R1 https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8

Data Sets | fp8 | Wint4Afp8（previous） | Wint4Afp8（per-token optimize）
-- | -- | -- | --
gsm8k,02f245,accuracy,gen | 96.21 | 96.13 | 96.13
ceval,-,naive_average,gen | 92.50 | 92.15 | 92.31
mmlu,-,naive_average,gen | 91.49 | 91.61 | 91.70

</div>

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
### Summary
w4afp8(per-token optimize) VS fp8  same as w4afp8(per-token optimize) VS w4afp8(previous)
1. EP（ep-size=8）
   | batch-size | performance improvement with MoE GEMM | performance improvement with TPOT |
   | ---------- | -------------------- | ------------- |
   | 32         | **90%**             | **50% ～ 60%**       |
   | 64         | **80%**             | **50%**       |

2. TP（tp-size=8）
   | batch-size | performance improvement with MoE GEMM | performance improvement with TPOT |
   | ---------- | -------------------- | ------------- |
   | 32         | **60%**             | **5%**        |
   | 64         | **50%**             | **5%**        |

---




### Detail data
- Max request concurrency: **32**  
- Successful requests: **300**  
- Total input tokens: **1,228,500**  
- Total input text tokens: **1,228,500**  
- Total generated tokens: **307,200**  
- ep-size: **8**  

| | **fp8**<br/> | - | **Wint4Afp8**<br/>**（sglang previous）**<br/> | - | **Wint4Afp8**<br/>**(per-token)**<br/>**(pipeline optimized)**<br/>**(tile shape optimized)**<br/> | - |
| --- | --- | --- | --- | --- | --- | --- |
| | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 |
| Request throughput (req/s) | 0.42 | 0.47 | 0.43 | 0.47 | 0.60 | 0.69 |
| Input token throughput (tok/s) | 1737 | 1906 | 1747 | 1924 | 2453 | 2821 |
| Output token throughput (tok/s) | 434 | 476 | 436 | 481 | 613 | 706 |
| Total token throughput (tok/s) | 2172 | 2382 | 2184 | 2405 | 3066 | 3527 |
| Mean E2E Latency (ms) | 72335 | 65756 | 71608 | 64868 | 51170 | 44294 |
| Mean ITL (ms) | 64.94 | 58.82 | 63.68 | 57.45 | 43.02 | 36.44 |
| Mean TTFT (ms) | 5899 | 5588 | 6460 | 6096 | 7161 | 7020 |
| Mean TPOT (ms) | **<font style="color:#DF2A3F;">64.94</font>** | **<font style="color:#DF2A3F;">58.81</font>** | 63.68 | 57.45 | **<font style="color:#DF2A3F;">43.02</font>** | **<font style="color:#DF2A3F;">36.44</font>** |

- Max request concurrency: **64**  
- Successful requests: **300**  
- Total input tokens: **1,228,500**  
- Total input text tokens: **1,228,500**  
- Total generated tokens: **307,200**  
- ep-size: **8** 

| | **fp8**<br/> | - | **Wint4Afp8**<br/>**（sglang previous）**<br/> | - | **Wint4Afp8**<br/>**(per-token)**<br/>**(pipeline optimized)**<br/>**(tile shape optimized)**<br/> | - |
| --- | --- | --- | --- | --- | --- | --- |
| | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 |
| Request throughput (req/s) | 0.43 | 0.68 | 0.43 | 0.71 | 0.60 | 0.93 |
| Input token throughput (tok/s) | 1769 | 2785 | 1771 | 2894 | 2460 | 3825 |
| Output token throughput (tok/s) | 442 | 696 | 443 | 723 | 615 | 956 |
| Total token throughput (tok/s) | 2212 | 3481 | 2214 | 3618 | 3075 | 4781 |
| Mean E2E Latency (ms) | 136359 | 87896 | 134694 | 84463 | 97293 | 63847 |
| Mean ITL (ms) | 68.70 | 76.53 | 67.26 | 72.44 | 46.26 | 51.15 |
| Mean TTFT (ms) | 66077 | 9603 | 65886 | 10357 | 49970 | 11524 |
| Mean TPOT (ms) | **<font style="color:#DF2A3F;">68.70</font>** | **<font style="color:#DF2A3F;">76.53</font>** | 67.26 | 72.44 | **<font style="color:#DF2A3F;">46.26</font>** | **<font style="color:#DF2A3F;">51.15</font>** |

- Max request concurrency: **32**  
- Successful requests: **300**  
- Total input tokens: **1,228,500**  
- Total input text tokens: **1,228,500**  
- Total generated tokens: **307,200**  
- tp-size: **8** 

| | **fp8**<br/> | - | **Wint4Afp8**<br/>**（sglang previous）**<br/> | - | **Wint4Afp8**<br/>**(per-token)**<br/>**(pipeline optimized)**<br/>**(tile shape optimized)**<br/> | - |
| --- | --- | --- | --- | --- | --- | --- |
| | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 |
| Request throughput (req/s) | 0.64 | 0.68 | 0.52 | 0.54 | 0.67 | 0.71 |
| Input token throughput (tok/s) | 2600 | 2769 | 2118 | 2230 | 2745 | 2906 |
| Output token throughput (tok/s) | 650 | 692 | 530 | 557 | 686 | 727 |
| Total token throughput (tok/s) | 3251 | 3461 | 2648 | 2787 | 3432 | 3633 |
| Mean E2E Latency (ms) | 48530 | 45207 | 59607 | 56296 | 45851 | 42967 |
| Mean ITL (ms) | 42.42 | 39.00 | 52.59 | 49.35 | 39.03 | 36.14 |
| Mean TTFT (ms) | 5131 | 5312 | 5809 | 5809 | 5927 | 5993 |
| Mean TPOT (ms) | **<font style="color:#DF2A3F;">42.42</font>** | **<font style="color:#DF2A3F;">39.00</font>** | 52.59 | 49.35 | **<font style="color:#DF2A3F;">39.03</font>** | **<font style="color:#DF2A3F;">36.14</font>** |

- Max request concurrency: **64**  
- Successful requests: **300**  
- Total input tokens: **1,228,500**  
- Total input text tokens: **1,228,500**  
- Total generated tokens: **307,200**  
- tp-size: **8** 

| | **fp8**<br/> | - | **Wint4Afp8**<br/>**（sglang previous）**<br/> | - | **Wint4Afp8**<br/>**(per-token)**<br/>**(pipeline optimized)**<br/>**(tile shape optimized)**<br/> | - |
| --- | --- | --- | --- | --- | --- | --- |
| | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 | dp-size=1 | dp-size=2 |
| Request throughput (req/s) | 0.66 | 0.90 | 0.51 | 0.74 | 0.67 | 0.96 |
| Input token throughput (tok/s) | 2716 | 3673 | 2097 | 3038 | 2722 | 3921 |
| Output token throughput (tok/s) | 679 | 918 | 524 | 759 | 681 | 981 |
| Total token throughput (tok/s) | 3395 | 4591 | 2627 | 3797 | 3403 | 4902 |
| Mean E2E Latency (ms) | 90289 | 66558 | 115518 | 80557 | 88295 | 62168 |
| Mean ITL (ms) | 44.63 | 56.03 | 57.48 | 68.73 | 42.61 | 50.63 |
| Mean TTFT (ms) | 44628 | 9238 | 56717 | 10250 | 44707 | 10375 |
| Mean TPOT (ms) | **<font style="color:#DF2A3F;">44.63</font>** | **<font style="color:#DF2A3F;">56.03</font>** | 57.48 | 68.73 | **<font style="color:#DF2A3F;">42.61</font>** | **<font style="color:#DF2A3F;">50.63</font>** |

---
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
