### PR TITLE
[AMD] Add fused GemmaRMSNorm forward_hip to use aiter/vllm kernels for qwen3.5

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -451,9 +451,6 @@ class GemmaRMSNorm(MultiPlatformOp):
         super().__init__()
         self.weight = nn.Parameter(torch.zeros(hidden_size))
         self.variance_epsilon = eps
-        # Re-dispatch
-        if _is_hip:
-            self._forward_method = self.forward_native
 
     def _forward_impl(
         self,
@@ -498,6 +495,47 @@ class GemmaRMSNorm(MultiPlatformOp):
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         return self._forward_impl(x, residual, post_residual_addition)
+
+    def forward_hip(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+        post_residual_addition: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if not _has_vllm_rms_norm:
+            return self.forward_native(x, residual, post_residual_addition)
+
+        w = self.weight.data + 1.0
+        if _use_aiter:
+            # aiter API: rms_norm(input, weight, eps) -> output
+            #            fused_add_rms_norm(output, input, residual, residual_out, weight, eps)
+            if residual is not None:
+                output = torch.empty_like(x)
+                residual_out = torch.empty_like(x)
+                if post_residual_addition is not None:
+                    residual = residual + post_residual_addition
+                fused_add_rms_norm(
+                    output, x, residual, residual_out, w, self.variance_epsilon
+                )
+                return output, residual_out
+            return rms_norm(x, w, self.variance_epsilon)
+        else:
+            # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
+            #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
+            if not x.is_contiguous():
+                x = x.contiguous()
+            if residual is not None:
+                out = torch.empty_like(x)
+                residual_out = torch.empty_like(x)
+                if post_residual_addition is not None:
+                    residual = residual + post_residual_addition
+                fused_add_rms_norm(
+                    out, x, residual_out, residual, w, self.variance_epsilon
+                )
+                return out, residual_out
+            out = torch.empty_like(x)
+            rms_norm(out, x, w, self.variance_epsilon)
+            return out
 
     def forward_cpu(
         self,


### PR DESCRIPTION
co-author: @zhentaocc 
## Motivation

Previously `GemmaRMSNorm` re-dispatched HIP to `forward_native`, bypassing fused kernels. This adds a dedicated `forward_hip` that routes through aiter or vllm `fused_add_rms_norm`/`rms_norm`, matching the existing CUDA path logic with the +1 weight offset that Gemma requires.

## Modifications

- Removed the `__init__` override that forced `_forward_method = forward_native` on HIP.
- Added `forward_hip()` method to `GemmaRMSNorm` that:
  - Applies the Gemma-specific `weight + 1.0` offset.
  - Routes through aiter fused kernels when `_use_aiter` is set.
  - Falls back to vllm fused kernels otherwise.
  - Falls back to `forward_native` if neither is available.

## Accuracy Tests

**Model:** Qwen3.5-397B-A17B-FP8, **Hardware:** 8x MI355X, **Image:** `rocm/sgl-dev:v0.5.9-rocm720-mi35x-20260318`

GSM8K (5-shot, 2000 questions, parallel=1000):

|               | Before (aiter) | After (aiter + PR) |
|---------------|:--------------:|:------------------:|
| **Accuracy**  | 0.943          | 0.955              |

Server launch command:
```bash
SGLANG_USE_AITER=1 python3 -m sglang.launch_server \
  --model-path /data/Qwen3.5-397B-A17B-FP8/ \
  --tp 8 \
  --attention-backend aiter \
  --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 \
  --mem-fraction-static 0.8 \
  --host 0.0.0.0 --port 9000
```

Accuracy test command:
```bash
python3 benchmark/gsm8k/bench_sglang.py \
  --num-questions 2000 --parallel 1000 --num-shots 5 --port 9000
```

## Benchmarking and Profiling

**Workload:** `sglang.bench_serving --dataset-name random --random-input 8192 --random-output 1024 --random-range-ratio 1.0`

Benchmark command:
```bash
python3 -m sglang.bench_serving \
  --host localhost --port 9000 \
  --model /data/Qwen3.5-397B-A17B-FP8/ \
  --dataset-name random \
  --random-input 8192 --random-output 1024 \
  --random-range-ratio 1.0 \
  --max-concurrency 1 --num-prompt 8
```

Concurrency=1 comparison (8 prompts):

**Latency & Throughput**

|                          | Before (aiter) | After (aiter + PR) | Improvement |
|--------------------------|:--------------:|:------------------:|:-----------:|
| Median E2E Latency (ms)  | 16,179.00      | 12,438.75          | **-23.1%**  |
| Total Throughput (tok/s)  | 569.53         | 740.14             | **+30.0%**  |

**TTFT & ITL**

|                    | Before (aiter) | After (aiter + PR) | Improvement |
|--------------------|:--------------:|:------------------:|:-----------:|
| Median TTFT (ms)   | 243.40         | 202.14             | **-17.0%**  |
| Median ITL (ms)    | 15.58          | 11.96              | **-23.2%**  |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
