### PR TITLE
[AMD] Fix Eagle3 eagle_config parsing when config is missing from draft model

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -363,19 +363,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.eagle_use_aux_hidden_state = True
 
             try:
-                # get the aux layer from draft model config
                 eagle_config = getattr(
                     draft_model_config.hf_config, "eagle_config", None
                 )
+                if eagle_config is None:
+                    raise ValueError("eagle_config not found in draft model config")
                 self.eagle_use_aux_hidden_state = eagle_config.get(
                     "use_aux_hidden_state", True
                 )
                 self.eagle_aux_hidden_state_layer_ids = eagle_config[
                     "eagle_aux_hidden_state_layer_ids"
                 ]
-            except:
-                # if there is no aux layer, set to None
+            except Exception:
                 self.eagle_aux_hidden_state_layer_ids = None
+                if self.eagle_use_aux_hidden_state:
+                    logger.info(
+                        "Draft model has no eagle_config with explicit "
+                        "layer IDs. Using default aux hidden state layers."
+                    )
 
         # Apply the rank zero filter to logger
         if server_args.show_time_cost:


### PR DESCRIPTION
## Motivation

When an Eagle3 draft model's HuggingFace config does not include an `eagle_config` field (e.g. `lightseekorg/kimi-k2.5-eagle3`), the initialization code in `model_runner.py` hits an `AttributeError` on `None.get()`:

```python
eagle_config = getattr(draft_model_config.hf_config, "eagle_config", None)
# eagle_config is None here
self.eagle_use_aux_hidden_state = eagle_config.get(...)  # AttributeError
```

The bare `except:` catches this silently and only resets `eagle_aux_hidden_state_layer_ids = None`. The actual behavior happens to be correct — `set_eagle3_layers_to_capture(None)` falls through to sensible default layers `[2, num_layers//2, num_layers-3]`. But the control flow is fragile and opaque: it relies on an exception from `None.get()` to reach the fallback path.

## Changes

In `model_runner.py` Eagle3 initialization:
- Explicitly check `eagle_config is None` and raise a clear `ValueError` instead of falling through via `AttributeError`
- Change bare `except:` to `except Exception:` (PEP 8)
- Add an `logger.info()` message when falling back to default aux hidden state layers, so operators can see the fallback in server logs

**1 file changed, 8 insertions, 3 deletions. No behavior change.**

## Testing

Tested on MI355X with `Kimi-K2.5` + `kimi-k2.5-eagle3` (which lacks `eagle_config`). Server starts correctly and logs:
```
Draft model has no eagle_config with explicit layer IDs. Using default aux hidden state layers.
```
`accept_length` and throughput unchanged from before the patch.

## Related

- Companion PRs: [Auto-detect Eagle3 mismatch](https://github.com/sgl-project/sglang/pull/21272), [ROCm non-greedy fallback kernels](#TBD_PR1)