### PR TITLE
Fix trtllm_mla backend for Draft_extend

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -540,6 +540,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         if forward_mode.is_target_verify():
             seq_lens = seq_lens[:bs] + self.num_draft_tokens
             metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
+            metadata.max_seq_len_k = max(seq_lens)
             del seq_lens_sum  # not handle "num_draft_tokens" but we do not need it
         elif forward_mode.is_draft_extend(include_v2=True):
             accept_length = spec_info.accept_length[:bs]
@@ -549,15 +550,14 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             else:
                 metadata.max_seq_len_q = 1
                 metadata.sum_seq_lens_q = bs
-            # draft_extend uses (accept_length + 1) query tokens per sequence
-            extend_seq_lens = accept_length + 1
             metadata.cu_seqlens_q[1:].copy_(
-                torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32)
+                torch.cumsum(accept_length, dim=0, dtype=torch.int32)
             )
-            metadata.seq_lens_q.copy_(extend_seq_lens)
+            metadata.seq_lens_q.copy_(accept_length)
             # see NOTE(draft_extend seq_len handling)
             seq_lens = seq_lens[:bs] - metadata.seq_lens_q + metadata.max_seq_len_q
             metadata.seq_lens_k.copy_(seq_lens.to(torch.int32))
+            metadata.max_seq_len_k = max(seq_lens)
 
         # Update block indices for new sequences.
         create_flashmla_kv_indices_triton[(bs,)](
@@ -995,60 +995,27 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             q = q.to(self.data_type)
 
             bmm1_scale = q_scale * k_scale * layer.scaling
-            if forward_batch.forward_mode.is_target_verify():
-                max_seq_len = (
-                    metadata.max_seq_len_k + forward_batch.spec_info.draft_token_num
-                )
-                # For target_verify, all sequences have the same number of draft tokens
-                q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
-                needs_unpad = False
-            else:
-                # draft_extend: handle varying accept_lengths. If total_tokens % bs == 0,
-                # we can directly reshape q; otherwise, pad to max_seq_len_q.
-                total_tokens = q.shape[0]
-                tokens_per_seq = total_tokens // bs if bs > 0 else 0
-                can_direct_view = bs > 0 and (total_tokens % bs == 0)
-
-                if can_direct_view:
-                    max_seq_len = metadata.max_seq_len_k + tokens_per_seq
-                    q = q.view(bs, tokens_per_seq, layer.tp_q_head_num, layer.head_dim)
-                    needs_unpad = False
+            if forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                # Check if we're in CUDA graph mode (buffers are pre-allocated)
+                if self.padded_q_buffer is not None:
+                    # Use pre-allocated buffer for CUDA graph compatibility
+                    padded_q = self.padded_q_buffer[
+                        :bs, : metadata.max_seq_len_q, :, :
+                    ].to(dtype=q.dtype)
                 else:
-                    # Varying lengths: pad q to (bs, max_seq_len_q, ...)
-                    actual_seq_lens_q = forward_batch.extend_seq_lens
-                    actual_max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
-                    max_seq_len = metadata.max_seq_len_k + actual_max_seq_len_q
-
-                    actual_cu_seqlens_q = torch.nn.functional.pad(
-                        torch.cumsum(actual_seq_lens_q, dim=0, dtype=torch.int32),
-                        (1, 0),
+                    # Dynamic allocation for non-CUDA graph mode
+                    padded_q = torch.zeros(
+                        bs,
+                        metadata.max_seq_len_q,
+                        layer.tp_q_head_num,
+                        layer.head_dim,
+                        dtype=q.dtype,
+                        device=q.device,
                     )
-
-                    if self.padded_q_buffer is not None:
-                        padded_q = self.padded_q_buffer[
-                            :bs, :actual_max_seq_len_q, :, :
-                        ].to(dtype=q.dtype)
-                        padded_q.zero_()
-                    else:
-                        padded_q = torch.zeros(
-                            (
-                                bs,
-                                actual_max_seq_len_q,
-                                layer.tp_q_head_num,
-                                layer.head_dim,
-                            ),
-                            dtype=q.dtype,
-                            device=q.device,
-                        )
-
-                    q = self.pad_draft_extend_query(
-                        q, padded_q, actual_seq_lens_q, actual_cu_seqlens_q
-                    )
-                    needs_unpad = True
-                    unpad_seq_lens_q = actual_seq_lens_q
-                    unpad_cu_seqlens_q = actual_cu_seqlens_q
-                    unpad_sum_seq_lens_q = total_tokens
-
+                q = self.pad_draft_extend_query(
+                    q, padded_q, metadata.seq_lens_q, metadata.cu_seqlens_q
+                )
+            q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
             assert kv_cache.dtype == self.data_type
 
             raw_out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
@@ -1060,22 +1027,20 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 qk_rope_head_dim=self.qk_rope_head_dim,
                 block_tables=metadata.block_kv_indices,
                 seq_lens=metadata.seq_lens_k,
-                max_seq_len=max_seq_len,
+                max_seq_len=metadata.max_seq_len_k,
                 bmm1_scale=bmm1_scale,
             )
 
-            if needs_unpad:
-                # Unpad the output for draft_extend mode with varying lengths
-                # Use the actual values computed during padding, not from metadata
+            if forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                # 需要使用 unpad_draft_extend_output 处理变长输出
                 output = self.unpad_draft_extend_output(
                     raw_out,
-                    unpad_cu_seqlens_q,
-                    unpad_seq_lens_q,
-                    unpad_sum_seq_lens_q,
+                    metadata.cu_seqlens_q,
+                    metadata.seq_lens_q,
+                    metadata.sum_seq_lens_q,
                 )
-                output = output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-            else:
-                output = raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+                return output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+            output = raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
             return output
 
         if k_rope is not None:


### PR DESCRIPTION
## Background

On `v5.9.0`, when using the `trtllm_mla` attention backend with MTP enabled, we observed an unexpected regression on our internal dataset: the acceptance length at large batch size was lower than at small batch size.

Specifically, under the `v31` model with `3,1,4 eagle` configuration and `TP8 DP8`, the `trt_mla` backend showed worse acceptance length at `BS per DP = 32` than at `BS per DP = 2`. This behavior was not expected and was inconsistent with the `flashinfer` baseline.

## Problem

Before this PR:

- `trt_mla + trt_mla`
  - `BS per DP = 32`: `2.27`
  - `BS per DP = 2`: `2.41`
- `flashinfer + flashinfer`
  - `BS per DP = 32`: `2.49`
  - `BS per DP = 2`: `2.52`

This indicates that, with MTP enabled, the `trtllm_mla` backend regressed at larger batch size on our internal workload.

## Improvement

After this PR:

- `trt_mla + trt_mla`
  - `BS per DP = 32`: improved from `2.27` to `2.52`
  - `BS per DP = 2`: `2.51`
- `flashinfer + flashinfer`
  - `BS per DP = 32`: `2.49`
  - `BS per DP = 2`: `2.52`

The issue is resolved: the acceptance length for `trt_mla` at large batch size is no longer lower than at small batch size, and the result is now aligned with the expected trend and comparable to the `flashinfer` baseline.

## Benchmark Summary

### Before PR

| Model | Version | Config | Parallel Config | Target Backend | Draft Backend | BS per DP | Accept Len |
|---|---|---|---|---|---|---:|---:|
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | trt_mla | trt_mla | 32 | 2.27 |
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | trt_mla | trt_mla | 2 | 2.41 |
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | flashinfer | flashinfer | 32 | 2.49 |
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | flashinfer | flashinfer | 2 | 2.52 |

### After PR

| Model | Version | Config | Parallel Config | Target Backend | Draft Backend | BS per DP | Accept Len |
|---|---|---|---|---|---|---:|---:|
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | trt_mla | trt_mla | 32 | 2.52 |
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | trt_mla | trt_mla | 2 | 2.51 |
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | flashinfer | flashinfer | 32 | 2.49 |
| v31 | v5.9.0 | 3,1,4 eagle | TP8 DP8 | flashinfer | flashinfer | 2 | 2.52 |

## Reproduction

The issue can be reproduced with the following launch configuration:

```bash
python3 -m sglang.launch_server \
    --model-path /model-v3.1 \
    --dp-size 8 \
    --enable-dp-attention \
    --tp-size 8 \
    --trust-remote-code \
    --mem-fraction-static 0.75 \
    --max-running-requests 256 \
    --cuda-graph-max-bs 32 \
    --chunked-prefill-size 16384 \
    --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}' \
    --speculative-algorithm EAGLE \
    --speculative-num-steps=3 \
    --speculative-eagle-topk=1 \
    --speculative-num-draft-tokens=4 \
    --max-total-tokens 400000 \
    --host 0.0.0.0 --port 8000 \
    --dist-init-addr localhost:6676
```
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
