### PR TITLE
[KDA] Support CuTeDSL KDA decode kernel

### DIFF
--- a/benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py
+++ b/benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py
@@ -1,19 +1,10 @@
-"""
-Benchmark & Correctness: CuTe DSL KDA Decode vs Triton KDA Decode.
+"""Benchmark & Correctness: CuTe DSL KDA Decode vs Triton KDA Decode.
 
-Benchmark modes:
-  - Default (wall-clock): Measures Python dispatch + GPU execution.
-    CuTe DSL has ~120us Python overhead from from_dlpack/mark_layout_dynamic
-    that Triton doesn't have. This does NOT reflect production performance.
-  - --cuda-graph: Uses CUDA graph capture/replay, eliminating ALL Python dispatch
-    overhead for both backends. This reflects actual production performance
-    where SGLang uses CUDA graphs for decode.
+This benchmark assumes the production / Triton canonical state layout:
+    ssm_states.shape == (pool_size, HV, V, K)
 
-Usage:
-    python bench_cutedsl_kda_decode.py --mode bench --cuda-graph   # recommended
-    python bench_cutedsl_kda_decode.py --mode bench                # wall-clock
-    python bench_cutedsl_kda_decode.py --mode correctness
-    python bench_cutedsl_kda_decode.py                             # all
+Both the Triton baseline and the CuTe DSL candidate operate directly on that VK
+layout. No transpose is performed anywhere in the benchmark.
 """
 
 import argparse
@@ -21,21 +12,32 @@ import os
 import sys
 import time
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "python"))
 
 import torch
 import triton
 
-from sglang.jit_kernel.cutedsl_kda import (
-    cutedsl_fused_sigmoid_gating_kda_update,
-)
+from sglang.jit_kernel.cutedsl_kda import cutedsl_fused_sigmoid_gating_kda_update
 from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
     fused_sigmoid_gating_delta_rule_update,
 )
+from sglang.srt.layers.attention.fla.kda import chunk_kda
 
 
-def make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
+def make_inputs(
+    B: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    pool_size: int,
+    device: str,
+    dtype: torch.dtype,
+    layout: str,
+    seed: int = 42,
+):
     torch.manual_seed(seed)
+
     assert K == 128
     assert V % 16 == 0 and V % 32 == 0
 
@@ -43,23 +45,40 @@ def make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
         q = torch.randn(1, B, H, K, device=device, dtype=dtype)
         k = torch.randn(1, B, H, K, device=device, dtype=dtype)
         v = torch.randn(1, B, HV, V, device=device, dtype=dtype)
+
+        # decode params
         a = torch.randn(B, HV, K, device=device, dtype=dtype)
         b = torch.randn(B, HV, device=device, dtype=dtype)
+
+        # prefill params for chunk_kda must keep batch dim = 1
+        prefill_g = torch.randn(1, B, HV, K, device=device, dtype=dtype)
+        prefill_beta = torch.sigmoid(torch.randn(1, B, HV, device=device, dtype=dtype))
+
         cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
-    else:
+
+    elif layout == "dense":
         q = torch.randn(B, 1, H, K, device=device, dtype=dtype)
         k = torch.randn(B, 1, H, K, device=device, dtype=dtype)
         v = torch.randn(B, 1, HV, V, device=device, dtype=dtype)
+
+        # decode params
         a = torch.randn(B, 1, HV, K, device=device, dtype=dtype)
         b = torch.randn(B, 1, HV, device=device, dtype=dtype)
+
+        # prefill params for chunk_kda dense path
+        prefill_g = torch.randn(B, 1, HV, K, device=device, dtype=dtype)
+        prefill_beta = torch.sigmoid(torch.randn(B, 1, HV, device=device, dtype=dtype))
+
         cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
+    else:
+        raise ValueError(f"Unknown layout: {layout}")
 
     A_log = torch.randn(HV, device=device, dtype=torch.float32)
     dt_bias = torch.randn(HV, K, device=device, dtype=dtype)
-    ssm_states_cute = (
-        torch.randn(pool_size, HV, K, V, device=device, dtype=torch.float32) * 0.1
+
+    ssm_states = (
+        torch.randn(pool_size, HV, V, K, device=device, dtype=torch.float32) * 0.1
     )
-    ssm_states_triton = ssm_states_cute.transpose(-1, -2).contiguous()
     cache_indices = torch.arange(B, device=device, dtype=torch.int32)
 
     return dict(
@@ -75,17 +94,18 @@ def make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
         v=v,
         a=a,
         b=b,
+        prefill_g=prefill_g,
+        prefill_beta=prefill_beta,
         A_log=A_log,
         dt_bias=dt_bias,
-        ssm_states_cute=ssm_states_cute,
-        ssm_states_triton=ssm_states_triton,
+        ssm_states=ssm_states,
         cache_indices=cache_indices,
         cu_seqlens=cu_seqlens,
     )
 
 
 def run_baseline(inp):
-    state = inp["ssm_states_triton"].clone()
+    state = inp["ssm_states"].clone()
     o = fused_sigmoid_gating_delta_rule_update(
         A_log=inp["A_log"],
         dt_bias=inp["dt_bias"],
@@ -106,7 +126,7 @@ def run_baseline(inp):
 
 
 def run_cutedsl(inp):
-    state = inp["ssm_states_cute"].clone()
+    state = inp["ssm_states"].clone()
     o = cutedsl_fused_sigmoid_gating_kda_update(
         A_log=inp["A_log"],
         dt_bias=inp["dt_bias"],
@@ -117,7 +137,7 @@ def run_cutedsl(inp):
         b=inp["b"],
         initial_state_source=state,
         initial_state_indices=inp["cache_indices"],
-        cu_seqlens=inp["cu_seqlens"],
+        cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
         use_qk_l2norm_in_kernel=True,
         softplus_beta=1.0,
         softplus_threshold=20.0,
@@ -125,91 +145,144 @@ def run_cutedsl(inp):
     return o, state
 
 
-def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
-    tag = f"layout={layout:<6} B={B:>2} H={H:>2} HV={HV:>2} K={K:>3} V={V:>3} pool={pool_size:>4}"
-    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=seed)
+def run_prefill_then_decode_baseline(inp):
+    ssm_states = inp["ssm_states"].clone()
+    v_clone = inp["v"].clone()
+
+    _ = chunk_kda(
+        q=inp["q"],
+        k=inp["k"],
+        v=v_clone,
+        g=inp["prefill_g"],
+        beta=inp["prefill_beta"],
+        initial_state=ssm_states,
+        initial_state_indices=inp["cache_indices"],
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
+    )
+
+    o = fused_sigmoid_gating_delta_rule_update(
+        A_log=inp["A_log"],
+        dt_bias=inp["dt_bias"],
+        q=inp["q"],
+        k=inp["k"],
+        v=v_clone,
+        a=inp["a"],
+        b=inp["b"],
+        initial_state_source=ssm_states,
+        initial_state_indices=inp["cache_indices"],
+        cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        is_kda=True,
+    )
+    return o, ssm_states
+
+
+def run_prefill_then_decode_cutedsl(inp):
+    ssm_states = inp["ssm_states"].clone()
+    v_clone = inp["v"].clone()
+
+    _ = chunk_kda(
+        q=inp["q"],
+        k=inp["k"],
+        v=v_clone,
+        g=inp["prefill_g"],
+        beta=inp["prefill_beta"],
+        initial_state=ssm_states,
+        initial_state_indices=inp["cache_indices"],
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
+    )
+
+    o = cutedsl_fused_sigmoid_gating_kda_update(
+        A_log=inp["A_log"],
+        dt_bias=inp["dt_bias"],
+        q=inp["q"],
+        k=inp["k"],
+        v=v_clone,
+        a=inp["a"],
+        b=inp["b"],
+        initial_state_source=ssm_states,
+        initial_state_indices=inp["cache_indices"],
+        cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+    )
+    return o, ssm_states
+
+
+def _assert_close(name, x, y, atol=3e-2, rtol=2e-2):
+    try:
+        torch.testing.assert_close(x.float(), y.float(), atol=atol, rtol=rtol)
+        return True, 0.0
+    except AssertionError:
+        max_diff = (x - y).abs().max().item()
+        return False, max_diff
+
+
+def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout):
+    tag = (
+        f"layout={layout:<6} B={B:>4} H={H:>2} HV={HV:>2} "
+        f"K={K:>3} V={V:>3} pool={pool_size:>4}"
+    )
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout)
+
     o_ref, st_ref = run_baseline(inp)
     o_cute, st_cute = run_cutedsl(inp)
 
-    atol = 3e-2 if dtype != torch.float32 else 1e-4
-    rtol = 2e-2 if dtype != torch.float32 else 1e-4
-    output_ok = state_ok = True
-    out_diff = st_diff = 0.0
+    ok_o, diff_o = _assert_close("output", o_cute, o_ref)
+    valid_mask = inp["cache_indices"] >= 0
+    valid_idx = inp["cache_indices"][valid_mask]
+    ok_s, diff_s = _assert_close("state", st_cute[valid_idx], st_ref[valid_idx])
 
-    try:
-        torch.testing.assert_close(o_cute.float(), o_ref.float(), atol=atol, rtol=rtol)
-    except AssertionError:
-        output_ok = False
-        out_diff = (o_cute.float() - o_ref.float()).abs().max().item()
-
-    st_cute_vk = st_cute.transpose(-1, -2).contiguous()
-    valid_slots = inp["cache_indices"][inp["cache_indices"] >= 0].unique()
-    try:
-        torch.testing.assert_close(
-            st_cute_vk[valid_slots].float(),
-            st_ref[valid_slots].float(),
-            atol=atol,
-            rtol=rtol,
-        )
-    except AssertionError:
-        state_ok = False
-        st_diff = (
-            (st_cute_vk[valid_slots].float() - st_ref[valid_slots].float())
-            .abs()
-            .max()
-            .item()
-        )
-
-    passed = output_ok and state_ok
-    if passed:
+    if ok_o and ok_s:
         print(f"  [PASS] {tag}")
-    else:
-        details = []
-        if not output_ok:
-            details.append(f"output max_diff={out_diff:.6f}")
-        if not state_ok:
-            details.append(f"state max_diff={st_diff:.6f}")
-        print(f"  [FAIL] {tag}  ({', '.join(details)})")
-    return passed
+        return True
+
+    details = []
+    if not ok_o:
+        details.append(f"output max_diff={diff_o:.6f}")
+    if not ok_s:
+        details.append(f"state max_diff={diff_s:.6f}")
+    print(f"  [FAIL] {tag} ({', '.join(details)})")
+    return False
 
 
-def bench_cuda_graph(fn, warmup=50, rep=200):
-    """Capture fn into CUDA graph, then benchmark replay with CUDA events."""
-    # Warmup + trigger JIT
-    for _ in range(5):
-        fn()
-    torch.cuda.synchronize()
-
-    # Capture
-    g = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(g):
-        fn()
-    torch.cuda.synchronize()
-
-    # Warmup replay
-    for _ in range(warmup):
-        g.replay()
-    torch.cuda.synchronize()
-
-    # Timed replay
-    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
-    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
-    for i in range(rep):
-        start_events[i].record()
-        g.replay()
-        end_events[i].record()
-    torch.cuda.synchronize()
-
-    times_ms = sorted(s.elapsed_time(e) for s, e in zip(start_events, end_events))
-    return times_ms[len(times_ms) // 2]
-
-
-def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout, use_cuda_graph=False):
+def check_prefill_chain(B, H, HV, K, V, pool_size, device, dtype, layout):
+    tag = (
+        f"[prefill->decode] layout={layout:<6} B={B:>4} H={H:>2} HV={HV:>2} "
+        f"K={K:>3} V={V:>3} pool={pool_size:>4}"
+    )
     inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout)
-    state_ref = inp["ssm_states_triton"].clone()
-    state_cute = inp["ssm_states_cute"].clone()
 
-    def fn_baseline():
+    o_ref, st_ref = run_prefill_then_decode_baseline(inp)
+    o_cute, st_cute = run_prefill_then_decode_cutedsl(inp)
+
+    ok_o, diff_o = _assert_close("output", o_cute, o_ref)
+    valid_mask = inp["cache_indices"] >= 0
+    valid_idx = inp["cache_indices"][valid_mask]
+    ok_s, diff_s = _assert_close("state", st_cute[valid_idx], st_ref[valid_idx])
+
+    if ok_o and ok_s:
+        print(f"  [PASS] {tag}")
+        return True
+
+    details = []
+    if not ok_o:
+        details.append(f"output max_diff={diff_o:.6f}")
+    if not ok_s:
+        details.append(f"state max_diff={diff_s:.6f}")
+    print(f"  [FAIL] {tag} ({', '.join(details)})")
+    return False
+
+
+def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout):
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout)
+
+    def fn_triton():
         fused_sigmoid_gating_delta_rule_update(
             A_log=inp["A_log"],
             dt_bias=inp["dt_bias"],
@@ -218,7 +291,7 @@ def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout, use_cuda_graph
             v=inp["v"],
             a=inp["a"],
             b=inp["b"],
-            initial_state_source=state_ref,
+            initial_state_source=inp["ssm_states"],
             initial_state_indices=inp["cache_indices"],
             cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
             use_qk_l2norm_in_kernel=True,
@@ -227,7 +300,7 @@ def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout, use_cuda_graph
             is_kda=True,
         )
 
-    def fn_cutedsl():
+    def fn_cute():
         cutedsl_fused_sigmoid_gating_kda_update(
             A_log=inp["A_log"],
             dt_bias=inp["dt_bias"],
@@ -236,52 +309,48 @@ def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout, use_cuda_graph
             v=inp["v"],
             a=inp["a"],
             b=inp["b"],
-            initial_state_source=state_cute,
+            initial_state_source=inp["ssm_states"],
             initial_state_indices=inp["cache_indices"],
-            cu_seqlens=inp["cu_seqlens"],
+            cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
             use_qk_l2norm_in_kernel=True,
             softplus_beta=1.0,
             softplus_threshold=20.0,
         )
 
-    # Warmup
     for _ in range(10):
-        fn_baseline()
-        fn_cutedsl()
+        fn_triton()
+        fn_cute()
     torch.cuda.synchronize()
 
-    if use_cuda_graph:
-        ms_baseline = bench_cuda_graph(fn_baseline)
-        ms_cutedsl = bench_cuda_graph(fn_cutedsl)
-    else:
-        quantiles = [0.5, 0.2, 0.8]
-        try:
-            ms_baseline, _, _ = triton.testing.do_bench(
-                fn_baseline, quantiles=quantiles, warmup=50, rep=200
-            )
-            ms_cutedsl, _, _ = triton.testing.do_bench(
-                fn_cutedsl, quantiles=quantiles, warmup=50, rep=200
-            )
-        except Exception:
-            torch.cuda.synchronize()
-            N = 200
-            start = time.perf_counter()
-            for _ in range(N):
-                fn_baseline()
-            torch.cuda.synchronize()
-            ms_baseline = (time.perf_counter() - start) / N * 1000
-            start = time.perf_counter()
-            for _ in range(N):
-                fn_cutedsl()
-            torch.cuda.synchronize()
-            ms_cutedsl = (time.perf_counter() - start) / N * 1000
+    try:
+        ms_triton, _, _ = triton.testing.do_bench(
+            fn_triton, quantiles=[0.5, 0.2, 0.8], warmup=50, rep=200
+        )
+        ms_cute, _, _ = triton.testing.do_bench(
+            fn_cute, quantiles=[0.5, 0.2, 0.8], warmup=50, rep=200
+        )
+    except Exception:
+        rep = 100
+        st = time.perf_counter()
+        for _ in range(rep):
+            fn_triton()
+        torch.cuda.synchronize()
+        ms_triton = (time.perf_counter() - st) / rep * 1000
 
-    speedup = ms_baseline / ms_cutedsl if ms_cutedsl > 0 else float("inf")
-    delta_us = (ms_baseline - ms_cutedsl) * 1000
+        st = time.perf_counter()
+        for _ in range(rep):
+            fn_cute()
+        torch.cuda.synchronize()
+        ms_cute = (time.perf_counter() - st) / rep * 1000
+
+    speedup = ms_triton / ms_cute if ms_cute > 0 else float("inf")
+    delta = (ms_cute - ms_triton) * 1000
     print(
         f"  {layout:>6}  {B:>5}  {H:>3}  {HV:>3}  {K:>3}  {V:>3} | "
-        f"{ms_baseline * 1000:>10.1f} | {ms_cutedsl * 1000:>10.1f} | "
-        f"{speedup:>7.2f}x | {delta_us:>+9.1f}"
+        f"{ms_triton * 1000:>12.1f} | "
+        f"{ms_cute * 1000:>13.1f} | "
+        f"{speedup:>8.2f} | "
+        f"{delta:>11.1f}"
     )
 
 
@@ -289,6 +358,7 @@ def run_correctness(device, dtype):
     print("=" * 78)
     print("Correctness: Triton KDA Decode vs CuTe DSL KDA Decode")
     print("=" * 78)
+
     shapes = [
         ("dense", 1, 8, 16, 128, 128, 32),
         ("dense", 4, 8, 16, 128, 128, 32),
@@ -302,96 +372,32 @@ def run_correctness(device, dtype):
         ("varlen", 32, 16, 32, 128, 128, 128),
         ("varlen", 64, 16, 16, 128, 128, 128),
     ]
+
     all_pass = True
     for layout, B, H, HV, K, V, pool_size in shapes:
         if not check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout):
             all_pass = False
 
-    print("\n  PAD_SLOT_ID test (indices with -1):")
-    inp = make_inputs(32, 8, 16, 128, 128, 128, device, dtype, layout="varlen")
-    inp["cache_indices"][::5] = -1
-    st_ref_before = inp["ssm_states_triton"].clone()
-    st_cute_before = inp["ssm_states_cute"].clone()
-    o_ref, st_ref = run_baseline(inp)
-    o_cute, st_cute = run_cutedsl(inp)
-    st_cute_vk = st_cute.transpose(-1, -2).contiguous()
-    st_cute_before_vk = st_cute_before.transpose(-1, -2).contiguous()
-    valid_token_pos = (inp["cache_indices"] >= 0).nonzero(as_tuple=False).squeeze(-1)
-    valid_slots = inp["cache_indices"][inp["cache_indices"] >= 0].unique()
-    atol = 3e-2 if dtype != torch.float32 else 1e-4
-    rtol = 2e-2 if dtype != torch.float32 else 1e-4
-    pad_ok = True
-    details = []
-    try:
-        torch.testing.assert_close(
-            o_cute[:, valid_token_pos].float(),
-            o_ref[:, valid_token_pos].float(),
-            atol=atol,
-            rtol=rtol,
-        )
-    except AssertionError:
-        pad_ok = False
-        details.append(
-            f"valid_output max_diff={(o_cute[:, valid_token_pos].float() - o_ref[:, valid_token_pos].float()).abs().max().item():.6f}"
-        )
-    try:
-        torch.testing.assert_close(
-            st_cute_vk[valid_slots].float(),
-            st_ref[valid_slots].float(),
-            atol=atol,
-            rtol=rtol,
-        )
-    except AssertionError:
-        pad_ok = False
-        details.append(
-            f"valid_state max_diff={(st_cute_vk[valid_slots].float() - st_ref[valid_slots].float()).abs().max().item():.6f}"
-        )
-    untouched = torch.ones(inp["pool_size"], device=device, dtype=torch.bool)
-    untouched[valid_slots] = False
-    try:
-        torch.testing.assert_close(
-            st_ref[untouched].float(),
-            st_ref_before[untouched].float(),
-            atol=0.0,
-            rtol=0.0,
-        )
-        torch.testing.assert_close(
-            st_cute_vk[untouched].float(),
-            st_cute_before_vk[untouched].float(),
-            atol=0.0,
-            rtol=0.0,
-        )
-    except AssertionError:
-        pad_ok = False
-        details.append("untouched_slots modified")
-    print(
-        f"  [{'PASS' if pad_ok else 'FAIL'}] PAD_SLOT_ID=-1 handling"
-        + (f" ({', '.join(details)})" if details else " (valid outputs/states only)")
-    )
-    if not pad_ok:
-        all_pass = False
+    print()
+    print("=" * 78)
+    print("Correctness: Triton prefill/extend -> CuTe decode chain")
+    print("=" * 78)
+    for layout, B, H, HV, K, V, pool_size in shapes[:8]:
+        if not check_prefill_chain(B, H, HV, K, V, pool_size, device, dtype, layout):
+            all_pass = False
+
     print()
     print("ALL PASSED." if all_pass else "SOME FAILED.")
     return all_pass
 
 
-def run_benchmark(device, dtype, use_cuda_graph=False):
+def run_benchmark(device, dtype):
     print()
     print("=" * 92)
-    if use_cuda_graph:
-        print(
-            "Benchmark: Triton vs CuTe DSL KDA Decode  [CUDA Graph replay — production mode]"
-        )
-    else:
-        print(
-            "Benchmark: Triton vs CuTe DSL KDA Decode  [Wall-clock — includes Python dispatch]"
-        )
-        print(
-            "  NOTE: CuTe DSL shows ~120us Python overhead here that vanishes with CUDA graphs."
-        )
+    print("Benchmark: Triton KDA Decode vs CuTe DSL KDA Decode")
     print("=" * 92)
 
-    configs = [
+    bench_configs = [
         ("dense", 1, 8, 16),
         ("dense", 4, 8, 16),
         ("dense", 32, 8, 16),
@@ -406,47 +412,49 @@ def run_benchmark(device, dtype, use_cuda_graph=False):
         ("varlen", 32, 16, 32),
         ("varlen", 64, 16, 16),
     ]
-    K, V, pool_size = 128, 128, 512
+
+    K = 128
+    V = 128
+    pool_size = 512
+
     print(f"  Config: K={K}, V={V}, pool_size={pool_size}, dtype={dtype}")
     print(
-        f"  {'layout':>6}  {'B':>5}  {'H':>3}  {'HV':>3}  {'K':>3}  {'V':>3} | {'triton (us)':>12} | {'cutedsl (us)':>13} | {'speedup':>8} | {'delta (us)':>11}"
+        f"  {'layout':>6}  {'B':>5}  {'H':>3}  {'HV':>3}  {'K':>3}  {'V':>3} | "
+        f"{'triton (μs)':>12} | "
+        f"{'cutedsl (μs)':>13} | "
+        f"{'speedup':>8} | "
+        f"{'delta (μs)':>11}"
     )
     print("  " + "-" * 82)
-    for layout, B, H, HV in configs:
-        bench_shape(
-            B,
-            H,
-            HV,
-            K,
-            V,
-            max(pool_size, B + 16),
-            device,
-            dtype,
-            layout,
-            use_cuda_graph=use_cuda_graph,
-        )
+
+    for layout, B, H, HV in bench_configs:
+        actual_pool = max(pool_size, B + 16)
+        bench_shape(B, H, HV, K, V, actual_pool, device, dtype, layout)
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--mode", choices=["all", "correctness", "bench"], default="all"
+    parser = argparse.ArgumentParser(
+        description="Benchmark & Correctness: Triton KDA Decode vs CuTe DSL KDA Decode"
     )
     parser.add_argument(
-        "--dtype", choices=["float16", "bfloat16", "float32"], default="bfloat16"
+        "--mode",
+        choices=["all", "correctness", "bench"],
+        default="all",
+        help="Run mode (default: all)",
     )
     parser.add_argument(
-        "--cuda-graph",
-        action="store_true",
-        default=False,
-        help="Use CUDA graph capture/replay (recommended, matches production)",
+        "--dtype",
+        choices=["float16", "bfloat16", "float32"],
+        default="bfloat16",
     )
     args = parser.parse_args()
 
     device = "cuda"
     dtype = getattr(torch, args.dtype)
+
     cap = torch.cuda.get_device_capability()
-    print(f"Device: {torch.cuda.get_device_name()}  (SM {cap[0]}{cap[1]})")
+    dev_name = torch.cuda.get_device_name()
+    print(f"Device: {dev_name}  (SM {cap[0]}{cap[1]})")
 
     if args.mode in ("all", "correctness"):
         all_pass = run_correctness(device, dtype)
@@ -455,11 +463,7 @@ def main():
             return 1
 
     if args.mode in ("all", "bench"):
-        if args.cuda_graph:
-            run_benchmark(device, dtype, use_cuda_graph=True)
-        else:
-            run_benchmark(device, dtype, use_cuda_graph=False)
-            run_benchmark(device, dtype, use_cuda_graph=True)
+        run_benchmark(device, dtype)
 
     return 0
 

--- a/benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py
+++ b/benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py
@@ -1,0 +1,490 @@
+"""
+Benchmark & Correctness: CuTe DSL KDA Decode vs Triton KDA Decode.
+
+Compares:
+  - Baseline: Triton fused_sigmoid_gating_delta_rule_update(..., is_kda=True)
+  - CuTe DSL: cutedsl_fused_sigmoid_gating_delta_rule_update_kda
+
+Notes:
+  - Triton KDA state layout is [pool, HV, V, K]
+  - CuTe DSL KDA state layout here is [pool, HV, K, V]
+  - We initialize both from the same canonical values and transpose when comparing states.
+
+Usage:
+    python bench_cutedsl_kda_decode.py
+    python bench_cutedsl_kda_decode.py --mode correctness
+    python bench_cutedsl_kda_decode.py --mode bench
+"""
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+
+import torch
+import triton
+
+from sglang.jit_kernel.cutedsl_kda import (
+    cutedsl_fused_sigmoid_gating_kda_update,
+)
+from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_update,
+)
+
+
+def make_inputs(
+    B: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    pool_size: int,
+    device: str,
+    dtype: torch.dtype,
+    layout: str,
+    seed: int = 42,
+):
+    torch.manual_seed(seed)
+
+    assert K == 128, "Current CuTe DSL KDA kernel assumes K=128"
+    assert (
+        V % 16 == 0 and V % 32 == 0
+    ), "Current CuTe DSL KDA kernel expects tile-friendly V"
+
+    if layout == "varlen":
+        q = torch.randn(1, B, H, K, device=device, dtype=dtype)
+        k = torch.randn(1, B, H, K, device=device, dtype=dtype)
+        v = torch.randn(1, B, HV, V, device=device, dtype=dtype)
+        a = torch.randn(B, HV, K, device=device, dtype=dtype)
+        b = torch.randn(B, HV, device=device, dtype=dtype)
+        cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
+    elif layout == "dense":
+        q = torch.randn(B, 1, H, K, device=device, dtype=dtype)
+        k = torch.randn(B, 1, H, K, device=device, dtype=dtype)
+        v = torch.randn(B, 1, HV, V, device=device, dtype=dtype)
+        a = torch.randn(B, 1, HV, K, device=device, dtype=dtype)
+        b = torch.randn(B, 1, HV, device=device, dtype=dtype)
+        cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
+    else:
+        raise ValueError(f"Unknown layout: {layout}")
+
+    A_log = torch.randn(HV, device=device, dtype=torch.float32)
+    dt_bias = torch.randn(HV, K, device=device, dtype=dtype)
+
+    # Canonical logical state in [pool, HV, K, V] for CuTe.
+    ssm_states_cute = (
+        torch.randn(pool_size, HV, K, V, device=device, dtype=torch.float32) * 0.1
+    )
+    # Triton expects [pool, HV, V, K].
+    ssm_states_triton = ssm_states_cute.transpose(-1, -2).contiguous()
+
+    cache_indices = torch.arange(B, device=device, dtype=torch.int32)
+
+    return dict(
+        B=B,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        pool_size=pool_size,
+        layout=layout,
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        ssm_states_cute=ssm_states_cute,
+        ssm_states_triton=ssm_states_triton,
+        cache_indices=cache_indices,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+def run_baseline(inp):
+    state = inp["ssm_states_triton"].clone()
+    o = fused_sigmoid_gating_delta_rule_update(
+        A_log=inp["A_log"],
+        dt_bias=inp["dt_bias"],
+        q=inp["q"],
+        k=inp["k"],
+        v=inp["v"],
+        a=inp["a"],
+        b=inp["b"],
+        initial_state_source=state,
+        initial_state_indices=inp["cache_indices"],
+        cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        is_kda=True,
+    )
+    return o, state
+
+
+def run_cutedsl(inp):
+    state = inp["ssm_states_cute"].clone()
+    o = cutedsl_fused_sigmoid_gating_kda_update(
+        A_log=inp["A_log"],
+        dt_bias=inp["dt_bias"],
+        q=inp["q"],
+        k=inp["k"],
+        v=inp["v"],
+        a=inp["a"],
+        b=inp["b"],
+        initial_state_source=state,
+        initial_state_indices=inp["cache_indices"],
+        cu_seqlens=inp["cu_seqlens"],
+        use_qk_l2norm_in_kernel=True,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+    )
+    return o, state
+
+
+def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
+    tag = (
+        f"layout={layout:<6} "
+        f"B={B:>2} H={H:>2} HV={HV:>2} K={K:>3} V={V:>3} pool={pool_size:>4}"
+    )
+
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=seed)
+
+    o_ref, st_ref = run_baseline(inp)
+    o_cute, st_cute = run_cutedsl(inp)
+
+    # Compare outputs directly; both return same logical layout as input q/v path.
+    atol = 3e-2 if dtype != torch.float32 else 1e-4
+    rtol = 2e-2 if dtype != torch.float32 else 1e-4
+
+    output_ok = True
+    state_ok = True
+    out_diff = 0.0
+    st_diff = 0.0
+
+    try:
+        torch.testing.assert_close(o_cute.float(), o_ref.float(), atol=atol, rtol=rtol)
+    except AssertionError:
+        output_ok = False
+        out_diff = (o_cute.float() - o_ref.float()).abs().max().item()
+
+    # Triton: [pool, HV, V, K], CuTe: [pool, HV, K, V]
+    st_cute_vk = st_cute.transpose(-1, -2).contiguous()
+    idx = inp["cache_indices"]
+    valid_slots = idx[idx >= 0].unique()
+
+    try:
+        torch.testing.assert_close(
+            st_cute_vk[valid_slots].float(),
+            st_ref[valid_slots].float(),
+            atol=atol,
+            rtol=rtol,
+        )
+    except AssertionError:
+        state_ok = False
+        st_diff = (
+            (st_cute_vk[valid_slots].float() - st_ref[valid_slots].float())
+            .abs()
+            .max()
+            .item()
+        )
+
+    passed = output_ok and state_ok
+
+    if passed:
+        print(f"  [PASS] {tag}")
+    else:
+        details = []
+        if not output_ok:
+            details.append(f"output max_diff={out_diff:.6f}")
+        if not state_ok:
+            details.append(f"state max_diff={st_diff:.6f}")
+        print(f"  [FAIL] {tag}  ({', '.join(details)})")
+
+    return passed
+
+
+def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout):
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout)
+
+    state_ref = inp["ssm_states_triton"].clone()
+    state_cute = inp["ssm_states_cute"].clone()
+
+    def fn_baseline():
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=inp["A_log"],
+            dt_bias=inp["dt_bias"],
+            q=inp["q"],
+            k=inp["k"],
+            v=inp["v"],
+            a=inp["a"],
+            b=inp["b"],
+            initial_state_source=state_ref,
+            initial_state_indices=inp["cache_indices"],
+            cu_seqlens=inp["cu_seqlens"] if inp["layout"] == "varlen" else None,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            is_kda=True,
+        )
+
+    def fn_cutedsl():
+        cutedsl_fused_sigmoid_gating_kda_update(
+            A_log=inp["A_log"],
+            dt_bias=inp["dt_bias"],
+            q=inp["q"],
+            k=inp["k"],
+            v=inp["v"],
+            a=inp["a"],
+            b=inp["b"],
+            initial_state_source=state_cute,
+            initial_state_indices=inp["cache_indices"],
+            cu_seqlens=inp["cu_seqlens"],
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+        )
+
+    for _ in range(10):
+        fn_baseline()
+        fn_cutedsl()
+    torch.cuda.synchronize()
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    try:
+        ms_baseline, _, _ = triton.testing.do_bench(
+            fn_baseline, quantiles=quantiles, warmup=50, rep=200
+        )
+        ms_cutedsl, _, _ = triton.testing.do_bench(
+            fn_cutedsl, quantiles=quantiles, warmup=50, rep=200
+        )
+    except Exception:
+        torch.cuda.synchronize()
+        N = 200
+
+        start = time.perf_counter()
+        for _ in range(N):
+            fn_baseline()
+        torch.cuda.synchronize()
+        ms_baseline = (time.perf_counter() - start) / N * 1000
+
+        start = time.perf_counter()
+        for _ in range(N):
+            fn_cutedsl()
+        torch.cuda.synchronize()
+        ms_cutedsl = (time.perf_counter() - start) / N * 1000
+
+    speedup = ms_baseline / ms_cutedsl if ms_cutedsl > 0 else float("inf")
+    delta_us = (ms_baseline - ms_cutedsl) * 1000
+
+    print(
+        f"  {layout:>6}  {B:>5}  {H:>3}  {HV:>3}  {K:>3}  {V:>3} | "
+        f"{ms_baseline * 1000:>10.1f} | "
+        f"{ms_cutedsl * 1000:>10.1f} | "
+        f"{speedup:>7.2f}x | "
+        f"{delta_us:>+9.1f}"
+    )
+
+
+def run_correctness(device, dtype):
+    print("=" * 78)
+    print("Correctness: Triton KDA Decode vs CuTe DSL KDA Decode")
+    print("=" * 78)
+
+    shapes = [
+        # layout, B, H, HV, K, V, pool
+        ("dense", 1, 8, 16, 128, 128, 32),
+        ("dense", 4, 8, 16, 128, 128, 32),
+        ("dense", 32, 8, 16, 128, 128, 128),
+        ("dense", 64, 8, 16, 128, 128, 128),
+        ("varlen", 4, 8, 16, 128, 128, 32),
+        ("varlen", 16, 8, 16, 128, 128, 64),
+        ("varlen", 32, 8, 16, 128, 128, 128),
+        ("varlen", 64, 8, 16, 128, 128, 128),
+        ("varlen", 1, 16, 32, 128, 128, 32),
+        ("varlen", 32, 16, 32, 128, 128, 128),
+        ("varlen", 64, 16, 16, 128, 128, 128),
+    ]
+
+    all_pass = True
+    for layout, B, H, HV, K, V, pool_size in shapes:
+        if not check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout):
+            all_pass = False
+
+    print("\n  PAD_SLOT_ID test (indices with -1):")
+    inp = make_inputs(32, 8, 16, 128, 128, 128, device, dtype, layout="varlen")
+    inp["cache_indices"][::5] = -1
+
+    # Save pristine states to verify untouched pool slots remain unchanged.
+    st_ref_before = inp["ssm_states_triton"].clone()
+    st_cute_before = inp["ssm_states_cute"].clone()
+
+    o_ref, st_ref = run_baseline(inp)
+    o_cute, st_cute = run_cutedsl(inp)
+
+    # Triton: [pool, HV, V, K], CuTe: [pool, HV, K, V] -> [pool, HV, V, K]
+    st_cute_vk = st_cute.transpose(-1, -2).contiguous()
+    st_cute_before_vk = st_cute_before.transpose(-1, -2).contiguous()
+
+    # token positions in batch dimension
+    valid_token_pos = (inp["cache_indices"] >= 0).nonzero(as_tuple=False).squeeze(-1)
+    # pool slots actually referenced by valid tokens
+    valid_slots = inp["cache_indices"][inp["cache_indices"] >= 0].unique()
+
+    atol = 3e-2 if dtype != torch.float32 else 1e-4
+    rtol = 2e-2 if dtype != torch.float32 else 1e-4
+
+    pad_ok = True
+    details = []
+
+    # 1) Compare outputs only for valid tokens.
+    try:
+        torch.testing.assert_close(
+            o_cute[:, valid_token_pos].float(),
+            o_ref[:, valid_token_pos].float(),
+            atol=atol,
+            rtol=rtol,
+        )
+    except AssertionError:
+        pad_ok = False
+        out_diff = (
+            (o_cute[:, valid_token_pos].float() - o_ref[:, valid_token_pos].float())
+            .abs()
+            .max()
+            .item()
+        )
+        details.append(f"valid_output max_diff={out_diff:.6f}")
+
+    # 2) Compare states only for valid pool slots.
+    try:
+        torch.testing.assert_close(
+            st_cute_vk[valid_slots].float(),
+            st_ref[valid_slots].float(),
+            atol=atol,
+            rtol=rtol,
+        )
+    except AssertionError:
+        pad_ok = False
+        st_diff = (
+            (st_cute_vk[valid_slots].float() - st_ref[valid_slots].float())
+            .abs()
+            .max()
+            .item()
+        )
+        details.append(f"valid_state max_diff={st_diff:.6f}")
+
+    # 3) Untouched pool slots must remain unchanged.
+    untouched = torch.ones(inp["pool_size"], device=device, dtype=torch.bool)
+    untouched[valid_slots] = False
+
+    try:
+        torch.testing.assert_close(
+            st_ref[untouched].float(),
+            st_ref_before[untouched].float(),
+            atol=0.0,
+            rtol=0.0,
+        )
+        torch.testing.assert_close(
+            st_cute_vk[untouched].float(),
+            st_cute_before_vk[untouched].float(),
+            atol=0.0,
+            rtol=0.0,
+        )
+    except AssertionError:
+        pad_ok = False
+        details.append("untouched_slots modified")
+
+    if pad_ok:
+        print("  [PASS] PAD_SLOT_ID=-1 handling (valid outputs/states only)")
+    else:
+        print(f"  [FAIL] PAD_SLOT_ID=-1 handling ({', '.join(details)})")
+        all_pass = False
+
+    print()
+    print("ALL PASSED." if all_pass else "SOME FAILED.")
+    return all_pass
+
+
+def run_benchmark(device, dtype):
+    print()
+    print("=" * 92)
+    print("Benchmark: Triton KDA Decode vs CuTe DSL KDA Decode")
+    print("=" * 92)
+
+    bench_configs = [
+        ("dense", 1, 8, 16),
+        ("dense", 4, 8, 16),
+        ("dense", 32, 8, 16),
+        ("dense", 64, 8, 16),
+        ("varlen", 1, 8, 16),
+        ("varlen", 4, 8, 16),
+        ("varlen", 8, 8, 16),
+        ("varlen", 16, 8, 16),
+        ("varlen", 32, 8, 16),
+        ("varlen", 64, 8, 16),
+        ("varlen", 128, 8, 16),
+        ("varlen", 32, 16, 32),
+        ("varlen", 64, 16, 16),
+    ]
+
+    K = 128
+    V = 128
+    pool_size = 512
+
+    print(f"  Config: K={K}, V={V}, pool_size={pool_size}, dtype={dtype}")
+    print(
+        f"  {'layout':>6}  {'B':>5}  {'H':>3}  {'HV':>3}  {'K':>3}  {'V':>3} | "
+        f"{'triton (μs)':>12} | "
+        f"{'cutedsl (μs)':>13} | "
+        f"{'speedup':>8} | "
+        f"{'delta (μs)':>11}"
+    )
+    print("  " + "-" * 82)
+
+    for layout, B, H, HV in bench_configs:
+        actual_pool = max(pool_size, B + 16)
+        bench_shape(B, H, HV, K, V, actual_pool, device, dtype, layout)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark & Correctness: Triton KDA Decode vs CuTe DSL KDA Decode"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["all", "correctness", "bench"],
+        default="all",
+        help="Run mode (default: all)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16", "float32"],
+        default="bfloat16",
+    )
+    args = parser.parse_args()
+
+    device = "cuda"
+    dtype = getattr(torch, args.dtype)
+
+    cap = torch.cuda.get_device_capability()
+    dev_name = torch.cuda.get_device_name()
+    print(f"Device: {dev_name}  (SM {cap[0]}{cap[1]})")
+
+    if args.mode in ("all", "correctness"):
+        all_pass = run_correctness(device, dtype)
+        if not all_pass and args.mode == "all":
+            print("\nSkipping benchmark due to correctness failures.")
+            return 1
+
+    if args.mode in ("all", "bench"):
+        run_benchmark(device, dtype)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py
+++ b/benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py
@@ -1,19 +1,19 @@
 """
 Benchmark & Correctness: CuTe DSL KDA Decode vs Triton KDA Decode.
 
-Compares:
-  - Baseline: Triton fused_sigmoid_gating_delta_rule_update(..., is_kda=True)
-  - CuTe DSL: cutedsl_fused_sigmoid_gating_delta_rule_update_kda
-
-Notes:
-  - Triton KDA state layout is [pool, HV, V, K]
-  - CuTe DSL KDA state layout here is [pool, HV, K, V]
-  - We initialize both from the same canonical values and transpose when comparing states.
+Benchmark modes:
+  - Default (wall-clock): Measures Python dispatch + GPU execution.
+    CuTe DSL has ~120us Python overhead from from_dlpack/mark_layout_dynamic
+    that Triton doesn't have. This does NOT reflect production performance.
+  - --cuda-graph: Uses CUDA graph capture/replay, eliminating ALL Python dispatch
+    overhead for both backends. This reflects actual production performance
+    where SGLang uses CUDA graphs for decode.
 
 Usage:
-    python bench_cutedsl_kda_decode.py
+    python bench_cutedsl_kda_decode.py --mode bench --cuda-graph   # recommended
+    python bench_cutedsl_kda_decode.py --mode bench                # wall-clock
     python bench_cutedsl_kda_decode.py --mode correctness
-    python bench_cutedsl_kda_decode.py --mode bench
+    python bench_cutedsl_kda_decode.py                             # all
 """
 
 import argparse
@@ -34,24 +34,10 @@ from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
 )
 
 
-def make_inputs(
-    B: int,
-    H: int,
-    HV: int,
-    K: int,
-    V: int,
-    pool_size: int,
-    device: str,
-    dtype: torch.dtype,
-    layout: str,
-    seed: int = 42,
-):
+def make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
     torch.manual_seed(seed)
-
-    assert K == 128, "Current CuTe DSL KDA kernel assumes K=128"
-    assert (
-        V % 16 == 0 and V % 32 == 0
-    ), "Current CuTe DSL KDA kernel expects tile-friendly V"
+    assert K == 128
+    assert V % 16 == 0 and V % 32 == 0
 
     if layout == "varlen":
         q = torch.randn(1, B, H, K, device=device, dtype=dtype)
@@ -60,26 +46,20 @@ def make_inputs(
         a = torch.randn(B, HV, K, device=device, dtype=dtype)
         b = torch.randn(B, HV, device=device, dtype=dtype)
         cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
-    elif layout == "dense":
+    else:
         q = torch.randn(B, 1, H, K, device=device, dtype=dtype)
         k = torch.randn(B, 1, H, K, device=device, dtype=dtype)
         v = torch.randn(B, 1, HV, V, device=device, dtype=dtype)
         a = torch.randn(B, 1, HV, K, device=device, dtype=dtype)
         b = torch.randn(B, 1, HV, device=device, dtype=dtype)
         cu_seqlens = torch.arange(B + 1, device=device, dtype=torch.int32)
-    else:
-        raise ValueError(f"Unknown layout: {layout}")
 
     A_log = torch.randn(HV, device=device, dtype=torch.float32)
     dt_bias = torch.randn(HV, K, device=device, dtype=dtype)
-
-    # Canonical logical state in [pool, HV, K, V] for CuTe.
     ssm_states_cute = (
         torch.randn(pool_size, HV, K, V, device=device, dtype=torch.float32) * 0.1
     )
-    # Triton expects [pool, HV, V, K].
     ssm_states_triton = ssm_states_cute.transpose(-1, -2).contiguous()
-
     cache_indices = torch.arange(B, device=device, dtype=torch.int32)
 
     return dict(
@@ -146,24 +126,15 @@ def run_cutedsl(inp):
 
 
 def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42):
-    tag = (
-        f"layout={layout:<6} "
-        f"B={B:>2} H={H:>2} HV={HV:>2} K={K:>3} V={V:>3} pool={pool_size:>4}"
-    )
-
+    tag = f"layout={layout:<6} B={B:>2} H={H:>2} HV={HV:>2} K={K:>3} V={V:>3} pool={pool_size:>4}"
     inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout, seed=seed)
-
     o_ref, st_ref = run_baseline(inp)
     o_cute, st_cute = run_cutedsl(inp)
 
-    # Compare outputs directly; both return same logical layout as input q/v path.
     atol = 3e-2 if dtype != torch.float32 else 1e-4
     rtol = 2e-2 if dtype != torch.float32 else 1e-4
-
-    output_ok = True
-    state_ok = True
-    out_diff = 0.0
-    st_diff = 0.0
+    output_ok = state_ok = True
+    out_diff = st_diff = 0.0
 
     try:
         torch.testing.assert_close(o_cute.float(), o_ref.float(), atol=atol, rtol=rtol)
@@ -171,11 +142,8 @@ def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42)
         output_ok = False
         out_diff = (o_cute.float() - o_ref.float()).abs().max().item()
 
-    # Triton: [pool, HV, V, K], CuTe: [pool, HV, K, V]
     st_cute_vk = st_cute.transpose(-1, -2).contiguous()
-    idx = inp["cache_indices"]
-    valid_slots = idx[idx >= 0].unique()
-
+    valid_slots = inp["cache_indices"][inp["cache_indices"] >= 0].unique()
     try:
         torch.testing.assert_close(
             st_cute_vk[valid_slots].float(),
@@ -193,7 +161,6 @@ def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42)
         )
 
     passed = output_ok and state_ok
-
     if passed:
         print(f"  [PASS] {tag}")
     else:
@@ -203,13 +170,42 @@ def check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout, seed=42)
         if not state_ok:
             details.append(f"state max_diff={st_diff:.6f}")
         print(f"  [FAIL] {tag}  ({', '.join(details)})")
-
     return passed
 
 
-def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout):
-    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout)
+def bench_cuda_graph(fn, warmup=50, rep=200):
+    """Capture fn into CUDA graph, then benchmark replay with CUDA events."""
+    # Warmup + trigger JIT
+    for _ in range(5):
+        fn()
+    torch.cuda.synchronize()
 
+    # Capture
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+    torch.cuda.synchronize()
+
+    # Warmup replay
+    for _ in range(warmup):
+        g.replay()
+    torch.cuda.synchronize()
+
+    # Timed replay
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(rep)]
+    for i in range(rep):
+        start_events[i].record()
+        g.replay()
+        end_events[i].record()
+    torch.cuda.synchronize()
+
+    times_ms = sorted(s.elapsed_time(e) for s, e in zip(start_events, end_events))
+    return times_ms[len(times_ms) // 2]
+
+
+def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout, use_cuda_graph=False):
+    inp = make_inputs(B, H, HV, K, V, pool_size, device, dtype, layout)
     state_ref = inp["ssm_states_triton"].clone()
     state_cute = inp["ssm_states_cute"].clone()
 
@@ -248,45 +244,44 @@ def bench_shape(B, H, HV, K, V, pool_size, device, dtype, layout):
             softplus_threshold=20.0,
         )
 
+    # Warmup
     for _ in range(10):
         fn_baseline()
         fn_cutedsl()
     torch.cuda.synchronize()
 
-    quantiles = [0.5, 0.2, 0.8]
-
-    try:
-        ms_baseline, _, _ = triton.testing.do_bench(
-            fn_baseline, quantiles=quantiles, warmup=50, rep=200
-        )
-        ms_cutedsl, _, _ = triton.testing.do_bench(
-            fn_cutedsl, quantiles=quantiles, warmup=50, rep=200
-        )
-    except Exception:
-        torch.cuda.synchronize()
-        N = 200
-
-        start = time.perf_counter()
-        for _ in range(N):
-            fn_baseline()
-        torch.cuda.synchronize()
-        ms_baseline = (time.perf_counter() - start) / N * 1000
-
-        start = time.perf_counter()
-        for _ in range(N):
-            fn_cutedsl()
-        torch.cuda.synchronize()
-        ms_cutedsl = (time.perf_counter() - start) / N * 1000
+    if use_cuda_graph:
+        ms_baseline = bench_cuda_graph(fn_baseline)
+        ms_cutedsl = bench_cuda_graph(fn_cutedsl)
+    else:
+        quantiles = [0.5, 0.2, 0.8]
+        try:
+            ms_baseline, _, _ = triton.testing.do_bench(
+                fn_baseline, quantiles=quantiles, warmup=50, rep=200
+            )
+            ms_cutedsl, _, _ = triton.testing.do_bench(
+                fn_cutedsl, quantiles=quantiles, warmup=50, rep=200
+            )
+        except Exception:
+            torch.cuda.synchronize()
+            N = 200
+            start = time.perf_counter()
+            for _ in range(N):
+                fn_baseline()
+            torch.cuda.synchronize()
+            ms_baseline = (time.perf_counter() - start) / N * 1000
+            start = time.perf_counter()
+            for _ in range(N):
+                fn_cutedsl()
+            torch.cuda.synchronize()
+            ms_cutedsl = (time.perf_counter() - start) / N * 1000
 
     speedup = ms_baseline / ms_cutedsl if ms_cutedsl > 0 else float("inf")
     delta_us = (ms_baseline - ms_cutedsl) * 1000
-
     print(
         f"  {layout:>6}  {B:>5}  {H:>3}  {HV:>3}  {K:>3}  {V:>3} | "
-        f"{ms_baseline * 1000:>10.1f} | "
-        f"{ms_cutedsl * 1000:>10.1f} | "
-        f"{speedup:>7.2f}x | "
-        f"{delta_us:>+9.1f}"
+        f"{ms_baseline * 1000:>10.1f} | {ms_cutedsl * 1000:>10.1f} | "
+        f"{speedup:>7.2f}x | {delta_us:>+9.1f}"
     )
 
 
@@ -294,9 +289,7 @@ def run_correctness(device, dtype):
     print("=" * 78)
     print("Correctness: Triton KDA Decode vs CuTe DSL KDA Decode")
     print("=" * 78)
-
     shapes = [
-        # layout, B, H, HV, K, V, pool
         ("dense", 1, 8, 16, 128, 128, 32),
         ("dense", 4, 8, 16, 128, 128, 32),
         ("dense", 32, 8, 16, 128, 128, 128),
@@ -309,7 +302,6 @@ def run_correctness(device, dtype):
         ("varlen", 32, 16, 32, 128, 128, 128),
         ("varlen", 64, 16, 16, 128, 128, 128),
     ]
-
     all_pass = True
     for layout, B, H, HV, K, V, pool_size in shapes:
         if not check_correctness(B, H, HV, K, V, pool_size, device, dtype, layout):
@@ -318,30 +310,18 @@ def run_correctness(device, dtype):
     print("\n  PAD_SLOT_ID test (indices with -1):")
     inp = make_inputs(32, 8, 16, 128, 128, 128, device, dtype, layout="varlen")
     inp["cache_indices"][::5] = -1
-
-    # Save pristine states to verify untouched pool slots remain unchanged.
     st_ref_before = inp["ssm_states_triton"].clone()
     st_cute_before = inp["ssm_states_cute"].clone()
-
     o_ref, st_ref = run_baseline(inp)
     o_cute, st_cute = run_cutedsl(inp)
-
-    # Triton: [pool, HV, V, K], CuTe: [pool, HV, K, V] -> [pool, HV, V, K]
     st_cute_vk = st_cute.transpose(-1, -2).contiguous()
     st_cute_before_vk = st_cute_before.transpose(-1, -2).contiguous()
-
-    # token positions in batch dimension
     valid_token_pos = (inp["cache_indices"] >= 0).nonzero(as_tuple=False).squeeze(-1)
-    # pool slots actually referenced by valid tokens
     valid_slots = inp["cache_indices"][inp["cache_indices"] >= 0].unique()
-
     atol = 3e-2 if dtype != torch.float32 else 1e-4
     rtol = 2e-2 if dtype != torch.float32 else 1e-4
-
     pad_ok = True
     details = []
-
-    # 1) Compare outputs only for valid tokens.
     try:
         torch.testing.assert_close(
             o_cute[:, valid_token_pos].float(),
@@ -351,15 +331,9 @@ def run_correctness(device, dtype):
         )
     except AssertionError:
         pad_ok = False
-        out_diff = (
-            (o_cute[:, valid_token_pos].float() - o_ref[:, valid_token_pos].float())
-            .abs()
-            .max()
-            .item()
+        details.append(
+            f"valid_output max_diff={(o_cute[:, valid_token_pos].float() - o_ref[:, valid_token_pos].float()).abs().max().item():.6f}"
         )
-        details.append(f"valid_output max_diff={out_diff:.6f}")
-
-    # 2) Compare states only for valid pool slots.
     try:
         torch.testing.assert_close(
             st_cute_vk[valid_slots].float(),
@@ -369,18 +343,11 @@ def run_correctness(device, dtype):
         )
     except AssertionError:
         pad_ok = False
-        st_diff = (
-            (st_cute_vk[valid_slots].float() - st_ref[valid_slots].float())
-            .abs()
-            .max()
-            .item()
+        details.append(
+            f"valid_state max_diff={(st_cute_vk[valid_slots].float() - st_ref[valid_slots].float()).abs().max().item():.6f}"
         )
-        details.append(f"valid_state max_diff={st_diff:.6f}")
-
-    # 3) Untouched pool slots must remain unchanged.
     untouched = torch.ones(inp["pool_size"], device=device, dtype=torch.bool)
     untouched[valid_slots] = False
-
     try:
         torch.testing.assert_close(
             st_ref[untouched].float(),
@@ -397,25 +364,34 @@ def run_correctness(device, dtype):
     except AssertionError:
         pad_ok = False
         details.append("untouched_slots modified")
-
-    if pad_ok:
-        print("  [PASS] PAD_SLOT_ID=-1 handling (valid outputs/states only)")
-    else:
-        print(f"  [FAIL] PAD_SLOT_ID=-1 handling ({', '.join(details)})")
+    print(
+        f"  [{'PASS' if pad_ok else 'FAIL'}] PAD_SLOT_ID=-1 handling"
+        + (f" ({', '.join(details)})" if details else " (valid outputs/states only)")
+    )
+    if not pad_ok:
         all_pass = False
-
     print()
     print("ALL PASSED." if all_pass else "SOME FAILED.")
     return all_pass
 
 
-def run_benchmark(device, dtype):
+def run_benchmark(device, dtype, use_cuda_graph=False):
     print()
     print("=" * 92)
-    print("Benchmark: Triton KDA Decode vs CuTe DSL KDA Decode")
+    if use_cuda_graph:
+        print(
+            "Benchmark: Triton vs CuTe DSL KDA Decode  [CUDA Graph replay — production mode]"
+        )
+    else:
+        print(
+            "Benchmark: Triton vs CuTe DSL KDA Decode  [Wall-clock — includes Python dispatch]"
+        )
+        print(
+            "  NOTE: CuTe DSL shows ~120us Python overhead here that vanishes with CUDA graphs."
+        )
     print("=" * 92)
 
-    bench_configs = [
+    configs = [
         ("dense", 1, 8, 16),
         ("dense", 4, 8, 16),
         ("dense", 32, 8, 16),
@@ -430,49 +406,47 @@ def run_benchmark(device, dtype):
         ("varlen", 32, 16, 32),
         ("varlen", 64, 16, 16),
     ]
-
-    K = 128
-    V = 128
-    pool_size = 512
-
+    K, V, pool_size = 128, 128, 512
     print(f"  Config: K={K}, V={V}, pool_size={pool_size}, dtype={dtype}")
     print(
-        f"  {'layout':>6}  {'B':>5}  {'H':>3}  {'HV':>3}  {'K':>3}  {'V':>3} | "
-        f"{'triton (μs)':>12} | "
-        f"{'cutedsl (μs)':>13} | "
-        f"{'speedup':>8} | "
-        f"{'delta (μs)':>11}"
+        f"  {'layout':>6}  {'B':>5}  {'H':>3}  {'HV':>3}  {'K':>3}  {'V':>3} | {'triton (us)':>12} | {'cutedsl (us)':>13} | {'speedup':>8} | {'delta (us)':>11}"
     )
     print("  " + "-" * 82)
-
-    for layout, B, H, HV in bench_configs:
-        actual_pool = max(pool_size, B + 16)
-        bench_shape(B, H, HV, K, V, actual_pool, device, dtype, layout)
+    for layout, B, H, HV in configs:
+        bench_shape(
+            B,
+            H,
+            HV,
+            K,
+            V,
+            max(pool_size, B + 16),
+            device,
+            dtype,
+            layout,
+            use_cuda_graph=use_cuda_graph,
+        )
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Benchmark & Correctness: Triton KDA Decode vs CuTe DSL KDA Decode"
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode", choices=["all", "correctness", "bench"], default="all"
     )
     parser.add_argument(
-        "--mode",
-        choices=["all", "correctness", "bench"],
-        default="all",
-        help="Run mode (default: all)",
+        "--dtype", choices=["float16", "bfloat16", "float32"], default="bfloat16"
     )
     parser.add_argument(
-        "--dtype",
-        choices=["float16", "bfloat16", "float32"],
-        default="bfloat16",
+        "--cuda-graph",
+        action="store_true",
+        default=False,
+        help="Use CUDA graph capture/replay (recommended, matches production)",
     )
     args = parser.parse_args()
 
     device = "cuda"
     dtype = getattr(torch, args.dtype)
-
     cap = torch.cuda.get_device_capability()
-    dev_name = torch.cuda.get_device_name()
-    print(f"Device: {dev_name}  (SM {cap[0]}{cap[1]})")
+    print(f"Device: {torch.cuda.get_device_name()}  (SM {cap[0]}{cap[1]})")
 
     if args.mode in ("all", "correctness"):
         all_pass = run_correctness(device, dtype)
@@ -481,7 +455,11 @@ def main():
             return 1
 
     if args.mode in ("all", "bench"):
-        run_benchmark(device, dtype)
+        if args.cuda_graph:
+            run_benchmark(device, dtype, use_cuda_graph=True)
+        else:
+            run_benchmark(device, dtype, use_cuda_graph=False)
+            run_benchmark(device, dtype, use_cuda_graph=True)
 
     return 0
 

--- a/python/sglang/jit_kernel/cutedsl_kda.py
+++ b/python/sglang/jit_kernel/cutedsl_kda.py
@@ -1,0 +1,1569 @@
+"""CuTe DSL Fused Sigmoid Gating Delta Rule Kernel for KDA Decode.
+
+KDA (Kimi Delta Attention) differs from GDN in that the gating parameters
+`a` and `dt_bias` are per-key-dimension vectors instead of scalars.
+This results in per-row (per-K-dim) gating of the hidden state matrix:
+    h[k, v] *= exp(g[k])   (KDA, g is a K-vector)
+vs.
+    h *= exp(g)             (GDN, g is a scalar)
+"""
+
+import logging
+from typing import Dict, Optional, Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+
+logger = logging.getLogger(__name__)
+
+_compiled_kernels: Dict[Tuple, object] = {}
+_cu_seqlens_cache: Dict[Tuple, torch.Tensor] = {}
+TILE_K = 128
+TILE_V = 32
+TILE_V_PADDED = 36
+TILE_V_SMALL = 16
+TILE_V_SMALL_PADDED = 20
+NUM_STAGES = 2
+NUM_THREADS = 128
+NUM_BLOCKS_PER_STATE_SMALL = 8
+NUM_THREADS_LARGE = 256
+NUM_WARPS_LARGE = 8
+V_PER_WARP = 4
+ROWS_PER_ITER = 8
+NUM_K_ITERS = TILE_K // ROWS_PER_ITER
+SMALL_BATCH_THRESHOLD = 32
+
+
+def _define_kernels():
+    """Define CuTe DSL kernels for KDA normal and varlen decode modes."""
+
+    NUM_WARPS_SMALL = 4
+    V_PER_WARP_SMALL = TILE_V_SMALL // NUM_WARPS_SMALL
+    ROWS_PER_ITER_SMALL = 32 // V_PER_WARP_SMALL
+    NUM_K_ITERS_SMALL = TILE_K // ROWS_PER_ITER_SMALL
+
+    @cute.kernel
+    def kda_kernel_small_batch(
+        tiled_copy_load: cute.TiledCopy,
+        h0_source: cute.Tensor,
+        smem_layout_staged: cute.Layout,
+        num_v_tiles: cutlass.Constexpr[int],
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        o: cute.Tensor,
+        h0_indices: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+    ):
+        """Small batch KDA kernel for (N, 1, ...) format."""
+        tidx, _, _ = cute.arch.thread_idx()
+        in_warp_tid = tidx % 32
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        block_idx, _, _ = cute.arch.block_idx()
+
+        batch_idx = block_idx // NUM_BLOCKS_PER_STATE_SMALL
+        batch_inner = block_idx % NUM_BLOCKS_PER_STATE_SMALL
+        num_v_tiles_per_block = num_v_tiles // NUM_BLOCKS_PER_STATE_SMALL
+        start_v_tile = batch_inner * num_v_tiles_per_block
+
+        i_n = batch_idx // HV
+        i_hv = batch_idx % HV
+        i_h = i_hv // (HV // H)
+
+        pool_idx = h0_indices[i_n]
+
+        if pool_idx >= 0:
+            k_local = in_warp_tid // V_PER_WARP_SMALL
+            v_local = in_warp_tid % V_PER_WARP_SMALL
+            v_base = warp_idx * V_PER_WARP_SMALL
+            v_idx = v_base + v_local
+
+            smem = cutlass.utils.SmemAllocator()
+            sData = smem.allocate_tensor(cutlass.Float32, smem_layout_staged, 128)
+            smem_o_layout = cute.make_layout((TILE_V_SMALL,), stride=(1,))
+            smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
+            smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
+            sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
+            # KDA: shared memory for per-K gating values
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
+
+            if tidx < TILE_K:
+                sK[tidx] = cutlass.Float32(k[i_n, 0, i_h, tidx])
+                sQ[tidx] = cutlass.Float32(q[i_n, 0, i_h, tidx])
+
+            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
+            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V_SMALL), (0, None))
+            thr_copy_load = tiled_copy_load.get_slice(tidx)
+
+            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles_per_block)
+            for v_tile_offset in range(prefetch_count):
+                v_tile = start_v_tile + v_tile_offset
+                stage = v_tile_offset % NUM_STAGES
+                gSrc_tile = gSrc[(None, None, v_tile)]
+                sData_stage = sData[(None, None, stage)]
+                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
+                thr_sData = thr_copy_load.partition_D(sData_stage)
+                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                cute.arch.cp_async_commit_group()
+
+            # KDA: compute per-K gating values in parallel
+            r_A_log = cutlass.Float32(A_log[i_hv])
+            if tidx < TILE_K:
+                r_a_k = cutlass.Float32(a[i_n, 0, i_hv, tidx])
+                r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
+                x = r_a_k + r_dt_bias_k
+                beta_x = softplus_beta * x
+                softplus_x = 0.0
+                if beta_x <= softplus_threshold:
+                    exp_beta_x = cute.exp(beta_x)
+                    log_input = cutlass.Float32(1.0 + exp_beta_x)
+                    log_result = cutlass.Float32(cute.log(log_input))
+                    softplus_x = cutlass.Float32(
+                        (cutlass.Float32(1.0) / softplus_beta) * log_result
+                    )
+                else:
+                    softplus_x = x
+                r_g_value = -cute.exp(r_A_log) * softplus_x
+                sG[tidx] = cute.exp(r_g_value)
+
+            # Compute beta (scalar, same as GDN)
+            r_b = cutlass.Float32(b[i_n, 0, i_hv])
+            r_beta = 0.0
+            if in_warp_tid == 0:
+                r_beta = 1.0 / (1.0 + cute.exp(-r_b))
+            r_beta = cute.arch.shuffle_sync(r_beta, 0)
+
+            cute.arch.barrier()
+
+            if use_qk_l2norm:
+                sum_q_partial = 0.0
+                sum_k_partial = 0.0
+                if tidx < TILE_K:
+                    q_val = sQ[tidx]
+                    k_val = sK[tidx]
+                    sum_q_partial = q_val * q_val
+                    sum_k_partial = k_val * k_val
+
+                for offset in [16, 8, 4, 2, 1]:
+                    sum_q_partial += cute.arch.shuffle_sync_bfly(
+                        sum_q_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sum_k_partial += cute.arch.shuffle_sync_bfly(
+                        sum_k_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                if in_warp_tid == 0:
+                    smem_o[warp_idx] = sum_q_partial
+                    smem_o[warp_idx + 4] = sum_k_partial
+                cute.arch.barrier()
+
+                inv_norm_q = 0.0
+                inv_norm_k = 0.0
+                if warp_idx == 0:
+                    local_sum_q = 0.0
+                    local_sum_k = 0.0
+                    if in_warp_tid < NUM_WARPS_SMALL:
+                        local_sum_q = smem_o[in_warp_tid]
+                        local_sum_k = smem_o[in_warp_tid + 4]
+                    for offset in [2, 1]:
+                        local_sum_q += cute.arch.shuffle_sync_bfly(
+                            local_sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                        local_sum_k += cute.arch.shuffle_sync_bfly(
+                            local_sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                    if in_warp_tid == 0:
+                        smem_o[0] = cute.rsqrt(local_sum_q + 1e-6)
+                        smem_o[1] = cute.rsqrt(local_sum_k + 1e-6)
+                cute.arch.barrier()
+
+                inv_norm_q = smem_o[0]
+                inv_norm_k = smem_o[1]
+
+                if tidx < TILE_K:
+                    sK[tidx] = sK[tidx] * inv_norm_k
+                    sQ[tidx] = sQ[tidx] * scale * inv_norm_q
+                cute.arch.barrier()
+            else:
+                if tidx < TILE_K:
+                    sQ[tidx] = sQ[tidx] * scale
+                cute.arch.barrier()
+
+            for v_tile_offset in range(num_v_tiles_per_block):
+                v_tile = start_v_tile + v_tile_offset
+                stage = v_tile_offset % NUM_STAGES
+
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+
+                next_v_tile_offset = v_tile_offset + prefetch_count
+                if next_v_tile_offset < num_v_tiles_per_block:
+                    next_v_tile = start_v_tile + next_v_tile_offset
+                    next_stage = next_v_tile_offset % NUM_STAGES
+                    gSrc_next = gSrc[(None, None, next_v_tile)]
+                    sData_next = sData[(None, None, next_stage)]
+                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
+                    thr_sData = thr_copy_load.partition_D(sData_next)
+                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                    cute.arch.cp_async_commit_group()
+
+                v_global = v_tile * TILE_V_SMALL + v_idx
+                r_v = cutlass.Float32(v[i_n, 0, i_hv, v_global])
+
+                # KDA: use per-K gating sG[k_idx] instead of scalar r_g
+                sum_hk = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                    k_base = k_iter * ROWS_PER_ITER_SMALL
+                    k_idx = k_base + k_local
+                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    sum_hk += h_val * r_k_val
+
+                for offset in [4, 2, 1]:
+                    sum_hk += cute.arch.shuffle_sync_bfly(
+                        sum_hk,
+                        offset=offset * V_PER_WARP_SMALL,
+                        mask=-1,
+                        mask_and_clamp=31,
+                    )
+
+                v_new = (r_v - sum_hk) * r_beta
+                v_new = cute.arch.shuffle_sync(v_new, v_local)
+
+                # KDA: use per-K gating sG[k_idx] instead of scalar r_g
+                sum_hq = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                    k_base = k_iter * ROWS_PER_ITER_SMALL
+                    k_idx = k_base + k_local
+                    h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    r_q_val = sQ[k_idx]
+                    h_new = h_old + r_k_val * v_new
+                    sData[(k_idx, v_idx, stage)] = h_new
+                    sum_hq += h_new * r_q_val
+
+                for offset in [4, 2, 1]:
+                    sum_hq += cute.arch.shuffle_sync_bfly(
+                        sum_hq,
+                        offset=offset * V_PER_WARP_SMALL,
+                        mask=-1,
+                        mask_and_clamp=31,
+                    )
+
+                if k_local == 0:
+                    v_global_out = v_tile * TILE_V_SMALL + v_idx
+                    o[(i_n, 0, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+
+                cute.arch.barrier()
+
+                for k_iter in range(NUM_K_ITERS_SMALL):
+                    flat_idx = tidx + k_iter * 128
+                    k_write = flat_idx // TILE_V_SMALL
+                    v_write = flat_idx % TILE_V_SMALL
+                    if k_write < TILE_K:
+                        h_val = sData[(k_write, v_write, stage)]
+                        v_global_write = v_tile * TILE_V_SMALL + v_write
+                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+
+                cute.arch.barrier()
+
+    @cute.kernel
+    def kda_kernel_small_batch_varlen(
+        tiled_copy_load: cute.TiledCopy,
+        h0_source: cute.Tensor,
+        smem_layout_staged: cute.Layout,
+        num_v_tiles: cutlass.Constexpr[int],
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        o: cute.Tensor,
+        h0_indices: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+    ):
+        """Small batch KDA kernel for varlen decode (1, N, ...) format."""
+        tidx, _, _ = cute.arch.thread_idx()
+        in_warp_tid = tidx % 32
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        block_idx, _, _ = cute.arch.block_idx()
+
+        batch_idx = block_idx // NUM_BLOCKS_PER_STATE_SMALL
+        batch_inner = block_idx % NUM_BLOCKS_PER_STATE_SMALL
+        num_v_tiles_per_block = num_v_tiles // NUM_BLOCKS_PER_STATE_SMALL
+        start_v_tile = batch_inner * num_v_tiles_per_block
+
+        i_n = batch_idx // HV
+        i_hv = batch_idx % HV
+        i_h = i_hv // (HV // H)
+
+        pool_idx = h0_indices[i_n]
+
+        if pool_idx >= 0:
+            k_local = in_warp_tid // V_PER_WARP_SMALL
+            v_local = in_warp_tid % V_PER_WARP_SMALL
+            v_base = warp_idx * V_PER_WARP_SMALL
+            v_idx = v_base + v_local
+
+            smem = cutlass.utils.SmemAllocator()
+            sData = smem.allocate_tensor(cutlass.Float32, smem_layout_staged, 128)
+            smem_o_layout = cute.make_layout((TILE_V_SMALL,), stride=(1,))
+            smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
+            smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
+            sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
+            # KDA: shared memory for per-K gating values
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
+
+            if tidx < TILE_K:
+                sK[tidx] = cutlass.Float32(k[0, i_n, i_h, tidx])
+                sQ[tidx] = cutlass.Float32(q[0, i_n, i_h, tidx])
+
+            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
+            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V_SMALL), (0, None))
+            thr_copy_load = tiled_copy_load.get_slice(tidx)
+
+            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles_per_block)
+            for v_tile_offset in range(prefetch_count):
+                v_tile = start_v_tile + v_tile_offset
+                stage = v_tile_offset % NUM_STAGES
+                gSrc_tile = gSrc[(None, None, v_tile)]
+                sData_stage = sData[(None, None, stage)]
+                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
+                thr_sData = thr_copy_load.partition_D(sData_stage)
+                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                cute.arch.cp_async_commit_group()
+
+            # KDA: compute per-K gating values in parallel
+            # Varlen: a shape is (N, HV, K), dt_bias shape is (HV, K)
+            r_A_log = cutlass.Float32(A_log[i_hv])
+            if tidx < TILE_K:
+                r_a_k = cutlass.Float32(a[i_n, i_hv, tidx])
+                r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
+                x = r_a_k + r_dt_bias_k
+                beta_x = softplus_beta * x
+                softplus_x = 0.0
+                if beta_x <= softplus_threshold:
+                    exp_beta_x = cute.exp(beta_x)
+                    log_input = cutlass.Float32(1.0 + exp_beta_x)
+                    log_result = cutlass.Float32(cute.log(log_input))
+                    softplus_x = cutlass.Float32(
+                        (cutlass.Float32(1.0) / softplus_beta) * log_result
+                    )
+                else:
+                    softplus_x = x
+                r_g_value = -cute.exp(r_A_log) * softplus_x
+                sG[tidx] = cute.exp(r_g_value)
+
+            # Compute beta (scalar, same as GDN)
+            # Varlen: b shape is (N, HV)
+            r_b = cutlass.Float32(b[i_n, i_hv])
+            r_beta = 0.0
+            if in_warp_tid == 0:
+                r_beta = 1.0 / (1.0 + cute.exp(-r_b))
+            r_beta = cute.arch.shuffle_sync(r_beta, 0)
+
+            cute.arch.barrier()
+
+            if use_qk_l2norm:
+                sum_q_partial = 0.0
+                sum_k_partial = 0.0
+                if tidx < TILE_K:
+                    q_val = sQ[tidx]
+                    k_val = sK[tidx]
+                    sum_q_partial = q_val * q_val
+                    sum_k_partial = k_val * k_val
+
+                for offset in [16, 8, 4, 2, 1]:
+                    sum_q_partial += cute.arch.shuffle_sync_bfly(
+                        sum_q_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sum_k_partial += cute.arch.shuffle_sync_bfly(
+                        sum_k_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                if in_warp_tid == 0:
+                    smem_o[warp_idx] = sum_q_partial
+                    smem_o[warp_idx + 4] = sum_k_partial
+                cute.arch.barrier()
+
+                inv_norm_q = 0.0
+                inv_norm_k = 0.0
+                if warp_idx == 0:
+                    local_sum_q = 0.0
+                    local_sum_k = 0.0
+                    if in_warp_tid < NUM_WARPS_SMALL:
+                        local_sum_q = smem_o[in_warp_tid]
+                        local_sum_k = smem_o[in_warp_tid + 4]
+                    for offset in [2, 1]:
+                        local_sum_q += cute.arch.shuffle_sync_bfly(
+                            local_sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                        local_sum_k += cute.arch.shuffle_sync_bfly(
+                            local_sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                    if in_warp_tid == 0:
+                        smem_o[0] = cute.rsqrt(local_sum_q + 1e-6)
+                        smem_o[1] = cute.rsqrt(local_sum_k + 1e-6)
+                cute.arch.barrier()
+
+                inv_norm_q = smem_o[0]
+                inv_norm_k = smem_o[1]
+
+                if tidx < TILE_K:
+                    sK[tidx] = sK[tidx] * inv_norm_k
+                    sQ[tidx] = sQ[tidx] * scale * inv_norm_q
+                cute.arch.barrier()
+            else:
+                if tidx < TILE_K:
+                    sQ[tidx] = sQ[tidx] * scale
+                cute.arch.barrier()
+
+            for v_tile_offset in range(num_v_tiles_per_block):
+                v_tile = start_v_tile + v_tile_offset
+                stage = v_tile_offset % NUM_STAGES
+
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+
+                next_v_tile_offset = v_tile_offset + prefetch_count
+                if next_v_tile_offset < num_v_tiles_per_block:
+                    next_v_tile = start_v_tile + next_v_tile_offset
+                    next_stage = next_v_tile_offset % NUM_STAGES
+                    gSrc_next = gSrc[(None, None, next_v_tile)]
+                    sData_next = sData[(None, None, next_stage)]
+                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
+                    thr_sData = thr_copy_load.partition_D(sData_next)
+                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                    cute.arch.cp_async_commit_group()
+
+                v_global = v_tile * TILE_V_SMALL + v_idx
+                r_v = cutlass.Float32(v[0, i_n, i_hv, v_global])
+
+                # KDA: use per-K gating sG[k_idx]
+                sum_hk = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                    k_base = k_iter * ROWS_PER_ITER_SMALL
+                    k_idx = k_base + k_local
+                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    sum_hk += h_val * r_k_val
+
+                for offset in [4, 2, 1]:
+                    sum_hk += cute.arch.shuffle_sync_bfly(
+                        sum_hk,
+                        offset=offset * V_PER_WARP_SMALL,
+                        mask=-1,
+                        mask_and_clamp=31,
+                    )
+
+                v_new = (r_v - sum_hk) * r_beta
+                v_new = cute.arch.shuffle_sync(v_new, v_local)
+
+                # KDA: use per-K gating sG[k_idx]
+                sum_hq = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                    k_base = k_iter * ROWS_PER_ITER_SMALL
+                    k_idx = k_base + k_local
+                    h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    r_q_val = sQ[k_idx]
+                    h_new = h_old + r_k_val * v_new
+                    sData[(k_idx, v_idx, stage)] = h_new
+                    sum_hq += h_new * r_q_val
+
+                for offset in [4, 2, 1]:
+                    sum_hq += cute.arch.shuffle_sync_bfly(
+                        sum_hq,
+                        offset=offset * V_PER_WARP_SMALL,
+                        mask=-1,
+                        mask_and_clamp=31,
+                    )
+
+                if k_local == 0:
+                    v_global_out = v_tile * TILE_V_SMALL + v_idx
+                    o[(0, i_n, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+
+                cute.arch.barrier()
+
+                for k_iter in range(NUM_K_ITERS_SMALL):
+                    flat_idx = tidx + k_iter * 128
+                    k_write = flat_idx // TILE_V_SMALL
+                    v_write = flat_idx % TILE_V_SMALL
+                    if k_write < TILE_K:
+                        h_val = sData[(k_write, v_write, stage)]
+                        v_global_write = v_tile * TILE_V_SMALL + v_write
+                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+
+                cute.arch.barrier()
+
+    @cute.kernel
+    def kda_kernel_large_batch(
+        tiled_copy_load: cute.TiledCopy,
+        h0_source: cute.Tensor,
+        smem_layout_staged: cute.Layout,
+        num_v_tiles: cutlass.Constexpr[int],
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        o: cute.Tensor,
+        h0_indices: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+    ):
+        """Large batch KDA kernel for (N, 1, ...) format."""
+        tidx, _, _ = cute.arch.thread_idx()
+        in_warp_tid = tidx % 32
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        batch_idx, _, _ = cute.arch.block_idx()
+        i_n = batch_idx // HV
+        i_hv = batch_idx % HV
+        i_h = i_hv // (HV // H)
+
+        pool_idx = h0_indices[i_n]
+
+        if pool_idx >= 0:
+            k_local = in_warp_tid // V_PER_WARP
+            v_local = in_warp_tid % V_PER_WARP
+            v_base = warp_idx * V_PER_WARP
+            v_idx = v_base + v_local
+
+            smem = cutlass.utils.SmemAllocator()
+            sData = smem.allocate_tensor(cutlass.Float32, smem_layout_staged, 128)
+            smem_o_layout = cute.make_layout((TILE_V,), stride=(1,))
+            smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
+            smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
+            sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
+            # KDA: shared memory for per-K gating values
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
+
+            if tidx < TILE_K:
+                sK[tidx] = cutlass.Float32(k[i_n, 0, i_h, tidx])
+                sQ[tidx] = cutlass.Float32(q[i_n, 0, i_h, tidx])
+
+            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
+            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V), (0, None))
+            thr_copy_load = tiled_copy_load.get_slice(tidx)
+
+            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles)
+            for v_tile in range(prefetch_count):
+                stage = v_tile % NUM_STAGES
+                gSrc_tile = gSrc[(None, None, v_tile)]
+                sData_stage = sData[(None, None, stage)]
+                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
+                thr_sData = thr_copy_load.partition_D(sData_stage)
+                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                cute.arch.cp_async_commit_group()
+
+            # KDA: compute per-K gating values in parallel
+            # Normal: a shape is (N, 1, HV, K), dt_bias shape is (HV, K)
+            r_A_log = cutlass.Float32(A_log[i_hv])
+            if tidx < TILE_K:
+                r_a_k = cutlass.Float32(a[i_n, 0, i_hv, tidx])
+                r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
+                x = r_a_k + r_dt_bias_k
+                beta_x = softplus_beta * x
+                softplus_x = 0.0
+                if beta_x <= softplus_threshold:
+                    exp_beta_x = cute.exp(beta_x)
+                    log_input = cutlass.Float32(1.0 + exp_beta_x)
+                    log_result = cutlass.Float32(cute.log(log_input))
+                    softplus_x = cutlass.Float32(
+                        (cutlass.Float32(1.0) / softplus_beta) * log_result
+                    )
+                else:
+                    softplus_x = x
+                r_g_value = -cute.exp(r_A_log) * softplus_x
+                sG[tidx] = cute.exp(r_g_value)
+
+            # Compute beta (scalar, same as GDN)
+            r_b = cutlass.Float32(b[i_n, 0, i_hv])
+            r_beta = 0.0
+            if in_warp_tid == 0:
+                r_beta = 1.0 / (1.0 + cute.exp(-r_b))
+            r_beta = cute.arch.shuffle_sync(r_beta, 0)
+
+            cute.arch.barrier()
+
+            if use_qk_l2norm:
+                sum_q_partial = 0.0
+                sum_k_partial = 0.0
+                if tidx < TILE_K:
+                    q_val = sQ[tidx]
+                    k_val = sK[tidx]
+                    sum_q_partial = q_val * q_val
+                    sum_k_partial = k_val * k_val
+
+                for offset in [16, 8, 4, 2, 1]:
+                    sum_q_partial += cute.arch.shuffle_sync_bfly(
+                        sum_q_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sum_k_partial += cute.arch.shuffle_sync_bfly(
+                        sum_k_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                if in_warp_tid == 0:
+                    smem_o[warp_idx] = sum_q_partial
+                    smem_o[warp_idx + 8] = sum_k_partial
+                cute.arch.barrier()
+
+                inv_norm_q = 0.0
+                inv_norm_k = 0.0
+                if warp_idx == 0:
+                    local_sum_q = 0.0
+                    local_sum_k = 0.0
+                    if in_warp_tid < NUM_WARPS_LARGE:
+                        local_sum_q = smem_o[in_warp_tid]
+                        local_sum_k = smem_o[in_warp_tid + 8]
+                    for offset in [4, 2, 1]:
+                        local_sum_q += cute.arch.shuffle_sync_bfly(
+                            local_sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                        local_sum_k += cute.arch.shuffle_sync_bfly(
+                            local_sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                    if in_warp_tid == 0:
+                        smem_o[0] = cute.rsqrt(local_sum_q + 1e-6)
+                        smem_o[1] = cute.rsqrt(local_sum_k + 1e-6)
+                cute.arch.barrier()
+
+                inv_norm_q = smem_o[0]
+                inv_norm_k = smem_o[1]
+
+                if tidx < TILE_K:
+                    sK[tidx] = sK[tidx] * inv_norm_k
+                    sQ[tidx] = sQ[tidx] * scale * inv_norm_q
+                cute.arch.barrier()
+            else:
+                if tidx < TILE_K:
+                    sQ[tidx] = sQ[tidx] * scale
+                cute.arch.barrier()
+
+            for v_tile in range(num_v_tiles):
+                stage = v_tile % NUM_STAGES
+
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+
+                next_v_tile = v_tile + prefetch_count
+                if next_v_tile < num_v_tiles:
+                    next_stage = next_v_tile % NUM_STAGES
+                    gSrc_next = gSrc[(None, None, next_v_tile)]
+                    sData_next = sData[(None, None, next_stage)]
+                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
+                    thr_sData = thr_copy_load.partition_D(sData_next)
+                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                    cute.arch.cp_async_commit_group()
+
+                v_global = v_tile * TILE_V + v_idx
+                r_v = cutlass.Float32(v[i_n, 0, i_hv, v_global])
+
+                # KDA: use per-K gating sG[k_idx]
+                sum_hk = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                    k_base = k_iter * ROWS_PER_ITER
+                    k_idx = k_base + k_local
+                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    sum_hk += h_val * r_k_val
+
+                for offset in [4, 2, 1]:
+                    sum_hk += cute.arch.shuffle_sync_bfly(
+                        sum_hk, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                    )
+
+                v_new = (r_v - sum_hk) * r_beta
+                v_new = cute.arch.shuffle_sync(v_new, v_local)
+
+                # KDA: use per-K gating sG[k_idx]
+                sum_hq = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                    k_base = k_iter * ROWS_PER_ITER
+                    k_idx = k_base + k_local
+                    h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    r_q_val = sQ[k_idx]
+                    h_new = h_old + r_k_val * v_new
+                    sData[(k_idx, v_idx, stage)] = h_new
+                    sum_hq += h_new * r_q_val
+
+                for offset in [4, 2, 1]:
+                    sum_hq += cute.arch.shuffle_sync_bfly(
+                        sum_hq, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                    )
+
+                if k_local == 0:
+                    v_global_out = v_tile * TILE_V + v_idx
+                    o[(i_n, 0, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+
+                cute.arch.barrier()
+
+                for k_iter in range(NUM_K_ITERS):
+                    flat_idx = tidx + k_iter * 256
+                    k_write = flat_idx // TILE_V
+                    v_write = flat_idx % TILE_V
+                    if k_write < TILE_K:
+                        h_val = sData[(k_write, v_write, stage)]
+                        v_global_write = v_tile * TILE_V + v_write
+                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+
+                cute.arch.barrier()
+
+    @cute.kernel
+    def kda_kernel_large_batch_varlen(
+        tiled_copy_load: cute.TiledCopy,
+        h0_source: cute.Tensor,
+        smem_layout_staged: cute.Layout,
+        num_v_tiles: cutlass.Constexpr[int],
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        o: cute.Tensor,
+        h0_indices: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+    ):
+        """Large batch KDA kernel for varlen decode (1, N, ...) format."""
+        tidx, _, _ = cute.arch.thread_idx()
+        in_warp_tid = tidx % 32
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        batch_idx, _, _ = cute.arch.block_idx()
+        i_n = batch_idx // HV
+        i_hv = batch_idx % HV
+        i_h = i_hv // (HV // H)
+
+        pool_idx = h0_indices[i_n]
+
+        if pool_idx >= 0:
+            k_local = in_warp_tid // V_PER_WARP
+            v_local = in_warp_tid % V_PER_WARP
+            v_base = warp_idx * V_PER_WARP
+            v_idx = v_base + v_local
+
+            smem = cutlass.utils.SmemAllocator()
+            sData = smem.allocate_tensor(cutlass.Float32, smem_layout_staged, 128)
+            smem_o_layout = cute.make_layout((TILE_V,), stride=(1,))
+            smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
+            smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
+            sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
+            # KDA: shared memory for per-K gating values
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
+            sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
+
+            if tidx < TILE_K:
+                sK[tidx] = cutlass.Float32(k[0, i_n, i_h, tidx])
+                sQ[tidx] = cutlass.Float32(q[0, i_n, i_h, tidx])
+
+            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
+            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V), (0, None))
+            thr_copy_load = tiled_copy_load.get_slice(tidx)
+
+            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles)
+            for v_tile in range(prefetch_count):
+                stage = v_tile % NUM_STAGES
+                gSrc_tile = gSrc[(None, None, v_tile)]
+                sData_stage = sData[(None, None, stage)]
+                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
+                thr_sData = thr_copy_load.partition_D(sData_stage)
+                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                cute.arch.cp_async_commit_group()
+
+            # KDA: compute per-K gating values in parallel
+            # Varlen: a shape is (N, HV, K), dt_bias shape is (HV, K)
+            r_A_log = cutlass.Float32(A_log[i_hv])
+            if tidx < TILE_K:
+                r_a_k = cutlass.Float32(a[i_n, i_hv, tidx])
+                r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
+                x = r_a_k + r_dt_bias_k
+                beta_x = softplus_beta * x
+                softplus_x = 0.0
+                if beta_x <= softplus_threshold:
+                    exp_beta_x = cute.exp(beta_x)
+                    log_input = cutlass.Float32(1.0 + exp_beta_x)
+                    log_result = cutlass.Float32(cute.log(log_input))
+                    softplus_x = cutlass.Float32(
+                        (cutlass.Float32(1.0) / softplus_beta) * log_result
+                    )
+                else:
+                    softplus_x = x
+                r_g_value = -cute.exp(r_A_log) * softplus_x
+                sG[tidx] = cute.exp(r_g_value)
+
+            # Compute beta (scalar, same as GDN)
+            # Varlen: b shape is (N, HV)
+            r_b = cutlass.Float32(b[i_n, i_hv])
+            r_beta = 0.0
+            if in_warp_tid == 0:
+                r_beta = 1.0 / (1.0 + cute.exp(-r_b))
+            r_beta = cute.arch.shuffle_sync(r_beta, 0)
+
+            cute.arch.barrier()
+
+            if use_qk_l2norm:
+                sum_q_partial = 0.0
+                sum_k_partial = 0.0
+                if tidx < TILE_K:
+                    q_val = sQ[tidx]
+                    k_val = sK[tidx]
+                    sum_q_partial = q_val * q_val
+                    sum_k_partial = k_val * k_val
+
+                for offset in [16, 8, 4, 2, 1]:
+                    sum_q_partial += cute.arch.shuffle_sync_bfly(
+                        sum_q_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+                    sum_k_partial += cute.arch.shuffle_sync_bfly(
+                        sum_k_partial, offset=offset, mask=-1, mask_and_clamp=31
+                    )
+
+                if in_warp_tid == 0:
+                    smem_o[warp_idx] = sum_q_partial
+                    smem_o[warp_idx + 8] = sum_k_partial
+                cute.arch.barrier()
+
+                inv_norm_q = 0.0
+                inv_norm_k = 0.0
+                if warp_idx == 0:
+                    local_sum_q = 0.0
+                    local_sum_k = 0.0
+                    if in_warp_tid < NUM_WARPS_LARGE:
+                        local_sum_q = smem_o[in_warp_tid]
+                        local_sum_k = smem_o[in_warp_tid + 8]
+                    for offset in [4, 2, 1]:
+                        local_sum_q += cute.arch.shuffle_sync_bfly(
+                            local_sum_q, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                        local_sum_k += cute.arch.shuffle_sync_bfly(
+                            local_sum_k, offset=offset, mask=-1, mask_and_clamp=31
+                        )
+                    if in_warp_tid == 0:
+                        smem_o[0] = cute.rsqrt(local_sum_q + 1e-6)
+                        smem_o[1] = cute.rsqrt(local_sum_k + 1e-6)
+                cute.arch.barrier()
+
+                inv_norm_q = smem_o[0]
+                inv_norm_k = smem_o[1]
+
+                if tidx < TILE_K:
+                    sK[tidx] = sK[tidx] * inv_norm_k
+                    sQ[tidx] = sQ[tidx] * scale * inv_norm_q
+                cute.arch.barrier()
+            else:
+                if tidx < TILE_K:
+                    sQ[tidx] = sQ[tidx] * scale
+                cute.arch.barrier()
+
+            for v_tile in range(num_v_tiles):
+                stage = v_tile % NUM_STAGES
+
+                cute.arch.cp_async_wait_group(0)
+                cute.arch.barrier()
+
+                next_v_tile = v_tile + prefetch_count
+                if next_v_tile < num_v_tiles:
+                    next_stage = next_v_tile % NUM_STAGES
+                    gSrc_next = gSrc[(None, None, next_v_tile)]
+                    sData_next = sData[(None, None, next_stage)]
+                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
+                    thr_sData = thr_copy_load.partition_D(sData_next)
+                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
+                    cute.arch.cp_async_commit_group()
+
+                v_global = v_tile * TILE_V + v_idx
+                r_v = cutlass.Float32(v[0, i_n, i_hv, v_global])
+
+                # KDA: use per-K gating sG[k_idx]
+                sum_hk = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                    k_base = k_iter * ROWS_PER_ITER
+                    k_idx = k_base + k_local
+                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    sum_hk += h_val * r_k_val
+
+                for offset in [4, 2, 1]:
+                    sum_hk += cute.arch.shuffle_sync_bfly(
+                        sum_hk, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                    )
+
+                v_new = (r_v - sum_hk) * r_beta
+                v_new = cute.arch.shuffle_sync(v_new, v_local)
+
+                # KDA: use per-K gating sG[k_idx]
+                sum_hq = 0.0
+                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                    k_base = k_iter * ROWS_PER_ITER
+                    k_idx = k_base + k_local
+                    h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
+                    r_k_val = sK[k_idx]
+                    r_q_val = sQ[k_idx]
+                    h_new = h_old + r_k_val * v_new
+                    sData[(k_idx, v_idx, stage)] = h_new
+                    sum_hq += h_new * r_q_val
+
+                for offset in [4, 2, 1]:
+                    sum_hq += cute.arch.shuffle_sync_bfly(
+                        sum_hq, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                    )
+
+                if k_local == 0:
+                    v_global_out = v_tile * TILE_V + v_idx
+                    o[(0, i_n, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+
+                cute.arch.barrier()
+
+                for k_iter in range(NUM_K_ITERS):
+                    flat_idx = tidx + k_iter * 256
+                    k_write = flat_idx // TILE_V
+                    v_write = flat_idx % TILE_V
+                    if k_write < TILE_K:
+                        h_val = sData[(k_write, v_write, stage)]
+                        v_global_write = v_tile * TILE_V + v_write
+                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+
+                cute.arch.barrier()
+
+    return (
+        kda_kernel_small_batch,
+        kda_kernel_small_batch_varlen,
+        kda_kernel_large_batch,
+        kda_kernel_large_batch_varlen,
+    )
+
+
+def _create_jit_functions():
+    """Create JIT-compiled launcher functions for all KDA kernel variants."""
+
+    kda_small, kda_small_varlen, kda_large, kda_large_varlen = _define_kernels()
+
+    @cute.jit
+    def run_small_batch(
+        cu_seqlens: cute.Tensor,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        h0_source: cute.Tensor,
+        h0_indices: cute.Tensor,
+        o: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        B: cutlass.Constexpr[int],
+        T: cutlass.Constexpr[int],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        K: cutlass.Constexpr[int],
+        V: cutlass.Constexpr[int],
+        use_initial_state: cutlass.Constexpr[bool],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+        stream: cuda.CUstream,
+    ):
+        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        n_indices = h0_indices.layout.shape[0]
+        batch_size = n_indices * hv_dim
+
+        copy_atom = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            cutlass.Float32,
+            num_bits_per_copy=128,
+        )
+        num_v_tiles_small = cute.ceil_div(v_dim, TILE_V_SMALL)
+        smem_layout_small = cute.make_layout(
+            (TILE_K, TILE_V_SMALL, NUM_STAGES),
+            stride=(TILE_V_SMALL_PADDED, 1, TILE_K * TILE_V_SMALL_PADDED),
+        )
+        thread_layout_small = cute.make_layout((32, 4), stride=(4, 1))
+        val_layout_small = cute.make_layout((1, 4))
+        tiled_copy_load_small = cute.make_tiled_copy_tv(
+            copy_atom, thread_layout_small, val_layout_small
+        )
+        # KDA: extra TILE_K floats for sG
+        smem_bytes_small = (
+            4 * TILE_K * TILE_V_SMALL_PADDED * NUM_STAGES
+            + 4 * TILE_V_SMALL
+            + 4 * TILE_K * 2
+            + 4 * TILE_K
+            + 64
+        )
+
+        kda_small(
+            tiled_copy_load_small,
+            h0_source,
+            smem_layout_small,
+            num_v_tiles_small,
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            o,
+            h0_indices,
+            softplus_beta,
+            softplus_threshold,
+            scale,
+            H,
+            HV,
+            use_qk_l2norm,
+        ).launch(
+            grid=(batch_size * NUM_BLOCKS_PER_STATE_SMALL, 1, 1),
+            block=[NUM_THREADS, 1, 1],
+            smem=smem_bytes_small,
+            stream=stream,
+        )
+
+    @cute.jit
+    def run_small_batch_varlen(
+        cu_seqlens: cute.Tensor,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        h0_source: cute.Tensor,
+        h0_indices: cute.Tensor,
+        o: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        B: cutlass.Constexpr[int],
+        T: cutlass.Constexpr[int],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        K: cutlass.Constexpr[int],
+        V: cutlass.Constexpr[int],
+        use_initial_state: cutlass.Constexpr[bool],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+        stream: cuda.CUstream,
+    ):
+        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        n_indices = h0_indices.layout.shape[0]
+        batch_size = n_indices * hv_dim
+
+        copy_atom = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            cutlass.Float32,
+            num_bits_per_copy=128,
+        )
+        num_v_tiles_small = cute.ceil_div(v_dim, TILE_V_SMALL)
+        smem_layout_small = cute.make_layout(
+            (TILE_K, TILE_V_SMALL, NUM_STAGES),
+            stride=(TILE_V_SMALL_PADDED, 1, TILE_K * TILE_V_SMALL_PADDED),
+        )
+        thread_layout_small = cute.make_layout((32, 4), stride=(4, 1))
+        val_layout_small = cute.make_layout((1, 4))
+        tiled_copy_load_small = cute.make_tiled_copy_tv(
+            copy_atom, thread_layout_small, val_layout_small
+        )
+        # KDA: extra TILE_K floats for sG
+        smem_bytes_small = (
+            4 * TILE_K * TILE_V_SMALL_PADDED * NUM_STAGES
+            + 4 * TILE_V_SMALL
+            + 4 * TILE_K * 2
+            + 4 * TILE_K
+            + 64
+        )
+
+        kda_small_varlen(
+            tiled_copy_load_small,
+            h0_source,
+            smem_layout_small,
+            num_v_tiles_small,
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            o,
+            h0_indices,
+            softplus_beta,
+            softplus_threshold,
+            scale,
+            H,
+            HV,
+            use_qk_l2norm,
+        ).launch(
+            grid=(batch_size * NUM_BLOCKS_PER_STATE_SMALL, 1, 1),
+            block=[NUM_THREADS, 1, 1],
+            smem=smem_bytes_small,
+            stream=stream,
+        )
+
+    @cute.jit
+    def run_large_batch(
+        cu_seqlens: cute.Tensor,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        h0_source: cute.Tensor,
+        h0_indices: cute.Tensor,
+        o: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        B: cutlass.Constexpr[int],
+        T: cutlass.Constexpr[int],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        K: cutlass.Constexpr[int],
+        V: cutlass.Constexpr[int],
+        use_initial_state: cutlass.Constexpr[bool],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+        stream: cuda.CUstream,
+    ):
+        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        n_indices = h0_indices.layout.shape[0]
+        batch_size = n_indices * hv_dim
+
+        copy_atom = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            cutlass.Float32,
+            num_bits_per_copy=128,
+        )
+        num_v_tiles = cute.ceil_div(v_dim, TILE_V)
+        base_smem_layout = cute.make_layout(
+            (TILE_K, TILE_V, NUM_STAGES),
+            stride=(TILE_V_PADDED, 1, TILE_K * TILE_V_PADDED),
+        )
+        thread_layout = cute.make_layout((32, 8), stride=(8, 1))
+        val_layout = cute.make_layout((1, 4))
+        tiled_copy_load = cute.make_tiled_copy_tv(copy_atom, thread_layout, val_layout)
+        # KDA: extra TILE_K floats for sG
+        smem_bytes = (
+            4 * TILE_K * TILE_V_PADDED * NUM_STAGES
+            + 4 * TILE_V
+            + 4 * TILE_K * 2
+            + 4 * TILE_K
+            + 64
+        )
+
+        kda_large(
+            tiled_copy_load,
+            h0_source,
+            base_smem_layout,
+            num_v_tiles,
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            o,
+            h0_indices,
+            softplus_beta,
+            softplus_threshold,
+            scale,
+            H,
+            HV,
+            use_qk_l2norm,
+        ).launch(
+            grid=(batch_size, 1, 1),
+            block=[NUM_THREADS_LARGE, 1, 1],
+            smem=smem_bytes,
+            stream=stream,
+        )
+
+    @cute.jit
+    def run_large_batch_varlen(
+        cu_seqlens: cute.Tensor,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        A_log: cute.Tensor,
+        dt_bias: cute.Tensor,
+        h0_source: cute.Tensor,
+        h0_indices: cute.Tensor,
+        o: cute.Tensor,
+        softplus_beta: cutlass.Constexpr[float],
+        softplus_threshold: cutlass.Constexpr[float],
+        scale: cutlass.Constexpr[float],
+        B: cutlass.Constexpr[int],
+        T: cutlass.Constexpr[int],
+        H: cutlass.Constexpr[int],
+        HV: cutlass.Constexpr[int],
+        K: cutlass.Constexpr[int],
+        V: cutlass.Constexpr[int],
+        use_initial_state: cutlass.Constexpr[bool],
+        use_qk_l2norm: cutlass.Constexpr[bool],
+        stream: cuda.CUstream,
+    ):
+        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        n_indices = h0_indices.layout.shape[0]
+        batch_size = n_indices * hv_dim
+
+        copy_atom = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            cutlass.Float32,
+            num_bits_per_copy=128,
+        )
+        num_v_tiles = cute.ceil_div(v_dim, TILE_V)
+        base_smem_layout = cute.make_layout(
+            (TILE_K, TILE_V, NUM_STAGES),
+            stride=(TILE_V_PADDED, 1, TILE_K * TILE_V_PADDED),
+        )
+        thread_layout = cute.make_layout((32, 8), stride=(8, 1))
+        val_layout = cute.make_layout((1, 4))
+        tiled_copy_load = cute.make_tiled_copy_tv(copy_atom, thread_layout, val_layout)
+        # KDA: extra TILE_K floats for sG
+        smem_bytes = (
+            4 * TILE_K * TILE_V_PADDED * NUM_STAGES
+            + 4 * TILE_V
+            + 4 * TILE_K * 2
+            + 4 * TILE_K
+            + 64
+        )
+
+        kda_large_varlen(
+            tiled_copy_load,
+            h0_source,
+            base_smem_layout,
+            num_v_tiles,
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            o,
+            h0_indices,
+            softplus_beta,
+            softplus_threshold,
+            scale,
+            H,
+            HV,
+            use_qk_l2norm,
+        ).launch(
+            grid=(batch_size, 1, 1),
+            block=[NUM_THREADS_LARGE, 1, 1],
+            smem=smem_bytes,
+            stream=stream,
+        )
+
+    return (
+        run_small_batch,
+        run_small_batch_varlen,
+        run_large_batch,
+        run_large_batch_varlen,
+    )
+
+
+_jit_functions = None
+
+
+def _get_jit_functions():
+    global _jit_functions
+    if _jit_functions is None:
+        _jit_functions = _create_jit_functions()
+    return _jit_functions
+
+
+def _get_compiled_kernel(N, H, HV, K, V, pool_size, use_small_batch, is_varlen_decode):
+    """Get or compile the KDA kernel for given dimensions."""
+    global _compiled_kernels
+
+    key = (N, H, HV, K, V, pool_size, use_small_batch, is_varlen_decode)
+    if key in _compiled_kernels:
+        return _compiled_kernels[key]
+
+    cu_seqlens = torch.zeros(N + 1, dtype=torch.int32, device="cuda")
+
+    if is_varlen_decode:
+        q = torch.zeros(1, N, H, K, dtype=torch.bfloat16, device="cuda")
+        k = torch.zeros(1, N, H, K, dtype=torch.bfloat16, device="cuda")
+        v = torch.zeros(1, N, HV, V, dtype=torch.bfloat16, device="cuda")
+        # KDA: a has extra K dimension; varlen shape (N, HV, K)
+        a = torch.zeros(N, HV, K, dtype=torch.bfloat16, device="cuda")
+        b = torch.zeros(N, HV, dtype=torch.bfloat16, device="cuda")
+        o = torch.zeros(1, N, HV, V, dtype=torch.bfloat16, device="cuda")
+    else:
+        q = torch.zeros(N, 1, H, K, dtype=torch.bfloat16, device="cuda")
+        k = torch.zeros(N, 1, H, K, dtype=torch.bfloat16, device="cuda")
+        v = torch.zeros(N, 1, HV, V, dtype=torch.bfloat16, device="cuda")
+        # KDA: a has extra K dimension; normal shape (N, 1, HV, K)
+        a = torch.zeros(N, 1, HV, K, dtype=torch.bfloat16, device="cuda")
+        b = torch.zeros(N, 1, HV, dtype=torch.bfloat16, device="cuda")
+        o = torch.zeros(N, 1, HV, V, dtype=torch.bfloat16, device="cuda")
+
+    A_log = torch.zeros(HV, dtype=torch.float32, device="cuda")
+    # KDA: dt_bias has extra K dimension; shape (HV, K)
+    dt_bias = torch.zeros(HV, K, dtype=torch.bfloat16, device="cuda")
+    h0_source = torch.zeros(pool_size, HV, K, V, dtype=torch.float32, device="cuda")
+    h0_indices = torch.zeros(N, dtype=torch.int32, device="cuda")
+
+    cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+    q_tensor = from_dlpack(q, assumed_align=16)
+    k_tensor = from_dlpack(k, assumed_align=16)
+    v_tensor = from_dlpack(v, assumed_align=16)
+    a_tensor = from_dlpack(a, assumed_align=16)
+    b_tensor = from_dlpack(b, assumed_align=16)
+    A_log_tensor = from_dlpack(A_log, assumed_align=16)
+    dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
+    h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
+    h0_indices_tensor = from_dlpack(h0_indices, assumed_align=16)
+    o_tensor = from_dlpack(o, assumed_align=16)
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    run_small, run_small_varlen, run_large, run_large_varlen = _get_jit_functions()
+
+    if use_small_batch:
+        kernel_func = run_small_varlen if is_varlen_decode else run_small
+    else:
+        kernel_func = run_large_varlen if is_varlen_decode else run_large
+
+    scale = K**-0.5
+    softplus_beta = 1.0
+    softplus_threshold = 20.0
+
+    B_compile = 1 if is_varlen_decode else N
+    T_compile = N if is_varlen_decode else 1
+
+    compiled_kernel = cute.compile(
+        kernel_func,
+        cu_seqlens_tensor,
+        q_tensor,
+        k_tensor,
+        v_tensor,
+        a_tensor,
+        b_tensor,
+        A_log_tensor,
+        dt_bias_tensor,
+        h0_source_tensor,
+        h0_indices_tensor,
+        o_tensor,
+        softplus_beta=softplus_beta,
+        softplus_threshold=softplus_threshold,
+        scale=scale,
+        B=B_compile,
+        T=T_compile,
+        H=H,
+        K=K,
+        V=V,
+        HV=HV,
+        use_initial_state=True,
+        use_qk_l2norm=True,
+        stream=stream,
+    )
+
+    _compiled_kernels[key] = compiled_kernel
+    logger.info(
+        f"CuTe DSL KDA kernel compiled: N={N}, H={H}, HV={HV}, K={K}, V={V}, "
+        f"pool_size={pool_size}, small_batch={use_small_batch}, varlen={is_varlen_decode}"
+    )
+
+    return compiled_kernel
+
+
+def cutedsl_fused_sigmoid_gating_kda_update(
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    use_qk_l2norm_in_kernel: bool = True,
+    softplus_beta: float = 1.0,
+    softplus_threshold: float = 20.0,
+) -> torch.Tensor:
+    """CuTe DSL implementation of fused sigmoid gating KDA (delta rule) update.
+
+    Key difference from GDN: `a` and `dt_bias` are per-key-dimension vectors,
+    resulting in per-row gating of the hidden state matrix.
+
+    Args:
+        A_log: Log of decay rate, shape (HV,)
+        dt_bias: Timestep bias, shape (HV, K) — per-key in KDA
+        q: Query, shape (B, T, H, K) or (1, N, H, K) for varlen
+        k: Key, shape (B, T, H, K) or (1, N, H, K) for varlen
+        v: Value, shape (B, T, HV, V) or (1, N, HV, V) for varlen
+        a: Gating input, shape (B, T, HV, K) — per-key in KDA
+        b: Beta gating input, shape (B, T, HV) — scalar per head
+        initial_state_source: State pool, shape (pool_size, HV, K, V)
+        initial_state_indices: Indices into state pool, shape (N,)
+        cu_seqlens: Cumulative sequence lengths for varlen mode
+        scale: Query scaling factor (default: K^{-0.5})
+        use_qk_l2norm_in_kernel: Whether to L2-normalize q and k
+        softplus_beta: Softplus beta parameter
+        softplus_threshold: Softplus threshold for numerical stability
+    """
+
+    B_q, T_q, H, K = q.shape
+    HV = v.shape[2]
+    V = v.shape[3]
+    N = initial_state_indices.shape[0]
+
+    is_varlen_decode = B_q == 1 and T_q == N and N > 1
+    if scale is None:
+        scale = K**-0.5
+
+    use_small_batch = N < SMALL_BATCH_THRESHOLD
+
+    if initial_state_source.dim() == 1:
+        pool_size = initial_state_source.numel() // (HV * K * V)
+        h0_source = initial_state_source.view(pool_size, HV, K, V)
+    elif initial_state_source.dim() == 4:
+        pool_size = initial_state_source.shape[0]
+        h0_source = initial_state_source
+    else:
+        raise ValueError(
+            f"Unexpected initial_state_source shape: {initial_state_source.shape}"
+        )
+
+    if is_varlen_decode:
+        # KDA varlen: a is (1, N, HV, K) -> squeeze to (N, HV, K)
+        if a.dim() == 4:
+            a = a.squeeze(0)
+        # b is (1, N, HV) -> squeeze to (N, HV)
+        if b.dim() == 3:
+            b = b.squeeze(0)
+        o = q.new_empty(1, N, HV, V, dtype=torch.bfloat16)
+    else:
+        # KDA normal: a is (N, 1, HV, K), keep as-is
+        if a.dim() == 3:
+            a = a.unsqueeze(1)
+        # b is (N, HV) -> unsqueeze to (N, 1, HV)
+        if b.dim() == 2:
+            b = b.unsqueeze(1)
+        o = q.new_empty(N, 1, HV, V, dtype=torch.bfloat16)
+
+    q, k, v = [t.contiguous() for t in (q, k, v)]
+
+    global _cu_seqlens_cache
+    if cu_seqlens is not None:
+        cu_seqlens_to_use = cu_seqlens
+    else:
+        cache_key = (N, str(q.device))
+        if cache_key not in _cu_seqlens_cache:
+            _cu_seqlens_cache[cache_key] = torch.arange(
+                N + 1, dtype=torch.int32, device=q.device
+            )
+        cu_seqlens_to_use = _cu_seqlens_cache[cache_key]
+
+    cu_seqlens_tensor = from_dlpack(
+        cu_seqlens_to_use.detach(), assumed_align=16
+    ).mark_layout_dynamic(leading_dim=0)
+    q_tensor = from_dlpack(q.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=q.ndim - 1
+    )
+    k_tensor = from_dlpack(k.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=k.ndim - 1
+    )
+    v_tensor = from_dlpack(v.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=v.ndim - 1
+    )
+    a_tensor = from_dlpack(a.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=a.ndim - 1
+    )
+    b_tensor = from_dlpack(b.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=b.ndim - 1
+    )
+    A_log_tensor = from_dlpack(A_log.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=0
+    )
+    dt_bias_tensor = from_dlpack(
+        dt_bias.detach(), assumed_align=16
+    ).mark_layout_dynamic(leading_dim=dt_bias.ndim - 1)
+    h0_source_tensor = from_dlpack(
+        h0_source.detach(), assumed_align=16
+    ).mark_layout_dynamic(leading_dim=h0_source.ndim - 1)
+    h0_indices_tensor = from_dlpack(
+        initial_state_indices.detach(), assumed_align=16
+    ).mark_layout_dynamic(leading_dim=0)
+    o_tensor = from_dlpack(o.detach(), assumed_align=16).mark_layout_dynamic(
+        leading_dim=o.ndim - 1
+    )
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compiled_kernel = _get_compiled_kernel(
+        N, H, HV, K, V, pool_size, use_small_batch, is_varlen_decode
+    )
+
+    compiled_kernel(
+        cu_seqlens_tensor,
+        q_tensor,
+        k_tensor,
+        v_tensor,
+        a_tensor,
+        b_tensor,
+        A_log_tensor,
+        dt_bias_tensor,
+        h0_source_tensor,
+        h0_indices_tensor,
+        o_tensor,
+        stream,
+    )
+
+    return o

--- a/python/sglang/jit_kernel/cutedsl_kda.py
+++ b/python/sglang/jit_kernel/cutedsl_kda.py
@@ -1,11 +1,17 @@
 """CuTe DSL Fused Sigmoid Gating Delta Rule Kernel for KDA Decode.
 
-KDA (Kimi Delta Attention) differs from GDN in that the gating parameters
-`a` and `dt_bias` are per-key-dimension vectors instead of scalars.
-This results in per-row (per-K-dim) gating of the hidden state matrix:
-    h[k, v] *= exp(g[k])   (KDA, g is a K-vector)
-vs.
-    h *= exp(g)             (GDN, g is a scalar)
+This version uses production / Triton-compatible VK state layout:
+    state.shape == (pool_size, HV, V, K)
+
+The kernel still computes on a logical (K, V) matrix in shared memory. Global
+state loads/stores therefore explicitly map:
+    global(V, K) <-> shared(K, V)
+
+Notes:
+- This is a correctness-first implementation for decode.
+- It keeps the original small-batch / large-batch split.
+- It preserves the previous PAD semantics: if pool_idx < 0 the block does not
+  load / update / write output or state, consistent with the earlier CuTe path.
 """
 
 import logging
@@ -15,13 +21,13 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.runtime import from_dlpack
 
 logger = logging.getLogger(__name__)
 
 _compiled_kernels: Dict[Tuple, object] = {}
 _cu_seqlens_cache: Dict[Tuple, torch.Tensor] = {}
+
 TILE_K = 128
 TILE_V = 32
 TILE_V_PADDED = 36
@@ -68,7 +74,8 @@ def _define_kernels():
         HV: cutlass.Constexpr[int],
         use_qk_l2norm: cutlass.Constexpr[bool],
     ):
-        """Small batch KDA kernel for (N, 1, ...) format."""
+        """Small batch KDA kernel for dense decode: q/k/v shapes (N, 1, ...)."""
+        del tiled_copy_load
         tidx, _, _ = cute.arch.thread_idx()
         in_warp_tid = tidx % 32
         warp_idx = cute.arch.warp_idx()
@@ -98,33 +105,17 @@ def _define_kernels():
             smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
             smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
             smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
             sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
-            # KDA: shared memory for per-K gating values
-            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
 
             if tidx < TILE_K:
                 sK[tidx] = cutlass.Float32(k[i_n, 0, i_h, tidx])
                 sQ[tidx] = cutlass.Float32(q[i_n, 0, i_h, tidx])
 
-            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
-            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V_SMALL), (0, None))
-            thr_copy_load = tiled_copy_load.get_slice(tidx)
-
-            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles_per_block)
-            for v_tile_offset in range(prefetch_count):
-                v_tile = start_v_tile + v_tile_offset
-                stage = v_tile_offset % NUM_STAGES
-                gSrc_tile = gSrc[(None, None, v_tile)]
-                sData_stage = sData[(None, None, stage)]
-                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
-                thr_sData = thr_copy_load.partition_D(sData_stage)
-                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                cute.arch.cp_async_commit_group()
-
-            # KDA: compute per-K gating values in parallel
             r_A_log = cutlass.Float32(A_log[i_hv])
+            r_exp_A = cute.exp(r_A_log)
             if tidx < TILE_K:
                 r_a_k = cutlass.Float32(a[i_n, 0, i_hv, tidx])
                 r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
@@ -140,13 +131,11 @@ def _define_kernels():
                     )
                 else:
                     softplus_x = x
-                r_g_value = -cute.exp(r_A_log) * softplus_x
-                sG[tidx] = cute.exp(r_g_value)
+                sG[tidx] = cute.exp(-r_exp_A * softplus_x)
 
-            # Compute beta (scalar, same as GDN)
-            r_b = cutlass.Float32(b[i_n, 0, i_hv])
             r_beta = 0.0
             if in_warp_tid == 0:
+                r_b = cutlass.Float32(b[i_n, 0, i_hv])
                 r_beta = 1.0 / (1.0 + cute.exp(-r_b))
             r_beta = cute.arch.shuffle_sync(r_beta, 0)
 
@@ -174,8 +163,6 @@ def _define_kernels():
                     smem_o[warp_idx + 4] = sum_k_partial
                 cute.arch.barrier()
 
-                inv_norm_q = 0.0
-                inv_norm_k = 0.0
                 if warp_idx == 0:
                     local_sum_q = 0.0
                     local_sum_k = 0.0
@@ -207,34 +194,34 @@ def _define_kernels():
                 cute.arch.barrier()
 
             for v_tile_offset in range(num_v_tiles_per_block):
-                v_tile = start_v_tile + v_tile_offset
                 stage = v_tile_offset % NUM_STAGES
+                v_tile = start_v_tile + v_tile_offset
 
-                cute.arch.cp_async_wait_group(0)
+                for k_iter in range(NUM_K_ITERS_SMALL):
+                    flat_idx = tidx + k_iter * NUM_THREADS
+                    k_load = flat_idx // TILE_V_SMALL
+                    v_load = flat_idx % TILE_V_SMALL
+                    if k_load < TILE_K:
+                        v_global_load = v_tile * TILE_V_SMALL + v_load
+                        h_val = 0.0
+                        if v_global_load < v.shape[3]:
+                            h_val = cutlass.Float32(
+                                h0_source[(pool_idx, i_hv, v_global_load, k_load)]
+                            )
+                        sData[(k_load, v_load, stage)] = h_val
+
                 cute.arch.barrier()
 
-                next_v_tile_offset = v_tile_offset + prefetch_count
-                if next_v_tile_offset < num_v_tiles_per_block:
-                    next_v_tile = start_v_tile + next_v_tile_offset
-                    next_stage = next_v_tile_offset % NUM_STAGES
-                    gSrc_next = gSrc[(None, None, next_v_tile)]
-                    sData_next = sData[(None, None, next_stage)]
-                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
-                    thr_sData = thr_copy_load.partition_D(sData_next)
-                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                    cute.arch.cp_async_commit_group()
-
                 v_global = v_tile * TILE_V_SMALL + v_idx
-                r_v = cutlass.Float32(v[i_n, 0, i_hv, v_global])
+                r_v = 0.0
+                if v_global < v.shape[3]:
+                    r_v = cutlass.Float32(v[i_n, 0, i_hv, v_global])
 
-                # KDA: use per-K gating sG[k_idx] instead of scalar r_g
                 sum_hk = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                for k_iter in range(NUM_K_ITERS_SMALL):
                     k_base = k_iter * ROWS_PER_ITER_SMALL
                     k_idx = k_base + k_local
-                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    sum_hk += h_val * r_k_val
+                    sum_hk += sData[(k_idx, v_idx, stage)] * sG[k_idx] * sK[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hk += cute.arch.shuffle_sync_bfly(
@@ -247,17 +234,14 @@ def _define_kernels():
                 v_new = (r_v - sum_hk) * r_beta
                 v_new = cute.arch.shuffle_sync(v_new, v_local)
 
-                # KDA: use per-K gating sG[k_idx] instead of scalar r_g
                 sum_hq = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                for k_iter in range(NUM_K_ITERS_SMALL):
                     k_base = k_iter * ROWS_PER_ITER_SMALL
                     k_idx = k_base + k_local
                     h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    r_q_val = sQ[k_idx]
-                    h_new = h_old + r_k_val * v_new
+                    h_new = h_old + sK[k_idx] * v_new
                     sData[(k_idx, v_idx, stage)] = h_new
-                    sum_hq += h_new * r_q_val
+                    sum_hq += h_new * sQ[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hq += cute.arch.shuffle_sync_bfly(
@@ -267,20 +251,21 @@ def _define_kernels():
                         mask_and_clamp=31,
                     )
 
-                if k_local == 0:
-                    v_global_out = v_tile * TILE_V_SMALL + v_idx
-                    o[(i_n, 0, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+                if k_local == 0 and v_global < v.shape[3]:
+                    o[(i_n, 0, i_hv, v_global)] = cutlass.BFloat16(sum_hq)
 
                 cute.arch.barrier()
 
                 for k_iter in range(NUM_K_ITERS_SMALL):
-                    flat_idx = tidx + k_iter * 128
+                    flat_idx = tidx + k_iter * NUM_THREADS
                     k_write = flat_idx // TILE_V_SMALL
                     v_write = flat_idx % TILE_V_SMALL
                     if k_write < TILE_K:
-                        h_val = sData[(k_write, v_write, stage)]
                         v_global_write = v_tile * TILE_V_SMALL + v_write
-                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+                        if v_global_write < v.shape[3]:
+                            h0_source[(pool_idx, i_hv, v_global_write, k_write)] = (
+                                sData[(k_write, v_write, stage)]
+                            )
 
                 cute.arch.barrier()
 
@@ -306,7 +291,8 @@ def _define_kernels():
         HV: cutlass.Constexpr[int],
         use_qk_l2norm: cutlass.Constexpr[bool],
     ):
-        """Small batch KDA kernel for varlen decode (1, N, ...) format."""
+        """Small batch KDA kernel for varlen decode: q/k/v shapes (1, N, ...)."""
+        del tiled_copy_load
         tidx, _, _ = cute.arch.thread_idx()
         in_warp_tid = tidx % 32
         warp_idx = cute.arch.warp_idx()
@@ -336,34 +322,17 @@ def _define_kernels():
             smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
             smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
             smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
             sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
-            # KDA: shared memory for per-K gating values
-            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
 
             if tidx < TILE_K:
                 sK[tidx] = cutlass.Float32(k[0, i_n, i_h, tidx])
                 sQ[tidx] = cutlass.Float32(q[0, i_n, i_h, tidx])
 
-            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
-            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V_SMALL), (0, None))
-            thr_copy_load = tiled_copy_load.get_slice(tidx)
-
-            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles_per_block)
-            for v_tile_offset in range(prefetch_count):
-                v_tile = start_v_tile + v_tile_offset
-                stage = v_tile_offset % NUM_STAGES
-                gSrc_tile = gSrc[(None, None, v_tile)]
-                sData_stage = sData[(None, None, stage)]
-                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
-                thr_sData = thr_copy_load.partition_D(sData_stage)
-                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                cute.arch.cp_async_commit_group()
-
-            # KDA: compute per-K gating values in parallel
-            # Varlen: a shape is (N, HV, K), dt_bias shape is (HV, K)
             r_A_log = cutlass.Float32(A_log[i_hv])
+            r_exp_A = cute.exp(r_A_log)
             if tidx < TILE_K:
                 r_a_k = cutlass.Float32(a[i_n, i_hv, tidx])
                 r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
@@ -379,14 +348,11 @@ def _define_kernels():
                     )
                 else:
                     softplus_x = x
-                r_g_value = -cute.exp(r_A_log) * softplus_x
-                sG[tidx] = cute.exp(r_g_value)
+                sG[tidx] = cute.exp(-r_exp_A * softplus_x)
 
-            # Compute beta (scalar, same as GDN)
-            # Varlen: b shape is (N, HV)
-            r_b = cutlass.Float32(b[i_n, i_hv])
             r_beta = 0.0
             if in_warp_tid == 0:
+                r_b = cutlass.Float32(b[i_n, i_hv])
                 r_beta = 1.0 / (1.0 + cute.exp(-r_b))
             r_beta = cute.arch.shuffle_sync(r_beta, 0)
 
@@ -414,8 +380,6 @@ def _define_kernels():
                     smem_o[warp_idx + 4] = sum_k_partial
                 cute.arch.barrier()
 
-                inv_norm_q = 0.0
-                inv_norm_k = 0.0
                 if warp_idx == 0:
                     local_sum_q = 0.0
                     local_sum_k = 0.0
@@ -447,34 +411,34 @@ def _define_kernels():
                 cute.arch.barrier()
 
             for v_tile_offset in range(num_v_tiles_per_block):
-                v_tile = start_v_tile + v_tile_offset
                 stage = v_tile_offset % NUM_STAGES
+                v_tile = start_v_tile + v_tile_offset
 
-                cute.arch.cp_async_wait_group(0)
+                for k_iter in range(NUM_K_ITERS_SMALL):
+                    flat_idx = tidx + k_iter * NUM_THREADS
+                    k_load = flat_idx // TILE_V_SMALL
+                    v_load = flat_idx % TILE_V_SMALL
+                    if k_load < TILE_K:
+                        v_global_load = v_tile * TILE_V_SMALL + v_load
+                        h_val = 0.0
+                        if v_global_load < v.shape[3]:
+                            h_val = cutlass.Float32(
+                                h0_source[(pool_idx, i_hv, v_global_load, k_load)]
+                            )
+                        sData[(k_load, v_load, stage)] = h_val
+
                 cute.arch.barrier()
 
-                next_v_tile_offset = v_tile_offset + prefetch_count
-                if next_v_tile_offset < num_v_tiles_per_block:
-                    next_v_tile = start_v_tile + next_v_tile_offset
-                    next_stage = next_v_tile_offset % NUM_STAGES
-                    gSrc_next = gSrc[(None, None, next_v_tile)]
-                    sData_next = sData[(None, None, next_stage)]
-                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
-                    thr_sData = thr_copy_load.partition_D(sData_next)
-                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                    cute.arch.cp_async_commit_group()
-
                 v_global = v_tile * TILE_V_SMALL + v_idx
-                r_v = cutlass.Float32(v[0, i_n, i_hv, v_global])
+                r_v = 0.0
+                if v_global < v.shape[3]:
+                    r_v = cutlass.Float32(v[0, i_n, i_hv, v_global])
 
-                # KDA: use per-K gating sG[k_idx]
                 sum_hk = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                for k_iter in range(NUM_K_ITERS_SMALL):
                     k_base = k_iter * ROWS_PER_ITER_SMALL
                     k_idx = k_base + k_local
-                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    sum_hk += h_val * r_k_val
+                    sum_hk += sData[(k_idx, v_idx, stage)] * sG[k_idx] * sK[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hk += cute.arch.shuffle_sync_bfly(
@@ -487,17 +451,14 @@ def _define_kernels():
                 v_new = (r_v - sum_hk) * r_beta
                 v_new = cute.arch.shuffle_sync(v_new, v_local)
 
-                # KDA: use per-K gating sG[k_idx]
                 sum_hq = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
+                for k_iter in range(NUM_K_ITERS_SMALL):
                     k_base = k_iter * ROWS_PER_ITER_SMALL
                     k_idx = k_base + k_local
                     h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    r_q_val = sQ[k_idx]
-                    h_new = h_old + r_k_val * v_new
+                    h_new = h_old + sK[k_idx] * v_new
                     sData[(k_idx, v_idx, stage)] = h_new
-                    sum_hq += h_new * r_q_val
+                    sum_hq += h_new * sQ[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hq += cute.arch.shuffle_sync_bfly(
@@ -507,20 +468,21 @@ def _define_kernels():
                         mask_and_clamp=31,
                     )
 
-                if k_local == 0:
-                    v_global_out = v_tile * TILE_V_SMALL + v_idx
-                    o[(0, i_n, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+                if k_local == 0 and v_global < v.shape[3]:
+                    o[(0, i_n, i_hv, v_global)] = cutlass.BFloat16(sum_hq)
 
                 cute.arch.barrier()
 
                 for k_iter in range(NUM_K_ITERS_SMALL):
-                    flat_idx = tidx + k_iter * 128
+                    flat_idx = tidx + k_iter * NUM_THREADS
                     k_write = flat_idx // TILE_V_SMALL
                     v_write = flat_idx % TILE_V_SMALL
                     if k_write < TILE_K:
-                        h_val = sData[(k_write, v_write, stage)]
                         v_global_write = v_tile * TILE_V_SMALL + v_write
-                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+                        if v_global_write < v.shape[3]:
+                            h0_source[(pool_idx, i_hv, v_global_write, k_write)] = (
+                                sData[(k_write, v_write, stage)]
+                            )
 
                 cute.arch.barrier()
 
@@ -546,12 +508,14 @@ def _define_kernels():
         HV: cutlass.Constexpr[int],
         use_qk_l2norm: cutlass.Constexpr[bool],
     ):
-        """Large batch KDA kernel for (N, 1, ...) format."""
+        """Large batch KDA kernel for dense decode: q/k/v shapes (N, 1, ...)."""
+        del tiled_copy_load
         tidx, _, _ = cute.arch.thread_idx()
         in_warp_tid = tidx % 32
         warp_idx = cute.arch.warp_idx()
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
         batch_idx, _, _ = cute.arch.block_idx()
+
         i_n = batch_idx // HV
         i_hv = batch_idx % HV
         i_h = i_hv // (HV // H)
@@ -570,33 +534,17 @@ def _define_kernels():
             smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
             smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
             smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
             sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
-            # KDA: shared memory for per-K gating values
-            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
 
             if tidx < TILE_K:
                 sK[tidx] = cutlass.Float32(k[i_n, 0, i_h, tidx])
                 sQ[tidx] = cutlass.Float32(q[i_n, 0, i_h, tidx])
 
-            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
-            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V), (0, None))
-            thr_copy_load = tiled_copy_load.get_slice(tidx)
-
-            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles)
-            for v_tile in range(prefetch_count):
-                stage = v_tile % NUM_STAGES
-                gSrc_tile = gSrc[(None, None, v_tile)]
-                sData_stage = sData[(None, None, stage)]
-                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
-                thr_sData = thr_copy_load.partition_D(sData_stage)
-                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                cute.arch.cp_async_commit_group()
-
-            # KDA: compute per-K gating values in parallel
-            # Normal: a shape is (N, 1, HV, K), dt_bias shape is (HV, K)
             r_A_log = cutlass.Float32(A_log[i_hv])
+            r_exp_A = cute.exp(r_A_log)
             if tidx < TILE_K:
                 r_a_k = cutlass.Float32(a[i_n, 0, i_hv, tidx])
                 r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
@@ -612,13 +560,11 @@ def _define_kernels():
                     )
                 else:
                     softplus_x = x
-                r_g_value = -cute.exp(r_A_log) * softplus_x
-                sG[tidx] = cute.exp(r_g_value)
+                sG[tidx] = cute.exp(-r_exp_A * softplus_x)
 
-            # Compute beta (scalar, same as GDN)
-            r_b = cutlass.Float32(b[i_n, 0, i_hv])
             r_beta = 0.0
             if in_warp_tid == 0:
+                r_b = cutlass.Float32(b[i_n, 0, i_hv])
                 r_beta = 1.0 / (1.0 + cute.exp(-r_b))
             r_beta = cute.arch.shuffle_sync(r_beta, 0)
 
@@ -646,8 +592,6 @@ def _define_kernels():
                     smem_o[warp_idx + 8] = sum_k_partial
                 cute.arch.barrier()
 
-                inv_norm_q = 0.0
-                inv_norm_k = 0.0
                 if warp_idx == 0:
                     local_sum_q = 0.0
                     local_sum_k = 0.0
@@ -681,70 +625,75 @@ def _define_kernels():
             for v_tile in range(num_v_tiles):
                 stage = v_tile % NUM_STAGES
 
-                cute.arch.cp_async_wait_group(0)
+                for k_iter in range(NUM_K_ITERS):
+                    flat_idx = tidx + k_iter * NUM_THREADS_LARGE
+                    k_load = flat_idx // TILE_V
+                    v_load = flat_idx % TILE_V
+                    if k_load < TILE_K:
+                        v_global_load = v_tile * TILE_V + v_load
+                        h_val = 0.0
+                        if v_global_load < v.shape[3]:
+                            h_val = cutlass.Float32(
+                                h0_source[(pool_idx, i_hv, v_global_load, k_load)]
+                            )
+                        sData[(k_load, v_load, stage)] = h_val
+
                 cute.arch.barrier()
 
-                next_v_tile = v_tile + prefetch_count
-                if next_v_tile < num_v_tiles:
-                    next_stage = next_v_tile % NUM_STAGES
-                    gSrc_next = gSrc[(None, None, next_v_tile)]
-                    sData_next = sData[(None, None, next_stage)]
-                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
-                    thr_sData = thr_copy_load.partition_D(sData_next)
-                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                    cute.arch.cp_async_commit_group()
-
                 v_global = v_tile * TILE_V + v_idx
-                r_v = cutlass.Float32(v[i_n, 0, i_hv, v_global])
+                r_v = 0.0
+                if v_global < v.shape[3]:
+                    r_v = cutlass.Float32(v[i_n, 0, i_hv, v_global])
 
-                # KDA: use per-K gating sG[k_idx]
                 sum_hk = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                for k_iter in range(NUM_K_ITERS):
                     k_base = k_iter * ROWS_PER_ITER
                     k_idx = k_base + k_local
-                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    sum_hk += h_val * r_k_val
+                    sum_hk += sData[(k_idx, v_idx, stage)] * sG[k_idx] * sK[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hk += cute.arch.shuffle_sync_bfly(
-                        sum_hk, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                        sum_hk,
+                        offset=offset * V_PER_WARP,
+                        mask=-1,
+                        mask_and_clamp=31,
                     )
 
                 v_new = (r_v - sum_hk) * r_beta
                 v_new = cute.arch.shuffle_sync(v_new, v_local)
 
-                # KDA: use per-K gating sG[k_idx]
                 sum_hq = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                for k_iter in range(NUM_K_ITERS):
                     k_base = k_iter * ROWS_PER_ITER
                     k_idx = k_base + k_local
                     h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    r_q_val = sQ[k_idx]
-                    h_new = h_old + r_k_val * v_new
+                    h_new = h_old + sK[k_idx] * v_new
                     sData[(k_idx, v_idx, stage)] = h_new
-                    sum_hq += h_new * r_q_val
+                    sum_hq += h_new * sQ[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hq += cute.arch.shuffle_sync_bfly(
-                        sum_hq, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                        sum_hq,
+                        offset=offset * V_PER_WARP,
+                        mask=-1,
+                        mask_and_clamp=31,
                     )
 
-                if k_local == 0:
-                    v_global_out = v_tile * TILE_V + v_idx
-                    o[(i_n, 0, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+                if k_local == 0 and v_global < v.shape[3]:
+                    o[(i_n, 0, i_hv, v_global)] = cutlass.BFloat16(sum_hq)
 
                 cute.arch.barrier()
 
                 for k_iter in range(NUM_K_ITERS):
-                    flat_idx = tidx + k_iter * 256
+                    flat_idx = tidx + k_iter * NUM_THREADS_LARGE
                     k_write = flat_idx // TILE_V
                     v_write = flat_idx % TILE_V
                     if k_write < TILE_K:
-                        h_val = sData[(k_write, v_write, stage)]
                         v_global_write = v_tile * TILE_V + v_write
-                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+                        if v_global_write < v.shape[3]:
+                            h0_source[(pool_idx, i_hv, v_global_write, k_write)] = (
+                                sData[(k_write, v_write, stage)]
+                            )
 
                 cute.arch.barrier()
 
@@ -770,12 +719,14 @@ def _define_kernels():
         HV: cutlass.Constexpr[int],
         use_qk_l2norm: cutlass.Constexpr[bool],
     ):
-        """Large batch KDA kernel for varlen decode (1, N, ...) format."""
+        """Large batch KDA kernel for varlen decode: q/k/v shapes (1, N, ...)."""
+        del tiled_copy_load
         tidx, _, _ = cute.arch.thread_idx()
         in_warp_tid = tidx % 32
         warp_idx = cute.arch.warp_idx()
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
         batch_idx, _, _ = cute.arch.block_idx()
+
         i_n = batch_idx // HV
         i_hv = batch_idx % HV
         i_h = i_hv // (HV // H)
@@ -794,33 +745,17 @@ def _define_kernels():
             smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
             smem_k_layout = cute.make_layout((TILE_K,), stride=(1,))
             smem_q_layout = cute.make_layout((TILE_K,), stride=(1,))
+            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sK = smem.allocate_tensor(cutlass.Float32, smem_k_layout, 128)
             sQ = smem.allocate_tensor(cutlass.Float32, smem_q_layout, 128)
-            # KDA: shared memory for per-K gating values
-            smem_g_layout = cute.make_layout((TILE_K,), stride=(1,))
             sG = smem.allocate_tensor(cutlass.Float32, smem_g_layout, 128)
 
             if tidx < TILE_K:
                 sK[tidx] = cutlass.Float32(k[0, i_n, i_h, tidx])
                 sQ[tidx] = cutlass.Float32(q[0, i_n, i_h, tidx])
 
-            gSrc_batch = h0_source[(pool_idx, i_hv, None, None)]
-            gSrc = cute.local_tile(gSrc_batch, (TILE_K, TILE_V), (0, None))
-            thr_copy_load = tiled_copy_load.get_slice(tidx)
-
-            prefetch_count = cutlass.min(NUM_STAGES - 1, num_v_tiles)
-            for v_tile in range(prefetch_count):
-                stage = v_tile % NUM_STAGES
-                gSrc_tile = gSrc[(None, None, v_tile)]
-                sData_stage = sData[(None, None, stage)]
-                thr_gSrc = thr_copy_load.partition_S(gSrc_tile)
-                thr_sData = thr_copy_load.partition_D(sData_stage)
-                cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                cute.arch.cp_async_commit_group()
-
-            # KDA: compute per-K gating values in parallel
-            # Varlen: a shape is (N, HV, K), dt_bias shape is (HV, K)
             r_A_log = cutlass.Float32(A_log[i_hv])
+            r_exp_A = cute.exp(r_A_log)
             if tidx < TILE_K:
                 r_a_k = cutlass.Float32(a[i_n, i_hv, tidx])
                 r_dt_bias_k = cutlass.Float32(dt_bias[i_hv, tidx])
@@ -836,14 +771,11 @@ def _define_kernels():
                     )
                 else:
                     softplus_x = x
-                r_g_value = -cute.exp(r_A_log) * softplus_x
-                sG[tidx] = cute.exp(r_g_value)
+                sG[tidx] = cute.exp(-r_exp_A * softplus_x)
 
-            # Compute beta (scalar, same as GDN)
-            # Varlen: b shape is (N, HV)
-            r_b = cutlass.Float32(b[i_n, i_hv])
             r_beta = 0.0
             if in_warp_tid == 0:
+                r_b = cutlass.Float32(b[i_n, i_hv])
                 r_beta = 1.0 / (1.0 + cute.exp(-r_b))
             r_beta = cute.arch.shuffle_sync(r_beta, 0)
 
@@ -871,8 +803,6 @@ def _define_kernels():
                     smem_o[warp_idx + 8] = sum_k_partial
                 cute.arch.barrier()
 
-                inv_norm_q = 0.0
-                inv_norm_k = 0.0
                 if warp_idx == 0:
                     local_sum_q = 0.0
                     local_sum_k = 0.0
@@ -906,70 +836,75 @@ def _define_kernels():
             for v_tile in range(num_v_tiles):
                 stage = v_tile % NUM_STAGES
 
-                cute.arch.cp_async_wait_group(0)
+                for k_iter in range(NUM_K_ITERS):
+                    flat_idx = tidx + k_iter * NUM_THREADS_LARGE
+                    k_load = flat_idx // TILE_V
+                    v_load = flat_idx % TILE_V
+                    if k_load < TILE_K:
+                        v_global_load = v_tile * TILE_V + v_load
+                        h_val = 0.0
+                        if v_global_load < v.shape[3]:
+                            h_val = cutlass.Float32(
+                                h0_source[(pool_idx, i_hv, v_global_load, k_load)]
+                            )
+                        sData[(k_load, v_load, stage)] = h_val
+
                 cute.arch.barrier()
 
-                next_v_tile = v_tile + prefetch_count
-                if next_v_tile < num_v_tiles:
-                    next_stage = next_v_tile % NUM_STAGES
-                    gSrc_next = gSrc[(None, None, next_v_tile)]
-                    sData_next = sData[(None, None, next_stage)]
-                    thr_gSrc = thr_copy_load.partition_S(gSrc_next)
-                    thr_sData = thr_copy_load.partition_D(sData_next)
-                    cute.copy(tiled_copy_load, thr_gSrc, thr_sData)
-                    cute.arch.cp_async_commit_group()
-
                 v_global = v_tile * TILE_V + v_idx
-                r_v = cutlass.Float32(v[0, i_n, i_hv, v_global])
+                r_v = 0.0
+                if v_global < v.shape[3]:
+                    r_v = cutlass.Float32(v[0, i_n, i_hv, v_global])
 
-                # KDA: use per-K gating sG[k_idx]
                 sum_hk = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                for k_iter in range(NUM_K_ITERS):
                     k_base = k_iter * ROWS_PER_ITER
                     k_idx = k_base + k_local
-                    h_val = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    sum_hk += h_val * r_k_val
+                    sum_hk += sData[(k_idx, v_idx, stage)] * sG[k_idx] * sK[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hk += cute.arch.shuffle_sync_bfly(
-                        sum_hk, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                        sum_hk,
+                        offset=offset * V_PER_WARP,
+                        mask=-1,
+                        mask_and_clamp=31,
                     )
 
                 v_new = (r_v - sum_hk) * r_beta
                 v_new = cute.arch.shuffle_sync(v_new, v_local)
 
-                # KDA: use per-K gating sG[k_idx]
                 sum_hq = 0.0
-                for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
+                for k_iter in range(NUM_K_ITERS):
                     k_base = k_iter * ROWS_PER_ITER
                     k_idx = k_base + k_local
                     h_old = sData[(k_idx, v_idx, stage)] * sG[k_idx]
-                    r_k_val = sK[k_idx]
-                    r_q_val = sQ[k_idx]
-                    h_new = h_old + r_k_val * v_new
+                    h_new = h_old + sK[k_idx] * v_new
                     sData[(k_idx, v_idx, stage)] = h_new
-                    sum_hq += h_new * r_q_val
+                    sum_hq += h_new * sQ[k_idx]
 
                 for offset in [4, 2, 1]:
                     sum_hq += cute.arch.shuffle_sync_bfly(
-                        sum_hq, offset=offset * V_PER_WARP, mask=-1, mask_and_clamp=31
+                        sum_hq,
+                        offset=offset * V_PER_WARP,
+                        mask=-1,
+                        mask_and_clamp=31,
                     )
 
-                if k_local == 0:
-                    v_global_out = v_tile * TILE_V + v_idx
-                    o[(0, i_n, i_hv, v_global_out)] = cutlass.BFloat16(sum_hq)
+                if k_local == 0 and v_global < v.shape[3]:
+                    o[(0, i_n, i_hv, v_global)] = cutlass.BFloat16(sum_hq)
 
                 cute.arch.barrier()
 
                 for k_iter in range(NUM_K_ITERS):
-                    flat_idx = tidx + k_iter * 256
+                    flat_idx = tidx + k_iter * NUM_THREADS_LARGE
                     k_write = flat_idx // TILE_V
                     v_write = flat_idx % TILE_V
                     if k_write < TILE_K:
-                        h_val = sData[(k_write, v_write, stage)]
                         v_global_write = v_tile * TILE_V + v_write
-                        h0_source[(pool_idx, i_hv, k_write, v_global_write)] = h_val
+                        if v_global_write < v.shape[3]:
+                            h0_source[(pool_idx, i_hv, v_global_write, k_write)] = (
+                                sData[(k_write, v_write, stage)]
+                            )
 
                 cute.arch.barrier()
 
@@ -1012,26 +947,16 @@ def _create_jit_functions():
         use_qk_l2norm: cutlass.Constexpr[bool],
         stream: cuda.CUstream,
     ):
-        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        del cu_seqlens, B, T, K, use_initial_state
+        _, hv_dim, v_dim, _ = h0_source.layout.shape
         n_indices = h0_indices.layout.shape[0]
         batch_size = n_indices * hv_dim
 
-        copy_atom = cute.make_copy_atom(
-            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
-            cutlass.Float32,
-            num_bits_per_copy=128,
-        )
         num_v_tiles_small = cute.ceil_div(v_dim, TILE_V_SMALL)
         smem_layout_small = cute.make_layout(
             (TILE_K, TILE_V_SMALL, NUM_STAGES),
             stride=(TILE_V_SMALL_PADDED, 1, TILE_K * TILE_V_SMALL_PADDED),
         )
-        thread_layout_small = cute.make_layout((32, 4), stride=(4, 1))
-        val_layout_small = cute.make_layout((1, 4))
-        tiled_copy_load_small = cute.make_tiled_copy_tv(
-            copy_atom, thread_layout_small, val_layout_small
-        )
-        # KDA: extra TILE_K floats for sG
         smem_bytes_small = (
             4 * TILE_K * TILE_V_SMALL_PADDED * NUM_STAGES
             + 4 * TILE_V_SMALL
@@ -1041,7 +966,7 @@ def _create_jit_functions():
         )
 
         kda_small(
-            tiled_copy_load_small,
+            None,
             h0_source,
             smem_layout_small,
             num_v_tiles_small,
@@ -1093,26 +1018,16 @@ def _create_jit_functions():
         use_qk_l2norm: cutlass.Constexpr[bool],
         stream: cuda.CUstream,
     ):
-        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        del cu_seqlens, B, T, K, use_initial_state
+        _, hv_dim, v_dim, _ = h0_source.layout.shape
         n_indices = h0_indices.layout.shape[0]
         batch_size = n_indices * hv_dim
 
-        copy_atom = cute.make_copy_atom(
-            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
-            cutlass.Float32,
-            num_bits_per_copy=128,
-        )
         num_v_tiles_small = cute.ceil_div(v_dim, TILE_V_SMALL)
         smem_layout_small = cute.make_layout(
             (TILE_K, TILE_V_SMALL, NUM_STAGES),
             stride=(TILE_V_SMALL_PADDED, 1, TILE_K * TILE_V_SMALL_PADDED),
         )
-        thread_layout_small = cute.make_layout((32, 4), stride=(4, 1))
-        val_layout_small = cute.make_layout((1, 4))
-        tiled_copy_load_small = cute.make_tiled_copy_tv(
-            copy_atom, thread_layout_small, val_layout_small
-        )
-        # KDA: extra TILE_K floats for sG
         smem_bytes_small = (
             4 * TILE_K * TILE_V_SMALL_PADDED * NUM_STAGES
             + 4 * TILE_V_SMALL
@@ -1122,7 +1037,7 @@ def _create_jit_functions():
         )
 
         kda_small_varlen(
-            tiled_copy_load_small,
+            None,
             h0_source,
             smem_layout_small,
             num_v_tiles_small,
@@ -1174,24 +1089,16 @@ def _create_jit_functions():
         use_qk_l2norm: cutlass.Constexpr[bool],
         stream: cuda.CUstream,
     ):
-        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        del cu_seqlens, B, T, K, use_initial_state
+        _, hv_dim, v_dim, _ = h0_source.layout.shape
         n_indices = h0_indices.layout.shape[0]
         batch_size = n_indices * hv_dim
 
-        copy_atom = cute.make_copy_atom(
-            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
-            cutlass.Float32,
-            num_bits_per_copy=128,
-        )
         num_v_tiles = cute.ceil_div(v_dim, TILE_V)
-        base_smem_layout = cute.make_layout(
+        smem_layout = cute.make_layout(
             (TILE_K, TILE_V, NUM_STAGES),
             stride=(TILE_V_PADDED, 1, TILE_K * TILE_V_PADDED),
         )
-        thread_layout = cute.make_layout((32, 8), stride=(8, 1))
-        val_layout = cute.make_layout((1, 4))
-        tiled_copy_load = cute.make_tiled_copy_tv(copy_atom, thread_layout, val_layout)
-        # KDA: extra TILE_K floats for sG
         smem_bytes = (
             4 * TILE_K * TILE_V_PADDED * NUM_STAGES
             + 4 * TILE_V
@@ -1201,9 +1108,9 @@ def _create_jit_functions():
         )
 
         kda_large(
-            tiled_copy_load,
+            None,
             h0_source,
-            base_smem_layout,
+            smem_layout,
             num_v_tiles,
             q,
             k,
@@ -1253,24 +1160,16 @@ def _create_jit_functions():
         use_qk_l2norm: cutlass.Constexpr[bool],
         stream: cuda.CUstream,
     ):
-        pool_size, hv_dim, k_dim, v_dim = h0_source.layout.shape
+        del cu_seqlens, B, T, K, use_initial_state
+        _, hv_dim, v_dim, _ = h0_source.layout.shape
         n_indices = h0_indices.layout.shape[0]
         batch_size = n_indices * hv_dim
 
-        copy_atom = cute.make_copy_atom(
-            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
-            cutlass.Float32,
-            num_bits_per_copy=128,
-        )
         num_v_tiles = cute.ceil_div(v_dim, TILE_V)
-        base_smem_layout = cute.make_layout(
+        smem_layout = cute.make_layout(
             (TILE_K, TILE_V, NUM_STAGES),
             stride=(TILE_V_PADDED, 1, TILE_K * TILE_V_PADDED),
         )
-        thread_layout = cute.make_layout((32, 8), stride=(8, 1))
-        val_layout = cute.make_layout((1, 4))
-        tiled_copy_load = cute.make_tiled_copy_tv(copy_atom, thread_layout, val_layout)
-        # KDA: extra TILE_K floats for sG
         smem_bytes = (
             4 * TILE_K * TILE_V_PADDED * NUM_STAGES
             + 4 * TILE_V
@@ -1280,9 +1179,9 @@ def _create_jit_functions():
         )
 
         kda_large_varlen(
-            tiled_copy_load,
+            None,
             h0_source,
-            base_smem_layout,
+            smem_layout,
             num_v_tiles,
             q,
             k,
@@ -1338,7 +1237,6 @@ def _get_compiled_kernel(N, H, HV, K, V, pool_size, use_small_batch, is_varlen_d
         q = torch.zeros(1, N, H, K, dtype=torch.bfloat16, device="cuda")
         k = torch.zeros(1, N, H, K, dtype=torch.bfloat16, device="cuda")
         v = torch.zeros(1, N, HV, V, dtype=torch.bfloat16, device="cuda")
-        # KDA: a has extra K dimension; varlen shape (N, HV, K)
         a = torch.zeros(N, HV, K, dtype=torch.bfloat16, device="cuda")
         b = torch.zeros(N, HV, dtype=torch.bfloat16, device="cuda")
         o = torch.zeros(1, N, HV, V, dtype=torch.bfloat16, device="cuda")
@@ -1346,15 +1244,13 @@ def _get_compiled_kernel(N, H, HV, K, V, pool_size, use_small_batch, is_varlen_d
         q = torch.zeros(N, 1, H, K, dtype=torch.bfloat16, device="cuda")
         k = torch.zeros(N, 1, H, K, dtype=torch.bfloat16, device="cuda")
         v = torch.zeros(N, 1, HV, V, dtype=torch.bfloat16, device="cuda")
-        # KDA: a has extra K dimension; normal shape (N, 1, HV, K)
         a = torch.zeros(N, 1, HV, K, dtype=torch.bfloat16, device="cuda")
         b = torch.zeros(N, 1, HV, dtype=torch.bfloat16, device="cuda")
         o = torch.zeros(N, 1, HV, V, dtype=torch.bfloat16, device="cuda")
 
     A_log = torch.zeros(HV, dtype=torch.float32, device="cuda")
-    # KDA: dt_bias has extra K dimension; shape (HV, K)
     dt_bias = torch.zeros(HV, K, dtype=torch.bfloat16, device="cuda")
-    h0_source = torch.zeros(pool_size, HV, K, V, dtype=torch.float32, device="cuda")
+    h0_source = torch.zeros(pool_size, HV, V, K, dtype=torch.float32, device="cuda")
     h0_indices = torch.zeros(N, dtype=torch.int32, device="cuda")
 
     cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
@@ -1372,18 +1268,10 @@ def _get_compiled_kernel(N, H, HV, K, V, pool_size, use_small_batch, is_varlen_d
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
     run_small, run_small_varlen, run_large, run_large_varlen = _get_jit_functions()
-
     if use_small_batch:
         kernel_func = run_small_varlen if is_varlen_decode else run_small
     else:
         kernel_func = run_large_varlen if is_varlen_decode else run_large
-
-    scale = K**-0.5
-    softplus_beta = 1.0
-    softplus_threshold = 20.0
-
-    B_compile = 1 if is_varlen_decode else N
-    T_compile = N if is_varlen_decode else 1
 
     compiled_kernel = cute.compile(
         kernel_func,
@@ -1398,11 +1286,11 @@ def _get_compiled_kernel(N, H, HV, K, V, pool_size, use_small_batch, is_varlen_d
         h0_source_tensor,
         h0_indices_tensor,
         o_tensor,
-        softplus_beta=softplus_beta,
-        softplus_threshold=softplus_threshold,
-        scale=scale,
-        B=B_compile,
-        T=T_compile,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        scale=K**-0.5,
+        B=1 if is_varlen_decode else N,
+        T=N if is_varlen_decode else 1,
         H=H,
         K=K,
         V=V,
@@ -1414,11 +1302,51 @@ def _get_compiled_kernel(N, H, HV, K, V, pool_size, use_small_batch, is_varlen_d
 
     _compiled_kernels[key] = compiled_kernel
     logger.info(
-        f"CuTe DSL KDA kernel compiled: N={N}, H={H}, HV={HV}, K={K}, V={V}, "
-        f"pool_size={pool_size}, small_batch={use_small_batch}, varlen={is_varlen_decode}"
+        "CuTe DSL KDA kernel compiled: "
+        f"N={N}, H={H}, HV={HV}, K={K}, V={V}, pool_size={pool_size}, "
+        f"small_batch={use_small_batch}, varlen={is_varlen_decode}"
     )
-
     return compiled_kernel
+
+
+def _normalize_A_log(A_log: torch.Tensor, HV: int) -> torch.Tensor:
+    if A_log.numel() != HV:
+        raise ValueError(f"Unexpected A_log shape: {A_log.shape}; expected numel={HV}")
+    return A_log.reshape(HV).contiguous()
+
+
+def _normalize_dt_bias(dt_bias: torch.Tensor, HV: int, K: int) -> torch.Tensor:
+    if dt_bias.numel() != HV * K:
+        raise ValueError(
+            f"Unexpected dt_bias shape: {dt_bias.shape}; expected numel={HV * K}"
+        )
+    return dt_bias.reshape(HV, K).contiguous()
+
+
+def _normalize_kda_a(a, *, is_varlen_decode, N, HV, K):
+    """Normalize `a` to match the compile-time shape expected by the kernel.
+
+    varlen kernel compiled shape: (N, HV, K)  -- 3D
+    dense kernel compiled shape:  (N, 1, HV, K) -- 4D
+    """
+    if is_varlen_decode:
+        # Target: (N, HV, K) -- 3D
+        if a.dim() == 2 and a.shape == (N, HV * K):
+            return a.view(N, HV, K)
+        if a.dim() == 3 and a.shape == (N, HV, K):
+            return a  # already correct
+        if a.dim() == 4 and a.shape == (1, N, HV, K):
+            return a.squeeze(0)  # remove leading dim
+        raise ValueError(f"Unexpected a shape for varlen: {a.shape}")
+    else:
+        # Target: (N, 1, HV, K) -- 4D
+        if a.dim() == 2 and a.shape == (N, HV * K):
+            return a.view(N, 1, HV, K)
+        if a.dim() == 3 and a.shape == (N, HV, K):
+            return a.unsqueeze(1)
+        if a.dim() == 4 and a.shape == (N, 1, HV, K):
+            return a
+        raise ValueError(f"Unexpected a shape for dense: {a.shape}")
 
 
 def cutedsl_fused_sigmoid_gating_kda_update(
@@ -1437,42 +1365,54 @@ def cutedsl_fused_sigmoid_gating_kda_update(
     softplus_beta: float = 1.0,
     softplus_threshold: float = 20.0,
 ) -> torch.Tensor:
-    """CuTe DSL implementation of fused sigmoid gating KDA (delta rule) update.
+    """CuTe DSL implementation of fused sigmoid gating KDA update.
 
-    Key difference from GDN: `a` and `dt_bias` are per-key-dimension vectors,
-    resulting in per-row gating of the hidden state matrix.
+    State layout contract:
+        initial_state_source.shape == (pool_size, HV, V, K)
 
-    Args:
-        A_log: Log of decay rate, shape (HV,)
-        dt_bias: Timestep bias, shape (HV, K) — per-key in KDA
-        q: Query, shape (B, T, H, K) or (1, N, H, K) for varlen
-        k: Key, shape (B, T, H, K) or (1, N, H, K) for varlen
-        v: Value, shape (B, T, HV, V) or (1, N, HV, V) for varlen
-        a: Gating input, shape (B, T, HV, K) — per-key in KDA
-        b: Beta gating input, shape (B, T, HV) — scalar per head
-        initial_state_source: State pool, shape (pool_size, HV, K, V)
-        initial_state_indices: Indices into state pool, shape (N,)
-        cu_seqlens: Cumulative sequence lengths for varlen mode
-        scale: Query scaling factor (default: K^{-0.5})
-        use_qk_l2norm_in_kernel: Whether to L2-normalize q and k
-        softplus_beta: Softplus beta parameter
-        softplus_threshold: Softplus threshold for numerical stability
+    Dense decode:
+        q/k: (N, 1, H, K)
+        v:   (N, 1, HV, V)
+        a:   (N, 1, HV, K)
+        b:   (N, 1, HV)
+
+    Varlen decode:
+        q/k: (1, N, H, K)
+        v:   (1, N, HV, V)
+        a:   (N, HV, K) or (1, N, HV, K)
+        b:   (N, HV) or (1, N, HV)
     """
+
+    A_log = A_log.contiguous()
 
     B_q, T_q, H, K = q.shape
     HV = v.shape[2]
     V = v.shape[3]
     N = initial_state_indices.shape[0]
 
+    assert K == TILE_K, f"Current CuTe DSL KDA kernel requires K={TILE_K}, got {K}"
+    assert (
+        V % TILE_V_SMALL == 0
+    ), f"Current CuTe DSL KDA kernel requires V % {TILE_V_SMALL} == 0, got V={V}"
+    assert (
+        V % TILE_V == 0
+    ), f"Current CuTe DSL KDA kernel requires V % {TILE_V} == 0, got V={V}"
+    assert (V // TILE_V_SMALL) % NUM_BLOCKS_PER_STATE_SMALL == 0, (
+        "Small-batch KDA kernel requires num_v_tiles_small divisible by "
+        f"{NUM_BLOCKS_PER_STATE_SMALL}, got V={V}"
+    )
+
     is_varlen_decode = B_q == 1 and T_q == N and N > 1
     if scale is None:
         scale = K**-0.5
+    else:
+        assert scale > 0, f"scale must be positive, got {scale}"
 
     use_small_batch = N < SMALL_BATCH_THRESHOLD
 
     if initial_state_source.dim() == 1:
-        pool_size = initial_state_source.numel() // (HV * K * V)
-        h0_source = initial_state_source.view(pool_size, HV, K, V)
+        pool_size = initial_state_source.numel() // (HV * V * K)
+        h0_source = initial_state_source.view(pool_size, HV, V, K)
     elif initial_state_source.dim() == 4:
         pool_size = initial_state_source.shape[0]
         h0_source = initial_state_source
@@ -1481,24 +1421,23 @@ def cutedsl_fused_sigmoid_gating_kda_update(
             f"Unexpected initial_state_source shape: {initial_state_source.shape}"
         )
 
+    a = _normalize_kda_a(a, is_varlen_decode=is_varlen_decode, N=N, HV=HV, K=K)
+
     if is_varlen_decode:
-        # KDA varlen: a is (1, N, HV, K) -> squeeze to (N, HV, K)
-        if a.dim() == 4:
-            a = a.squeeze(0)
-        # b is (1, N, HV) -> squeeze to (N, HV)
+        # varlen b compiled: (N, HV) -- 2D
         if b.dim() == 3:
-            b = b.squeeze(0)
+            b = b.squeeze(0)  # (1, N, HV) -> (N, HV)
+        # b should be 2D (N, HV)
         o = q.new_empty(1, N, HV, V, dtype=torch.bfloat16)
     else:
-        # KDA normal: a is (N, 1, HV, K), keep as-is
-        if a.dim() == 3:
-            a = a.unsqueeze(1)
-        # b is (N, HV) -> unsqueeze to (N, 1, HV)
+        # dense b compiled: (N, 1, HV) -- 3D
         if b.dim() == 2:
             b = b.unsqueeze(1)
+        # b should be 3D (N, 1, HV)
         o = q.new_empty(N, 1, HV, V, dtype=torch.bfloat16)
 
-    q, k, v = [t.contiguous() for t in (q, k, v)]
+    q, k, v, a, b = [t.contiguous() for t in (q, k, v, a, b)]
+    dt_bias = dt_bias.contiguous()
 
     global _cu_seqlens_cache
     if cu_seqlens is not None:
@@ -1510,6 +1449,15 @@ def cutedsl_fused_sigmoid_gating_kda_update(
                 N + 1, dtype=torch.int32, device=q.device
             )
         cu_seqlens_to_use = _cu_seqlens_cache[cache_key]
+
+    A_log = _normalize_A_log(A_log, HV)
+    dt_bias = _normalize_dt_bias(dt_bias, HV, K)
+
+    h0_source = h0_source.contiguous()
+
+    initial_state_indices = initial_state_indices.contiguous()
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.contiguous()
 
     cu_seqlens_tensor = from_dlpack(
         cu_seqlens_to_use.detach(), assumed_align=16

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -64,7 +64,7 @@ class GDNKernelDispatcher:
             self.decode_kernel = triton_kernel
         elif decode_backend.is_cutedsl():
             if not is_cuda():
-                raise ValueError("CuTe DSL backend requires CUDA")
+                raise ValueError("GDN CuTe DSL backend requires CUDA")
             from sglang.srt.layers.attention.linear.kernels.gdn_cutedsl import (
                 CuteDSLGDNKernel,
             )

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -3,6 +3,9 @@ from typing import Tuple, Union
 import torch
 
 from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
+from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
+    CuteDSLKDAKernel,
+)
 from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
@@ -46,11 +49,7 @@ class KDAKernelDispatcher:
             self.decode_kernel = triton_kernel
         elif decode_backend.is_cutedsl():
             if not is_cuda():
-                raise ValueError("CuTe DSL backend requires CUDA")
-            from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
-                CuteDSLKDAKernel,
-            )
-
+                raise ValueError("KDA CuTe DSL backend requires CUDA")
             self.decode_kernel = CuteDSLKDAKernel()
         else:
             raise ValueError(

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -14,7 +14,7 @@ from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
     causal_conv1d_update,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
-from sglang.srt.utils import is_cpu, is_npu
+from sglang.srt.utils import is_cpu, is_cuda, is_npu
 from sglang.srt.utils.common import rank0_log
 
 # KDA always uses the triton causal_conv1d_fn (no CUDA override).
@@ -44,6 +44,14 @@ class KDAKernelDispatcher:
 
         if decode_backend.is_triton():
             self.decode_kernel = triton_kernel
+        elif decode_backend.is_cutedsl():
+            if not is_cuda():
+                raise ValueError("CuTe DSL backend requires CUDA")
+            from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
+                CuteDSLKDAKernel,
+            )
+
+            self.decode_kernel = CuteDSLKDAKernel()
         else:
             raise ValueError(
                 f"Unsupported KDA decode backend: {decode_backend}. "

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_cutedsl.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_cutedsl.py
@@ -1,0 +1,47 @@
+import torch
+
+from sglang.jit_kernel.cutedsl_kda import cutedsl_fused_sigmoid_gating_kda_update
+from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
+    LinearAttnKernelBase,
+)
+
+
+class CuteDSLKDAKernel(LinearAttnKernelBase):
+    """CuTe DSL kernel for KDA decode (CUDA only)."""
+
+    def decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        return cutedsl_fused_sigmoid_gating_kda_update(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            initial_state_source=ssm_states,
+            initial_state_indices=cache_indices,
+            cu_seqlens=query_start_loc,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+        )
+
+    def extend(self, *args, **kwargs):
+        raise NotImplementedError("CuteDSLKDAKernel only supports decode")
+
+    def target_verify(self, *args, **kwargs):
+        raise NotImplementedError("CuteDSLKDAKernel only supports decode")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to support CuTeDSL KDA decode kernel for Kimi-Linear/Kimi-2.5 and other models using KDA architecture.
Benchmark is conducted on H800. The accuracy is expected. The batch_size=1 gets about **1.05x** performance uplift.

Currently we haven't integrated this kernel to e2e backend the reason is that there's only CuTeDSL decode KDA kernel for now, when integrating with the flags: --linear-attn-prefill-backend triton --linear-attn-decode-backend cutedsl, due to the prefill triton KDA kernel (shared with GDN in underneath kernel) has been modified to VK layout (introduced in https://github.com/sgl-project/sglang/pull/20283), it doesn't match the cutedsl decode (in KV layout).

We plan to do the following tasks:
1. Support CuTeDSL KDA prefill kernel.
2. Support triton prefill KDA kernel with KV and VK layout switch off. 

Either approach can make the CuTeDSL KDA story model-wise completed.

```
oot@e1448ef40573:/sgl-workspace/sglang_dev2# python ./benchmark/bench_linear_attention/bench_cutedsl_kda_decode.py --cuda-graph
Device: NVIDIA L20Y  (SM 90)
==============================================================================
Correctness: Triton KDA Decode vs CuTe DSL KDA Decode
==============================================================================
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
  [PASS] layout=dense  B= 1 H= 8 HV=16 K=128 V=128 pool=  32
  [PASS] layout=dense  B= 4 H= 8 HV=16 K=128 V=128 pool=  32
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
  [PASS] layout=dense  B=32 H= 8 HV=16 K=128 V=128 pool= 128
  [PASS] layout=dense  B=64 H= 8 HV=16 K=128 V=128 pool= 128
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS_SMALL, unroll=16):
  [PASS] layout=varlen B= 4 H= 8 HV=16 K=128 V=128 pool=  32
  [PASS] layout=varlen B=16 H= 8 HV=16 K=128 V=128 pool=  64
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
  for k_iter in cutlass.range_dynamic(NUM_K_ITERS, unroll=8):
  [PASS] layout=varlen B=32 H= 8 HV=16 K=128 V=128 pool= 128
  [PASS] layout=varlen B=64 H= 8 HV=16 K=128 V=128 pool= 128
  [PASS] layout=varlen B= 1 H=16 HV=32 K=128 V=128 pool=  32
  [PASS] layout=varlen B=32 H=16 HV=32 K=128 V=128 pool= 128
  [PASS] layout=varlen B=64 H=16 HV=16 K=128 V=128 pool= 128

  PAD_SLOT_ID test (indices with -1):
  [PASS] PAD_SLOT_ID=-1 handling (valid outputs/states only)

ALL PASSED.

============================================================================================
Benchmark: Triton vs CuTe DSL KDA Decode  [CUDA Graph replay — production mode]
============================================================================================
  Config: K=128, V=128, pool_size=512, dtype=torch.bfloat16
  layout      B    H   HV    K    V |  triton (us) |  cutedsl (us) |  speedup |  delta (us)
  ----------------------------------------------------------------------------------
   dense      1    8   16  128  128 |       12.7 |       12.1 |    1.05x |      +0.6
   dense      4    8   16  128  128 |       12.6 |       12.6 |    1.01x |      +0.1
   dense     32    8   16  128  128 |       24.4 |       23.9 |    1.02x |      +0.6
   dense     64    8   16  128  128 |       60.2 |       60.7 |    0.99x |      -0.5
  varlen      1    8   16  128  128 |       12.6 |       12.2 |    1.03x |      +0.4
  varlen      4    8   16  128  128 |       12.7 |       12.6 |    1.01x |      +0.1
  varlen      8    8   16  128  128 |       13.6 |       13.6 |    1.00x |      +0.0
  varlen     16    8   16  128  128 |       16.3 |       16.6 |    0.98x |      -0.4
  varlen     32    8   16  128  128 |       24.5 |       24.1 |    1.02x |      +0.4
  varlen     64    8   16  128  128 |       59.2 |       60.6 |    0.98x |      -1.3
  varlen    128    8   16  128  128 |      103.6 |      105.9 |    0.98x |      -2.4
  varlen     32   16   32  128  128 |       59.2 |       60.8 |    0.97x |      -1.6
  varlen     64   16   16  128  128 |       59.8 |       60.8 |    0.98x |      -1.0
```

## Modifications

<!-- Detail the changes made in this pull request. -->
GDN/KDA are similar besides KDA uses K dimension-wise gating, while GDN uses head-wise gating. So KDA can learn more complicated forget pattern, with the cost of higher parameters(more dt_bias dimension) and higher compute complexity (need to handle K dimension gate). To be more specific:
1. a: GDN is per-head with shape (N, 1, HV), KDA is per-head-per-key with shape (N, 1, HV, K)
2. dt_bias: GDN is (HV, ), KDA is (HV, K)
4. g: GDN is scalar, KDA is vector in K dimension: h[k, v] *= exp(g[k])
5. beta and other logic are identical: A_log's shape (HV), b (H, HV), beta=sigmoid(b)

The KDA CuTeDSL decode kernel can hereby refer to GDN CuTeDSL decode kernel with some changes in a/dt_bias/g.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
6. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
7. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
8. After green CI and required approvals, ask Merge Oncalls to merge.
