### PR TITLE
feat: support cross-attn cuda graph for whisper

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1053,11 +1053,17 @@ class FlashInferIndicesUpdaterDecode:
                 # Normal attention
                 paged_kernel_lens = seq_lens
                 kv_start_idx = encoder_lens
+                paged_kernel_lens_cpu = seq_lens_cpu
             else:
                 # Cross attention
                 paged_kernel_lens = encoder_lens
                 kv_start_idx = torch.zeros_like(encoder_lens)
                 seq_lens_sum = encoder_lens.sum().item()
+                paged_kernel_lens_cpu = (
+                    encoder_lens.to(device="cpu", non_blocking=False)
+                    if encoder_lens is not None
+                    else None
+                )
 
             self.call_begin_forward(
                 decode_wrappers[wrapper_id],
@@ -1067,7 +1073,7 @@ class FlashInferIndicesUpdaterDecode:
                 self.kv_indptr[wrapper_id],
                 kv_start_idx,
                 spec_info,
-                seq_lens_cpu=seq_lens_cpu,
+                seq_lens_cpu=paged_kernel_lens_cpu,
             )
 
     def call_begin_forward(

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -259,49 +259,19 @@ class DecodeInputBuffers(ForwardInputBuffers):
         raw_num_token: int,
         bs: int,
         seq_len_fill_value: int,
-        encoder_len_fill_value: int,
         require_gathered_buffer: bool,
         num_tokens_per_bs: int,
         nsa_enable_prefill_cp: bool,
         enable_num_token_non_padded_flag: bool,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
-        max_num_token = bs * num_tokens_per_bs
         if bs != raw_bs:
             self.seq_lens.fill_(seq_len_fill_value)
             self.out_cache_loc.zero_()
-            if self.encoder_lens is not None:
-                self.encoder_lens.fill_(encoder_len_fill_value)
             if self.mamba_track_indices is not None:
                 self.mamba_track_indices.zero_()
             if self.mamba_track_mask is not None:
                 self.mamba_track_mask.fill_(False)
-
-            # Replay kernels still see the padded slots at capture batch size.
-            # Point them at a known-live request row instead of leaving stale
-            # req_pool_indices from a previous larger replay in place.
-            if raw_bs > 0:
-                self.req_pool_indices[raw_bs:bs].copy_(
-                    forward_batch.req_pool_indices[:1].expand(bs - raw_bs)
-                )
-            else:
-                self.req_pool_indices.zero_()
-
-            if raw_num_token < max_num_token:
-                if raw_num_token > 0:
-                    self.input_ids[raw_num_token:max_num_token].copy_(
-                        forward_batch.input_ids[:1].expand(
-                            max_num_token - raw_num_token
-                        )
-                    )
-                    self.positions[raw_num_token:max_num_token].copy_(
-                        forward_batch.positions[:1].expand(
-                            max_num_token - raw_num_token
-                        )
-                    )
-                else:
-                    self.input_ids.zero_()
-                    self.positions.zero_()
 
         # Build batched copy lists for all GPU tensors.
         dsts = [
@@ -619,7 +589,6 @@ class CudaGraphRunner:
             if self.dllm_config is None
             else self.dllm_config.block_size
         )
-
         self.encoder_len_fill_value = 0
         if self.is_encoder_decoder:
             self.encoder_len_fill_value = int(
@@ -1120,7 +1089,6 @@ class CudaGraphRunner:
             raw_num_token=raw_num_token,
             bs=bs,
             seq_len_fill_value=self.seq_len_fill_value,
-            encoder_len_fill_value=self.encoder_len_fill_value,
             require_gathered_buffer=self.require_gathered_buffer,
             num_tokens_per_bs=self.num_tokens_per_bs,
             nsa_enable_prefill_cp=self.nsa_enable_prefill_cp,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -259,19 +259,47 @@ class DecodeInputBuffers(ForwardInputBuffers):
         raw_num_token: int,
         bs: int,
         seq_len_fill_value: int,
+        encoder_len_fill_value: int,
         require_gathered_buffer: bool,
         num_tokens_per_bs: int,
         nsa_enable_prefill_cp: bool,
         enable_num_token_non_padded_flag: bool,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
+        max_num_token = bs * num_tokens_per_bs
         if bs != raw_bs:
             self.seq_lens.fill_(seq_len_fill_value)
             self.out_cache_loc.zero_()
+            if self.encoder_lens is not None:
+                self.encoder_lens.fill_(encoder_len_fill_value)
             if self.mamba_track_indices is not None:
                 self.mamba_track_indices.zero_()
             if self.mamba_track_mask is not None:
                 self.mamba_track_mask.fill_(False)
+
+            # Replay kernels still see the padded slots at capture batch size.
+            # Point them at a known-live request row instead of leaving stale
+            # req_pool_indices from a previous larger replay in place.
+            if raw_bs > 0:
+                self.req_pool_indices[raw_bs:bs].copy_(
+                    forward_batch.req_pool_indices[:1].expand(bs - raw_bs)
+                )
+            else:
+                self.req_pool_indices.zero_()
+
+            if raw_num_token < max_num_token:
+                if raw_num_token > 0:
+                    self.input_ids[raw_num_token:max_num_token].copy_(
+                        forward_batch.input_ids[:1].expand(max_num_token - raw_num_token)
+                    )
+                    self.positions[raw_num_token:max_num_token].copy_(
+                        forward_batch.positions[:1].expand(
+                            max_num_token - raw_num_token
+                        )
+                    )
+                else:
+                    self.input_ids.zero_()
+                    self.positions.zero_()
 
         # Build batched copy lists for all GPU tensors.
         dsts = [
@@ -591,6 +619,14 @@ class CudaGraphRunner:
         )
 
         self.encoder_len_fill_value = 0
+        if self.is_encoder_decoder:
+            self.encoder_len_fill_value = int(
+                getattr(
+                    self.model_runner.model_config.hf_config,
+                    "max_source_positions",
+                    1,
+                )
+            )
 
         if self.enable_torch_compile:
             set_torch_compile_config()
@@ -1082,6 +1118,7 @@ class CudaGraphRunner:
             raw_num_token=raw_num_token,
             bs=bs,
             seq_len_fill_value=self.seq_len_fill_value,
+            encoder_len_fill_value=self.encoder_len_fill_value,
             require_gathered_buffer=self.require_gathered_buffer,
             num_tokens_per_bs=self.num_tokens_per_bs,
             nsa_enable_prefill_cp=self.nsa_enable_prefill_cp,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -119,7 +119,6 @@ def _grouped_foreach_copy_(dsts: List[torch.Tensor], srcs: List[torch.Tensor]) -
 
 @dataclass
 class DecodeInputBuffers(ForwardInputBuffers):
-
     input_ids: torch.Tensor
     input_embeds: torch.Tensor
     req_pool_indices: torch.Tensor
@@ -436,7 +435,6 @@ def patch_model(
 
 
 def set_torch_compile_config():
-    import torch._dynamo.config
     import torch._inductor.config
 
     torch._inductor.config.coordinate_descent_tuning = True
@@ -589,7 +587,6 @@ class CudaGraphRunner:
             if self.dllm_config is None
             else self.dllm_config.block_size
         )
-        self.encoder_len_fill_value = 0
         if self.is_encoder_decoder:
             self.encoder_len_fill_value = int(
                 getattr(
@@ -598,6 +595,8 @@ class CudaGraphRunner:
                     1,
                 )
             )
+        else:
+            self.encoder_len_fill_value = 0
 
         if self.enable_torch_compile:
             set_torch_compile_config()

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -290,7 +290,9 @@ class DecodeInputBuffers(ForwardInputBuffers):
             if raw_num_token < max_num_token:
                 if raw_num_token > 0:
                     self.input_ids[raw_num_token:max_num_token].copy_(
-                        forward_batch.input_ids[:1].expand(max_num_token - raw_num_token)
+                        forward_batch.input_ids[:1].expand(
+                            max_num_token - raw_num_token
+                        )
                     )
                     self.positions[raw_num_token:max_num_token].copy_(
                         forward_batch.positions[:1].expand(

--- a/python/sglang/srt/models/whisper.py
+++ b/python/sglang/srt/models/whisper.py
@@ -99,65 +99,16 @@ class WhisperAttention(torch.nn.Module):
                 kv, _ = self.kv_proj(cross_hidden_states)
                 k, v = kv.split([self.kv_size, self.kv_size], dim=-1)
             else:
-                k = torch.zeros_like(q)
-                v = torch.zeros_like(q)
+                k = None
+                v = None
 
             q = q * self.scaling
-            num_heads = self.attn.tp_q_head_num
-            head_dim = self.attn.head_dim
+            q = q.view(-1, self.attn.tp_q_head_num, self.attn.head_dim)
+            if k is not None:
+                k = k.view(-1, self.attn.tp_k_head_num, self.attn.qk_head_dim)
+                v = v.view(-1, self.attn.tp_v_head_num, self.attn.v_head_dim)
 
-            q = q.view(-1, num_heads, head_dim)
-            k = k.view(-1, num_heads, head_dim)
-            v = v.view(-1, num_heads, head_dim)
-
-            q_len = q.shape[0]
-            kv_len = k.shape[0]
-
-            q = q.transpose(0, 1)
-            k = k.transpose(0, 1)
-            v = v.transpose(0, 1)
-
-            attn_weights = torch.bmm(q, k.transpose(1, 2))
-
-            # Apply block-diagonal mask for batched cross-attention
-            batch_size = forward_batch.batch_size if forward_batch else 1
-            if batch_size > 1 and kv_len > 0:
-                encoder_len_per_request = kv_len // batch_size
-                if encoder_len_per_request * batch_size == kv_len:
-                    is_decode = forward_batch.forward_mode.is_decode()
-                    if is_decode:
-                        mask = torch.zeros(
-                            (q_len, kv_len), device=q.device, dtype=torch.bool
-                        )
-                        for i in range(batch_size):
-                            enc_start = i * encoder_len_per_request
-                            enc_end = (i + 1) * encoder_len_per_request
-                            mask[i, enc_start:enc_end] = True
-                        attn_weights = attn_weights.masked_fill(
-                            ~mask.unsqueeze(0), float("-inf")
-                        )
-                    else:
-                        seq_lens = forward_batch.seq_lens
-                        if seq_lens is not None and len(seq_lens) == batch_size:
-                            seq_lens_list = seq_lens.tolist()
-                            mask = torch.zeros(
-                                (q_len, kv_len), device=q.device, dtype=torch.bool
-                            )
-                            q_start = 0
-                            for i, dec_len in enumerate(seq_lens_list):
-                                enc_start = i * encoder_len_per_request
-                                enc_end = (i + 1) * encoder_len_per_request
-                                q_end = q_start + dec_len
-                                mask[q_start:q_end, enc_start:enc_end] = True
-                                q_start = q_end
-                            attn_weights = attn_weights.masked_fill(
-                                ~mask.unsqueeze(0), float("-inf")
-                            )
-
-            attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1)
-            attn_output = torch.bmm(attn_weights, v)
-            attn_output = attn_output.transpose(0, 1)
-            attn_output = attn_output.reshape(q_len, num_heads * head_dim)
+            attn_output = self.attn(q, k, v, forward_batch)
         else:
             qkv, _ = self.qkv_proj(hidden_states)
             q, k, v = qkv.chunk(chunks=3, dim=-1)
@@ -313,7 +264,6 @@ class WhisperDecoderLayer(torch.nn.Module):
 
 
 class WhisperEncoder(torch.nn.Module):
-
     def __init__(
         self, config: WhisperConfig, quant_config: Optional[QuantizationConfig] = None
     ):
@@ -361,7 +311,6 @@ class WhisperEncoder(torch.nn.Module):
 
 
 class WhisperDecoder(torch.nn.Module):
-
     def __init__(
         self, config: WhisperConfig, quant_config: Optional[QuantizationConfig] = None
     ):
@@ -408,7 +357,6 @@ class WhisperDecoder(torch.nn.Module):
 
 
 class WhisperForConditionalGeneration(torch.nn.Module):
-
     def __init__(
         self, config: WhisperConfig, quant_config: Optional[QuantizationConfig] = None
     ):
@@ -420,7 +368,6 @@ class WhisperForConditionalGeneration(torch.nn.Module):
         )
         self.logits_processor = LogitsProcessor(config)
         self.config = config
-        self._encoder_cache = {}
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
@@ -468,8 +415,74 @@ class WhisperForConditionalGeneration(torch.nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 
-    def pad_input_ids(self, input_ids: List[int], _mm_inputs: MultimodalInputs):
-        return input_ids
+    def _get_encoder_len(self, mm_inputs: Optional[MultimodalInputs]) -> int:
+        if mm_inputs is None or not mm_inputs.mm_items:
+            return 0
+        return self.config.max_source_positions
+
+    def _batch_audio_inputs(
+        self, forward_batch: ForwardBatch
+    ) -> tuple[Optional[torch.Tensor], List[int]]:
+        if (
+            forward_batch.forward_mode.is_decode()
+            or not forward_batch.mm_inputs
+            or all(forward_batch.encoder_cached)
+        ):
+            return None, []
+
+        batched_features = []
+        encoder_lens_need = []
+        for i, mm_input in enumerate(forward_batch.mm_inputs):
+            if (
+                forward_batch.encoder_cached[i]
+                or mm_input is None
+                or not mm_input.mm_items
+            ):
+                continue
+
+            features = mm_input.mm_items[0].feature
+            if features.ndim == 2:
+                features = features.unsqueeze(0)
+
+            batched_features.append(features)
+            encoder_lens_need.append(int(forward_batch.encoder_lens[i].item()))
+
+        if not batched_features:
+            return None, []
+
+        return torch.cat(batched_features, dim=0), encoder_lens_need
+
+    def _flatten_encoder_outputs(
+        self, encoder_outputs: torch.Tensor, encoder_lens_need: List[int]
+    ) -> torch.Tensor:
+        hidden_size = encoder_outputs.shape[-1]
+        total_encoder_len = sum(encoder_lens_need)
+        encoder_outputs_flat = torch.zeros(
+            total_encoder_len,
+            hidden_size,
+            device=encoder_outputs.device,
+            dtype=encoder_outputs.dtype,
+        )
+
+        i = start_pos = 0
+        for encoder_len in encoder_lens_need:
+            if encoder_len == 0:
+                continue
+            end_pos = start_pos + encoder_len
+            encoder_outputs_flat[start_pos:end_pos] = encoder_outputs[i, :encoder_len]
+            i += 1
+            start_pos += encoder_len
+
+        return encoder_outputs_flat
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        encoder_len = self._get_encoder_len(mm_inputs)
+        if encoder_len == 0:
+            return input_ids
+
+        mm_inputs.num_image_tokens = encoder_len
+        pad_id = self.config.pad_token_id if self.config.pad_token_id is not None else 0
+        return [pad_id] * encoder_len + input_ids
 
     def forward(
         self,
@@ -479,52 +492,23 @@ class WhisperForConditionalGeneration(torch.nn.Module):
         **kwargs: Any,
     ) -> LogitsProcessorOutput:
         dtype = self.encoder.conv1.weight.dtype
-        is_decode = forward_batch.forward_mode.is_decode()
-
-        if is_decode:
-            encoder_outputs = None
-            if forward_batch.req_pool_indices is not None:
-                req_indices = forward_batch.req_pool_indices.tolist()
-                encoder_list = []
-                for req_idx in req_indices:
-                    if req_idx in self._encoder_cache:
-                        encoder_list.append(self._encoder_cache[req_idx])
-                if encoder_list:
-                    encoder_outputs = torch.cat(encoder_list, dim=0)
-        else:
-            encoder_list = []
-            mm_inputs_list = forward_batch.mm_inputs if forward_batch.mm_inputs else []
-            req_indices = (
-                forward_batch.req_pool_indices.tolist()
-                if forward_batch.req_pool_indices is not None
-                else []
+        encoder_outputs = None
+        batched_audio_features, encoder_lens_need = self._batch_audio_inputs(
+            forward_batch
+        )
+        if batched_audio_features is not None:
+            encoder_position_ids = torch.arange(
+                self.config.max_source_positions,
+                device=batched_audio_features.device,
             )
-
-            for req_idx, mm_input in zip(req_indices, mm_inputs_list):
-                if mm_input is None or not mm_input.mm_items:
-                    continue
-
-                features = mm_input.mm_items[0].feature
-                if features.ndim == 2:
-                    features = features.unsqueeze(0)
-
-                encoder_len = features.shape[-1] // 2
-                encoder_position_ids = torch.arange(encoder_len).to(
-                    features.device, non_blocking=True
-                )
-
-                req_encoder_outputs = self.encoder(
-                    features.to(dtype), encoder_position_ids, forward_batch
-                )
-                req_encoder_outputs = req_encoder_outputs.squeeze(0)
-
-                self._encoder_cache[req_idx] = req_encoder_outputs
-                encoder_list.append(req_encoder_outputs)
-
-            if encoder_list:
-                encoder_outputs = torch.cat(encoder_list, dim=0)
-            else:
-                encoder_outputs = None
+            encoder_outputs = self.encoder(
+                batched_audio_features.to(dtype),
+                encoder_position_ids,
+                forward_batch,
+            )
+            encoder_outputs = self._flatten_encoder_outputs(
+                encoder_outputs, encoder_lens_need
+            )
 
         decoder_outputs = self.decoder(
             input_ids, encoder_outputs, forward_batch, positions

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2256,12 +2256,30 @@ class ServerArgs:
                 self.speculative_algorithm is None
             ), "Speculative decoding is currently not supported with Flex Attention backend"
 
-        # Encoder-decoder models (e.g., Whisper)
+        # Whisper currently only supports cuda graph on the native flashinfer
+        # cross-attention path.
         if model_config.is_encoder_decoder:
-            logger.warning(
-                "Cuda graph is disabled for encoder-decoder models (e.g., Whisper)"
+            model_architectures = model_config.hf_config.architectures or []
+            is_whisper = "WhisperForConditionalGeneration" in model_architectures
+            effective_prefill_backend = (
+                self.prefill_attention_backend or self.attention_backend
             )
-            self.disable_cuda_graph = True
+            effective_decode_backend = (
+                self.decode_attention_backend or self.attention_backend
+            )
+            if not is_whisper:
+                logger.warning(
+                    "Cuda graph is disabled for non-Whisper encoder-decoder models"
+                )
+                self.disable_cuda_graph = True
+            elif (
+                effective_prefill_backend != "flashinfer"
+                or effective_decode_backend != "flashinfer"
+            ):
+                logger.warning(
+                    "Cuda graph is disabled for Whisper unless both prefill and decode attention backends are flashinfer"
+                )
+                self.disable_cuda_graph = True
 
         # Major NVIDIA platforms backends
         if (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Previously, whisper model use custom `bmm + mask` implementation of cross-attn, which make it in-compatible with cuda graph


## Motivation


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

 - Reworked cross-attention to use native `RadixAttention` path instead of the custom `bmm + mask` implementation.
  - Removed the Python-side Whisper encoder cache, switched encoder outputs to the native encoder-decoder cache flow managed by scheduler/attention backends.
  - Fixed CUDA graph replay padding for encoder-decoder batches by initializing replay buffers with valid encoder length metadata.
  - Narrowed CUDA graph enablement in `server_args`: explicitly allow Whisper only when both prefill and decode use`flashinfer`
  - Fixed `flashinfer` decode cross-attention CUDA-graph planning to use encoder-side CPU lengths, instead of incorrectly reusing decoder `seq_lens_cpu`

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
# launch server
$ sglang serve \
    --model-path openai/whisper-tiny \
    --attention-backend flashinfer \
    --host 0.0.0.0 \
    --port 31018 \
    --cuda-graph-max-bs 2

# benchmark
$ python benchmark/asr/bench_sglang.py \
    --base-url http://127.0.0.1:31011 \
    --model openai/whisper-tiny \
    --api-type transcription \
    --language en \
    --concurrency 1 \
    -n 100
```

  - no-cg: WER 176.8765, avg latency 0.0980s, throughput 8.96 req/s
  - cuda-graph: WER 176.8765, avg latency 0.0503s, throughput 15.60 req/s
  
  
  
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
