### PR TITLE
Fix Qwen3.5 MoE KeyError with pipeline parallelism

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1248,6 +1248,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
                             and name_mapped not in params_dict
                         ):
                             continue
+                        # With PP, layers on other ranks won't be in params_dict
+                        if name_mapped not in params_dict:
+                            continue
                         param = params_dict[name_mapped]
                         # We should ask the weight loader to return success or
                         # not here since otherwise we may skip experts with
@@ -1588,6 +1591,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
                             name_mapped.endswith(ignore_suffixes)
                             and name_mapped not in params_dict
                         ):
+                            continue
+                        # With PP, layers on other ranks won't be in params_dict
+                        if name_mapped not in params_dict:
                             continue
                         param = params_dict[name_mapped]
                         # We should ask the weight loader to return success or


### PR DESCRIPTION
## Motivation

Running Qwen3.5-122B-A10B with `--pipeline-parallel-size 8` crashes during weight loading:

```
KeyError: 'model.layers.4.mlp.experts.w13_weight'
```

The fused expert path (`load_fused_expert_weights`) was already fixed in #21070 to handle missing params under PP, but the non-fused expert else branch was missed — it still does a bare `params_dict[name_mapped]` without checking if the key exists.

With pipeline parallelism, layers assigned to other ranks don't have their parameters in the local `params_dict`, so any access without a guard will KeyError.

## Modifications

Added `if name_mapped not in params_dict: continue` before the dict access in the non-fused expert path, matching the pattern already used in:
- `load_fused_expert_weights` (same file, fixed in #21070)
- `qwen3_5_mtp.py` (already guarded)
- `qwen3_omni_moe.py` (already guarded)

Applied to both `Qwen3_5MoeForCausalLM` and `Qwen3_5MoeForConditionalGeneration`.

Fixes #21184