### PR TITLE
fix(qwen3.5): guard embed/head sharing for FP8-quantized lm_head

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1089,7 +1089,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
         self.is_mrope_enabled = "mrope_section" in rope_config
 
-        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+        self.deepstack_visual_indexes = (
+            self.visual.deepstack_visual_indexes if self.visual is not None else []
+        )
 
     @property
     def start_layer(self) -> int:
@@ -1106,14 +1108,14 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
     def get_embed_and_head(self):
         embed = self.model.embed_tokens.weight if self.pp_group.is_first_rank else None
-        head = self.lm_head.weight if self.pp_group.is_last_rank else None
+        head = getattr(self.lm_head, "weight", None) if self.pp_group.is_last_rank else None
         return embed, head
 
     def set_embed_and_head(self, embed, head):
         if self.pp_group.is_first_rank and embed is not None:
             del self.model.embed_tokens.weight
             self.model.embed_tokens.weight = embed
-        if self.pp_group.is_last_rank and head is not None:
+        if self.pp_group.is_last_rank and head is not None and hasattr(self.lm_head, "weight"):
             del self.lm_head.weight
             self.lm_head.weight = head
         torch.cuda.empty_cache()
@@ -1198,18 +1200,20 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
         self.is_mrope_enabled = "mrope_section" in rope_config
 
-        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+        self.deepstack_visual_indexes = (
+            self.visual.deepstack_visual_indexes if self.visual is not None else []
+        )
 
     def get_embed_and_head(self):
         embed = self.model.embed_tokens.weight if self.pp_group.is_first_rank else None
-        head = self.lm_head.weight if self.pp_group.is_last_rank else None
+        head = getattr(self.lm_head, "weight", None) if self.pp_group.is_last_rank else None
         return embed, head
 
     def set_embed_and_head(self, embed, head):
         if self.pp_group.is_first_rank and embed is not None:
             del self.model.embed_tokens.weight
             self.model.embed_tokens.weight = embed
-        if self.pp_group.is_last_rank and head is not None:
+        if self.pp_group.is_last_rank and head is not None and hasattr(self.lm_head, "weight"):
             del self.lm_head.weight
             self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -97,15 +97,15 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         )
 
     def get_embed_and_head(self):
-        return self.model.embed_tokens.weight, self.lm_head.weight
+        return self.model.embed_tokens.weight, getattr(self.lm_head, "weight", None)
 
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
-        if not self.config.tie_word_embeddings:
-            del self.lm_head.weight
-
         self.model.embed_tokens.weight = embed
-        self.lm_head.weight = head
+        if head is not None and hasattr(self.lm_head, "weight"):
+            if not self.config.tie_word_embeddings:
+                del self.lm_head.weight
+            self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -1067,13 +1067,14 @@ class Qwen3NextForCausalLM(nn.Module):
         )
 
     def get_embed_and_head(self):
-        return self.model.embed_tokens.weight, self.lm_head.weight
+        return self.model.embed_tokens.weight, getattr(self.lm_head, "weight", None)
 
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
-        del self.lm_head.weight
         self.model.embed_tokens.weight = embed
-        self.lm_head.weight = head
+        if head is not None and hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
+            self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 


### PR DESCRIPTION
Closes #21150

## Summary
- Guard `get_embed_and_head()` and `set_embed_and_head()` in Qwen3.5, Qwen3.5-MoE, Qwen3.5-MTP, and Qwen3-Next models against FP8-quantized lm_head
- When lm_head is quantized via `Fp8LinearMethod`, the weight may be stored differently (e.g., transposed, with separate scales). Accessing `.weight` directly crashes or returns wrong data
- Use `getattr(self.lm_head, "weight", None)` in getters and `hasattr` guards in setters
- Also guard `deepstack_visual_indexes` access for `language_only` mode where `self.visual` is None

## Test plan
- [ ] Verify MTP speculative decoding works with FP8-quantized lm_head
- [ ] Verify embed/head sharing works normally (non-FP8 case)
- [ ] Verify Qwen3.5 VL model with --language-only doesn't crash on deepstack_visual_indexes