### PR TITLE
RPD profiler data loss when used with loadTracer.sh

### DIFF
--- a/python/sglang/srt/managers/scheduler_profiler_mixin.py
+++ b/python/sglang/srt/managers/scheduler_profiler_mixin.py
@@ -165,25 +165,26 @@ class SchedulerProfilerMixin:
 
             rpdTracerControl.skipCreate()
 
+            rpd_filename = os.environ.get("RPDT_FILENAME", "trace.rpd")
             self.rpd_profile_path = os.path.join(
                 self.torch_profiler_output_dir,
                 "rpd-" + str(time.time()) + f"-TP-{self.tp_rank}" + ".trace.json.gz",
             )
 
             if self.tp_rank == 0:
-                import sqlite3
+                if not os.path.exists(rpd_filename):
+                    import sqlite3
 
-                from rocpd.schema import RocpdSchema
+                    from rocpd.schema import RocpdSchema
 
-                if os.path.exists("trace.rpd"):
-                    os.unlink("trace.rpd")
-                schema = RocpdSchema()
-                connection = sqlite3.connect("trace.rpd")
-                schema.writeSchema(connection)
-                connection.commit()
-                del connection
+                    schema = RocpdSchema()
+                    connection = sqlite3.connect(rpd_filename)
+                    schema.writeSchema(connection)
+                    connection.commit()
+                    del connection
             torch.distributed.barrier(self.dp_tp_cpu_group)
 
+            self.rpd_filename = rpd_filename
             self.rpd_profiler = rpdTracerControl()
             self.rpd_profiler.setPythonTrace(True)
             self.rpd_profiler.start()
@@ -304,7 +305,7 @@ class SchedulerProfilerMixin:
             if self.tp_rank == 0:
                 from sglang.srt.utils.rpd_utils import rpd_to_chrome_trace
 
-                rpd_to_chrome_trace("trace.rpd", self.rpd_profile_path)
+                rpd_to_chrome_trace(self.rpd_filename, self.rpd_profile_path)
             self.rpd_profiler = None
             self.rpd_profile_path = None
 


### PR DESCRIPTION
Fixes #22875
## Motivation

When RPD profiling is triggered via `/start_profile` with `activities=["RPD"]`, the code in `scheduler_profiler_mixin.py` unconditionally deletes and recreates `trace.rpd` on rank 0. However, when the server is launched with `loadTracer.sh` (the documented AMD profiling workflow in `3rdparty/amd/profiling/PROFILING.md`), `librpd_tracer.so` is already loaded via `LD_PRELOAD` and holds an open file descriptor to the original `trace.rpd`.

Deleting and recreating the file produces a new inode, while the tracer continues writing to the old (now unlinked) file descriptor. This causes **all GPU kernel data to be silently lost** — the resulting `trace.rpd` contains only an empty schema with 0 GPU ops.

## Changes

- Remove the unconditional `os.unlink("trace.rpd")` call. Instead, only create `trace.rpd` if it does not already exist, preserving the file descriptor when `loadTracer.sh` is in use.
- Replace all hardcoded `"trace.rpd"` references with the `RPDT_FILENAME` environment variable (set by `loadTracer.sh`), falling back to `"trace.rpd"` as default. This also enables `loadTracer.sh`'s `-o` flag for custom output filenames.

## Test plan

Tested with Qwen3.5-397B-A17B-FP8 on 8x AMD MI355X GPUs with TP=8 and `loadTracer.sh`:
- **Before fix**: 0 GPU ops captured (all data lost to orphaned file descriptor)
- **After fix**: 212,693 GPU ops and 147,528 kernel launches captured successfully
- Backward compatible: when `loadTracer.sh` is not used, behavior is unchanged (file is created if absent)