### PR TITLE
[Test] Add unit tests for srt/entrypoints/openai, srt/function_call, and srt/managers

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_openai_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_openai_utils.py
@@ -14,9 +14,10 @@ from sglang.srt.entrypoints.openai.utils import (
     process_routed_experts_from_ret,
     to_openai_style_logprobs,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestToOpenaiStyleLogprobs(unittest.TestCase):
+class TestToOpenaiStyleLogprobs(CustomTestCase):
 
     def test_all_none_returns_empty_logprobs(self):
         result = to_openai_style_logprobs()
@@ -53,7 +54,7 @@ class TestToOpenaiStyleLogprobs(unittest.TestCase):
         self.assertEqual(result.top_logprobs[1], {"z": -0.2})
 
 
-class TestProcessHiddenStates(unittest.TestCase):
+class TestProcessHiddenStates(CustomTestCase):
 
     def _make_request(self, return_hidden_states=False):
         req = Mock()
@@ -83,7 +84,7 @@ class TestProcessHiddenStates(unittest.TestCase):
         self.assertEqual(result, [])
 
 
-class TestProcessRoutedExperts(unittest.TestCase):
+class TestProcessRoutedExperts(CustomTestCase):
 
     def test_no_attribute_returns_none(self):
         req = Mock(spec=[])
@@ -103,7 +104,7 @@ class TestProcessRoutedExperts(unittest.TestCase):
         self.assertIsNone(process_routed_experts_from_ret(ret, req))
 
 
-class TestProcessCachedTokensDetails(unittest.TestCase):
+class TestProcessCachedTokensDetails(CustomTestCase):
 
     def test_no_attribute_returns_none(self):
         req = Mock(spec=[])

--- a/test/registered/unit/entrypoints/openai/test_openai_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_openai_utils.py
@@ -1,0 +1,159 @@
+"""Unit tests for entrypoints/openai/utils.py — no server, no model loading."""
+
+import sys
+from unittest.mock import MagicMock, Mock
+
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.utils import (
+    process_cached_tokens_details_from_ret,
+    process_hidden_states_from_ret,
+    process_routed_experts_from_ret,
+    to_openai_style_logprobs,
+)
+
+
+class TestToOpenaiStyleLogprobs(unittest.TestCase):
+
+    def test_all_none_returns_empty_logprobs(self):
+        result = to_openai_style_logprobs()
+        self.assertEqual(result.tokens, [])
+        self.assertEqual(result.token_logprobs, [])
+
+    def test_input_logprobs(self):
+        result = to_openai_style_logprobs(
+            input_token_logprobs=[(-0.5, 1, "hello"), (-1.0, 2, "world")]
+        )
+        self.assertEqual(result.tokens, ["hello", "world"])
+        self.assertEqual(result.token_logprobs, [-0.5, -1.0])
+        # text_offset is currently hardcoded to -1
+        self.assertEqual(result.text_offset, [-1, -1])
+
+    def test_input_and_output_concatenated(self):
+        result = to_openai_style_logprobs(
+            input_token_logprobs=[(-0.5, 1, "a")],
+            output_token_logprobs=[(-0.3, 2, "b")],
+        )
+        self.assertEqual(result.tokens, ["a", "b"])
+        self.assertEqual(result.token_logprobs, [-0.5, -0.3])
+
+    def test_top_logprobs_converted_to_dict(self):
+        """Each token list becomes {text: logprob} dict."""
+        top = [[(-0.1, 10, "x"), (-0.5, 11, "y")]]
+        result = to_openai_style_logprobs(output_top_logprobs=top)
+        self.assertEqual(result.top_logprobs[0], {"x": -0.1, "y": -0.5})
+
+    def test_none_entry_in_top_logprobs(self):
+        """A None in the top_logprobs list should be preserved as None."""
+        result = to_openai_style_logprobs(output_top_logprobs=[None, [(-0.2, 5, "z")]])
+        self.assertIsNone(result.top_logprobs[0])
+        self.assertEqual(result.top_logprobs[1], {"z": -0.2})
+
+
+class TestProcessHiddenStates(unittest.TestCase):
+
+    def _make_request(self, return_hidden_states=False):
+        req = Mock()
+        req.return_hidden_states = return_hidden_states
+        return req
+
+    def test_flag_disabled_skips_extraction(self):
+        ret = {"meta_info": {"hidden_states": [[1, 2], [3, 4]]}}
+        self.assertIsNone(
+            process_hidden_states_from_ret(ret, self._make_request(False))
+        )
+
+    def test_missing_key_returns_none(self):
+        ret = {"meta_info": {}}
+        self.assertIsNone(process_hidden_states_from_ret(ret, self._make_request(True)))
+
+    def test_multi_element_returns_last(self):
+        """Source code does hidden_states[-1] when len > 1."""
+        ret = {"meta_info": {"hidden_states": [[1, 2], [3, 4], [5, 6]]}}
+        result = process_hidden_states_from_ret(ret, self._make_request(True))
+        self.assertEqual(result, [5, 6])
+
+    def test_single_element_returns_empty_list(self):
+        """Source code returns [] when len(hidden_states) == 1."""
+        ret = {"meta_info": {"hidden_states": [[1, 2]]}}
+        result = process_hidden_states_from_ret(ret, self._make_request(True))
+        self.assertEqual(result, [])
+
+
+class TestProcessRoutedExperts(unittest.TestCase):
+
+    def test_no_attribute_returns_none(self):
+        req = Mock(spec=[])
+        ret = {"meta_info": {"routed_experts": "data"}}
+        self.assertIsNone(process_routed_experts_from_ret(ret, req))
+
+    def test_flag_enabled_extracts_value(self):
+        req = Mock()
+        req.return_routed_experts = True
+        ret = {"meta_info": {"routed_experts": "expert_data"}}
+        self.assertEqual(process_routed_experts_from_ret(ret, req), "expert_data")
+
+    def test_flag_enabled_missing_key(self):
+        req = Mock()
+        req.return_routed_experts = True
+        ret = {"meta_info": {}}
+        self.assertIsNone(process_routed_experts_from_ret(ret, req))
+
+
+class TestProcessCachedTokensDetails(unittest.TestCase):
+
+    def test_no_attribute_returns_none(self):
+        req = Mock(spec=[])
+        ret = {"meta_info": {"cached_tokens_details": {"device": 5}}}
+        self.assertIsNone(process_cached_tokens_details_from_ret(ret, req))
+
+    def test_without_storage_field(self):
+        req = Mock()
+        req.return_cached_tokens_details = True
+        ret = {"meta_info": {"cached_tokens_details": {"device": 10, "host": 5}}}
+        result = process_cached_tokens_details_from_ret(ret, req)
+        self.assertEqual(result.device, 10)
+        self.assertEqual(result.host, 5)
+        self.assertIsNone(result.storage)
+
+    def test_with_storage_field(self):
+        """When 'storage' key is present, L3 cache fields are populated."""
+        req = Mock()
+        req.return_cached_tokens_details = True
+        ret = {
+            "meta_info": {
+                "cached_tokens_details": {
+                    "device": 10,
+                    "host": 5,
+                    "storage": 3,
+                    "storage_backend": "disk",
+                }
+            }
+        }
+        result = process_cached_tokens_details_from_ret(ret, req)
+        self.assertEqual(result.storage, 3)
+        self.assertEqual(result.storage_backend, "disk")
+
+    def test_none_details_returns_none(self):
+        req = Mock()
+        req.return_cached_tokens_details = True
+        ret = {"meta_info": {"cached_tokens_details": None}}
+        self.assertIsNone(process_cached_tokens_details_from_ret(ret, req))
+
+    def test_missing_key_returns_none(self):
+        req = Mock()
+        req.return_cached_tokens_details = True
+        ret = {"meta_info": {}}
+        self.assertIsNone(process_cached_tokens_details_from_ret(ret, req))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_openai_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_openai_utils.py
@@ -1,11 +1,6 @@
 """Unit tests for entrypoints/openai/utils.py — no server, no model loading."""
 
-import sys
-from unittest.mock import MagicMock, Mock
-
-for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/entrypoints/openai/test_openai_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_openai_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -1,11 +1,6 @@
 """Unit tests for OpenAIServingBase — no server, no model loading."""
 
-import sys
-from unittest.mock import MagicMock, Mock
-
-for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -1,6 +1,44 @@
 """Unit tests for OpenAIServingBase — no server, no model loading."""
 
-from unittest.mock import Mock
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock, Mock
+
+
+# Stub out sgl_kernel (and all submodules) before any sglang import so
+# the test runs on CPU-only runners without the real CUDA library.
+class _SglKernelMockLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        mod = types.ModuleType(spec.name)
+        mod.__path__ = []
+        mod.__package__ = spec.name
+        mod.__loader__ = self
+        mod.__getattr__ = lambda name: MagicMock()
+        return mod
+
+    def exec_module(self, module):
+        pass
+
+
+class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
+    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
+
+    _PREFIX = "sgl_kernel"
+    _loader = _SglKernelMockLoader()
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
+            return importlib.machinery.ModuleSpec(
+                fullname, self._loader, is_package=True
+            )
+        return None
+
+
+if "sgl_kernel" not in sys.modules:
+    sys.meta_path.insert(0, _SglKernelMockFinder())
 
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -16,16 +16,10 @@ class _MockTokenizerManager:
         self.model_config = Mock()
         self.server_args = Mock()
         self.server_args.enable_cache_report = False
+        self.server_args.tokenizer_metrics_allowed_custom_labels = None
         self.model_path = "test-model"
         self.tokenizer = Mock()
         self.tokenizer.chat_template = None
-
-
-class _MockTemplateManager:
-    def __init__(self):
-        self.chat_template_name = None
-        self.jinja_template_content_format = None
-        self.completion_template_name = None
 
 
 class _ConcreteServingBase(OpenAIServingBase):
@@ -38,7 +32,7 @@ class _ConcreteServingBase(OpenAIServingBase):
 
 
 def _make_serving():
-    return _ConcreteServingBase(_MockTokenizerManager(), _MockTemplateManager())
+    return _ConcreteServingBase(_MockTokenizerManager())
 
 
 class TestParseModelParameter(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -1,53 +1,16 @@
 """Unit tests for OpenAIServingBase — no server, no model loading."""
 
-import importlib
-import importlib.abc
-import importlib.machinery
-import sys
-import types
-from unittest.mock import MagicMock, Mock
-
-
-# Stub out sgl_kernel (and all submodules) before any sglang import so
-# the test runs on CPU-only runners without the real CUDA library.
-class _SglKernelMockLoader(importlib.abc.Loader):
-    def create_module(self, spec):
-        mod = types.ModuleType(spec.name)
-        mod.__path__ = []
-        mod.__package__ = spec.name
-        mod.__loader__ = self
-        mod.__getattr__ = lambda name: MagicMock()
-        return mod
-
-    def exec_module(self, module):
-        pass
-
-
-class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
-    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
-
-    _PREFIX = "sgl_kernel"
-    _loader = _SglKernelMockLoader()
-
-    def find_spec(self, fullname, path, target=None):
-        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
-            return importlib.machinery.ModuleSpec(
-                fullname, self._loader, is_package=True
-            )
-        return None
-
-
-if "sgl_kernel" not in sys.modules:
-    sys.meta_path.insert(0, _SglKernelMockFinder())
+import unittest
+from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
-
-import unittest
+maybe_stub_sgl_kernel()
 
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
-from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
 class _MockTokenizerManager:

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -1,0 +1,117 @@
+"""Unit tests for OpenAIServingBase — no server, no model loading."""
+
+import sys
+from unittest.mock import MagicMock, Mock
+
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+
+
+class _MockTokenizerManager:
+    def __init__(self):
+        self.model_config = Mock()
+        self.server_args = Mock()
+        self.server_args.enable_cache_report = False
+        self.model_path = "test-model"
+        self.tokenizer = Mock()
+        self.tokenizer.chat_template = None
+
+
+class _MockTemplateManager:
+    def __init__(self):
+        self.chat_template_name = None
+        self.jinja_template_content_format = None
+        self.completion_template_name = None
+
+
+def _make_serving():
+    return OpenAIServingBase(_MockTokenizerManager(), _MockTemplateManager())
+
+
+class TestParseModelParameter(unittest.TestCase):
+
+    def setUp(self):
+        self.serving = _make_serving()
+
+    def test_no_colon(self):
+        base, adapter = self.serving._parse_model_parameter("my-model")
+        self.assertEqual(base, "my-model")
+        self.assertIsNone(adapter)
+
+    def test_single_colon(self):
+        base, adapter = self.serving._parse_model_parameter("base-model:adapter-v1")
+        self.assertEqual(base, "base-model")
+        self.assertEqual(adapter, "adapter-v1")
+
+    def test_multiple_colons_splits_on_first(self):
+        """Model paths like 'org:model:adapter' should split on the first colon only."""
+        base, adapter = self.serving._parse_model_parameter("org:model:adapter")
+        self.assertEqual(base, "org")
+        self.assertEqual(adapter, "model:adapter")
+
+    def test_empty_adapter_becomes_none(self):
+        base, adapter = self.serving._parse_model_parameter("base-model:")
+        self.assertEqual(base, "base-model")
+        self.assertIsNone(adapter)
+
+    def test_whitespace_trimmed(self):
+        base, adapter = self.serving._parse_model_parameter("  base : adapter  ")
+        self.assertEqual(base, "base")
+        self.assertEqual(adapter, "adapter")
+
+    def test_whitespace_only_adapter_becomes_none(self):
+        base, adapter = self.serving._parse_model_parameter("base:   ")
+        self.assertEqual(base, "base")
+        self.assertIsNone(adapter)
+
+
+class TestResolveLoraPath(unittest.TestCase):
+
+    def setUp(self):
+        self.serving = _make_serving()
+
+    def test_adapter_from_model_takes_precedence(self):
+        result = self.serving._resolve_lora_path("base:adapter-A", "adapter-B")
+        self.assertEqual(result, "adapter-A")
+
+    def test_fallback_to_explicit_lora_path(self):
+        result = self.serving._resolve_lora_path("base-model", "explicit-adapter")
+        self.assertEqual(result, "explicit-adapter")
+
+    def test_no_adapter_anywhere(self):
+        result = self.serving._resolve_lora_path("base-model", None)
+        self.assertIsNone(result)
+
+    def test_list_lora_path_passthrough(self):
+        """Batch requests pass a list of lora_paths; should be returned as-is."""
+        result = self.serving._resolve_lora_path("base-model", ["a", "b"])
+        self.assertEqual(result, ["a", "b"])
+
+
+class TestCreateErrorResponse(unittest.TestCase):
+
+    def setUp(self):
+        self.serving = _make_serving()
+
+    def test_default_status_code(self):
+        resp = self.serving.create_error_response("Something went wrong")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_custom_status_code(self):
+        resp = self.serving.create_error_response(
+            "Not found", err_type="NotFoundError", status_code=404
+        )
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -9,6 +9,7 @@ register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 import unittest
 
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+from sglang.test.test_utils import CustomTestCase
 
 
 class _MockTokenizerManager:
@@ -35,7 +36,7 @@ def _make_serving():
     return _ConcreteServingBase(_MockTokenizerManager())
 
 
-class TestParseModelParameter(unittest.TestCase):
+class TestParseModelParameter(CustomTestCase):
 
     def setUp(self):
         self.serving = _make_serving()
@@ -72,7 +73,7 @@ class TestParseModelParameter(unittest.TestCase):
         self.assertIsNone(adapter)
 
 
-class TestResolveLoraPath(unittest.TestCase):
+class TestResolveLoraPath(CustomTestCase):
 
     def setUp(self):
         self.serving = _make_serving()
@@ -95,7 +96,7 @@ class TestResolveLoraPath(unittest.TestCase):
         self.assertEqual(result, ["a", "b"])
 
 
-class TestCreateErrorResponse(unittest.TestCase):
+class TestCreateErrorResponse(CustomTestCase):
 
     def setUp(self):
         self.serving = _make_serving()

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -28,8 +28,17 @@ class _MockTemplateManager:
         self.completion_template_name = None
 
 
+class _ConcreteServingBase(OpenAIServingBase):
+    """Minimal concrete subclass so we can test base-class methods."""
+
+    _request_id_prefix = "test"
+
+    def _convert_to_internal_request(self, request):
+        pass
+
+
 def _make_serving():
-    return OpenAIServingBase(_MockTokenizerManager(), _MockTemplateManager())
+    return _ConcreteServingBase(_MockTokenizerManager(), _MockTemplateManager())
 
 
 class TestParseModelParameter(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -2,7 +2,7 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -8,9 +8,10 @@ import unittest
 
 from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails
 from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestDetailsIfCached(unittest.TestCase):
+class TestDetailsIfCached(CustomTestCase):
 
     def test_zero_returns_none(self):
         self.assertIsNone(UsageProcessor._details_if_cached(0))
@@ -24,7 +25,7 @@ class TestDetailsIfCached(unittest.TestCase):
         self.assertEqual(result.cached_tokens, 42)
 
 
-class TestCalculateTokenUsage(unittest.TestCase):
+class TestCalculateTokenUsage(CustomTestCase):
 
     def test_total_equals_sum(self):
         usage = UsageProcessor.calculate_token_usage(
@@ -43,7 +44,7 @@ class TestCalculateTokenUsage(unittest.TestCase):
         self.assertEqual(usage.prompt_tokens_details.cached_tokens, 5)
 
 
-class TestCalculateResponseUsage(unittest.TestCase):
+class TestCalculateResponseUsage(CustomTestCase):
 
     def _make_response(self, prompt_tokens=10, completion_tokens=5, cached_tokens=0):
         return {
@@ -113,7 +114,7 @@ class TestCalculateResponseUsage(unittest.TestCase):
         self.assertEqual(usage.completion_tokens, 0)
 
 
-class TestCalculateStreamingUsage(unittest.TestCase):
+class TestCalculateStreamingUsage(CustomTestCase):
 
     def test_single_choice(self):
         usage = UsageProcessor.calculate_streaming_usage(

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -1,0 +1,162 @@
+"""Unit tests for UsageProcessor — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+
+
+class TestDetailsIfCached(unittest.TestCase):
+
+    def test_zero_returns_none(self):
+        self.assertIsNone(UsageProcessor._details_if_cached(0))
+
+    def test_negative_returns_none(self):
+        self.assertIsNone(UsageProcessor._details_if_cached(-1))
+
+    def test_positive_returns_details(self):
+        result = UsageProcessor._details_if_cached(42)
+        self.assertIsInstance(result, PromptTokensDetails)
+        self.assertEqual(result.cached_tokens, 42)
+
+
+class TestCalculateTokenUsage(unittest.TestCase):
+
+    def test_total_equals_sum(self):
+        usage = UsageProcessor.calculate_token_usage(
+            prompt_tokens=10, completion_tokens=20
+        )
+        self.assertEqual(usage.prompt_tokens, 10)
+        self.assertEqual(usage.completion_tokens, 20)
+        self.assertEqual(usage.total_tokens, 30)
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_cached_details_propagated(self):
+        cached = PromptTokensDetails(cached_tokens=5)
+        usage = UsageProcessor.calculate_token_usage(
+            prompt_tokens=10, completion_tokens=20, cached_tokens=cached
+        )
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 5)
+
+
+class TestCalculateResponseUsage(unittest.TestCase):
+
+    def _make_response(self, prompt_tokens=10, completion_tokens=5, cached_tokens=0):
+        return {
+            "meta_info": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "cached_tokens": cached_tokens,
+            }
+        }
+
+    def test_single_response(self):
+        responses = [self._make_response(prompt_tokens=10, completion_tokens=5)]
+        usage = UsageProcessor.calculate_response_usage(responses)
+        self.assertEqual(usage.prompt_tokens, 10)
+        self.assertEqual(usage.completion_tokens, 5)
+        self.assertEqual(usage.total_tokens, 15)
+
+    def test_n_choices_skips_duplicate_prompt_counting(self):
+        """With n_choices=2 the source loops range(0, len, n_choices), so only
+        index 0 should contribute prompt_tokens, not index 1."""
+        responses = [
+            self._make_response(prompt_tokens=10, completion_tokens=3),
+            self._make_response(prompt_tokens=99, completion_tokens=4),
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+        self.assertEqual(usage.prompt_tokens, 10)
+        self.assertEqual(usage.completion_tokens, 7)
+
+    def test_n_choices_with_four_responses(self):
+        """4 responses with n_choices=2: prompt counted at index 0 and 2 only."""
+        responses = [
+            self._make_response(prompt_tokens=10, completion_tokens=1),
+            self._make_response(prompt_tokens=99, completion_tokens=2),
+            self._make_response(prompt_tokens=20, completion_tokens=3),
+            self._make_response(prompt_tokens=99, completion_tokens=4),
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+        self.assertEqual(usage.prompt_tokens, 30)
+        self.assertEqual(usage.completion_tokens, 10)
+
+    def test_cache_report_disabled_omits_details(self):
+        responses = [self._make_response(cached_tokens=5)]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, enable_cache_report=False
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_cache_report_enabled(self):
+        responses = [self._make_response(cached_tokens=5)]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, enable_cache_report=True
+        )
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 5)
+
+    def test_cache_report_zero_cached_stays_none(self):
+        """_details_if_cached returns None for 0, so prompt_tokens_details should be None."""
+        responses = [self._make_response(cached_tokens=0)]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, enable_cache_report=True
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_missing_meta_info_keys_default_to_zero(self):
+        responses = [{"meta_info": {}}]
+        usage = UsageProcessor.calculate_response_usage(responses)
+        self.assertEqual(usage.prompt_tokens, 0)
+        self.assertEqual(usage.completion_tokens, 0)
+
+
+class TestCalculateStreamingUsage(unittest.TestCase):
+
+    def test_single_choice(self):
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10},
+            completion_tokens={0: 20},
+            cached_tokens={0: 0},
+            n_choices=1,
+        )
+        self.assertEqual(usage.prompt_tokens, 10)
+        self.assertEqual(usage.completion_tokens, 20)
+
+    def test_multi_choice_prompt_filtering(self):
+        """Prompt tokens are only summed for indices where idx % n_choices == 0,
+        while completion tokens are summed across all indices."""
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10, 1: 99, 2: 10, 3: 99},
+            completion_tokens={0: 5, 1: 5, 2: 5, 3: 5},
+            cached_tokens={0: 0, 1: 0, 2: 0, 3: 0},
+            n_choices=2,
+        )
+        self.assertEqual(usage.prompt_tokens, 20)
+        self.assertEqual(usage.completion_tokens, 20)
+
+    def test_streaming_cache_report(self):
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10},
+            completion_tokens={0: 5},
+            cached_tokens={0: 3},
+            n_choices=1,
+            enable_cache_report=True,
+        )
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 3)
+
+    def test_streaming_cache_report_disabled(self):
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10},
+            completion_tokens={0: 5},
+            cached_tokens={0: 3},
+            n_choices=1,
+            enable_cache_report=False,
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -119,6 +119,7 @@ class TestCalculateStreamingUsage(CustomTestCase):
     def test_single_choice(self):
         usage = UsageProcessor.calculate_streaming_usage(
             prompt_tokens={0: 10},
+            reasoning_tokens={0: 0},
             completion_tokens={0: 20},
             cached_tokens={0: 0},
             n_choices=1,
@@ -131,6 +132,7 @@ class TestCalculateStreamingUsage(CustomTestCase):
         while completion tokens are summed across all indices."""
         usage = UsageProcessor.calculate_streaming_usage(
             prompt_tokens={0: 10, 1: 99, 2: 10, 3: 99},
+            reasoning_tokens={0: 0, 1: 0, 2: 0, 3: 0},
             completion_tokens={0: 5, 1: 5, 2: 5, 3: 5},
             cached_tokens={0: 0, 1: 0, 2: 0, 3: 0},
             n_choices=2,
@@ -141,6 +143,7 @@ class TestCalculateStreamingUsage(CustomTestCase):
     def test_streaming_cache_report(self):
         usage = UsageProcessor.calculate_streaming_usage(
             prompt_tokens={0: 10},
+            reasoning_tokens={0: 0},
             completion_tokens={0: 5},
             cached_tokens={0: 3},
             n_choices=1,
@@ -151,6 +154,7 @@ class TestCalculateStreamingUsage(CustomTestCase):
     def test_streaming_cache_report_disabled(self):
         usage = UsageProcessor.calculate_streaming_usage(
             prompt_tokens={0: 10},
+            reasoning_tokens={0: 0},
             completion_tokens={0: 5},
             cached_tokens={0: 3},
             n_choices=1,

--- a/test/registered/unit/function_call/test_function_call_utils.py
+++ b/test/registered/unit/function_call/test_function_call_utils.py
@@ -2,7 +2,7 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/function_call/test_function_call_utils.py
+++ b/test/registered/unit/function_call/test_function_call_utils.py
@@ -228,7 +228,8 @@ class TestGetJsonSchemaConstraint(CustomTestCase):
         result = get_json_schema_constraint(tools, choice)
         self.assertEqual(result["type"], "array")
         self.assertEqual(result["minItems"], 1)
-        self.assertEqual(result["maxItems"], 1)
+        # parallel_tool_calls defaults to True, so maxItems is not set (#20208)
+        self.assertNotIn("maxItems", result)
 
     def test_specific_tool_choice_not_found_returns_none(self):
         tools = [_make_tool("weather", {"type": "object"})]

--- a/test/registered/unit/function_call/test_function_call_utils.py
+++ b/test/registered/unit/function_call/test_function_call_utils.py
@@ -1,0 +1,259 @@
+"""Unit tests for function_call/utils.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import (
+    Function,
+    Tool,
+    ToolChoice,
+    ToolChoiceFuncName,
+)
+from sglang.srt.function_call.utils import (
+    _find_common_prefix,
+    _get_tool_schema,
+    _get_tool_schema_defs,
+    _is_complete_json,
+    get_json_schema_constraint,
+    infer_type_from_json_schema,
+)
+
+
+def _make_tool(name, parameters=None):
+    return Tool(function=Function(name=name, parameters=parameters))
+
+
+class TestFindCommonPrefix(unittest.TestCase):
+
+    def test_identical_strings(self):
+        self.assertEqual(_find_common_prefix("abc", "abc"), "abc")
+
+    def test_no_common_prefix(self):
+        self.assertEqual(_find_common_prefix("abc", "xyz"), "")
+
+    def test_partial_prefix(self):
+        self.assertEqual(_find_common_prefix("abcdef", "abcxyz"), "abc")
+
+    def test_one_empty(self):
+        self.assertEqual(_find_common_prefix("abc", ""), "")
+
+    def test_both_empty(self):
+        self.assertEqual(_find_common_prefix("", ""), "")
+
+    def test_first_shorter(self):
+        self.assertEqual(_find_common_prefix("ab", "abcdef"), "ab")
+
+    def test_second_shorter(self):
+        self.assertEqual(_find_common_prefix("abcdef", "ab"), "ab")
+
+
+class TestIsCompleteJson(unittest.TestCase):
+
+    def test_valid_object(self):
+        self.assertTrue(_is_complete_json('{"key": "value"}'))
+
+    def test_valid_array(self):
+        self.assertTrue(_is_complete_json("[1, 2, 3]"))
+
+    def test_valid_string(self):
+        self.assertTrue(_is_complete_json('"hello"'))
+
+    def test_incomplete_object(self):
+        self.assertFalse(_is_complete_json('{"key":'))
+
+    def test_incomplete_array(self):
+        self.assertFalse(_is_complete_json("[1, 2,"))
+
+    def test_empty_string(self):
+        self.assertFalse(_is_complete_json(""))
+
+    def test_nested_complete(self):
+        self.assertTrue(_is_complete_json('{"a": {"b": [1, 2]}}'))
+
+    def test_nested_incomplete(self):
+        self.assertFalse(_is_complete_json('{"a": {"b": [1, 2'))
+
+
+class TestInferTypeFromJsonSchema(unittest.TestCase):
+
+    def test_direct_type_string(self):
+        self.assertEqual(infer_type_from_json_schema({"type": "string"}), "string")
+
+    def test_direct_type_integer(self):
+        self.assertEqual(infer_type_from_json_schema({"type": "integer"}), "integer")
+
+    def test_type_array_filters_null(self):
+        """type: ["string", "null"] should return "string", skipping null."""
+        self.assertEqual(
+            infer_type_from_json_schema({"type": ["string", "null"]}), "string"
+        )
+
+    def test_type_array_only_null_defaults_to_string(self):
+        self.assertEqual(infer_type_from_json_schema({"type": ["null"]}), "string")
+
+    def test_anyof_uniform_types(self):
+        schema = {"anyOf": [{"type": "string"}, {"type": "string"}]}
+        self.assertEqual(infer_type_from_json_schema(schema), "string")
+
+    def test_anyof_mixed_types_prefers_string(self):
+        schema = {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+        self.assertEqual(infer_type_from_json_schema(schema), "string")
+
+    def test_anyof_without_string_returns_first(self):
+        schema = {"anyOf": [{"type": "integer"}, {"type": "number"}]}
+        self.assertEqual(infer_type_from_json_schema(schema), "integer")
+
+    def test_oneof_handled_same_as_anyof(self):
+        schema = {"oneOf": [{"type": "boolean"}, {"type": "boolean"}]}
+        self.assertEqual(infer_type_from_json_schema(schema), "boolean")
+
+    def test_enum_all_strings(self):
+        self.assertEqual(
+            infer_type_from_json_schema({"enum": ["a", "b", "c"]}), "string"
+        )
+
+    def test_enum_all_integers(self):
+        self.assertEqual(infer_type_from_json_schema({"enum": [1, 2, 3]}), "integer")
+
+    def test_enum_mixed_returns_string(self):
+        self.assertEqual(
+            infer_type_from_json_schema({"enum": [1, "a", True]}), "string"
+        )
+
+    def test_enum_empty(self):
+        self.assertEqual(infer_type_from_json_schema({"enum": []}), "string")
+
+    def test_enum_with_none_value(self):
+        self.assertEqual(infer_type_from_json_schema({"enum": [None]}), "null")
+
+    def test_enum_with_list_values(self):
+        self.assertEqual(
+            infer_type_from_json_schema({"enum": [[1, 2], [3, 4]]}), "array"
+        )
+
+    def test_enum_with_dict_values(self):
+        self.assertEqual(infer_type_from_json_schema({"enum": [{"a": 1}]}), "object")
+
+    def test_allof_returns_non_string_type(self):
+        """allOf skips string sub-schemas and returns the first non-string type."""
+        schema = {"allOf": [{"type": "string"}, {"type": "object"}]}
+        self.assertEqual(infer_type_from_json_schema(schema), "object")
+
+    def test_allof_all_string_returns_string(self):
+        schema = {"allOf": [{"type": "string"}]}
+        self.assertEqual(infer_type_from_json_schema(schema), "string")
+
+    def test_properties_implies_object(self):
+        schema = {"properties": {"name": {"type": "string"}}}
+        self.assertEqual(infer_type_from_json_schema(schema), "object")
+
+    def test_items_implies_array(self):
+        schema = {"items": {"type": "string"}}
+        self.assertEqual(infer_type_from_json_schema(schema), "array")
+
+    def test_non_dict_returns_none(self):
+        self.assertIsNone(infer_type_from_json_schema("not a dict"))
+
+    def test_empty_dict_returns_none(self):
+        self.assertIsNone(infer_type_from_json_schema({}))
+
+
+class TestGetToolSchema(unittest.TestCase):
+
+    def test_with_parameters(self):
+        tool = _make_tool(
+            "weather",
+            {"type": "object", "properties": {"city": {"type": "string"}}},
+        )
+        schema = _get_tool_schema(tool)
+        self.assertEqual(schema["properties"]["name"]["enum"], ["weather"])
+        self.assertEqual(
+            schema["properties"]["parameters"]["properties"]["city"]["type"], "string"
+        )
+        self.assertEqual(schema["required"], ["name", "parameters"])
+
+    def test_none_parameters_gets_empty_object(self):
+        """When tool.function.parameters is None, schema should substitute
+        an empty object so downstream JSON schema validation still works."""
+        tool = _make_tool("ping", None)
+        schema = _get_tool_schema(tool)
+        self.assertEqual(
+            schema["properties"]["parameters"],
+            {"type": "object", "properties": {}},
+        )
+
+
+class TestGetToolSchemaDefs(unittest.TestCase):
+
+    def test_no_defs(self):
+        tools = [_make_tool("a", {"type": "object"})]
+        self.assertEqual(_get_tool_schema_defs(tools), {})
+
+    def test_identical_defs_merged(self):
+        shared_def = {"type": "string"}
+        tools = [
+            _make_tool("a", {"$defs": {"MyType": shared_def}}),
+            _make_tool("b", {"$defs": {"MyType": shared_def}}),
+        ]
+        result = _get_tool_schema_defs(tools)
+        self.assertEqual(result, {"MyType": shared_def})
+
+    def test_conflicting_defs_raise(self):
+        tools = [
+            _make_tool("a", {"$defs": {"MyType": {"type": "string"}}}),
+            _make_tool("b", {"$defs": {"MyType": {"type": "integer"}}}),
+        ]
+        with self.assertRaises(ValueError):
+            _get_tool_schema_defs(tools)
+
+    def test_none_parameters_skipped(self):
+        tools = [_make_tool("a", None)]
+        self.assertEqual(_get_tool_schema_defs(tools), {})
+
+
+class TestGetJsonSchemaConstraint(unittest.TestCase):
+
+    def test_specific_tool_choice(self):
+        tools = [
+            _make_tool(
+                "weather",
+                {"type": "object", "properties": {"city": {"type": "string"}}},
+            )
+        ]
+        choice = ToolChoice(function=ToolChoiceFuncName(name="weather"))
+        result = get_json_schema_constraint(tools, choice)
+        self.assertEqual(result["type"], "array")
+        self.assertEqual(result["minItems"], 1)
+        self.assertEqual(result["maxItems"], 1)
+
+    def test_specific_tool_choice_not_found_returns_none(self):
+        tools = [_make_tool("weather", {"type": "object"})]
+        choice = ToolChoice(function=ToolChoiceFuncName(name="nonexistent"))
+        self.assertIsNone(get_json_schema_constraint(tools, choice))
+
+    def test_required_lists_all_tools(self):
+        tools = [
+            _make_tool("a", {"type": "object"}),
+            _make_tool("b", {"type": "object"}),
+        ]
+        result = get_json_schema_constraint(tools, "required")
+        self.assertEqual(result["type"], "array")
+        self.assertEqual(result["minItems"], 1)
+        self.assertEqual(len(result["items"]["anyOf"]), 2)
+
+    def test_required_includes_defs(self):
+        tools = [_make_tool("a", {"$defs": {"T": {"type": "string"}}})]
+        result = get_json_schema_constraint(tools, "required")
+        self.assertIn("T", result["$defs"])
+
+    def test_auto_returns_none(self):
+        self.assertIsNone(
+            get_json_schema_constraint([_make_tool("a", {"type": "object"})], "auto")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/function_call/test_function_call_utils.py
+++ b/test/registered/unit/function_call/test_function_call_utils.py
@@ -20,13 +20,14 @@ from sglang.srt.function_call.utils import (
     get_json_schema_constraint,
     infer_type_from_json_schema,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_tool(name, parameters=None):
     return Tool(function=Function(name=name, parameters=parameters))
 
 
-class TestFindCommonPrefix(unittest.TestCase):
+class TestFindCommonPrefix(CustomTestCase):
 
     def test_identical_strings(self):
         self.assertEqual(_find_common_prefix("abc", "abc"), "abc")
@@ -50,7 +51,7 @@ class TestFindCommonPrefix(unittest.TestCase):
         self.assertEqual(_find_common_prefix("abcdef", "ab"), "ab")
 
 
-class TestIsCompleteJson(unittest.TestCase):
+class TestIsCompleteJson(CustomTestCase):
 
     def test_valid_object(self):
         self.assertTrue(_is_complete_json('{"key": "value"}'))
@@ -77,7 +78,7 @@ class TestIsCompleteJson(unittest.TestCase):
         self.assertFalse(_is_complete_json('{"a": {"b": [1, 2'))
 
 
-class TestInferTypeFromJsonSchema(unittest.TestCase):
+class TestInferTypeFromJsonSchema(CustomTestCase):
 
     def test_direct_type_string(self):
         self.assertEqual(infer_type_from_json_schema({"type": "string"}), "string")
@@ -161,7 +162,7 @@ class TestInferTypeFromJsonSchema(unittest.TestCase):
         self.assertIsNone(infer_type_from_json_schema({}))
 
 
-class TestGetToolSchema(unittest.TestCase):
+class TestGetToolSchema(CustomTestCase):
 
     def test_with_parameters(self):
         tool = _make_tool(
@@ -186,7 +187,7 @@ class TestGetToolSchema(unittest.TestCase):
         )
 
 
-class TestGetToolSchemaDefs(unittest.TestCase):
+class TestGetToolSchemaDefs(CustomTestCase):
 
     def test_no_defs(self):
         tools = [_make_tool("a", {"type": "object"})]
@@ -214,7 +215,7 @@ class TestGetToolSchemaDefs(unittest.TestCase):
         self.assertEqual(_get_tool_schema_defs(tools), {})
 
 
-class TestGetJsonSchemaConstraint(unittest.TestCase):
+class TestGetJsonSchemaConstraint(CustomTestCase):
 
     def test_specific_tool_choice(self):
         tools = [

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -1,0 +1,120 @@
+"""Unit tests for managers/utils.py — no server, no model loading."""
+
+import sys
+from unittest.mock import MagicMock, Mock
+
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.managers.utils import get_alloc_len_per_decode, validate_input_length
+
+
+def _make_req(input_ids):
+    req = Mock()
+    req.origin_input_ids = list(input_ids)
+    return req
+
+
+class TestValidateInputLength(unittest.TestCase):
+
+    def test_within_limit(self):
+        req = _make_req(range(10))
+        self.assertIsNone(
+            validate_input_length(req, max_req_input_len=100, allow_auto_truncate=False)
+        )
+
+    def test_at_exact_boundary_returns_error(self):
+        """The check is >=, so input_len == max triggers rejection."""
+        req = _make_req(range(100))
+        error = validate_input_length(
+            req, max_req_input_len=100, allow_auto_truncate=False
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("100", error)
+
+    def test_exceeds_limit_no_truncate(self):
+        req = _make_req(range(200))
+        error = validate_input_length(
+            req, max_req_input_len=100, allow_auto_truncate=False
+        )
+        self.assertIn("200", error)
+
+    def test_exceeds_limit_with_truncate(self):
+        req = _make_req(range(200))
+        result = validate_input_length(
+            req, max_req_input_len=100, allow_auto_truncate=True
+        )
+        self.assertIsNone(result)
+        self.assertEqual(len(req.origin_input_ids), 100)
+
+    def test_within_limit_no_truncation_applied(self):
+        req = _make_req(range(50))
+        validate_input_length(req, max_req_input_len=100, allow_auto_truncate=True)
+        self.assertEqual(len(req.origin_input_ids), 50)
+
+
+def _make_server_args(
+    speculative_algorithm=None,
+    num_steps=None,
+    eagle_topk=None,
+    num_draft_tokens=1,
+    page_size=1,
+):
+    args = Mock()
+    args.speculative_algorithm = speculative_algorithm
+    args.speculative_num_steps = num_steps
+    args.speculative_eagle_topk = eagle_topk
+    args.speculative_num_draft_tokens = num_draft_tokens
+    args.page_size = page_size
+    return args
+
+
+class TestGetAllocLenPerDecode(unittest.TestCase):
+
+    def test_no_speculative_returns_one(self):
+        args = _make_server_args()
+        self.assertEqual(get_alloc_len_per_decode(args), 1)
+
+    def test_steps_times_topk_larger(self):
+        args = _make_server_args(
+            speculative_algorithm="eagle",
+            num_steps=3,
+            eagle_topk=2,
+            num_draft_tokens=5,
+            page_size=1,
+        )
+        # max(3*2, 5) = 6
+        self.assertEqual(get_alloc_len_per_decode(args), 6)
+
+    def test_draft_tokens_larger(self):
+        args = _make_server_args(
+            speculative_algorithm="eagle",
+            num_steps=2,
+            eagle_topk=1,
+            num_draft_tokens=10,
+            page_size=1,
+        )
+        # max(2*1, 10) = 10
+        self.assertEqual(get_alloc_len_per_decode(args), 10)
+
+    def test_page_size_gt1_with_topk_gt1_raises(self):
+        args = _make_server_args(
+            speculative_algorithm="eagle",
+            num_steps=2,
+            eagle_topk=2,
+            num_draft_tokens=5,
+            page_size=4,
+        )
+        with self.assertRaises(NotImplementedError):
+            get_alloc_len_per_decode(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -1,53 +1,16 @@
 """Unit tests for managers/utils.py — no server, no model loading."""
 
-import importlib
-import importlib.abc
-import importlib.machinery
-import sys
-import types
-from unittest.mock import MagicMock, Mock
-
-
-# Stub out sgl_kernel (and all submodules) before any sglang import so
-# the test runs on CPU-only runners without the real CUDA library.
-class _SglKernelMockLoader(importlib.abc.Loader):
-    def create_module(self, spec):
-        mod = types.ModuleType(spec.name)
-        mod.__path__ = []
-        mod.__package__ = spec.name
-        mod.__loader__ = self
-        mod.__getattr__ = lambda name: MagicMock()
-        return mod
-
-    def exec_module(self, module):
-        pass
-
-
-class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
-    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
-
-    _PREFIX = "sgl_kernel"
-    _loader = _SglKernelMockLoader()
-
-    def find_spec(self, fullname, path, target=None):
-        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
-            return importlib.machinery.ModuleSpec(
-                fullname, self._loader, is_package=True
-            )
-        return None
-
-
-if "sgl_kernel" not in sys.modules:
-    sys.meta_path.insert(0, _SglKernelMockFinder())
+import unittest
+from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
-
-import unittest
+maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.utils import get_alloc_len_per_decode, validate_input_length
-from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
 def _make_req(input_ids):

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -1,6 +1,44 @@
 """Unit tests for managers/utils.py — no server, no model loading."""
 
-from unittest.mock import Mock
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock, Mock
+
+
+# Stub out sgl_kernel (and all submodules) before any sglang import so
+# the test runs on CPU-only runners without the real CUDA library.
+class _SglKernelMockLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        mod = types.ModuleType(spec.name)
+        mod.__path__ = []
+        mod.__package__ = spec.name
+        mod.__loader__ = self
+        mod.__getattr__ = lambda name: MagicMock()
+        return mod
+
+    def exec_module(self, module):
+        pass
+
+
+class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
+    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
+
+    _PREFIX = "sgl_kernel"
+    _loader = _SglKernelMockLoader()
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
+            return importlib.machinery.ModuleSpec(
+                fullname, self._loader, is_package=True
+            )
+        return None
+
+
+if "sgl_kernel" not in sys.modules:
+    sys.meta_path.insert(0, _SglKernelMockFinder())
 
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -9,6 +9,7 @@ register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 import unittest
 
 from sglang.srt.managers.utils import get_alloc_len_per_decode, validate_input_length
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_req(input_ids):
@@ -17,7 +18,7 @@ def _make_req(input_ids):
     return req
 
 
-class TestValidateInputLength(unittest.TestCase):
+class TestValidateInputLength(CustomTestCase):
 
     def test_within_limit(self):
         req = _make_req(range(10))
@@ -71,7 +72,7 @@ def _make_server_args(
     return args
 
 
-class TestGetAllocLenPerDecode(unittest.TestCase):
+class TestGetAllocLenPerDecode(CustomTestCase):
 
     def test_no_speculative_returns_one(self):
         args = _make_server_args()

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -1,11 +1,6 @@
 """Unit tests for managers/utils.py — no server, no model loading."""
 
-import sys
-from unittest.mock import MagicMock, Mock
-
-for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+from unittest.mock import Mock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -2,7 +2,7 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -1,50 +1,11 @@
 """Unit tests for schedule_batch.py finish reasons, enums, and pad utilities."""
 
-import importlib
-import importlib.abc
-import importlib.machinery
-import sys
-import types
-from unittest.mock import MagicMock
-
-
-# Stub out sgl_kernel (and all submodules) before any sglang import so
-# the test runs on CPU-only runners without the real CUDA library.
-class _SglKernelMockLoader(importlib.abc.Loader):
-    def create_module(self, spec):
-        mod = types.ModuleType(spec.name)
-        mod.__path__ = []
-        mod.__package__ = spec.name
-        mod.__loader__ = self
-        mod.__getattr__ = lambda name: MagicMock()
-        return mod
-
-    def exec_module(self, module):
-        pass
-
-
-class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
-    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
-
-    _PREFIX = "sgl_kernel"
-    _loader = _SglKernelMockLoader()
-
-    def find_spec(self, fullname, path, target=None):
-        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
-            return importlib.machinery.ModuleSpec(
-                fullname, self._loader, is_package=True
-            )
-        return None
-
-
-if "sgl_kernel" not in sys.modules:
-    sys.meta_path.insert(0, _SglKernelMockFinder())
+import unittest
 
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
-
-import unittest
+maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
@@ -58,7 +19,8 @@ from sglang.srt.managers.schedule_batch import (
     _compute_pad_value,
     sanity_check_mm_pad_shift_value,
 )
-from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
 class TestBaseFinishReason(CustomTestCase):

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -18,9 +18,10 @@ from sglang.srt.managers.schedule_batch import (
     _compute_pad_value,
     sanity_check_mm_pad_shift_value,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestBaseFinishReason(unittest.TestCase):
+class TestBaseFinishReason(CustomTestCase):
 
     def test_default_is_not_error(self):
         self.assertFalse(BaseFinishReason().is_error)
@@ -29,7 +30,7 @@ class TestBaseFinishReason(unittest.TestCase):
         self.assertTrue(BaseFinishReason(is_error=True).is_error)
 
 
-class TestFinishMatchedToken(unittest.TestCase):
+class TestFinishMatchedToken(CustomTestCase):
 
     def test_to_json_with_int(self):
         result = FINISH_MATCHED_TOKEN(matched=42).to_json()
@@ -43,21 +44,21 @@ class TestFinishMatchedToken(unittest.TestCase):
         self.assertFalse(FINISH_MATCHED_TOKEN(matched=0).is_error)
 
 
-class TestFinishMatchedStr(unittest.TestCase):
+class TestFinishMatchedStr(CustomTestCase):
 
     def test_to_json(self):
         result = FINISH_MATCHED_STR(matched="</s>").to_json()
         self.assertEqual(result, {"type": "stop", "matched": "</s>"})
 
 
-class TestFinishedMatchedRegex(unittest.TestCase):
+class TestFinishedMatchedRegex(CustomTestCase):
 
     def test_to_json(self):
         result = FINISHED_MATCHED_REGEX(matched="pattern.*").to_json()
         self.assertEqual(result, {"type": "stop", "matched": "pattern.*"})
 
 
-class TestFinishLength(unittest.TestCase):
+class TestFinishLength(CustomTestCase):
 
     def test_to_json(self):
         result = FINISH_LENGTH(length=100).to_json()
@@ -67,7 +68,7 @@ class TestFinishLength(unittest.TestCase):
         self.assertFalse(FINISH_LENGTH(length=50).is_error)
 
 
-class TestFinishAbort(unittest.TestCase):
+class TestFinishAbort(CustomTestCase):
 
     def test_default_message(self):
         result = FINISH_ABORT().to_json()
@@ -87,7 +88,7 @@ class TestFinishAbort(unittest.TestCase):
         self.assertTrue(FINISH_ABORT().is_error)
 
 
-class TestModality(unittest.TestCase):
+class TestModality(CustomTestCase):
 
     def test_from_str_valid(self):
         self.assertEqual(Modality.from_str("image"), Modality.IMAGE)
@@ -111,7 +112,7 @@ class TestModality(unittest.TestCase):
         self.assertEqual(len(result), 3)
 
 
-class TestComputePadValue(unittest.TestCase):
+class TestComputePadValue(CustomTestCase):
 
     def test_deterministic(self):
         self.assertEqual(_compute_pad_value(12345), _compute_pad_value(12345))
@@ -123,7 +124,7 @@ class TestComputePadValue(unittest.TestCase):
         self.assertGreaterEqual(_compute_pad_value(0), MM_PAD_SHIFT_VALUE)
 
 
-class TestSanityCheckMmPadShiftValue(unittest.TestCase):
+class TestSanityCheckMmPadShiftValue(CustomTestCase):
 
     def test_valid_vocab_size_passes(self):
         sanity_check_mm_pad_shift_value.cache_clear()

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -1,5 +1,45 @@
 """Unit tests for schedule_batch.py finish reasons, enums, and pad utilities."""
 
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+# Stub out sgl_kernel (and all submodules) before any sglang import so
+# the test runs on CPU-only runners without the real CUDA library.
+class _SglKernelMockLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        mod = types.ModuleType(spec.name)
+        mod.__path__ = []
+        mod.__package__ = spec.name
+        mod.__loader__ = self
+        mod.__getattr__ = lambda name: MagicMock()
+        return mod
+
+    def exec_module(self, module):
+        pass
+
+
+class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
+    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
+
+    _PREFIX = "sgl_kernel"
+    _loader = _SglKernelMockLoader()
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
+            return importlib.machinery.ModuleSpec(
+                fullname, self._loader, is_package=True
+            )
+        return None
+
+
+if "sgl_kernel" not in sys.modules:
+    sys.meta_path.insert(0, _SglKernelMockFinder())
+
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu")

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -12,6 +12,7 @@ from sglang.srt.managers.schedule_batch import (
     FINISH_MATCHED_STR,
     FINISH_MATCHED_TOKEN,
     FINISHED_MATCHED_REGEX,
+    MM_PAD_SHIFT_VALUE,
     BaseFinishReason,
     Modality,
     _compute_pad_value,
@@ -119,8 +120,7 @@ class TestComputePadValue(unittest.TestCase):
         self.assertNotEqual(_compute_pad_value(1), _compute_pad_value(2))
 
     def test_result_above_mm_pad_shift(self):
-        # MM_PAD_SHIFT_VALUE = 1 << 40
-        self.assertGreaterEqual(_compute_pad_value(0), 1 << 40)
+        self.assertGreaterEqual(_compute_pad_value(0), MM_PAD_SHIFT_VALUE)
 
 
 class TestSanityCheckMmPadShiftValue(unittest.TestCase):
@@ -132,7 +132,7 @@ class TestSanityCheckMmPadShiftValue(unittest.TestCase):
     def test_oversized_vocab_raises(self):
         sanity_check_mm_pad_shift_value.cache_clear()
         with self.assertRaises(ValueError) as ctx:
-            sanity_check_mm_pad_shift_value((1 << 40) + 1)
+            sanity_check_mm_pad_shift_value(MM_PAD_SHIFT_VALUE + 1)
         self.assertIn("MM_PAD_SHIFT_VALUE", str(ctx.exception))
 
 

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -1,12 +1,5 @@
 """Unit tests for schedule_batch.py finish reasons, enums, and pad utilities."""
 
-import sys
-from unittest.mock import MagicMock
-
-for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
-
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="stage-a-cpu-only")

--- a/test/registered/unit/managers/test_schedule_batch.py
+++ b/test/registered/unit/managers/test_schedule_batch.py
@@ -1,0 +1,147 @@
+"""Unit tests for schedule_batch.py finish reasons, enums, and pad utilities."""
+
+import sys
+from unittest.mock import MagicMock
+
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.managers.schedule_batch import (
+    FINISH_ABORT,
+    FINISH_LENGTH,
+    FINISH_MATCHED_STR,
+    FINISH_MATCHED_TOKEN,
+    FINISHED_MATCHED_REGEX,
+    BaseFinishReason,
+    Modality,
+    _compute_pad_value,
+    sanity_check_mm_pad_shift_value,
+)
+
+
+class TestBaseFinishReason(unittest.TestCase):
+
+    def test_default_is_not_error(self):
+        self.assertFalse(BaseFinishReason().is_error)
+
+    def test_can_set_error(self):
+        self.assertTrue(BaseFinishReason(is_error=True).is_error)
+
+
+class TestFinishMatchedToken(unittest.TestCase):
+
+    def test_to_json_with_int(self):
+        result = FINISH_MATCHED_TOKEN(matched=42).to_json()
+        self.assertEqual(result, {"type": "stop", "matched": 42})
+
+    def test_to_json_with_list(self):
+        result = FINISH_MATCHED_TOKEN(matched=[1, 2, 3]).to_json()
+        self.assertEqual(result["matched"], [1, 2, 3])
+
+    def test_not_an_error(self):
+        self.assertFalse(FINISH_MATCHED_TOKEN(matched=0).is_error)
+
+
+class TestFinishMatchedStr(unittest.TestCase):
+
+    def test_to_json(self):
+        result = FINISH_MATCHED_STR(matched="</s>").to_json()
+        self.assertEqual(result, {"type": "stop", "matched": "</s>"})
+
+
+class TestFinishedMatchedRegex(unittest.TestCase):
+
+    def test_to_json(self):
+        result = FINISHED_MATCHED_REGEX(matched="pattern.*").to_json()
+        self.assertEqual(result, {"type": "stop", "matched": "pattern.*"})
+
+
+class TestFinishLength(unittest.TestCase):
+
+    def test_to_json(self):
+        result = FINISH_LENGTH(length=100).to_json()
+        self.assertEqual(result, {"type": "length", "length": 100})
+
+    def test_not_an_error(self):
+        self.assertFalse(FINISH_LENGTH(length=50).is_error)
+
+
+class TestFinishAbort(unittest.TestCase):
+
+    def test_default_message(self):
+        result = FINISH_ABORT().to_json()
+        self.assertEqual(result["type"], "abort")
+        self.assertEqual(result["message"], "Aborted")
+        self.assertIsNone(result["status_code"])
+        self.assertIsNone(result["err_type"])
+
+    def test_custom_fields(self):
+        reason = FINISH_ABORT(message="OOM", status_code=500, err_type="InternalError")
+        result = reason.to_json()
+        self.assertEqual(result["message"], "OOM")
+        self.assertEqual(result["status_code"], 500)
+        self.assertEqual(result["err_type"], "InternalError")
+
+    def test_is_always_error(self):
+        self.assertTrue(FINISH_ABORT().is_error)
+
+
+class TestModality(unittest.TestCase):
+
+    def test_from_str_valid(self):
+        self.assertEqual(Modality.from_str("image"), Modality.IMAGE)
+        self.assertEqual(Modality.from_str("video"), Modality.VIDEO)
+        self.assertEqual(Modality.from_str("audio"), Modality.AUDIO)
+
+    def test_from_str_case_insensitive(self):
+        self.assertEqual(Modality.from_str("IMAGE"), Modality.IMAGE)
+        self.assertEqual(Modality.from_str("Video"), Modality.VIDEO)
+
+    def test_from_str_invalid_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            Modality.from_str("text")
+        self.assertIn("text", str(ctx.exception))
+
+    def test_all_returns_image_video_audio(self):
+        result = Modality.all()
+        self.assertIn(Modality.IMAGE, result)
+        self.assertIn(Modality.VIDEO, result)
+        self.assertIn(Modality.AUDIO, result)
+        self.assertEqual(len(result), 3)
+
+
+class TestComputePadValue(unittest.TestCase):
+
+    def test_deterministic(self):
+        self.assertEqual(_compute_pad_value(12345), _compute_pad_value(12345))
+
+    def test_different_hashes_differ(self):
+        self.assertNotEqual(_compute_pad_value(1), _compute_pad_value(2))
+
+    def test_result_above_mm_pad_shift(self):
+        # MM_PAD_SHIFT_VALUE = 1 << 40
+        self.assertGreaterEqual(_compute_pad_value(0), 1 << 40)
+
+
+class TestSanityCheckMmPadShiftValue(unittest.TestCase):
+
+    def test_valid_vocab_size_passes(self):
+        sanity_check_mm_pad_shift_value.cache_clear()
+        sanity_check_mm_pad_shift_value(32000)
+
+    def test_oversized_vocab_raises(self):
+        sanity_check_mm_pad_shift_value.cache_clear()
+        with self.assertRaises(ValueError) as ctx:
+            sanity_check_mm_pad_shift_value((1 << 40) + 1)
+        self.assertIn("MM_PAD_SHIFT_VALUE", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_template_manager.py
+++ b/test/registered/unit/managers/test_template_manager.py
@@ -1,53 +1,16 @@
 """Unit tests for template_manager.py — no server, no model loading."""
 
-import importlib
-import importlib.abc
-import importlib.machinery
-import sys
-import types
-from unittest.mock import MagicMock, Mock, patch
-
-
-# Stub out sgl_kernel (and all submodules) before any sglang import so
-# the test runs on CPU-only runners without the real CUDA library.
-class _SglKernelMockLoader(importlib.abc.Loader):
-    def create_module(self, spec):
-        mod = types.ModuleType(spec.name)
-        mod.__path__ = []
-        mod.__package__ = spec.name
-        mod.__loader__ = self
-        mod.__getattr__ = lambda name: MagicMock()
-        return mod
-
-    def exec_module(self, module):
-        pass
-
-
-class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
-    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
-
-    _PREFIX = "sgl_kernel"
-    _loader = _SglKernelMockLoader()
-
-    def find_spec(self, fullname, path, target=None):
-        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
-            return importlib.machinery.ModuleSpec(
-                fullname, self._loader, is_package=True
-            )
-        return None
-
-
-if "sgl_kernel" not in sys.modules:
-    sys.meta_path.insert(0, _SglKernelMockFinder())
+import unittest
+from unittest.mock import Mock, patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
-
-import unittest
+maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.template_manager import TemplateManager
-from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
 class TestTemplateManagerInit(CustomTestCase):

--- a/test/registered/unit/managers/test_template_manager.py
+++ b/test/registered/unit/managers/test_template_manager.py
@@ -1,0 +1,152 @@
+"""Unit tests for template_manager.py — no server, no model loading."""
+
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+import unittest
+
+from sglang.srt.managers.template_manager import TemplateManager
+
+
+class TestTemplateManagerInit(unittest.TestCase):
+
+    def test_defaults(self):
+        tm = TemplateManager()
+        self.assertIsNone(tm.chat_template_name)
+        self.assertIsNone(tm.completion_template_name)
+        self.assertEqual(tm.jinja_template_content_format, "openai")
+        self.assertFalse(tm.force_reasoning)
+
+
+class TestDetectReasoningPattern(unittest.TestCase):
+
+    def test_none_template(self):
+        self.assertFalse(TemplateManager()._detect_reasoning_pattern(None))
+
+    def test_no_reasoning_pattern(self):
+        self.assertFalse(
+            TemplateManager()._detect_reasoning_pattern("Hello {{ message }}")
+        )
+
+    def test_with_reasoning_pattern(self):
+        template = r"<|im_start|>assistant\n<think>\n"
+        self.assertTrue(TemplateManager()._detect_reasoning_pattern(template))
+
+    def test_think_tag_alone_does_not_match(self):
+        """The regex requires the full im_start + assistant + think sequence."""
+        self.assertFalse(TemplateManager()._detect_reasoning_pattern("<think>"))
+
+
+class TestSelectNamedTemplate(unittest.TestCase):
+
+    def _make_tokenizer_manager(self, preferred_name=None):
+        tm = Mock()
+        tm.server_args = Mock()
+        tm.server_args.hf_chat_template_name = preferred_name
+        return tm
+
+    def test_preferred_name_found(self):
+        tm = TemplateManager()
+        templates = {"default": "template_a", "tool_use": "template_b"}
+        result = tm._select_named_template(
+            templates, self._make_tokenizer_manager("tool_use")
+        )
+        self.assertEqual(result, "template_b")
+
+    def test_preferred_name_not_found_raises(self):
+        tm = TemplateManager()
+        with self.assertRaises(ValueError) as ctx:
+            tm._select_named_template(
+                {"default": "t"}, self._make_tokenizer_manager("nonexistent")
+            )
+        self.assertIn("nonexistent", str(ctx.exception))
+
+    def test_empty_dict_raises(self):
+        tm = TemplateManager()
+        with self.assertRaises(ValueError):
+            tm._select_named_template({}, self._make_tokenizer_manager(None))
+
+    def test_no_preference_uses_first(self):
+        tm = TemplateManager()
+        templates = {"alpha": "tmpl_a", "beta": "tmpl_b"}
+        result = tm._select_named_template(
+            templates, self._make_tokenizer_manager(None)
+        )
+        self.assertEqual(result, "tmpl_a")
+
+
+class TestResolveHfChatTemplate(unittest.TestCase):
+
+    def test_string_template_returned(self):
+        tm = TemplateManager()
+        tok_mgr = Mock()
+        tok_mgr.processor = None
+        tok_mgr.tokenizer = Mock()
+        tok_mgr.tokenizer.chat_template = "simple template"
+        self.assertEqual(tm._resolve_hf_chat_template(tok_mgr), "simple template")
+
+    def test_none_template(self):
+        tm = TemplateManager()
+        tok_mgr = Mock()
+        tok_mgr.processor = None
+        tok_mgr.tokenizer = Mock()
+        tok_mgr.tokenizer.chat_template = None
+        self.assertIsNone(tm._resolve_hf_chat_template(tok_mgr))
+
+    def test_processor_prioritized_over_tokenizer(self):
+        """mm-processor's chat_template takes precedence over tokenizer's."""
+        tm = TemplateManager()
+        tok_mgr = Mock()
+        tok_mgr.processor = Mock()
+        tok_mgr.processor.chat_template = "processor_template"
+        tok_mgr.tokenizer = Mock()
+        tok_mgr.tokenizer.chat_template = "tokenizer_template"
+        self.assertEqual(tm._resolve_hf_chat_template(tok_mgr), "processor_template")
+
+    def test_no_tokenizer_no_processor(self):
+        tm = TemplateManager()
+        tok_mgr = Mock()
+        tok_mgr.processor = None
+        tok_mgr.tokenizer = None
+        self.assertIsNone(tm._resolve_hf_chat_template(tok_mgr))
+
+    def test_dict_template_selects_first(self):
+        """Dict templates dispatch to _select_named_template; without a
+        preference the first key is used."""
+        tm = TemplateManager()
+        tok_mgr = Mock()
+        tok_mgr.processor = None
+        tok_mgr.tokenizer = Mock()
+        tok_mgr.tokenizer.chat_template = {"default": "tmpl_a", "tool": "tmpl_b"}
+        tok_mgr.server_args = Mock()
+        tok_mgr.server_args.hf_chat_template_name = None
+        self.assertEqual(tm._resolve_hf_chat_template(tok_mgr), "tmpl_a")
+
+
+class TestGuessFromModelPath(unittest.TestCase):
+
+    @patch("sglang.srt.managers.template_manager.get_conv_template_by_model_path")
+    def test_known_model_sets_name(self, mock_get):
+        mock_get.return_value = "chatml"
+        tm = TemplateManager()
+        tm.guess_chat_template_from_model_path("/models/qwen-7b")
+        self.assertEqual(tm.chat_template_name, "chatml")
+
+    @patch("sglang.srt.managers.template_manager.get_conv_template_by_model_path")
+    def test_unknown_model_stays_none(self, mock_get):
+        mock_get.return_value = None
+        tm = TemplateManager()
+        tm.guess_chat_template_from_model_path("/models/unknown")
+        self.assertIsNone(tm.chat_template_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_template_manager.py
+++ b/test/registered/unit/managers/test_template_manager.py
@@ -1,11 +1,6 @@
 """Unit tests for template_manager.py — no server, no model loading."""
 
-import sys
-from unittest.mock import MagicMock, Mock, patch
-
-for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+from unittest.mock import Mock, patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/managers/test_template_manager.py
+++ b/test/registered/unit/managers/test_template_manager.py
@@ -9,9 +9,10 @@ register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 import unittest
 
 from sglang.srt.managers.template_manager import TemplateManager
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestTemplateManagerInit(unittest.TestCase):
+class TestTemplateManagerInit(CustomTestCase):
 
     def test_defaults(self):
         tm = TemplateManager()
@@ -21,7 +22,7 @@ class TestTemplateManagerInit(unittest.TestCase):
         self.assertFalse(tm.force_reasoning)
 
 
-class TestDetectReasoningPattern(unittest.TestCase):
+class TestDetectReasoningPattern(CustomTestCase):
 
     def test_none_template(self):
         self.assertFalse(TemplateManager()._detect_reasoning_pattern(None))
@@ -40,7 +41,7 @@ class TestDetectReasoningPattern(unittest.TestCase):
         self.assertFalse(TemplateManager()._detect_reasoning_pattern("<think>"))
 
 
-class TestSelectNamedTemplate(unittest.TestCase):
+class TestSelectNamedTemplate(CustomTestCase):
 
     def _make_tokenizer_manager(self, preferred_name=None):
         tm = Mock()
@@ -78,7 +79,7 @@ class TestSelectNamedTemplate(unittest.TestCase):
         self.assertEqual(result, "tmpl_a")
 
 
-class TestResolveHfChatTemplate(unittest.TestCase):
+class TestResolveHfChatTemplate(CustomTestCase):
 
     def test_string_template_returned(self):
         tm = TemplateManager()
@@ -126,7 +127,7 @@ class TestResolveHfChatTemplate(unittest.TestCase):
         self.assertEqual(tm._resolve_hf_chat_template(tok_mgr), "tmpl_a")
 
 
-class TestGuessFromModelPath(unittest.TestCase):
+class TestGuessFromModelPath(CustomTestCase):
 
     @patch("sglang.srt.managers.template_manager.get_conv_template_by_model_path")
     def test_known_model_sets_name(self, mock_get):

--- a/test/registered/unit/managers/test_template_manager.py
+++ b/test/registered/unit/managers/test_template_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/managers/test_template_manager.py
+++ b/test/registered/unit/managers/test_template_manager.py
@@ -1,6 +1,44 @@
 """Unit tests for template_manager.py — no server, no model loading."""
 
-from unittest.mock import Mock, patch
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock, Mock, patch
+
+
+# Stub out sgl_kernel (and all submodules) before any sglang import so
+# the test runs on CPU-only runners without the real CUDA library.
+class _SglKernelMockLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        mod = types.ModuleType(spec.name)
+        mod.__path__ = []
+        mod.__package__ = spec.name
+        mod.__loader__ = self
+        mod.__getattr__ = lambda name: MagicMock()
+        return mod
+
+    def exec_module(self, module):
+        pass
+
+
+class _SglKernelMockFinder(importlib.abc.MetaPathFinder):
+    """Import hook that intercepts all sgl_kernel.* imports and returns mocks."""
+
+    _PREFIX = "sgl_kernel"
+    _loader = _SglKernelMockLoader()
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self._PREFIX or fullname.startswith(self._PREFIX + "."):
+            return importlib.machinery.ModuleSpec(
+                fullname, self._loader, is_package=True
+            )
+        return None
+
+
+if "sgl_kernel" not in sys.modules:
+    sys.meta_path.insert(0, _SglKernelMockFinder())
 
 from sglang.test.ci.ci_register import register_cpu_ci
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Part of #20865 - Improve unit test coverage.
 Adds 7 new unit test files (138 tests) covering three modules:
  - `srt/entrypoints/openai/` - UsageProcessor, utils, OpenAIServingBase
  - `srt/function_call/` - utils (JSON parsing, schema inference, tool schema generation)
  - `srt/managers/` - schedule_batch (finish reasons, Modality, pad utils), utils (input validation, speculative decode
  allocation), template_manager (template resolution, reasoning detection)

  No server launch, no model weight loading. All tests registered with `register_cpu_ci()`.

## Coverage (138 tests, 7 files)

  | Source File | Stmts | Miss | Cover | Missing Lines |
  |---|---|---|---|---|
  | `srt/entrypoints/openai/usage_processor.py` | 26 | 0 | **100%** | |
  | `srt/entrypoints/openai/utils.py` | 45 | 1 | **98%** | 44 |
  | `srt/entrypoints/openai/serving_base.py` | 115 | 67 | **42%** | 79-129, 138, 142, 153-162, 171, 183, 199, 207, 234-241, 244-275, 284-306 |
  | `srt/function_call/utils.py` | 118 | 10 | **92%** | 41-49, 173 |
  | `srt/managers/schedule_batch.py` | 1169 | 843 | **28%** | finish reasons / enums / pad utilities tested;
  | `srt/managers/utils.py` | 82 | 30 | **63%** | 57-93, 100-101, 148-151, 170-194, 199-201 |
  | `srt/managers/template_manager.py` | 130 | 60 | **54%** | 117-146, 154-169, 190-203, 222-226, 232-240, 246-271, 275-298, 326-328 |

## Test Plan

  ```
  pytest test/registered/unit/entrypoints/openai/test_usage_processor.py
  test/registered/unit/entrypoints/openai/test_openai_utils.py
  test/registered/unit/entrypoints/openai/test_serving_base.py
  test/registered/unit/function_call/test_function_call_utils.py test/registered/unit/managers/test_schedule_batch.py
  test/registered/unit/managers/test_managers_utils.py test/registered/unit/managers/test_template_manager.py -v
  ```

  ```
========================================================================= test session starts =========================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /venv/main/bin/python3.12
cachedir: .pytest_cache
rootdir: /workspace/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.12.1
collected 138 items                                                                                                                                                   

test/registered/unit/entrypoints/openai/test_usage_processor.py::TestDetailsIfCached::test_negative_returns_none PASSED                                         [  0%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestDetailsIfCached::test_positive_returns_details PASSED                                      [  1%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestDetailsIfCached::test_zero_returns_none PASSED                                             [  2%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateTokenUsage::test_cached_details_propagated PASSED                                 [  2%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateTokenUsage::test_total_equals_sum PASSED                                          [  3%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_cache_report_disabled_omits_details PASSED                    [  4%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_cache_report_enabled PASSED                                   [  5%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_cache_report_zero_cached_stays_none PASSED                    [  5%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_missing_meta_info_keys_default_to_zero PASSED                 [  6%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_n_choices_skips_duplicate_prompt_counting PASSED              [  7%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_n_choices_with_four_responses PASSED                          [  7%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateResponseUsage::test_single_response PASSED                                        [  8%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_multi_choice_prompt_filtering PASSED                         [  9%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_single_choice PASSED                                         [ 10%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_streaming_cache_report PASSED                                [ 10%]
test/registered/unit/entrypoints/openai/test_usage_processor.py::TestCalculateStreamingUsage::test_streaming_cache_report_disabled PASSED                       [ 11%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestToOpenaiStyleLogprobs::test_all_none_returns_empty_logprobs PASSED                            [ 12%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestToOpenaiStyleLogprobs::test_input_and_output_concatenated PASSED                              [ 13%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestToOpenaiStyleLogprobs::test_input_logprobs PASSED                                             [ 13%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestToOpenaiStyleLogprobs::test_none_entry_in_top_logprobs PASSED                                 [ 14%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestToOpenaiStyleLogprobs::test_top_logprobs_converted_to_dict PASSED                             [ 15%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessHiddenStates::test_flag_disabled_skips_extraction PASSED                               [ 15%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessHiddenStates::test_missing_key_returns_none PASSED                                     [ 16%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessHiddenStates::test_multi_element_returns_last PASSED                                   [ 17%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessHiddenStates::test_single_element_returns_empty_list PASSED                            [ 18%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessRoutedExperts::test_flag_enabled_extracts_value PASSED                                 [ 18%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessRoutedExperts::test_flag_enabled_missing_key PASSED                                    [ 19%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessRoutedExperts::test_no_attribute_returns_none PASSED                                   [ 20%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessCachedTokensDetails::test_missing_key_returns_none PASSED                              [ 21%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessCachedTokensDetails::test_no_attribute_returns_none PASSED                             [ 21%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessCachedTokensDetails::test_none_details_returns_none PASSED                             [ 22%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessCachedTokensDetails::test_with_storage_field PASSED                                    [ 23%]
test/registered/unit/entrypoints/openai/test_openai_utils.py::TestProcessCachedTokensDetails::test_without_storage_field PASSED                                 [ 23%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestParseModelParameter::test_empty_adapter_becomes_none PASSED                                   [ 24%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestParseModelParameter::test_multiple_colons_splits_on_first PASSED                              [ 25%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestParseModelParameter::test_no_colon PASSED                                                     [ 26%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestParseModelParameter::test_single_colon PASSED                                                 [ 26%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestParseModelParameter::test_whitespace_only_adapter_becomes_none PASSED                         [ 27%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestParseModelParameter::test_whitespace_trimmed PASSED                                           [ 28%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestResolveLoraPath::test_adapter_from_model_takes_precedence PASSED                              [ 28%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestResolveLoraPath::test_fallback_to_explicit_lora_path PASSED                                   [ 29%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestResolveLoraPath::test_list_lora_path_passthrough PASSED                                       [ 30%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestResolveLoraPath::test_no_adapter_anywhere PASSED                                              [ 31%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestCreateErrorResponse::test_custom_status_code PASSED                                           [ 31%]
test/registered/unit/entrypoints/openai/test_serving_base.py::TestCreateErrorResponse::test_default_status_code PASSED                                          [ 32%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_both_empty PASSED                                                    [ 33%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_first_shorter PASSED                                                 [ 34%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_identical_strings PASSED                                             [ 34%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_no_common_prefix PASSED                                              [ 35%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_one_empty PASSED                                                     [ 36%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_partial_prefix PASSED                                                [ 36%]
test/registered/unit/function_call/test_function_call_utils.py::TestFindCommonPrefix::test_second_shorter PASSED                                                [ 37%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_empty_string PASSED                                                    [ 38%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_incomplete_array PASSED                                                [ 39%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_incomplete_object PASSED                                               [ 39%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_nested_complete PASSED                                                 [ 40%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_nested_incomplete PASSED                                               [ 41%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_valid_array PASSED                                                     [ 42%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_valid_object PASSED                                                    [ 42%]
test/registered/unit/function_call/test_function_call_utils.py::TestIsCompleteJson::test_valid_string PASSED                                                    [ 43%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_allof_all_string_returns_string PASSED                        [ 44%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_allof_returns_non_string_type PASSED                          [ 44%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_anyof_mixed_types_prefers_string PASSED                       [ 45%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_anyof_uniform_types PASSED                                    [ 46%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_anyof_without_string_returns_first PASSED                     [ 47%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_direct_type_integer PASSED                                    [ 47%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_direct_type_string PASSED                                     [ 48%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_empty_dict_returns_none PASSED                                [ 49%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_all_integers PASSED                                      [ 50%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_all_strings PASSED                                       [ 50%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_empty PASSED                                             [ 51%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_mixed_returns_string PASSED                              [ 52%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_with_dict_values PASSED                                  [ 52%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_with_list_values PASSED                                  [ 53%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_enum_with_none_value PASSED                                   [ 54%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_items_implies_array PASSED                                    [ 55%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_non_dict_returns_none PASSED                                  [ 55%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_oneof_handled_same_as_anyof PASSED                            [ 56%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_properties_implies_object PASSED                              [ 57%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_type_array_filters_null PASSED                                [ 57%]
test/registered/unit/function_call/test_function_call_utils.py::TestInferTypeFromJsonSchema::test_type_array_only_null_defaults_to_string PASSED                [ 58%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetToolSchema::test_none_parameters_gets_empty_object PASSED                                [ 59%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetToolSchema::test_with_parameters PASSED                                                  [ 60%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetToolSchemaDefs::test_conflicting_defs_raise PASSED                                       [ 60%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetToolSchemaDefs::test_identical_defs_merged PASSED                                        [ 61%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetToolSchemaDefs::test_no_defs PASSED                                                      [ 62%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetToolSchemaDefs::test_none_parameters_skipped PASSED                                      [ 63%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetJsonSchemaConstraint::test_auto_returns_none PASSED                                      [ 63%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetJsonSchemaConstraint::test_required_includes_defs PASSED                                 [ 64%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetJsonSchemaConstraint::test_required_lists_all_tools PASSED                               [ 65%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetJsonSchemaConstraint::test_specific_tool_choice PASSED                                   [ 65%]
test/registered/unit/function_call/test_function_call_utils.py::TestGetJsonSchemaConstraint::test_specific_tool_choice_not_found_returns_none PASSED            [ 66%]
test/registered/unit/managers/test_schedule_batch.py::TestBaseFinishReason::test_can_set_error PASSED                                                           [ 67%]
test/registered/unit/managers/test_schedule_batch.py::TestBaseFinishReason::test_default_is_not_error PASSED                                                    [ 68%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishMatchedToken::test_not_an_error PASSED                                                          [ 68%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishMatchedToken::test_to_json_with_int PASSED                                                      [ 69%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishMatchedToken::test_to_json_with_list PASSED                                                     [ 70%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishMatchedStr::test_to_json PASSED                                                                 [ 71%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishedMatchedRegex::test_to_json PASSED                                                             [ 71%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishLength::test_not_an_error PASSED                                                                [ 72%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishLength::test_to_json PASSED                                                                     [ 73%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishAbort::test_custom_fields PASSED                                                                [ 73%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishAbort::test_default_message PASSED                                                              [ 74%]
test/registered/unit/managers/test_schedule_batch.py::TestFinishAbort::test_is_always_error PASSED                                                              [ 75%]
test/registered/unit/managers/test_schedule_batch.py::TestModality::test_all_returns_image_video_audio PASSED                                                   [ 76%]
test/registered/unit/managers/test_schedule_batch.py::TestModality::test_from_str_case_insensitive PASSED                                                       [ 76%]
test/registered/unit/managers/test_schedule_batch.py::TestModality::test_from_str_invalid_raises PASSED                                                         [ 77%]
test/registered/unit/managers/test_schedule_batch.py::TestModality::test_from_str_valid PASSED                                                                  [ 78%]
test/registered/unit/managers/test_schedule_batch.py::TestComputePadValue::test_deterministic PASSED                                                            [ 78%]
test/registered/unit/managers/test_schedule_batch.py::TestComputePadValue::test_different_hashes_differ PASSED                                                  [ 79%]
test/registered/unit/managers/test_schedule_batch.py::TestComputePadValue::test_result_above_mm_pad_shift PASSED                                                [ 80%]
test/registered/unit/managers/test_schedule_batch.py::TestSanityCheckMmPadShiftValue::test_oversized_vocab_raises PASSED                                        [ 81%]
test/registered/unit/managers/test_schedule_batch.py::TestSanityCheckMmPadShiftValue::test_valid_vocab_size_passes PASSED                                       [ 81%]
test/registered/unit/managers/test_managers_utils.py::TestValidateInputLength::test_at_exact_boundary_returns_error PASSED                                      [ 82%]
test/registered/unit/managers/test_managers_utils.py::TestValidateInputLength::test_exceeds_limit_no_truncate PASSED                                            [ 83%]
test/registered/unit/managers/test_managers_utils.py::TestValidateInputLength::test_exceeds_limit_with_truncate PASSED                                          [ 84%]
test/registered/unit/managers/test_managers_utils.py::TestValidateInputLength::test_within_limit PASSED                                                         [ 84%]
test/registered/unit/managers/test_managers_utils.py::TestValidateInputLength::test_within_limit_no_truncation_applied PASSED                                   [ 85%]
test/registered/unit/managers/test_managers_utils.py::TestGetAllocLenPerDecode::test_draft_tokens_larger PASSED                                                 [ 86%]
test/registered/unit/managers/test_managers_utils.py::TestGetAllocLenPerDecode::test_no_speculative_returns_one PASSED                                          [ 86%]
test/registered/unit/managers/test_managers_utils.py::TestGetAllocLenPerDecode::test_page_size_gt1_with_topk_gt1_raises PASSED                                  [ 87%]
test/registered/unit/managers/test_managers_utils.py::TestGetAllocLenPerDecode::test_steps_times_topk_larger PASSED                                             [ 88%]
test/registered/unit/managers/test_template_manager.py::TestTemplateManagerInit::test_defaults PASSED                                                           [ 89%]
test/registered/unit/managers/test_template_manager.py::TestDetectReasoningPattern::test_no_reasoning_pattern PASSED                                            [ 89%]
test/registered/unit/managers/test_template_manager.py::TestDetectReasoningPattern::test_none_template PASSED                                                   [ 90%]
test/registered/unit/managers/test_template_manager.py::TestDetectReasoningPattern::test_think_tag_alone_does_not_match PASSED                                  [ 91%]
test/registered/unit/managers/test_template_manager.py::TestDetectReasoningPattern::test_with_reasoning_pattern PASSED                                          [ 92%]
test/registered/unit/managers/test_template_manager.py::TestSelectNamedTemplate::test_empty_dict_raises PASSED                                                  [ 92%]
test/registered/unit/managers/test_template_manager.py::TestSelectNamedTemplate::test_no_preference_uses_first PASSED                                           [ 93%]
test/registered/unit/managers/test_template_manager.py::TestSelectNamedTemplate::test_preferred_name_found PASSED                                               [ 94%]
test/registered/unit/managers/test_template_manager.py::TestSelectNamedTemplate::test_preferred_name_not_found_raises PASSED                                    [ 94%]
test/registered/unit/managers/test_template_manager.py::TestResolveHfChatTemplate::test_dict_template_selects_first PASSED                                      [ 95%]
test/registered/unit/managers/test_template_manager.py::TestResolveHfChatTemplate::test_no_tokenizer_no_processor PASSED                                        [ 96%]
test/registered/unit/managers/test_template_manager.py::TestResolveHfChatTemplate::test_none_template PASSED                                                    [ 97%]
test/registered/unit/managers/test_template_manager.py::TestResolveHfChatTemplate::test_processor_prioritized_over_tokenizer PASSED                             [ 97%]
test/registered/unit/managers/test_template_manager.py::TestResolveHfChatTemplate::test_string_template_returned PASSED                                         [ 98%]
test/registered/unit/managers/test_template_manager.py::TestGuessFromModelPath::test_known_model_sets_name PASSED                                               [ 99%]
test/registered/unit/managers/test_template_manager.py::TestGuessFromModelPath::test_unknown_model_stays_none PASSED                                            [100%]

========================================================================== warnings summary ===========================================================================
../../venv/main/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /venv/main/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

<frozen importlib._bootstrap_external>:1301
  <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.

<frozen importlib._bootstrap_external>:1301
  <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.

registered/unit/entrypoints/openai/test_serving_base.py::TestCreateErrorResponse::test_custom_status_code
  /workspace/sglang/test/registered/unit/entrypoints/openai/test_serving_base.py:108: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
    resp = self.serving.create_error_response(

registered/unit/entrypoints/openai/test_serving_base.py::TestCreateErrorResponse::test_default_status_code
  /workspace/sglang/test/registered/unit/entrypoints/openai/test_serving_base.py:104: FastAPIDeprecationWarning: ORJSONResponse is deprecated, FastAPI now serializes data directly to JSON bytes via Pydantic when a return type or response model is set, which is faster and doesn't need a custom response class. Read more in the FastAPI docs: https://fastapi.tiangolo.com/advanced/custom-response/#orjson-or-response-model and https://fastapi.tiangolo.com/tutorial/response-model/
    resp = self.serving.create_error_response("Something went wrong")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 138 passed, 7 warnings in 5.11s ===================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
## PR Requirements

  - [x] Test is in `test/registered/unit/<module>/` (mirroring `srt/`)
  - [x] Does NOT launch a server or load real model weights
  - [x] Includes edge cases, not just happy paths
  - [x] Registered with `register_cpu_ci()`
  - [x] Locally tested and passing (output above)