### PR TITLE
[Bug Fix] Fix IndexError in embed_mm_inputs when mixed image+video with deepstack and prefix caching

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -939,8 +939,8 @@ def embed_mm_inputs(
     for mm_inputs in mm_inputs_list:
         item_flatten_list += [item for item in mm_inputs.mm_items if item is not None]
 
-    # deepstack_embeddings: per-modality
-    modalities, embeddings, masks, deepstack_embeddings = [], [], [], []
+    modalities, embeddings, masks = [], [], []
+    deepstack_embeddings = {}
 
     # 2. Get multimodal embedding separately
     # Try get mm embedding if any
@@ -993,7 +993,7 @@ def embed_mm_inputs(
                 embedding, deepstack_embedding = (
                     multimodal_model.separate_deepstack_embeds(embedding)
                 )
-                deepstack_embeddings += [deepstack_embedding]
+                deepstack_embeddings[modality] = deepstack_embedding
             modalities += [modality]
             embeddings += [embedding]
             masks += [mask]
@@ -1024,16 +1024,14 @@ def embed_mm_inputs(
         other_info["input_deepstack_embeds"] = input_deepstack_embeds
 
     # 4. scatter embeddings into input embedding
-    for i, modality, embedding, mask in zip(
-        range(len(embeddings)), modalities, embeddings, masks
-    ):
+    for modality, embedding, mask in zip(modalities, embeddings, masks):
         if embedding is None or mask is None:
             continue
         # in-place update
         indices = torch.where(mask.squeeze(dim=-1))[0]
         input_embeds[indices] = embedding.to(input_embeds.device, input_embeds.dtype)
-        if use_deepstack.get(modality, None):
-            input_deepstack_embeds[indices] = deepstack_embeddings[i].to(
+        if modality in deepstack_embeddings:
+            input_deepstack_embeds[indices] = deepstack_embeddings[modality].to(
                 input_embeds.device, input_embeds.dtype
             )
 

--- a/test/registered/unit/test_deepstack_embed_index.py
+++ b/test/registered/unit/test_deepstack_embed_index.py
@@ -1,0 +1,240 @@
+"""Unit test for deepstack_embeddings indexing in embed_mm_inputs.
+
+Reproduces the IndexError when prefix caching causes one modality's
+embedding to be None while another's is not, and use_deepstack is
+enabled for both.
+"""
+
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.managers.mm_utils import embed_mm_inputs
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+
+# Pad values for image and video (must be > vocab_size to avoid collision)
+IMAGE_PAD = 1_000_100
+VIDEO_PAD = 1_000_200
+HIDDEN = 8
+VOCAB = 32
+
+
+def _make_mm_inputs(
+    image_offsets: list[tuple[int, int]],
+    video_offsets: list[tuple[int, int]],
+) -> MultimodalInputs:
+    """Create a MultimodalInputs with one image item and one video item."""
+    image_item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        pad_value=IMAGE_PAD,
+        offsets=image_offsets,
+        feature=torch.zeros(1),  # dummy
+    )
+    video_item = MultimodalDataItem(
+        modality=Modality.VIDEO,
+        pad_value=VIDEO_PAD,
+        offsets=video_offsets,
+        feature=torch.zeros(1),  # dummy
+    )
+    return MultimodalInputs(
+        mm_items=[image_item, video_item],
+        im_token_id=IMAGE_PAD,
+        video_token_id=VIDEO_PAD,
+    )
+
+
+def _mock_get_embedding_and_mask(cached_modality: Modality, embed_width: int = HIDDEN):
+    """Return a mock that returns None for the cached modality, real tensors for others.
+
+    embed_width should be HIDDEN * (1 + num_deepstack_layers) when deepstack
+    is active, since separate_deepstack_embeds splits the wide embedding.
+    """
+
+    def mock_fn(
+        data_embedding_func,
+        embedding_items,
+        placeholder_tensor,
+        input_ids,
+        items_size,
+        prefix_length,
+        extend_length,
+        items_offset_list,
+    ):
+        modality = embedding_items[0].modality
+        if modality == cached_modality:
+            return None, None, input_ids
+
+        # Return a real embedding + mask for the non-cached modality.
+        # Width must match what the real embedder would produce (wide when
+        # deepstack is active, since separate_deepstack_embeds splits it).
+        mask = (input_ids == placeholder_tensor[0]).unsqueeze(-1)
+        n_tokens = mask.sum().item()
+        embedding = torch.ones(n_tokens, embed_width)
+        return embedding, mask, input_ids
+
+    return mock_fn
+
+
+def _make_multimodal_model(num_deepstack_layers: int):
+    """Create a mock multimodal model with deepstack support."""
+    model = nn.Module()
+    model.deepstack_visual_indexes = list(range(num_deepstack_layers))
+
+    def separate_deepstack_embeds(embedding):
+        base = embedding[:, :HIDDEN]
+        deepstack = embedding[:, HIDDEN:]
+        return base, deepstack
+
+    # When deepstack is active, the embedding func returns wider tensors
+    width = HIDDEN * (1 + num_deepstack_layers)
+
+    def get_image_feature(items):
+        total = sum(1 for item in items for _ in item.offsets)
+        return torch.ones(total, width)
+
+    def get_video_feature(items):
+        total = sum(1 for item in items for _ in item.offsets)
+        return torch.ones(total, width)
+
+    model.separate_deepstack_embeds = separate_deepstack_embeds
+    model.get_image_feature = get_image_feature
+    model.get_video_feature = get_video_feature
+    return model
+
+
+class TestDeepstackEmbedIndex:
+    """Tests for deepstack_embeddings indexing in embed_mm_inputs."""
+
+    def _build_input_ids(self, img_tokens: int, vid_tokens: int) -> torch.Tensor:
+        """Build input_ids: [text...] [IMAGE_PAD × img] [text...] [VIDEO_PAD × vid] [text...]"""
+        text = list(range(10))  # 10 text tokens (within vocab)
+        ids = text + [IMAGE_PAD] * img_tokens + text + [VIDEO_PAD] * vid_tokens + text
+        return torch.tensor(ids, dtype=torch.long)
+
+    @patch("sglang.srt.managers.mm_utils.get_embedding_and_mask")
+    def test_image_cached_video_not_cached(self, mock_get_emb):
+        """IMAGE fully cached (None), VIDEO not cached — should not crash."""
+        num_ds = 3
+        mock_get_emb.side_effect = _mock_get_embedding_and_mask(
+            cached_modality=Modality.IMAGE,
+            embed_width=HIDDEN * (1 + num_ds),
+        )
+
+        input_ids = self._build_input_ids(img_tokens=4, vid_tokens=4)
+        embedding_layer = nn.Embedding(VOCAB, HIDDEN)
+        model = _make_multimodal_model(num_deepstack_layers=num_ds)
+        mm_inputs = _make_mm_inputs(
+            image_offsets=[(10, 13)],
+            video_offsets=[(24, 27)],
+        )
+
+        result, _ = embed_mm_inputs(
+            mm_inputs_list=[mm_inputs],
+            extend_prefix_lens=[0],
+            extend_seq_lens=[len(input_ids)],
+            input_ids=input_ids,
+            input_embedding=embedding_layer,
+            multimodal_model=model,
+            use_deepstack={Modality.IMAGE: True, Modality.VIDEO: True},
+        )
+
+        assert result is not None
+        assert result.shape[0] == len(input_ids)
+
+    @patch("sglang.srt.managers.mm_utils.get_embedding_and_mask")
+    def test_video_cached_image_not_cached(self, mock_get_emb):
+        """VIDEO fully cached (None), IMAGE not cached — should not crash."""
+        num_ds = 3
+        mock_get_emb.side_effect = _mock_get_embedding_and_mask(
+            cached_modality=Modality.VIDEO,
+            embed_width=HIDDEN * (1 + num_ds),
+        )
+
+        input_ids = self._build_input_ids(img_tokens=4, vid_tokens=4)
+        embedding_layer = nn.Embedding(VOCAB, HIDDEN)
+        model = _make_multimodal_model(num_deepstack_layers=3)
+        mm_inputs = _make_mm_inputs(
+            image_offsets=[(10, 13)],
+            video_offsets=[(24, 27)],
+        )
+
+        result, _ = embed_mm_inputs(
+            mm_inputs_list=[mm_inputs],
+            extend_prefix_lens=[0],
+            extend_seq_lens=[len(input_ids)],
+            input_ids=input_ids,
+            input_embedding=embedding_layer,
+            multimodal_model=model,
+            use_deepstack={Modality.IMAGE: True, Modality.VIDEO: True},
+        )
+
+        assert result is not None
+        assert result.shape[0] == len(input_ids)
+
+    @patch("sglang.srt.managers.mm_utils.get_embedding_and_mask")
+    def test_both_not_cached(self, mock_get_emb):
+        """Neither cached — both get embeddings, should work."""
+        num_ds = 3
+        mock_get_emb.side_effect = _mock_get_embedding_and_mask(
+            cached_modality=None,  # nothing cached
+            embed_width=HIDDEN * (1 + num_ds),
+        )
+
+        input_ids = self._build_input_ids(img_tokens=4, vid_tokens=4)
+        embedding_layer = nn.Embedding(VOCAB, HIDDEN)
+        model = _make_multimodal_model(num_deepstack_layers=num_ds)
+        mm_inputs = _make_mm_inputs(
+            image_offsets=[(10, 13)],
+            video_offsets=[(24, 27)],
+        )
+
+        result, _ = embed_mm_inputs(
+            mm_inputs_list=[mm_inputs],
+            extend_prefix_lens=[0],
+            extend_seq_lens=[len(input_ids)],
+            input_ids=input_ids,
+            input_embedding=embedding_layer,
+            multimodal_model=model,
+            use_deepstack={Modality.IMAGE: True, Modality.VIDEO: True},
+        )
+
+        assert result is not None
+
+    @patch("sglang.srt.managers.mm_utils.get_embedding_and_mask")
+    def test_no_deepstack(self, mock_get_emb):
+        """Without deepstack, mixed cached/non-cached should always work."""
+        mock_get_emb.side_effect = _mock_get_embedding_and_mask(
+            cached_modality=Modality.IMAGE
+        )
+
+        input_ids = self._build_input_ids(img_tokens=4, vid_tokens=4)
+        embedding_layer = nn.Embedding(VOCAB, HIDDEN)
+        mm_inputs = _make_mm_inputs(
+            image_offsets=[(10, 13)],
+            video_offsets=[(24, 27)],
+        )
+
+        result, _ = embed_mm_inputs(
+            mm_inputs_list=[mm_inputs],
+            extend_prefix_lens=[0],
+            extend_seq_lens=[len(input_ids)],
+            input_ids=input_ids,
+            input_embedding=embedding_layer,
+            multimodal_model=None,
+            data_embedding_func_mapping={
+                Modality.IMAGE: lambda items: torch.ones(
+                    sum(1 for item in items for _ in item.offsets), HIDDEN
+                ),
+                Modality.VIDEO: lambda items: torch.ones(
+                    sum(1 for item in items for _ in item.offsets), HIDDEN
+                ),
+            },
+            use_deepstack={},
+        )
+
+        assert result is not None


### PR DESCRIPTION
## Motivation

This fixes #21327

When a request contains both image and video inputs on a model with deepstack (Qwen3-VL, Qwen3.5), and prefix caching causes one modality's embedding to be None (fully cached) while the other is not, `deepstack_embeddings[i]` crashes with IndexError.

Root cause: `deepstack_embeddings` is a flat list indexed by `i` (which counts all modalities), but only modalities with non-None embeddings append to the list. When IMAGE is cached (embedding=None, skipped) and VIDEO is not (embedding present, appended at index 0), the loop reaches VIDEO at i=1 but deepstack_embeddings only has index 0.

## Modifications

Fix: use a dict keyed by Modality instead of a positional list.

## Accuracy Tests

n/a

## Benchmarking and Profiling

n/a

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
