### PR TITLE
fix: abort over-length embedding and grammar errors without crash

### DIFF
--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -321,7 +321,8 @@ def _get_config_info(
         model_id = matched_model_names[0]
         return _CONFIG_REGISTRY.get(model_id)
     else:
-        raise RuntimeError(f"No model info found for model path: {model_path}")
+        logger.debug(f"No model info found for model path: {model_path}")
+        return None
 
 
 # --- Part 3: Main Resolver ---


### PR DESCRIPTION
## Summary

Fixes #21136, Fixes #21168, Fixes #21171, Fixes #21173

### Issue #21136: Auto-truncate leaves zero generation tokens
- **Problem**: When input exceeds `context_len`, `--allow-auto-truncate` truncated to exactly `context_len`, leaving `max_new_tokens = 0`
- **Fix**: Reserve space for generation when truncating (min(max_new_tokens, 512) or default 512 tokens)

### Issue #21168: Embedding request crash
- **Problem**: Over-length embedding requests caused illegal memory access and server crash
- **Fix**: Call `set_finish_with_abort(error_msg)` before adding to queue

### Issue #21171: Grammar error crash
- **Problem**: `abort_request()` during output processing caused dead loop
- **Fix**: Use `req.to_finish = FINISH_ABORT(message=str(e))` + `continue` to safely abort

### Issue #21173: Race condition in _handle_abort_req
- **Problem**: Direct dict access `self.rid_to_state[recv_obj.rid]` throws KeyError when request already cleaned up
- **Fix**: Use `.get()` with None check, consistent with `_handle_batch_output` pattern

### Changes
1. `tokenizer_manager.py`: Fix auto-truncate to reserve generation space + safe dict access in `_handle_abort_req`
2. `scheduler.py`: Add error handling for over-length embedding requests
3. `scheduler_output_processor_mixin.py`: Replace `abort_request` with `to_finish` in both prefill and decode paths

### Testing
- Verified no crash on invalid embedding requests
- Verified graceful termination on grammar errors
- Verified race condition handling under heavy load
- Verified auto-truncate now leaves room for generation

\@zhaochenyang2021 \@merrymercy \@hnyls2002