### PR TITLE
fix: multiple issues in embedding, truncation, and abort handling

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2015,6 +2015,7 @@ class Scheduler(
             self.server_args.allow_auto_truncate,
         )
         if error_msg:
+            req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
             return
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -797,12 +797,22 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
         # Validate input length
         if input_token_num >= self.context_len:
             if self.server_args.allow_auto_truncate:
+                # Reserve space for generation when truncating
+                max_new_tokens = obj.sampling_params.get("max_new_tokens")
+                reserve_tokens = min(max_new_tokens if max_new_tokens else 512, 512)
+                truncate_to = max(0, _max_req_len - reserve_tokens)
+                if truncate_to == 0:
+                    raise ValueError(
+                        f"Cannot truncate: context_len ({self.context_len}) is too small "
+                        f"to reserve any space for generation."
+                    )
                 logger.warning(
                     f"The input ({input_token_num} tokens) is longer than the "
                     f"model's context length ({self.context_len} tokens). "
-                    "Truncating the input."
+                    f"Truncating the input to {truncate_to} tokens, reserving "
+                    f"{reserve_tokens} tokens for generation."
                 )
-                del input_ids[_max_req_len:]
+                del input_ids[truncate_to:]
                 input_token_num = len(input_ids)
             else:
                 raise ValueError(
@@ -2159,6 +2169,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
     def _handle_abort_req(self, recv_obj: AbortReq):
         if is_health_check_generate_req(recv_obj):
+            return
+        # Check if request exists to avoid KeyError when already completed
+        if recv_obj.rid not in self.rid_to_state:
+            logger.debug(f"Abort request for unknown/finished rid: {recv_obj.rid}")
             return
         state = self.rid_to_state[recv_obj.rid]
         state.finished = True


### PR DESCRIPTION
## Summary
Fixes #21136, #21168, #21173

### Issue #21136: Truncation doesn't reserve space for generation
When `allow_auto_truncate` is enabled and input exceeds context length, the current code truncates to `context_len` but doesn't reserve any tokens for generation. This means:
- User gets truncated input but zero generation capacity
- Subsequent requests still fail due to no generation tokens available

**Fix**: Reserve up to 512 tokens for generation when truncating, ensuring users can still get some output even with truncated input.

### Issue #21168: Embedding request validation doesn't call set_finish_with_abort
When `validate_input_length` fails for embedding requests, the error is returned but `set_finish_with_abort` is not called. This causes the request to be processed incorrectly.

**Fix**: Added `req.set_finish_with_abort(error_msg)` before adding request to queue, consistent with generate request handling.

### Issue #21173: KeyError when aborting unknown/finished requests
When a request is aborted but already completed (not in `rid_to_state`), a KeyError is raised:
```
state = self.rid_to_state[recv_obj.rid]
KeyError: '...'
```

**Fix**: Check if `rid` exists in `rid_to_state` before accessing, return early with debug log if not found.

## Test Plan
- Test truncation with long input + allow_auto_truncate
- Test embedding request with input exceeding max length
- Test aborting completed/unknown requests

🤖 Generated with [Claude Code](https://claude.ai/code)