### PR TITLE
[Bugfix] Improve reusable Mamba prefix tracking for aligned prefills

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1739,7 +1739,29 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             return i + 1
 
         mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
-        mask = req.extend_input_len >= mamba_cache_chunk_size
+        prefix_len = len(req.prefix_indices)
+        mamba_track_seqlen_aligned = (
+            prefix_len
+            + (req.extend_input_len // mamba_cache_chunk_size) * mamba_cache_chunk_size
+        )
+        needs_first_token_logits = (
+            req.is_chunked <= 0
+            and req.sampling_params.max_new_tokens > 0
+            and not (req.return_logprob and req.logprob_start_len >= 0)
+        )
+        if (
+            needs_first_token_logits
+            and req.extend_input_len % mamba_cache_chunk_size == 0
+            and mamba_track_seqlen_aligned > prefix_len
+        ):
+            # Exact chunk-aligned Mamba states are not reusable for the next identical
+            # generation request because init_next_round_input() still leaves one prompt
+            # token uncached to obtain first-token logits. In the aligned case, track the
+            # previous chunk boundary instead so the next request can reuse almost the
+            # entire prompt without falling back to a zero-token extend.
+            mamba_track_seqlen_aligned -= mamba_cache_chunk_size
+
+        mask = mamba_track_seqlen_aligned > prefix_len
         mamba_track_mask_cpu.append(mask)
         mamba_track_indices_cpu.append(
             req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
@@ -1753,22 +1775,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # otherwise retrieved from h (i.e. unaligned).
             # We need to pass the non-aligned seqlen to the calculation. Even though
             # we pass in mamba_track_seqlen, the actual tracked seqlen is mamba_last_track_seqlen.
-            mamba_track_seqlen = len(req.prefix_indices) + req.extend_input_len
-
-            # mamba_track_seqlen_aligned/mamba_last_track_seqlen is actual tracked seqlen. Used to pass to
-            # mamba radix cache to track which seqlen this mamba state should store at.
-            mamba_track_seqlen_aligned = (
-                len(req.prefix_indices)
-                + (req.extend_input_len // mamba_cache_chunk_size)
-                * mamba_cache_chunk_size
-            )
+            mamba_track_seqlen = prefix_len + req.extend_input_len
 
             # mamba_track_fla_chunk_aligned is the aligned seqlen based on FLA_CHUNK_SIZE
             # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which can be true when
             # page_size > FLA_CHUNK_SIZE, we need to force the math calculation to retrieve the correct mamba state from h
             # by _force_track_h()
             mamba_track_fla_chunk_aligned = (
-                len(req.prefix_indices)
+                prefix_len
                 + (req.extend_input_len // FLA_CHUNK_SIZE) * FLA_CHUNK_SIZE
             )
             if mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned:
@@ -1785,10 +1799,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # track branching point in this forward if the branching point
                 # is within the current extend batch.
                 branching_seqlen_aligned_mask = (
-                    req.mamba_branching_seqlen - len(req.prefix_indices)
+                    req.mamba_branching_seqlen - prefix_len
                 ) % mamba_cache_chunk_size == 0
                 if (
-                    req.mamba_branching_seqlen > len(req.prefix_indices)
+                    req.mamba_branching_seqlen > prefix_len
                     and req.mamba_branching_seqlen < mamba_track_seqlen
                     and branching_seqlen_aligned_mask
                 ):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2147,6 +2147,12 @@ class ServerArgs:
                     "Disabling overlap schedule since mamba no_buffer is not compatible with "
                     "overlap schedule, try to use --disable-radix-cache if overlap schedule is necessary"
                 )
+                logger.warning(
+                    "Mamba radix cache with --mamba-scheduler-strategy no_buffer does not "
+                    "track branching states, so repeated generation prompts may see little "
+                    "or no prefix-cache reuse. Use --mamba-scheduler-strategy extra_buffer "
+                    "for effective repeated-prompt prefix caching."
+                )
                 self.disable_overlap_schedule = True
                 if self.attention_backend == "trtllm_mha":
                     logger.warning(

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -4,7 +4,7 @@ import torch
 
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
 from sglang.srt.environ import envs
-from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
@@ -299,10 +299,16 @@ class TestMamba(unittest.TestCase):
         print(available_and_evictable_str(tree))
         tree.sanity_check()
 
-    def _setup_tree_and_allocator(self):
+    def _setup_tree_and_allocator(self, enable_mamba_extra_buffer: bool = False):
         """Helper to create a MambaRadixCache with allocator for testing."""
         set_global_server_args_for_scheduler(
-            ServerArgs(model_path="dummy", page_size=1)
+            ServerArgs(
+                model_path="dummy",
+                page_size=1,
+                mamba_scheduler_strategy=(
+                    "extra_buffer" if enable_mamba_extra_buffer else "no_buffer"
+                ),
+            )
         )
         size = 128
         dtype = torch.bfloat16
@@ -340,7 +346,7 @@ class TestMamba(unittest.TestCase):
             device=device,
             enable_memory_saver=False,
             cache_params=mamba2_cache_params,
-            enable_mamba_extra_buffer=False,
+            enable_mamba_extra_buffer=enable_mamba_extra_buffer,
             speculative_num_draft_tokens=3,
         )
         pool = HybridLinearKVPool(
@@ -381,10 +387,87 @@ class TestMamba(unittest.TestCase):
                 origin_input_ids=[],
                 sampling_params=sampling_params,
             )
-            req_to_token_pool.alloc([req])
+            req.req_pool_idx = req_to_token_pool.alloc([req])[0]
             return req
 
         return tree, allocator, req_to_token_pool, make_dummy_req
+
+    def test_extra_buffer_prefill_tracks_reusable_aligned_boundary(self):
+        tree, allocator, req_to_token_pool, _ = self._setup_tree_and_allocator(
+            enable_mamba_extra_buffer=True
+        )
+
+        prompt_ids = list(range(128))
+        req = Req(
+            rid="req1",
+            origin_input_text="",
+            origin_input_ids=prompt_ids,
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req.req_pool_idx = req_to_token_pool.alloc([req])[0]
+        req.init_next_round_input(tree)
+
+        batch = ScheduleBatch(reqs=[req], req_to_token_pool=req_to_token_pool)
+        mamba_track_mask_cpu = []
+        mamba_track_indices_cpu = []
+        mamba_track_seqlens_cpu = []
+        batch._mamba_radix_cache_v2_req_prepare_for_extend(
+            req,
+            mamba_track_mask_cpu,
+            mamba_track_indices_cpu,
+            mamba_track_seqlens_cpu,
+        )
+
+        assert mamba_track_mask_cpu == [True]
+        assert req.mamba_last_track_seqlen == 64
+        assert mamba_track_seqlens_cpu == [65]
+
+        kv_indices = allocator.alloc(len(req.fill_ids))
+        req_to_token_pool.req_to_token[req.req_pool_idx, : len(req.fill_ids)] = (
+            kv_indices
+        )
+        tree.cache_unfinished_req(req)
+
+        req2 = Req(
+            rid="req2",
+            origin_input_text="",
+            origin_input_ids=prompt_ids,
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req2.req_pool_idx = req_to_token_pool.alloc([req2])[0]
+        req2.init_next_round_input(tree)
+
+        assert len(req2.prefix_indices) == 64
+        assert req2.mamba_branching_seqlen is None
+
+    def test_extra_buffer_keeps_full_aligned_boundary_for_chunked_prefill(self):
+        tree, _, req_to_token_pool, _ = self._setup_tree_and_allocator(
+            enable_mamba_extra_buffer=True
+        )
+
+        req = Req(
+            rid="chunked",
+            origin_input_text="",
+            origin_input_ids=list(range(128)),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req.req_pool_idx = req_to_token_pool.alloc([req])[0]
+        req.is_chunked = 1
+        req.init_next_round_input(tree)
+
+        batch = ScheduleBatch(reqs=[req], req_to_token_pool=req_to_token_pool)
+        mamba_track_mask_cpu = []
+        mamba_track_indices_cpu = []
+        mamba_track_seqlens_cpu = []
+        batch._mamba_radix_cache_v2_req_prepare_for_extend(
+            req,
+            mamba_track_mask_cpu,
+            mamba_track_indices_cpu,
+            mamba_track_seqlens_cpu,
+        )
+
+        assert mamba_track_mask_cpu == [True]
+        assert req.mamba_last_track_seqlen == 128
 
     def test_insert_prev_prefix_len(self):
         """Test that prev_prefix_len correctly controls which KV indices are freed


### PR DESCRIPTION
## Summary
- track the previous reusable Mamba chunk boundary for aligned non-chunked generation prefills when using `extra_buffer`
- keep the existing full-boundary behavior for chunked prefills, where the current chunk must remain resumable
- warn when `no_buffer` is used with radix cache, since it cannot track branching states for repeated-prompt reuse
- add unit coverage for the aligned-prefill and chunked-prefill behaviors

## Root Cause
The reverted `max_prefix_len == input_len` fix only addressed the scheduler symptom and ran into the zero-token-extend problem. The deeper issue is that Mamba generation still needs one uncached prompt token to compute first-token logits, so an aligned full-prefix state is not directly reusable for the next identical request.

With `extra_buffer`, SGLang already has the machinery to track an alternate reusable Mamba state. The current code, however, stores the full aligned boundary for non-chunked prefills. When the next identical request asks for `input_len - 1`, that exact aligned state is too deep, so the cache falls back to splitting and misses the reusable branch.

## Fix
For non-chunked generation prefills in `extra_buffer`, when the extend length lands exactly on a Mamba cache chunk boundary, track the previous chunk boundary instead of the exact end. This preserves the current scheduler/logits contract (still at least one token to extend) while making the cached Mamba state reusable by the next identical prompt.

Chunked prefills keep the old behavior because they need the current chunk boundary to resume the same request correctly.

## Validation
- `python -m py_compile python/sglang/srt/managers/schedule_batch.py python/sglang/srt/server_args.py test/registered/unit/mem_cache/test_mamba_unittest.py`
- `python test/registered/unit/mem_cache/test_mamba_unittest.py` is blocked locally in this environment because the repo import path requires packages that are not installed here (`IPython`, and later `triton` on this machine).

## Notes
This does **not** try to make zero-token extend work. That would still need a separate design, because the current EXTEND path assumes at least one token is forwarded to obtain first-token logits.
