### PR TITLE
fix: Use base GPU ID CUDA device for multimodal processor

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -436,7 +436,8 @@ class BaseMultimodalProcessor(ABC):
             elif _is_xpu:
                 kwargs["device"] = "xpu"
             elif not _is_npu:
-                kwargs["device"] = "cuda"
+                base_gpu_id = get_global_server_args().base_gpu_id
+                kwargs["device"] = f"cuda:{base_gpu_id}"
             elif processor.__class__.__name__ not in {
                 "Glm4vProcessor",
             }:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

multimodal processor will be process image in main process and default cuda device, which is gpu 0, making more gpu memory allocated in gpu 0.

test boot command:

```bash
export SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=1

SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server --base-gpu-id 0 --model-path "/workspace/data/model/Qwen3.5-35B-A3B-FP8" --port "8061" > "./log/single_worker_0.log" 2>&1 &
SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server --base-gpu-id 1 --model-path "/workspace/data/model/Qwen3.5-35B-A3B-FP8" --port "8062" > "./log/single_worker_1.log" 2>&1 &
SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server --base-gpu-id 2 --model-path "/workspace/data/model/Qwen3.5-35B-A3B-FP8" --port "8063" > "./log/single_worker_2.log" 2>&1 &
```

before fix:

<img width="3014" height="314" alt="before" src="https://github.com/user-attachments/assets/5f4f45fc-86a0-4cd1-8a53-6a0740f3ba02" />

after fix:

<img width="2996" height="302" alt="after" src="https://github.com/user-attachments/assets/bc86b5e5-b7ee-4083-b072-2c67f0dc9bed" />

## Modifications

<!-- Detail the changes made in this pull request. -->

set process device to cuda:{base_gpu_id}

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26152979194](https://github.com/sgl-project/sglang/actions/runs/26152979194)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26152979272](https://github.com/sgl-project/sglang/actions/runs/26152979272)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->