### PR TITLE
[Bugfix] restore EAGLE draft padding state between speculative decode steps

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -677,9 +677,19 @@ class EAGLEWorker(TpModelWorker):
             spec_info.hidden_states = hidden_states
 
             # Run forward
+            # Preserve state that may be overwritten by the DP-attention MLP sync path.
+            accept_length_backup = spec_info.accept_length
+            global_num_tokens_cpu_backup = (
+                list(forward_batch.global_num_tokens_cpu)
+                if forward_batch.global_num_tokens_cpu is not None
+                else None
+            )
             logits_output = self.draft_model_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
+            spec_info.accept_length = accept_length_backup
+            if global_num_tokens_cpu_backup is not None:
+                forward_batch.global_num_tokens_cpu = global_num_tokens_cpu_backup
             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
To fix #21210 
EAGLE `draft_forward()` runs multiple decode-mode forwards on the same `forward_batch`.

  Under DP attention, each forward may enter `prepare_mlp_sync_batch()` and introduce padding for MLP sync. Although
  `_forward_raw()` already calls `post_forward_mlp_sync_batch()` after the forward, the decode branch does not fully
  restore all fields needed by the next speculative draft step.

  In particular, the following state can leak across draft steps:

  - `spec_info.accept_length`
  - `forward_batch.global_num_tokens_cpu`

  When that happens, a later speculative step may re-enter padding logic with stale padded state and fail in
  `_pad_tensor_to_size()` with a negative dimension error.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
 This PR applies a minimal fix in `python/sglang/srt/speculative/eagle_worker.py`:

  - save `spec_info.accept_length` before `draft_model_runner.forward(...)`
  - save `forward_batch.global_num_tokens_cpu` before `draft_model_runner.forward(...)`
  - restore both fields immediately after the forward returns

  This keeps the fix local to the EAGLE multi-step draft path and avoids altering broader decode post-processing
  behavior.

  `_forward_raw()` already restores most of the decode-time padded state through `post_forward_mlp_sync_batch()`. For
  the multi-step EAGLE draft loop, the remaining missing state is exactly the state that later speculative steps still
  rely on.

  This change is intentionally minimal and scoped to the known failing path.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
 I validated this fix with a dedicated stress script that repeatedly sends high-concurrency odd-sized batches to
  trigger the DP-attention padding path in EAGLE draft forward.

  Observed behavior:

  - Without this patch:
    - the server crashes reliably after a few hundred requests (around the 800th request in our runs)
    - failure mode matches the negative-dimension crash in `_pad_tensor_to_size()`

  - With this patch:
    - the same stress script can continue running stably
    - the previous crash no longer reproduces
    - the run completes successfully under the same test configuration

  This was the main regression test used for this fix.

```text
python3 -m sglang.launch_server \
    --model-path /gfs/space/chatrl/public/models/ZhipuAI/GLM-4.7-Flash-0309 \
    --trust-remote-code \
    --tp-size 8 \
    --dp-size 4 \
    --enable-dp-attention \
    --enable-dp-lm-head \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 2 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 3 \
    --moe-dense-tp-size 1 \
    --mem-fraction-static 0.7 \
    --max-running-requests 512
```

Script
```python

#!/usr/bin/env python3
import json
import hashlib
import random
import threading
from concurrent.futures import ThreadPoolExecutor, as_completed

import requests
from requests.adapters import HTTPAdapter

URL = "http://localhost:30000/generate"
DATA_PATH = "/gfs/space/chatrl/users/hxh/data/rule_based_rl/DAPO-Math-17k/data/dapo-math-17k_dedup.jsonl"

ATTN_TP_SIZE = 2

# 每轮总请求数。维持奇数，继续触发 ceil_align padding 条件
BATCH_SIZE = 2049

# 真正的并发线程数。想“一次打更多”就把这个和 BATCH_SIZE 一起加大
CONCURRENCY = 2049

ROUNDS = 3000
TIMEOUT = 3600
MAX_NEW_TOKENS = 30000
SEED = 42

# 逐条打印会明显拖慢高并发压测，默认关闭
VERBOSE_EACH_REQ = False

random.seed(SEED)
thread_local = threading.local()


def extract_prompt(obj):
   for k in ("prompt", "question", "problem", "input", "text"):
         if k in obj and isinstance(obj[k], str) and obj[k].strip():
            q = obj[k].strip()
            return f"<_system>你是智谱GLM大模型，接下来请解决用户给出的问题，答案请放在boxed{{}}里面。<_user>{q}<_bot>"

   if "messages" in obj and isinstance(obj["messages"], list):
         user_parts = []
         for m in obj["messages"]:
            if isinstance(m, dict) and m.get("role") == "user":
               c = m.get("content", "")
               if isinstance(c, str) and c.strip():
                     user_parts.append(c.strip())
         if user_parts:
            q = "\n".join(user_parts)
            return f"<_system>你是智谱GLM大模型，接下来请解决用户给出的问题，答案请放在boxed{{}}里面。<_user>{q}<_bot>"

   return None


def load_prompts(path):
   prompts = []
   with open(path, "r", encoding="utf-8") as f:
         for _, line in enumerate(f, 1):
            line = line.strip()
            if not line:
               continue
            try:
               obj = json.loads(line)
            except Exception:
               continue
            p = extract_prompt(obj)
            if p:
               prompts.append(p)

   if not prompts:
         raise RuntimeError(f"No valid prompts parsed from {path}")
   return prompts


def get_session():
   sess = getattr(thread_local, "session", None)
   if sess is None:
         sess = requests.Session()
         sess.trust_env = False

         # 每个线程一个 session，跨轮次复用连接，避免每次重新建连
         adapter = HTTPAdapter(
            pool_connections=1,
            pool_maxsize=1,
            max_retries=0,
            pool_block=False,
         )
         sess.mount("http://", adapter)
         sess.mount("https://", adapter)
         thread_local.session = sess
   return sess


def one_req(idx, prompt, start_event):
   start_event.wait()

   payload = {
         "text": prompt,
         "sampling_params": {
            "temperature": 1.0,
            "top_p": 1.0,
            "max_new_tokens": MAX_NEW_TOKENS,
         },
   }

   sess = get_session()
   r = sess.post(URL, json=payload, timeout=TIMEOUT)
   r.raise_for_status()

   obj = r.json()
   text = obj["text"]
   h = hashlib.sha256(text.encode("utf-8")).hexdigest()
   return idx, h, len(text), text[:120].replace("\n", "\\n")


def main():
   prompts = load_prompts(DATA_PATH)
   print(f"loaded prompts: {len(prompts)}")
   print(f"batch_size={BATCH_SIZE}, concurrency={CONCURRENCY}")

   assert BATCH_SIZE % 2 == 1, "BATCH_SIZE 必须保持奇数"
   assert BATCH_SIZE % ATTN_TP_SIZE != 0, "BATCH_SIZE 必须对 attn_tp_size 不整除"
   assert CONCURRENCY >= BATCH_SIZE, "想一波同时打满时，CONCURRENCY 至少要 >= BATCH_SIZE"

   with ThreadPoolExecutor(max_workers=CONCURRENCY) as ex:
         for rd in range(ROUNDS):
            print(f"\n=== round {rd} | batch={BATCH_SIZE} | concurrency={CONCURRENCY} ===")
            batch_prompts = random.choices(prompts, k=BATCH_SIZE)

            start_event = threading.Event()
            futs = [
               ex.submit(one_req, i, batch_prompts[i], start_event)
               for i in range(BATCH_SIZE)
            ]

            # 所有任务提交完后统一放行，尽量形成瞬时洪峰
            start_event.set()

            hashes = []
            done = 0
            for fut in as_completed(futs):
               idx, h, n, head = fut.result()
               hashes.append(h)
               done += 1

               if VERBOSE_EACH_REQ:
                     print(f"req={idx:04d} sha256={h} len={n} head={head}")
               elif done % 50 == 0 or done == BATCH_SIZE:
                     print(f"done={done}/{BATCH_SIZE}")

            print(f"[round {rd}] unique_hashes={len(set(hashes))}/{BATCH_SIZE}")
            print("-" * 100)


if __name__ == "__main__":
   main()
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.


# CC @FortPercent @qzweng