### PR TITLE
fix(scheduler): abort over-length embedding requests before enqueuing

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2011,6 +2011,7 @@ class Scheduler(
             self.server_args.allow_auto_truncate,
         )
         if error_msg:
+            req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
             return
 


### PR DESCRIPTION
## Summary

- `handle_embedding_request` does not call `req.set_finish_with_abort(error_msg)` when `validate_input_length()` returns an error, causing invalid requests to enter the scheduler
- This one-line fix matches the existing correct pattern in `handle_generate_request` (line 1764-1766)

Fixes #21168

## What changed

```diff
 if error_msg:
+    req.set_finish_with_abort(error_msg)
     self._add_request_to_queue(req)
     return
```

## Impact

Without this fix, an over-length embedding request is enqueued without being marked as aborted. The scheduler then attempts a forward pass on it, potentially causing illegal memory access or a server crash.