### PR TITLE
[Disagg DP-Balancing] Refactor Disagg Conn and Fix Hang with total_request/total_tokens Balancing

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -123,12 +123,22 @@ class BaseKVReceiver(ABC):
     @abstractmethod
     def init(
         self,
+        prefill_dp_rank: int,
+    ):
+        """
+        Resolve bootstrap metadata and mark the receiver ready for transfer metadata.
+        """
+        ...
+
+    @abstractmethod
+    def send_metadata(
+        self,
         kv_indices: npt.NDArray[np.int32],
         aux_index: Optional[int] = None,
         state_indices: Optional[List[int]] = None,
     ):
         """
-        Set req's index metadata locally or notify the prefill server about the kv indices, aux index, and state_indices.
+        Notify the prefill server about the kv indices, aux index, and state_indices.
         """
         ...
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -490,7 +490,6 @@ class CommonKVReceiver(BaseKVReceiver):
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
     ):
-        super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.bootstrap_room = bootstrap_room
         self.bootstrap_addr = bootstrap_addr
         self.kv_mgr = mgr

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -490,9 +490,11 @@ class CommonKVReceiver(BaseKVReceiver):
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
     ):
+        super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.bootstrap_room = bootstrap_room
         self.bootstrap_addr = bootstrap_addr
         self.kv_mgr = mgr
+        self.conclude_state: Optional[KVPoll] = None
         self.bootstrap_infos = None
         self.prefill_info = None
         self.prefill_dp_rank = None
@@ -502,17 +504,16 @@ class CommonKVReceiver(BaseKVReceiver):
         self.target_pp_ranks = None
         self.required_dst_info_num = None
         self.required_prefill_response_num = None
-        self.bootstrap_initialized = False
+        self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
 
     def init(self, prefill_dp_rank: int):
-        if self.bootstrap_initialized:
-            return
         if self.bootstrap_addr not in self.kv_mgr.prefill_info_table:
             self.kv_mgr.record_failure(
                 self.bootstrap_room,
                 f"Prefill server with bootstrap_addr: {self.bootstrap_addr} is healthy before, but now it is down. Request (bootstrap_room: {self.bootstrap_room}) has been marked as failed.",
             )
+            self.conclude_state = KVPoll.Failed
             self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
             return
 
@@ -533,9 +534,7 @@ class CommonKVReceiver(BaseKVReceiver):
 
         self.prefill_dp_rank = prefill_dp_rank
         self._setup_bootstrap_infos()
-        if self.kv_mgr.check_status(self.bootstrap_room) == KVPoll.Failed:
-            return
-        self.bootstrap_initialized = True
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
 
     def _setup_bootstrap_infos(self):
         all_bootstrap_infos = []
@@ -573,6 +572,7 @@ class CommonKVReceiver(BaseKVReceiver):
                                 self.bootstrap_room,
                                 f"Could not fetch bootstrap info for: prefill_dp_rank: {self.prefill_dp_rank} prefill_cp_rank: {target_cp_rank} target_tp_rank: {target_tp_rank} and target_pp_rank {target_pp_rank}",
                             )
+                            self.conclude_state = KVPoll.Failed
                             self.kv_mgr.update_status(
                                 self.bootstrap_room, KVPoll.Failed
                             )

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -489,20 +489,31 @@ class CommonKVReceiver(BaseKVReceiver):
         mgr: CommonKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
-        prefill_dp_rank: Optional[int] = None,
     ):
         self.bootstrap_room = bootstrap_room
         self.bootstrap_addr = bootstrap_addr
         self.kv_mgr = mgr
+        self.bootstrap_infos = None
+        self.prefill_info = None
+        self.prefill_dp_rank = None
+        self.target_tp_rank = None
+        self.target_tp_ranks = None
+        self.target_cp_ranks = None
+        self.target_pp_ranks = None
+        self.required_dst_info_num = None
+        self.required_prefill_response_num = None
+        self.bootstrap_initialized = False
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
 
+    def init(self, prefill_dp_rank: int):
+        if self.bootstrap_initialized:
+            return
         if self.bootstrap_addr not in self.kv_mgr.prefill_info_table:
             self.kv_mgr.record_failure(
                 self.bootstrap_room,
                 f"Prefill server with bootstrap_addr: {self.bootstrap_addr} is healthy before, but now it is down. Request (bootstrap_room: {self.bootstrap_room}) has been marked as failed.",
             )
             self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
-            self.bootstrap_infos = None
             return
 
         # Read pre-computed rank mapping from prefill_info (computed in try_ensure_parallel_info)
@@ -520,11 +531,11 @@ class CommonKVReceiver(BaseKVReceiver):
             self.required_prefill_response_num
         )
 
-        assert (
-            prefill_dp_rank is not None
-        ), "prefill_dp_rank must be resolved before creating receiver"
         self.prefill_dp_rank = prefill_dp_rank
         self._setup_bootstrap_infos()
+        if self.kv_mgr.check_status(self.bootstrap_room) == KVPoll.Failed:
+            return
+        self.bootstrap_initialized = True
 
     def _setup_bootstrap_infos(self):
         all_bootstrap_infos = []
@@ -644,6 +655,14 @@ class CommonKVReceiver(BaseKVReceiver):
 
     def _register_kv_args(self):
         pass
+
+    def send_metadata(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        aux_index: Optional[int] = None,
+        state_indices: Optional[List[int]] = None,
+    ):
+        raise NotImplementedError
 
     def failure_exception(self):
         raise Exception("Fake KVReceiver Exception")

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -276,7 +276,7 @@ class DecodePreallocQueue:
         # Queue for requests pending pre-allocation
         self.queue: List[DecodeRequest] = []
         self.retracted_queue: List[Req] = []
-        self.pending_reqs: List[Req] = []
+        self.pending_reqs: List[DecodeRequest] = []
         self._ensure_retry_count: Dict[str, int] = {}
         self._max_ensure_retries: int = 20  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
@@ -368,17 +368,20 @@ class DecodePreallocQueue:
             req.retraction_mb_id = None
             self.retracted_queue.append(req)
         else:
+            decode_req = self._create_receiver_and_enqueue(req)
+
             # NOTE: fake transfer does not need to resolve prefill dp rank in the pending queue
             if _is_fake_transfer(req, self.scheduler.server_args):
-                self._create_receiver_and_enqueue(req, 0)
+                decode_req.kv_receiver.init(0)
                 return
 
             # Fast path: cache-only lookup, no network calls
             prefill_dp_rank = self._resolve_prefill_dp_rank(req)
             if prefill_dp_rank is not None:
-                self._create_receiver_and_enqueue(req, prefill_dp_rank)
-            else:
-                self.pending_reqs.append(req)
+                decode_req.kv_receiver.init(prefill_dp_rank)
+                return
+
+            self.pending_reqs.append(decode_req)
 
     def _resolve_prefill_dp_rank(self, req: Req) -> Optional[int]:
         if req.disagg_prefill_dp_rank is not None:
@@ -396,7 +399,7 @@ class DecodePreallocQueue:
 
         return None
 
-    def _create_receiver_and_enqueue(self, req: Req, prefill_dp_rank: int) -> None:
+    def _create_receiver_and_enqueue(self, req: Req) -> DecodeRequest:
         backend = (
             TransferBackend.FAKE
             if _is_fake_transfer(req, self.scheduler.server_args)
@@ -408,12 +411,11 @@ class DecodePreallocQueue:
             mgr=self.kv_manager,
             bootstrap_addr=_bootstrap_addr(req),
             bootstrap_room=req.bootstrap_room,
-            prefill_dp_rank=prefill_dp_rank,
         )
 
-        self.queue.append(
-            DecodeRequest(req=req, kv_receiver=kv_receiver, waiting_for_input=False)
-        )
+        decode_req = DecodeRequest(req=req, kv_receiver=kv_receiver)
+        self.queue.append(decode_req)
+        return decode_req
 
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
         if len(req.origin_input_ids) > self.max_total_num_tokens:
@@ -511,12 +513,12 @@ class DecodePreallocQueue:
                 raise ValueError(f"Unexpected poll case: {poll}")
 
     def _ensure_prefill_info(
-        self, addr_to_reqs: Dict[str, List[Req]]
-    ) -> Tuple[Dict[str, List[Req]], List[Req]]:
+        self, addr_to_reqs: Dict[str, List[DecodeRequest]]
+    ) -> Tuple[Dict[str, List[DecodeRequest]], List[DecodeRequest]]:
         """Non-blocking ensure parallel info for each addr.
         Returns (ready_addrs, remaining_reqs)."""
-        ready: Dict[str, List[Req]] = {}
-        remaining: List[Req] = []
+        ready: Dict[str, List[DecodeRequest]] = {}
+        remaining: List[DecodeRequest] = []
 
         now = time.monotonic()
         for bootstrap_addr, reqs in addr_to_reqs.items():
@@ -543,13 +545,17 @@ class DecodePreallocQueue:
             if count >= self._max_ensure_retries:
                 error_msg = f"Could not fetch prefill parallel info from {bootstrap_addr} after {count} attempts"
                 logger.error(error_msg)
-                for req in reqs:
+                for decode_req in reqs:
                     prepare_abort(
-                        req, error_msg, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                        decode_req.req,
+                        error_msg,
+                        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                     )
                     if self.scheduler.enable_metrics:
                         self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
-                    self.scheduler.stream_output([req], req.return_logprob)
+                    self.scheduler.stream_output(
+                        [decode_req.req], decode_req.req.return_logprob
+                    )
                 del self._ensure_retry_count[bootstrap_addr]
                 del self._ensure_last_attempt_time[bootstrap_addr]
             else:
@@ -558,46 +564,51 @@ class DecodePreallocQueue:
         return ready, remaining
 
     def _resolve_pending_reqs(self) -> None:
-        """Batch-resolve prefill_dp_ranks for pending requests and create receivers."""
+        """Batch-resolve prefill_dp_ranks for pending requests and initialize receivers."""
         if not self.pending_reqs:
             return
 
         # Group pending requests by bootstrap_addr
-        addr_to_reqs: Dict[str, List[Req]] = {}
-        for req in self.pending_reqs:
-            addr = _bootstrap_addr(req)
-            addr_to_reqs.setdefault(addr, []).append(req)
+        addr_to_reqs: Dict[str, List[DecodeRequest]] = {}
+        for decode_req in self.pending_reqs:
+            addr = _bootstrap_addr(decode_req.req)
+            addr_to_reqs.setdefault(addr, []).append(decode_req)
 
         # Pass 1: ensure parallel info for each addr
         ready_addrs, remaining = self._ensure_prefill_info(addr_to_reqs)
 
-        # Pass 2: resolve dp rank for addrs whose info is available
-        resolved = []
-        for bootstrap_addr, reqs in ready_addrs.items():
-            need_query: List[Req] = []
-            for req in reqs:
-                prefill_dp_rank = self._resolve_prefill_dp_rank(req)
-                if prefill_dp_rank is not None:
-                    resolved.append((req, prefill_dp_rank))
-                else:
-                    need_query.append(req)
+        resolved: List[Tuple[DecodeRequest, int]] = []
+        for bootstrap_addr, decode_reqs in addr_to_reqs.items():
+            if bootstrap_addr not in ready_addrs:
+                continue
 
+            need_query: List[DecodeRequest] = []
+            for decode_req in decode_reqs:
+                prefill_dp_rank = self._resolve_prefill_dp_rank(decode_req.req)
+                if prefill_dp_rank is not None:
+                    resolved.append((decode_req, prefill_dp_rank))
+                else:
+                    need_query.append(decode_req)
+
+            # Pass 2: resolve dp rank for addrs whose info is available
             if need_query:
-                rooms = [req.bootstrap_room for req in need_query]
+                rooms = [decode_req.req.bootstrap_room for decode_req in need_query]
                 room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
                     bootstrap_addr, rooms
                 )
-                for req in need_query:
-                    prefill_dp_rank = room_to_rank.get(str(req.bootstrap_room))
+                for decode_req in need_query:
+                    prefill_dp_rank = room_to_rank.get(
+                        str(decode_req.req.bootstrap_room)
+                    )
                     if prefill_dp_rank is not None:
-                        resolved.append((req, int(prefill_dp_rank)))
+                        resolved.append((decode_req, int(prefill_dp_rank)))
                     else:
-                        remaining.append(req)
+                        remaining.append(decode_req)
 
         self.pending_reqs = remaining
 
-        for req, prefill_dp_rank in resolved:
-            self._create_receiver_and_enqueue(req, prefill_dp_rank)
+        for decode_req, prefill_dp_rank in resolved:
+            decode_req.kv_receiver.init(prefill_dp_rank)
 
     def pop_preallocated(
         self, rids_to_check: Optional[List[str]] = None
@@ -726,7 +737,7 @@ class DecodePreallocQueue:
             )
             assert decode_req.metadata_buffer_index is not None
             page_indices = kv_to_page_indices(kv_indices, page_size)
-            decode_req.kv_receiver.init(
+            decode_req.kv_receiver.send_metadata(
                 page_indices, decode_req.metadata_buffer_index, state_indices
             )
             preallocated_reqs.append(decode_req)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -278,6 +278,9 @@ class DecodePreallocQueue:
         self.queue: List[DecodeRequest] = []
         self.retracted_queue: List[Req] = []
         self.pending_reqs: List[Req] = []
+        # Only allow add() fast path after an address is globally confirmed ready
+        # across all decode TP/CP ranks.
+        self._globally_ready_prefill_addrs: set[str] = set()
         self._ensure_retry_count: Dict[str, int] = {}
         self._max_ensure_retries: int = 20  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
@@ -435,12 +438,17 @@ class DecodePreallocQueue:
                 self._create_receiver_and_enqueue(req, 0)
                 return
 
-            # Fast path: cache-only lookup, no network calls
-            prefill_dp_rank = self._resolve_prefill_dp_rank(req)
-            if prefill_dp_rank is not None:
-                self._create_receiver_and_enqueue(req, prefill_dp_rank)
-            else:
-                self.pending_reqs.append(req)
+            bootstrap_addr = _bootstrap_addr(req)
+
+            # Fast path is gated by global readiness to avoid per-rank divergence
+            # (some ranks enqueue while others still leave the same request pending).
+            if bootstrap_addr in self._globally_ready_prefill_addrs:
+                prefill_dp_rank = self._resolve_prefill_dp_rank(req)
+                if prefill_dp_rank is not None:
+                    self._create_receiver_and_enqueue(req, prefill_dp_rank)
+                    return
+
+            self.pending_reqs.append(req)
 
     def _resolve_prefill_dp_rank(self, req: Req) -> Optional[int]:
         if req.disagg_prefill_dp_rank is not None:
@@ -626,6 +634,8 @@ class DecodePreallocQueue:
         global_ready_addrs, global_failed_addrs = (
             self._sync_pending_prefill_info_state(ready_addrs, failed_addrs)
         )
+        self._globally_ready_prefill_addrs.update(global_ready_addrs)
+        self._globally_ready_prefill_addrs.difference_update(global_failed_addrs)
 
         for bootstrap_addr in global_failed_addrs:
             error_msg = (

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -578,10 +578,7 @@ class DecodePreallocQueue:
         ready_addrs, remaining = self._ensure_prefill_info(addr_to_reqs)
 
         resolved: List[Tuple[DecodeRequest, int]] = []
-        for bootstrap_addr, decode_reqs in addr_to_reqs.items():
-            if bootstrap_addr not in ready_addrs:
-                continue
-
+        for bootstrap_addr, decode_reqs in ready_addrs.items():
             need_query: List[DecodeRequest] = []
             for decode_req in decode_reqs:
                 prefill_dp_rank = self._resolve_prefill_dp_rank(decode_req.req)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -278,8 +278,6 @@ class DecodePreallocQueue:
         self.queue: List[DecodeRequest] = []
         self.retracted_queue: List[Req] = []
         self.pending_reqs: List[Req] = []
-        # Only allow add() fast path after an address is globally confirmed ready
-        # across all decode TP/CP ranks.
         self._globally_ready_prefill_addrs: set[str] = set()
         self._ensure_retry_count: Dict[str, int] = {}
         self._max_ensure_retries: int = 20  # scheduling cycles

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -66,7 +66,6 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
-from sglang.srt.utils.common import broadcast_pyobj
 from sglang.srt.utils.network import NetworkAddress
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
@@ -278,7 +277,6 @@ class DecodePreallocQueue:
         self.queue: List[DecodeRequest] = []
         self.retracted_queue: List[Req] = []
         self.pending_reqs: List[Req] = []
-        self._globally_ready_prefill_addrs: set[str] = set()
         self._ensure_retry_count: Dict[str, int] = {}
         self._max_ensure_retries: int = 20  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
@@ -291,67 +289,6 @@ class DecodePreallocQueue:
                 self.max_total_num_tokens,
                 self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
             )
-
-    def _broadcast_pending_resolution(
-        self, payload: Optional[dict], is_pending_resolution_leader: bool
-    ) -> Optional[dict]:
-        payload_list = [payload] if is_pending_resolution_leader else []
-
-        if self.scheduler.attn_tp_size != 1:
-            payload_list = broadcast_pyobj(
-                payload_list,
-                self.scheduler.attn_tp_group.rank,
-                self.scheduler.attn_tp_cpu_group,
-                src=self.scheduler.attn_tp_group.ranks[0],
-            )
-
-        if self.scheduler.attn_cp_size != 1:
-            payload_list = broadcast_pyobj(
-                payload_list,
-                self.scheduler.attn_cp_group.rank,
-                self.scheduler.attn_cp_cpu_group,
-                src=self.scheduler.attn_cp_group.ranks[0],
-            )
-
-        return payload_list[0] if payload_list else None
-
-    def _sync_pending_prefill_info_state(
-        self, ready_addrs: Dict[str, List[Req]], failed_addrs: set[str]
-    ) -> Tuple[set[str], set[str]]:
-        state = {
-            "ready_addrs": sorted(ready_addrs.keys()),
-            "failed_addrs": sorted(failed_addrs),
-        }
-
-        if self.scheduler.attn_tp_size != 1:
-            gathered = [None] * self.scheduler.attn_tp_size
-            torch.distributed.all_gather_object(
-                gathered, state, group=self.scheduler.attn_tp_cpu_group
-            )
-            ready_sets = [set(item["ready_addrs"]) for item in gathered]
-            merged_failed = set().union(
-                *(set(item["failed_addrs"]) for item in gathered)
-            )
-            state = {
-                "ready_addrs": sorted(set.intersection(*ready_sets)),
-                "failed_addrs": sorted(merged_failed),
-            }
-
-        if self.scheduler.attn_cp_size != 1:
-            gathered = [None] * self.scheduler.attn_cp_size
-            torch.distributed.all_gather_object(
-                gathered, state, group=self.scheduler.attn_cp_cpu_group
-            )
-            ready_sets = [set(item["ready_addrs"]) for item in gathered]
-            merged_failed = set().union(
-                *(set(item["failed_addrs"]) for item in gathered)
-            )
-            state = {
-                "ready_addrs": sorted(set.intersection(*ready_sets)),
-                "failed_addrs": sorted(merged_failed),
-            }
-
-        return set(state["ready_addrs"]), set(state["failed_addrs"])
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
@@ -436,17 +373,12 @@ class DecodePreallocQueue:
                 self._create_receiver_and_enqueue(req, 0)
                 return
 
-            bootstrap_addr = _bootstrap_addr(req)
-
-            # Fast path is gated by global readiness to avoid per-rank divergence
-            # (some ranks enqueue while others still leave the same request pending).
-            if bootstrap_addr in self._globally_ready_prefill_addrs:
-                prefill_dp_rank = self._resolve_prefill_dp_rank(req)
-                if prefill_dp_rank is not None:
-                    self._create_receiver_and_enqueue(req, prefill_dp_rank)
-                    return
-
-            self.pending_reqs.append(req)
+            # Fast path: cache-only lookup, no network calls
+            prefill_dp_rank = self._resolve_prefill_dp_rank(req)
+            if prefill_dp_rank is not None:
+                self._create_receiver_and_enqueue(req, prefill_dp_rank)
+            else:
+                self.pending_reqs.append(req)
 
     def _resolve_prefill_dp_rank(self, req: Req) -> Optional[int]:
         if req.disagg_prefill_dp_rank is not None:
@@ -580,11 +512,11 @@ class DecodePreallocQueue:
 
     def _ensure_prefill_info(
         self, addr_to_reqs: Dict[str, List[Req]]
-    ) -> Tuple[Dict[str, List[Req]], set[str]]:
+    ) -> Tuple[Dict[str, List[Req]], List[Req]]:
         """Non-blocking ensure parallel info for each addr.
-        Returns (ready_addrs, failed_addrs)."""
+        Returns (ready_addrs, remaining_reqs)."""
         ready: Dict[str, List[Req]] = {}
-        failed_addrs: set[str] = set()
+        remaining: List[Req] = []
 
         now = time.monotonic()
         for bootstrap_addr, reqs in addr_to_reqs.items():
@@ -592,6 +524,7 @@ class DecodePreallocQueue:
             if last_attempt is not None and (
                 now - last_attempt < self._ensure_retry_interval
             ):
+                remaining.extend(reqs)
                 continue
 
             self._ensure_last_attempt_time[bootstrap_addr] = now
@@ -610,11 +543,19 @@ class DecodePreallocQueue:
             if count >= self._max_ensure_retries:
                 error_msg = f"Could not fetch prefill parallel info from {bootstrap_addr} after {count} attempts"
                 logger.error(error_msg)
-                failed_addrs.add(bootstrap_addr)
+                for req in reqs:
+                    prepare_abort(
+                        req, error_msg, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                    )
+                    if self.scheduler.enable_metrics:
+                        self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
+                    self.scheduler.stream_output([req], req.return_logprob)
                 del self._ensure_retry_count[bootstrap_addr]
                 del self._ensure_last_attempt_time[bootstrap_addr]
+            else:
+                remaining.extend(reqs)
 
-        return ready, failed_addrs
+        return ready, remaining
 
     def _resolve_pending_reqs(self) -> None:
         """Batch-resolve prefill_dp_ranks for pending requests and create receivers."""
@@ -628,84 +569,30 @@ class DecodePreallocQueue:
             addr_to_reqs.setdefault(addr, []).append(req)
 
         # Pass 1: ensure parallel info for each addr
-        ready_addrs, failed_addrs = self._ensure_prefill_info(addr_to_reqs)
-        global_ready_addrs, global_failed_addrs = (
-            self._sync_pending_prefill_info_state(ready_addrs, failed_addrs)
-        )
-        self._globally_ready_prefill_addrs.update(global_ready_addrs)
-        self._globally_ready_prefill_addrs.difference_update(global_failed_addrs)
-
-        for bootstrap_addr in global_failed_addrs:
-            error_msg = (
-                f"Failed to synchronize prefill parallel info readiness for {bootstrap_addr}: "
-                f"at least one decode rank entered a terminal error state while ensuring local prefill info"
-            )
-            for req in addr_to_reqs.get(bootstrap_addr, []):
-                prepare_abort(
-                    req, error_msg, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-                )
-                if self.scheduler.enable_metrics:
-                    self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
-                self.scheduler.stream_output([req], req.return_logprob)
+        ready_addrs, remaining = self._ensure_prefill_info(addr_to_reqs)
 
         # Pass 2: resolve dp rank for addrs whose info is available
-
-        is_pending_resolution_leader = (
-            self.scheduler.attn_tp_rank == 0 and self.scheduler.attn_cp_rank == 0
-        )
-        payload = None
-        if is_pending_resolution_leader:
-            resolved_by_rid: Dict[str, int] = {}
-            remaining: List[Req] = []
-            for bootstrap_addr, reqs in addr_to_reqs.items():
-                if (
-                    bootstrap_addr not in global_ready_addrs
-                    and bootstrap_addr not in global_failed_addrs
-                ):
-                    remaining.extend(reqs)
-
-            for bootstrap_addr in global_ready_addrs:
-                reqs = ready_addrs[bootstrap_addr]
-                need_query: List[Req] = []
-                for req in reqs:
-                    prefill_dp_rank = self._resolve_prefill_dp_rank(req)
-                    if prefill_dp_rank is not None:
-                        resolved_by_rid[req.rid] = prefill_dp_rank
-                    else:
-                        need_query.append(req)
-
-                if need_query:
-                    rooms = [req.bootstrap_room for req in need_query]
-                    room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
-                        bootstrap_addr, rooms
-                    )
-                    for req in need_query:
-                        prefill_dp_rank = room_to_rank.get(str(req.bootstrap_room))
-                        if prefill_dp_rank is not None:
-                            resolved_by_rid[req.rid] = int(prefill_dp_rank)
-                        else:
-                            remaining.append(req)
-
-            payload = {
-                "resolved_by_rid": resolved_by_rid,
-                "remaining_rids": [req.rid for req in remaining],
-            }
-
-        payload = self._broadcast_pending_resolution(
-            payload, is_pending_resolution_leader
-        )
-        if payload is None:
-            return
-
         resolved = []
-        remaining = []
-        resolved_by_rid = payload["resolved_by_rid"]
-        remaining_rids = set(payload["remaining_rids"])
-        for req in self.pending_reqs:
-            if req.rid in resolved_by_rid:
-                resolved.append((req, int(resolved_by_rid[req.rid])))
-            elif req.rid in remaining_rids:
-                remaining.append(req)
+        for bootstrap_addr, reqs in ready_addrs.items():
+            need_query: List[Req] = []
+            for req in reqs:
+                prefill_dp_rank = self._resolve_prefill_dp_rank(req)
+                if prefill_dp_rank is not None:
+                    resolved.append((req, prefill_dp_rank))
+                else:
+                    need_query.append(req)
+
+            if need_query:
+                rooms = [req.bootstrap_room for req in need_query]
+                room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
+                    bootstrap_addr, rooms
+                )
+                for req in need_query:
+                    prefill_dp_rank = room_to_rank.get(str(req.bootstrap_room))
+                    if prefill_dp_rank is not None:
+                        resolved.append((req, int(prefill_dp_rank)))
+                    else:
+                        remaining.append(req)
 
         self.pending_reqs = remaining
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -66,6 +66,7 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
+from sglang.srt.utils.common import broadcast_pyobj
 from sglang.srt.utils.network import NetworkAddress
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
@@ -290,6 +291,67 @@ class DecodePreallocQueue:
                 self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
             )
 
+    def _broadcast_pending_resolution(
+        self, payload: Optional[dict], is_pending_resolution_leader: bool
+    ) -> Optional[dict]:
+        payload_list = [payload] if is_pending_resolution_leader else []
+
+        if self.scheduler.attn_tp_size != 1:
+            payload_list = broadcast_pyobj(
+                payload_list,
+                self.scheduler.attn_tp_group.rank,
+                self.scheduler.attn_tp_cpu_group,
+                src=self.scheduler.attn_tp_group.ranks[0],
+            )
+
+        if self.scheduler.attn_cp_size != 1:
+            payload_list = broadcast_pyobj(
+                payload_list,
+                self.scheduler.attn_cp_group.rank,
+                self.scheduler.attn_cp_cpu_group,
+                src=self.scheduler.attn_cp_group.ranks[0],
+            )
+
+        return payload_list[0] if payload_list else None
+
+    def _sync_pending_prefill_info_state(
+        self, ready_addrs: Dict[str, List[Req]], failed_addrs: set[str]
+    ) -> Tuple[set[str], set[str]]:
+        state = {
+            "ready_addrs": sorted(ready_addrs.keys()),
+            "failed_addrs": sorted(failed_addrs),
+        }
+
+        if self.scheduler.attn_tp_size != 1:
+            gathered = [None] * self.scheduler.attn_tp_size
+            torch.distributed.all_gather_object(
+                gathered, state, group=self.scheduler.attn_tp_cpu_group
+            )
+            ready_sets = [set(item["ready_addrs"]) for item in gathered]
+            merged_failed = set().union(
+                *(set(item["failed_addrs"]) for item in gathered)
+            )
+            state = {
+                "ready_addrs": sorted(set.intersection(*ready_sets)),
+                "failed_addrs": sorted(merged_failed),
+            }
+
+        if self.scheduler.attn_cp_size != 1:
+            gathered = [None] * self.scheduler.attn_cp_size
+            torch.distributed.all_gather_object(
+                gathered, state, group=self.scheduler.attn_cp_cpu_group
+            )
+            ready_sets = [set(item["ready_addrs"]) for item in gathered]
+            merged_failed = set().union(
+                *(set(item["failed_addrs"]) for item in gathered)
+            )
+            state = {
+                "ready_addrs": sorted(set.intersection(*ready_sets)),
+                "failed_addrs": sorted(merged_failed),
+            }
+
+        return set(state["ready_addrs"]), set(state["failed_addrs"])
+
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
         kv_args = kv_args_class()
@@ -512,11 +574,11 @@ class DecodePreallocQueue:
 
     def _ensure_prefill_info(
         self, addr_to_reqs: Dict[str, List[Req]]
-    ) -> Tuple[Dict[str, List[Req]], List[Req]]:
+    ) -> Tuple[Dict[str, List[Req]], set[str]]:
         """Non-blocking ensure parallel info for each addr.
-        Returns (ready_addrs, remaining_reqs)."""
+        Returns (ready_addrs, failed_addrs)."""
         ready: Dict[str, List[Req]] = {}
-        remaining: List[Req] = []
+        failed_addrs: set[str] = set()
 
         now = time.monotonic()
         for bootstrap_addr, reqs in addr_to_reqs.items():
@@ -524,7 +586,6 @@ class DecodePreallocQueue:
             if last_attempt is not None and (
                 now - last_attempt < self._ensure_retry_interval
             ):
-                remaining.extend(reqs)
                 continue
 
             self._ensure_last_attempt_time[bootstrap_addr] = now
@@ -543,19 +604,11 @@ class DecodePreallocQueue:
             if count >= self._max_ensure_retries:
                 error_msg = f"Could not fetch prefill parallel info from {bootstrap_addr} after {count} attempts"
                 logger.error(error_msg)
-                for req in reqs:
-                    prepare_abort(
-                        req, error_msg, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-                    )
-                    if self.scheduler.enable_metrics:
-                        self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
-                    self.scheduler.stream_output([req], req.return_logprob)
+                failed_addrs.add(bootstrap_addr)
                 del self._ensure_retry_count[bootstrap_addr]
                 del self._ensure_last_attempt_time[bootstrap_addr]
-            else:
-                remaining.extend(reqs)
 
-        return ready, remaining
+        return ready, failed_addrs
 
     def _resolve_pending_reqs(self) -> None:
         """Batch-resolve prefill_dp_ranks for pending requests and create receivers."""
@@ -569,30 +622,82 @@ class DecodePreallocQueue:
             addr_to_reqs.setdefault(addr, []).append(req)
 
         # Pass 1: ensure parallel info for each addr
-        ready_addrs, remaining = self._ensure_prefill_info(addr_to_reqs)
+        ready_addrs, failed_addrs = self._ensure_prefill_info(addr_to_reqs)
+        global_ready_addrs, global_failed_addrs = (
+            self._sync_pending_prefill_info_state(ready_addrs, failed_addrs)
+        )
+
+        for bootstrap_addr in global_failed_addrs:
+            error_msg = (
+                f"Failed to synchronize prefill parallel info readiness for {bootstrap_addr}: "
+                f"at least one decode rank entered a terminal error state while ensuring local prefill info"
+            )
+            for req in addr_to_reqs.get(bootstrap_addr, []):
+                prepare_abort(
+                    req, error_msg, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                )
+                if self.scheduler.enable_metrics:
+                    self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
+                self.scheduler.stream_output([req], req.return_logprob)
 
         # Pass 2: resolve dp rank for addrs whose info is available
-        resolved = []
-        for bootstrap_addr, reqs in ready_addrs.items():
-            need_query: List[Req] = []
-            for req in reqs:
-                prefill_dp_rank = self._resolve_prefill_dp_rank(req)
-                if prefill_dp_rank is not None:
-                    resolved.append((req, prefill_dp_rank))
-                else:
-                    need_query.append(req)
 
-            if need_query:
-                rooms = [req.bootstrap_room for req in need_query]
-                room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
-                    bootstrap_addr, rooms
-                )
-                for req in need_query:
-                    prefill_dp_rank = room_to_rank.get(str(req.bootstrap_room))
+        is_pending_resolution_leader = (
+            self.scheduler.attn_tp_rank == 0 and self.scheduler.attn_cp_rank == 0
+        )
+        payload = None
+        if is_pending_resolution_leader:
+            resolved_by_rid: Dict[str, int] = {}
+            remaining: List[Req] = []
+            for bootstrap_addr, reqs in addr_to_reqs.items():
+                if (
+                    bootstrap_addr not in global_ready_addrs
+                    and bootstrap_addr not in global_failed_addrs
+                ):
+                    remaining.extend(reqs)
+
+            for bootstrap_addr in global_ready_addrs:
+                reqs = ready_addrs[bootstrap_addr]
+                need_query: List[Req] = []
+                for req in reqs:
+                    prefill_dp_rank = self._resolve_prefill_dp_rank(req)
                     if prefill_dp_rank is not None:
-                        resolved.append((req, int(prefill_dp_rank)))
+                        resolved_by_rid[req.rid] = prefill_dp_rank
                     else:
-                        remaining.append(req)
+                        need_query.append(req)
+
+                if need_query:
+                    rooms = [req.bootstrap_room for req in need_query]
+                    room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
+                        bootstrap_addr, rooms
+                    )
+                    for req in need_query:
+                        prefill_dp_rank = room_to_rank.get(str(req.bootstrap_room))
+                        if prefill_dp_rank is not None:
+                            resolved_by_rid[req.rid] = int(prefill_dp_rank)
+                        else:
+                            remaining.append(req)
+
+            payload = {
+                "resolved_by_rid": resolved_by_rid,
+                "remaining_rids": [req.rid for req in remaining],
+            }
+
+        payload = self._broadcast_pending_resolution(
+            payload, is_pending_resolution_leader
+        )
+        if payload is None:
+            return
+
+        resolved = []
+        remaining = []
+        resolved_by_rid = payload["resolved_by_rid"]
+        remaining_rids = set(payload["remaining_rids"])
+        for req in self.pending_reqs:
+            if req.rid in resolved_by_rid:
+                resolved.append((req, int(resolved_by_rid[req.rid])))
+            elif req.rid in remaining_rids:
+                remaining.append(req)
 
         self.pending_reqs = remaining
 

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -82,28 +82,33 @@ class FakeKVReceiver(BaseKVReceiver):
         mgr: BaseKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
-        prefill_dp_rank: Optional[int] = None,
     ):
-        self.has_init = False
+        self.bootstrap_done = False
+        self.has_sent_metadata = False
 
     def poll(self) -> KVPoll:
-        if self.has_init is False:
-            # Assume handshake completed instantly
+        if not self.bootstrap_done:
+            return KVPoll.Bootstrapping
+        if not self.has_sent_metadata:
             return KVPoll.WaitingForInput
-        else:
-            # Assume transfer completed instantly
-            logger.debug("FakeKVReceiver poll success")
-            return KVPoll.Success
+        logger.debug("FakeKVReceiver poll success")
+        return KVPoll.Success
 
     def init(
+        self,
+        prefill_dp_rank: int,
+    ):
+        self.bootstrap_done = True
+
+    def send_metadata(
         self,
         kv_indices: list[int],
         aux_index: Optional[int] = None,
         state_indices: Optional[List[int]] = None,
     ):
-        self.has_init = True
+        self.has_sent_metadata = True
         logger.debug(
-            f"FakeKVReceiver init with kv_indices: {kv_indices}, aux_index: {aux_index}, state_indices: {state_indices}"
+            f"FakeKVReceiver send_metadata with kv_indices: {kv_indices}, aux_index: {aux_index}, state_indices: {state_indices}"
         )
 
     def failure_exception(self):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1238,15 +1238,11 @@ class MooncakeKVReceiver(CommonKVReceiver):
         mgr: MooncakeKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
-        prefill_dp_rank: Optional[int] = None,
     ):
         self.session_id = mgr.get_session_id()
         self.conclude_state = None
         self.init_time = None
-        super().__init__(mgr, bootstrap_addr, bootstrap_room, prefill_dp_rank)
-
-        self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
+        super().__init__(mgr, bootstrap_addr, bootstrap_room)
 
     def _register_kv_args(self):
         for bootstrap_info in self.bootstrap_infos:
@@ -1297,6 +1293,18 @@ class MooncakeKVReceiver(CommonKVReceiver):
                 )
 
     def init(
+        self,
+        prefill_dp_rank: int,
+    ):
+        if self.bootstrap_initialized:
+            return
+        super().init(prefill_dp_rank)
+        if not self.bootstrap_initialized:
+            return
+        self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
+
+    def send_metadata(
         self,
         kv_indices: npt.NDArray[np.int32],
         aux_index: Optional[int] = None,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1240,7 +1240,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
         bootstrap_room: Optional[int] = None,
     ):
         self.session_id = mgr.get_session_id()
-        self.conclude_state = None
         self.init_time = None
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
 
@@ -1296,13 +1295,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
         self,
         prefill_dp_rank: int,
     ):
-        if self.bootstrap_initialized:
-            return
         super().init(prefill_dp_rank)
-        if not self.bootstrap_initialized:
-            return
-        self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
 
     def send_metadata(
         self,

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -987,21 +987,16 @@ class MoriKVReceiver(CommonKVReceiver):
         bootstrap_room: Optional[int] = None,
     ):
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
-        self.conclude_state: Optional[KVPoll] = None
         self.init_time: Optional[float] = None
 
     def init(
         self,
         prefill_dp_rank: int,
     ):
-        if self.bootstrap_initialized:
-            return
         super().init(prefill_dp_rank)
-        if not self.bootstrap_initialized or self.bootstrap_room is None:
+        if self.bootstrap_room is None:
             return
-        self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.room_to_bootstrap_addr[self.bootstrap_room] = self.bootstrap_addr
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
 
     def _register_kv_args(self):
         if self.bootstrap_infos is None:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -985,17 +985,23 @@ class MoriKVReceiver(CommonKVReceiver):
         mgr: MoriKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
-        prefill_dp_rank: Optional[int] = None,
     ):
-        super().__init__(mgr, bootstrap_addr, bootstrap_room, prefill_dp_rank)
+        super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.conclude_state: Optional[KVPoll] = None
         self.init_time: Optional[float] = None
-        if self.bootstrap_room is None or self.bootstrap_infos is None:
+
+    def init(
+        self,
+        prefill_dp_rank: int,
+    ):
+        if self.bootstrap_initialized:
+            return
+        super().init(prefill_dp_rank)
+        if not self.bootstrap_initialized or self.bootstrap_room is None:
             return
         self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.room_to_bootstrap_addr[self.bootstrap_room] = self.bootstrap_addr
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
-        self._register_kv_args()
 
     def _register_kv_args(self):
         if self.bootstrap_infos is None:
@@ -1029,7 +1035,7 @@ class MoriKVReceiver(CommonKVReceiver):
                     ]
                 )
 
-    def init(
+    def send_metadata(
         self,
         kv_indices: npt.NDArray[np.int32],
         aux_index: Optional[int] = None,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -957,20 +957,28 @@ class NixlKVReceiver(CommonKVReceiver):
         mgr: NixlKVManager,
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
-        prefill_dp_rank: Optional[int] = None,
     ):
         self.started_transfer = False
         self.conclude_state = None
-        super().__init__(mgr, bootstrap_addr, bootstrap_room, prefill_dp_rank)
+        super().__init__(mgr, bootstrap_addr, bootstrap_room)
+        self.init_time = None
 
-        # Track this room with its bootstrap address for heartbeat monitoring
+    def init(
+        self,
+        prefill_dp_rank: int,
+    ):
+        if self.bootstrap_initialized:
+            return
+        super().init(prefill_dp_rank)
+        if not self.bootstrap_initialized:
+            return
         if hasattr(self.kv_mgr, "addr_to_rooms_tracker"):
             self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(
                 self.bootstrap_room
             )
-        self.init_time = None
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
 
-    def init(
+    def send_metadata(
         self,
         kv_indices: npt.NDArray[np.int32],
         aux_index: Optional[int] = None,
@@ -1026,7 +1034,7 @@ class NixlKVReceiver(CommonKVReceiver):
             self.conclude_state = status
             return status
         if not self.started_transfer:
-            return KVPoll.WaitingForInput  # type: ignore
+            return status
 
         now = time.time()
         elapsed = now - self.init_time

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -959,7 +959,6 @@ class NixlKVReceiver(CommonKVReceiver):
         bootstrap_room: Optional[int] = None,
     ):
         self.started_transfer = False
-        self.conclude_state = None
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.init_time = None
 
@@ -967,16 +966,7 @@ class NixlKVReceiver(CommonKVReceiver):
         self,
         prefill_dp_rank: int,
     ):
-        if self.bootstrap_initialized:
-            return
         super().init(prefill_dp_rank)
-        if not self.bootstrap_initialized:
-            return
-        if hasattr(self.kv_mgr, "addr_to_rooms_tracker"):
-            self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(
-                self.bootstrap_room
-            )
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
 
     def send_metadata(
         self,

--- a/test/registered/distributed/test_disaggregation_dp_attention.py
+++ b/test/registered/distributed/test_disaggregation_dp_attention.py
@@ -131,9 +131,9 @@ class TestDisaggregationDPAttentionRoundRobin(TestDisaggregationDPAttention):
 
 class TestDisaggregationDPAttentionTotalRequests(TestDisaggregationDPAttention):
     LOAD_BALANCE_METHOD = "total_requests"
-    test_gsm8k = unittest.skip("Covered by base class; this class targets total_requests path.")(
-        TestDisaggregationDPAttention.test_gsm8k
-    )
+    test_gsm8k = unittest.skip(
+        "Covered by base class; this class targets total_requests path."
+    )(TestDisaggregationDPAttention.test_gsm8k)
 
     def test_bench_serving(self):
         args = get_benchmark_args(
@@ -152,9 +152,9 @@ class TestDisaggregationDPAttentionTotalRequests(TestDisaggregationDPAttention):
 
 class TestDisaggregationDPAttentionTotalTokens(TestDisaggregationDPAttention):
     LOAD_BALANCE_METHOD = "total_tokens"
-    test_gsm8k = unittest.skip("Covered by base class; this class targets total_tokens path.")(
-        TestDisaggregationDPAttention.test_gsm8k
-    )
+    test_gsm8k = unittest.skip(
+        "Covered by base class; this class targets total_tokens path."
+    )(TestDisaggregationDPAttention.test_gsm8k)
 
     def test_bench_serving(self):
         args = get_benchmark_args(

--- a/test/registered/distributed/test_disaggregation_dp_attention.py
+++ b/test/registered/distributed/test_disaggregation_dp_attention.py
@@ -110,7 +110,6 @@ class TestDisaggregationDPAttention(PDDisaggregationServerBase):
 
 class TestDisaggregationDPAttentionRoundRobin(TestDisaggregationDPAttention):
     LOAD_BALANCE_METHOD = "round_robin"
-    # TODO: add test for other load balance methods
     # TODO: add a balancedness metric
 
     def test_bench_serving(self):
@@ -128,6 +127,48 @@ class TestDisaggregationDPAttentionRoundRobin(TestDisaggregationDPAttention):
 
         self.assertLess(result["mean_tpot_ms"], 20)
         self.assertEqual(result["completed"], 1000)
+
+
+class TestDisaggregationDPAttentionTotalRequests(TestDisaggregationDPAttention):
+    LOAD_BALANCE_METHOD = "total_requests"
+    test_gsm8k = unittest.skip("Covered by base class; this class targets total_requests path.")(
+        TestDisaggregationDPAttention.test_gsm8k
+    )
+
+    def test_bench_serving(self):
+        args = get_benchmark_args(
+            base_url=f"http://{self.base_host}:{self.lb_port}",
+            dataset_name="random",
+            tokenizer=self.model,
+            num_prompts=256,
+            random_input_len=2048,
+            random_output_len=512,
+            request_rate=float("inf"),
+            max_concurrency=128,
+        )
+        result = run_benchmark(args)
+        self.assertEqual(result["completed"], 256)
+
+
+class TestDisaggregationDPAttentionTotalTokens(TestDisaggregationDPAttention):
+    LOAD_BALANCE_METHOD = "total_tokens"
+    test_gsm8k = unittest.skip("Covered by base class; this class targets total_tokens path.")(
+        TestDisaggregationDPAttention.test_gsm8k
+    )
+
+    def test_bench_serving(self):
+        args = get_benchmark_args(
+            base_url=f"http://{self.base_host}:{self.lb_port}",
+            dataset_name="random",
+            tokenizer=self.model,
+            num_prompts=256,
+            random_input_len=2048,
+            random_output_len=512,
+            request_rate=float("inf"),
+            max_concurrency=128,
+        )
+        result = run_benchmark(args)
+        self.assertEqual(result["completed"], 256)
 
 
 @unittest.skip(


### PR DESCRIPTION
## Summary

Fix  [PD disaggregation hang](https://github.com/sgl-project/sglang/issues/21297).
When prefill uses internal DP balancing such as `total_requests`, decode may receive a request before the corresponding `bootstrap_room ->
  prefill_dp_rank` mapping is available. Previously, each decode TP/CP rank resolved pending requests independently. That could lead to some ranks moving a request from `pending_reqs` into the handshake queue earlier than others.

  Once that happened, later collective polling on the decode side could observe inconsistent local queue state across ranks and stall the request pipeline.

## Changes

Update: changed to approach discussed in https://github.com/sgl-project/sglang/issues/21680.

What changed now:

Reverted the earlier decode-side pending-sync / global-ready fast-path workaround
Switched to a receiver lifecycle refactor instead
DecodePreallocQueue.add() now enqueues receivers immediately on all decode TP/CP ranks, and delays bootstrap init until the prefill DP-rank is available
Split receiver setup so bootstrap-dependent work happens after construction, and metadata sending is a separate step
Kept the added total_requests / total_tokens test coverage

I also validated the new version with the 1p1d disagg DSR1 with GPQA benchmark and looks good.

Old change:
- Resolve pending prefill DP ranks on a single decode leader rank
- Broadcast the resolution result to all TP/CP ranks
- Enqueue resolved requests in lockstep across decode ranks
