### PR TITLE
fix(tokenizer_manager): guard _handle_abort_req against missing rid

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2160,7 +2160,9 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
     def _handle_abort_req(self, recv_obj: AbortReq):
         if is_health_check_generate_req(recv_obj):
             return
-        state = self.rid_to_state[recv_obj.rid]
+        state = self.rid_to_state.get(recv_obj.rid)
+        if state is None:
+            return
         state.finished = True
         state.time_stats.set_finished_time()
 


### PR DESCRIPTION
## Summary

- Use `.get()` instead of direct dict access in `_handle_abort_req` to prevent `KeyError` when the request has already been cleaned up
- Consistent with the safe access pattern already used in `_handle_batch_output`

Fixes #21173

## What changed

```diff
- state = self.rid_to_state[recv_obj.rid]
+ state = self.rid_to_state.get(recv_obj.rid)
+ if state is None:
+     return
```