### PR TITLE
Fix customized_info offset truncation

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1109,7 +1109,7 @@ class SchedulerOutputProcessorMixin:
                     for k, v in req.customized_info.items():
                         if k not in customized_info:
                             customized_info[k] = []
-                        customized_info[k].append(v[send_token_offset:])
+                        customized_info[k].append(v[send_token_offset:len(output_ids_)])
 
             if (
                 req.finished()

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1109,7 +1109,9 @@ class SchedulerOutputProcessorMixin:
                     for k, v in req.customized_info.items():
                         if k not in customized_info:
                             customized_info[k] = []
-                        customized_info[k].append(v[send_token_offset:len(output_ids_)])
+                        customized_info[k].append(
+                            v[send_token_offset:len(output_ids_)]
+                        )
 
             if (
                 req.finished()

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -1110,7 +1110,7 @@ class SchedulerOutputProcessorMixin:
                         if k not in customized_info:
                             customized_info[k] = []
                         customized_info[k].append(
-                            v[send_token_offset:len(output_ids_)]
+                            v[send_token_offset : len(output_ids_)]
                         )
 
             if (


### PR DESCRIPTION
`customized_info` can be sliced incorrectly when output is truncated due to stop token. This makes it match the slicing for `output_ids`