### PR TITLE
fix: disable attn_tp_input_scattered when input_embeds is provided externally for Kimi-K2.5

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -147,7 +147,6 @@ class ScatterMode(Enum):
 
 
 class AttentionInputs:
-
     def __init__(
         self,
         hidden_states: torch.Tensor,
@@ -220,6 +219,7 @@ class AttnTpContext:
     def use_input_scattered(self, forward_batch: ForwardBatch):
         return (
             self.allow_input_scattered
+            and forward_batch is not None
             and forward_batch.forward_mode.is_extend()
             and not forward_batch.forward_mode.is_target_verify()
             and not forward_batch.forward_mode.is_draft_extend()
@@ -309,8 +309,8 @@ class LayerScatterModes:
         if context.is_layer_sparse:
             return (
                 ScatterMode.SCATTERED
+                # Token dispatch/combine will be handled outside of LayerCommunicator for these modes.
                 if (
-                    # Token dispatch/combine will be handled outside of LayerCommunicator for these modes.
                     not get_moe_a2a_backend().is_none()
                     or should_use_flashinfer_cutlass_moe_fp4_allgather()
                 )
@@ -483,7 +483,6 @@ class LayerCommunicator:
                             None,
                         )
                     elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
-
                         hidden_states, _, _, _res = fused_rms_fp8_group_quant(
                             hidden_states,
                             self.input_layernorm.weight,
@@ -500,7 +499,6 @@ class LayerCommunicator:
                     else:
                         hidden_states = self.input_layernorm(hidden_states)
                 else:
-
                     if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
                         hidden_states, *_, residual = fused_rms_mxfp4_quant(
                             hidden_states,
@@ -554,9 +552,9 @@ class LayerCommunicator:
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if hidden_states.shape[0] == 0:
             return hidden_states, hidden_states
-        assert (
-            hidden_states.shape[0] % self._context.tp_size == 0
-        ), f"Expected total tokens {hidden_states.shape[0]} % tp_size {self._context.tp_size} to be 0"
+        assert hidden_states.shape[0] % self._context.tp_size == 0, (
+            f"Expected total tokens {hidden_states.shape[0]} % tp_size {self._context.tp_size} to be 0"
+        )
         local_tokens = hidden_states.shape[0] // self._context.tp_size
         output = hidden_states.new_empty(local_tokens, *hidden_states.shape[1:])
         get_tp_group().reduce_scatter_tensor(output, hidden_states)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2193,7 +2193,12 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                     forward_batch.seq_lens_cpu.tolist(),
                 )
 
-        with get_attn_tp_context().maybe_input_scattered(forward_batch):
+        # When input_embeds is provided externally (e.g., from multimodal models
+        # like Kimi-K2.5 via general_mm_embed_routine), the embeddings are already
+        # full (all_reduced). Using input_scattered mode would cause attention layers
+        # to incorrectly all_gather already-complete data, producing garbled output.
+        _scattered_batch = forward_batch if input_embeds is None else None
+        with get_attn_tp_context().maybe_input_scattered(_scattered_batch):
             hidden_states = self.model(
                 input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors
             )


### PR DESCRIPTION
## Motivation

When `--enable-attn-tp-input-scattered` is used with multimodal models based on DeepSeek V3 architecture (e.g., Kimi-K2.5), the model produces garbled/garbage output. Pure text models like DeepSeek-R1 are not affected.

**Root cause**: Multimodal models use `general_mm_embed_routine` (in `mm_utils.py`) which computes embeddings **outside** the `maybe_input_scattered` context manager. The resulting `input_embeds` tensor is already full (all_reduced). When this tensor is passed to `DeepseekV3ForCausalLM.forward()`, the `maybe_input_scattered` context activates `input_scattered=True`, causing attention layers to incorrectly `all_gather` already-complete data — producing 8x repeated/corrupted tensors and garbled output.

In contrast, pure text models (DeepSeek-R1) call `embed_tokens(input_ids)` **inside** the `maybe_input_scattered` context, where `VocabParallelEmbedding.forward()` correctly skips `all_reduce`, producing genuinely scattered data that subsequent `all_gather` operations can correctly reconstruct.

**Call path comparison**:
```
DeepSeek-R1 (WORKS):
  DeepseekV3ForCausalLM.forward(input_ids=tokens, input_embeds=None)
    └─ with maybe_input_scattered():  # input_scattered = True
         └─ embed_tokens(input_ids)   # skips all_reduce → scattered output ✓
         └─ attention layers all_gather scattered data → correct ✓

Kimi-K2.5 (BROKEN):
  general_mm_embed_routine()
    └─ embed_tokens(input_ids)        # input_scattered=False → all_reduce → FULL output
    └─ language_model(input_embeds=FULL_EMBEDS)
         └─ with maybe_input_scattered():  # input_scattered = True
              └─ uses FULL input_embeds directly (no embed_tokens call)
              └─ attention layers all_gather FULL data → corrupted ✗
```

## Modifications

**`python/sglang/srt/models/deepseek_v2.py`**:
- In `DeepseekV3ForCausalLM.forward()`, pass `None` instead of `forward_batch` to `maybe_input_scattered` when `input_embeds` is provided externally. This disables scattered mode for externally-computed embeddings that are already full.

**`python/sglang/srt/layers/communicator.py`**:
- Add `forward_batch is not None` guard in `use_input_scattered()` to safely handle `None` input from the above change.

## Accuracy Tests

Tested on 8x NVIDIA H20 with sglang 0.5.9, Kimi-K2.5 (BF16, TP=8):

| Config | Before Fix | After Fix |
|--------|-----------|-----------|
| `--enable-attn-tp-input-scattered --chunked-prefill-size 32768` | Garbled output | Correct output |
| Pure TP=8 (no scattered) | Correct output | Correct output (unchanged) |

**After fix, sample outputs**:
- Input: "请用中文简单介绍一下你自己" → Output: "你好！我是 Kimi，由月之暗面（Moonshot AI）开发的人工智能助手。" ✓
- Input: "What is 2+3? Answer in one word." → Output: "five" ✓

DeepSeek-R1 behavior is unchanged (was already working correctly, and the fix does not alter its code path since `input_embeds is None` for pure text models).

## Benchmarking and Profiling

This fix only adds a conditional check (`input_embeds is None`) before entering the scattered context. No performance impact on pure text models. For multimodal models, scattered mode is disabled when external embeddings are provided — this trades the scattered optimization for correctness. A future optimization could scatter the pre-computed embeddings to re-enable the optimization path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).