### PR TITLE
[BUGFIX] Fix CP residual size mismatch crash when tp_size == attn_cp_size 

### DIFF
--- a/python/sglang/srt/layers/communicator_nsa_cp.py
+++ b/python/sglang/srt/layers/communicator_nsa_cp.py
@@ -174,17 +174,21 @@ class NSACPCommunicateSummableTensorPairFn(CommunicateSummableTensorPairFn):
         output_mode: ScatterMode,
         context: CommunicateContext,
     ):
-        if context.is_same_group_size(
-            hidden_states_input_mode, output_mode
-        ) and context.is_same_group_size(residual_input_mode, output_mode):
-            return NSACPCommunicateSummableTensorPairFn._trivial
-
+        # Check exact enum match first: even if group sizes happen to be equal
+        # (e.g. tp_size == attn_cp_size makes FULL and SCATTERED both size 1),
+        # FULL and SCATTERED have different data layouts under CP and require
+        # an explicit scatter operation.
         if (
             (hidden_states_input_mode == ScatterMode.FULL)
             and (residual_input_mode == ScatterMode.SCATTERED)
             and (output_mode == ScatterMode.SCATTERED)
         ):
             return NSACPCommunicateSummableTensorPairFn._scatter_hidden_states
+
+        if context.is_same_group_size(
+            hidden_states_input_mode, output_mode
+        ) and context.is_same_group_size(residual_input_mode, output_mode):
+            return NSACPCommunicateSummableTensorPairFn._trivial
 
         raise NotImplementedError(
             f"{hidden_states_input_mode=} {residual_input_mode=} {output_mode=}"


### PR DESCRIPTION
## Problem                                                                                                                                                                       
                                         
  After merging commit bb737d7a829bac8fb6386fb6f494e1b2403c598f https://github.com/sgl-project/sglang/pull/18233, GLM-5/DS-V3.2 with context parallelism (CP) crashes during inference with:

  RuntimeError: Check failed: residual.size(0) == batch_size (885 vs. 7080)

```
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468] Scheduler hit an exception: Traceback (most recent call last):
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 3464, in run_scheduler_process
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     scheduler.run_event_loop()
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1248, in run_event_loop
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     dispatch_event_loop(self)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 3340, in dispatch_event_loop
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     scheduler.event_loop_overlap()
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return func(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1309, in event_loop_overlap
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     batch_result = self.run_batch(batch)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 2561, in run_batch
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     batch_result = self.model_worker.forward_batch_generation(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/speculative/eagle_worker_v2.py", line 697, in forward_batch_generation
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     batch_output = self.target_worker.forward_batch_generation(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 472, in forward_batch_generation
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     out = self.model_runner.forward(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2656, in forward
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     output = self._forward_raw(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2762, in _forward_raw
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     ret, can_run_graph = self.forward_extend(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2593, in forward_extend
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     self.model.forward(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return func(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/deepseek_v2.py", line 2203, in forward
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     hidden_states = self.model(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return self._call_impl(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return forward_call(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/deepseek_v2.py", line 2014, in forward
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     hidden_states, residual = layer(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return self._call_impl(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return forward_call(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/deepseek_v2.py", line 1665, in forward
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     hidden_states, residual = self.layer_communicator.prepare_attn(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/communicator.py", line 532, in prepare_attn
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     hidden_states, residual = self.input_layernorm(
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return self._call_impl(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return forward_call(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/utils/multi_platform.py", line 73, in forward
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     return self._forward_method(*args, **kwargs)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/layernorm.py", line 205, in forward_cuda
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     fused_add_rmsnorm(x, residual, self.weight.data, self.variance_epsilon)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/sgl_kernel/elementwise.py", line 166, in fused_add_rmsnorm
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     _flashinfer_norm.fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/flashinfer/norm.py", line 180, in fused_add_rmsnorm
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     get_norm_module().fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "python/tvm_ffi/cython/function.pxi", line 923, in tvm_ffi.core.Function.__call__
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "<unknown>", line 0, in __tvm_ffi_fused_add_rmsnorm
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]   File "/opt/conda/lib/python3.10/site-packages/flashinfer/data/csrc/norm.cu", line 129, in void fused_add_rmsnorm(tvm::ffi::TensorView, tvm::ffi::TensorView, tvm::ffi::TensorView, double, bool)
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468]     TVM_FFI_ICHECK_EQ(residual.size(0), batch_size);
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468] RuntimeError: Check failed: residual.size(0) == batch_size (885 vs. 7080) : 
2026-03-23 01:10:21.463 ERROR 502747 [ ATTN_CP4 TP4 scheduler.py:3468] 
```

  The 8x mismatch corresponds exactly to ```--attn-cp-size 8```.

## Root Cause

  Commit bb737d7a829bac8fb6386fb6f494e1b2403c598f changed the ```ScatterMode.FULL``` process group size from ```tp_size``` to ```tp_size // attn_cp_size``` in ```CommunicateContext.init_new()```. This is conceptually correct with CP enabled, the effective "full" group excludes CP ranks.

<img width="1065" height="252" alt="image" src="https://github.com/user-attachments/assets/c4afb8b4-7c84-4788-af54-79d569f4badd" />


  However, ```when tp_size == attn_cp_size``` (e.g. both equal 8), this makes ```FULL``` and ```SCATTERED``` have the same group size of 1. In ```NSACPCommunicateSummableTensorPairFn.get_fn()```, the routing logic uses ```is_same_group_size()``` to decide whether communication is needed. With both sizes equal, it incorrectly returns ```_trivial``` (no-op) instead of ```_scatter_hidden_states```, skipping the CP reduce-scatter of ```hidden_states``` after MLP.

  This causes the following cascade:
  1. ```prepare_mlp()``` all-gathers ```hidden_states``` to full size (7080) while ```residual``` stays CP-local (885).
  2. ```postprocess_layer()``` should reduce-scatter ```hidden_states``` back, but ```_trivial``` passes it through unchanged.
  3. Next layer's ```prepare_attn()``` receives mismatched tensors: ```hidden_states``` at full size (7080) vs ```residual``` at CP-local size (885).
  4. ```fused_add_rmsnorm``` asserts on the size mismatch.

## Fix

  Reorder the checks in ```NSACPCommunicateSummableTensorPairFn.get_fn()``` so that the exact enum match for ```FULL → SCATTERED``` is evaluated before the group-size-based shortcut. Even when group sizes coincide, ```FULL``` and ```SCATTERED``` represent fundamentally different data layouts under CP and require an explicit scatter operation.