### PR TITLE
[Test] Add unit tests for srt/mem_cache (allocator, common, utils)

### DIFF
--- a/test/registered/unit/mem_cache/test_allocator_cpu.py
+++ b/test/registered/unit/mem_cache/test_allocator_cpu.py
@@ -1,0 +1,443 @@
+"""Unit tests for allocator.py — CPU-only tests"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.allocator import (
+    BaseTokenToKVPoolAllocator,
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+    alloc_extend_naive,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _token_alloc(size=16, need_sort=False, device="cpu"):
+    return TokenToKVPoolAllocator(
+        size=size,
+        dtype=torch.int64,
+        device=device,
+        kvcache=MagicMock(),
+        need_sort=need_sort,
+    )
+
+
+def _paged_alloc(size=64, page_size=4, need_sort=False, device="cpu"):
+    return PagedTokenToKVPoolAllocator(
+        size=size,
+        page_size=page_size,
+        dtype=torch.int64,
+        device=device,
+        kvcache=MagicMock(),
+        need_sort=need_sort,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BaseTokenToKVPoolAllocator
+# ---------------------------------------------------------------------------
+
+
+class TestBaseAllocatorNotImplemented(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+
+        class MinimalAlloc(BaseTokenToKVPoolAllocator):
+            def __init__(self):
+                super().__init__(8, 1, torch.int64, "cpu", MagicMock(), False)
+                self.free_pages = torch.arange(1, 9, dtype=torch.int64)
+                self.release_pages = torch.empty(0, dtype=torch.int64)
+
+            def clear(self):
+                pass
+
+            def alloc(self, n):
+                pass
+
+            def free(self, idx):
+                pass
+
+        self.a = MinimalAlloc()
+
+    def test_get_cpu_copy_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.a.get_cpu_copy()
+
+    def test_load_cpu_copy_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.a.load_cpu_copy()
+
+    def test_alloc_extend_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.a.alloc_extend()
+
+    def test_alloc_decode_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.a.alloc_decode()
+
+    def test_available_size(self):
+        self.assertEqual(self.a.available_size(), 8)
+
+    def test_debug_print_empty_string(self):
+        self.assertEqual(self.a.debug_print(), "")
+
+    def test_get_kvcache(self):
+        self.assertEqual(self.a.get_kvcache(), self.a._kvcache)
+
+    def test_merge_and_sort_free(self):
+        self.a.release_pages = torch.tensor([3, 1, 2], dtype=torch.int64)
+        self.a.free_pages = torch.tensor([6, 5], dtype=torch.int64)
+        self.a.merge_and_sort_free()
+        self.assertEqual(self.a.free_pages.tolist(), sorted([6, 5, 3, 1, 2]))
+        self.assertEqual(len(self.a.release_pages), 0)
+
+    def test_merge_and_sort_free_empty_release_is_noop(self):
+        before = self.a.free_pages.tolist()
+        self.a.merge_and_sort_free()
+        self.assertEqual(self.a.free_pages.tolist(), before)
+
+
+# ---------------------------------------------------------------------------
+# TokenToKVPoolAllocator
+# ---------------------------------------------------------------------------
+
+
+class TestTokenAllocatorAlloc(CustomTestCase):
+    def test_returns_correct_count(self):
+        self.assertEqual(len(_token_alloc(16).alloc(4)), 4)
+
+    def test_reduces_available_size(self):
+        a = _token_alloc(16)
+        a.alloc(4)
+        self.assertEqual(a.available_size(), 12)
+
+    def test_returns_unique_indices(self):
+        out = _token_alloc(16).alloc(8)
+        self.assertEqual(len(torch.unique(out)), 8)
+
+    def test_exact_capacity_succeeds(self):
+        a = _token_alloc(8)
+        self.assertIsNotNone(a.alloc(8))
+        self.assertEqual(a.available_size(), 0)
+
+    def test_over_capacity_returns_none(self):
+        self.assertIsNone(_token_alloc(8).alloc(9))
+
+    def test_over_capacity_after_need_sort_merge_returns_none(self):
+        a = _token_alloc(4, need_sort=True)
+        self.assertIsNone(a.alloc(8))
+
+    def test_zero_alloc_is_noop(self):
+        a = _token_alloc(8)
+        out = a.alloc(0)
+        self.assertEqual(len(out), 0)
+        self.assertEqual(a.available_size(), 8)
+
+    def test_sequential_allocs_non_overlapping(self):
+        a = _token_alloc(16)
+        s1 = set(a.alloc(4).tolist())
+        s2 = set(a.alloc(4).tolist())
+        self.assertEqual(len(s1 & s2), 0)
+
+    def test_slot_zero_never_returned(self):
+        self.assertNotIn(0, _token_alloc(16).alloc(16).tolist())
+
+    def test_need_sort_triggers_merge_before_alloc(self):
+        a = _token_alloc(8, need_sort=True)
+        a.free(a.alloc(4))
+        self.assertIsNotNone(a.alloc(8))
+
+
+class TestTokenAllocatorFree(CustomTestCase):
+    def test_restores_available_size(self):
+        a = _token_alloc(16)
+        a.free(a.alloc(4))
+        self.assertEqual(a.available_size(), 16)
+
+    def test_empty_tensor_is_noop(self):
+        a = _token_alloc(8)
+        before = a.available_size()
+        a.free(torch.tensor([], dtype=torch.int64))
+        self.assertEqual(a.available_size(), before)
+
+    def test_freed_indices_reusable(self):
+        a = _token_alloc(8)
+        a.free(a.alloc(8))
+        self.assertIsNotNone(a.alloc(8))
+
+    def test_need_sort_free_goes_to_release_pages(self):
+        a = _token_alloc(8, need_sort=True)
+        a.free(a.alloc(4))
+        self.assertEqual(len(a.release_pages), 4)
+
+    def test_no_sort_free_goes_directly_to_free_pages(self):
+        a = _token_alloc(8, need_sort=False)
+        out = a.alloc(4)
+        a.free(out)
+        self.assertEqual(len(a.free_pages), 8)
+
+
+class TestTokenAllocatorBackupRestore(CustomTestCase):
+    def test_restore_reverts_alloc(self):
+        a = _token_alloc(16)
+        state = a.backup_state()
+        a.alloc(8)
+        a.restore_state(state)
+        self.assertEqual(a.available_size(), 16)
+
+    def test_restore_reverts_free(self):
+        a = _token_alloc(16)
+        out = a.alloc(4)
+        state = a.backup_state()
+        a.free(out)
+        a.restore_state(state)
+        self.assertEqual(a.available_size(), 12)
+
+    def test_backup_is_snapshot_not_reference(self):
+        a = _token_alloc(16)
+        state = a.backup_state()
+        a.alloc(8)
+        a.alloc(4)
+        a.restore_state(state)
+        self.assertEqual(a.available_size(), 16)
+
+
+class TestTokenAllocatorFreeGroup(CustomTestCase):
+    def test_batches_frees_until_end(self):
+        a = _token_alloc(16)
+        x, y = a.alloc(4), a.alloc(4)
+        a.free_group_begin()
+        a.free(x)
+        a.free(y)
+        self.assertEqual(a.available_size(), 8)
+        a.free_group_end()
+        self.assertEqual(a.available_size(), 16)
+
+    def test_empty_group_end_is_noop(self):
+        a = _token_alloc(8)
+        a.alloc(4)
+        a.free_group_begin()
+        a.free_group_end()
+        self.assertEqual(a.available_size(), 4)
+
+
+class TestTokenAllocatorKVCacheDelegation(CustomTestCase):
+    def test_get_cpu_copy_delegates(self):
+        kv = MagicMock()
+        kv.get_cpu_copy.return_value = "cpu_data"
+        a = TokenToKVPoolAllocator(8, torch.int64, "cpu", kv, False)
+        result = a.get_cpu_copy(torch.tensor([1, 2]))
+        kv.get_cpu_copy.assert_called_once()
+        self.assertEqual(result, "cpu_data")
+
+    def test_load_cpu_copy_delegates(self):
+        kv = MagicMock()
+        a = TokenToKVPoolAllocator(8, torch.int64, "cpu", kv, False)
+        a.load_cpu_copy("data", torch.tensor([1, 2]))
+        kv.load_cpu_copy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# alloc_extend_naive
+# ---------------------------------------------------------------------------
+
+
+class TestAllocExtendNaive(CustomTestCase):
+    PAGE = 4
+
+    def _run(self, prefix_lens, seq_lens, last_loc, free_pages):
+        pl = torch.tensor(prefix_lens, dtype=torch.int64, device="cpu")
+        sl = torch.tensor(seq_lens, dtype=torch.int64, device="cpu")
+        ll = torch.tensor(last_loc, dtype=torch.int64, device="cpu")
+        fp = torch.tensor(free_pages, dtype=torch.int64, device="cpu")
+        total = int((sl - pl).sum().item())
+        out = torch.empty(total, dtype=torch.int64, device="cpu")
+        alloc_extend_naive(pl, sl, ll, fp, out, self.PAGE, "cpu")
+        return out
+
+    def test_num1_only(self):
+        out = self._run([2], [4], [1], [])
+        self.assertEqual(out.tolist(), [2, 3])
+
+    def test_num2_only(self):
+        out = self._run([0], [8], [-1], [5, 6])
+        self.assertEqual(out.tolist(), list(range(20, 24)) + list(range(24, 28)))
+
+    def test_num3_only(self):
+        out = self._run([4], [7], [3], [3])
+        self.assertEqual(len(out), 3)
+        base = 3 * self.PAGE
+        self.assertEqual(out.tolist(), [base, base + 1, base + 2])
+
+    def test_num1_and_num2(self):
+        out = self._run([2], [8], [1], [3])
+        self.assertEqual(out[:2].tolist(), [2, 3])
+        self.assertEqual(out[2:].tolist(), list(range(12, 16)))
+
+    def test_num1_and_num3(self):
+        out = self._run([2], [7], [1], [3])
+        self.assertEqual(out[:2].tolist(), [2, 3])
+        self.assertEqual(out[2:].tolist(), [12, 13, 14])
+
+    def test_num2_and_num3(self):
+        out = self._run([4], [11], [3], [2, 3])
+        self.assertEqual(out[:4].tolist(), list(range(8, 12)))
+        self.assertEqual(out[4:].tolist(), [12, 13, 14])
+
+    def test_num1_and_num2_and_num3(self):
+        out = self._run([2], [11], [1], [3, 4])
+        self.assertEqual(out[:2].tolist(), [2, 3])
+        self.assertEqual(out[2:6].tolist(), list(range(12, 16)))
+        self.assertEqual(out[6:].tolist(), [16, 17, 18])
+
+    def test_zero_extend(self):
+        out = self._run([4], [4], [3], [])
+        self.assertEqual(len(out), 0)
+
+    def test_multi_req_no_overlap(self):
+        out = self._run([0, 0], [4, 4], [-1, -1], [1, 2])
+        self.assertEqual(len(torch.unique(out)), 8)
+
+    def test_output_length_equals_extend_sum(self):
+        out = self._run([0, 2, 4], [4, 6, 8], [-1, 1, 3], list(range(1, 20)))
+        self.assertEqual(len(out), 12)
+
+
+# ---------------------------------------------------------------------------
+# PagedTokenToKVPoolAllocator — CPU paths
+# ---------------------------------------------------------------------------
+
+
+class TestPagedAllocatorCPU(CustomTestCase):
+    def test_alloc_returns_correct_count(self):
+        self.assertEqual(len(_paged_alloc(64, 4).alloc(8)), 8)
+
+    def test_alloc_reduces_available_size(self):
+        a = _paged_alloc(64, 4)
+        a.alloc(8)
+        self.assertEqual(a.available_size(), 56)
+
+    def test_over_capacity_returns_none(self):
+        self.assertIsNone(_paged_alloc(16, 4).alloc(20))
+
+    def test_alloc_need_sort_oom(self):
+        a = _paged_alloc(16, 4, need_sort=True)
+        self.assertIsNone(a.alloc(32))
+
+    def test_indices_are_page_aligned(self):
+        out = _paged_alloc(64, 4).alloc(8)
+        self.assertEqual(out[0].item() % 4, 0)
+        self.assertEqual(out[4].item() % 4, 0)
+
+    def test_indices_are_unique(self):
+        out = _paged_alloc(64, 4).alloc(16)
+        self.assertEqual(len(torch.unique(out)), 16)
+
+    def test_slot_zero_never_returned(self):
+        self.assertNotIn(0, _paged_alloc(64, 4).alloc(64).tolist())
+
+    def test_free_restores_available_size(self):
+        a = _paged_alloc(32, 4)
+        a.free(a.alloc(8))
+        self.assertEqual(a.available_size(), 32)
+
+    def test_free_empty_tensor_is_noop(self):
+        a = _paged_alloc(16, 4)
+        before = a.available_size()
+        a.free(torch.tensor([], dtype=torch.int64))
+        self.assertEqual(a.available_size(), before)
+
+    def test_freed_pages_reusable(self):
+        a = _paged_alloc(16, 4)
+        a.free(a.alloc(16))
+        self.assertIsNotNone(a.alloc(16))
+
+    def test_need_sort_free_goes_to_release_pages(self):
+        a = _paged_alloc(32, 4, need_sort=True)
+        a.free(a.alloc(4))
+        self.assertEqual(a.available_size(), 32)
+
+    def test_free_group_batches_until_end(self):
+        a = _paged_alloc(32, 4)
+        x, y = a.alloc(4), a.alloc(4)
+        a.free_group_begin()
+        a.free(x)
+        a.free(y)
+        self.assertEqual(a.available_size(), 24)
+        a.free_group_end()
+        self.assertEqual(a.available_size(), 32)
+
+    def test_restore_after_alloc(self):
+        a = _paged_alloc(32, 4)
+        state = a.backup_state()
+        a.alloc(16)
+        a.restore_state(state)
+        self.assertEqual(a.available_size(), 32)
+
+    def test_clear_restores_full_capacity(self):
+        a = _paged_alloc(32, 4)
+        a.alloc(32)
+        a.clear()
+        self.assertEqual(a.available_size(), 32)
+
+    def test_get_cpu_copy_delegates(self):
+        kv = MagicMock()
+        kv.get_cpu_copy.return_value = "data"
+        a = PagedTokenToKVPoolAllocator(16, 4, torch.int64, "cpu", kv, False)
+        result = a.get_cpu_copy(torch.tensor([4, 8]))
+        kv.get_cpu_copy.assert_called_once()
+        self.assertEqual(result, "data")
+
+    def test_load_cpu_copy_delegates(self):
+        kv = MagicMock()
+        a = PagedTokenToKVPoolAllocator(16, 4, torch.int64, "cpu", kv, False)
+        a.load_cpu_copy("data", torch.tensor([4, 8]))
+        kv.load_cpu_copy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# PagedTokenToKVPoolAllocator — debug_mode CPU paths
+# ---------------------------------------------------------------------------
+
+
+class TestPagedAllocatorDebugModeCPU(CustomTestCase):
+    def _debug_alloc(self, size=64, page_size=4, device="cpu"):
+        return PagedTokenToKVPoolAllocator(
+            size=size,
+            page_size=page_size,
+            dtype=torch.int64,
+            device=device,
+            kvcache=MagicMock(),
+            need_sort=False,
+        )
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_alloc_unaligned_size_raises(self):
+        a = self._debug_alloc()
+        with self.assertRaises(AssertionError):
+            a.alloc(3)
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_alloc_aligned_size_passes(self):
+        a = self._debug_alloc()
+        out = a.alloc(4)
+        self.assertIsNotNone(out)
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_free_duplicate_pages_raises(self):
+        a = self._debug_alloc()
+        out = a.alloc(4)
+        a.free(out)
+        with self.assertRaises(AssertionError):
+            a.free(out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_allocator_gpu.py
+++ b/test/registered/unit/mem_cache/test_allocator_gpu.py
@@ -1,0 +1,228 @@
+"""Unit tests for allocator.py — GPU-required tests"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, suite="stage-b-test-small-1-gpu")
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.allocator import PagedTokenToKVPoolAllocator
+from sglang.test.test_utils import CustomTestCase
+
+CUDA = torch.cuda.is_available()
+
+
+def _paged_alloc(size=64, page_size=4, need_sort=False, device="cpu"):
+    return PagedTokenToKVPoolAllocator(
+        size=size,
+        page_size=page_size,
+        dtype=torch.int64,
+        device=device,
+        kvcache=MagicMock(),
+        need_sort=need_sort,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PagedTokenToKVPoolAllocator — GPU / Triton paths
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestPagedAllocatorGPU(CustomTestCase):
+    D = "cuda"
+
+    def _alloc(self, size=256, page_size=4, need_sort=False):
+        return _paged_alloc(
+            size=size, page_size=page_size, need_sort=need_sort, device=self.D
+        )
+
+    def _t(self, data):
+        return torch.tensor(data, dtype=torch.int64, device=self.D)
+
+    def test_alloc_extend_output_length(self):
+        a = self._alloc()
+        pre, seq, ll = self._t([0, 4]), self._t([8, 8]), self._t([-1, 3])
+        extend = int((seq - pre).sum())
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, extend)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), extend)
+
+    def test_alloc_extend_unique_indices(self):
+        a = self._alloc()
+        pre, seq, ll = self._t([0]), self._t([8]), self._t([-1])
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 8)
+        self.assertEqual(len(torch.unique(out)), 8)
+
+    def test_alloc_extend_reduces_available(self):
+        a = self._alloc()
+        before = a.available_size()
+        pre, seq, ll = self._t([0]), self._t([8]), self._t([-1])
+        a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 8)
+        self.assertLess(a.available_size(), before)
+
+    def test_alloc_extend_backup_restore(self):
+        a = self._alloc()
+        state = a.backup_state()
+        pre, seq, ll = self._t([0]), self._t([8]), self._t([-1])
+        a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 8)
+        a.restore_state(state)
+        self.assertEqual(a.available_size(), 256)
+
+    def test_alloc_extend_need_sort_triggers_merge(self):
+        a = self._alloc(need_sort=True)
+        pre, seq, ll = self._t([0]), self._t([8]), self._t([-1])
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 8)
+        self.assertIsNotNone(out)
+
+    def test_alloc_extend_need_sort_oom(self):
+        a = self._alloc(size=16, page_size=4, need_sort=True)
+        pre = self._t([0])
+        seq = self._t([32])
+        ll = self._t([-1])
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 32)
+        self.assertIsNone(out)
+
+    def test_alloc_decode_output_length(self):
+        a = self._alloc()
+        seq = self._t([4, 8, 12, 16])
+        ll = self._t([3, 7, 11, 15])
+        out = a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), 4)
+
+    def test_alloc_decode_crossing_page_boundary(self):
+        a = self._alloc()
+        seq, ll = self._t([5]), self._t([3])
+        out = a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), 1)
+
+    def test_alloc_decode_within_page_no_new_page_consumed(self):
+        a = self._alloc(256, 4)
+        before = a.available_size()
+        seq, ll = self._t([4]), self._t([2])
+        a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertEqual(a.available_size(), before)
+
+    def test_alloc_decode_reduces_available(self):
+        a = self._alloc()
+        before = a.available_size()
+        seq, ll = self._t([5]), self._t([3])
+        a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertLess(a.available_size(), before)
+
+    def test_alloc_decode_need_sort_triggers_merge(self):
+        a = self._alloc(need_sort=True)
+        seq, ll = self._t([5]), self._t([3])
+        out = a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertIsNotNone(out)
+
+    def test_alloc_decode_need_sort_oom(self):
+        a = self._alloc(size=16, page_size=4, need_sort=True)
+        seq = self._t([5, 9, 13, 17, 21])
+        ll = self._t([3, 7, 11, 15, 19])
+        out = a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertIsNone(out)
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestPagedAllocatorGPUTritonCoverage(CustomTestCase):
+    D = "cuda"
+
+    def _alloc(self, size=256, page_size=4, need_sort=False):
+        return _paged_alloc(
+            size=size, page_size=page_size, need_sort=need_sort, device=self.D
+        )
+
+    def _t(self, data):
+        return torch.tensor(data, dtype=torch.int64, device=self.D)
+
+    def test_alloc_extend_unaligned_branches(self):
+        a = self._alloc(size=256, page_size=4)
+        pre = self._t([2])
+        seq = self._t([11])
+        ll = self._t([1])
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 9)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), 9)
+        self.assertEqual(len(torch.unique(out)), 9)
+
+        out_list = out.tolist()
+        self.assertEqual(out_list[:2], [2, 3])
+        self.assertEqual(out_list[2:6], [4, 5, 6, 7])
+        self.assertEqual(out_list[6:], [8, 9, 10])
+
+    def test_alloc_extend_multiple_unaligned_requests(self):
+        a = self._alloc(size=256, page_size=4)
+        _ = a.alloc(8)
+        pre = self._t([1, 3])
+        seq = self._t([6, 7])
+        ll = self._t([4, 10])
+        extend_num = int((seq - pre).sum().item())
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, extend_num)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out), 9)
+        self.assertEqual(len(torch.unique(out)), 9)
+
+
+# ---------------------------------------------------------------------------
+# PagedTokenToKVPoolAllocator — debug_mode GPU paths
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestPagedAllocatorDebugModeGPU(CustomTestCase):
+    def _debug_alloc(self, size=256, page_size=4, device="cuda"):
+        return PagedTokenToKVPoolAllocator(
+            size=size,
+            page_size=page_size,
+            dtype=torch.int64,
+            device=device,
+            kvcache=MagicMock(),
+            need_sort=False,
+        )
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_alloc_extend_debug_unique_assert(self):
+        a = self._debug_alloc()
+        pre = torch.tensor([0], dtype=torch.int64, device="cuda")
+        seq = torch.tensor([8], dtype=torch.int64, device="cuda")
+        ll = torch.tensor([-1], dtype=torch.int64, device="cuda")
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 8)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(torch.unique(out)), len(out))
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_alloc_extend_debug_mode_succeeds_when_last_loc_aligned_with_prefix(self):
+        a = self._debug_alloc()
+        pre = torch.tensor([4], dtype=torch.int64, device="cuda")
+        seq = torch.tensor([8], dtype=torch.int64, device="cuda")
+        ll = torch.tensor([3], dtype=torch.int64, device="cuda")
+        out = a.alloc_extend(pre, pre.cpu(), seq, seq.cpu(), ll, 4)
+        self.assertIsNotNone(out)
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_alloc_decode_debug_unique_assert(self):
+        a = self._debug_alloc()
+        seq = torch.tensor([5, 9], dtype=torch.int64, device="cuda")
+        ll = torch.tensor([3, 7], dtype=torch.int64, device="cuda")
+        out = a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertIsNotNone(out)
+        self.assertEqual(len(torch.unique(out)), len(out))
+
+    @patch.dict(os.environ, {"SGLANG_DEBUG_MEMORY_POOL": "1"})
+    def test_alloc_decode_debug_mode_succeeds_when_last_loc_aligned_with_seq_len(self):
+        a = self._debug_alloc()
+        seq = torch.tensor([5], dtype=torch.int64, device="cuda")
+        ll = torch.tensor([3], dtype=torch.int64, device="cuda")
+        out = a.alloc_decode(seq, seq.cpu(), ll)
+        self.assertIsNotNone(out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_common_cpu.py
+++ b/test/registered/unit/mem_cache/test_common_cpu.py
@@ -1,0 +1,520 @@
+"""Unit tests for common.py — CPU-only tests"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.common import (
+    alloc_token_slots,
+    available_and_evictable_str,
+    evict_from_tree_cache,
+    get_last_loc_torch,
+    write_cache_indices,
+)
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
+from sglang.test.test_utils import CustomTestCase
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tree_cache(available=100, is_chunk=False):
+    tc = MagicMock()
+    tc.is_chunk_cache.return_value = is_chunk
+    tc.available_and_evictable_str.return_value = "available: 0, evictable: 0"
+    alloc = MagicMock()
+    alloc.available_size.return_value = available
+    tc.token_to_kv_pool_allocator = alloc
+    return tc
+
+
+# ---------------------------------------------------------------------------
+# get_last_loc_torch (CPU)
+# ---------------------------------------------------------------------------
+
+
+class TestGetLastLocTorch(CustomTestCase):
+    def _pool(self, rows, cols):
+        return torch.arange(rows * cols, dtype=torch.int64).reshape(rows, cols)
+
+    def test_positive_prefix_returns_last_slot(self):
+        pool = self._pool(4, 8)
+        out = get_last_loc_torch(pool, torch.tensor([0]), torch.tensor([3]))
+        self.assertEqual(out[0].item(), pool[0, 2].item())
+
+    def test_zero_prefix_returns_minus_one(self):
+        pool = self._pool(4, 8)
+        out = get_last_loc_torch(pool, torch.tensor([1]), torch.tensor([0]))
+        self.assertEqual(out[0].item(), -1)
+
+    def test_batch_mixed_prefix_lens(self):
+        pool = self._pool(4, 8)
+        req = torch.tensor([0, 1, 2])
+        pre = torch.tensor([0, 4, 2])
+        out = get_last_loc_torch(pool, req, pre)
+        self.assertEqual(out[0].item(), -1)
+        self.assertEqual(out[1].item(), pool[1, 3].item())
+        self.assertEqual(out[2].item(), pool[2, 1].item())
+
+    def test_output_shape_matches_input(self):
+        pool = self._pool(8, 16)
+        req = torch.zeros(5, dtype=torch.int64)
+        pre = torch.ones(5, dtype=torch.int64)
+        self.assertEqual(get_last_loc_torch(pool, req, pre).shape, pre.shape)
+
+    def test_all_zero_prefix_returns_all_minus_one(self):
+        pool = self._pool(3, 8)
+        req = torch.tensor([0, 1, 2])
+        pre = torch.zeros(3, dtype=torch.int64)
+        self.assertTrue((get_last_loc_torch(pool, req, pre) == -1).all())
+
+    def test_single_token_prefix(self):
+        pool = self._pool(2, 4)
+        out = get_last_loc_torch(pool, torch.tensor([1]), torch.tensor([1]))
+        self.assertEqual(out[0].item(), pool[1, 0].item())
+
+    def test_different_req_pool_indices(self):
+        pool = self._pool(4, 4)
+        req = torch.tensor([0, 3])
+        pre = torch.tensor([2, 2])
+        out = get_last_loc_torch(pool, req, pre)
+        self.assertEqual(out[0].item(), pool[0, 1].item())
+        self.assertEqual(out[1].item(), pool[3, 1].item())
+
+    def test_prefix_len_equals_context_len(self):
+        pool = self._pool(2, 4)
+        out = get_last_loc_torch(pool, torch.tensor([0]), torch.tensor([4]))
+        self.assertEqual(out[0].item(), pool[0, 3].item())
+
+
+# ---------------------------------------------------------------------------
+# evict_from_tree_cache
+# ---------------------------------------------------------------------------
+
+
+class TestEvictFromTreeCache(CustomTestCase):
+    def test_none_tree_cache_is_noop(self):
+        evict_from_tree_cache(None, 10)
+
+    def test_chunk_cache_is_noop(self):
+        tc = _make_tree_cache(is_chunk=True)
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_not_called()
+
+    def test_no_eviction_when_space_sufficient(self):
+        tc = _make_tree_cache(available=50)
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_not_called()
+
+    def test_evicts_when_space_insufficient(self):
+        tc = _make_tree_cache(available=5)
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_called_once()
+
+    def test_evict_called_with_correct_num_tokens(self):
+        tc = _make_tree_cache(available=5)
+        evict_from_tree_cache(tc, 20)
+        evict_params = tc.evict.call_args[0][0]
+        self.assertEqual(evict_params.num_tokens, 20)
+
+    def test_no_eviction_when_available_equals_requested(self):
+        tc = _make_tree_cache(available=10)
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_not_called()
+
+    def test_evicts_when_one_less_than_needed(self):
+        tc = _make_tree_cache(available=9)
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_called_once()
+
+    def test_swa_both_pools_sufficient_no_evict(self):
+        from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+
+        tc = MagicMock()
+        tc.is_chunk_cache.return_value = False
+        alloc = MagicMock(spec=SWATokenToKVPoolAllocator)
+        alloc.full_available_size.return_value = 50
+        alloc.swa_available_size.return_value = 50
+        tc.token_to_kv_pool_allocator = alloc
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_not_called()
+
+    def test_swa_full_pool_short_triggers_evict(self):
+        from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+
+        tc = MagicMock()
+        tc.is_chunk_cache.return_value = False
+        alloc = MagicMock(spec=SWATokenToKVPoolAllocator)
+        alloc.full_available_size.return_value = 5
+        alloc.swa_available_size.return_value = 50
+        tc.token_to_kv_pool_allocator = alloc
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_called_once()
+
+    def test_swa_swa_pool_short_triggers_evict(self):
+        from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+
+        tc = MagicMock()
+        tc.is_chunk_cache.return_value = False
+        alloc = MagicMock(spec=SWATokenToKVPoolAllocator)
+        alloc.full_available_size.return_value = 50
+        alloc.swa_available_size.return_value = 3
+        tc.token_to_kv_pool_allocator = alloc
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_called_once()
+
+    def test_swa_evict_params_both_pools(self):
+        from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+
+        tc = MagicMock()
+        tc.is_chunk_cache.return_value = False
+        alloc = MagicMock(spec=SWATokenToKVPoolAllocator)
+        alloc.full_available_size.return_value = 3
+        alloc.swa_available_size.return_value = 6
+        tc.token_to_kv_pool_allocator = alloc
+        evict_from_tree_cache(tc, 10)
+        tc.evict.assert_called_once()
+        params = tc.evict.call_args[0][0]
+        self.assertEqual(params.num_tokens, 7)
+        self.assertEqual(params.swa_num_tokens, 4)
+
+
+# ---------------------------------------------------------------------------
+# alloc_token_slots
+# ---------------------------------------------------------------------------
+
+
+class TestAllocTokenSlots(CustomTestCase):
+    def _make_tc(self, alloc_result):
+        tc = MagicMock()
+        tc.is_chunk_cache.return_value = True
+        tc.available_and_evictable_str.return_value = "available: 0"
+        alloc = MagicMock()
+        alloc.alloc.return_value = alloc_result
+        alloc.backup_state.return_value = ("fp", "rp")
+        tc.token_to_kv_pool_allocator = alloc
+        return tc
+
+    def test_returns_allocated_tensor(self):
+        expected = torch.tensor([1, 2, 3])
+        tc = self._make_tc(expected)
+        out = alloc_token_slots(tc, 3)
+        self.assertTrue(torch.equal(out, expected))
+
+    def test_oom_raises_runtime_error(self):
+        tc = self._make_tc(None)
+        with self.assertRaises(RuntimeError):
+            alloc_token_slots(tc, 10)
+
+    def test_backup_state_true_returns_tuple(self):
+        expected = torch.tensor([1, 2, 3])
+        tc = self._make_tc(expected)
+        out, state = alloc_token_slots(tc, 3, backup_state=True)
+        self.assertTrue(torch.equal(out, expected))
+        self.assertEqual(state, ("fp", "rp"))
+
+    def test_backup_state_false_returns_tensor_only(self):
+        expected = torch.tensor([4, 5])
+        tc = self._make_tc(expected)
+        out = alloc_token_slots(tc, 2, backup_state=False)
+        self.assertTrue(torch.equal(out, expected))
+
+    def test_eviction_called_when_space_insufficient(self):
+        tc = MagicMock()
+        tc.is_chunk_cache.return_value = False
+        alloc = MagicMock()
+        alloc.available_size.return_value = 0
+        alloc.alloc.return_value = torch.tensor([1])
+        tc.token_to_kv_pool_allocator = alloc
+        alloc_token_slots(tc, 1)
+        tc.evict.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# available_and_evictable_str
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableAndEvictableStr(CustomTestCase):
+    def test_delegates_to_tree_cache(self):
+        tc = MagicMock()
+        tc.available_and_evictable_str.return_value = "available: 10, evictable: 5"
+        result = available_and_evictable_str(tc)
+        tc.available_and_evictable_str.assert_called_once()
+        self.assertEqual(result, "available: 10, evictable: 5")
+
+    def test_returns_string(self):
+        tc = MagicMock()
+        tc.available_and_evictable_str.return_value = "x"
+        self.assertIsInstance(available_and_evictable_str(tc), str)
+
+
+# ---------------------------------------------------------------------------
+# write_cache_indices — non-Triton path
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCacheIndicesNonTriton(CustomTestCase):
+    def _run(self, n_reqs=2, seq_len=4, prefix_len=2):
+        extend_len = seq_len - prefix_len
+        out_cache_loc = torch.arange(n_reqs * extend_len, dtype=torch.int32)
+        req_pool_idx_cpu = torch.arange(n_reqs, dtype=torch.int64)
+        prefix_lens_cpu = torch.full((n_reqs,), prefix_len, dtype=torch.int64)
+        seq_lens_cpu = torch.full((n_reqs,), seq_len, dtype=torch.int64)
+        extend_lens_cpu = torch.full((n_reqs,), extend_len, dtype=torch.int64)
+        prefix_tensors = [
+            torch.zeros(prefix_len, dtype=torch.int64) for _ in range(n_reqs)
+        ]
+        pool = MagicMock()
+
+        with patch(
+            "sglang.srt.mem_cache.common.support_triton", return_value=False
+        ), patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "torch_native"
+            write_cache_indices(
+                out_cache_loc,
+                req_pool_idx_cpu,
+                req_pool_idx_cpu,
+                prefix_lens_cpu,
+                prefix_lens_cpu,
+                seq_lens_cpu,
+                seq_lens_cpu,
+                extend_lens_cpu,
+                extend_lens_cpu,
+                prefix_tensors,
+                pool,
+            )
+        return pool
+
+    def test_write_called_for_each_request(self):
+        pool = self._run(n_reqs=3)
+        self.assertEqual(pool.write.call_count, 6)
+
+    def test_prefix_slice_written(self):
+        pool = self._run(n_reqs=1, seq_len=4, prefix_len=2)
+        first_call_key = pool.write.call_args_list[0][0][0]
+        self.assertEqual(first_call_key, (0, slice(0, 2)))
+
+    def test_extend_slice_written(self):
+        pool = self._run(n_reqs=1, seq_len=4, prefix_len=2)
+        second_call_key = pool.write.call_args_list[1][0][0]
+        self.assertEqual(second_call_key, (0, slice(2, 4)))
+
+
+# ---------------------------------------------------------------------------
+# High-Level Operations
+# ---------------------------------------------------------------------------
+
+
+class TestCommonHighLevelFunctions(CustomTestCase):
+    @patch("sglang.srt.mem_cache.common.get_global_server_args")
+    def test_alloc_paged_token_slots_extend(self, mock_args):
+        from sglang.srt.mem_cache.common import alloc_paged_token_slots_extend
+
+        tc = MagicMock()
+        tc.token_to_kv_pool_allocator.alloc_extend.return_value = torch.tensor([1])
+        tc.token_to_kv_pool_allocator.page_size = 4
+
+        out, state = alloc_paged_token_slots_extend(
+            tc,
+            torch.tensor([1]),
+            torch.tensor([1]),
+            torch.tensor([5]),
+            torch.tensor([5]),
+            torch.tensor([0]),
+            4,
+            backup_state=True,
+        )
+        self.assertIsNotNone(out)
+
+        tc.token_to_kv_pool_allocator.alloc_extend.return_value = None
+        with self.assertRaises(RuntimeError):
+            alloc_paged_token_slots_extend(
+                tc,
+                torch.tensor([1]),
+                torch.tensor([1]),
+                torch.tensor([5]),
+                torch.tensor([5]),
+                torch.tensor([0]),
+                4,
+            )
+
+    @patch("sglang.srt.mem_cache.common.get_global_server_args")
+    def test_alloc_req_slots(self, mock_args):
+        from sglang.srt.mem_cache.common import alloc_req_slots
+
+        pool = MagicMock()
+        pool.__class__ = HybridReqToTokenPool
+        pool.mamba_pool.available_size.return_value = 0
+        pool.alloc.return_value = [1]
+
+        tc = MagicMock()
+        tc.supports_mamba.return_value = True
+
+        out = alloc_req_slots(pool, [MagicMock()], tc)
+        self.assertEqual(out, [1])
+        tc.evict.assert_called_once()
+
+        pool.alloc.return_value = None
+        with self.assertRaises(RuntimeError):
+            alloc_req_slots(pool, [MagicMock()], tc)
+
+    @patch("sglang.srt.mem_cache.common.get_global_server_args")
+    def test_alloc_for_extend(self, mock_args):
+        from sglang.srt.mem_cache.common import alloc_for_extend
+
+        batch = MagicMock()
+        batch.reqs = [MagicMock()]
+        batch.reqs[0].prefix_indices = torch.tensor([1])
+        batch.prefix_lens = [1]
+        batch.extend_lens = [4]
+        batch.device = "cpu"
+        batch.seq_lens = torch.tensor([5])
+        batch.seq_lens_cpu = torch.tensor([5])
+        batch.extend_num_tokens = 4
+        batch.tree_cache.page_size = 1
+
+        with patch(
+            "sglang.srt.mem_cache.common.alloc_token_slots",
+            return_value=torch.tensor([1]),
+        ), patch(
+            "sglang.srt.mem_cache.common.alloc_req_slots", return_value=[1]
+        ), patch(
+            "sglang.srt.mem_cache.common.write_cache_indices"
+        ):
+            out, dev, req = alloc_for_extend(batch)
+            self.assertIsNotNone(out)
+
+        batch.tree_cache.page_size = 4
+        with patch(
+            "sglang.srt.mem_cache.common.alloc_paged_token_slots_extend",
+            return_value=torch.tensor([1]),
+        ), patch(
+            "sglang.srt.mem_cache.common.alloc_req_slots", return_value=[1]
+        ), patch(
+            "sglang.srt.mem_cache.common.write_cache_indices"
+        ):
+            out, dev, req = alloc_for_extend(batch)
+            self.assertIsNotNone(out)
+
+    @patch("sglang.srt.mem_cache.common.get_global_server_args")
+    def test_alloc_paged_token_slots_decode(self, mock_args):
+        from sglang.srt.mem_cache.common import alloc_paged_token_slots_decode
+
+        tc = MagicMock()
+        tc.token_to_kv_pool_allocator.alloc_decode.return_value = torch.tensor([1])
+        tc.token_to_kv_pool_allocator.page_size = 4
+
+        out = alloc_paged_token_slots_decode(
+            tc, torch.tensor([5]), torch.tensor([5]), torch.tensor([4])
+        )
+        self.assertIsNotNone(out)
+
+        tc.token_to_kv_pool_allocator.alloc_decode.return_value = None
+        with self.assertRaises(RuntimeError):
+            alloc_paged_token_slots_decode(
+                tc, torch.tensor([5]), torch.tensor([5]), torch.tensor([4])
+            )
+
+    @patch("sglang.srt.mem_cache.common.get_global_server_args")
+    def test_alloc_for_decode(self, mock_args):
+        from sglang.srt.mem_cache.common import alloc_for_decode
+
+        batch = MagicMock()
+        batch.seq_lens = torch.tensor([5])
+        batch.seq_lens_cpu = torch.tensor([5])
+        batch.tree_cache.page_size = 1
+        batch.model_config.is_encoder_decoder = True
+        batch.encoder_lens = torch.tensor([2])
+        batch.req_pool_indices = torch.tensor([0])
+
+        with patch(
+            "sglang.srt.mem_cache.common.alloc_token_slots",
+            return_value=torch.tensor([1]),
+        ):
+            out = alloc_for_decode(batch, 1)
+            self.assertIsNotNone(out)
+
+        batch.tree_cache.page_size = 4
+        batch.model_config.is_encoder_decoder = False
+        with patch(
+            "sglang.srt.mem_cache.common.alloc_paged_token_slots_decode",
+            return_value=torch.tensor([1]),
+        ):
+            out = alloc_for_decode(batch, 1)
+            self.assertIsNotNone(out)
+
+    @patch("sglang.srt.mem_cache.common.get_global_server_args")
+    def test_release_kv_cache(self, mock_args):
+        from sglang.srt.mem_cache.common import release_kv_cache
+
+        # Branch 1: early alloc mamba state release (mamba_pool_idx is not None)
+        req = MagicMock()
+        tc = MagicMock()
+        req.req_pool_idx = None
+        tc.supports_mamba.return_value = True
+        req.mamba_pool_idx = torch.tensor([1])
+        release_kv_cache(req, tc)
+        self.assertIsNone(req.mamba_pool_idx)
+
+        # Branch 2: early alloc mamba state release (mamba_pool_idx is None)
+        req = MagicMock()
+        tc = MagicMock()
+        req.req_pool_idx = None
+        tc.supports_mamba.return_value = True
+        req.mamba_pool_idx = None
+        release_kv_cache(req, tc)
+
+        # Branch 3: cache_finished_req sets req_pool_idx to None
+        req = MagicMock()
+        tc = MagicMock()
+        req.req_pool_idx = 1
+
+        def side_effect(r, is_insert):
+            r.req_pool_idx = None
+
+        tc.cache_finished_req.side_effect = side_effect
+        release_kv_cache(req, tc)
+
+        # Branch 4: normal release with overallocation & HybridReqToTokenPool
+        req = MagicMock()
+        tc = MagicMock()
+        req.req_pool_idx = 1
+        req.pop_overallocated_kv_cache.return_value = (2, 4)
+        mock_args.return_value.page_size = 2
+        mock_args.return_value.speculative_algorithm = "EAGLE"
+
+        tc.req_to_token_pool = MagicMock()
+        tc.req_to_token_pool.__class__ = HybridReqToTokenPool
+        tc.req_to_token_pool.req_to_token = torch.arange(20).reshape(2, 10)
+
+        tc.supports_mamba.return_value = False
+        req.mamba_pool_idx = 1
+
+        release_kv_cache(req, tc)
+
+        tc.req_to_token_pool.free_mamba_cache.assert_called_with(req)
+        tc.req_to_token_pool.free.assert_called_with(req)
+
+        # Branch 5: normal release without overallocation
+        req = MagicMock()
+        tc = MagicMock()
+        req.req_pool_idx = 1
+        req.pop_overallocated_kv_cache.return_value = (2, 2)
+        mock_args.return_value.page_size = 1
+        mock_args.return_value.speculative_algorithm = None
+
+        tc.req_to_token_pool = MagicMock()
+
+        release_kv_cache(req, tc)
+        tc.req_to_token_pool.free.assert_called_with(req)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_common_gpu.py
+++ b/test/registered/unit/mem_cache/test_common_gpu.py
@@ -1,0 +1,205 @@
+"""Unit tests for common.py — GPU-required tests"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="stage-b-test-small-1-gpu")
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.common import (
+    get_last_loc_torch,
+    get_last_loc_triton,
+    write_cache_indices,
+)
+from sglang.test.test_utils import CustomTestCase
+
+CUDA = torch.cuda.is_available()
+
+
+# ---------------------------------------------------------------------------
+# get_last_loc_triton (GPU)
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestGetLastLocTriton(CustomTestCase):
+    D = "cuda"
+
+    def _pool(self, rows, cols):
+        return torch.arange(rows * cols, dtype=torch.int64, device=self.D).reshape(
+            rows, cols
+        )
+
+    def _t(self, data):
+        return torch.tensor(data, dtype=torch.int64, device=self.D)
+
+    def test_matches_torch_impl_single(self):
+        pool = self._pool(4, 8)
+        req, pre = self._t([0]), self._t([3])
+        self.assertTrue(
+            torch.equal(
+                get_last_loc_torch(pool, req, pre),
+                get_last_loc_triton(pool, req, pre),
+            )
+        )
+
+    def test_matches_torch_impl_batch(self):
+        pool = self._pool(8, 16)
+        req = self._t([0, 1, 2, 3])
+        pre = self._t([0, 4, 2, 8])
+        self.assertTrue(
+            torch.equal(
+                get_last_loc_torch(pool, req, pre),
+                get_last_loc_triton(pool, req, pre),
+            )
+        )
+
+    def test_zero_prefix_returns_minus_one(self):
+        pool = self._pool(4, 8)
+        out = get_last_loc_triton(pool, self._t([1]), self._t([0]))
+        self.assertEqual(out[0].item(), -1)
+
+    def test_all_zero_prefix(self):
+        pool = self._pool(4, 8)
+        out = get_last_loc_triton(pool, self._t([0, 1, 2, 3]), self._t([0, 0, 0, 0]))
+        self.assertTrue((out == -1).all())
+
+    def test_output_shape(self):
+        pool = self._pool(8, 16)
+        pre = self._t([1, 2, 3])
+        out = get_last_loc_triton(pool, self._t([0, 1, 2]), pre)
+        self.assertEqual(out.shape, pre.shape)
+
+    def test_large_batch(self):
+        n = 256
+        pool = self._pool(n, 32)
+        req = torch.arange(n, dtype=torch.int64, device=self.D)
+        pre = torch.randint(1, 32, (n,), dtype=torch.int64, device=self.D)
+        self.assertTrue(
+            torch.equal(
+                get_last_loc_torch(pool, req, pre),
+                get_last_loc_triton(pool, req, pre),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_last_loc dispatcher
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestGetLastLocDispatcher(CustomTestCase):
+    def _pool(self, rows, cols, device="cuda"):
+        return torch.arange(rows * cols, dtype=torch.int64, device=device).reshape(
+            rows, cols
+        )
+
+    def test_routes_to_triton_for_default_backend(self):
+        from sglang.srt.mem_cache.common import get_last_loc
+
+        pool = self._pool(4, 8)
+        req = torch.tensor([0], dtype=torch.int64, device="cuda")
+        pre = torch.tensor([3], dtype=torch.int64, device="cuda")
+        with patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "flashinfer"
+            out = get_last_loc(pool, req, pre)
+        self.assertEqual(out[0].item(), pool[0, 2].item())
+
+    def test_routes_to_torch_for_torch_native_backend(self):
+        from sglang.srt.mem_cache.common import get_last_loc
+
+        pool = self._pool(4, 8)
+        req = torch.tensor([0], dtype=torch.int64, device="cuda")
+        pre = torch.tensor([3], dtype=torch.int64, device="cuda")
+        with patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "torch_native"
+            out = get_last_loc(pool, req, pre)
+        self.assertEqual(out[0].item(), pool[0, 2].item())
+
+    def test_routes_to_torch_for_ascend_backend(self):
+        from sglang.srt.mem_cache.common import get_last_loc
+
+        pool = self._pool(4, 8)
+        req = torch.tensor([0], dtype=torch.int64, device="cuda")
+        pre = torch.tensor([0], dtype=torch.int64, device="cuda")
+        with patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "ascend"
+            out = get_last_loc(pool, req, pre)
+        self.assertEqual(out[0].item(), -1)
+
+    def test_triton_and_torch_agree(self):
+        from sglang.srt.mem_cache.common import get_last_loc
+
+        pool = self._pool(8, 16)
+        req = torch.tensor([0, 1, 2, 3], dtype=torch.int64, device="cuda")
+        pre = torch.tensor([0, 4, 2, 8], dtype=torch.int64, device="cuda")
+
+        with patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "flashinfer"
+            triton_out = get_last_loc(pool, req, pre)
+
+        with patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "torch_native"
+            torch_out = get_last_loc(pool, req, pre)
+
+        self.assertTrue(torch.equal(triton_out, torch_out))
+
+
+# ---------------------------------------------------------------------------
+# write_cache_indices — Triton path
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestWriteCacheIndicesTritonPath(CustomTestCase):
+    def test_triton_path_executes_without_error(self):
+        n_reqs, prefix_len, seq_len = 2, 2, 4
+        extend_len = seq_len - prefix_len
+        max_ctx = 16
+
+        req_to_token = torch.zeros(n_reqs, max_ctx, dtype=torch.int32, device="cuda")
+        pool = MagicMock()
+        pool.device = "cuda"
+        pool.req_to_token = req_to_token
+
+        out_cache_loc = torch.arange(
+            n_reqs * extend_len, dtype=torch.int32, device="cuda"
+        )
+        req_idx_dev = torch.arange(n_reqs, dtype=torch.int64, device="cuda")
+        req_idx_cpu = req_idx_dev.cpu()
+        pre_dev = torch.full((n_reqs,), prefix_len, dtype=torch.int64, device="cuda")
+        pre_cpu = pre_dev.cpu()
+        seq_dev = torch.full((n_reqs,), seq_len, dtype=torch.int64, device="cuda")
+        seq_cpu = seq_dev.cpu()
+        ext_dev = torch.full((n_reqs,), extend_len, dtype=torch.int64, device="cuda")
+        ext_cpu = ext_dev.cpu()
+        prefix_tensors = [
+            torch.zeros(prefix_len, dtype=torch.int64, device="cuda")
+            for _ in range(n_reqs)
+        ]
+
+        with patch(
+            "sglang.srt.mem_cache.common.support_triton", return_value=True
+        ), patch("sglang.srt.mem_cache.common.get_global_server_args") as mock_args:
+            mock_args.return_value.attention_backend = "flashinfer"
+            write_cache_indices(
+                out_cache_loc,
+                req_idx_dev,
+                req_idx_cpu,
+                pre_dev,
+                pre_cpu,
+                seq_dev,
+                seq_cpu,
+                ext_dev,
+                ext_cpu,
+                prefix_tensors,
+                pool,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_utils_cpu.py
+++ b/test/registered/unit/mem_cache/test_utils_cpu.py
@@ -1,0 +1,105 @@
+"""Unit tests for utils.py — CPU-only tests"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.mem_cache.utils import (
+    convert_to_bigram_key,
+    maybe_init_custom_mem_pool,
+)
+from sglang.test.test_utils import CustomTestCase
+
+# ---------------------------------------------------------------------------
+# convert_to_bigram_key
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToBigramKey(CustomTestCase):
+    def test_empty_list(self):
+        self.assertEqual(convert_to_bigram_key([]), [])
+
+    def test_single_token(self):
+        self.assertEqual(convert_to_bigram_key([42]), [])
+
+    def test_two_tokens(self):
+        self.assertEqual(convert_to_bigram_key([1, 2]), [(1, 2)])
+
+    def test_multiple_tokens(self):
+        self.assertEqual(
+            convert_to_bigram_key([1, 2, 3, 4]),
+            [(1, 2), (2, 3), (3, 4)],
+        )
+
+    def test_output_length(self):
+        tokens = list(range(10))
+        self.assertEqual(len(convert_to_bigram_key(tokens)), 9)
+
+    def test_consecutive_pairs_overlap(self):
+        out = convert_to_bigram_key([10, 20, 30, 40])
+        for i in range(len(out) - 1):
+            self.assertEqual(out[i][1], out[i + 1][0])
+
+    def test_duplicate_tokens(self):
+        self.assertEqual(convert_to_bigram_key([5, 5, 5]), [(5, 5), (5, 5)])
+
+    def test_already_tuples_passthrough(self):
+        tokens = [(1, 2), (2, 3)]
+        self.assertIs(convert_to_bigram_key(tokens), tokens)
+
+    def test_large_token_ids(self):
+        out = convert_to_bigram_key([999999, 0, 123456])
+        self.assertEqual(out, [(999999, 0), (0, 123456)])
+
+
+# ---------------------------------------------------------------------------
+# maybe_init_custom_mem_pool
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeInitCustomMemPool(CustomTestCase):
+    def test_disabled_when_env_not_set(self):
+        with patch(
+            "sglang.srt.mem_cache.utils.envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL"
+        ) as m:
+            m.get.return_value = None
+            enabled, pool, pool_type = maybe_init_custom_mem_pool("cpu")
+        self.assertFalse(enabled)
+        self.assertIsNone(pool)
+        self.assertIsNone(pool_type)
+
+    def test_returns_three_tuple(self):
+        with patch(
+            "sglang.srt.mem_cache.utils.envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL"
+        ) as m:
+            m.get.return_value = None
+            result = maybe_init_custom_mem_pool("cpu")
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+
+    def test_enabled_when_env_set(self):
+        mock_mooncake = MagicMock()
+        mock_mooncake.init_mooncake_custom_mem_pool.return_value = (
+            True,
+            object(),
+            "mooncake",
+        )
+        with patch(
+            "sglang.srt.mem_cache.utils.envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL"
+        ) as m, patch.dict(
+            sys.modules,
+            {"sglang.srt.disaggregation.mooncake.utils": mock_mooncake},
+        ):
+            m.get.return_value = "/some/path"
+            from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
+
+            enabled, _, _ = maybe_init_custom_mem_pool("cuda")
+        self.assertTrue(enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_utils_gpu.py
+++ b/test/registered/unit/mem_cache/test_utils_gpu.py
@@ -1,0 +1,193 @@
+"""Unit tests for utils.py — GPU-required tests"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="stage-b-test-small-1-gpu")
+
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+CUDA = torch.cuda.is_available()
+
+
+# ---------------------------------------------------------------------------
+# set_mla_kv_buffer_triton — GPU
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestSetMLAKVBufferTriton(CustomTestCase):
+    NOPE, ROPE, N_LOC = 128, 64, 4
+
+    def _tensors(self, nope=None, rope=None, n_loc=None):
+        nope = nope or self.NOPE
+        rope = rope or self.ROPE
+        n_loc = n_loc or self.N_LOC
+        kv = torch.zeros(n_loc * 2, nope + rope, dtype=torch.float32, device="cuda")
+        loc = torch.arange(n_loc, dtype=torch.int64, device="cuda")
+        k_nope = torch.rand(n_loc, nope, dtype=torch.float32, device="cuda")
+        k_rope = torch.rand(n_loc, rope, dtype=torch.float32, device="cuda")
+        return kv, loc, k_nope, k_rope
+
+    def test_nope_region_written_correctly(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_buffer_triton
+
+        kv, loc, nope, rope = self._tensors()
+        set_mla_kv_buffer_triton(kv, loc, nope, rope)
+        for i in range(self.N_LOC):
+            self.assertTrue(torch.allclose(kv[i, : self.NOPE], nope[i]))
+
+    def test_rope_region_written_correctly(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_buffer_triton
+
+        kv, loc, nope, rope = self._tensors()
+        set_mla_kv_buffer_triton(kv, loc, nope, rope)
+        for i in range(self.N_LOC):
+            self.assertTrue(
+                torch.allclose(kv[i, self.NOPE : self.NOPE + self.ROPE], rope[i])
+            )
+
+    def test_non_contiguous_locations(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.zeros(16, total, dtype=torch.float32, device="cuda")
+        loc = torch.tensor([0, 3, 7, 12], dtype=torch.int64, device="cuda")
+        nope = torch.rand(4, self.NOPE, device="cuda")
+        rope = torch.rand(4, self.ROPE, device="cuda")
+        set_mla_kv_buffer_triton(kv, loc, nope, rope)
+        for idx, l in enumerate(loc.tolist()):
+            self.assertTrue(torch.allclose(kv[l, : self.NOPE], nope[idx]))
+
+    def test_boundary_nope_dim_not_multiple_of_block(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_buffer_triton
+
+        nope_dim, rope_dim, n = 160, 64, 2
+        kv = torch.zeros(n, nope_dim + rope_dim, dtype=torch.float32, device="cuda")
+        loc = torch.arange(n, dtype=torch.int64, device="cuda")
+        nope = torch.rand(n, nope_dim, device="cuda")
+        rope = torch.rand(n, rope_dim, device="cuda")
+        set_mla_kv_buffer_triton(kv, loc, nope, rope)
+        for i in range(n):
+            self.assertTrue(torch.allclose(kv[i, :nope_dim], nope[i]))
+            self.assertTrue(
+                torch.allclose(kv[i, nope_dim : nope_dim + rope_dim], rope[i])
+            )
+
+
+# ---------------------------------------------------------------------------
+# set_mla_kv_scale_buffer_triton — GPU
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestSetMLAKVScaleBufferTriton(CustomTestCase):
+    NOPE, ROPE, N_LOC = 128, 64, 4
+
+    def test_scale_nope_region(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_scale_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.zeros(self.N_LOC, total, dtype=torch.float32, device="cuda")
+        loc = torch.arange(self.N_LOC, dtype=torch.int64, device="cuda")
+        nope = torch.rand(self.N_LOC, self.NOPE, device="cuda")
+        rope = torch.zeros(self.N_LOC, self.ROPE, device="cuda")
+        set_mla_kv_scale_buffer_triton(kv, loc, nope, rope)
+        for i in range(self.N_LOC):
+            self.assertTrue(torch.allclose(kv[i, : self.NOPE], nope[i]))
+
+    def test_scale_rope_region(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_scale_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.zeros(self.N_LOC, total, dtype=torch.float32, device="cuda")
+        loc = torch.arange(self.N_LOC, dtype=torch.int64, device="cuda")
+        nope = torch.zeros(self.N_LOC, self.NOPE, device="cuda")
+        rope = torch.rand(self.N_LOC, self.ROPE, device="cuda")
+        set_mla_kv_scale_buffer_triton(kv, loc, nope, rope)
+        for i in range(self.N_LOC):
+            self.assertTrue(torch.allclose(kv[i, self.NOPE :], rope[i]))
+
+    def test_scale_both_regions_combined(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_scale_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.zeros(self.N_LOC, total, dtype=torch.float32, device="cuda")
+        loc = torch.arange(self.N_LOC, dtype=torch.int64, device="cuda")
+        nope = torch.rand(self.N_LOC, self.NOPE, device="cuda")
+        rope = torch.rand(self.N_LOC, self.ROPE, device="cuda")
+        set_mla_kv_scale_buffer_triton(kv, loc, nope, rope)
+        for i in range(self.N_LOC):
+            self.assertTrue(torch.allclose(kv[i, : self.NOPE], nope[i]))
+            self.assertTrue(torch.allclose(kv[i, self.NOPE :], rope[i]))
+
+    def test_non_contiguous_locations(self):
+        from sglang.srt.mem_cache.utils import set_mla_kv_scale_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.zeros(16, total, dtype=torch.float32, device="cuda")
+        loc = torch.tensor([1, 5, 9, 13], dtype=torch.int64, device="cuda")
+        nope = torch.rand(4, self.NOPE, device="cuda")
+        rope = torch.rand(4, self.ROPE, device="cuda")
+        set_mla_kv_scale_buffer_triton(kv, loc, nope, rope)
+        for idx, l in enumerate(loc.tolist()):
+            self.assertTrue(torch.allclose(kv[l, : self.NOPE], nope[idx]))
+
+
+# ---------------------------------------------------------------------------
+# get_mla_kv_buffer_triton — GPU
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(CUDA, "CUDA required")
+class TestGetMLAKVBufferTriton(CustomTestCase):
+    NOPE, ROPE, N_LOC = 128, 64, 4
+
+    def test_roundtrip_set_then_get(self):
+        from sglang.srt.mem_cache.utils import (
+            get_mla_kv_buffer_triton,
+            set_mla_kv_buffer_triton,
+        )
+
+        total = self.NOPE + self.ROPE
+        kv = torch.zeros(self.N_LOC, total, dtype=torch.float32, device="cuda")
+        loc = torch.arange(self.N_LOC, dtype=torch.int64, device="cuda")
+        nope_in = torch.rand(self.N_LOC, self.NOPE, device="cuda")
+        rope_in = torch.rand(self.N_LOC, self.ROPE, device="cuda")
+        set_mla_kv_buffer_triton(kv, loc, nope_in, rope_in)
+        nope_out = torch.empty_like(nope_in)
+        rope_out = torch.empty_like(rope_in)
+        get_mla_kv_buffer_triton(kv, loc, nope_out, rope_out)
+        self.assertTrue(torch.allclose(nope_in, nope_out, atol=1e-5))
+        self.assertTrue(torch.allclose(rope_in, rope_out, atol=1e-5))
+
+    def test_get_reads_correct_locations(self):
+        from sglang.srt.mem_cache.utils import get_mla_kv_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.rand(16, total, dtype=torch.float32, device="cuda")
+        loc = torch.tensor([2, 5], dtype=torch.int64, device="cuda")
+        nope_out = torch.empty(2, self.NOPE, device="cuda")
+        rope_out = torch.empty(2, self.ROPE, device="cuda")
+        get_mla_kv_buffer_triton(kv, loc, nope_out, rope_out)
+        self.assertTrue(torch.allclose(nope_out[0], kv[2, : self.NOPE]))
+        self.assertTrue(torch.allclose(rope_out[1], kv[5, self.NOPE :]))
+
+    def test_get_single_location(self):
+        from sglang.srt.mem_cache.utils import get_mla_kv_buffer_triton
+
+        total = self.NOPE + self.ROPE
+        kv = torch.rand(8, total, dtype=torch.float32, device="cuda")
+        loc = torch.tensor([3], dtype=torch.int64, device="cuda")
+        nope_out = torch.empty(1, self.NOPE, device="cuda")
+        rope_out = torch.empty(1, self.ROPE, device="cuda")
+        get_mla_kv_buffer_triton(kv, loc, nope_out, rope_out)
+        self.assertTrue(torch.allclose(nope_out[0], kv[3, : self.NOPE]))
+        self.assertTrue(torch.allclose(rope_out[0], kv[3, self.NOPE :]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Part of https://github.com/sgl-project/sglang/issues/20865 (Improve Unit Test Coverage)

## Modifications
This PR adds 147 unit tests in 6 test files, covering 3 source files under `srt/mem_cache`
| Source | Tests | Unit test file |
|--------|------:|----------------|
| `python/sglang/srt/mem_cache/allocator.py` | 60 | `test/registered/unit/mem_cache/test_allocator_cpu.py` |
| `python/sglang/srt/mem_cache/allocator.py` | 18 | `test/registered/unit/mem_cache/test_allocator_gpu.py` |
| `python/sglang/srt/mem_cache/common.py` | 35 | `test/registered/unit/mem_cache/test_common_cpu.py` |
| `python/sglang/srt/mem_cache/common.py` | 11 | `test/registered/unit/mem_cache/test_common_gpu.py` |
| `python/sglang/srt/mem_cache/utils.py` | 12 | `test/registered/unit/mem_cache/test_utils_cpu.py` |
| `python/sglang/srt/mem_cache/utils.py` | 11 | `test/registered/unit/mem_cache/test_utils_gpu.py` |

## Coverage
```
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
python/sglang/srt/mem_cache/allocator.py       235     53    77%   244-313, 329-353
python/sglang/srt/mem_cache/common.py          202     30    85%   38-68, 165-176
python/sglang/srt/mem_cache/utils.py           117     69    41%   38-82, 126-165, 176-185, 212-236, 278-294
```

## Test Plan
```
# command
pytest test/registered/unit/mem_cache/test_allocator_cpu.py -v
# output
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, typeguard-4.5.1, langsmith-0.7.23, anyio-4.13.0
collected 60 items                                                             

test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_alloc_decode_raises PASSED [  1%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_alloc_extend_raises PASSED [  3%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_available_size PASSED [  5%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_debug_print_empty_string PASSED [  6%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_get_cpu_copy_raises PASSED [  8%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_get_kvcache PASSED [ 10%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_load_cpu_copy_raises PASSED [ 11%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_merge_and_sort_free PASSED [ 13%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestBaseAllocatorNotImplemented::test_merge_and_sort_free_empty_release_is_noop PASSED [ 15%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_exact_capacity_succeeds PASSED [ 16%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_need_sort_triggers_merge_before_alloc PASSED [ 18%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_over_capacity_after_need_sort_merge_returns_none PASSED [ 20%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_over_capacity_returns_none PASSED [ 21%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_reduces_available_size PASSED [ 23%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_returns_correct_count PASSED [ 25%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_returns_unique_indices PASSED [ 26%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_sequential_allocs_non_overlapping PASSED [ 28%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_slot_zero_never_returned PASSED [ 30%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorAlloc::test_zero_alloc_is_noop PASSED [ 31%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFree::test_empty_tensor_is_noop PASSED [ 33%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFree::test_freed_indices_reusable PASSED [ 35%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFree::test_need_sort_free_goes_to_release_pages PASSED [ 36%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFree::test_no_sort_free_goes_directly_to_free_pages PASSED [ 38%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFree::test_restores_available_size PASSED [ 40%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorBackupRestore::test_backup_is_snapshot_not_reference PASSED [ 41%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorBackupRestore::test_restore_reverts_alloc PASSED [ 43%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorBackupRestore::test_restore_reverts_free PASSED [ 45%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFreeGroup::test_batches_frees_until_end PASSED [ 46%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorFreeGroup::test_empty_group_end_is_noop PASSED [ 48%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorKVCacheDelegation::test_get_cpu_copy_delegates PASSED [ 50%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestTokenAllocatorKVCacheDelegation::test_load_cpu_copy_delegates PASSED [ 51%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_multi_req_no_overlap PASSED [ 53%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num1_and_num2 PASSED [ 55%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num1_and_num2_and_num3 PASSED [ 56%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num1_and_num3 PASSED [ 58%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num1_only PASSED [ 60%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num2_and_num3 PASSED [ 61%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num2_only PASSED [ 63%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_num3_only PASSED [ 65%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_output_length_equals_extend_sum PASSED [ 66%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestAllocExtendNaive::test_zero_extend PASSED [ 68%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_alloc_need_sort_oom PASSED [ 70%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_alloc_reduces_available_size PASSED [ 71%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_alloc_returns_correct_count PASSED [ 73%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_clear_restores_full_capacity PASSED [ 75%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_free_empty_tensor_is_noop PASSED [ 76%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_free_group_batches_until_end PASSED [ 78%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_free_restores_available_size PASSED [ 80%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_freed_pages_reusable PASSED [ 81%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_get_cpu_copy_delegates PASSED [ 83%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_indices_are_page_aligned PASSED [ 85%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_indices_are_unique PASSED [ 86%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_load_cpu_copy_delegates PASSED [ 88%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_need_sort_free_goes_to_release_pages PASSED [ 90%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_over_capacity_returns_none PASSED [ 91%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_restore_after_alloc PASSED [ 93%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorCPU::test_slot_zero_never_returned PASSED [ 95%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorDebugModeCPU::test_alloc_aligned_size_passes PASSED [ 96%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorDebugModeCPU::test_alloc_unaligned_size_raises PASSED [ 98%]
test/registered/unit/mem_cache/test_allocator_cpu.py::TestPagedAllocatorDebugModeCPU::test_free_duplicate_pages_raises PASSED [100%]

=============================== warnings summary ===============================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 60 passed, 1 warning in 11.80s ========================
```

```
# command
pytest test/registered/unit/mem_cache/test_allocator_gpu.py -v
# output
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, typeguard-4.5.1, langsmith-0.7.23, anyio-4.13.0
collected 18 items                                                             

test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_decode_crossing_page_boundary PASSED [  5%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_decode_need_sort_oom PASSED [ 11%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_decode_need_sort_triggers_merge PASSED [ 16%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_decode_output_length PASSED [ 22%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_decode_reduces_available PASSED [ 27%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_decode_within_page_no_new_page_consumed PASSED [ 33%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_extend_backup_restore PASSED [ 38%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_extend_need_sort_oom PASSED [ 44%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_extend_need_sort_triggers_merge PASSED [ 50%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_extend_output_length PASSED [ 55%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_extend_reduces_available PASSED [ 61%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPU::test_alloc_extend_unique_indices PASSED [ 66%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPUTritonCoverage::test_alloc_extend_multiple_unaligned_requests PASSED [ 72%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorGPUTritonCoverage::test_alloc_extend_unaligned_branches PASSED [ 77%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorDebugModeGPU::test_alloc_decode_debug_mode_succeeds_when_last_loc_aligned_with_seq_len PASSED [ 83%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorDebugModeGPU::test_alloc_decode_debug_unique_assert PASSED [ 88%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorDebugModeGPU::test_alloc_extend_debug_mode_succeeds_when_last_loc_aligned_with_prefix PASSED [ 94%]
test/registered/unit/mem_cache/test_allocator_gpu.py::TestPagedAllocatorDebugModeGPU::test_alloc_extend_debug_unique_assert PASSED [100%]

=============================== warnings summary ===============================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 18 passed, 1 warning in 13.57s ========================
```

```
# command
pytest test/registered/unit/mem_cache/test_common_cpu.py -v
# output
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, typeguard-4.5.1, langsmith-0.7.23, anyio-4.13.0
collected 35 items                                                             

test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_all_zero_prefix_returns_all_minus_one PASSED [  2%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_batch_mixed_prefix_lens PASSED [  5%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_different_req_pool_indices PASSED [  8%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_output_shape_matches_input PASSED [ 11%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_positive_prefix_returns_last_slot PASSED [ 14%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_prefix_len_equals_context_len PASSED [ 17%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_single_token_prefix PASSED [ 20%]
test/registered/unit/mem_cache/test_common_cpu.py::TestGetLastLocTorch::test_zero_prefix_returns_minus_one PASSED [ 22%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_chunk_cache_is_noop PASSED [ 25%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_evict_called_with_correct_num_tokens PASSED [ 28%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_evicts_when_one_less_than_needed PASSED [ 31%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_evicts_when_space_insufficient PASSED [ 34%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_no_eviction_when_available_equals_requested PASSED [ 37%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_no_eviction_when_space_sufficient PASSED [ 40%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_none_tree_cache_is_noop PASSED [ 42%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_swa_both_pools_sufficient_no_evict PASSED [ 45%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_swa_evict_params_both_pools PASSED [ 48%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_swa_full_pool_short_triggers_evict PASSED [ 51%]
test/registered/unit/mem_cache/test_common_cpu.py::TestEvictFromTreeCache::test_swa_swa_pool_short_triggers_evict PASSED [ 54%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAllocTokenSlots::test_backup_state_false_returns_tensor_only PASSED [ 57%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAllocTokenSlots::test_backup_state_true_returns_tuple PASSED [ 60%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAllocTokenSlots::test_eviction_called_when_space_insufficient PASSED [ 62%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAllocTokenSlots::test_oom_raises_runtime_error PASSED [ 65%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAllocTokenSlots::test_returns_allocated_tensor PASSED [ 68%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAvailableAndEvictableStr::test_delegates_to_tree_cache PASSED [ 71%]
test/registered/unit/mem_cache/test_common_cpu.py::TestAvailableAndEvictableStr::test_returns_string PASSED [ 74%]
test/registered/unit/mem_cache/test_common_cpu.py::TestWriteCacheIndicesNonTriton::test_extend_slice_written PASSED [ 77%]
test/registered/unit/mem_cache/test_common_cpu.py::TestWriteCacheIndicesNonTriton::test_prefix_slice_written PASSED [ 80%]
test/registered/unit/mem_cache/test_common_cpu.py::TestWriteCacheIndicesNonTriton::test_write_called_for_each_request PASSED [ 82%]
test/registered/unit/mem_cache/test_common_cpu.py::TestCommonHighLevelFunctions::test_alloc_for_decode PASSED [ 85%]
test/registered/unit/mem_cache/test_common_cpu.py::TestCommonHighLevelFunctions::test_alloc_for_extend PASSED [ 88%]
test/registered/unit/mem_cache/test_common_cpu.py::TestCommonHighLevelFunctions::test_alloc_paged_token_slots_decode PASSED [ 91%]
test/registered/unit/mem_cache/test_common_cpu.py::TestCommonHighLevelFunctions::test_alloc_paged_token_slots_extend PASSED [ 94%]
test/registered/unit/mem_cache/test_common_cpu.py::TestCommonHighLevelFunctions::test_alloc_req_slots PASSED [ 97%]
test/registered/unit/mem_cache/test_common_cpu.py::TestCommonHighLevelFunctions::test_release_kv_cache PASSED [100%]

=============================== warnings summary ===============================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 35 passed, 1 warning in 17.06s ========================
```

```
# command
pytest test/registered/unit/mem_cache/test_common_gpu.py -v
# output
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, typeguard-4.5.1, langsmith-0.7.23, anyio-4.13.0
collected 11 items                                                             

test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocTriton::test_all_zero_prefix PASSED [  9%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocTriton::test_large_batch PASSED [ 18%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocTriton::test_matches_torch_impl_batch PASSED [ 27%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocTriton::test_matches_torch_impl_single PASSED [ 36%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocTriton::test_output_shape PASSED [ 45%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocTriton::test_zero_prefix_returns_minus_one PASSED [ 54%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocDispatcher::test_routes_to_torch_for_ascend_backend PASSED [ 63%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocDispatcher::test_routes_to_torch_for_torch_native_backend PASSED [ 72%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocDispatcher::test_routes_to_triton_for_default_backend PASSED [ 81%]
test/registered/unit/mem_cache/test_common_gpu.py::TestGetLastLocDispatcher::test_triton_and_torch_agree PASSED [ 90%]
test/registered/unit/mem_cache/test_common_gpu.py::TestWriteCacheIndicesTritonPath::test_triton_path_executes_without_error PASSED [100%]

=============================== warnings summary ===============================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 11 passed, 1 warning in 19.11s ========================
```

```
# command
pytest test/registered/unit/mem_cache/test_utils_cpu.py -v
# output
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, typeguard-4.5.1, langsmith-0.7.23, anyio-4.13.0
collected 12 items                                                             

test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_already_tuples_passthrough PASSED [  8%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_consecutive_pairs_overlap PASSED [ 16%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_duplicate_tokens PASSED [ 25%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_empty_list PASSED [ 33%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_large_token_ids PASSED [ 41%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_multiple_tokens PASSED [ 50%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_output_length PASSED [ 58%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_single_token PASSED [ 66%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestConvertToBigramKey::test_two_tokens PASSED [ 75%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestMaybeInitCustomMemPool::test_disabled_when_env_not_set PASSED [ 83%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestMaybeInitCustomMemPool::test_enabled_when_env_set PASSED [ 91%]
test/registered/unit/mem_cache/test_utils_cpu.py::TestMaybeInitCustomMemPool::test_returns_three_tuple PASSED [100%]

=============================== warnings summary ===============================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 12 passed, 1 warning in 12.09s ========================
```

```
# command
pytest test/registered/unit/mem_cache/test_utils_gpu.py -v
# output
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, typeguard-4.5.1, langsmith-0.7.23, anyio-4.13.0
collected 11 items                                                             

test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVBufferTriton::test_boundary_nope_dim_not_multiple_of_block PASSED [  9%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVBufferTriton::test_non_contiguous_locations PASSED [ 18%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVBufferTriton::test_nope_region_written_correctly PASSED [ 27%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVBufferTriton::test_rope_region_written_correctly PASSED [ 36%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVScaleBufferTriton::test_non_contiguous_locations PASSED [ 45%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVScaleBufferTriton::test_scale_both_regions_combined PASSED [ 54%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVScaleBufferTriton::test_scale_nope_region PASSED [ 63%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestSetMLAKVScaleBufferTriton::test_scale_rope_region PASSED [ 72%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestGetMLAKVBufferTriton::test_get_reads_correct_locations PASSED [ 81%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestGetMLAKVBufferTriton::test_get_single_location PASSED [ 90%]
test/registered/unit/mem_cache/test_utils_gpu.py::TestGetMLAKVBufferTriton::test_roundtrip_set_then_get PASSED [100%]

=============================== warnings summary ===============================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 11 passed, 1 warning in 13.80s ========================
```