### PR TITLE
[NVIDIA] Enable FP4 flashinfer trtllm routed moe

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -559,13 +559,17 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     dispatch_output: StandardDispatchOutput,
     quant_info: FlashInferTrtllmFp4MoeQuantInfo,
     runner_config: MoeRunnerConfig,
+    use_routed_topk: bool = False,
 ) -> StandardCombineInput:
     """FlashInfer TRTLLM FP4 MoE forward pass.
 
     This function handles the FP4 TRTLLM MoE path that was previously in
     ModelOptNvFp4FusedMoEMethod.apply.
     """
-    from flashinfer.fused_moe import trtllm_fp4_block_scale_moe
+    from flashinfer.fused_moe import (
+        trtllm_fp4_block_scale_moe,
+        trtllm_fp4_block_scale_routed_moe,
+    )
 
     from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
     from sglang.srt.layers.moe.topk import TopKOutputChecker
@@ -576,25 +580,13 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
 
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
-    assert TopKOutputChecker.format_is_bypassed(topk_output)
-
-    router_logits = topk_output.router_logits
-    topk_config = topk_output.topk_config
-    routing_method_type = quant_info.routing_method_type
 
     # Quantize hidden states to FP4
     hs_fp4, hs_scale_linear = quantize_hidden_states_fp4(
         hidden_states, quant_info.w13_input_scale_quant
     )
-
-    # DeepSeekV3 style routing requires float32 router logits
-    if routing_method_type == RoutingMethodType.DeepSeekV3:
-        router_logits = router_logits.to(torch.float32)
-
-    correction_bias = (
-        None
-        if topk_config.correction_bias is None
-        else topk_config.correction_bias.to(hidden_states.dtype)
+    hs_scale = hs_scale_linear.view(torch.float8_e4m3fn).reshape(
+        *hs_scale_linear.shape[:-1], -1
     )
 
     with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
@@ -603,49 +595,103 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
             hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
         )
         symm_output = torch.empty(
-            num_tokens, hidden_size, dtype=torch.bfloat16, device=hs_fp4.device
+            num_tokens, hidden_size, dtype=hidden_states.dtype, device=hs_fp4.device
         )
 
-    result = trtllm_fp4_block_scale_moe(
-        routing_logits=router_logits,
-        routing_bias=correction_bias,
-        hidden_states=hs_fp4,
-        hidden_states_scale=hs_scale_linear.view(torch.float8_e4m3fn).reshape(
-            *hs_scale_linear.shape[:-1], -1
-        ),
-        gemm1_weights=quant_info.gemm1_weights_fp4_shuffled,
-        gemm1_weights_scale=quant_info.gemm1_scales_fp4_shuffled.view(
-            torch.float8_e4m3fn
-        ),
-        gemm1_bias=None,
-        gemm1_alpha=None,
-        gemm1_beta=None,
-        gemm1_clamp_limit=None,
-        gemm2_weights=quant_info.gemm2_weights_fp4_shuffled,
-        gemm2_weights_scale=quant_info.gemm2_scales_fp4_shuffled.view(
-            torch.float8_e4m3fn
-        ),
-        gemm2_bias=None,
-        output1_scale_scalar=quant_info.g1_scale_c,
-        output1_scale_gate_scalar=quant_info.g1_alphas,
-        output2_scale_scalar=quant_info.g2_alphas,
-        num_experts=quant_info.global_num_experts,
-        top_k=topk_config.top_k,
-        n_group=topk_config.num_expert_group,
-        topk_group=topk_config.topk_group,
-        intermediate_size=quant_info.intermediate_size_per_partition,
-        local_expert_offset=quant_info.local_expert_offset,
-        local_num_experts=quant_info.local_num_experts,
-        routed_scaling_factor=runner_config.routed_scaling_factor,
-        routing_method_type=(
-            routing_method_type
-            if routing_method_type is not None
-            else RoutingMethodType.Default
-        ),
-        do_finalize=True,
-        tune_max_num_tokens=next_power_of_2(hs_fp4.shape[0]),
-        output=symm_output,
-    )[0]
+    if use_routed_topk:
+        assert TopKOutputChecker.format_is_standard(topk_output)
+
+        packed_topk_ids = _pack_topk_for_flashinfer_routed(
+            topk_output.topk_ids, topk_output.topk_weights
+        )
+        result = trtllm_fp4_block_scale_routed_moe(
+            topk_ids=packed_topk_ids,
+            routing_bias=None,
+            hidden_states=hs_fp4,
+            hidden_states_scale=hs_scale,
+            gemm1_weights=quant_info.gemm1_weights_fp4_shuffled,
+            gemm1_weights_scale=quant_info.gemm1_scales_fp4_shuffled.view(
+                torch.float8_e4m3fn
+            ),
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=quant_info.gemm2_weights_fp4_shuffled,
+            gemm2_weights_scale=quant_info.gemm2_scales_fp4_shuffled.view(
+                torch.float8_e4m3fn
+            ),
+            gemm2_bias=None,
+            output1_scale_scalar=quant_info.g1_scale_c,
+            output1_scale_gate_scalar=quant_info.g1_alphas,
+            output2_scale_scalar=quant_info.g2_alphas,
+            num_experts=quant_info.global_num_experts,
+            top_k=topk_output.topk_ids.shape[1],
+            n_group=0,
+            topk_group=0,
+            intermediate_size=quant_info.intermediate_size_per_partition,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=1,  # Unused, but must be 1 to pass validation.
+            do_finalize=True,
+            tune_max_num_tokens=next_power_of_2(hs_fp4.shape[0]),
+            output=symm_output,
+        )[0]
+    else:
+        assert TopKOutputChecker.format_is_bypassed(topk_output)
+
+        router_logits = topk_output.router_logits
+        topk_config = topk_output.topk_config
+        routing_method_type = quant_info.routing_method_type
+
+        # DeepSeekV3 style routing requires float32 router logits
+        if routing_method_type == RoutingMethodType.DeepSeekV3:
+            router_logits = router_logits.to(torch.float32)
+
+        correction_bias = (
+            None
+            if topk_config.correction_bias is None
+            else topk_config.correction_bias.to(hidden_states.dtype)
+        )
+        result = trtllm_fp4_block_scale_moe(
+            routing_logits=router_logits,
+            routing_bias=correction_bias,
+            hidden_states=hs_fp4,
+            hidden_states_scale=hs_scale,
+            gemm1_weights=quant_info.gemm1_weights_fp4_shuffled,
+            gemm1_weights_scale=quant_info.gemm1_scales_fp4_shuffled.view(
+                torch.float8_e4m3fn
+            ),
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=quant_info.gemm2_weights_fp4_shuffled,
+            gemm2_weights_scale=quant_info.gemm2_scales_fp4_shuffled.view(
+                torch.float8_e4m3fn
+            ),
+            gemm2_bias=None,
+            output1_scale_scalar=quant_info.g1_scale_c,
+            output1_scale_gate_scalar=quant_info.g1_alphas,
+            output2_scale_scalar=quant_info.g2_alphas,
+            num_experts=quant_info.global_num_experts,
+            top_k=topk_config.top_k,
+            n_group=topk_config.num_expert_group,
+            topk_group=topk_config.topk_group,
+            intermediate_size=quant_info.intermediate_size_per_partition,
+            local_expert_offset=quant_info.local_expert_offset,
+            local_num_experts=quant_info.local_num_experts,
+            routed_scaling_factor=runner_config.routed_scaling_factor,
+            routing_method_type=(
+                routing_method_type
+                if routing_method_type is not None
+                else RoutingMethodType.Default
+            ),
+            do_finalize=True,
+            tune_max_num_tokens=next_power_of_2(hs_fp4.shape[0]),
+            output=symm_output,
+        )[0]
 
     return StandardCombineInput(hidden_states=result)
 
@@ -801,6 +847,13 @@ def fused_experts_none_to_flashinfer_trtllm_routed(
     quant_info: MoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
+    if isinstance(quant_info, FlashInferTrtllmFp4MoeQuantInfo):
+        return fused_experts_none_to_flashinfer_trtllm_fp4(
+            dispatch_output,
+            quant_info,
+            runner_config,
+            use_routed_topk=True,
+        )
     if isinstance(quant_info, FlashInferTrtllmFp8MoeQuantInfo):
         return fused_experts_none_to_flashinfer_trtllm_fp8(
             dispatch_output,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1534,6 +1534,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             )
         self.enable_flashinfer_trtllm_moe = (
             get_moe_runner_backend().is_flashinfer_trtllm()
+            or get_moe_runner_backend().is_flashinfer_trtllm_routed()
         )
         self._cache_permute_indices = {}
 
@@ -1903,6 +1904,10 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         if get_moe_runner_backend().is_flashinfer_trtllm():
             self.runner = MoeRunner(
                 MoeRunnerBackend.FLASHINFER_TRTLLM, moe_runner_config
+            )
+        elif get_moe_runner_backend().is_flashinfer_trtllm_routed():
+            self.runner = MoeRunner(
+                MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED, moe_runner_config
             )
 
     def apply(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable FP4 support for `--moe-runner-backend=flashinfer_trtllm_routed`

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
sglang serve --model-path nvidia/DeepSeek-R1-0528-FP4-v2 --tp 4 --moe-runner-backend flashinfer_trtllm_routed
Accuracy: 0.983
Invalid: 0.000
Latency: 27.109 s
Output throughput: 4489.171 token/s

sglang serve --model-path /trevor2/saved_models_MiniMax-M2_5_nvfp4_mlp_only --served-model-name MiniMax-M2.5   --reasoning-parser minimax   --tool-call-parser minimax-m2 --tp 4 --moe-runner-backend flashinfer_trtllm_routed
Accuracy: 0.959
Invalid: 0.000
Latency: 16.585 s
Output throughput: 7436.500 token/s
```

## Benchmarking and Profiling

Flashinfer cutlass
```
python3 -m sglang.launch_server   --model /trevor2/saved_models_MiniMax-M2_5_nvfp4  --served-model-name MiniMax-M2.5   --reasoning-parser minimax   --tool-call-parser minimax-m2   --trust-remote-code   --tp 4 --ep 4 --mem-fraction-static 0.9   --max-running-requests 512 --cuda-graph-max-bs 512   --kv-cache-dtype fp8_e4m3   --quantization modelopt_fp4   --attention-backend flashinfer   --moe-runner-backend flashinfer_cutlass --enable-flashinfer-allreduce-fusion --enforce-piecewise-cuda-graph
python3 /trevor/bench_serving/benchmark_serving.py --backend openai --host 0.0.0.0 --port 30000 --model MiniMaxAI/MiniMax-M2.5 --num-prompts 1280 --trust-remote-code --ignore-eos --max-concurrency 128 --random-input-len 1024 --random-output-len 1024 --random-range-ratio 0.8 --use-chat-template --dataset-name random
============ Serving Benchmark Result ============
Successful requests:                     1280      
Benchmark duration (s):                  338.69    
Total input tokens:                      1185656   
Total generated tokens:                  1177625   
Request throughput (req/s):              3.78      
Output token throughput (tok/s):         3476.95   
Total Token throughput (tok/s):          6977.61   
---------------Time to First Token----------------
Mean TTFT (ms):                          252.12    
Median TTFT (ms):                        118.38    
P99 TTFT (ms):                           2142.02   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.69     
Median TPOT (ms):                        36.33     
P99 TPOT (ms):                           37.71     
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.72     
Median ITL (ms):                         29.96     
P99 ITL (ms):                            116.02    
==================================================
```

Flashinfer trtllm
```
python3 -m sglang.launch_server   --model /trevor2/saved_models_MiniMax-M2_5_nvfp4  --served-model-name MiniMax-M2.5   --reasoning-parser minimax   --tool-call-parser minimax-m2   --trust-remote-code   --tp 4 --ep 4 --mem-fraction-static 0.9   --max-running-requests 512 --cuda-graph-max-bs 512   --kv-cache-dtype fp8_e4m3   --quantization modelopt_fp4   --attention-backend flashinfer   --moe-runner-backend flashinfer_trtllm --enable-flashinfer-allreduce-fusion --enforce-piecewise-cuda-graph
python3 /trevor/bench_serving/benchmark_serving.py --backend openai --host 0.0.0.0 --port 30000 --model MiniMaxAI/MiniMax-M2.5 --num-prompts 1280 --trust-remote-code --ignore-eos --max-concurrency 128 --random-input-len 1024 --random-output-len 1024 --random-range-ratio 0.8 --use-chat-template --dataset-name random
============ Serving Benchmark Result ============
Successful requests:                     1280      
Benchmark duration (s):                  252.67    
Total input tokens:                      1185656   
Total generated tokens:                  1177625   
Request throughput (req/s):              5.07      
Output token throughput (tok/s):         4660.73   
Total Token throughput (tok/s):          9353.24   
---------------Time to First Token----------------
Mean TTFT (ms):                          207.34    
Median TTFT (ms):                        93.28     
P99 TTFT (ms):                           1749.72   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          26.59     
Median TPOT (ms):                        27.07     
P99 TPOT (ms):                           28.19     
---------------Inter-token Latency----------------
Mean ITL (ms):                           26.61     
Median ITL (ms):                         22.00     
P99 ITL (ms):                            87.82     
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
