### PR TITLE
ci(slash-cmd): allow repo write-permission users to /rerun-ut

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -711,6 +711,19 @@ def main():
         user_perms["can_rerun_failed_ci"] = True
         user_perms["can_rerun_ut"] = True
 
+    # Users with write (or higher) permission on the repo can rerun UTs on any PR,
+    # even if they are not the PR author or listed in CI_PERMISSIONS.json.
+    if not user_perms or not user_perms.get("can_rerun_ut", False):
+        perm = repo.get_collaborator_permission(user_login)
+        if perm in ("admin", "write"):
+            print(
+                f"User {user_login} has '{perm}' repo permission. "
+                "Granting can_rerun_ut."
+            )
+            if user_perms is None:
+                user_perms = {}
+            user_perms["can_rerun_ut"] = True
+
     if not user_perms:
         print(f"User {user_login} does not have any configured permissions. Exiting.")
         return


### PR DESCRIPTION
## Summary
- Users with **write** or **admin** permission on the repo can now use `/rerun-ut` on any PR, not just their own
- Permission is checked via GitHub API (`get_collaborator_permission`) and grants `can_rerun_ut` dynamically
- `/tag-run-ci-label` and `/rerun-stage` still require explicit `CI_PERMISSIONS.json` entries

## Test plan
- [ ] Verify a write-permission user (not PR author, not in CI_PERMISSIONS.json) can `/rerun-ut` on a PR
- [ ] Verify a read-only user still cannot `/rerun-ut`
- [ ] Verify PR authors still get permissions as before
- [ ] Verify `/tag-run-ci-label` and `/rerun-stage` are unaffected