### PR TITLE
fix: prevent KeyError in _handle_abort_req when request already completed

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2160,7 +2160,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
     def _handle_abort_req(self, recv_obj: AbortReq):
         if is_health_check_generate_req(recv_obj):
             return
-        state = self.rid_to_state[recv_obj.rid]
+        state = self.rid_to_state.get(recv_obj.rid)
+        if state is None:
+            # Request already completed and cleaned up
+            return
         state.finished = True
         state.time_stats.set_finished_time()
 


### PR DESCRIPTION
Fixes #21173

Problem: _handle_abort_req crashes with KeyError when trying to abort a request that has already completed.

Fix: Use dict.get() with None check, matching the pattern in _handle_batch_output.