### PR TITLE
[AMD] Auto-detect Eagle3 draft model when --speculative-algorithm EAGLE is used

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2927,6 +2927,34 @@ class ServerArgs:
         if self.speculative_algorithm == "NEXTN":
             self.speculative_algorithm = "EAGLE"
 
+        if (
+            self.speculative_algorithm == "EAGLE"
+            and self.speculative_draft_model_path
+        ):
+            try:
+                from sglang.srt.model_config import ModelConfig
+
+                draft_cfg = ModelConfig.from_server_args(
+                    self,
+                    model_path=self.speculative_draft_model_path,
+                    model_revision=self.speculative_draft_model_revision,
+                    is_draft_model=True,
+                )
+                arch = draft_cfg.hf_config.architectures[0]
+                if "Eagle3" in arch:
+                    logger.warning(
+                        "Draft model '%s' uses Eagle3 architecture (%s) but "
+                        "--speculative-algorithm is set to EAGLE. "
+                        "Automatically upgrading to EAGLE3. Using EAGLE with "
+                        "an Eagle3 draft model would silently produce "
+                        "accept_length=1.0 due to missing aux hidden states.",
+                        self.speculative_draft_model_path,
+                        arch,
+                    )
+                    self.speculative_algorithm = "EAGLE3"
+            except Exception:
+                pass
+
         if self.speculative_algorithm in ("EAGLE", "EAGLE3", "STANDALONE"):
             if self.speculative_algorithm == "STANDALONE" and self.enable_dp_attention:
                 # TODO: support dp attention for standalone speculative decoding


### PR DESCRIPTION
## Motivation

Using `--speculative-algorithm EAGLE` with an Eagle3 draft model (e.g. `lightseekorg/kimi-k2.5-eagle3`) silently degrades performance with **no error or warning**. The `accept_length` drops to exactly 1.0, making Eagle3 slower than running without speculation.

Root cause: `EAGLE` mode does not enable aux hidden state capture (3-layer concatenation). Eagle3 draft models have an `fc` layer that expects `3 * hidden_size` input, but under `EAGLE` mode they receive `1 * hidden_size`. The `fc` projection is silently skipped because the dimension check `hidden_states.shape[-1] != embeds.shape[-1]` evaluates to False (both are `hidden_size`), producing garbage predictions.

This was discovered while debugging Eagle3 on MI355X — the only visible symptom was `accept_len: 1.00` in server logs, with no indication of misconfiguration.

## Changes

In `server_args.py` `_handle_speculative_decoding()`: when `--speculative-algorithm EAGLE` is specified, inspect the draft model's HuggingFace config architecture. If it contains "Eagle3" (e.g. `LlamaForCausalLMEagle3`), auto-upgrade to `EAGLE3` and emit a warning.

**1 file changed, 28 insertions.**

## Testing

Validated on 8× MI355X (gfx950) with `moonshotai/Kimi-K2.5` + `lightseekorg/kimi-k2.5-eagle3`:

| Config | accept_length | decode tok/s (BS=1) |
|--------|--------------|-------------------|
| `--speculative-algorithm EAGLE` (before) | 1.00 | 22 tok/s (slower than no Eagle3) |
| `--speculative-algorithm EAGLE3` (after auto-upgrade) | 2.3–3.6 | 66 tok/s (1.8× over baseline) |

## Related

- Companion PRs: [Fix eagle_config parsing](#TBD_PR2), [ROCm non-greedy fallback kernels](#TBD_PR1)