### PR TITLE
[Bug] Preserve DeepSeek-V3.2 tool-call markers in reasoning parsing

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Type
+from typing import Dict, Optional, Tuple, Type, Union
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import dsml_token
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
@@ -26,7 +26,7 @@ class BaseReasoningFormatDetector:
         think_end_token: str,
         force_reasoning: bool = False,
         stream_reasoning: bool = True,
-        tool_start_token: Optional[str] = None,
+        tool_start_token: Optional[Union[str, Tuple[str, ...]]] = None,
         continue_final_message: bool = False,
         previous_content: str = "",
     ):
@@ -52,6 +52,31 @@ class BaseReasoningFormatDetector:
         if self.think_end_token in self.previous_content:
             self._in_reasoning = False
 
+    def _tool_start_tokens(self) -> Tuple[str, ...]:
+        if self.tool_start_token is None:
+            return ()
+        if isinstance(self.tool_start_token, tuple):
+            return self.tool_start_token
+        return (self.tool_start_token,)
+
+    def _find_tool_start(self, text: str) -> Optional[Tuple[int, str]]:
+        matches = [
+            (idx, token)
+            for token in self._tool_start_tokens()
+            if (idx := text.find(token)) != -1
+        ]
+        return min(matches, key=lambda match: match[0]) if matches else None
+
+    def _find_partial_tool_start_suffix_len(self, text: str) -> int:
+        longest = 0
+        for token in self._tool_start_tokens():
+            max_prefix_len = min(len(text), len(token) - 1)
+            for prefix_len in range(max_prefix_len, 0, -1):
+                if text.endswith(token[:prefix_len]):
+                    longest = max(longest, prefix_len)
+                    break
+        return longest
+
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         """
         One-time parsing: Detects and parses reasoning sections in the provided text.
@@ -70,13 +95,10 @@ class BaseReasoningFormatDetector:
             and self.think_end_token not in self.previous_content
         ):
             # Check for tool_start_token interruption
-            if (
-                in_reasoning
-                and self.tool_start_token is not None
-                and self.tool_start_token in processed_text
-            ):
+            tool_match = self._find_tool_start(processed_text) if in_reasoning else None
+            if tool_match is not None:
                 # Find the first occurrence of tool_start_token and split there
-                tool_idx = processed_text.find(self.tool_start_token)
+                tool_idx, _ = tool_match
                 reasoning_text = processed_text[:tool_idx].strip()
                 # Preserve tool_start_token in normal text
                 normal_text = processed_text[tool_idx:]
@@ -114,8 +136,7 @@ class BaseReasoningFormatDetector:
 
         # If the current text is a prefix of the think token, keep buffering
         tokens_to_check = [self.think_start_token, self.think_end_token]
-        if self.tool_start_token:
-            tokens_to_check.append(self.tool_start_token)
+        tokens_to_check.extend(self._tool_start_tokens())
         if any(
             token.startswith(current_text) and token != current_text
             for token in tokens_to_check
@@ -145,8 +166,9 @@ class BaseReasoningFormatDetector:
         # Continue with reasoning content
         if self._in_reasoning:
             # Check for tool_start_token interruption
-            if self.tool_start_token and self.tool_start_token in current_text:
-                tool_idx = current_text.find(self.tool_start_token)
+            tool_match = self._find_tool_start(current_text)
+            if tool_match is not None:
+                tool_idx, _ = tool_match
                 reasoning_text = current_text[:tool_idx]
                 # Preserve tool_start_token in normal text
                 normal_text = current_text[tool_idx:]
@@ -156,6 +178,13 @@ class BaseReasoningFormatDetector:
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
             if self.stream_reasoning:
+                partial_tool_prefix_len = self._find_partial_tool_start_suffix_len(
+                    current_text
+                )
+                if partial_tool_prefix_len:
+                    reasoning_text = current_text[:-partial_tool_prefix_len]
+                    self._buffer = current_text[-partial_tool_prefix_len:]
+                    return StreamingParseResult(reasoning_text=reasoning_text)
                 # Stream the content immediately
                 self._buffer = ""
                 return StreamingParseResult(reasoning_text=current_text)
@@ -264,7 +293,10 @@ class DeepSeekV3Detector(BaseReasoningFormatDetector):
             "</think>",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
-            tool_start_token=f"<{dsml_token}function_calls>",
+            tool_start_token=(
+                f"<{dsml_token}function_calls>",
+                f"\n\n<{dsml_token}function_calls>",
+            ),
             continue_final_message=continue_final_message,
             previous_content=previous_content,
         )

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Tuple, Type
 
+from sglang.srt.entrypoints.openai.encoding_dsv32 import dsml_token
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.parser.harmony_parser import HarmonyParser
 
@@ -242,6 +243,33 @@ class Qwen3Detector(BaseReasoningFormatDetector):
         )
 
 
+class DeepSeekV3Detector(BaseReasoningFormatDetector):
+    """
+    Detector for DeepSeek-V3 style reasoning.
+
+    DeepSeek-V3.2 can switch from reasoning mode directly into a DSML function-call
+    block before emitting `</think>`, so the reasoning parser needs to preserve the
+    raw tool-call marker for the downstream function-call parser.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+    ):
+        super().__init__(
+            "<think>",
+            "</think>",
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            tool_start_token=f"<{dsml_token}function_calls>",
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+        )
+
+
 class KimiDetector(BaseReasoningFormatDetector):
     """
     Detector for Kimi Thinking model.
@@ -463,7 +491,7 @@ class ReasoningParser:
 
     DetectorMap: Dict[str, Type[BaseReasoningFormatDetector]] = {
         "deepseek-r1": DeepSeekR1Detector,
-        "deepseek-v3": Qwen3Detector,
+        "deepseek-v3": DeepSeekV3Detector,
         "glm45": Glm45Detector,
         "gpt-oss": GptOssDetector,
         "kimi": KimiDetector,

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1,8 +1,10 @@
 import unittest
 
+from sglang.srt.entrypoints.openai.encoding_dsv32 import dsml_token
 from sglang.srt.parser.reasoning_parser import (
     BaseReasoningFormatDetector,
     DeepSeekR1Detector,
+    DeepSeekV3Detector,
     Glm45Detector,
     KimiDetector,
     KimiK2Detector,
@@ -15,6 +17,9 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+
+DEEPSEEK_V32_TOOL_START = f"<{dsml_token}function_calls>"
 
 
 class TestStreamingParseResult(CustomTestCase):
@@ -219,6 +224,40 @@ class TestQwen3Detector(CustomTestCase):
         result = self.detector.detect_and_parse(text)
         self.assertEqual(result.normal_text, text)
         self.assertEqual(result.reasoning_text, "")
+
+
+class TestDeepSeekV3Detector(CustomTestCase):
+    def setUp(self):
+        self.detector = DeepSeekV3Detector()
+
+    def test_init(self):
+        """Test DeepSeekV3Detector initialization."""
+        self.assertEqual(self.detector.think_start_token, "<think>")
+        self.assertEqual(self.detector.think_end_token, "</think>")
+        self.assertEqual(self.detector.tool_start_token, DEEPSEEK_V32_TOOL_START)
+        self.assertFalse(self.detector._in_reasoning)
+
+    def test_detect_and_parse_tool_interrupt(self):
+        """Test parsing with DeepSeek-V3.2 DSML tool interruption."""
+        text = f"<think>thinking{DEEPSEEK_V32_TOOL_START}\n<tool payload>"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "thinking")
+        self.assertEqual(
+            result.normal_text, f"{DEEPSEEK_V32_TOOL_START}\n<tool payload>"
+        )
+
+    def test_parse_streaming_increment_tool_interrupt(self):
+        """Test streaming parsing preserves the DSML tool-call marker."""
+        self.detector.parse_streaming_increment("<think>")
+        reasoning = self.detector.parse_streaming_increment("thinking")
+        tool_call = self.detector.parse_streaming_increment(DEEPSEEK_V32_TOOL_START)
+        trailing = self.detector.parse_streaming_increment("\n<tool payload>")
+
+        self.assertEqual(reasoning.reasoning_text, "thinking")
+        self.assertEqual(tool_call.reasoning_text, "")
+        self.assertEqual(tool_call.normal_text, DEEPSEEK_V32_TOOL_START)
+        self.assertEqual(trailing.reasoning_text, "")
+        self.assertEqual(trailing.normal_text, "\n<tool payload>")
 
 
 class TestQwen3ForcedReasoningDetector(CustomTestCase):
@@ -644,10 +683,12 @@ class TestReasoningParser(CustomTestCase):
         parser1 = ReasoningParser("DeepSeek-R1")
         parser2 = ReasoningParser("QWEN3")
         parser3 = ReasoningParser("Kimi")
+        parser4 = ReasoningParser("DeepSeek-V3")
 
         self.assertIsInstance(parser1.detector, DeepSeekR1Detector)
         self.assertIsInstance(parser2.detector, Qwen3Detector)
         self.assertIsInstance(parser3.detector, KimiDetector)
+        self.assertIsInstance(parser4.detector, DeepSeekV3Detector)
 
     def test_stream_reasoning_parameter(self):
         """Test stream_reasoning parameter is passed correctly."""
@@ -713,6 +754,30 @@ class TestReasoningParser(CustomTestCase):
 
         self.assertEqual(all_reasoning, "reasoning")
         self.assertEqual(all_normal, "<|tool_calls_section_begin|><|tool_call_begin|>")
+
+    def test_deepseek_v3_tool_interruption(self):
+        """Test DeepSeek-V3 tool interruption through ReasoningParser API."""
+        parser = ReasoningParser("deepseek-v3")
+
+        reasoning, normal = parser.parse_non_stream(
+            f"<think>thinking{DEEPSEEK_V32_TOOL_START}\n<invoke>"
+        )
+        self.assertEqual(reasoning, "thinking")
+        self.assertEqual(normal, f"{DEEPSEEK_V32_TOOL_START}\n<invoke>")
+
+        parser = ReasoningParser("deepseek-v3")
+        chunks = ["<think>", "reasoning", DEEPSEEK_V32_TOOL_START, "\n<invoke>"]
+        all_reasoning = ""
+        all_normal = ""
+        for chunk in chunks:
+            reasoning, normal = parser.parse_stream_chunk(chunk)
+            if reasoning:
+                all_reasoning += reasoning
+            if normal:
+                all_normal += normal
+
+        self.assertEqual(all_reasoning, "reasoning")
+        self.assertEqual(all_normal, f"{DEEPSEEK_V32_TOOL_START}\n<invoke>")
 
 
 class TestIntegrationScenarios(CustomTestCase):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -20,6 +20,7 @@ register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 
 
 DEEPSEEK_V32_TOOL_START = f"<{dsml_token}function_calls>"
+DEEPSEEK_V32_FORMATTED_TOOL_START = f"\n\n<{dsml_token}function_calls>"
 
 
 class TestStreamingParseResult(CustomTestCase):
@@ -234,7 +235,10 @@ class TestDeepSeekV3Detector(CustomTestCase):
         """Test DeepSeekV3Detector initialization."""
         self.assertEqual(self.detector.think_start_token, "<think>")
         self.assertEqual(self.detector.think_end_token, "</think>")
-        self.assertEqual(self.detector.tool_start_token, DEEPSEEK_V32_TOOL_START)
+        self.assertEqual(
+            self.detector.tool_start_token,
+            (DEEPSEEK_V32_TOOL_START, DEEPSEEK_V32_FORMATTED_TOOL_START),
+        )
         self.assertFalse(self.detector._in_reasoning)
 
     def test_detect_and_parse_tool_interrupt(self):
@@ -256,6 +260,22 @@ class TestDeepSeekV3Detector(CustomTestCase):
         self.assertEqual(reasoning.reasoning_text, "thinking")
         self.assertEqual(tool_call.reasoning_text, "")
         self.assertEqual(tool_call.normal_text, DEEPSEEK_V32_TOOL_START)
+        self.assertEqual(trailing.reasoning_text, "")
+        self.assertEqual(trailing.normal_text, "\n<tool payload>")
+
+    def test_parse_streaming_increment_formatted_tool_interrupt(self):
+        """Test streaming parsing buffers a newline-prefixed DSML marker."""
+        self.detector.parse_streaming_increment("<think>")
+        reasoning = self.detector.parse_streaming_increment("thinking\n\n<")
+        tool_call = self.detector.parse_streaming_increment(
+            f"{dsml_token}function_calls>"
+        )
+        trailing = self.detector.parse_streaming_increment("\n<tool payload>")
+
+        self.assertEqual(reasoning.reasoning_text, "thinking")
+        self.assertEqual(reasoning.normal_text, "")
+        self.assertEqual(tool_call.reasoning_text, "")
+        self.assertEqual(tool_call.normal_text, DEEPSEEK_V32_FORMATTED_TOOL_START)
         self.assertEqual(trailing.reasoning_text, "")
         self.assertEqual(trailing.normal_text, "\n<tool payload>")
 
@@ -778,6 +798,27 @@ class TestReasoningParser(CustomTestCase):
 
         self.assertEqual(all_reasoning, "reasoning")
         self.assertEqual(all_normal, f"{DEEPSEEK_V32_TOOL_START}\n<invoke>")
+
+    def test_deepseek_v3_formatted_tool_interruption(self):
+        """Test DeepSeek-V3 tool interruption with formatted DSML output."""
+        parser = ReasoningParser("deepseek-v3")
+        chunks = [
+            "<think>",
+            "reasoning\n\n<",
+            f"{dsml_token}function_calls>",
+            "\n<invoke>",
+        ]
+        all_reasoning = ""
+        all_normal = ""
+        for chunk in chunks:
+            reasoning, normal = parser.parse_stream_chunk(chunk)
+            if reasoning:
+                all_reasoning += reasoning
+            if normal:
+                all_normal += normal
+
+        self.assertEqual(all_reasoning, "reasoning")
+        self.assertEqual(all_normal, f"{DEEPSEEK_V32_FORMATTED_TOOL_START}\n<invoke>")
 
 
 class TestIntegrationScenarios(CustomTestCase):


### PR DESCRIPTION
## Summary
- preserve DeepSeek-V3.2 DSML tool-call markers when `deepseek-v3` reasoning output switches into tool calls
- add DeepSeek-V3-specific reasoning detector coverage for both non-streaming and streaming parsing
- keep the downstream DeepSeek-V3.2 function-call parser on the existing raw marker path

## Root Cause
`deepseek-v3` currently reuses `Qwen3Detector`, which only recognizes `<think>` / `</think>` transitions. DeepSeek-V3.2 tool calls can start with the DSML `<function_calls>` marker before `</think>` is emitted. In that case the reasoning parser keeps treating the DSML marker as reasoning text instead of handing it off to the function-call parser, which can surface as malformed tool-call deltas or empty tool output in PD mode.

## Fix
Introduce a DeepSeek-V3-specific reasoning detector that uses the DeepSeek-V3.2 DSML function-call start marker as a reasoning interruption token. This preserves the raw tool-call marker in normal text so the existing DeepSeek-V3.2 tool-call parser can consume it unchanged.

## Testing
- `python -m py_compile python/sglang/srt/parser/reasoning_parser.py test/registered/unit/parser/test_reasoning_parser.py`
- DeepSeek-V3 parser smoke test covering non-stream and stream interruption paths
- `python test/registered/unit/parser/test_reasoning_parser.py` *(blocked locally because this environment is missing `Pillow`, which is imported by the repo test utilities)*

Fixes #21176
