### PR TITLE
[CI] Fix cutlass import error: restore nvidia-cutlass-dsl force-reinstall

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -340,6 +340,11 @@ fi
 
 mark_step_done "Fix other dependencies"
 
+# Force reinstall nvidia-cutlass-dsl to ensure the .pth file exists.
+# The Docker image ships nvidia-cutlass-dsl-libs-base 4.3.5; upgrading to 4.4.2
+# can delete the .pth file without reliably recreating it (pip race condition).
+$PIP_CMD install "nvidia-cutlass-dsl>=4.4.1" "nvidia-cutlass-dsl-libs-base>=4.4.1" --no-deps --force-reinstall $PIP_INSTALL_SUFFIX || true
+
 # ------------------------------------------------------------------------------
 # Prepare runner
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Temporary fix: PR #21017 refactored the CI install script but accidentally dropped the `nvidia-cutlass-dsl` force-reinstall
- This causes stage-b/c jobs to fail with `ModuleNotFoundError: No module named 'cutlass'` across all runner types (5090, H100, B200)
- **Root cause**: Docker images ship `nvidia-cutlass-dsl-libs-base` 4.3.5, but `pyproject.toml` requires `>=4.4.1`. During the pip upgrade, the `.pth` file (which makes `import cutlass` work) gets deleted but is not reliably recreated — a pip race condition. The force-reinstall ensures the `.pth` file is always present.
- **Long-term fix**: rebuild Docker images with `nvidia-cutlass-dsl-libs-base` 4.4.2 baked in, so the upgrade doesn't happen at CI runtime

**Failing jobs**: https://github.com/sgl-project/sglang/actions/runs/23418883303/job/68120071432, https://github.com/sgl-project/sglang/actions/runs/23421614705/job/68127702256

## Test plan
- [ ] Stage-b/c CI jobs pass the `python3 -c 'import cutlass; import cutlass.cute;'` verification step