### PR TITLE
[Diffusion] Speed up Qwen select01 Triton modulation kernels

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -71,41 +71,21 @@ def _fused_layernorm_scale_shift_gate_select01_kernel(
     seq_idx = row % seq_len
     idx = tl.load(index_ptr + batch_idx * stride_i_b + seq_idx * stride_i_l).to(tl.int1)
 
-    scale0 = tl.load(
-        scale0_ptr + batch_idx * stride_s0_b + cols * stride_s0_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    shift0 = tl.load(
-        shift0_ptr + batch_idx * stride_sh0_b + cols * stride_sh0_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    gate0 = tl.load(
-        gate0_ptr + batch_idx * stride_g0_b + cols * stride_g0_c,
-        mask=mask,
-        other=0.0,
-    )
+    scale0_ptrs = scale0_ptr + batch_idx * stride_s0_b + cols * stride_s0_c
+    shift0_ptrs = shift0_ptr + batch_idx * stride_sh0_b + cols * stride_sh0_c
+    gate0_ptrs = gate0_ptr + batch_idx * stride_g0_b + cols * stride_g0_c
 
-    scale1 = tl.load(
-        scale1_ptr + batch_idx * stride_s1_b + cols * stride_s1_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    shift1 = tl.load(
-        shift1_ptr + batch_idx * stride_sh1_b + cols * stride_sh1_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    gate1 = tl.load(
-        gate1_ptr + batch_idx * stride_g1_b + cols * stride_g1_c,
-        mask=mask,
-        other=0.0,
-    )
+    scale1_ptrs = scale1_ptr + batch_idx * stride_s1_b + cols * stride_s1_c
+    shift1_ptrs = shift1_ptr + batch_idx * stride_sh1_b + cols * stride_sh1_c
+    gate1_ptrs = gate1_ptr + batch_idx * stride_g1_b + cols * stride_g1_c
 
-    scale = tl.where(idx, scale1, scale0)
-    shift = tl.where(idx, shift1, shift0)
-    gate = tl.where(idx, gate1, gate0)
+    scale_ptrs = tl.where(idx, scale1_ptrs, scale0_ptrs)
+    shift_ptrs = tl.where(idx, shift1_ptrs, shift0_ptrs)
+    gate_ptrs = tl.where(idx, gate1_ptrs, gate0_ptrs)
+
+    scale = tl.load(scale_ptrs, mask=mask, other=0.0).to(tl.float32)
+    shift = tl.load(shift_ptrs, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.load(gate_ptrs, mask=mask, other=0.0)
     y = x_hat * (1.0 + scale) + shift
 
     tl.store(out_row_ptr + cols, y, mask=mask)
@@ -192,41 +172,21 @@ def _fused_residual_layernorm_scale_shift_gate_select01_kernel(
     seq_idx = row % seq_len
     idx = tl.load(index_ptr + batch_idx * stride_i_b + seq_idx * stride_i_l).to(tl.int1)
 
-    scale0 = tl.load(
-        scale0_ptr + batch_idx * stride_s0_b + cols * stride_s0_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    shift0 = tl.load(
-        shift0_ptr + batch_idx * stride_sh0_b + cols * stride_sh0_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    gate0 = tl.load(
-        gate0_ptr + batch_idx * stride_g0_b + cols * stride_g0_c,
-        mask=mask,
-        other=0.0,
-    )
+    scale0_ptrs = scale0_ptr + batch_idx * stride_s0_b + cols * stride_s0_c
+    shift0_ptrs = shift0_ptr + batch_idx * stride_sh0_b + cols * stride_sh0_c
+    gate0_ptrs = gate0_ptr + batch_idx * stride_g0_b + cols * stride_g0_c
 
-    scale1 = tl.load(
-        scale1_ptr + batch_idx * stride_s1_b + cols * stride_s1_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    shift1 = tl.load(
-        shift1_ptr + batch_idx * stride_sh1_b + cols * stride_sh1_c,
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    gate1 = tl.load(
-        gate1_ptr + batch_idx * stride_g1_b + cols * stride_g1_c,
-        mask=mask,
-        other=0.0,
-    )
+    scale1_ptrs = scale1_ptr + batch_idx * stride_s1_b + cols * stride_s1_c
+    shift1_ptrs = shift1_ptr + batch_idx * stride_sh1_b + cols * stride_sh1_c
+    gate1_ptrs = gate1_ptr + batch_idx * stride_g1_b + cols * stride_g1_c
 
-    scale = tl.where(idx, scale1, scale0)
-    shift = tl.where(idx, shift1, shift0)
-    gate = tl.where(idx, gate1, gate0)
+    scale_ptrs = tl.where(idx, scale1_ptrs, scale0_ptrs)
+    shift_ptrs = tl.where(idx, shift1_ptrs, shift0_ptrs)
+    gate_ptrs = tl.where(idx, gate1_ptrs, gate0_ptrs)
+
+    scale = tl.load(scale_ptrs, mask=mask, other=0.0).to(tl.float32)
+    shift = tl.load(shift_ptrs, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.load(gate_ptrs, mask=mask, other=0.0)
     y = x_hat * (1.0 + scale) + shift
 
     tl.store(out_row_ptr + cols, y, mask=mask)
@@ -523,6 +483,7 @@ def fuse_layernorm_scale_shift_gate_select01_kernel(
     BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(C))
     if C > BLOCK_N:
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+    num_warps, num_stages = 4, 4
 
     grid = (B * L,)
     _fused_layernorm_scale_shift_gate_select01_kernel[grid](
@@ -563,6 +524,8 @@ def fuse_layernorm_scale_shift_gate_select01_kernel(
         HAS_WEIGHT=weight is not x_2d,
         HAS_BIAS=bias is not x_2d,
         BLOCK_N=BLOCK_N,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output, gate_out
 
@@ -624,6 +587,7 @@ def fuse_residual_layernorm_scale_shift_gate_select01_kernel(
     BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(C))
     if C > BLOCK_N:
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+    num_warps, num_stages = 4, 4
 
     grid = (B * L,)
     _fused_residual_layernorm_scale_shift_gate_select01_kernel[grid](
@@ -670,6 +634,8 @@ def fuse_residual_layernorm_scale_shift_gate_select01_kernel(
         HAS_WEIGHT=weight is not x_2d,
         HAS_BIAS=bias is not x_2d,
         BLOCK_N=BLOCK_N,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return output, residual_out, gate_out
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

This PR keeps the Qwen select01 Triton kernel version that showed a stable end-to-end win in Qwen-Image denoise.

The final change set:
- switches modulation loads to pointer-select so each row only loads the chosen `scale/shift/gate` branch
- pins both select01 launches to `num_warps=4`, `num_stages=4`
- drops later scalar-base / `8w1s` / residual-only experiments from the active code path because they did not produce stable model-level gains

<img width="1570" height="1674" alt="图片" src="https://github.com/user-attachments/assets/9071f716-2a9d-4f52-b10c-db095a5919a1" />

Made with Codex(AKO4ALL framework and SGLang Diffusion SKILL).

## Implementation

The optimized kernels are:
- `fuse_layernorm_scale_shift_gate_select01_kernel`
- `fuse_residual_layernorm_scale_shift_gate_select01_kernel`

Main code changes:
- build branch-specific pointer tensors for `scale0/1`, `shift0/1`, and `gate0/1`
- select pointers with `tl.where(idx, ...)`
- issue only one load for each modulation tensor on the chosen branch
- keep the validated `4w4s` launch config for both kernels

## Validation

Correctness:
- `python -m py_compile python/sglang/jit_kernel/diffusion/triton/scale_shift.py`
- `pytest -q python/sglang/jit_kernel/tests/test_qwen_image_modulation.py -q`

Performance:

| Benchmark | Baseline | New | Delta |
|---|---:|---:|---:|
| AKO aggregate microbench | 0.039589 ms | 0.036297 ms | 1.090681x |
| layernorm `(2,2048,3072)` | 0.036896 ms | 0.031680 ms | 1.164647x |
| residual `(2,2048,3072)` | 0.049248 ms | 0.046528 ms | 1.058459x |
| Qwen DenoisingStage | 12788.15 ms | 12432.77 ms | -355.39 ms (-2.8%) |
| Qwen E2E | 12838.08 ms | 12526.77 ms | -311.30 ms (-2.4%) |

## Nsight Compute

A representative `ncu` check on the layernorm select01 kernel at `(2,2048,3072)` shows:
- `gpu__time_duration.avg`: `35.744 us -> 28.704 us`
- `launch__registers_per_thread`: `96 -> 72`

The optimized kernel reduces single-launch latency from the baseline by 19.7% (28.70 us here), while also increasing L2 and DRAM throughput. This indicates that the win is not just a launch-parameter artifact: the kernel is doing less wasted work and using the memory hierarchy more effectively.

<img width="2770" height="1166" alt="图片" src="https://github.com/user-attachments/assets/f4ccabc7-5d10-4f77-baa8-28e63cd70b90" />

Executed and issued instruction counts both drop by about 18.5%, which is consistent with the kernel rewrite: the pointer-select path avoids loading and computing both modulation branches before selecting one.

<img width="2838" height="1258" alt="图片" src="https://github.com/user-attachments/assets/759a9560-be7f-4e6e-a757-cecfa541f3e0" />

This kernel is register-limited, and lowering register pressure improves occupancy materially. In this tuned version, registers per thread drop from 96 to 72, which raises both theoretical and achieved occupancy and improves latency hiding.

<img width="2756" height="1166" alt="图片" src="https://github.com/user-attachments/assets/5c4e95b4-2184-4453-afd2-0663d49c90c6" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
