### PR TITLE
[CI] Reduce session correctness test to 30 turns to fix flakiness

### DIFF
--- a/test/registered/sessions/test_session_latency.py
+++ b/test/registered/sessions/test_session_latency.py
@@ -424,8 +424,13 @@ class TestSessionLatency(CustomTestCase):
 
     def test_streaming_session_correctness(self):
         """Correctness test: bs=1, assert output equal + latency speedup."""
-        reg = self._run_concurrent_session(streaming=False, num_concurrent=1)
-        stm = self._run_concurrent_session(streaming=True, num_concurrent=1)
+        correctness_turns = 30
+        reg = self._run_concurrent_session(
+            streaming=False, num_concurrent=1, num_turns=correctness_turns
+        )
+        stm = self._run_concurrent_session(
+            streaming=True, num_concurrent=1, num_turns=correctness_turns
+        )
 
         _print_mode_table(reg[0], label="correctness regular")
         _print_mode_table(stm[0], label="correctness streaming")


### PR DESCRIPTION
- Reduce `test_streaming_session_correctness` from 150 to 30 turns — GPU floating-point non-determinism causes greedy decoding to diverge on long multi-turn contexts, leading to cascading mismatches (see [failed CI](https://github.com/sgl-project/sglang/actions/runs/23518261034/job/68455993786?pr=21338))
- Latency tests (`test_regular_session`, `test_streaming_session`) keep 150 turns