### PR TITLE
ci(slash-cmd): allow write-permission users to /rerun-ut on fork PRs

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -515,19 +515,27 @@ def handle_rerun_ut(gh_repo, pr, comment, user_perms, test_spec, token):
     Handles the /rerun-ut <file>::<TestClass.test_method> command.
     Dispatches a lightweight workflow to run a single test on the correct CUDA runner.
     """
-    # SECURITY: Block /rerun-ut entirely for fork PRs. This command checks out and
-    # executes code from the PR branch on self-hosted GPU runners, which would bypass
-    # the run-ci label gate that requires maintainer review for fork PRs.
+    # SECURITY: For fork PRs, only allow /rerun-ut if the commenter has write+ permission.
+    # This command checks out and executes code from the PR branch on self-hosted GPU
+    # runners, so we must ensure the commenter is a trusted collaborator.
     is_fork = pr.head.repo is None or pr.head.repo.owner.login != gh_repo.owner.login
     if is_fork:
-        print("Permission denied: /rerun-ut is not allowed on fork PRs.")
-        comment.create_reaction("confused")
-        pr.create_issue_comment(
-            "❌ `/rerun-ut` is not available for fork PRs (security restriction).\n\n"
-            "Please ask a maintainer to add the `run-ci` label and use the normal CI flow, "
-            "or use `/rerun-failed-ci` to rerun workflows that have already passed the gate."
+        commenter = comment.user.login
+        perm = gh_repo.get_collaborator_permission(commenter)
+        if perm not in ("admin", "write"):
+            print(
+                f"Permission denied: /rerun-ut on fork PR by {commenter} (perm={perm})."
+            )
+            comment.create_reaction("confused")
+            pr.create_issue_comment(
+                "❌ `/rerun-ut` is not available for fork PRs unless the commenter "
+                "has write permission on the repo.\n\n"
+                "Please ask a maintainer to run this command, or use the normal CI flow."
+            )
+            return False
+        print(
+            f"Fork PR, but commenter {commenter} has '{perm}' permission. Proceeding."
         )
-        return False
 
     if not (
         user_perms.get("can_rerun_ut", False)

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -523,9 +523,7 @@ def handle_rerun_ut(gh_repo, pr, comment, user_perms, test_spec, token):
         commenter = comment.user.login
         perm = gh_repo.get_collaborator_permission(commenter)
         if perm not in ("admin", "write"):
-            print(
-                f"Permission denied: /rerun-ut on fork PR by {commenter} (perm={perm})."
-            )
+            print(f"Permission denied: /rerun-ut on fork PR by {commenter}.")
             comment.create_reaction("confused")
             pr.create_issue_comment(
                 "❌ `/rerun-ut` is not available for fork PRs unless the commenter "
@@ -533,9 +531,7 @@ def handle_rerun_ut(gh_repo, pr, comment, user_perms, test_spec, token):
                 "Please ask a maintainer to run this command, or use the normal CI flow."
             )
             return False
-        print(
-            f"Fork PR, but commenter {commenter} has '{perm}' permission. Proceeding."
-        )
+        print(f"Fork PR, but commenter {commenter} has write+ permission. Proceeding.")
 
     if not (
         user_perms.get("can_rerun_ut", False)

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -719,19 +719,6 @@ def main():
         user_perms["can_rerun_failed_ci"] = True
         user_perms["can_rerun_ut"] = True
 
-    # Users with write (or higher) permission on the repo can rerun UTs on any PR,
-    # even if they are not the PR author or listed in CI_PERMISSIONS.json.
-    if not user_perms or not user_perms.get("can_rerun_ut", False):
-        perm = repo.get_collaborator_permission(user_login)
-        if perm in ("admin", "write"):
-            print(
-                f"User {user_login} has '{perm}' repo permission. "
-                "Granting can_rerun_ut."
-            )
-            if user_perms is None:
-                user_perms = {}
-            user_perms["can_rerun_ut"] = True
-
     if not user_perms:
         print(f"User {user_login} does not have any configured permissions. Exiting.")
         return


### PR DESCRIPTION
## Summary
- Instead of blocking `/rerun-ut` entirely on fork PRs, check if the commenter has repo write/admin permission via GitHub API
- Write-permission maintainers can now trigger `/rerun-ut` on fork PRs
- Unprivileged users are still blocked with an error message

Follows up on #21120 and also reverts the unnecessary `main()` check added there.

## Test plan
- [ ] Write-permission user comments `/rerun-ut` on a fork PR → should proceed
- [ ] Read-only user comments `/rerun-ut` on a fork PR → should get blocked with error message
- [ ] Non-fork PRs unaffected