### PR TITLE
fix(test): correct UE8M0 scale comparison in per_token_group_quant_8bit test

### DIFF
--- a/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/jit_kernel/tests/test_per_token_group_quant_8bit.py
@@ -118,8 +118,10 @@ def test_per_token_group_quant_with_column_major(
         pytest.skip("Only Blackwell need ue8m0 fusion")
         return
 
-    if (flags["scale_ue8m0"] and (group_size != 128)) or (
-        (dst_dtype == torch.int8) and flags["column_major_scales"]
+    if (
+        (flags["scale_ue8m0"] and (group_size != 128))
+        or ((dst_dtype == torch.int8) and flags["column_major_scales"])
+        or flags["fuse_silu_and_mul"]
     ):
         pytest.skip()
         return
@@ -149,8 +151,11 @@ def test_per_token_group_quant_with_column_major(
         *triton_per_token_group_quant_8bit(**execute_kwargs)
     )
 
-    fuse_silu_and_mul = False
-    out_shape = (*x.shape[:-1], x.shape[-1] // (2 if fuse_silu_and_mul else 1))
+    scale_ue8m0 = flags["scale_ue8m0"]
+    column_major_scales = flags["column_major_scales"]
+    scale_tma_aligned = flags["scale_tma_aligned"]
+
+    out_shape = x.shape
 
     fp8_dtype = torch.float8_e4m3fn
     fp8_max = torch.finfo(fp8_dtype).max
@@ -160,10 +165,15 @@ def test_per_token_group_quant_with_column_major(
         x_shape=out_shape,
         device=x.device,
         group_size=group_size,
-        column_major_scales=False,
-        scale_tma_aligned=False,
-        scale_ue8m0=False,
+        column_major_scales=column_major_scales,
+        scale_tma_aligned=scale_tma_aligned,
+        scale_ue8m0=scale_ue8m0,
     )
+    if scale_ue8m0:
+        # The JIT kernel writes one uint8 per int32 slot; zero-init so unused
+        # bytes within each pack don't contain garbage when num_groups_per_row
+        # is not a multiple of 4.
+        x_s.zero_()
 
     execute_kwargs = dict(
         input=x,
@@ -173,6 +183,7 @@ def test_per_token_group_quant_with_column_major(
         eps=1e-10,
         fp8_max=fp8_max,
         fp8_min=fp8_min,
+        scale_ue8m0=scale_ue8m0,
     )
     x_q_sglang, x_s_sglang = _postprocess(
         *sglang_per_token_group_quant_8bit(**execute_kwargs)


### PR DESCRIPTION
## Motivation
  The JIT kernel test `test_per_token_group_quant_with_column_major` was failing with 222 test cases on Blackwell GPUs (SM ≥ 10), where `scale_ue8m0=True` tests are not skipped. The test incorrectly compared the sglang JIT kernel output (always using float32 row-major scales) against the triton reference output (using UE8M0 int32-packed scales), causing systematic dtype and value mismatches.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
  Three bugs fixed in `test_per_token_group_quant_with_column_major`:

  1. **Skip `fuse_silu_and_mul=True` configs** — the sglang JIT kernel does not implement fused SiLU+mul, so those configs cannot be meaningfully compared against the triton reference.

  2. **Pass matching scale flags to the sglang path** — the test was hardcoding`column_major_scales=False`, `scale_tma_aligned=False`, `scale_ue8m0=False` for the sglang output scale allocation and kernel call, causing dtype/format mismatches. Now uses the actual flags from the test config.

  3. **Zero-initialize the UE8M0 scale buffer** — the JIT kernel writes one `uint8` per `int32` slot. When `num_groups_per_row % 4 != 0`, unused bytes within each int32 pack remain as uninitialized garbage from `torch.empty()`.  Adding `x_s.zero_()` ensures unused bytes are 0, matching the output of triton's `deep_gemm.transform_sf_into_required_layout`.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
N/A — test-only fix, no changes to kernel logic.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
 N/A — test-only fix.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
