### PR TITLE
Reject non-dict sampling_params at request boundary

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -269,6 +269,7 @@ class GenerateReqInput(BaseReq):
 
         self._validate_inputs()
         self._determine_batch_size()
+        self._validate_sampling_params_type()
         self._handle_parallel_sampling()
 
         if self.is_single:
@@ -317,31 +318,44 @@ class GenerateReqInput(BaseReq):
                 self.is_single = False
                 self.batch_size = len(self.input_embeds)
 
-    def _handle_parallel_sampling(self):
-        """Handle parallel sampling parameters and adjust batch size if needed."""
-        get_sampling_param_n = (
-            lambda sampling_params: sampling_params.get("n", 1)
-            if isinstance(sampling_params, dict)
-            else sampling_params.n
+    def _validate_sampling_params_type(self):
+        """Validate sampling_params stays on the public request shape."""
+        if self.sampling_params is None or isinstance(self.sampling_params, dict):
+            return
+
+        if isinstance(self.sampling_params, list):
+            invalid_types = {
+                type(sampling_params).__name__
+                for sampling_params in self.sampling_params
+                if not isinstance(sampling_params, dict)
+            }
+            if not invalid_types:
+                return
+            raise TypeError(
+                "sampling_params must be a dict or list of dicts, "
+                f"got list containing {', '.join(sorted(invalid_types))}."
+            )
+
+        raise TypeError(
+            "sampling_params must be a dict or list of dicts, "
+            f"got {type(self.sampling_params).__name__}."
         )
 
+    def _handle_parallel_sampling(self):
+        """Handle parallel sampling parameters and adjust batch size if needed."""
         # Determine parallel sample count
         if self.sampling_params is None:
             self.parallel_sample_num = 1
             return
-
-        sampling_params_list = (
-            self.sampling_params
-            if isinstance(self.sampling_params, list)
-            else [self.sampling_params]
-        )
-        self.parallel_sample_num = get_sampling_param_n(sampling_params_list[0])
-        for sampling_params in sampling_params_list[1:]:
-            sample_n = get_sampling_param_n(sampling_params)
-            if self.parallel_sample_num != sample_n:
-                raise ValueError(
-                    "The parallel_sample_num should be the same for all samples in sample params."
-                )
+        elif isinstance(self.sampling_params, dict):
+            self.parallel_sample_num = self.sampling_params.get("n", 1)
+        else:  # isinstance(self.sampling_params, list):
+            self.parallel_sample_num = self.sampling_params[0].get("n", 1)
+            for sampling_params in self.sampling_params:
+                if self.parallel_sample_num != sampling_params.get("n", 1):
+                    raise ValueError(
+                        "The parallel_sample_num should be the same for all samples in sample params."
+                    )
 
         # If using parallel sampling with a single example, convert to batch
         if self.parallel_sample_num > 1 and self.is_single:
@@ -483,8 +497,6 @@ class GenerateReqInput(BaseReq):
         if self.sampling_params is None:
             self.sampling_params = [{}] * num
         elif isinstance(self.sampling_params, dict):
-            self.sampling_params = [self.sampling_params] * num
-        elif isinstance(self.sampling_params, SamplingParams):
             self.sampling_params = [self.sampling_params] * num
         else:  # Already a list
             self.sampling_params = self.sampling_params * self.parallel_sample_num

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -288,26 +288,25 @@ class GenerateReqInput(BaseReq):
             raise ValueError(
                 "Either text, input_ids or input_embeds should be provided."
             )
-        if self.sampling_params is None or isinstance(self.sampling_params, dict):
-            return
-
-        if isinstance(self.sampling_params, list):
-            invalid_types = {
-                type(sampling_params).__name__
-                for sampling_params in self.sampling_params
-                if not isinstance(sampling_params, dict)
-            }
-            if not invalid_types:
-                return
-            raise TypeError(
-                "sampling_params must be a dict or list of dicts, "
-                f"got list containing {', '.join(sorted(invalid_types))}."
-            )
-
-        raise TypeError(
-            "sampling_params must be a dict or list of dicts, "
-            f"got {type(self.sampling_params).__name__}."
-        )
+        error_prefix = "sampling_params must be a dict or list of dicts"
+        if self.sampling_params is not None and not isinstance(
+            self.sampling_params, dict
+        ):
+            if isinstance(self.sampling_params, list):
+                invalid_types = {
+                    type(sampling_params).__name__
+                    for sampling_params in self.sampling_params
+                    if not isinstance(sampling_params, dict)
+                }
+                if invalid_types:
+                    raise TypeError(
+                        f"{error_prefix}, got list containing "
+                        f"{', '.join(sorted(invalid_types))}."
+                    )
+            else:
+                raise TypeError(
+                    f"{error_prefix}, got {type(self.sampling_params).__name__}."
+                )
 
     def _determine_batch_size(self):
         """Determine if this is a single example or a batch and the batch size."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -288,7 +288,6 @@ class GenerateReqInput(BaseReq):
             raise ValueError(
                 "Either text, input_ids or input_embeds should be provided."
             )
-        invalid_sampling_params_type = None
         if self.sampling_params is not None and not isinstance(
             self.sampling_params, dict
         ):
@@ -299,17 +298,15 @@ class GenerateReqInput(BaseReq):
                     if not isinstance(sampling_params, dict)
                 }
                 if invalid_types:
-                    invalid_sampling_params_type = (
-                        f"list containing {', '.join(sorted(invalid_types))}"
+                    raise TypeError(
+                        "sampling_params must be a dict or list of dicts, "
+                        f"got list containing {', '.join(sorted(invalid_types))}."
                     )
             else:
-                invalid_sampling_params_type = type(self.sampling_params).__name__
-
-        if invalid_sampling_params_type is not None:
-            raise TypeError(
-                "sampling_params must be a dict or list of dicts, "
-                f"got {invalid_sampling_params_type}."
-            )
+                raise TypeError(
+                    "sampling_params must be a dict or list of dicts, "
+                    f"got {type(self.sampling_params).__name__}."
+                )
 
     def _determine_batch_size(self):
         """Determine if this is a single example or a batch and the batch size."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -269,7 +269,6 @@ class GenerateReqInput(BaseReq):
 
         self._validate_inputs()
         self._determine_batch_size()
-        self._validate_sampling_params_type()
         self._handle_parallel_sampling()
 
         if self.is_single:
@@ -289,6 +288,7 @@ class GenerateReqInput(BaseReq):
             raise ValueError(
                 "Either text, input_ids or input_embeds should be provided."
             )
+        self._validate_sampling_params_type()
 
     def _determine_batch_size(self):
         """Determine if this is a single example or a batch and the batch size."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -288,7 +288,7 @@ class GenerateReqInput(BaseReq):
             raise ValueError(
                 "Either text, input_ids or input_embeds should be provided."
             )
-        error_prefix = "sampling_params must be a dict or list of dicts"
+        invalid_sampling_params_type = None
         if self.sampling_params is not None and not isinstance(
             self.sampling_params, dict
         ):
@@ -299,14 +299,17 @@ class GenerateReqInput(BaseReq):
                     if not isinstance(sampling_params, dict)
                 }
                 if invalid_types:
-                    raise TypeError(
-                        f"{error_prefix}, got list containing "
-                        f"{', '.join(sorted(invalid_types))}."
+                    invalid_sampling_params_type = (
+                        f"list containing {', '.join(sorted(invalid_types))}"
                     )
             else:
-                raise TypeError(
-                    f"{error_prefix}, got {type(self.sampling_params).__name__}."
-                )
+                invalid_sampling_params_type = type(self.sampling_params).__name__
+
+        if invalid_sampling_params_type is not None:
+            raise TypeError(
+                "sampling_params must be a dict or list of dicts, "
+                f"got {invalid_sampling_params_type}."
+            )
 
     def _determine_batch_size(self):
         """Determine if this is a single example or a batch and the batch size."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -288,7 +288,26 @@ class GenerateReqInput(BaseReq):
             raise ValueError(
                 "Either text, input_ids or input_embeds should be provided."
             )
-        self._validate_sampling_params_type()
+        if self.sampling_params is None or isinstance(self.sampling_params, dict):
+            return
+
+        if isinstance(self.sampling_params, list):
+            invalid_types = {
+                type(sampling_params).__name__
+                for sampling_params in self.sampling_params
+                if not isinstance(sampling_params, dict)
+            }
+            if not invalid_types:
+                return
+            raise TypeError(
+                "sampling_params must be a dict or list of dicts, "
+                f"got list containing {', '.join(sorted(invalid_types))}."
+            )
+
+        raise TypeError(
+            "sampling_params must be a dict or list of dicts, "
+            f"got {type(self.sampling_params).__name__}."
+        )
 
     def _determine_batch_size(self):
         """Determine if this is a single example or a batch and the batch size."""
@@ -317,29 +336,6 @@ class GenerateReqInput(BaseReq):
             else:
                 self.is_single = False
                 self.batch_size = len(self.input_embeds)
-
-    def _validate_sampling_params_type(self):
-        """Validate sampling_params stays on the public request shape."""
-        if self.sampling_params is None or isinstance(self.sampling_params, dict):
-            return
-
-        if isinstance(self.sampling_params, list):
-            invalid_types = {
-                type(sampling_params).__name__
-                for sampling_params in self.sampling_params
-                if not isinstance(sampling_params, dict)
-            }
-            if not invalid_types:
-                return
-            raise TypeError(
-                "sampling_params must be a dict or list of dicts, "
-                f"got list containing {', '.join(sorted(invalid_types))}."
-            )
-
-        raise TypeError(
-            "sampling_params must be a dict or list of dicts, "
-            f"got {type(self.sampling_params).__name__}."
-        )
 
     def _handle_parallel_sampling(self):
         """Handle parallel sampling parameters and adjust batch size if needed."""

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -319,19 +319,29 @@ class GenerateReqInput(BaseReq):
 
     def _handle_parallel_sampling(self):
         """Handle parallel sampling parameters and adjust batch size if needed."""
+        get_sampling_param_n = (
+            lambda sampling_params: sampling_params.get("n", 1)
+            if isinstance(sampling_params, dict)
+            else sampling_params.n
+        )
+
         # Determine parallel sample count
         if self.sampling_params is None:
             self.parallel_sample_num = 1
             return
-        elif isinstance(self.sampling_params, dict):
-            self.parallel_sample_num = self.sampling_params.get("n", 1)
-        else:  # isinstance(self.sampling_params, list):
-            self.parallel_sample_num = self.sampling_params[0].get("n", 1)
-            for sampling_params in self.sampling_params:
-                if self.parallel_sample_num != sampling_params.get("n", 1):
-                    raise ValueError(
-                        "The parallel_sample_num should be the same for all samples in sample params."
-                    )
+
+        sampling_params_list = (
+            self.sampling_params
+            if isinstance(self.sampling_params, list)
+            else [self.sampling_params]
+        )
+        self.parallel_sample_num = get_sampling_param_n(sampling_params_list[0])
+        for sampling_params in sampling_params_list[1:]:
+            sample_n = get_sampling_param_n(sampling_params)
+            if self.parallel_sample_num != sample_n:
+                raise ValueError(
+                    "The parallel_sample_num should be the same for all samples in sample params."
+                )
 
         # If using parallel sampling with a single example, convert to batch
         if self.parallel_sample_num > 1 and self.is_single:
@@ -473,6 +483,8 @@ class GenerateReqInput(BaseReq):
         if self.sampling_params is None:
             self.sampling_params = [{}] * num
         elif isinstance(self.sampling_params, dict):
+            self.sampling_params = [self.sampling_params] * num
+        elif isinstance(self.sampling_params, SamplingParams):
             self.sampling_params = [self.sampling_params] * num
         else:  # Already a list
             self.sampling_params = self.sampling_params * self.parallel_sample_num

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -2,6 +2,7 @@ import copy
 import unittest
 
 from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -557,6 +558,35 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             req = GenerateReqInput(
                 text="Hello", input_ids=[1, 2, 3], input_embeds=[[0.1, 0.2]]
             )
+            req.normalize_batch_and_arguments()
+
+    def test_sampling_params_rejects_sampling_params_object(self):
+        """GenerateReqInput should reject internal SamplingParams objects."""
+        req = GenerateReqInput(
+            input_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_new_tokens=1),
+        )
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "sampling_params must be a dict or list of dicts, got SamplingParams.",
+        ):
+            req.normalize_batch_and_arguments()
+
+    def test_sampling_params_rejects_list_of_sampling_params_objects(self):
+        """GenerateReqInput should reject batched internal SamplingParams objects."""
+        req = GenerateReqInput(
+            input_ids=[[1, 2, 3], [4, 5, 6]],
+            sampling_params=[
+                SamplingParams(max_new_tokens=1),
+                SamplingParams(max_new_tokens=2),
+            ],
+        )
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "sampling_params must be a dict or list of dicts, got list containing SamplingParams.",
+        ):
             req.normalize_batch_and_arguments()
 
     def test_multiple_input_formats(self):


### PR DESCRIPTION
## Summary
- reject non-dict `sampling_params` at the `GenerateReqInput` request boundary
- restore request normalization to only handle the documented `dict` / `list[dict]` shapes
- add simple unit coverage for rejecting `SamplingParams` and `list[SamplingParams]`

## Why
`GenerateReqInput` and `Engine.generate`/`async_generate` document `sampling_params` as `dict` or `list[dict]`.
The warmup failure came from an internal caller passing an already-instantiated `SamplingParams` object through that boundary.

Rather than broadening this request boundary to accept internal runtime objects, this change makes the contract explicit and fails early with a clear error message.

## Validation
- `python3 -m py_compile python/sglang/srt/managers/io_struct.py test/registered/unit/managers/test_io_struct.py`
- `PYTHONPATH=/tmp/sglang-pr-21261/python python3 -m unittest discover -s /tmp/sglang-pr-21261/test/registered/unit/managers -p 'test_io_struct.py'` *(fails in the current environment because `numpy` is not installed)*
