### PR TITLE
fix: enable attn_tp_input_scattered for VL models with external input_embeds

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -43,6 +43,7 @@ from sglang.srt.distributed import (
     divide,
     get_moe_expert_parallel_world_size,
     get_pp_group,
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
@@ -2193,6 +2194,17 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                     forward_batch.seq_lens_cpu.tolist(),
                 )
 
+        # When input_embeds is provided externally (e.g., from multimodal models
+        # via general_mm_embed_routine), embeddings are full (all_reduced) on every
+        # TP rank. To enable scattered mode, zero out non-rank-0 copies so that
+        # reduce_scatter in the first layer correctly produces the scattered state:
+        #   sum(full, 0, 0, ...) = full → scatter across ranks.
+        if (
+            input_embeds is not None
+            and get_attn_tp_context().use_input_scattered(forward_batch)
+        ):
+            if get_tensor_model_parallel_rank() != 0:
+                input_embeds = torch.zeros_like(input_embeds)
         with get_attn_tp_context().maybe_input_scattered(forward_batch):
             hidden_states = self.model(
                 input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors


### PR DESCRIPTION


## Motivation

When VL models (e.g., Kimi-K2.5) provide `input_embeds` via `general_mm_embed_routine`, the embeddings are already all-reduced (full) on every TP rank. Previously, `attn_tp_input_scattered` was effectively force-disabled for all VL models because the optimization only activated when `input_embeds is None`. This meant multimodal models backed by DeepSeek-V2/V3 (Kimi-K2.5, Kimi-VL, DeepSeek-VL2, etc.) could never benefit from the scattered optimization, even for pure text requests.

## Modifications

**File**: `python/sglang/srt/models/deepseek_v2.py`

- Added `get_tensor_model_parallel_rank` to the import.
- Before entering `maybe_input_scattered`, when `input_embeds` is externally provided and scattered mode conditions are met, zero out `input_embeds` on all non-rank-0 TP ranks. This ensures the first layer's `reduce_scatter` correctly produces the scattered state: `sum(full, 0, 0, ...) = full → scatter across ranks`. All subsequent layers then follow the standard scattered flow.

## Accuracy Tests

Tested on Kimi-K2.5 (TP=8, H800) with `--enable-attn-tp-input-scattered`:

| Request Type | Result |
|---|---|
| Pure text ("What is 2+3?") | Correct — model outputs "2+3 = 5" |
| Multimodal (solid red image + "What color?") | Correct — model outputs "solid red color" |

## Benchmarking and Profiling

Kimi-K2.5 on 8x H800, aiperf config: ISL=68.7k, OSL=437, QPS=0.1, 10 requests.

| Metric | Baseline (off) | Scattered (on) | Delta |
|---|---|---|---|
| TTFT avg | 46,752 ms | 41,222 ms | **-11.8%** |
| TTFT p90 | 85,223 ms | 76,115 ms | **-10.7%** |
| Request Latency avg | 111,260 ms | 102,900 ms | **-7.5%** |
| Request Latency p90 | 139,384 ms | 131,418 ms | **-5.7%** |
| ITL avg | 147.62 ms | 141.14 ms | **-4.4%** |
| Output Throughput | 23.33 tok/s | 24.63 tok/s | **+5.6%** |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).