### PR TITLE
perf: precompute FA3 scheduler_metadata to eliminate per-layer prepare_varlen_num_blocks

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1140,6 +1140,7 @@ class FlashAttentionBackend(AttentionBackend):
                     v_descale=v_descale,
                     return_softmax_lse=use_cascade_attn,
                     num_splits=self.num_splits,
+                    ver=self.fa_impl_ver,
                     scheduler_metadata=sched_meta,
                     **kwargs,
                 )

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -57,6 +57,8 @@ class FlashAttentionMetadata:
     page_table: torch.Tensor = None
     # Page table for Sliding Window Attention
     swa_page_table: torch.Tensor = None
+    # Precomputed FA3 scheduler metadata (avoids per-layer prepare_varlen_num_blocks)
+    scheduler_metadata: torch.Tensor = None
 
     # Encoder metadata
     # Cumulative sequence lengths for encoder key
@@ -167,17 +169,36 @@ class FlashAttentionBackend(AttentionBackend):
             from sgl_kernel.flash_attn import (
                 flash_attn_varlen_func,
                 flash_attn_with_kvcache,
+                get_scheduler_metadata,
             )
+
+            self._get_scheduler_metadata = get_scheduler_metadata
         elif self.fa_impl_ver == 4:
             from sglang.jit_kernel.flash_attention_v4 import (
                 flash_attn_varlen_func,
                 flash_attn_with_kvcache,
             )
+
+            self._get_scheduler_metadata = None
         else:
             raise ValueError(f"Invalid version: {self.fa_impl_ver=}")
 
         self.flash_attn_varlen_func = flash_attn_varlen_func
         self.flash_attn_with_kvcache = flash_attn_with_kvcache
+
+        # Store head info for precomputing FA3 scheduler metadata
+        self.head_dim = model_runner.model_config.head_dim
+        self.num_attention_heads = (
+            model_runner.model_config.hf_text_config.num_attention_heads
+            // model_runner.tp_size
+        )
+        self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            model_runner.tp_size
+        )
+        _softcapping = getattr(
+            model_runner.model_config.hf_text_config, "attn_logit_softcapping", None
+        )
+        self.has_softcap = _softcapping is not None and _softcapping > 0.0
 
         # If num_splits == 0, we use a heuristic to automatically determine the number of splits.
         # We set nums splits to 1 if deterministic inference is enabled.
@@ -191,6 +212,33 @@ class FlashAttentionBackend(AttentionBackend):
                 and not model_runner.server_args.disable_cuda_graph
             )
             else 0
+        )
+
+    def _compute_scheduler_metadata(
+        self, batch_size, max_seq_len_k, cache_seqlens, cu_seqlens_q
+    ):
+        """Compute FA3 scheduler metadata for decode.
+
+        Returns the scheduler_metadata tensor, or None if not applicable.
+        """
+        if self._get_scheduler_metadata is None or self.use_mla:
+            return None
+        # Always use window_size=(-1, -1) because scheduler_metadata is only
+        # consumed by non-SWA layers (SWA layers skip it in forward_decode).
+        return self._get_scheduler_metadata(
+            batch_size=batch_size,
+            max_seqlen_q=1,
+            max_seqlen_k=max_seq_len_k,
+            num_heads=self.num_attention_heads,
+            num_heads_k=self.num_kv_heads,
+            headdim=self.head_dim,
+            cache_seqlens=cache_seqlens,
+            qkv_dtype=self.kv_cache_dtype,
+            cu_seqlens_q=cu_seqlens_q,
+            page_size=self.page_size,
+            causal=True,
+            has_softcap=self.has_softcap,
+            num_splits=self.num_splits,
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -285,6 +333,14 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
                     forward_batch.req_pool_indices, : metadata.max_seq_len_k
                 ]
+                # Precompute FA3 scheduler metadata to avoid per-layer
+                # prepare_varlen_num_blocks kernel calls
+                metadata.scheduler_metadata = self._compute_scheduler_metadata(
+                    batch_size,
+                    metadata.max_seq_len_k,
+                    metadata.cache_seqlens_int32,
+                    metadata.cu_seqlens_q,
+                )
             # TODO: we need to test this part for llama 4 eagle case
             self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
         elif forward_batch.forward_mode.is_target_verify():
@@ -1059,6 +1115,15 @@ class FlashAttentionBackend(AttentionBackend):
                 )
 
                 # Default: single-token self-attention
+                # Use precomputed scheduler_metadata when available and applicable.
+                # scheduler_metadata is only valid for non-SWA, non-cascade decode.
+                sched_meta = None
+                if (
+                    metadata.scheduler_metadata is not None
+                    and not is_swa_layer
+                    and not use_cascade_attn
+                ):
+                    sched_meta = metadata.scheduler_metadata
                 result = flash_attn_with_kvcache(
                     q=q_reshaped,
                     k_cache=key_cache,
@@ -1075,7 +1140,7 @@ class FlashAttentionBackend(AttentionBackend):
                     v_descale=v_descale,
                     return_softmax_lse=use_cascade_attn,
                     num_splits=self.num_splits,
-                    ver=self.fa_impl_ver,
+                    scheduler_metadata=sched_meta,
                     **kwargs,
                 )
                 if use_cascade_attn:
@@ -1220,6 +1285,16 @@ class FlashAttentionBackend(AttentionBackend):
                 0, self.max_context_len, self.page_size, device=self.device
             ),
         }
+        # Pre-allocate scheduler_metadata buffer for CUDA graph
+        # Size: 1 (semaphore) + round_up(max_bs, 4) * 4 (causal decode vectors)
+        if self._get_scheduler_metadata is not None and not self.use_mla:
+            b_rounded = ((max_bs + 3) // 4) * 4
+            self._sched_meta_buf = torch.zeros(
+                1 + b_rounded * 4, dtype=torch.int32, device=self.device
+            )
+        else:
+            self._sched_meta_buf = None
+
         # Only allocate local attention buffers if local attention is enabled
         # This prevents OOM errors when local attention is not being used
         if self.has_local_attention:
@@ -1589,6 +1664,20 @@ class FlashAttentionBackend(AttentionBackend):
 
                 self._maybe_update_local_attn_metadata_for_capture(metadata, batch_size)
 
+                # Compute scheduler_metadata into pre-allocated buffer for CUDA graph capture
+                if self._sched_meta_buf is not None:
+                    sched = self._compute_scheduler_metadata(
+                        batch_size,
+                        max(metadata.max_seq_len_k, 1),
+                        metadata.cache_seqlens_int32,
+                        metadata.cu_seqlens_q,
+                    )
+                    if sched is not None:
+                        n = sched.shape[0]
+                        self._sched_meta_buf[:n] = sched
+                        self._sched_meta_buf[n:] = 0
+                        metadata.scheduler_metadata = self._sched_meta_buf[:n]
+
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata.cache_seqlens_int32 = self.target_verify_metadata[
@@ -1855,6 +1944,23 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata,
                     bs,
                 )
+
+                # Recompute scheduler_metadata into pre-allocated buffer
+                if (
+                    self._sched_meta_buf is not None
+                    and metadata.scheduler_metadata is not None
+                ):
+                    sched = self._compute_scheduler_metadata(
+                        bs,
+                        metadata.max_seq_len_k,
+                        metadata.cache_seqlens_int32,
+                        metadata.cu_seqlens_q,
+                    )
+                    if sched is not None:
+                        n = sched.shape[0]
+                        self._sched_meta_buf[:n] = sched
+                        self._sched_meta_buf[n:] = 0
+
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]


### PR DESCRIPTION
## Summary

Call `get_scheduler_metadata` once per batch in decode metadata init (including CUDA graph capture/replay paths) and pass the result to `flash_attn_with_kvcache` so FA3 skips the internal `prepare_varlen_num_blocks` kernel on every layer.

This eliminates 63 redundant GPU kernel calls per decode step (64 layers → 1 call via `get_scheduler_metadata`), matching what vLLM does. 

## Changes (1 file, Python only)

**`flashattention_backend.py`**: Compute and pass `scheduler_metadata` in all decode paths:
  - `init_forward_metadata` (non-CUDA-graph decode)
  - `init_cuda_graph_state` (pre-allocate buffer)
  - `init_forward_metadata_capture_cuda_graph` (capture path)
  - `init_forward_metadata_replay_cuda_graph` (replay path)
  - `forward_decode` (pass to `flash_attn_with_kvcache`)

This is **part 2 of 2**: sglang Python changes only.
Requires sgl-kernel with `get_scheduler_metadata` (#21103) for the optimization to activate (falls back to no-op without it).

## Benchmark Results (TP=4, Qwen3-32B, 4×H200, 3 runs averaged, fresh server restart each)

### BS=1 Decode-heavy (input=500, output=8K)

| Metric | Baseline (avg) | Optimized (avg) | Delta |
|--------|---------------|-----------------|-------|
| Output throughput (tok/s) | 131.41 | 134.83 | **+2.6%** |
| Mean TPOT (ms) | 7.61 | 7.41 | **-2.6%** |
| Mean ITL (ms) | 7.61 | 7.41 | **-2.6%** |
| Mean TTFT (ms) | 27.99 | 26.18 | ~same |

### BS=4 Decode-heavy (input=500, output=8K)

| Metric | Baseline (avg) | Optimized (avg) | Delta |
|--------|---------------|-----------------|-------|
| Output throughput (tok/s) | 496.63 | 508.21 | **+2.3%** |
| Mean TPOT (ms) | 8.04 | 7.86 | **-2.2%** |
| Mean ITL (ms) | 8.04 | 7.86 | **-2.2%** |
| Mean TTFT (ms) | 117.68 | 117.51 | -0.1% (no regression) |

### BS=16 Decode-heavy (input=500, output=8K)

| Metric | Baseline (avg) | Optimized (avg) | Delta |
|--------|---------------|-----------------|-------|
| Output throughput (tok/s) | 1735.09 | 1768.68 | **+1.9%** |
| Mean TPOT (ms) | 9.19 | 9.01 | **-2.0%** |
| Mean TTFT (ms) | 295.75 | 290.28 | ~same |

### BS=8 Balanced (input=2K, output=2K)

| Metric | Baseline (avg) | Optimized (avg) | Delta |
|--------|---------------|-----------------|-------|
| Output throughput (tok/s) | 934.61 | 955.25 | **+2.2%** |
| Mean TPOT (ms) | 8.34 | 8.15 | **-2.3%** |
| Mean ITL (ms) | 8.34 | 8.15 | **-2.3%** |
| Mean TTFT (ms) | 445.16 | 449.32 | +0.9% (within noise) |

### BS=8 Prefill-heavy (input=8K, output=500)

| Metric | Baseline (avg) | Optimized (avg) | Delta |
|--------|---------------|-----------------|-------|
| Output throughput (tok/s) | 594.83 | 603.30 | **+1.4%** |
| Mean TPOT (ms) | 10.10 | 9.92 | **-1.8%** |
| Mean ITL (ms) | 10.10 | 9.92 | **-1.8%** |
| Mean TTFT (ms) | 1670.04 | 1669.40 | -0.04% (no regression) |

### Accuracy (GSM8K, 1319 questions, parallel=1319)

| Branch | Accuracy |
|--------|----------|
| Baseline | 0.858 |
| Optimized | 0.861 |

No accuracy regression (within normal sampling variance).

## How to Reproduce

**Server (Qwen3-32B, TP=4):**
```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3-32B \
  --reasoning-parser qwen3 \
  --tp 4 --port 30000
```

**Decode-heavy benchmark:**
```bash
python -m sglang.bench_serving --backend sglang \
  --num-prompts 4 --dataset-name random-ids \
  --random-input-len 500 --random-output-len 8000 \
  --random-range-ratio 1.0 --port 30000
```

**Balanced benchmark:**
```bash
python -m sglang.bench_serving --backend sglang \
  --num-prompts 8 --dataset-name random-ids \
  --random-input-len 2000 --random-output-len 2000 \
  --random-range-ratio 1.0 --port 30000
```

**Prefill-heavy benchmark:**
```bash
python -m sglang.bench_serving --backend sglang \
  --num-prompts 8 --dataset-name random-ids \
  --random-input-len 8000 --random-output-len 500 \
  --random-range-ratio 1.0 --port 30000
```

**GSM8K accuracy:**
```bash
python benchmark/gsm8k/bench_sglang.py \
  --num-questions 1319 --parallel 1319 --port 30000
```

### Key takeaways
- **Consistent 1.4-2.6% decode throughput improvement** across all traffic patterns and batch sizes
- **No TTFT regression** — averaged across 3 fresh-server runs for each configuration
- Gain is purely from decode optimization; prefill path is untouched
- The fixed ~200µs/step savings means gain scales inversely with TPOT: BS=1 TPOT=7.6ms → 2.6%, BS=8 TPOT=10.1ms → 1.8%
- Projected ~5% at TP=8 where TPOT is ~4ms

### Profile verification
- `prepare_varlen_num_blocks` calls reduced from 576 → 72 per profiling window (64 from prefill + 8 from `get_scheduler_metadata`; all per-layer decode calls eliminated)

main:
<img width="1469" height="933" alt="image" src="https://github.com/user-attachments/assets/10e89dec-7ab6-46f2-96be-069de5756ec6" />

this PR:
<img width="1463" height="937" alt="image" src="https://github.com/user-attachments/assets/eddb20ef-51f4-4b82-a944-62ade7af4a60" />
