### PR TITLE
[Benchmark] Add --flush-between-rounds to bench_multiturn.py

### DIFF
--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -165,6 +165,19 @@ def parse_args():
         help="API format to use: 'sglang' for native /generate endpoint, "
         "'openai' for OpenAI-compatible /v1/chat/completions endpoint.",
     )
+    parser.add_argument(
+        "--flush-between-rounds",
+        action="store_true",
+        help="If set, flush the radix cache between each round (requires --enable-round-barrier). "
+        "Forces subsequent rounds to prefetch KV from storage backend (e.g. Mooncake).",
+    )
+    parser.add_argument(
+        "--flush-url",
+        type=str,
+        default="",
+        help="URL for flush_cache endpoint (default: http://host:port/flush_cache). "
+        "Set to prefill server URL (e.g. http://localhost:30000/flush_cache) in PD mode.",
+    )
     return parser.parse_args()
 
 
@@ -212,6 +225,8 @@ class WorkloadGenerator:
     def __init__(self, args):
         self.api_format = args.api_format
         self.model_path = args.model_path
+        self.flush_between_rounds = args.flush_between_rounds
+        self.flush_url = args.flush_url or f"http://{args.host}:{args.port}/flush_cache"
 
         # Construct the base URL and select request/payload functions
         if self.api_format == "openai":
@@ -530,6 +545,13 @@ class WorkloadGenerator:
                             f"requests for round {current_barrier_round + 1}"
                         )
                         self._send_heartbeat(input_len=100, output_len=100)
+                        if self.flush_between_rounds:
+                            try:
+                                resp = requests.post(self.flush_url, timeout=10)
+                                print(f"  Flush cache: {resp.status_code}")
+                                time.sleep(1)
+                            except Exception as e:
+                                print(f"  Flush cache failed: {e}")
                         time.sleep(10)
                         for req in next_round_reqs:
                             self.ready_queue.append(req)


### PR DESCRIPTION
## Motivation

When testing L3 cache backends like Mooncake, cached KV in the radix tree can prevent the L3 read path from being exercised. By flushing the cache between rounds, every round is forced to read KV from L3 storage, which helps verify that the L3 backend's read path implementation is correct.

## Modifications

Add `--flush-between-rounds` and `--flush-url` CLI options to `bench_multiturn.py`.

When `--flush-between-rounds` is set, flushes the radix cache between each round via the `/flush_cache` endpoint. Force subsequent rounds to prefetch KV from the storage backend (e.g. Mooncake L3), useful for verifying the correctness and performance of L3 read paths

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
