### PR TITLE
fix(logits): route FP8 e4m3 lm_head through quant_method for CUTLASS GEMM

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -890,6 +890,14 @@ class LogitsProcessor(nn.Module):
                 logits = torch.matmul(
                     hidden_states.bfloat16(), lm_head.weight.T.bfloat16()
                 )
+            elif lm_head.weight.dtype == torch.float8_e4m3fn and hasattr(
+                lm_head, "quant_method"
+            ):
+                # FP8-quantized lm_head — use quant_method.apply() for
+                # CUTLASS FP8 GEMM instead of naive torch.matmul
+                logits = lm_head.quant_method.apply(
+                    lm_head, hidden_states, embedding_bias
+                )
             else:
                 logits = torch.matmul(
                     hidden_states.to(lm_head.weight.dtype), lm_head.weight.T


### PR DESCRIPTION
Closes #21148

## Summary
- Fix FP8 lm_head routing in `LogitsProcessor._compute_lm_head()` — when lm_head has `float8_e4m3fn` weights and a `quant_method`, use `quant_method.apply()` for proper CUTLASS FP8 GEMM instead of falling through to naive `torch.matmul`
- The existing code checks `hasattr(lm_head, "weight")` which is True for ParallelLMHead, then falls to the dtype-based dispatch. FP8 e5m2 is handled (cast to bf16), but FP8 e4m3 with a quant_method was missing — causing it to hit the generic matmul path which uses BF16 fallback, wasting bandwidth

## Test plan
- [ ] Verify FP8-quantized lm_head uses CUTLASS GEMM path (check logs for fp8_scaled_mm calls)
- [ ] Verify non-FP8 lm_head behavior unchanged
- [ ] Verify models with `SGLANG_QUANTIZE_LM_HEAD_FP8=1` get the fast path