### PR TITLE
Fix FlashInfer GDN decode on Blackwell and re-enable Qwen3.5 FP4 test

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -59,6 +59,8 @@ class GDNKernelDispatcher:
         prefill_backend: LinearAttnKernelBackend,
     ):
         triton_kernel = TritonGDNKernel()
+        flashinfer_kernel = None
+        flashinfer_verify_kernel = None
 
         if decode_backend.is_triton():
             self.decode_kernel = triton_kernel
@@ -94,6 +96,11 @@ class GDNKernelDispatcher:
                 raise ValueError("FlashInfer GDN backend requires CUDA")
             # Reuse the FlashInfer kernel if already created for decode
             if decode_backend.is_flashinfer():
+                if not flashinfer_kernel.supports_extend:
+                    raise ValueError(
+                        "FlashInfer GDN prefill is not supported on SM100+. "
+                        "Use --linear-attn-prefill-backend triton instead."
+                    )
                 self.extend_kernel = flashinfer_kernel
             else:
                 from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
@@ -101,13 +108,27 @@ class GDNKernelDispatcher:
                 )
 
                 flashinfer_kernel = FlashInferGDNKernel()
+                if not flashinfer_kernel.supports_extend:
+                    raise ValueError(
+                        "FlashInfer GDN prefill is not supported on SM100+. "
+                        "Use --linear-attn-prefill-backend triton instead."
+                    )
                 self.extend_kernel = flashinfer_kernel
         else:
             raise ValueError(f"Unsupported GDN prefill backend: {prefill_backend}")
 
-        # Verify kernel: use FlashInfer if either decode or prefill selected it
-        if decode_backend.is_flashinfer() or prefill_backend.is_flashinfer():
-            self.verify_kernel = flashinfer_kernel
+        if (
+            flashinfer_kernel is not None
+            and flashinfer_kernel.supports_target_verify
+            and (decode_backend.is_flashinfer() or prefill_backend.is_flashinfer())
+        ):
+            flashinfer_verify_kernel = flashinfer_kernel
+
+        # Verify kernel: use FlashInfer only when the selected device/backend
+        # supports MTP verify. On SM100 decode-only FlashInfer should still use
+        # Triton verify.
+        if flashinfer_verify_kernel is not None:
+            self.verify_kernel = flashinfer_verify_kernel
         else:
             self.verify_kernel = triton_kernel
 

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -98,14 +98,36 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         sm_major = torch.cuda.get_device_capability()[0]
         self.use_state_pool = sm_major != 9
+        self.supports_extend = sm_major == 9
+        self.supports_target_verify = sm_major == 9
+        # Slot 0 is reserved for padded requests in SGLang's MambaPool.
+        self.pad_state_slot = 0
 
-        if sm_major == 9:
+        if self.supports_extend:
             if self._prefill_fn is None:
                 raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
-            if self._mtp_fn is None:
-                raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
+        if self.supports_target_verify and self._mtp_fn is None:
+            raise RuntimeError("FlashInfer GDN MTP (verify) kernel is unavailable.")
 
         logger.info("Using FlashInfer GDN kernels")
+
+    def _sanitize_cache_indices(
+        self, cache_indices: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Remap padded graph-replay slots to the reserved dummy state slot.
+
+        FlashInfer's pooled GDN decode kernel does not safely handle negative
+        padding indices, while SGLang uses `-1` for padded requests during CUDA
+        graph replay. Valid requests are always allocated from slots 1..N, so
+        mapping padded slots to 0 keeps writes isolated to the dummy state slot.
+        """
+        pad_mask = cache_indices < 0
+        safe_cache_indices = torch.where(
+            pad_mask,
+            torch.full_like(cache_indices, self.pad_state_slot),
+            cache_indices,
+        )
+        return safe_cache_indices, pad_mask
 
     # ---- decode ----
 
@@ -129,6 +151,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         head_k_dim = q.shape[3]
         num_v_heads = v.shape[2]
         head_v_dim = v.shape[3]
+        safe_cache_indices, pad_mask = self._sanitize_cache_indices(cache_indices)
 
         query_fi = q.view(batch_size, 1, num_heads, head_k_dim)
         key_fi = k.view(batch_size, 1, num_heads, head_k_dim)
@@ -148,12 +171,12 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 b=b_fi,
                 use_qk_l2norm=True,
                 initial_state=ssm_states,
-                initial_state_indices=cache_indices,
+                initial_state_indices=safe_cache_indices,
             )
         else:
             # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
             # will no longer be needed here.
-            state_batch = ssm_states[cache_indices]
+            state_batch = ssm_states[safe_cache_indices]
             output_fi, new_state = self._decode_fn(
                 q=query_fi,
                 k=key_fi,
@@ -167,7 +190,12 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 output=None,
                 use_qk_l2norm=True,
             )
-            ssm_states[cache_indices] = new_state
+            ssm_states[safe_cache_indices] = new_state
+
+        output_fi = output_fi.masked_fill(
+            pad_mask.view(batch_size, 1, 1, 1),
+            0,
+        )
 
         return output_fi.view(1, batch_size, num_v_heads, head_v_dim)
 
@@ -282,6 +310,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         seq_len = q.shape[1]
         batch_size = query_start_loc.shape[0] - 1
         draft_token_num = seq_len // batch_size
+        safe_cache_indices, pad_mask = self._sanitize_cache_indices(cache_indices)
 
         num_heads = q.shape[2]
         head_k_dim = q.shape[3]
@@ -305,7 +334,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             k=key_mtp,
             v=value_mtp,
             initial_state=ssm_states,
-            initial_state_indices=cache_indices,
+            initial_state_indices=safe_cache_indices,
             A_log=A_log.detach(),
             a=a_mtp,
             dt_bias=dt_bias.detach(),
@@ -315,6 +344,10 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             intermediate_states_buffer=intermediate_states_buffer,
             disable_state_update=True,
             use_qk_l2norm=True,
+        )
+        output_fi = output_fi.masked_fill(
+            pad_mask.view(batch_size, 1, 1, 1),
+            0,
         )
 
         return output_fi.view(1, seq_len, num_v_heads, head_v_dim)

--- a/test/registered/4-gpu-models/test_qwen35_models.py
+++ b/test/registered/4-gpu-models/test_qwen35_models.py
@@ -60,12 +60,11 @@ class TestQwen35FP4(unittest.TestCase):
                 extra_args=base_args,
                 variant="Triton",
             ),
-            # TODO: Fix this and re-enable it
-            # ModelLaunchSettings(
-            #     QWEN35_FP4_MODEL,
-            #     extra_args=base_args + ["--linear-attn-decode-backend", "flashinfer"],
-            #     variant="FlashInfer",
-            # ),
+            ModelLaunchSettings(
+                QWEN35_FP4_MODEL,
+                extra_args=base_args + ["--linear-attn-decode-backend", "flashinfer"],
+                variant="FlashInfer",
+            ),
         ]
 
         run_combined_tests(


### PR DESCRIPTION
## Summary

FlashInfer's pooled GDN decode kernel on SM100 did not handle SGLang's `-1` padding sentinel used during CUDA graph replay, causing incorrect outputs from padded lanes. The fix remaps padded indices to the reserved dummy slot `0` and masks their outputs to zero.

The dispatcher also incorrectly routed extend and verify operations to FlashInfer on SM100 where only decode is supported. The dispatcher now checks device capabilities and falls back to Triton for unsupported modes.

## Accuracy Test

```
sglang serve \
    --model-path nvidia/Qwen3.5-397B-A17B-NVFP4 \
    --tensor-parallel-size 4 \
    --mamba-scheduler-strategy extra_buffer \
    --mamba-ssm-dtype bfloat16 \
    --max-running-requests 324 \
    --reasoning-parser qwen3 \
    --tool-call-parser qwen3_coder \
    --attention-backend trtllm_mha \
    --quantization modelopt_fp4 \
    --model-loader-extra-config '{"enable_multithread_load": true,"num_threads": 11}' \
    --linear-attn-decode-backend flashinfer
```

```
python -m sglang.test.run_eval \
    --model nvidia/Qwen3.5-397B-A17B-NVFP4 \
    --eval-name gsm8k \
    --num-shots 5 \
    --max-tokens 512 \
    --num-threads 324 \
    --temperature 0.6 \
    --top-p 0.95 \
    --top-k 20 \
    --min-p 0.0 \
    --chat-template-kwargs '{"enable_thinking": false}' \
    --base-url http://127.0.0.1:30000

ChatCompletionSampler initialized with self.system_message=None self.temperature=0.6 self.max_tokens=512 self.reasoning_effort=None self.extra_body={'chat_template_kwargs': {'enable_thinking': False}, 'top_k': 20, 'min_p': 0.0}
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1314/1314 [01:41<00:00, 12.93it/s]
Total latency: 101.633 s
Score: 0.959
[METRIC] gsm8k_score=0.958904109589041 labels={"model": "nvidia/Qwen3.5-397B-A17B-NVFP4", "eval": "gsm8k"}
[METRIC] gsm8k_latency=101.63275832 labels={"model": "nvidia/Qwen3.5-397B-A17B-NVFP4", "eval": "gsm8k"}
Writing report to /tmp/gsm8k_nvidia_Qwen3.5-397B-A17B-NVFP4.html
{'score:std': np.float64(0.19851201022177314), 'score': np.float64(0.958904109589041)}
Writing results to /tmp/gsm8k_nvidia_Qwen3.5-397B-A17B-NVFP4.json
```