### PR TITLE
feat(pixtral): add language_only mode and EAGLE speculative decoding support

### DIFF
--- a/python/sglang/srt/models/pixtral.py
+++ b/python/sglang/srt/models/pixtral.py
@@ -82,44 +82,66 @@ class PixtralForConditionalGeneration(nn.Module):
     def __init__(self, *, config, prefix: str = "", **kwargs):
         super().__init__()
         self.config = config
-        dataclass_fields = {field.name for field in fields(VisionEncoderArgs)}
-        config_dict = self.config.vision_config.to_dict()
-        if config_dict.get("rope_parameters"):  # transformers v5 compatibility
-            config_dict["rope_theta"] = config_dict["rope_parameters"].get("rope_theta")
-            config_dict["rope_scaling"] = config_dict["rope_parameters"]
-            config_dict.pop("rope_parameters")
-        vision_args = {
-            key: value for key, value in config_dict.items() if key in dataclass_fields
-        }
-
-        self.vision_args = VisionEncoderArgs(**vision_args)
+        self.language_only = getattr(config, "language_only", False)
 
         self.language_model = MistralLarge3ForCausalLM(
             config=self.config.text_config,
             quant_config=kwargs.get("quant_config"),
         )
 
-        self.vision_encoder = VisionTransformer(self.vision_args)
+        if not self.language_only:
+            dataclass_fields = {field.name for field in fields(VisionEncoderArgs)}
+            config_dict = self.config.vision_config.to_dict()
+            if config_dict.get("rope_parameters"):  # transformers v5 compatibility
+                config_dict["rope_theta"] = config_dict["rope_parameters"].get(
+                    "rope_theta"
+                )
+                config_dict["rope_scaling"] = config_dict["rope_parameters"]
+                config_dict.pop("rope_parameters")
+            vision_args = {
+                key: value
+                for key, value in config_dict.items()
+                if key in dataclass_fields
+            }
 
-        if self.vision_args.add_pre_mm_projector_layer_norm:
-            self.pre_mm_projector_norm = RMSNorm(self.vision_args.hidden_size, eps=1e-5)
+            self.vision_args = VisionEncoderArgs(**vision_args)
 
-        if self.vision_args.mm_projector_id == PATCH_MERGE:
-            self.patch_merger = PatchMerger(
-                vision_encoder_dim=self.vision_args.hidden_size,
-                spatial_merge_size=self.vision_args.spatial_merge_size,
-                use_mlp_bias=False,
+            self.vision_encoder = VisionTransformer(self.vision_args)
+
+            if self.vision_args.add_pre_mm_projector_layer_norm:
+                self.pre_mm_projector_norm = RMSNorm(
+                    self.vision_args.hidden_size, eps=1e-5
+                )
+
+            if self.vision_args.mm_projector_id == PATCH_MERGE:
+                self.patch_merger = PatchMerger(
+                    vision_encoder_dim=self.vision_args.hidden_size,
+                    spatial_merge_size=self.vision_args.spatial_merge_size,
+                    use_mlp_bias=False,
+                )
+
+            self.vision_language_adapter = VisionLanguageAdapter(
+                self.vision_args, dim=self.config.text_config.hidden_size
             )
-
-        self.vision_language_adapter = VisionLanguageAdapter(
-            self.vision_args, dim=self.config.text_config.hidden_size
-        )
 
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        if self.language_only:
+            _vision_prefixes = (
+                "vision_encoder",
+                "vision_language_adapter",
+                "patch_merger",
+                "pre_mm_projector_norm",
+            )
+            llm_weights = (
+                (n, w) for n, w in weights if not n.startswith(_vision_prefixes)
+            )
+            self.language_model.load_weights(llm_weights)
+            return
+
         def is_vision_encoder_weights(weight: tuple[str, torch.Tensor]):
             return weight[0].startswith("vision_encoder")
 
@@ -210,6 +232,9 @@ class PixtralForConditionalGeneration(nn.Module):
         return image_embeds
 
     def forward(self, input_ids, positions, forward_batch):
+        if self.language_only:
+            return self.language_model.forward(input_ids, positions, forward_batch)
+
         return general_mm_embed_routine(
             input_ids=input_ids,
             forward_batch=forward_batch,
@@ -226,6 +251,13 @@ class PixtralForConditionalGeneration(nn.Module):
 
     def get_embed_and_head(self):
         return self.language_model.get_embed_and_head()
+
+    @property
+    def lm_head(self):
+        return self.language_model.lm_head
+
+    def set_embed_and_head(self, embed, head):
+        self.language_model.set_embed_and_head(embed, head)
 
 
 class PatchMerger(nn.Module):


### PR DESCRIPTION
Closes #21146

## Summary
- Add `language_only` mode to `PixtralForConditionalGeneration` that skips loading the vision encoder, saving ~2GB memory when only text inference is needed (e.g., EAGLE draft models that share the Pixtral architecture but don't process images)
- Add `lm_head` property and `set_embed_and_head()` method required by EAGLE/MTP speculative decoding workers to share embeddings between target and draft models
- When `language_only=True`, vision weights are filtered during loading, vision modules are not instantiated, and forward() delegates directly to the language model

## Test plan
- [ ] Verify Pixtral model loads normally (language_only=False, default)
- [ ] Verify Pixtral with --language-only flag skips vision encoder
- [ ] Verify EAGLE speculative decoding works with Pixtral-based draft models (set_embed_and_head + lm_head property)