### PR TITLE
fix: prevent KeyError in _handle_abort_req for already-completed requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2160,7 +2160,11 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
     def _handle_abort_req(self, recv_obj: AbortReq):
         if is_health_check_generate_req(recv_obj):
             return
-        state = self.rid_to_state[recv_obj.rid]
+        state = self.rid_to_state.get(recv_obj.rid, None)
+        if state is None:
+            # Request already cleaned up (race condition)
+            logger.debug(f"Abort request for unknown rid {recv_obj.rid}, already cleaned up")
+            return
         state.finished = True
         state.time_stats.set_finished_time()
 


### PR DESCRIPTION
## Summary
- Use `.get()` with None check instead of direct dict access in `_handle_abort_req`
- Prevents race condition crash when abort arrives after request cleanup
- Consistent with `_handle_batch_output` pattern (line ~1533)

## Problem
`_handle_abort_req` in `tokenizer_manager.py` accesses `self.rid_to_state[recv_obj.rid]` directly without checking if the key exists. If the request has already finished and been cleaned up from `rid_to_state` before the abort message arrives from the scheduler, this raises an unhandled `KeyError` that crashes the TokenizerManager event loop.

## Solution
Use `.get()` with a None check, consistent with the pattern in `_handle_batch_output`:

```python
state = self.rid_to_state.get(recv_obj.rid, None)
if state is None:
    logger.debug(f"Abort request for unknown rid {recv_obj.rid}, already cleaned up")
    return
```

## Test Plan
- Verified the fix addresses the race condition described in #21173
- Code follows existing patterns in the codebase

Fixes #21173