### PR TITLE
Fix disaggregation test bootstrap port conflict (CI-only)

### DIFF
--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -11,6 +11,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    find_available_port,
     is_in_ci,
     popen_with_error_check,
 )
@@ -33,6 +34,17 @@ class PDDisaggregationServerBase(CustomTestCase):
         cls.lb_url = f"http://{cls.base_host}:{cls.lb_port}"
         print(f"{cls.base_host=} {cls.lb_port=} {cls.prefill_port=} {cls.decode_port=}")
         cls.process_lb, cls.process_decode, cls.process_prefill = None, None, None
+
+        # Use dynamic bootstrap port in CI to avoid conflicts between
+        # --network=host containers sharing the same port space
+        if is_in_ci():
+            cls.bootstrap_port = str(find_available_port(8998))
+        else:
+            cls.bootstrap_port = "8998"
+        cls.bootstrap_port_args = [
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+        ]
 
         # config transfer backend and rdma devices
         if is_in_ci():

--- a/test/manual/hicache/test_disaggregation_hicache.py
+++ b/test/manual/hicache/test_disaggregation_hicache.py
@@ -64,7 +64,7 @@ class DisaggregationHiCacheBase(PDDisaggregationServerBase):
             "--mem-fraction-static",
             "0.8",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         env = {
             **os.environ,
             "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir,
@@ -139,7 +139,7 @@ class TestDisaggregationPrefillWithHiCache(DisaggregationHiCacheBase):
             "--base-gpu-id",
             "1",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         env = {
             **os.environ,
             "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir,
@@ -198,7 +198,7 @@ class TestDisaggregationDecodeWithHiCache(DisaggregationHiCacheBase):
             "--hicache-storage-prefetch-policy",
             "wait_complete",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         env = {
             **os.environ,
             "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir,

--- a/test/manual/piecewise_cudagraph/test_disaggregation_piecewise_cuda_graph.py
+++ b/test/manual/piecewise_cudagraph/test_disaggregation_piecewise_cuda_graph.py
@@ -40,7 +40,7 @@ class TestDisaggregationPiecewiseCudaGraph(PDDisaggregationServerBase):
             "1",
             "--enforce-piecewise-cuda-graph",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -59,7 +59,7 @@ class TestDisaggregationPiecewiseCudaGraph(PDDisaggregationServerBase):
             "--base-gpu-id",
             "1",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/manual/test_mori_transfer_engine_e2e.py
+++ b/test/manual/test_mori_transfer_engine_e2e.py
@@ -103,7 +103,7 @@ class TestMoriTransferEngineE2E(PDDisaggregationServerBase):
             "--tp",
             "1",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -122,7 +122,7 @@ class TestMoriTransferEngineE2E(PDDisaggregationServerBase):
             "--base-gpu-id",
             "1",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -246,7 +246,7 @@ class TestMoriTransferEngineTPMismatchE2E(PDDisaggregationServerBase):
             "--tp",
             "2",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -265,7 +265,7 @@ class TestMoriTransferEngineTPMismatchE2E(PDDisaggregationServerBase):
             "--base-gpu-id",
             "2",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/amd/disaggregation/test_disaggregation_basic.py
+++ b/test/registered/amd/disaggregation/test_disaggregation_basic.py
@@ -62,7 +62,7 @@ class TestDisaggregationAccuracy(PDDisaggregationServerBase):
             "--log-level",
             "debug",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -87,7 +87,7 @@ class TestDisaggregationAccuracy(PDDisaggregationServerBase):
             "--log-level",
             "debug",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         print("Debug")
         print(decode_args)
         cls.process_decode = popen_launch_pd_server(
@@ -261,7 +261,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
             "--log-level",
             "debug",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -286,7 +286,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
             "--log-level",
             "debug",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -369,7 +369,7 @@ class TestDisaggregationSimulatedRetract(PDDisaggregationServerBase):
             "--log-level",
             "debug",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -394,7 +394,7 @@ class TestDisaggregationSimulatedRetract(PDDisaggregationServerBase):
             "--log-level",
             "debug",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/amd/disaggregation/test_disaggregation_pp.py
+++ b/test/registered/amd/disaggregation/test_disaggregation_pp.py
@@ -59,7 +59,7 @@ class TestDisaggregationPrefillPPAccuracy(PDDisaggregationServerBase):
             "--attention-backend",
             "aiter",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -80,7 +80,7 @@ class TestDisaggregationPrefillPPAccuracy(PDDisaggregationServerBase):
             "--attention-backend",
             "aiter",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -149,7 +149,7 @@ class TestDisaggregationPrefillPPDynamicChunkAccuracy(PDDisaggregationServerBase
             "--attention-backend",
             "aiter",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -170,7 +170,7 @@ class TestDisaggregationPrefillPPDynamicChunkAccuracy(PDDisaggregationServerBase
             "--attention-backend",
             "aiter",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -238,7 +238,7 @@ class TestDisaggregationDecodePPAccuracy(PDDisaggregationServerBase):
             "--attention-backend",
             "aiter",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -261,7 +261,7 @@ class TestDisaggregationDecodePPAccuracy(PDDisaggregationServerBase):
             "--attention-backend",
             "aiter",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/disaggregation/test_disaggregation_basic.py
+++ b/test/registered/disaggregation/test_disaggregation_basic.py
@@ -48,7 +48,7 @@ class TestDisaggregationAccuracy(PDDisaggregationServerBase):
             "--tp",
             "1",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -67,7 +67,7 @@ class TestDisaggregationAccuracy(PDDisaggregationServerBase):
             "--base-gpu-id",
             "1",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -223,7 +223,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
             "--tp",
             "1",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -242,7 +242,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
             "--base-gpu-id",
             "1",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -320,7 +320,7 @@ class TestDisaggregationMooncakeSpec(PDDisaggregationServerBase):
             "--tp",
             "1",
         ] + cls.spec_args
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -339,7 +339,7 @@ class TestDisaggregationMooncakeSpec(PDDisaggregationServerBase):
             "--base-gpu-id",
             "1",
         ] + cls.spec_args
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -394,7 +394,7 @@ class TestDisaggregationSimulatedRetract(PDDisaggregationServerBase):
             "--tp",
             "1",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -413,7 +413,7 @@ class TestDisaggregationSimulatedRetract(PDDisaggregationServerBase):
             "--base-gpu-id",
             "1",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/disaggregation/test_disaggregation_decode_offload.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_offload.py
@@ -85,7 +85,7 @@ class TestDisaggregationDecodeOffload(PDDisaggregationServerBase):
             "--hicache-ratio",
             "2",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -113,7 +113,7 @@ class TestDisaggregationDecodeOffload(PDDisaggregationServerBase):
             "--hicache-storage-backend",
             "file",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/distributed/test_disaggregation_aarch64.py
+++ b/test/registered/distributed/test_disaggregation_aarch64.py
@@ -49,7 +49,7 @@ class TestDisaggregationMooncakeAARCH64Accuracy(PDDisaggregationServerBase):
             "--tp",
             "2",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -68,7 +68,7 @@ class TestDisaggregationMooncakeAARCH64Accuracy(PDDisaggregationServerBase):
             "--base-gpu-id",
             "2",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/distributed/test_disaggregation_different_tp.py
+++ b/test/registered/distributed/test_disaggregation_different_tp.py
@@ -46,7 +46,7 @@ class TestDisaggregationMooncakePrefillLargerTP(PDDisaggregationServerBase):
             "--tp",
             "4",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -65,7 +65,7 @@ class TestDisaggregationMooncakePrefillLargerTP(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -117,7 +117,7 @@ class TestDisaggregationMooncakeDecodeLargerTP(PDDisaggregationServerBase):
             "--tp",
             "2",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -136,7 +136,7 @@ class TestDisaggregationMooncakeDecodeLargerTP(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -188,7 +188,7 @@ class TestDisaggregationMooncakeMHAPrefillLargerTP(PDDisaggregationServerBase):
             "--tp",
             "4",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -207,7 +207,7 @@ class TestDisaggregationMooncakeMHAPrefillLargerTP(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -259,7 +259,7 @@ class TestDisaggregationMooncakeMHADecodeLargerTP(PDDisaggregationServerBase):
             "--tp",
             "2",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -278,7 +278,7 @@ class TestDisaggregationMooncakeMHADecodeLargerTP(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/distributed/test_disaggregation_dp_attention.py
+++ b/test/registered/distributed/test_disaggregation_dp_attention.py
@@ -56,7 +56,7 @@ class TestDisaggregationDPAttention(PDDisaggregationServerBase):
             "--load-balance-method",
             cls.LOAD_BALANCE_METHOD,
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -80,7 +80,7 @@ class TestDisaggregationDPAttention(PDDisaggregationServerBase):
             "--load-balance-method",
             cls.LOAD_BALANCE_METHOD,
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/distributed/test_disaggregation_hybrid_attention.py
+++ b/test/registered/distributed/test_disaggregation_hybrid_attention.py
@@ -41,7 +41,7 @@ class TestDisaggregationHybridAttentionMamba(PDDisaggregationServerBase):
             "--tp",
             "4",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -60,7 +60,7 @@ class TestDisaggregationHybridAttentionMamba(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -111,7 +111,7 @@ class TestDisaggregationHybridAttentionMambaExtraBuffer(PDDisaggregationServerBa
             "--mamba-scheduler-strategy",
             "extra_buffer",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -132,7 +132,7 @@ class TestDisaggregationHybridAttentionMambaExtraBuffer(PDDisaggregationServerBa
             "--mamba-scheduler-strategy",
             "extra_buffer",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -183,7 +183,7 @@ class TestDisaggregationHybridAttentionMambaDPDecode(PDDisaggregationServerBase)
             "--tp",
             "2",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -206,7 +206,7 @@ class TestDisaggregationHybridAttentionMambaDPDecode(PDDisaggregationServerBase)
             "--base-gpu-id",
             "2",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/distributed/test_disaggregation_pp.py
+++ b/test/registered/distributed/test_disaggregation_pp.py
@@ -45,7 +45,7 @@ class TestDisaggregationPrefillPPAccuracy(PDDisaggregationServerBase):
             "2",
             "--disable-overlap-schedule",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -64,7 +64,7 @@ class TestDisaggregationPrefillPPAccuracy(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -119,7 +119,7 @@ class TestDisaggregationPrefillPPDynamicChunkAccuracy(PDDisaggregationServerBase
             "--disable-overlap-schedule",
             "--enable-dynamic-chunking",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -138,7 +138,7 @@ class TestDisaggregationPrefillPPDynamicChunkAccuracy(PDDisaggregationServerBase
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,
@@ -192,7 +192,7 @@ class TestDisaggregationDecodePPAccuracy(PDDisaggregationServerBase):
             "2",
             "--disable-overlap-schedule",
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
             cls.prefill_url,
@@ -213,7 +213,7 @@ class TestDisaggregationDecodePPAccuracy(PDDisaggregationServerBase):
             "--base-gpu-id",
             "4",
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_pd_server(
             cls.model,
             cls.decode_url,

--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -183,7 +183,7 @@ class TestEPDDisaggregationOmni(PDDisaggregationServerBase):
             "--port",
             cls.prefill_port,
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         prefill_env = os.environ.copy()
         if cls.server_type == "grpc":
             prefill_env["SGLANG_ENCODER_MM_RECEIVER_MODE"] = "grpc"
@@ -208,7 +208,7 @@ class TestEPDDisaggregationOmni(PDDisaggregationServerBase):
             "--port",
             cls.decode_port,
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_server(
             cls.model,
             base_url=cls.decode_url,
@@ -690,7 +690,7 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
             "--port",
             cls.prefill_port,
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_server(
             cls.model,
             base_url=cls.prefill_url,
@@ -712,7 +712,7 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
             "--port",
             cls.decode_port,
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_server(
             cls.model,
             base_url=cls.decode_url,
@@ -905,7 +905,7 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
             "--port",
             cls.prefill_port,
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_prefill = popen_launch_server(
             cls.model,
             base_url=cls.prefill_url,
@@ -927,7 +927,7 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
             "--port",
             cls.decode_port,
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_server(
             cls.model,
             base_url=cls.decode_url,
@@ -1097,7 +1097,7 @@ class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
             "--port",
             cls.prefill_port,
         ]
-        prefill_args += cls.transfer_backend + cls.rdma_devices
+        prefill_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         prefill_env = os.environ.copy()
         prefill_env["SGLANG_ENCODER_MM_RECEIVER_MODE"] = "grpc"
         cls.process_prefill = popen_launch_server(
@@ -1121,7 +1121,7 @@ class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
             "--port",
             cls.decode_port,
         ]
-        decode_args += cls.transfer_backend + cls.rdma_devices
+        decode_args += cls.transfer_backend + cls.rdma_devices + cls.bootstrap_port_args
         cls.process_decode = popen_launch_server(
             cls.model,
             base_url=cls.decode_url,


### PR DESCRIPTION
## Summary
- Use `find_available_port(8998)` in CI only for the disaggregation bootstrap port, keeping deterministic port 8998 for local development
- Pass the dynamically allocated port via `--disaggregation-bootstrap-port` to both prefill and decode servers
- Updated all 14 disaggregation test files

Supersedes #20952 (addresses review feedback to make it CI-specific).

## Motivation
On CI machines using `--network=host` where multiple runner containers share the same port space, simultaneous disaggregation tests collide on port 8998, causing `OSError: [Errno 98] address already in use`.

Example failure: https://github.com/sgl-project/sglang/actions/runs/23436739759/job/68185165551

## Test plan
- [ ] Existing disaggregation CI tests pass (dynamic port in CI)
- [ ] Local development uses deterministic port 8998 (no behavior change)