### PR TITLE
[CI] Add cross-job fast-fail health check (Layer 3)

### DIFF
--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -1,5 +1,5 @@
 name: Check Stage Health
-description: Fail fast if any job in the current workflow run has already failed.
+description: Fail fast if any job in the current workflow run has already failed. Auto-skips for scheduled runs.
 
 inputs:
   github-token:
@@ -15,6 +15,12 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
+          // Skip for scheduled runs — they should collect all failures, not fast-fail
+          if (context.eventName === 'schedule') {
+            core.info('Skipping health check for scheduled run');
+            return;
+          }
+
           const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -1,0 +1,36 @@
+name: Check Stage Health
+description: Check if any job in the current workflow run has failed. Sets output healthy=true/false. Always succeeds.
+
+inputs:
+  github-token:
+    description: 'GitHub token for API calls'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  healthy:
+    description: '"true" if no job has failed, "false" otherwise'
+    value: ${{ steps.check.outputs.healthy }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check stage health
+      id: check
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+            per_page: 100,
+          });
+          const failed = jobs.filter(j => j.status === 'completed' && j.conclusion === 'failure');
+          if (failed.length > 0) {
+            core.warning(`Fast-fail: skipping — failed job(s): ${failed.map(j => j.name).join(', ')}`);
+            core.setOutput('healthy', 'false');
+          } else {
+            core.setOutput('healthy', 'true');
+          }

--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -21,7 +21,13 @@ runs:
             run_id: context.runId,
             per_page: 100,
           });
-          const failed = jobs.filter(j => j.status === 'completed' && j.conclusion === 'failure');
-          if (failed.length > 0) {
-            core.setFailed(`Fast-fail: skipping — failed job(s): ${failed.map(j => j.name).join(', ')}`);
+          // Find jobs that failed from a real error, not from fast-fail cascade
+          const rootCauseFailures = jobs.filter(j => {
+            if (j.status !== 'completed' || j.conclusion !== 'failure') return false;
+            // If the failing step is "Check stage health", it's a cascade — skip it
+            const failedStep = (j.steps || []).find(s => s.conclusion === 'failure');
+            return !failedStep || failedStep.name !== 'Check stage health';
+          });
+          if (rootCauseFailures.length > 0) {
+            core.setFailed(`Fast-fail: skipping — root cause job(s): ${rootCauseFailures.map(j => j.name).join(', ')}`);
           }

--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -24,9 +24,12 @@ runs:
           // Find jobs that failed from a real error, not from fast-fail cascade
           const rootCauseFailures = jobs.filter(j => {
             if (j.status !== 'completed' || j.conclusion !== 'failure') return false;
-            // If the failing step is "Check stage health", it's a cascade — skip it
+            // If the failing step is the health check, it's a cascade — skip it
             const failedStep = (j.steps || []).find(s => s.conclusion === 'failure');
-            return !failedStep || failedStep.name !== 'Check stage health';
+            if (failedStep && (failedStep.name.includes('check-stage-health') || failedStep.name.includes('Check stage health'))) {
+              return false;
+            }
+            return true;
           });
           if (rootCauseFailures.length > 0) {
             core.setFailed(`Fast-fail: skipping — root cause job(s): ${rootCauseFailures.map(j => j.name).join(', ')}`);

--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -1,5 +1,5 @@
 name: Check Stage Health
-description: Check if any job in the current workflow run has failed. Sets output healthy=true/false. Always succeeds.
+description: Fail fast if any job in the current workflow run has already failed.
 
 inputs:
   github-token:
@@ -7,16 +7,10 @@ inputs:
     required: false
     default: ${{ github.token }}
 
-outputs:
-  healthy:
-    description: '"true" if no job has failed, "false" otherwise'
-    value: ${{ steps.check.outputs.healthy }}
-
 runs:
   using: composite
   steps:
     - name: Check stage health
-      id: check
       uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github-token }}
@@ -29,8 +23,5 @@ runs:
           });
           const failed = jobs.filter(j => j.status === 'completed' && j.conclusion === 'failure');
           if (failed.length > 0) {
-            core.warning(`Fast-fail: skipping — failed job(s): ${failed.map(j => j.name).join(', ')}`);
-            core.setOutput('healthy', 'false');
-          } else {
-            core.setOutput('healthy', 'true');
+            core.setFailed(`Fast-fail: skipping — failed job(s): ${failed.map(j => j.name).join(', ')}`);
           }

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -18,7 +18,7 @@ inputs:
   poll-interval-seconds:
     description: 'Seconds between polling attempts'
     required: false
-    default: '120'
+    default: '30'
   github-token:
     description: 'GitHub token for API calls'
     required: false

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -18,7 +18,7 @@ inputs:
   poll-interval-seconds:
     description: 'Seconds between polling attempts'
     required: false
-    default: '30'
+    default: '120'
   github-token:
     description: 'GitHub token for API calls'
     required: false

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -48,18 +48,15 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd test/
@@ -81,18 +78,15 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run benchmark tests
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 45
         run: |
           cd test/

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -44,16 +44,22 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd test/
@@ -71,16 +77,22 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run benchmark tests
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 45
         run: |
           cd test/

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -62,12 +62,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: inputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -75,10 +79,12 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
       - name: Run diffusion server tests
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 240
         env:
           RUNAI_STREAMER_MEMORY_LIMIT: 0
@@ -92,7 +98,7 @@ jobs:
             $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -116,12 +122,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: inputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -129,11 +139,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run diffusion server tests
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 240
         env:
           RUNAI_STREAMER_MEMORY_LIMIT: 0
@@ -147,7 +159,7 @@ jobs:
             $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -167,12 +179,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: inputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -180,11 +196,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run diffusion unit tests
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 60
         run: |
           cd python

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -66,12 +66,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && inputs.sgl_kernel == 'true'
+        if: inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -79,12 +78,10 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
       - name: Run diffusion server tests
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 240
         env:
           RUNAI_STREAMER_MEMORY_LIMIT: 0
@@ -98,7 +95,7 @@ jobs:
             $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -126,12 +123,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && inputs.sgl_kernel == 'true'
+        if: inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -139,13 +135,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run diffusion server tests
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 240
         env:
           RUNAI_STREAMER_MEMORY_LIMIT: 0
@@ -159,7 +153,7 @@ jobs:
             $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -183,12 +177,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && inputs.sgl_kernel == 'true'
+        if: inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -196,13 +189,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run diffusion unit tests
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 60
         run: |
           cd python

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -34,16 +34,22 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
+        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
+        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -51,11 +57,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd sgl-kernel
@@ -69,16 +77,22 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
+        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
+        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -86,11 +100,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd test/registered/mla
@@ -104,16 +120,22 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
+        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
+        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -121,11 +143,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run benchmark tests
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 45
         run: |
           cd sgl-kernel/benchmark
@@ -151,16 +175,22 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
+        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
+        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -168,11 +198,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run sgl-kernel unit tests on B200
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd sgl-kernel

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -38,18 +38,15 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
-        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -57,13 +54,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd sgl-kernel
@@ -81,18 +76,15 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
-        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -100,13 +92,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd test/registered/mla
@@ -124,18 +114,15 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
-        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -143,13 +130,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run benchmark tests
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 45
         run: |
           cd sgl-kernel/benchmark
@@ -179,18 +164,15 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Cleanup
-        if: steps.stage-health.outputs.healthy == 'true'
         run: |
           ls -alh sgl-kernel/dist || true
           rm -rf sgl-kernel/dist/* || true
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -198,13 +180,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run sgl-kernel unit tests on B200
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         run: |
           cd sgl-kernel

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -679,10 +679,14 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - name: "[TEST] Deliberate failure for fast-fail testing"
-        if: matrix.partition == 0
+        if: matrix.partition == 0 || matrix.partition == 1
         run: |
-          echo "Deliberately failing partition 0 to test fast-fail"
+          echo "Deliberately failing partition ${{ matrix.partition }} to test fast-fail"
           exit 1
+
+      - name: "[TEST] Delay to let failures propagate"
+        if: matrix.partition != 0 && matrix.partition != 1
+        run: sleep 120
 
       - uses: ./.github/actions/check-stage-health
         id: stage-health

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -565,12 +565,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -578,11 +582,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 10
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -591,7 +597,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-a-test-1-gpu-small $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
 
   stage-a-test-cpu:
     needs: [check-changes, call-gate]
@@ -618,20 +624,27 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Set up Python
+        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: Install uv
+        if: steps.stage-health.outputs.healthy == 'true'
         uses: astral-sh/setup-uv@v5
 
       # uv pip targets a venv by default; setup-python has no venv — install into that interpreter (see UV_SYSTEM_PYTHON in https://docs.astral.sh/uv/guides/integration/github/)
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         env:
           UV_SYSTEM_PYTHON: "1"
@@ -639,6 +652,7 @@ jobs:
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 10
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -672,12 +686,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -685,6 +703,7 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           source /etc/profile.d/sglang-ci.sh
@@ -694,6 +713,7 @@ jobs:
           pip install -e . --no-build-isolation
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -703,7 +723,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-1-gpu-small --auto-partition-id ${{ matrix.partition }} --auto-partition-size 8 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.partition }}
 
@@ -733,12 +753,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -746,11 +770,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -759,7 +785,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-1-gpu-large --auto-partition-id ${{ matrix.partition }} --auto-partition-size 14 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.partition }}
 
@@ -787,12 +813,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -800,6 +830,7 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
@@ -808,6 +839,7 @@ jobs:
           pip install -e . --no-build-isolation
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -816,7 +848,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-2-gpu-large --auto-partition-id ${{ matrix.partition }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.partition }}
 
@@ -843,12 +875,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v6
         with:
           path: sgl-kernel/dist/
@@ -856,11 +892,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -869,12 +907,13 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-4-gpu-b200 $CONTINUE_ON_ERROR_FLAG
 
       - name: Run FA4 jit_kernel tests (SM100+)
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 10
         run: |
           python3 -m pytest -q python/sglang/jit_kernel/tests/test_flash_attention_4.py
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
 
   call-multimodal-gen-tests:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
@@ -927,12 +966,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -940,11 +983,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -953,7 +998,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-h100 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -981,12 +1026,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -994,11 +1043,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Warmup DeepGEMM JIT Compilation
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
@@ -1006,6 +1057,7 @@ jobs:
             deepseek-ai/DeepSeek-V3.2-Exp:8
 
       - name: Warmup Server CUDA Graphs
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_server.py \
@@ -1013,6 +1065,7 @@ jobs:
             inclusionAI/Ring-2.5-1T:8
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1021,7 +1074,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-8-gpu-h200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -1051,12 +1104,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1064,11 +1121,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1077,7 +1136,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-8-gpu-h20 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -1101,12 +1160,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1114,23 +1177,27 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Warmup DeepGEMM JIT Compilation
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
             lmsys/sglang-ci-dsv3-test:4
 
       - name: Warmup Server CUDA Graphs
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_server.py \
             lmsys/sglang-ci-dsv3-test:4
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1139,7 +1206,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-deepep-4-gpu-h100 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
 
   stage-c-test-deepep-8-gpu-h200:
     needs: [check-changes, call-gate, wait-for-stage-b]
@@ -1161,12 +1228,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1174,11 +1245,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Warmup DeepGEMM JIT Compilation
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
@@ -1186,12 +1259,14 @@ jobs:
             deepseek-ai/DeepSeek-V3.2-Exp:8
 
       - name: Warmup Server CUDA Graphs
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_server.py \
             deepseek-ai/DeepSeek-V3-0324:8
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 45
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1200,7 +1275,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-deepep-8-gpu-h200 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
 
   stage-c-test-4-gpu-b200:
     needs: [check-changes, call-gate, wait-for-stage-b]
@@ -1227,12 +1302,16 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - uses: ./.github/actions/check-stage-health
+        id: stage-health
+
       - uses: ./.github/actions/check-maintenance
+        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v6
         with:
           path: sgl-kernel/dist/
@@ -1240,11 +1319,13 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
+        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1253,7 +1334,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-b200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always()
+        if: always() && steps.stage-health.outputs.healthy == 'true'
         with:
           artifact-suffix: ${{ matrix.part }}
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -654,7 +654,7 @@ jobs:
 
   # Runs on 5090 (32GB, SM120)
   stage-b-test-1-gpu-small:
-    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
+    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
     if: |
       always() &&
       (
@@ -724,7 +724,7 @@ jobs:
 
   # Runs on H100 (80GB, SM90) - tests that don't pass on 5090 (FA3, FP8, high VRAM, etc.)
   stage-b-test-1-gpu-large:
-    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
+    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
     if: |
       always() &&
       (
@@ -782,7 +782,7 @@ jobs:
           artifact-suffix: ${{ matrix.partition }}
 
   stage-b-test-2-gpu-large:
-    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
+    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
     if: |
       always() &&
       (
@@ -842,7 +842,7 @@ jobs:
           artifact-suffix: ${{ matrix.partition }}
 
   stage-b-test-4-gpu-b200:
-    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
+    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
     if: |
       always() &&
       (

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -654,7 +654,7 @@ jobs:
 
   # Runs on 5090 (32GB, SM120)
   stage-b-test-1-gpu-small:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
     if: |
       always() &&
       (
@@ -678,6 +678,12 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
+      - name: "[TEST] Deliberate failure for fast-fail testing"
+        if: matrix.partition == 0
+        run: |
+          echo "Deliberately failing partition 0 to test fast-fail"
+          exit 1
+
       - uses: ./.github/actions/check-stage-health
         id: stage-health
 
@@ -692,12 +698,6 @@ jobs:
           path: sgl-kernel/dist/
           merge-multiple: true
           pattern: wheel-python3.10-cuda12.9
-
-      - name: "[TEST] Deliberate failure for fast-fail testing"
-        if: matrix.partition == 0
-        run: |
-          echo "Deliberately failing partition 0 to test fast-fail"
-          exit 1
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -724,7 +724,7 @@ jobs:
 
   # Runs on H100 (80GB, SM90) - tests that don't pass on 5090 (FA3, FP8, high VRAM, etc.)
   stage-b-test-1-gpu-large:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
     if: |
       always() &&
       (
@@ -782,7 +782,7 @@ jobs:
           artifact-suffix: ${{ matrix.partition }}
 
   stage-b-test-2-gpu-large:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
     if: |
       always() &&
       (
@@ -842,7 +842,7 @@ jobs:
           artifact-suffix: ${{ matrix.partition }}
 
   stage-b-test-4-gpu-b200:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+    needs: [check-changes, call-gate, wait-for-stage-a]  # TODO: restore sgl-kernel-build-wheels
     if: |
       always() &&
       (

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -693,6 +693,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda12.9
 
+      - name: "[TEST] Deliberate failure for fast-fail testing"
+        if: matrix.partition == 0
+        run: |
+          echo "Deliberately failing partition 0 to test fast-fail"
+          exit 1
+
       - name: Install dependencies
         timeout-minutes: 20
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -654,7 +654,7 @@ jobs:
 
   # Runs on 5090 (32GB, SM120)
   stage-b-test-1-gpu-small:
-    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
+    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
     if: |
       always() &&
       (
@@ -677,16 +677,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - name: "[TEST] Deliberate failure for fast-fail testing"
-        if: matrix.partition == 0 || matrix.partition == 1
-        run: |
-          echo "Deliberately failing partition ${{ matrix.partition }} to test fast-fail"
-          exit 1
-
-      - name: "[TEST] Delay to let failures propagate"
-        if: matrix.partition != 0 && matrix.partition != 1
-        run: sleep 120
 
       - uses: ./.github/actions/check-stage-health
         id: stage-health
@@ -728,7 +718,7 @@ jobs:
 
   # Runs on H100 (80GB, SM90) - tests that don't pass on 5090 (FA3, FP8, high VRAM, etc.)
   stage-b-test-1-gpu-large:
-    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
+    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
     if: |
       always() &&
       (
@@ -786,7 +776,7 @@ jobs:
           artifact-suffix: ${{ matrix.partition }}
 
   stage-b-test-2-gpu-large:
-    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
+    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
     if: |
       always() &&
       (
@@ -846,7 +836,7 @@ jobs:
           artifact-suffix: ${{ matrix.partition }}
 
   stage-b-test-4-gpu-b200:
-    needs: [check-changes, call-gate]  # TODO: restore wait-for-stage-a, sgl-kernel-build-wheels
+    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
     if: |
       always() &&
       (

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -569,12 +569,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -582,13 +581,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 10
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -597,7 +594,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-a-test-1-gpu-small $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
 
   stage-a-test-cpu:
     needs: [check-changes, call-gate]
@@ -628,23 +625,19 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Set up Python
-        if: steps.stage-health.outputs.healthy == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: Install uv
-        if: steps.stage-health.outputs.healthy == 'true'
         uses: astral-sh/setup-uv@v5
 
       # uv pip targets a venv by default; setup-python has no venv — install into that interpreter (see UV_SYSTEM_PYTHON in https://docs.astral.sh/uv/guides/integration/github/)
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         env:
           UV_SYSTEM_PYTHON: "1"
@@ -652,7 +645,6 @@ jobs:
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 10
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -690,12 +682,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -703,7 +694,6 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           source /etc/profile.d/sglang-ci.sh
@@ -713,7 +703,6 @@ jobs:
           pip install -e . --no-build-isolation
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -723,7 +712,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-1-gpu-small --auto-partition-id ${{ matrix.partition }} --auto-partition-size 8 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.partition }}
 
@@ -757,12 +746,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -770,13 +758,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -785,7 +771,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-1-gpu-large --auto-partition-id ${{ matrix.partition }} --auto-partition-size 14 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.partition }}
 
@@ -817,12 +803,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -830,7 +815,6 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
@@ -839,7 +823,6 @@ jobs:
           pip install -e . --no-build-isolation
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -848,7 +831,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-2-gpu-large --auto-partition-id ${{ matrix.partition }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.partition }}
 
@@ -879,12 +862,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v6
         with:
           path: sgl-kernel/dist/
@@ -892,13 +874,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -907,13 +887,12 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-b-test-4-gpu-b200 $CONTINUE_ON_ERROR_FLAG
 
       - name: Run FA4 jit_kernel tests (SM100+)
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 10
         run: |
           python3 -m pytest -q python/sglang/jit_kernel/tests/test_flash_attention_4.py
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
 
   call-multimodal-gen-tests:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
@@ -970,12 +949,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -983,13 +961,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -998,7 +974,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-h100 --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -1030,12 +1006,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1043,13 +1018,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
@@ -1057,7 +1030,6 @@ jobs:
             deepseek-ai/DeepSeek-V3.2-Exp:8
 
       - name: Warmup Server CUDA Graphs
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_server.py \
@@ -1065,7 +1037,6 @@ jobs:
             inclusionAI/Ring-2.5-1T:8
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1074,7 +1045,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-8-gpu-h200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -1108,12 +1079,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1121,13 +1091,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1136,7 +1104,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-8-gpu-h20 --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.part }}
 
@@ -1164,12 +1132,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1177,27 +1144,23 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
             lmsys/sglang-ci-dsv3-test:4
 
       - name: Warmup Server CUDA Graphs
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_server.py \
             lmsys/sglang-ci-dsv3-test:4
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1206,7 +1169,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-deepep-4-gpu-h100 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
 
   stage-c-test-deepep-8-gpu-h200:
     needs: [check-changes, call-gate, wait-for-stage-b]
@@ -1232,12 +1195,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -1245,13 +1207,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_deepep.sh
 
       - name: Warmup DeepGEMM JIT Compilation
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_deep_gemm.py \
@@ -1259,14 +1219,12 @@ jobs:
             deepseek-ai/DeepSeek-V3.2-Exp:8
 
       - name: Warmup Server CUDA Graphs
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 25
         run: |
           python3 scripts/ci/cuda/warmup_server.py \
             deepseek-ai/DeepSeek-V3-0324:8
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 45
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1275,7 +1233,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-deepep-8-gpu-h200 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
 
   stage-c-test-4-gpu-b200:
     needs: [check-changes, call-gate, wait-for-stage-b]
@@ -1306,12 +1264,11 @@ jobs:
         id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        if: steps.stage-health.outputs.healthy == 'true'
         with:
           github-token: ${{ github.token }}
 
       - name: Download artifacts
-        if: steps.stage-health.outputs.healthy == 'true' && needs.check-changes.outputs.sgl_kernel == 'true'
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v6
         with:
           path: sgl-kernel/dist/
@@ -1319,13 +1276,11 @@ jobs:
           pattern: wheel-python3.10-cuda12.9
 
       - name: Install dependencies
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 20
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
       - name: Run test
-        if: steps.stage-health.outputs.healthy == 'true'
         timeout-minutes: 30
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
@@ -1334,7 +1289,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite stage-c-test-4-gpu-b200 --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 1800 $CONTINUE_ON_ERROR_FLAG
 
       - uses: ./.github/actions/upload-cuda-coredumps
-        if: always() && steps.stage-health.outputs.healthy == 'true'
+        if: always()
         with:
           artifact-suffix: ${{ matrix.part }}
 


### PR DESCRIPTION
## Summary
- Add `check-stage-health` composite action — queries workflow run API for failed jobs, calls `core.setFailed()` with root cause job names
- Applied to all 21 stage test jobs across `pr-test.yml`, `pr-test-multimodal-gen.yml`, `pr-test-sgl-kernel.yml`, `pr-test-jit-kernel.yml`
- Filters out cascade failures: only shows root cause jobs (not jobs that failed from the health check itself)
- Auto-skips for `schedule` runs (they should collect all failures, not fast-fail)

## Key property: zero wasted CI resources
- **Running jobs are never cancelled** — they already passed the health check and continue to completion
- **Only waiting/queued jobs are affected** — when they finally get a runner, the health check takes ~2s and fails immediately, before any expensive steps (install deps, run tests)
- **No false positives** — cascade filtering ensures only root cause failures are reported, not fast-fail cascades

## Context: 4-layer fast-fail

| Layer | Mechanism | Granularity |
|-------|-----------|-------------|
| 1. method → file | `unittest -f` | PR #21330 |
| 2. file → suite | `run_unittest_files()` | Existing |
| **3. job → job** | **`check-stage-health`** | **This PR** |
| 4. stage → stage | `wait-for-stage` + `needs` | Existing |

This PR adds Layer 3 — when a job fails within a stage, other waiting jobs in the same stage (or later stages that already got a runner) detect the failure and fast-fail immediately after checkout (~5s), instead of running full install + test (~30min).

## Design decisions
- **`core.setFailed()` over step guards** — job shows red X (visible), subsequent steps naturally skip via default `if: success()`
- **Cascade filtering** — checks each failed job's `steps` array; if the failing step is `check-stage-health`, it's excluded from root cause list
- **Schedule auto-detection** — `context.eventName === 'schedule'` skips the health check; no caller input needed
- **After checkout** — composite action needs repo files; health check adds ~2s API call overhead

## Test plan
- [x] YAML validation (`yaml.safe_load`)
- [x] Tested with deliberate failure in partition 0+1 — other partitions fast-failed with correct root cause annotation
- [x] Verified cascade filtering works (fast-failed jobs excluded from root cause list)
- [x] All [TEST] commits reverted