### PR TITLE
[Feat] Support external custom models in multimodal_gen

### DIFF
--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -143,6 +143,11 @@ def _discover_and_register_pipelines():
     This function scans the 'sglang.multimodal_gen.runtime.pipelines' package,
     finds modules with an 'EntryClass' attribute, and maps the class's 'pipeline_name'
     to the class itself in a global registry.
+
+    If ``SGLANG_EXTERNAL_MODEL_PACKAGE`` is set, the same discovery is run on that
+    package so custom pipelines can override built-in ones by ``pipeline_name``.
+    External ``EntryClass`` values that are ``nn.Module`` subclasses are also
+    registered into ``runtime.models.registry.ModelRegistry``.
     """
     if _PIPELINE_REGISTRY:  # run only once
         return
@@ -166,7 +171,10 @@ def _discover_and_register_pipelines():
                         continue
                     if cls.pipeline_name in _PIPELINE_REGISTRY:
                         logger.warning(
-                            f"Duplicate pipeline name '{cls.pipeline_name}' found. Overwriting."
+                            "Pipeline name %s is already registered, and will be "
+                            "overwritten by the new pipeline class %s.",
+                            cls.pipeline_name,
+                            cls,
                         )
                     _PIPELINE_REGISTRY[cls.pipeline_name] = cls
 
@@ -185,6 +193,80 @@ def _discover_and_register_pipelines():
                             f"PipelineConfig={cls.pipeline_config_cls.__name__}, "
                             f"SamplingParams={cls.sampling_params_cls.__name__}"
                         )
+
+    external_pkg = os.environ.get("SGLANG_EXTERNAL_MODEL_PACKAGE", "")
+    if external_pkg:
+        from torch import nn
+
+        from sglang.multimodal_gen.runtime.models.registry import ModelRegistry
+
+        logger.info(
+            "Discovering external pipelines from SGLANG_EXTERNAL_MODEL_PACKAGE=%s",
+            external_pkg,
+        )
+        try:
+            external_package = importlib.import_module(external_pkg)
+        except ImportError as e:
+            logger.warning("Failed to import pipeline package %s: %s", external_pkg, e)
+        else:
+            for _, module_name, ispkg in pkgutil.walk_packages(
+                external_package.__path__, external_package.__name__ + "."
+            ):
+                if ispkg:
+                    continue
+                try:
+                    pipeline_module = importlib.import_module(module_name)
+                except Exception as e:
+                    logger.warning(
+                        "Ignore import error when loading pipeline module %s: %s",
+                        module_name,
+                        e,
+                    )
+                    continue
+
+                if not hasattr(pipeline_module, "EntryClass"):
+                    continue
+
+                entry_cls = pipeline_module.EntryClass
+                entry_cls_list = (
+                    [entry_cls] if not isinstance(entry_cls, list) else entry_cls
+                )
+                for cls in entry_cls_list:
+                    if not isinstance(cls, type):
+                        continue
+                    if issubclass(cls, ComposedPipelineBase):
+                        if cls.pipeline_name in _PIPELINE_REGISTRY:
+                            logger.warning(
+                                "Pipeline name %s is already registered, and will be "
+                                "overwritten by the new pipeline class %s.",
+                                cls.pipeline_name,
+                                cls,
+                            )
+                        _PIPELINE_REGISTRY[cls.pipeline_name] = cls
+
+                        if hasattr(cls, "pipeline_config_cls") and hasattr(
+                            cls, "sampling_params_cls"
+                        ):
+                            _PIPELINE_CONFIG_REGISTRY[cls.pipeline_name] = (
+                                cls.pipeline_config_cls,
+                                cls.sampling_params_cls,
+                            )
+                            logger.debug(
+                                f"Auto-registered config classes for pipeline '{cls.pipeline_name}': "
+                                f"PipelineConfig={cls.pipeline_config_cls.__name__}, "
+                                f"SamplingParams={cls.sampling_params_cls.__name__}"
+                            )
+                        continue
+
+                    if issubclass(cls, nn.Module):
+                        model_arch = cls.__name__
+                        ModelRegistry.register_model(model_arch, cls)
+                        logger.info(
+                            "Registered external model via pipeline discovery: %s from %s",
+                            model_arch,
+                            pipeline_module.__name__,
+                        )
+
     logger.debug(
         f"Registering pipelines complete, {len(_PIPELINE_REGISTRY)} pipelines registered"
     )

--- a/python/sglang/multimodal_gen/test/external_models/custom_pipeline.py
+++ b/python/sglang/multimodal_gen/test/external_models/custom_pipeline.py
@@ -1,0 +1,21 @@
+from sglang.multimodal_gen.runtime.pipelines.wan_pipeline import (
+    WanPipeline as OriginalWanPipeline,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+
+
+class WanPipeline(OriginalWanPipeline):
+    """Custom WAN pipeline that overrides the built-in implementation."""
+
+    pipeline_name = "WanPipeline"
+
+    def initialize_pipeline(self, server_args: ServerArgs):
+        print("[CustomPipeline] WanPipeline.initialize_pipeline")
+        super().initialize_pipeline(server_args)
+
+    def create_pipeline_stages(self, server_args: ServerArgs) -> None:
+        print("[CustomPipeline] WanPipeline.create_pipeline_stages")
+        super().create_pipeline_stages(server_args)
+
+
+EntryClass = WanPipeline

--- a/python/sglang/multimodal_gen/test/external_models/custom_wan_dit.py
+++ b/python/sglang/multimodal_gen/test/external_models/custom_wan_dit.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from sglang.multimodal_gen.runtime.models.dits.wanvideo import (
+    WanTransformer3DModel as OriginalWanTransformer3DModel,
+)
+
+
+class WanTransformer3DModel(OriginalWanTransformer3DModel):
+    """Custom WAN DiT model for testing external model replacement."""
+
+    _is_custom = True
+
+    def __init__(
+        self,
+        config,
+        hf_config: dict[str, Any] | None = None,
+        quant_config=None,
+    ) -> None:
+        super().__init__(config, hf_config=hf_config, quant_config=quant_config)
+        print(f"[CustomDiT] Initialized custom WanTransformer3DModel")
+
+
+EntryClass = WanTransformer3DModel

--- a/python/sglang/multimodal_gen/test/external_models/custom_wan_vae.py
+++ b/python/sglang/multimodal_gen/test/external_models/custom_wan_vae.py
@@ -1,0 +1,16 @@
+from sglang.multimodal_gen.runtime.models.vaes.wanvae import (
+    AutoencoderKLWan as OriginalAutoencoderKLWan,
+)
+
+
+class AutoencoderKLWan(OriginalAutoencoderKLWan):
+    """Custom WAN VAE model for testing external model replacement."""
+
+    _is_custom = True
+
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        print(f"[CustomVAE] Initialized custom AutoencoderKLWan")
+
+
+EntryClass = AutoencoderKLWan

--- a/python/sglang/multimodal_gen/test/test_external_models.py
+++ b/python/sglang/multimodal_gen/test/test_external_models.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+from sglang.multimodal_gen import DiffGenerator
+from sglang.multimodal_gen.test.test_utils import (
+    DEFAULT_WAN_2_1_T2V_1_3B_MODEL_NAME_FOR_TEST,
+)
+
+
+class TestExternalModels(unittest.TestCase):
+    def test_external_model(self):
+        os.environ["SGLANG_EXTERNAL_MODEL_PACKAGE"] = (
+            "sglang.multimodal_gen.test.external_models"
+        )
+
+        generator = DiffGenerator.from_pretrained(
+            model_path=DEFAULT_WAN_2_1_T2V_1_3B_MODEL_NAME_FOR_TEST,
+            num_gpus=1,
+            text_encoder_cpu_offload=True,
+            pin_cpu_memory=True,
+        )
+
+        result = generator.generate(
+            sampling_params_kwargs=dict(
+                prompt="A cat sitting on a table",
+                num_frames=17,
+                height=480,
+                width=720,
+                num_inference_steps=3,
+                seed=42,
+            )
+        )
+
+        generator.shutdown()
+        self.assertIsNotNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR summary for review

This PR adds external custom model support to multimodal_gen like https://github.com/sgl-project/sglang/pull/13429, so diffusion-style multimodal generation can load user-defined components in the same spirit as the existing external model mechanism already available for LLM/VLM serving.

# Motivation
SGLang already supports loading external custom models in the srt stack via SGLANG_EXTERNAL_MODEL_PACKAGE, but that mechanism was not wired into the multimodal_gen diffusion path yet.

This PR closes that gap by allowing multimodal_gen to discover and register external:
- pipeline classes
- diffusion model component classes such as DiT / VAE implementations

# Expected behavior after this PR
With this change, a user can package custom diffusion-related classes in a Python package, expose them via EntryClass, set:
`SGLANG_EXTERNAL_MODEL_PACKAGE=<their_package>
`
and have multimodal_gen automatically discover them at runtime.

This is especially useful when someone wants to:

- override an existing diffusion pipeline implementation
- replace specific internal components such as WAN DiT / VAE
- experiment with custom diffusion architectures without modifying SGLang source directly

# Why this is useful
This makes multimodal_gen more extensible and brings it closer to the extensibility already available in the LLM/VLM path.

Instead of editing SGLang internals, users can now:
- implement custom classes externally
- reuse the standard loading path

It is especially useful for private models, research variants, and downstream experiments, and makes multimodal_gen consistent with the external model mechanism already available in the srt stack. The change is opt-in and does not affect existing users by default.