### PR TITLE
fix(grammar): properly abort request on accept_token failure

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -10,7 +10,6 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.routed_experts_capturer import get_global_experts_capturer
 from sglang.srt.managers.io_struct import (
-    AbortReq,
     BatchEmbeddingOutput,
     BatchTokenIDOutput,
 )

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -15,6 +15,7 @@ from sglang.srt.managers.io_struct import (
     BatchTokenIDOutput,
 )
 from sglang.srt.managers.schedule_batch import (
+    FINISH_ABORT,
     BaseFinishReason,
     Req,
     ScheduleBatch,
@@ -226,7 +227,10 @@ class SchedulerOutputProcessorMixin:
                             logger.error(
                                 f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
                             )
-                            self.abort_request(AbortReq(rid=req.rid))
+                            req.to_finish = FINISH_ABORT(
+                                message=f"Grammar accept_token failed: {e}"
+                            )
+                            continue
                         req.grammar.finished = req.finished()
 
                 else:
@@ -509,7 +513,10 @@ class SchedulerOutputProcessorMixin:
                     logger.error(
                         f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
                     )
-                    self.abort_request(AbortReq(rid=req.rid))
+                    req.to_finish = FINISH_ABORT(
+                        message=f"Grammar accept_token failed: {e}"
+                    )
+                    continue
                 req.grammar.finished = req.finished()
 
         self.stream_output(batch.reqs, batch.return_logprob)


### PR DESCRIPTION
## Summary

- Replace ineffective `abort_request()` with `req.to_finish = FINISH_ABORT(...)` when `grammar.accept_token()` fails
- Add `continue` to prevent accessing corrupted grammar state after the error
- Applied to both prefill and decode paths

Fixes #21171

## What changed

In both prefill and decode paths of `scheduler_output_processor_mixin.py`:

```diff
 except ValueError as e:
     logger.error(...)
-    self.abort_request(AbortReq(rid=req.rid))
- req.grammar.finished = req.finished()
+    req.to_finish = FINISH_ABORT(
+        message=f"Grammar accept_token failed: {e}"
+    )
+    continue
+ req.grammar.finished = req.finished()
```

## Why

`abort_request()` only handles requests in the waiting/grammar queue — it is a no-op for requests already in the running batch. `req.to_finish = FINISH_ABORT(...)` is the correct mechanism used elsewhere in the scheduler (e.g., `scheduler.py:1204`, `scheduler.py:3069`) to mark running requests for cleanup.

Without the `continue`, `req.grammar.finished = req.finished()` accesses the grammar in a corrupted state after a partial accept failure.