### PR TITLE
feat: add --strict-ports option for predictable port assignment

### DIFF
--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -321,8 +321,10 @@ def _get_config_info(
         model_id = matched_model_names[0]
         return _CONFIG_REGISTRY.get(model_id)
     else:
-        logger.debug(f"No model info found for model path: {model_path}")
-        return None
+        raise RuntimeError(
+            f"No model info found for model path: {model_path}. "
+            f"Please check the model path or specify the model_id explicitly."
+        )
 
 
 # --- Part 3: Main Resolver ---

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -321,7 +321,8 @@ def _get_config_info(
         model_id = matched_model_names[0]
         return _CONFIG_REGISTRY.get(model_id)
     else:
-        raise RuntimeError(f"No model info found for model path: {model_path}")
+        logger.debug(f"No model info found for model path: {model_path}")
+        return None
 
 
 # --- Part 3: Main Resolver ---

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -387,11 +387,13 @@ class ServerArgs:
                 )
             if not is_port_available(self.scheduler_port):
                 raise RuntimeError(
-                    f"Scheduler port {self.scheduler_port} is unavailable and --strict-ports is enabled."
+                    f"Scheduler port {self.scheduler_port} is unavailable and --strict-ports is enabled. "
+                    f"Either use a different port or remove --strict-ports to allow auto-selection."
                 )
             if self.master_port is not None and not is_port_available(self.master_port):
                 raise RuntimeError(
-                    f"Master port {self.master_port} is unavailable and --strict-ports is enabled."
+                    f"Master port {self.master_port} is unavailable and --strict-ports is enabled. "
+                    f"Either use a different port or remove --strict-ports to allow auto-selection."
                 )
         else:
             self.port = self.settle_port(self.port)

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -186,6 +186,9 @@ class ServerArgs:
 
     scheduler_port: int = 5555
 
+    # Strict port mode: fail if requested port is unavailable instead of auto-selecting
+    strict_ports: bool = False
+
     output_path: str | None = "outputs/"
     input_save_path: str | None = "inputs/uploads"
 
@@ -375,17 +378,33 @@ class ServerArgs:
             )
 
     def _adjust_network_ports(self):
-        self.port = self.settle_port(self.port)
-        initial_scheduler_port = self.scheduler_port + (
-            random.randint(0, 100) if self.scheduler_port == 5555 else 0
-        )
-        self.scheduler_port = self.settle_port(initial_scheduler_port)
-        initial_master_port = (
-            self.master_port
-            if self.master_port is not None
-            else (30005 + random.randint(0, 100))
-        )
-        self.master_port = self.settle_port(initial_master_port, 37)
+        if self.strict_ports:
+            # Strict mode: fail if port is unavailable
+            if not is_port_available(self.port):
+                raise RuntimeError(
+                    f"Port {self.port} is unavailable and --strict-ports is enabled. "
+                    f"Either use a different port or remove --strict-ports to allow auto-selection."
+                )
+            if not is_port_available(self.scheduler_port):
+                raise RuntimeError(
+                    f"Scheduler port {self.scheduler_port} is unavailable and --strict-ports is enabled."
+                )
+            if self.master_port is not None and not is_port_available(self.master_port):
+                raise RuntimeError(
+                    f"Master port {self.master_port} is unavailable and --strict-ports is enabled."
+                )
+        else:
+            self.port = self.settle_port(self.port)
+            initial_scheduler_port = self.scheduler_port + (
+                random.randint(0, 100) if self.scheduler_port == 5555 else 0
+            )
+            self.scheduler_port = self.settle_port(initial_scheduler_port)
+            initial_master_port = (
+                self.master_port
+                if self.master_port is not None
+                else (30005 + random.randint(0, 100))
+            )
+            self.master_port = self.settle_port(initial_master_port, 37)
 
     def _adjust_parallelism(self):
         if self.tp_size is None:
@@ -750,6 +769,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.port,
             help="Port for the HTTP API server.",
+        )
+        parser.add_argument(
+            "--strict-ports",
+            action=StoreBoolean,
+            default=ServerArgs.strict_ports,
+            help="If enabled, fail when requested ports are unavailable instead of auto-selecting.",
         )
         parser.add_argument(
             "--webui",


### PR DESCRIPTION
## Summary
- Add `--strict-ports` option to disable automatic port selection
- When enabled, server fails immediately if requested ports are unavailable
- Ensures predictable port assignment for users who need to know exactly which ports will be used

## Problem
Currently, when a requested port is occupied, `settle_port` automatically selects an available port. This causes issues for users who:
1. Don't know which port the server ended up using
2. Cannot reliably create clients with the same configuration
3. Have port conflicts across multiple server instances

## Solution
Add `--strict-ports` option. When enabled:
- Check if requested ports are available (HTTP, scheduler, master)
- Fail with clear error message if any port is unavailable
- Do NOT auto-select alternative ports

### Usage
```bash
# Normal mode (default): auto-select ports if unavailable
python -m sglang.launch_server --model <model> --port 8080

# Strict mode: fail if port 8080 is unavailable
python -m sglang.launch_server --model <model> --port 8080 --strict-ports
```

Related to #21284

## Test Plan
- Start server with occupied port + --strict-ports → should fail with clear error
- Start server with available port + --strict-ports → should succeed
- Default behavior (no --strict-ports) → should auto-select ports as before