### PR TITLE
[Bug] Reserve generation space when auto-truncating long prompts  #21138

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -791,19 +791,32 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         """Validates that the input token count and the requested token count doesn't exceed the model's context length."""
         # FIXME: unify the length validation logic with the one in the scheduler.
         _max_req_len = self.context_len
-        input_token_num = len(input_ids) if input_ids is not None else 0
-        input_token_num += self.num_reserved_tokens
+        input_ids_len = len(input_ids) if input_ids is not None else 0
+        input_token_num = input_ids_len + self.num_reserved_tokens
+        max_new_tokens = obj.sampling_params.get("max_new_tokens")
 
         # Validate input length
         if input_token_num >= self.context_len:
             if self.server_args.allow_auto_truncate:
+                reserved_generation_tokens = (
+                    max_new_tokens
+                    if self.validate_total_tokens and max_new_tokens is not None
+                    else 0
+                )
+                truncated_input_len = max(
+                    0,
+                    _max_req_len
+                    - self.num_reserved_tokens
+                    - reserved_generation_tokens,
+                )
                 logger.warning(
                     f"The input ({input_token_num} tokens) is longer than the "
                     f"model's context length ({self.context_len} tokens). "
                     "Truncating the input."
                 )
-                del input_ids[_max_req_len:]
-                input_token_num = len(input_ids)
+                del input_ids[truncated_input_len:]
+                input_ids_len = len(input_ids)
+                input_token_num = input_ids_len + self.num_reserved_tokens
             else:
                 raise ValueError(
                     f"The input ({input_token_num} tokens) is longer than the "
@@ -811,7 +824,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 )
 
         # Validate total tokens (input + max_new_tokens)
-        max_new_tokens = obj.sampling_params.get("max_new_tokens")
         if (
             self.validate_total_tokens
             and max_new_tokens is not None

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -790,7 +790,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
     ) -> None:
         """Validates that the input token count and the requested token count doesn't exceed the model's context length."""
         # FIXME: unify the length validation logic with the one in the scheduler.
-        _max_req_len = self.context_len
+        scheduler_max_req_len = max(self.context_len - 1, 0)
+        _max_req_len = max(scheduler_max_req_len - 1, 0)
         input_ids_len = len(input_ids) if input_ids is not None else 0
         input_token_num = input_ids_len + self.num_reserved_tokens
         max_new_tokens = obj.sampling_params.get("max_new_tokens")
@@ -798,11 +799,24 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         # Validate input length
         if input_token_num >= self.context_len:
             if self.server_args.allow_auto_truncate:
-                reserved_generation_tokens = (
-                    max_new_tokens
-                    if self.validate_total_tokens and max_new_tokens is not None
-                    else 0
-                )
+                reserved_generation_tokens = 0
+                if self.validate_total_tokens and max_new_tokens is not None:
+                    max_reservable_generation_tokens = max(
+                        0,
+                        _max_req_len - self.num_reserved_tokens,
+                    )
+                    # Keep at least one prompt token when possible instead of letting an
+                    # oversized max_new_tokens value wipe out the entire input before the
+                    # later scheduler-aligned clamp runs.
+                    if input_ids_len > 0 and max_reservable_generation_tokens > 0:
+                        max_reservable_generation_tokens = max(
+                            max_reservable_generation_tokens - 1,
+                            0,
+                        )
+                    reserved_generation_tokens = min(
+                        max_new_tokens,
+                        max_reservable_generation_tokens,
+                    )
                 truncated_input_len = max(
                     0,
                     _max_req_len

--- a/test/manual/test_tokenizer_manager.py
+++ b/test/manual/test_tokenizer_manager.py
@@ -432,7 +432,7 @@ class TestTokenizerRequestValidation(unittest.TestCase):
 
         self.tokenizer_manager._validate_one_request(req, input_ids)
 
-        self.assertEqual(len(input_ids), 12)
+        self.assertEqual(len(input_ids), 10)
         self.assertEqual(req.sampling_params["max_new_tokens"], 4)
 
     def test_auto_truncate_accounts_for_reserved_tokens(self):
@@ -442,8 +442,17 @@ class TestTokenizerRequestValidation(unittest.TestCase):
 
         self.tokenizer_manager._validate_one_request(req, input_ids)
 
-        self.assertEqual(len(input_ids), 10)
+        self.assertEqual(len(input_ids), 8)
         self.assertEqual(req.sampling_params["max_new_tokens"], 4)
+
+    def test_auto_truncate_does_not_drop_entire_prompt_for_oversized_generation(self):
+        req = GenerateReqInput(text="hello", sampling_params={"max_new_tokens": 100})
+        input_ids = list(range(20))
+
+        self.tokenizer_manager._validate_one_request(req, input_ids)
+
+        self.assertEqual(len(input_ids), 1)
+        self.assertEqual(req.sampling_params["max_new_tokens"], 13)
 
 
 if __name__ == "__main__":

--- a/test/manual/test_tokenizer_manager.py
+++ b/test/manual/test_tokenizer_manager.py
@@ -14,6 +14,7 @@ python3 -m unittest test_tokenizer_manager.TestTokenizerManagerIntegration
 import unittest
 from unittest.mock import Mock, patch
 
+from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.managers.tokenizer_manager import InputFormat, TokenizerManager
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
@@ -402,6 +403,47 @@ class TestTokenizerManagerIntegration(unittest.TestCase):
             result_input_ids, [[101, 7592, 102], [101, 2088, 102], [101, 2774, 102]]
         )
         self.assertIsNone(result_token_type_ids)
+
+
+class TestTokenizerRequestValidation(unittest.TestCase):
+    """Test request length validation and auto truncation behavior."""
+
+    def setUp(self):
+        with patch("sglang.srt.utils.get_device", return_value="cpu"):
+            self.server_args = ServerArgs(model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
+            self.server_args.allow_auto_truncate = True
+            self.port_args = PortArgs.init_new(self.server_args)
+
+        with patch("zmq.asyncio.Context"), patch(
+            "sglang.srt.utils.get_zmq_socket"
+        ), patch(
+            "sglang.srt.utils.hf_transformers_utils.get_tokenizer"
+        ) as mock_tokenizer:
+            mock_tokenizer.return_value = Mock(vocab_size=32000)
+            self.tokenizer_manager = TokenizerManager(self.server_args, self.port_args)
+
+        self.tokenizer_manager.context_len = 16
+        self.tokenizer_manager.validate_total_tokens = True
+        self.tokenizer_manager.num_reserved_tokens = 0
+
+    def test_auto_truncate_preserves_requested_generation_space(self):
+        req = GenerateReqInput(text="hello", sampling_params={"max_new_tokens": 4})
+        input_ids = list(range(20))
+
+        self.tokenizer_manager._validate_one_request(req, input_ids)
+
+        self.assertEqual(len(input_ids), 12)
+        self.assertEqual(req.sampling_params["max_new_tokens"], 4)
+
+    def test_auto_truncate_accounts_for_reserved_tokens(self):
+        self.tokenizer_manager.num_reserved_tokens = 2
+        req = GenerateReqInput(text="hello", sampling_params={"max_new_tokens": 4})
+        input_ids = list(range(20))
+
+        self.tokenizer_manager._validate_one_request(req, input_ids)
+
+        self.assertEqual(len(input_ids), 10)
+        self.assertEqual(req.sampling_params["max_new_tokens"], 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reserve generation space when `--allow-auto-truncate` trims an overlong prompt
- keep `max_new_tokens` unchanged when the prompt can be truncated to fit
- add regression tests for requested generation space and reserved tokens

## Root Cause
`TokenizerManager._validate_one_request()` truncated overlong prompts to the full context length before checking `max_new_tokens`. With `--allow-auto-truncate`, that left no room for generation, so the follow-up total-token validation could clamp `max_new_tokens` to zero even when the user requested output tokens.

## Fix
When auto truncation is enabled, truncate `input_ids` to leave room for both reserved tokens and the requested `max_new_tokens` before running the total-token validation.

## Testing
- `python -m py_compile python/sglang/srt/managers/tokenizer_manager.py test/manual/test_tokenizer_manager.py`
- `python -m unittest test/manual/test_tokenizer_manager.py` *(blocked locally because this environment is missing optional Python dependencies such as `pybase64` / `IPython` needed during import)*

Fixes #21136
