### PR TITLE
Fix RDMA device mapping for non-zero GPU indices in disaggregation tests

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3228,9 +3228,15 @@ class ServerArgs:
         if len(devices) == 0:
             raise ValueError("No valid IB devices specified")
 
-        # Check for duplicates
-        if len(devices) != len(set(devices)):
-            raise ValueError(f"Duplicate IB devices specified: {device_str}")
+        # Deduplicate while preserving order
+        unique_devices = list(dict.fromkeys(devices))
+        if len(unique_devices) != len(devices):
+            logger.warning(
+                "Duplicate IB devices specified: %s. Deduplicating to: %s",
+                device_str,
+                ",".join(unique_devices),
+            )
+            devices = unique_devices
 
         # Get available IB devices from sysfs
         ib_sysfs_path = "/sys/class/infiniband"

--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -246,8 +246,9 @@ def get_rdma_devices_args():
     )
 
     rdma_devices = []
+    base_gpu = min(gpu_indices)
     for gpu_idx in gpu_indices:
-        nic_index = min(gpu_idx // gpus_per_rdma, n_rdma - 1)
+        nic_index = min((gpu_idx - base_gpu) // gpus_per_rdma, n_rdma - 1)
         rdma_devices.append(rdma_all_devices[nic_index])
 
     if not rdma_devices:

--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -254,4 +254,5 @@ def get_rdma_devices_args():
     if not rdma_devices:
         return ",".join(_pick_default_pair(rdma_all_devices))
 
-    return ",".join(rdma_devices)
+    # Deduplicate while preserving order
+    return ",".join(dict.fromkeys(rdma_devices))


### PR DESCRIPTION
## Summary
Fix RDMA device mapping in disaggregation test fixture and allow duplicate IB devices gracefully in server args.

**Changes:**
1. **Test fixture** (`disaggregation_fixture.py`): use relative GPU indices (offset by `base_gpu`) when mapping GPUs to RDMA NIC devices, and deduplicate output when NIC count < GPU count
2. **Server args** (`server_args.py`): change duplicate IB device check from hard `ValueError` to warning with automatic deduplication — multiple GPUs sharing one NIC is a valid configuration

## Motivation
On CI runners using `CUDA_VISIBLE_DEVICES` for GPU isolation (e.g., `CUDA_VISIBLE_DEVICES=2,3`), the RDMA device mapping used absolute GPU indices. With 2 RDMA devices `[mlx5_2, mlx5_3]`, GPU index 2 maps to `min(2//1, 1) = 1 → mlx5_3` and GPU index 3 also maps to `min(3//1, 1) = 1 → mlx5_3`, producing:

```
ValueError: Duplicate IB devices specified: mlx5_3,mlx5_3
```

Additionally, on machines where NIC count < GPU count, the fixture would legitimately produce duplicate NIC entries (multiple GPUs sharing one NIC), which server_args would reject. Now both the fixture deduplicates its output and server_args handles duplicates gracefully.

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/23511121479/job/68432080679

**Related PRs:**
- #21271 — fixes bootstrap port (8998) conflict (separate issue)
- #21331 — fixes `killall_sglang.sh` cross-container process killing with `--pid=host`

## Test plan
- [x] Verified on H100 RadixArk Host 1: concurrent disagg tests on GPUs 0,1 and 2,3 both pass
- [ ] CI disaggregation tests pass