### PR TITLE
[Diffusion][Feat] support LoKr 

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -304,9 +304,7 @@ class BaseLayerWithLoRA(nn.Module):
         delta = merged_weight
 
         delta_elements = delta.numel()
-        target_elements = 1
-        for dim in target_shape:
-            target_elements *= dim
+        target_elements = torch.Size(target_shape).numel()
 
         if delta_elements != target_elements:
             raise ValueError(

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -257,6 +257,13 @@ class BaseLayerWithLoRA(nn.Module):
                 "LoRA weights not merged. Please merge them first before unmerging."
             )
 
+        if getattr(self, "_lokr_merged", False):
+            raise ValueError(
+                "Cannot unmerge LoKr weights. LoKr merges are permanent - "
+                "the base weights are modified directly. "
+                "To restore original weights, reload the model."
+            )
+
         # avoid precision loss
         if isinstance(self.base_layer.weight, DTensor):
             device = self.base_layer.weight.data.device
@@ -275,6 +282,141 @@ class BaseLayerWithLoRA(nn.Module):
                 del cpu_weight_on_device
 
         self.merged = False
+
+    def _validate_and_prepare_delta(
+        self,
+        merged_weight: torch.Tensor,
+        target_shape: tuple[int, ...],
+    ) -> torch.Tensor:
+        """
+        Validate and prepare delta tensor for merging.
+
+        Args:
+            merged_weight: The delta weight tensor to validate.
+            target_shape: The expected shape after merging.
+
+        Returns:
+            The validated and reshaped delta tensor.
+
+        Raises:
+            ValueError: If shape is incompatible.
+        """
+        delta = merged_weight
+
+        delta_elements = delta.numel()
+        target_elements = 1
+        for dim in target_shape:
+            target_elements *= dim
+
+        if delta_elements != target_elements:
+            raise ValueError(
+                f"Shape mismatch in apply_merged_weight: "
+                f"delta has {delta_elements} elements but target weight has {target_elements} elements. "
+                f"Delta shape: {delta.shape}, target shape: {target_shape}"
+            )
+
+        if delta.shape != target_shape:
+            delta = delta.reshape(target_shape)
+
+        return delta
+
+    @torch.no_grad()
+    def apply_merged_weight(
+        self,
+        merged_weight: torch.Tensor,
+        strength: float = 1.0,
+    ) -> None:
+        """
+        Directly apply pre-computed merged weight delta (e.g., from LoKr conversion).
+
+        This bypasses the LoRA A/B decomposition and directly adds the delta
+        to the base layer weight. Used for formats like LoKr where the weight
+        delta is pre-computed via Kronecker product.
+
+        Note: Unlike standard LoRA merge, LoKr merges are permanent. Calling
+        unmerge_lora_weights() after LoKr merge will raise an error. To restore
+        original weights, reload the model.
+
+        Args:
+            merged_weight: Pre-computed weight delta to apply.
+            strength: Scaling factor for the merge.
+
+        Raises:
+            ValueError: If merged_weight is not a valid tensor, or if LoRA adapters
+                are already set (LoKr and standard LoRA cannot be mixed).
+        """
+        if merged_weight is None or not isinstance(merged_weight, torch.Tensor):
+            raise ValueError(
+                "merged_weight must be a valid torch.Tensor, "
+                f"got {type(merged_weight)}"
+            )
+
+        if self.lora_weights_list:
+            raise ValueError(
+                "Cannot apply LoKr merged_weight when LoRA adapters are already set. "
+                "LoKr and standard LoRA cannot be mixed on the same layer."
+            )
+
+        if self.merged:
+            self.unmerge_lora_weights()
+
+        if isinstance(self.base_layer.weight, DTensor):
+            mesh = self.base_layer.weight.data.device_mesh
+            old_base_layer = self.base_layer
+            unsharded_base_layer = ReplicatedLinear(
+                input_size=old_base_layer.input_size,
+                output_size=old_base_layer.output_size,
+                bias=getattr(old_base_layer, "bias", None) is not None,
+                skip_bias_add=old_base_layer.skip_bias_add,
+                params_dtype=old_base_layer.params_dtype,
+                quant_config=old_base_layer.quant_config,
+                prefix=old_base_layer.prefix,
+            )
+            current_device = old_base_layer.weight.data.device
+            data = old_base_layer.weight.data.to(get_local_torch_device()).full_tensor()
+
+            delta = merged_weight.to(data.dtype).to(data.device)
+            delta = self._validate_and_prepare_delta(delta, data.shape)
+            data += strength * delta
+
+            unsharded_base_layer.weight = nn.Parameter(data.to(current_device))
+            if isinstance(getattr(old_base_layer, "bias", None), DTensor):
+                unsharded_base_layer.bias = nn.Parameter(
+                    old_base_layer.bias.to(get_local_torch_device(), non_blocking=True)
+                    .full_tensor()
+                    .to(current_device)
+                )
+
+            offload_policy = (
+                CPUOffloadPolicy() if "cpu" in str(current_device) else OffloadPolicy()
+            )
+            mp_policy = get_mixed_precision_state().mp_policy
+
+            # Delete old base_layer before reassignment to prevent memory leak
+            del old_base_layer
+            self.base_layer = fully_shard(
+                unsharded_base_layer,
+                mesh=mesh,
+                mp_policy=mp_policy,
+                offload_policy=offload_policy,
+            )
+        else:
+            current_device = self.base_layer.weight.data.device
+            data = self.base_layer.weight.data.to(get_local_torch_device())
+
+            delta = merged_weight.to(data.dtype).to(data.device)
+            delta = self._validate_and_prepare_delta(delta, data.shape)
+            data += strength * delta
+
+            self.base_layer.weight.data = data.to(current_device, non_blocking=True)
+
+        self.merged = True
+        self.disable_lora = False
+        # Clear LoRA A/B since we're using merged weight path
+        self.lora_A = None
+        self.lora_B = None
+        self.lora_weights_list.clear()
+        self._lokr_merged = True
 
 
 class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Dict, Iterable, Mapping, Optional
 
 import torch
-
 from diffusers.loaders import lora_conversion_utils as lcu
 
 logger = logging.getLogger("LoRAFormatAdapter")

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Dict, Iterable, Mapping, Optional
 
 import torch
+
 from diffusers.loaders import lora_conversion_utils as lcu
 
 logger = logging.getLogger("LoRAFormatAdapter")
@@ -20,6 +21,7 @@ class LoRAFormat(str, Enum):
     KOHYA_FLUX = "kohya-flux"
     WAN = "wan"
     AI_TOOLKIT_FLUX = "ai-toolkit-flux"
+    LOKR = "lokr"
 
 
 def _sample_keys(keys: Iterable[str], k: int = 20) -> list[str]:
@@ -131,6 +133,28 @@ def _looks_like_ai_toolkit_flux_lora(state_dict: Mapping[str, torch.Tensor]) -> 
     return (has_double_blocks or has_single_blocks) and has_lora_ab
 
 
+def _looks_like_lokr(state_dict: Mapping[str, torch.Tensor]) -> bool:
+    """Detect LoKr (Low-Rank Kronecker) format from LyCORIS/ai-toolkit.
+
+    Key patterns: layers.X.attention.to_q.lokr_w1, layers.X.attention.to_q.lokr_w2
+    Also supports decomposed form: lokr_w1_a, lokr_w1_b, lokr_w2_a, lokr_w2_b
+    """
+    keys = list(state_dict.keys())
+    if not keys:
+        return False
+
+    # Check for lokr_w1/lokr_w2 keys (full matrix form)
+    has_lokr_w1 = _has_substring_key(keys, ".lokr_w1")
+    has_lokr_w2 = _has_substring_key(keys, ".lokr_w2")
+
+    # Check for decomposed form (lokr_w1_a, lokr_w1_b, lokr_w2_a, lokr_w2_b)
+    has_lokr_decomposed = _has_substring_key(keys, ".lokr_w1_a") or _has_substring_key(
+        keys, ".lokr_w2_a"
+    )
+
+    return (has_lokr_w1 and has_lokr_w2) or has_lokr_decomposed
+
+
 def detect_lora_format_from_state_dict(
     state_dict: Mapping[str, torch.Tensor],
 ) -> LoRAFormat:
@@ -138,6 +162,9 @@ def detect_lora_format_from_state_dict(
     keys = list(state_dict.keys())
     if not keys:
         return LoRAFormat.STANDARD
+
+    if _looks_like_lokr(state_dict):
+        return LoRAFormat.LOKR
 
     if _looks_like_ai_toolkit_flux_lora(state_dict):
         return LoRAFormat.AI_TOOLKIT_FLUX
@@ -487,12 +514,159 @@ def _convert_ai_toolkit_flux_lora(
     return final_out
 
 
+def _convert_lokr_to_merged_weights(
+    state_dict: Mapping[str, torch.Tensor],
+    log: logging.Logger,
+) -> Dict[str, torch.Tensor]:
+    """Convert LoKr format to merged weights for direct application.
+
+    LoKr uses Kronecker product decomposition: delta_W = scale * kron(w1, w2)
+    For inference, we pre-compute the full delta_W and store it as merged_weight.
+
+    Supports both full matrix form (lokr_w1, lokr_w2) and decomposed form
+    (lokr_w1_a @ lokr_w1_b, lokr_w2_a @ lokr_w2_b).
+    """
+    out: Dict[str, torch.Tensor] = {}
+    layer_weights: Dict[str, Dict[str, torch.Tensor]] = {}
+
+    for key, tensor in state_dict.items():
+        if ".lokr_w1" in key or ".lokr_w2" in key or ".alpha" in key:
+            base = None
+            weight_type = None
+
+            for suffix in [
+                ".lokr_w1",
+                ".lokr_w2",
+                ".lokr_w1_a",
+                ".lokr_w1_b",
+                ".lokr_w2_a",
+                ".lokr_w2_b",
+                ".alpha",
+            ]:
+                if key.endswith(suffix):
+                    base = key[: -len(suffix)]
+                    weight_type = suffix[1:]
+                    break
+
+            if base is None:
+                continue
+
+            if base not in layer_weights:
+                layer_weights[base] = {}
+            layer_weights[base][weight_type] = tensor
+        else:
+            out[key] = tensor
+
+    for layer_base, weights in layer_weights.items():
+        # Get alpha for scaling (default to 1.0)
+        alpha = 1.0
+        if "alpha" in weights:
+            alpha = weights["alpha"].item()
+
+        # Compute w1 from full matrix or decomposed form
+        w1 = weights.get("lokr_w1")
+        rank1 = None
+        if w1 is None:
+            if "lokr_w1_a" in weights and "lokr_w1_b" in weights:
+                # Decomposed form: w1 = w1_a @ w1_b, rank is the shared dimension
+                w1_a = weights["lokr_w1_a"]
+                w1_b = weights["lokr_w1_b"]
+                if w1_a.shape[1] != w1_b.shape[0]:
+                    log.warning(
+                        "[LoRAFormatAdapter] Rank mismatch in LoKr w1 decomposition "
+                        "for layer %s: w1_a.shape[1]=%d != w1_b.shape[0]=%d, skipping",
+                        layer_base,
+                        w1_a.shape[1],
+                        w1_b.shape[0],
+                    )
+                    continue
+                rank1 = w1_a.shape[1]
+                w1 = w1_a @ w1_b
+            else:
+                log.warning(
+                    "[LoRAFormatAdapter] Missing lokr_w1 for layer %s, skipping",
+                    layer_base,
+                )
+                continue
+
+        # Compute w2 from full matrix or decomposed form
+        w2 = weights.get("lokr_w2")
+        rank2 = None
+        if w2 is None:
+            if "lokr_w2_a" in weights and "lokr_w2_b" in weights:
+                # Decomposed form: w2 = w2_a @ w2_b, rank is the shared dimension
+                w2_a = weights["lokr_w2_a"]
+                w2_b = weights["lokr_w2_b"]
+                if w2_a.shape[1] != w2_b.shape[0]:
+                    log.warning(
+                        "[LoRAFormatAdapter] Rank mismatch in LoKr w2 decomposition "
+                        "for layer %s: w2_a.shape[1]=%d != w2_b.shape[0]=%d, skipping",
+                        layer_base,
+                        w2_a.shape[1],
+                        w2_b.shape[0],
+                    )
+                    continue
+                rank2 = w2_a.shape[1]
+                w2 = w2_a @ w2_b
+            else:
+                log.warning(
+                    "[LoRAFormatAdapter] Missing lokr_w2 for layer %s, skipping",
+                    layer_base,
+                )
+                continue
+
+        # Compute Kronecker product
+        delta_w = torch.kron(w1.float(), w2.float()).to(w1.dtype)
+
+        # Apply alpha scaling following LyCORIS convention:
+        # - Both decomposed: scale = alpha / lora_dim (ranks should be same)
+        # - Both full matrices: scale = 1 (alpha ignored)
+        # - Mixed: use rank from decomposed one
+        if rank1 is not None and rank2 is not None:
+            # Both decomposed: ranks should be the same (LyCORIS uses shared lora_dim)
+            if rank1 != rank2:
+                log.warning(
+                    "[LoRAFormatAdapter] LoKr ranks differ for layer %s: "
+                    "rank1=%d, rank2=%d, using max(rank1, rank2)",
+                    layer_base,
+                    rank1,
+                    rank2,
+                )
+            effective_rank = max(rank1, rank2)
+            scale = alpha / effective_rank
+        elif rank1 is not None or rank2 is not None:
+            # Mixed: one decomposed, one full - use the decomposed rank
+            effective_rank = rank1 if rank1 is not None else rank2
+            scale = alpha / effective_rank
+        else:
+            # Both full matrices: scale = 1 (per LyCORIS, alpha is ignored)
+            scale = 1.0
+
+        delta_w = scale * delta_w
+
+        new_key = layer_base
+        if new_key.startswith("diffusion_model."):
+            new_key = new_key[len("diffusion_model.") :]
+
+        out[f"{new_key}.merged_weight"] = delta_w
+
+    sample = _sample_keys(out.keys(), 20)
+    log.info(
+        "[LoRAFormatAdapter] after LOKR conversion, " "sample keys (<=20): %s",
+        ", ".join(sample),
+    )
+    return out
+
+
 def convert_lora_state_dict_by_format(
     state_dict: Mapping[str, torch.Tensor],
     fmt: LoRAFormat,
     log: logging.Logger,
 ) -> Dict[str, torch.Tensor]:
     """Normalize a raw LoRA state_dict into A/B + .weight naming."""
+    if fmt == LoRAFormat.LOKR:
+        return _convert_lokr_to_merged_weights(state_dict, log)
+
     if fmt == LoRAFormat.QWEN_IMAGE_STANDARD:
         return _convert_qwen_image_standard(state_dict, log)
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -424,13 +424,37 @@ class LoRAPipeline(ComposedPipelineBase):
             )
 
         adapted_count = 0
+        # Apply all LoRA adapters in order
         for name, layer in lora_layers.items():
-            # Apply all LoRA adapters in order
+            merged_weight_name = name + ".merged_weight"
+            lora_A_name = name + ".lora_A"
+            lora_B_name = name + ".lora_B"
+
+            has_lokr_for_layer = any(
+                merged_weight_name in self.lora_adapters[nickname]
+                for nickname in lora_nicknames
+            )
+            has_standard_lora_for_layer = any(
+                lora_A_name in self.lora_adapters[nickname]
+                and lora_B_name in self.lora_adapters[nickname]
+                for nickname in lora_nicknames
+            )
+
+            if has_lokr_for_layer and has_standard_lora_for_layer:
+                raise ValueError(
+                    f"Cannot mix LoKr and standard LoRA on the same layer '{name}'. "
+                    f"Found both formats across adapters: {lora_nicknames}"
+                )
+
             for idx, (nickname, path, lora_strength) in enumerate(
                 zip(lora_nicknames, lora_paths, strengths)
             ):
-                lora_A_name = name + ".lora_A"
-                lora_B_name = name + ".lora_B"
+                if merged_weight_name in self.lora_adapters[nickname]:
+                    merged_weight = self.lora_adapters[nickname][merged_weight_name]
+                    layer.apply_merged_weight(merged_weight, strength=lora_strength)
+                    adapted_count += 1
+                    continue
+
                 if (
                     lora_A_name in self.lora_adapters[nickname]
                     and lora_B_name in self.lora_adapters[nickname]
@@ -484,6 +508,9 @@ class LoRAPipeline(ComposedPipelineBase):
                         has_any_lora = any(
                             name + ".lora_A" in self.lora_adapters[n]
                             and name + ".lora_B" in self.lora_adapters[n]
+                            for n in lora_nicknames
+                        ) or any(
+                            name + ".merged_weight" in self.lora_adapters[n]
                             for n in lora_nicknames
                         )
                         if not has_any_lora:

--- a/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
@@ -280,6 +280,18 @@ def _run_all_tests() -> List[Dict]:
         )
     )
 
+    # LOKR Z-Image Turbo LoRA (LOKR → STANDARD).
+    results.append(
+        run_single_test(
+            name="LOKR Z-Image Turbo LoRA",
+            repo_id="F16/z-image-turbo-flow-dpo",
+            filename="zit_fdpo_v1.safetensors",
+            local_name="zit_fdpo_v1.safetensors",
+            expected_before=LoRAFormat.LOKR,
+            expected_after=LoRAFormat.STANDARD,
+        )
+    )
+
     return results
 
 


### PR DESCRIPTION
## Motivation

`**[03-23 20:38:54] Rank 0: LoRA adapter(s)Tongyi-MAI/z-image-turbo-flow-dpo applied to 0 layers (targets: all, strengths: 1.00)**`

Add LoKr (Low-Rank Kronecker Product) adapter support for diffusion models in SGLang.

`**[03-23 23:30:49] Rank 0: LoRA adapter(s) Tongyi-MAI/z-image-turbo-flow-dpo applied to 180 layers (targets: all, strengths: 1.00)**`

## Modifications


## Accuracy Tests

Prompt 1:
A professional realistic photograph of a woman standing by a window, golden hour lighting, cinematic shadows, highly detailed, 8k resolution

Prompt 2:
woman, Asian ethnicity, white dress, looking away, long hair, outdoor setting, building facade, plants, serene expression, elegance, side profile, standing, daylight, soft focus, pastel colors, fashion, youthful, casual elegance, architectural elements, natural light, tassel detail on dress
  
| Metric                    | NO LORA | LORA | 
|----------------------------|-------------|------------------------------|
|  Prompt 1             | <img width="1280" height="720" alt="A_professional_realistic_photograph_of_a_woman_standing" src="https://github.com/user-attachments/assets/8d7e5552-91fb-4cca-a2c6-71c44fb5f1f5" /> | <img width="1280" height="720" alt="A_professional_realistic_photograph_of_a_woman_standing_by_a_window_golden_" src="https://github.com/user-attachments/assets/a77a28e4-a41d-400b-b1a4-d2dbf9700dbf" /> | 
|  Prompt 2               | <img width="1280" height="720" alt="woman_Asian_ethnicity_white_dress_looking_away_long_hair_outdoor_" src="https://github.com/user-attachments/assets/ddfd0711-9065-4e62-9d4e-b9b557b8ecd8" /> | <img width="1280" height="720" alt="woman_Asian_ethnicity_white_dress_looking_away_long_hair_outdoor_setting_building_facade_plan_20260323-144623_fc61a82c" src="https://github.com/user-attachments/assets/497c8a9d-bd78-4a9b-af0a-dbe93943d221" />| 


## Benchmarking and Profiling




<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
