### PR TITLE
feat(moe): add non-gated activation support (relu2, gelu) to CUTLASS and Marlin MoE

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -3,6 +3,7 @@
 from typing import Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 
 from sglang.srt.layers.moe.cutlass_moe_params import CutlassMoEParams
 from sglang.srt.utils import is_cuda, is_sm90_supported, is_sm100_supported
@@ -359,6 +360,8 @@ def cutlass_moe_fp4(
     topk_ids: torch.Tensor,
     params: CutlassMoEParams,
     apply_router_weight_on_input: bool = False,
+    activation: str = "silu",
+    is_gated: bool = True,
 ):
     """
     MoE implementation for FP4 Inputs
@@ -423,10 +426,16 @@ def cutlass_moe_fp4(
     assert (
         k_a // 2 == half_k_w1 and params.hidden_size == k_w2
     ), "Hidden size mismatch between a, w1 and w2"
-    assert (
-        nx2_w1 == params.intermediate_size_per_partition * 2
-        and half_n_w2 == params.intermediate_size_per_partition // 2
-    ), ("mismatch in " "expected `n`")
+    if is_gated:
+        assert (
+            nx2_w1 == params.intermediate_size_per_partition * 2
+            and half_n_w2 == params.intermediate_size_per_partition // 2
+        ), ("mismatch in " "expected `n` (gated)")
+    else:
+        assert (
+            nx2_w1 == params.intermediate_size_per_partition
+            and half_n_w2 == params.intermediate_size_per_partition // 2
+        ), ("mismatch in " "expected `n` (non-gated)")
     assert 2 * half_k_w1 == k_w2, "Hidden size mismatch w2 and w1"
     assert a.dtype in [torch.half, torch.bfloat16], "Invalid input dtype"
 
@@ -448,6 +457,11 @@ def cutlass_moe_fp4(
         params.blockscale_offsets,
     )
 
+    # prepare_moe_input sets problem_sizes1[:, 1] = 2*N assuming gated.
+    # For non-gated activations, GEMM1 output is N columns, not 2*N.
+    if not is_gated:
+        params.problem_sizes1[:, 1] = params.intermediate_size_per_partition
+
     rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
         a,
         a1_gscale,
@@ -467,11 +481,33 @@ def cutlass_moe_fp4(
     )
     del rep_a_fp4, rep_a_blockscale
 
-    # hidden size dimension is split to one halfpytho sized tensor.
-    intermediate = torch.empty(
-        (m_a * num_topk, w1_fp4.shape[1] // 2), device=device, dtype=out_dtype
-    )
-    silu_and_mul(c1, intermediate)
+    # Apply activation: gated activations (silu_and_mul, gelu_and_mul) halve
+    # the GEMM1 output from 2*N to N; non-gated activations keep N columns.
+    if is_gated:
+        intermediate = torch.empty(
+            (m_a * num_topk, w1_fp4.shape[1] // 2), device=device, dtype=out_dtype
+        )
+        if activation == "silu":
+            silu_and_mul(c1, intermediate)
+        elif activation == "gelu":
+            from sgl_kernel import gelu_and_mul
+
+            gelu_and_mul(c1, intermediate)
+        else:
+            raise ValueError(
+                f"Unsupported gated activation: {activation}"
+            )
+    else:
+        if activation == "relu2":
+            intermediate = torch.square(F.relu(c1))
+        elif activation == "silu":
+            intermediate = F.silu(c1)
+        elif activation == "gelu":
+            intermediate = F.gelu(c1)
+        else:
+            raise ValueError(
+                f"Unsupported non-gated activation: {activation}"
+            )
 
     int_fp4, int_blockscale = scaled_fp4_experts_quant(
         intermediate,

--- a/python/sglang/srt/layers/moe/cutlass_moe_params.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe_params.py
@@ -99,12 +99,14 @@ class CutlassMoEParams:
         num_experts: int,
         intermediate_size_per_partition: int,
         hidden_size: int,
+        is_gated: bool = True,
     ):
         self.cutlass_moe_type = cutlass_moe_type
         self.device = device
         self.num_experts = num_experts
         self.intermediate_size_per_partition = intermediate_size_per_partition
         self.hidden_size = hidden_size
+        self.is_gated = is_gated
         self.n = self.intermediate_size_per_partition
         self.k = self.hidden_size
         self.e = self.num_experts
@@ -114,8 +116,12 @@ class CutlassMoEParams:
         self.ab_strides_2 = torch.full(
             (self.e,), self.n, dtype=torch.int64, device=self.device
         )
+        # For gated activations (e.g. SiLU-gated / SwiGLU), GEMM1 projects to
+        # 2*N columns (gate + up).  For non-gated activations (e.g. relu2),
+        # GEMM1 projects to N columns.
+        gemm1_out_cols = 2 * self.n if is_gated else self.n
         self.c_strides_13 = torch.full(
-            (self.e,), 2 * self.n, dtype=torch.int64, device=self.device
+            (self.e,), gemm1_out_cols, dtype=torch.int64, device=self.device
         )
         self.c_strides_2 = torch.full(
             (self.e,), self.k, dtype=torch.int64, device=self.device

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
 
 from sglang.srt.utils import is_cuda
 from sglang.srt.utils.custom_op import register_custom_op
@@ -46,6 +47,8 @@ def fused_marlin_moe(
     is_k_full: bool = True,
     inplace: bool = False,
     routed_scaling_factor: Optional[float] = None,
+    activation: str = "silu",
+    is_gated: bool = True,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -98,6 +101,10 @@ def fused_marlin_moe(
     N = w2.shape[1] * 16
     topk = topk_ids.shape[1]
 
+    # For gated activations, GEMM1 output is 2*N (gate + up projection).
+    # For non-gated activations, GEMM1 output is N.
+    w1_out = 2 * N if is_gated else N
+
     # M block size selection logic
     # TODO: tune this further for specific models
     for block_size_m in [8, 16, 32, 48, 64]:
@@ -111,7 +118,7 @@ def fused_marlin_moe(
     )
 
     if workspace is None:
-        max_workspace_size = (max(2 * N, K) // 64) * (
+        max_workspace_size = (max(w1_out, K) // 64) * (
             sorted_token_ids.size(0) // block_size_m
         )
         device = hidden_states.device
@@ -130,12 +137,12 @@ def fused_marlin_moe(
         dtype=hidden_states.dtype,
     )
     intermediate_cache13 = torch.empty(
-        (M * topk_ids.shape[1] * max(2 * N, K),),
+        (M * topk_ids.shape[1] * max(w1_out, K),),
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
-    intermediate_cache1 = intermediate_cache13[: M * topk_ids.shape[1] * 2 * N]
-    intermediate_cache1 = intermediate_cache1.view(-1, 2 * N)
+    intermediate_cache1 = intermediate_cache13[: M * topk_ids.shape[1] * w1_out]
+    intermediate_cache1 = intermediate_cache1.view(-1, w1_out)
     intermediate_cache3 = intermediate_cache13[: M * topk_ids.shape[1] * K]
     intermediate_cache3 = intermediate_cache3.view(-1, K)
 
@@ -165,7 +172,7 @@ def fused_marlin_moe(
         is_ep=expert_map is not None,
         b_q_type=scalar_type1,
         size_m=M,
-        size_n=2 * N,
+        size_n=w1_out,
         size_k=K,
         is_k_full=is_k_full,
         use_atomic_add=use_atomic_add,
@@ -173,7 +180,21 @@ def fused_marlin_moe(
         is_zp_float=False,
     )
 
-    silu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    # Activation dispatch
+    if activation == "silu" and is_gated:
+        silu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    elif activation == "silu" and not is_gated:
+        intermediate_cache2 = F.silu(intermediate_cache1.view(-1, N))
+    elif activation == "gelu" and is_gated:
+        from sgl_kernel import gelu_and_mul
+
+        gelu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    elif activation == "gelu" and not is_gated:
+        intermediate_cache2 = F.gelu(intermediate_cache1.view(-1, N))
+    elif activation == "relu2" and not is_gated:
+        intermediate_cache2 = torch.square(F.relu(intermediate_cache1.view(-1, N)))
+    else:
+        raise ValueError(f"Unsupported activation: {activation=}, with {is_gated=}")
 
     if expert_map is not None:
         intermediate_cache3.zero_()

--- a/python/sglang/srt/layers/moe/moe_runner/marlin.py
+++ b/python/sglang/srt/layers/moe/moe_runner/marlin.py
@@ -87,8 +87,6 @@ def fused_experts_none_to_marlin(
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
 
-    assert runner_config.activation == "silu", "Only SiLU activation is supported."
-
     if (
         MARLIN_MOE_WORKSPACE is None
         or MARLIN_MOE_WORKSPACE.device != hidden_states.device
@@ -118,6 +116,8 @@ def fused_experts_none_to_marlin(
         is_k_full=quant_info.is_k_full,
         inplace=runner_config.inplace,
         routed_scaling_factor=runner_config.routed_scaling_factor,
+        activation=runner_config.activation,
+        is_gated=runner_config.is_gated,
     ).to(hidden_states.dtype)
 
     return StandardCombineInput(

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -365,10 +365,6 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
         )
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
-        assert (
-            self.moe_runner_config.activation == "silu"
-        ), "Only SiLU activation is supported."
-
         x = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
 
@@ -402,6 +398,8 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             num_bits=self.num_bits,
             is_k_full=self.is_k_full,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
+            activation=self.moe_runner_config.activation,
+            is_gated=self.moe_runner_config.is_gated,
         )
         return StandardCombineInput(hidden_states=output)
 


### PR DESCRIPTION
Closes #21149

## Summary
- Add support for non-gated MoE activations (`relu2`, `gelu`) in CUTLASS FP4 MoE and Marlin MoE backends
- Previously, both backends hardcoded `silu_and_mul` (gated SiLU) which assumes w1 projects to 2*N columns (gate + up). Non-gated architectures like Nemotron use `relu2` with w1 projecting to N columns
- Changes:
  - `CutlassMoEParams`: Add `is_gated` flag, adjust GEMM1 output stride
  - `cutlass_moe_fp4()`: Dispatch activation by type, handle non-gated tensor sizes
  - `fused_marlin_moe()`: Same activation dispatch, dynamic `w1_out` sizing
  - `marlin.py`: Remove SiLU-only assertion, pass activation/is_gated through
  - `compressed_tensors_wNa16_moe.py`: Thread activation/is_gated to fused_marlin_moe

## Test plan
- [ ] Verify SiLU-gated MoE models (Qwen, Mixtral) still work correctly
- [ ] Verify relu2 non-gated MoE models (Nemotron) work with Marlin backend
- [ ] Verify CUTLASS FP4 MoE with non-gated activations produces correct output