### PR TITLE
[Test] Add unit tests for openai entrypoints utils and usage_processor

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -1,0 +1,235 @@
+"""
+Unit tests for sglang.srt.entrypoints.openai.usage_processor.UsageProcessor.
+
+Covers:
+  - calculate_token_usage
+  - calculate_response_usage (batch / n_choices)
+  - calculate_streaming_usage (streaming / n_choices)
+
+All tests run on CPU with no server or model weights required.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Stub out sgl_kernel before any sglang import so tests run on CPU-only runners.
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails, UsageInfo
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resp(prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0) -> dict:
+    return {
+        "meta_info": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "cached_tokens": cached_tokens,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# calculate_token_usage
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateTokenUsage(unittest.TestCase):
+    def test_basic_totals(self):
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=10, completion_tokens=5
+        )
+        self.assertIsInstance(result, UsageInfo)
+        self.assertEqual(result.prompt_tokens, 10)
+        self.assertEqual(result.completion_tokens, 5)
+        self.assertEqual(result.total_tokens, 15)
+
+    def test_total_is_sum_of_prompt_and_completion(self):
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=100, completion_tokens=200
+        )
+        self.assertEqual(result.total_tokens, 300)
+
+    def test_no_cached_tokens_details(self):
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=10, completion_tokens=5
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_with_cached_tokens_details(self):
+        details = PromptTokensDetails(cached_tokens=7)
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=10, completion_tokens=5, cached_tokens=details
+        )
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 7)
+
+    def test_zero_tokens(self):
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=0, completion_tokens=0
+        )
+        self.assertEqual(result.total_tokens, 0)
+
+
+# ---------------------------------------------------------------------------
+# calculate_response_usage
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateResponseUsage(unittest.TestCase):
+    def test_single_response(self):
+        responses = [_resp(prompt_tokens=20, completion_tokens=10)]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+        self.assertEqual(result.prompt_tokens, 20)
+        self.assertEqual(result.completion_tokens, 10)
+        self.assertEqual(result.total_tokens, 30)
+
+    def test_multiple_responses_n_choices_1(self):
+        # With n_choices=1 every response counts for prompt
+        responses = [
+            _resp(prompt_tokens=10, completion_tokens=5),
+            _resp(prompt_tokens=10, completion_tokens=3),
+        ]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+        self.assertEqual(result.prompt_tokens, 20)
+        self.assertEqual(result.completion_tokens, 8)
+
+    def test_n_choices_2_only_first_of_each_pair_counts_for_prompt(self):
+        # n=2 choices: responses[0] and responses[1] are choices for prompt A.
+        # prompt_tokens should be counted once (from index 0 only, not index 1).
+        responses = [
+            _resp(prompt_tokens=50, completion_tokens=5),  # idx 0 — counts for prompt
+            _resp(prompt_tokens=50, completion_tokens=3),  # idx 1 — skipped for prompt
+        ]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+        self.assertEqual(result.prompt_tokens, 50)  # only index 0
+        self.assertEqual(result.completion_tokens, 8)  # all choices sum
+
+    def test_n_choices_2_two_prompts(self):
+        # 4 responses, n_choices=2: two prompts × two choices each.
+        # prompt_tokens at indices 0 and 2 count; indices 1 and 3 are skipped.
+        responses = [
+            _resp(prompt_tokens=10, completion_tokens=1),  # prompt A, choice 0
+            _resp(prompt_tokens=10, completion_tokens=2),  # prompt A, choice 1
+            _resp(prompt_tokens=20, completion_tokens=3),  # prompt B, choice 0
+            _resp(prompt_tokens=20, completion_tokens=4),  # prompt B, choice 1
+        ]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+        self.assertEqual(result.prompt_tokens, 30)  # 10 + 20
+        self.assertEqual(result.completion_tokens, 10)  # 1+2+3+4
+
+    def test_cache_report_disabled_no_details(self):
+        responses = [_resp(prompt_tokens=10, completion_tokens=5, cached_tokens=3)]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=False
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_enabled_zero_cached_no_details(self):
+        # _details_if_cached returns None when count == 0
+        responses = [_resp(prompt_tokens=10, completion_tokens=5, cached_tokens=0)]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=True
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_enabled_with_cached_tokens(self):
+        responses = [_resp(prompt_tokens=10, completion_tokens=5, cached_tokens=4)]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=True
+        )
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 4)
+
+
+# ---------------------------------------------------------------------------
+# calculate_streaming_usage
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateStreamingUsage(unittest.TestCase):
+    def test_basic_single_choice(self):
+        prompt_tokens = {0: 15}
+        completion_tokens = {0: 7}
+        cached_tokens = {0: 0}
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            n_choices=1,
+        )
+        self.assertEqual(result.prompt_tokens, 15)
+        self.assertEqual(result.completion_tokens, 7)
+        self.assertEqual(result.total_tokens, 22)
+
+    def test_n_choices_2_only_even_indices_count_for_prompt(self):
+        # Indices 0 and 2 are "first of each prompt" (idx % 2 == 0).
+        prompt_tokens = {0: 10, 1: 10, 2: 20, 3: 20}
+        completion_tokens = {0: 1, 1: 2, 2: 3, 3: 4}
+        cached_tokens = {0: 0, 1: 0, 2: 0, 3: 0}
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_tokens=cached_tokens,
+            n_choices=2,
+        )
+        self.assertEqual(result.prompt_tokens, 30)  # 10 + 20
+        self.assertEqual(result.completion_tokens, 10)  # 1+2+3+4
+
+    def test_cache_report_disabled_no_details(self):
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10},
+            completion_tokens={0: 5},
+            cached_tokens={0: 3},
+            n_choices=1,
+            enable_cache_report=False,
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_enabled_zero_cached_no_details(self):
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10},
+            completion_tokens={0: 5},
+            cached_tokens={0: 0},
+            n_choices=1,
+            enable_cache_report=True,
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_enabled_with_cached_tokens(self):
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10},
+            completion_tokens={0: 5},
+            cached_tokens={0: 6},
+            n_choices=1,
+            enable_cache_report=True,
+        )
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 6)
+
+    def test_cache_report_n_choices_2_only_even_indices_sum(self):
+        # Only indices where idx % n_choices == 0 contribute to cached total.
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10, 1: 10},
+            completion_tokens={0: 1, 1: 2},
+            cached_tokens={0: 5, 1: 5},
+            n_choices=2,
+            enable_cache_report=True,
+        )
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 5)  # only idx 0
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -1,0 +1,246 @@
+"""
+Unit tests for sglang.srt.entrypoints.openai.utils.
+
+Covers:
+  - to_openai_style_logprobs
+  - process_hidden_states_from_ret
+  - process_routed_experts_from_ret
+  - process_cached_tokens_details_from_ret
+
+All tests run on CPU with no server or model weights required.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Stub out sgl_kernel before any sglang import so tests run on CPU-only runners.
+for _mod in ("sgl_kernel", "sgl_kernel.kvcacheio"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from sglang.srt.entrypoints.openai.protocol import CachedTokensDetails
+from sglang.srt.entrypoints.openai.utils import (
+    process_cached_tokens_details_from_ret,
+    process_hidden_states_from_ret,
+    process_routed_experts_from_ret,
+    to_openai_style_logprobs,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(**kwargs):
+    """Minimal request-like object with the fields used by utils.py."""
+
+    class _Req:
+        return_hidden_states = False
+        return_routed_experts = False
+        return_cached_tokens_details = False
+
+    req = _Req()
+    for k, v in kwargs.items():
+        setattr(req, k, v)
+    return req
+
+
+def _make_ret(meta_info: dict) -> dict:
+    return {"meta_info": meta_info}
+
+
+# ---------------------------------------------------------------------------
+# to_openai_style_logprobs
+# ---------------------------------------------------------------------------
+
+
+class TestToOpenaiStyleLogprobs(unittest.TestCase):
+    def test_all_none_returns_empty_logprobs(self):
+        result = to_openai_style_logprobs()
+        self.assertEqual(result.tokens, [])
+        self.assertEqual(result.token_logprobs, [])
+        self.assertEqual(result.top_logprobs, [])
+        self.assertEqual(result.text_offset, [])
+
+    def test_output_token_logprobs_only(self):
+        # Each entry is (logprob, token_id, token_text)
+        output = [(-0.1, 42, "Hello"), (-0.5, 99, " world")]
+        result = to_openai_style_logprobs(output_token_logprobs=output)
+        self.assertEqual(result.tokens, ["Hello", " world"])
+        self.assertEqual(result.token_logprobs, [-0.1, -0.5])
+        # text_offset is always -1 (not yet supported)
+        self.assertEqual(result.text_offset, [-1, -1])
+
+    def test_input_token_logprobs_only(self):
+        input_lp = [(-0.2, 1, "Hi"), (-0.3, 2, "!")]
+        result = to_openai_style_logprobs(input_token_logprobs=input_lp)
+        self.assertEqual(result.tokens, ["Hi", "!"])
+        self.assertEqual(result.token_logprobs, [-0.2, -0.3])
+
+    def test_input_then_output_appended_in_order(self):
+        input_lp = [(-0.1, 1, "A")]
+        output_lp = [(-0.2, 2, "B"), (-0.3, 3, "C")]
+        result = to_openai_style_logprobs(
+            input_token_logprobs=input_lp,
+            output_token_logprobs=output_lp,
+        )
+        self.assertEqual(result.tokens, ["A", "B", "C"])
+        self.assertEqual(result.token_logprobs, [-0.1, -0.2, -0.3])
+
+    def test_output_top_logprobs(self):
+        # top_logprobs: list of lists; each inner list is (logprob, token_id, token_text)
+        top = [[(-0.1, 1, "yes"), (-2.0, 2, "no")], None]
+        result = to_openai_style_logprobs(output_top_logprobs=top)
+        self.assertEqual(result.top_logprobs[0], {"yes": -0.1, "no": -2.0})
+        self.assertIsNone(result.top_logprobs[1])
+
+    def test_input_top_logprobs(self):
+        top = [[(-0.5, 10, "tok")]]
+        result = to_openai_style_logprobs(input_top_logprobs=top)
+        self.assertEqual(result.top_logprobs, [{"tok": -0.5}])
+
+    def test_combined_token_and_top_logprobs(self):
+        output_lp = [(-0.1, 1, "A")]
+        output_top = [[(-0.1, 1, "A"), (-1.0, 2, "B")]]
+        result = to_openai_style_logprobs(
+            output_token_logprobs=output_lp,
+            output_top_logprobs=output_top,
+        )
+        self.assertEqual(result.tokens, ["A"])
+        self.assertEqual(result.top_logprobs[0]["A"], -0.1)
+
+    def test_text_offset_always_minus_one(self):
+        output = [(-0.1, 1, "x"), (-0.2, 2, "y"), (-0.3, 3, "z")]
+        result = to_openai_style_logprobs(output_token_logprobs=output)
+        self.assertEqual(result.text_offset, [-1, -1, -1])
+
+
+# ---------------------------------------------------------------------------
+# process_hidden_states_from_ret
+# ---------------------------------------------------------------------------
+
+
+class TestProcessHiddenStates(unittest.TestCase):
+    def test_returns_none_when_flag_false(self):
+        req = _make_request(return_hidden_states=False)
+        ret = _make_ret({"hidden_states": [[1, 2, 3]]})
+        self.assertIsNone(process_hidden_states_from_ret(ret, req))
+
+    def test_returns_none_when_hidden_states_absent(self):
+        req = _make_request(return_hidden_states=True)
+        ret = _make_ret({})
+        self.assertIsNone(process_hidden_states_from_ret(ret, req))
+
+    def test_returns_none_when_hidden_states_is_none(self):
+        req = _make_request(return_hidden_states=True)
+        ret = _make_ret({"hidden_states": None})
+        self.assertIsNone(process_hidden_states_from_ret(ret, req))
+
+    def test_single_hidden_state_returns_empty_list(self):
+        # len == 1: the branch returns [] (not the single element)
+        req = _make_request(return_hidden_states=True)
+        ret = _make_ret({"hidden_states": [[0.1, 0.2]]})
+        self.assertEqual(process_hidden_states_from_ret(ret, req), [])
+
+    def test_multiple_hidden_states_returns_last(self):
+        states = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+        req = _make_request(return_hidden_states=True)
+        ret = _make_ret({"hidden_states": states})
+        self.assertEqual(process_hidden_states_from_ret(ret, req), [0.5, 0.6])
+
+
+# ---------------------------------------------------------------------------
+# process_routed_experts_from_ret
+# ---------------------------------------------------------------------------
+
+
+class TestProcessRoutedExperts(unittest.TestCase):
+    def test_returns_none_when_flag_false(self):
+        req = _make_request(return_routed_experts=False)
+        ret = _make_ret({"routed_experts": "expert_data"})
+        self.assertIsNone(process_routed_experts_from_ret(ret, req))
+
+    def test_returns_value_when_flag_true(self):
+        req = _make_request(return_routed_experts=True)
+        ret = _make_ret({"routed_experts": "expert_data"})
+        self.assertEqual(process_routed_experts_from_ret(ret, req), "expert_data")
+
+    def test_returns_none_when_key_missing(self):
+        req = _make_request(return_routed_experts=True)
+        ret = _make_ret({})
+        self.assertIsNone(process_routed_experts_from_ret(ret, req))
+
+    def test_request_without_attribute_treated_as_false(self):
+        # Objects without return_routed_experts attr default to False via getattr
+        class _MinReq:
+            pass
+
+        ret = _make_ret({"routed_experts": "data"})
+        self.assertIsNone(process_routed_experts_from_ret(ret, _MinReq()))
+
+
+# ---------------------------------------------------------------------------
+# process_cached_tokens_details_from_ret
+# ---------------------------------------------------------------------------
+
+
+class TestProcessCachedTokensDetails(unittest.TestCase):
+    def test_returns_none_when_flag_false(self):
+        req = _make_request(return_cached_tokens_details=False)
+        ret = _make_ret({"cached_tokens_details": {"device": 10, "host": 5}})
+        self.assertIsNone(process_cached_tokens_details_from_ret(ret, req))
+
+    def test_returns_none_when_details_absent(self):
+        req = _make_request(return_cached_tokens_details=True)
+        ret = _make_ret({})
+        self.assertIsNone(process_cached_tokens_details_from_ret(ret, req))
+
+    def test_returns_none_when_details_is_none(self):
+        req = _make_request(return_cached_tokens_details=True)
+        ret = _make_ret({"cached_tokens_details": None})
+        self.assertIsNone(process_cached_tokens_details_from_ret(ret, req))
+
+    def test_device_host_only(self):
+        req = _make_request(return_cached_tokens_details=True)
+        ret = _make_ret({"cached_tokens_details": {"device": 8, "host": 3}})
+        result = process_cached_tokens_details_from_ret(ret, req)
+        self.assertIsInstance(result, CachedTokensDetails)
+        self.assertEqual(result.device, 8)
+        self.assertEqual(result.host, 3)
+        self.assertIsNone(result.storage)
+        self.assertIsNone(result.storage_backend)
+
+    def test_with_storage_fields(self):
+        req = _make_request(return_cached_tokens_details=True)
+        ret = _make_ret(
+            {
+                "cached_tokens_details": {
+                    "device": 4,
+                    "host": 2,
+                    "storage": 6,
+                    "storage_backend": "s3",
+                }
+            }
+        )
+        result = process_cached_tokens_details_from_ret(ret, req)
+        self.assertIsInstance(result, CachedTokensDetails)
+        self.assertEqual(result.device, 4)
+        self.assertEqual(result.host, 2)
+        self.assertEqual(result.storage, 6)
+        self.assertEqual(result.storage_backend, "s3")
+
+    def test_missing_device_host_default_to_zero(self):
+        req = _make_request(return_cached_tokens_details=True)
+        ret = _make_ret({"cached_tokens_details": {}})
+        result = process_cached_tokens_details_from_ret(ret, req)
+        self.assertEqual(result.device, 0)
+        self.assertEqual(result.host, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds **41 unit tests** across two new files, contributing to #20865 (Improve Unit Test Coverage) — specifically the unclaimed `srt/entrypoints/openai/` task.

**`test/registered/unit/entrypoints/openai/test_utils.py`** (23 tests)
- `to_openai_style_logprobs` — input/output token logprobs, top logprobs with `None` entries, combined, text_offset always -1
- `process_hidden_states_from_ret` — flag off, missing/None hidden states, single-state edge case (returns `[]`), multi-state (returns last)
- `process_routed_experts_from_ret` — flag off, key missing, value present, objects without the attribute
- `process_cached_tokens_details_from_ret` — flag off, None/absent details, device+host only, with L3 storage fields, missing keys default to zero

**`test/registered/unit/entrypoints/openai/test_usage_processor.py`** (18 tests)
- `calculate_token_usage` — basic totals, total = prompt + completion, with/without cached details, zero tokens
- `calculate_response_usage` — single response, multiple responses, n_choices=2 (only first of each pair counted for prompt), cache report on/off, zero cached tokens
- `calculate_streaming_usage` — basic, n_choices=2 (even-index-only prompt counting), cache report on/off, zero cached tokens

All tests run on **CPU only** — no server launched, no model weights loaded. `sgl_kernel` is stubbed out for portability.

## Test run output

```
pytest test/registered/unit/entrypoints/openai/test_utils.py \
       test/registered/unit/entrypoints/openai/test_usage_processor.py -v

============================= test session starts ==============================
collected 41 items
...
============================== 41 passed in 0.47s ==============================
```

## Checklist

- [x] Test is in `test/registered/unit/entrypoints/openai/` (mirrors `srt/entrypoints/openai/`)
- [x] Does NOT launch a server or load real model weights
- [x] Includes edge cases, not just happy paths
- [x] Registered with `register_cpu_ci(est_time=5, suite="stage-a-cpu-only")`
- [x] Locally tested and passing

Closes part of #20865