### PR TITLE
[CI] Fix test port conflict on --network=host runners

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -217,9 +217,16 @@ def _use_cached_default_models(model_repo: str):
 
 
 if is_in_ci():
-    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
-        10000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 2000
+    # SGLANG_CI_BASE_GPU: physical GPU id for port offset calculation.
+    # Needed on --network=host runners where --runtime=nvidia remaps GPUs
+    # (physical 2,3 become container-local 0,1) but we still need unique ports.
+    _ci_gpu_for_port = int(
+        os.environ.get(
+            "SGLANG_CI_BASE_GPU",
+            os.environ.get("CUDA_VISIBLE_DEVICES", "0"),
+        )[0]
     )
+    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = 10000 + _ci_gpu_for_port * 2000
 else:
     DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
         20000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 1000


### PR DESCRIPTION
## Summary
- Add `SGLANG_CI_BASE_GPU` env var for deterministic test port calculation on `--network=host` CI runners
- Only affects CI path (`is_in_ci()`), non-CI behavior unchanged
- Falls back to existing `CUDA_VISIBLE_DEVICES` behavior when `SGLANG_CI_BASE_GPU` is not set

## Motivation
On CI runners using `--runtime=nvidia` with `--network=host` (e.g., H100 RadixArk 2-GPU runners), the nvidia container runtime remaps physical GPUs (e.g., physical 2,3 become container-local 0,1). Since `CUDA_VISIBLE_DEVICES` is unset inside the container, all containers compute the same default test port (11000), causing `[Errno 98] address already in use` when tests run concurrently.

`SGLANG_CI_BASE_GPU` lets each container specify its physical base GPU ID for port offset without affecting GPU visibility.

**Port mapping:** GPU 0 → 11000, GPU 2 → 15000, GPU 4 → 19000, GPU 6 → 23000

**Failing job example:** https://github.com/sgl-project/sglang/actions/runs/23416413582/job/68247825207

**Related:** PR #20952 fixes the disaggregation bootstrap port (8998) conflict separately. This PR fixes the sglang server port (11000) conflict.

## Test plan
- [ ] Existing CI runners (which set `CUDA_VISIBLE_DEVICES`) are unaffected — `SGLANG_CI_BASE_GPU` not set, falls back to existing behavior
- [ ] New `--network=host` runners with `SGLANG_CI_BASE_GPU` get unique ports per container