### PR TITLE
[diffusion] Skip automatic Wan/MOVA DiT layerwise offload on high-end GPUs

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -36,6 +36,10 @@ from sglang.multimodal_gen.runtime.utils.common import (
     is_valid_ipv6_address,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
+    CYAN,
+    GREEN,
+    RED,
+    RESET,
     _sanitize_for_logging,
     configure_logger,
     init_logger,
@@ -48,6 +52,18 @@ from sglang.multimodal_gen.utils import (
 )
 
 logger = init_logger(__name__)
+
+# Derived from single-H200 benchmarking (~140.4 GiB total) at the maximum
+# supported 720p workloads with dit_layerwise_offload=False and
+# num_inference_steps=1:
+# - Wan-AI/Wan2.2-T2V-A14B-Diffusers, 1280x720, 81 frames:
+#   peak_reserved=108076 MB (~105.5 GiB), peak_allocated=97665 MB (~95.4 GiB)
+# - OpenMOSS-Team/MOVA-720p, 1280x720, 193 frames:
+#   peak_reserved=130264 MB (~127.2 GiB), peak_allocated=108819 MB (~106.3 GiB)
+# Also, on H200, enabling dit_layerwise_offload regressed latency noticeably on
+# our validated Wan/MOVA workloads, so use a 130 GiB cutoff to keep H200-class
+# GPUs on the faster no-offload default while preserving some headroom.
+WAN_LAYERWISE_OFFLOAD_AUTO_DISABLE_MEM_GB = 130
 
 
 class Backend(str, Enum):
@@ -434,15 +450,33 @@ class ServerArgs:
         if not envs.SGLANG_CACHE_DIT_ENABLED:
             pipeline_name_lower = self.pipeline_config.__class__.__name__.lower()
             if (
-                ("wan" in pipeline_name_lower or "mova" in pipeline_name_lower)
-                and self.dit_layerwise_offload is None
-                and current_platform.enable_dit_layerwise_offload_for_wan_by_default()
-            ):
-                logger.info(
-                    f"Automatically enable dit_layerwise_offload for {self.pipeline_config.__class__.__name__} "
-                    "for low memory and performance balance"
+                "wan" in pipeline_name_lower or "mova" in pipeline_name_lower
+            ) and self.dit_layerwise_offload is None:
+                auto_enable_layerwise_offload = (
+                    current_platform.enable_dit_layerwise_offload_for_wan_by_default()
                 )
-                self.dit_layerwise_offload = True
+                if auto_enable_layerwise_offload and current_platform.is_cuda():
+                    device_total_memory_gb = (
+                        current_platform.get_device_total_memory() / BYTES_PER_GB
+                    )
+                    if (
+                        device_total_memory_gb
+                        >= WAN_LAYERWISE_OFFLOAD_AUTO_DISABLE_MEM_GB
+                    ):
+                        logger.info(
+                            "Skipping automatic dit_layerwise_offload for %s on a high-memory CUDA GPU (e.g. H200/B200/B300-class, %.2f GiB total)",
+                            self.pipeline_config.__class__.__name__,
+                            device_total_memory_gb,
+                        )
+                        auto_enable_layerwise_offload = False
+                        self.dit_layerwise_offload = False
+
+                if auto_enable_layerwise_offload:
+                    logger.info(
+                        f"Automatically enable dit_layerwise_offload for {self.pipeline_config.__class__.__name__} "
+                        "for low memory and performance balance"
+                    )
+                    self.dit_layerwise_offload = True
 
     def _adjust_autocast(self):
         if self.disable_autocast is None:
@@ -1056,6 +1090,18 @@ class ServerArgs:
                     "causing shape mismatch errors. "
                     "Please disable either --dit-layerwise-offload or SGLANG_CACHE_DIT_ENABLED."
                 )
+
+            logger.warning(
+                "dit_layerwise_offload is enabled: %slower GPU memory usage%s, but %smay reduce throughput or increase latency%s. "
+                "%sIf you are using multi-GPU deployment and already have enough memory headroom, prefer keeping dit_layerwise_offload disabled.%s "
+                "Please tune this based on your memory headroom and performance target.",
+                GREEN,
+                RESET,
+                RED,
+                RESET,
+                CYAN,
+                RESET,
+            )
 
     def _validate_parallelism(self):
         if self.sp_degree > self.num_gpus or self.num_gpus % self.sp_degree != 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

## Summary

This PR updates the default `dit_layerwise_offload` heuristic for Wan/MOVA on high-memory CUDA GPUs.

## Changes

- add `WAN_LAYERWISE_OFFLOAD_AUTO_DISABLE_MEM_GB = 130`
- skip automatic `dit_layerwise_offload` when CUDA total memory is `>= 130 GiB`
- keep the existing auto-enable behavior on smaller GPUs
- add a colored warning that `dit_layerwise_offload` lowers memory usage but may hurt latency
- document the cutoff with benchmark-backed comments

<img width="1259" height="75" alt="图片" src="https://github.com/user-attachments/assets/a8d063f5-bfcd-40df-af0c-600bb4de9f1c" />


## Why

On single-H200 runs, `dit_layerwise_offload=True` consistently regressed latency:

- `Wan2.2-T2V-A14B`, `832x480`, `17 frames`, `4 steps`: `4.22s -> 6.77s` (`+60.4%`)
- `Wan2.2-TI2V-5B`, `1280x704`, `17 frames`, `4 steps`: `5.91s -> 9.86s` (`+66.8%`)
- `MOVA-360p`, `640x352`, `17 frames`, `4 steps`: `3.12s -> 5.62s` (`+80.1%`)

To calibrate the cutoff, I also measured peak memory at the maximum supported 720p workloads on H200 with `dit_layerwise_offload=False` and `num_inference_steps=1`:

- `Wan2.2-T2V-A14B`, `1280x720`, `81 frames`: `peak_reserved=108076 MB` (`~105.5 GiB`)
- `MOVA-720p`, `1280x720`, `193 frames`: `peak_reserved=130264 MB` (`~127.2 GiB`)

So `130 GiB` is a proper memory threshold.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
