### PR TITLE
[Test] Add unit tests for openai entrypoints utils and usage_processor

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -2,7 +2,7 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -292,4 +292,4 @@ class TestCalculateStreamingUsage(CustomTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -2,15 +2,16 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 
 import unittest
 
 from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails, UsageInfo
 from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestDetailsIfCached(unittest.TestCase):
+class TestDetailsIfCached(CustomTestCase):
     """Tests for UsageProcessor._details_if_cached()."""
 
     def test_positive_count_returns_details(self):
@@ -30,7 +31,7 @@ class TestDetailsIfCached(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class TestCalculateTokenUsage(unittest.TestCase):
+class TestCalculateTokenUsage(CustomTestCase):
     """Tests for UsageProcessor.calculate_token_usage()."""
 
     def test_basic_usage(self):
@@ -68,7 +69,7 @@ class TestCalculateTokenUsage(unittest.TestCase):
         self.assertIsNone(result.prompt_tokens_details)
 
 
-class TestCalculateResponseUsage(unittest.TestCase):
+class TestCalculateResponseUsage(CustomTestCase):
     """Tests for UsageProcessor.calculate_response_usage()."""
 
     def _make_response(self, prompt_tokens, completion_tokens, cached_tokens=0):
@@ -176,7 +177,7 @@ class TestCalculateResponseUsage(unittest.TestCase):
         self.assertEqual(result.total_tokens, 0)
 
 
-class TestCalculateStreamingUsage(unittest.TestCase):
+class TestCalculateStreamingUsage(CustomTestCase):
     """Tests for UsageProcessor.calculate_streaming_usage()."""
 
     def test_single_choice_streaming(self):

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -1,0 +1,294 @@
+"""Unit tests for srt/entrypoints/openai/usage_processor.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails, UsageInfo
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+
+
+class TestDetailsIfCached(unittest.TestCase):
+    """Tests for UsageProcessor._details_if_cached()."""
+
+    def test_positive_count_returns_details(self):
+        """Positive cached count returns PromptTokensDetails."""
+        result = UsageProcessor._details_if_cached(10)
+        self.assertIsInstance(result, PromptTokensDetails)
+        self.assertEqual(result.cached_tokens, 10)
+
+    def test_zero_count_returns_none(self):
+        """Zero cached count returns None (keeps JSON slim)."""
+        result = UsageProcessor._details_if_cached(0)
+        self.assertIsNone(result)
+
+    def test_negative_count_returns_none(self):
+        """Negative cached count returns None."""
+        result = UsageProcessor._details_if_cached(-1)
+        self.assertIsNone(result)
+
+
+class TestCalculateTokenUsage(unittest.TestCase):
+    """Tests for UsageProcessor.calculate_token_usage()."""
+
+    def test_basic_usage(self):
+        """Basic prompt + completion tokens are summed correctly."""
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=100, completion_tokens=50
+        )
+        self.assertIsInstance(result, UsageInfo)
+        self.assertEqual(result.prompt_tokens, 100)
+        self.assertEqual(result.completion_tokens, 50)
+        self.assertEqual(result.total_tokens, 150)
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_zero_tokens(self):
+        """Zero tokens for both fields."""
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=0, completion_tokens=0
+        )
+        self.assertEqual(result.total_tokens, 0)
+
+    def test_with_cached_tokens(self):
+        """Cached tokens details are included when provided."""
+        cached = PromptTokensDetails(cached_tokens=30)
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=100, completion_tokens=50, cached_tokens=cached
+        )
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 30)
+
+    def test_without_cached_tokens(self):
+        """No cached_tokens argument means None prompt_tokens_details."""
+        result = UsageProcessor.calculate_token_usage(
+            prompt_tokens=10, completion_tokens=5
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+
+class TestCalculateResponseUsage(unittest.TestCase):
+    """Tests for UsageProcessor.calculate_response_usage()."""
+
+    def _make_response(self, prompt_tokens, completion_tokens, cached_tokens=0):
+        return {
+            "meta_info": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "cached_tokens": cached_tokens,
+            }
+        }
+
+    def test_single_response(self):
+        """Single response with n_choices=1."""
+        responses = [self._make_response(50, 20)]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+
+        self.assertEqual(result.prompt_tokens, 50)
+        self.assertEqual(result.completion_tokens, 20)
+        self.assertEqual(result.total_tokens, 70)
+
+    def test_multiple_responses_single_choice(self):
+        """Multiple responses each with n_choices=1 sums all prompts and completions."""
+        responses = [
+            self._make_response(50, 20),
+            self._make_response(30, 10),
+        ]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+
+        self.assertEqual(result.prompt_tokens, 80)
+        self.assertEqual(result.completion_tokens, 30)
+        self.assertEqual(result.total_tokens, 110)
+
+    def test_multiple_choices_prompt_counted_once_per_group(self):
+        """With n_choices=2, prompt tokens from every other response are summed."""
+        responses = [
+            self._make_response(100, 10),  # index 0 -> counted for prompt
+            self._make_response(100, 15),  # index 1 -> skipped for prompt
+        ]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+
+        # Only index 0 counted for prompt (100), both for completion (10+15)
+        self.assertEqual(result.prompt_tokens, 100)
+        self.assertEqual(result.completion_tokens, 25)
+        self.assertEqual(result.total_tokens, 125)
+
+    def test_four_responses_two_choices(self):
+        """Two prompts with n_choices=2 each -> 4 responses total."""
+        responses = [
+            self._make_response(50, 10),  # prompt 1, choice 1
+            self._make_response(50, 12),  # prompt 1, choice 2
+            self._make_response(60, 8),  # prompt 2, choice 1
+            self._make_response(60, 9),  # prompt 2, choice 2
+        ]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+
+        # prompt: index 0 (50) + index 2 (60) = 110
+        self.assertEqual(result.prompt_tokens, 110)
+        # completion: 10+12+8+9 = 39
+        self.assertEqual(result.completion_tokens, 39)
+        self.assertEqual(result.total_tokens, 149)
+
+    def test_cache_report_disabled(self):
+        """When enable_cache_report=False, no prompt_tokens_details."""
+        responses = [self._make_response(50, 20, cached_tokens=10)]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=False
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_enabled_with_cached_tokens(self):
+        """When enable_cache_report=True and cached_tokens > 0, details are included."""
+        responses = [self._make_response(50, 20, cached_tokens=15)]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=True
+        )
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 15)
+
+    def test_cache_report_enabled_zero_cached(self):
+        """When enable_cache_report=True but cached_tokens=0, details are None."""
+        responses = [self._make_response(50, 20, cached_tokens=0)]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=1, enable_cache_report=True
+        )
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_with_multiple_choices(self):
+        """Cached tokens with n_choices=2 only sums from first choice of each group."""
+        responses = [
+            self._make_response(50, 10, cached_tokens=20),
+            self._make_response(50, 12, cached_tokens=20),
+        ]
+        result = UsageProcessor.calculate_response_usage(
+            responses, n_choices=2, enable_cache_report=True
+        )
+        # Only index 0 cached_tokens (20), index 1 skipped
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 20)
+
+    def test_missing_meta_fields_default_to_zero(self):
+        """Missing prompt_tokens/completion_tokens in meta_info default to 0."""
+        responses = [{"meta_info": {}}]
+        result = UsageProcessor.calculate_response_usage(responses, n_choices=1)
+        self.assertEqual(result.prompt_tokens, 0)
+        self.assertEqual(result.completion_tokens, 0)
+        self.assertEqual(result.total_tokens, 0)
+
+
+class TestCalculateStreamingUsage(unittest.TestCase):
+    """Tests for UsageProcessor.calculate_streaming_usage()."""
+
+    def test_single_choice_streaming(self):
+        """Basic streaming usage with one choice."""
+        prompt_tokens = {0: 100}
+        completion_tokens = {0: 50}
+        cached_tokens = {0: 10}
+
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens, completion_tokens, cached_tokens, n_choices=1
+        )
+
+        self.assertEqual(result.prompt_tokens, 100)
+        self.assertEqual(result.completion_tokens, 50)
+        self.assertEqual(result.total_tokens, 150)
+        # cache report disabled by default
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_multiple_choices_prompt_dedup(self):
+        """With n_choices=2, only even-indexed entries are summed for prompt."""
+        prompt_tokens = {0: 100, 1: 100}
+        completion_tokens = {0: 20, 1: 25}
+        cached_tokens = {0: 10, 1: 10}
+
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens, completion_tokens, cached_tokens, n_choices=2
+        )
+
+        # Only index 0 for prompt (100)
+        self.assertEqual(result.prompt_tokens, 100)
+        # All completions: 20+25=45
+        self.assertEqual(result.completion_tokens, 45)
+        self.assertEqual(result.total_tokens, 145)
+
+    def test_four_entries_two_choices(self):
+        """Four entries with n_choices=2: two prompts, four completions."""
+        prompt_tokens = {0: 50, 1: 50, 2: 60, 3: 60}
+        completion_tokens = {0: 10, 1: 12, 2: 8, 3: 9}
+        cached_tokens = {0: 5, 1: 5, 2: 3, 3: 3}
+
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens, completion_tokens, cached_tokens, n_choices=2
+        )
+
+        # Prompt: index 0 (50) + index 2 (60) = 110
+        self.assertEqual(result.prompt_tokens, 110)
+        # Completion: 10+12+8+9 = 39
+        self.assertEqual(result.completion_tokens, 39)
+        self.assertEqual(result.total_tokens, 149)
+
+    def test_cache_report_enabled(self):
+        """Cached token details included when enable_cache_report=True."""
+        prompt_tokens = {0: 100}
+        completion_tokens = {0: 50}
+        cached_tokens = {0: 30}
+
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens,
+            n_choices=1,
+            enable_cache_report=True,
+        )
+
+        self.assertIsNotNone(result.prompt_tokens_details)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 30)
+
+    def test_cache_report_enabled_zero_cached(self):
+        """When enable_cache_report=True but all cached=0, details are None."""
+        prompt_tokens = {0: 100}
+        completion_tokens = {0: 50}
+        cached_tokens = {0: 0}
+
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens,
+            n_choices=1,
+            enable_cache_report=True,
+        )
+
+        self.assertIsNone(result.prompt_tokens_details)
+
+    def test_cache_report_with_multiple_choices(self):
+        """Cached tokens with n_choices=2 only sums even-indexed entries."""
+        prompt_tokens = {0: 100, 1: 100}
+        completion_tokens = {0: 20, 1: 25}
+        cached_tokens = {0: 15, 1: 15}
+
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens,
+            n_choices=2,
+            enable_cache_report=True,
+        )
+
+        # Only index 0 cached (15)
+        self.assertEqual(result.prompt_tokens_details.cached_tokens, 15)
+
+    def test_empty_dicts(self):
+        """Empty dictionaries produce zero-count usage."""
+        result = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={},
+            completion_tokens={},
+            cached_tokens={},
+            n_choices=1,
+        )
+        self.assertEqual(result.prompt_tokens, 0)
+        self.assertEqual(result.completion_tokens, 0)
+        self.assertEqual(result.total_tokens, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -2,7 +2,7 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 from unittest.mock import MagicMock

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -326,4 +326,4 @@ class TestProcessCachedTokensDetailsFromRet(CustomTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -2,7 +2,7 @@
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+register_cpu_ci(est_time=5, suite="stage-a-cpu-only")
 
 import unittest
 from unittest.mock import MagicMock
@@ -14,9 +14,10 @@ from sglang.srt.entrypoints.openai.utils import (
     process_routed_experts_from_ret,
     to_openai_style_logprobs,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
-class TestToOpenaiStyleLogprobs(unittest.TestCase):
+class TestToOpenaiStyleLogprobs(CustomTestCase):
     """Tests for to_openai_style_logprobs()."""
 
     def test_all_none_returns_empty_logprobs(self):
@@ -138,7 +139,7 @@ class TestToOpenaiStyleLogprobs(unittest.TestCase):
         self.assertEqual(result.top_logprobs, [])
 
 
-class TestProcessHiddenStatesFromRet(unittest.TestCase):
+class TestProcessHiddenStatesFromRet(CustomTestCase):
     """Tests for process_hidden_states_from_ret()."""
 
     def _make_request(self, return_hidden_states=False):
@@ -190,7 +191,7 @@ class TestProcessHiddenStatesFromRet(unittest.TestCase):
         self.assertEqual(result, [0.9])
 
 
-class TestProcessRoutedExpertsFromRet(unittest.TestCase):
+class TestProcessRoutedExpertsFromRet(CustomTestCase):
     """Tests for process_routed_experts_from_ret()."""
 
     def _make_request(self, return_routed_experts=False):
@@ -225,13 +226,13 @@ class TestProcessRoutedExpertsFromRet(unittest.TestCase):
 
     def test_attribute_not_present_returns_none(self):
         """When request has no return_routed_experts attribute, returns None."""
-        req = MagicMock(spec=[])  # empty spec, no attributes
+        req = object()  # plain object with no attributes
         ret_item = {"meta_info": {"routed_experts": "data"}}
         result = process_routed_experts_from_ret(ret_item, req)
         self.assertIsNone(result)
 
 
-class TestProcessCachedTokensDetailsFromRet(unittest.TestCase):
+class TestProcessCachedTokensDetailsFromRet(CustomTestCase):
     """Tests for process_cached_tokens_details_from_ret()."""
 
     def _make_request(self, return_cached_tokens_details=False):
@@ -318,7 +319,7 @@ class TestProcessCachedTokensDetailsFromRet(unittest.TestCase):
 
     def test_attribute_not_present_returns_none(self):
         """When request has no return_cached_tokens_details attribute, returns None."""
-        req = MagicMock(spec=[])  # empty spec, no attributes
+        req = object()  # plain object with no attributes
         ret_item = {"meta_info": {"cached_tokens_details": {"device": 1, "host": 2}}}
         result = process_cached_tokens_details_from_ret(ret_item, req)
         self.assertIsNone(result)

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -257,9 +257,7 @@ class TestProcessCachedTokensDetailsFromRet(unittest.TestCase):
 
     def test_device_and_host_only(self):
         """Without storage field, returns CachedTokensDetails with device+host."""
-        ret_item = {
-            "meta_info": {"cached_tokens_details": {"device": 100, "host": 50}}
-        }
+        ret_item = {"meta_info": {"cached_tokens_details": {"device": 100, "host": 50}}}
         result = process_cached_tokens_details_from_ret(
             ret_item, self._make_request(return_cached_tokens_details=True)
         )

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -1,0 +1,330 @@
+"""Unit tests for srt/entrypoints/openai/utils.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.entrypoints.openai.protocol import CachedTokensDetails, LogProbs
+from sglang.srt.entrypoints.openai.utils import (
+    process_cached_tokens_details_from_ret,
+    process_hidden_states_from_ret,
+    process_routed_experts_from_ret,
+    to_openai_style_logprobs,
+)
+
+
+class TestToOpenaiStyleLogprobs(unittest.TestCase):
+    """Tests for to_openai_style_logprobs()."""
+
+    def test_all_none_returns_empty_logprobs(self):
+        """All arguments None should return an empty LogProbs."""
+        result = to_openai_style_logprobs()
+        self.assertIsInstance(result, LogProbs)
+        self.assertEqual(result.tokens, [])
+        self.assertEqual(result.token_logprobs, [])
+        self.assertEqual(result.text_offset, [])
+        self.assertEqual(result.top_logprobs, [])
+
+    def test_input_token_logprobs_only(self):
+        """Input token logprobs are appended correctly."""
+        input_token_logprobs = [
+            (-0.5, 101, "hello"),
+            (-1.2, 102, " world"),
+        ]
+        result = to_openai_style_logprobs(input_token_logprobs=input_token_logprobs)
+
+        self.assertEqual(result.tokens, ["hello", " world"])
+        self.assertAlmostEqual(result.token_logprobs[0], -0.5)
+        self.assertAlmostEqual(result.token_logprobs[1], -1.2)
+        self.assertEqual(result.text_offset, [-1, -1])
+
+    def test_output_token_logprobs_only(self):
+        """Output token logprobs are appended correctly."""
+        output_token_logprobs = [
+            (-0.3, 200, "foo"),
+        ]
+        result = to_openai_style_logprobs(output_token_logprobs=output_token_logprobs)
+
+        self.assertEqual(result.tokens, ["foo"])
+        self.assertAlmostEqual(result.token_logprobs[0], -0.3)
+
+    def test_input_and_output_token_logprobs_concatenated(self):
+        """Both input and output token logprobs are concatenated in order."""
+        input_token_logprobs = [(-0.1, 1, "a")]
+        output_token_logprobs = [(-0.2, 2, "b"), (-0.3, 3, "c")]
+        result = to_openai_style_logprobs(
+            input_token_logprobs=input_token_logprobs,
+            output_token_logprobs=output_token_logprobs,
+        )
+
+        self.assertEqual(result.tokens, ["a", "b", "c"])
+        self.assertEqual(len(result.token_logprobs), 3)
+
+    def test_input_top_logprobs(self):
+        """Input top logprobs are converted to {text: logprob} dicts."""
+        input_top_logprobs = [
+            [(-0.1, 10, "x"), (-0.5, 11, "y")],
+            [(-0.2, 20, "z")],
+        ]
+        result = to_openai_style_logprobs(input_top_logprobs=input_top_logprobs)
+
+        self.assertEqual(len(result.top_logprobs), 2)
+        self.assertAlmostEqual(result.top_logprobs[0]["x"], -0.1)
+        self.assertAlmostEqual(result.top_logprobs[0]["y"], -0.5)
+        self.assertAlmostEqual(result.top_logprobs[1]["z"], -0.2)
+
+    def test_output_top_logprobs(self):
+        """Output top logprobs are converted similarly."""
+        output_top_logprobs = [
+            [(-0.4, 30, "w")],
+        ]
+        result = to_openai_style_logprobs(output_top_logprobs=output_top_logprobs)
+
+        self.assertEqual(len(result.top_logprobs), 1)
+        self.assertAlmostEqual(result.top_logprobs[0]["w"], -0.4)
+
+    def test_top_logprobs_none_entry(self):
+        """None entries in top_logprobs are preserved as None."""
+        output_top_logprobs = [
+            None,
+            [(-0.1, 1, "a")],
+        ]
+        result = to_openai_style_logprobs(output_top_logprobs=output_top_logprobs)
+
+        self.assertEqual(len(result.top_logprobs), 2)
+        self.assertIsNone(result.top_logprobs[0])
+        self.assertIsNotNone(result.top_logprobs[1])
+
+    def test_input_and_output_top_logprobs_concatenated(self):
+        """Both input and output top logprobs are concatenated."""
+        input_top_logprobs = [[(-0.1, 1, "a")]]
+        output_top_logprobs = [[(-0.2, 2, "b")]]
+        result = to_openai_style_logprobs(
+            input_top_logprobs=input_top_logprobs,
+            output_top_logprobs=output_top_logprobs,
+        )
+
+        self.assertEqual(len(result.top_logprobs), 2)
+
+    def test_all_arguments_provided(self):
+        """All four arguments provided together."""
+        input_tok = [(-0.1, 1, "in")]
+        output_tok = [(-0.2, 2, "out")]
+        input_top = [[(-0.3, 3, "top_in")]]
+        output_top = [[(-0.4, 4, "top_out")]]
+
+        result = to_openai_style_logprobs(
+            input_token_logprobs=input_tok,
+            output_token_logprobs=output_tok,
+            input_top_logprobs=input_top,
+            output_top_logprobs=output_top,
+        )
+
+        self.assertEqual(result.tokens, ["in", "out"])
+        self.assertEqual(len(result.top_logprobs), 2)
+
+    def test_empty_lists(self):
+        """Empty lists produce empty LogProbs fields."""
+        result = to_openai_style_logprobs(
+            input_token_logprobs=[],
+            output_token_logprobs=[],
+            input_top_logprobs=[],
+            output_top_logprobs=[],
+        )
+        self.assertEqual(result.tokens, [])
+        self.assertEqual(result.top_logprobs, [])
+
+
+class TestProcessHiddenStatesFromRet(unittest.TestCase):
+    """Tests for process_hidden_states_from_ret()."""
+
+    def _make_request(self, return_hidden_states=False):
+        req = MagicMock()
+        req.return_hidden_states = return_hidden_states
+        return req
+
+    def test_disabled_returns_none(self):
+        """When return_hidden_states is False, always returns None."""
+        ret_item = {"meta_info": {"hidden_states": [[0.1, 0.2]]}}
+        result = process_hidden_states_from_ret(
+            ret_item, self._make_request(return_hidden_states=False)
+        )
+        self.assertIsNone(result)
+
+    def test_no_hidden_states_in_meta_returns_none(self):
+        """When meta_info has no hidden_states key, returns None."""
+        ret_item = {"meta_info": {}}
+        result = process_hidden_states_from_ret(
+            ret_item, self._make_request(return_hidden_states=True)
+        )
+        self.assertIsNone(result)
+
+    def test_multiple_hidden_states_returns_last(self):
+        """With multiple hidden states, returns the last one."""
+        hidden = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+        ret_item = {"meta_info": {"hidden_states": hidden}}
+        result = process_hidden_states_from_ret(
+            ret_item, self._make_request(return_hidden_states=True)
+        )
+        self.assertEqual(result, [0.5, 0.6])
+
+    def test_single_hidden_state_returns_empty_list(self):
+        """With exactly one hidden state (len == 1), returns empty list."""
+        hidden = [[0.1, 0.2]]
+        ret_item = {"meta_info": {"hidden_states": hidden}}
+        result = process_hidden_states_from_ret(
+            ret_item, self._make_request(return_hidden_states=True)
+        )
+        self.assertEqual(result, [])
+
+    def test_two_hidden_states_returns_last(self):
+        """With two hidden states (len > 1), returns hidden_states[-1]."""
+        hidden = [[0.1], [0.9]]
+        ret_item = {"meta_info": {"hidden_states": hidden}}
+        result = process_hidden_states_from_ret(
+            ret_item, self._make_request(return_hidden_states=True)
+        )
+        self.assertEqual(result, [0.9])
+
+
+class TestProcessRoutedExpertsFromRet(unittest.TestCase):
+    """Tests for process_routed_experts_from_ret()."""
+
+    def _make_request(self, return_routed_experts=False):
+        req = MagicMock()
+        req.return_routed_experts = return_routed_experts
+        return req
+
+    def test_disabled_returns_none(self):
+        """When return_routed_experts is False, returns None."""
+        ret_item = {"meta_info": {"routed_experts": "some_data"}}
+        result = process_routed_experts_from_ret(
+            ret_item, self._make_request(return_routed_experts=False)
+        )
+        self.assertIsNone(result)
+
+    def test_enabled_returns_data(self):
+        """When enabled, returns the routed_experts from meta_info."""
+        expected = "expert_routing_info"
+        ret_item = {"meta_info": {"routed_experts": expected}}
+        result = process_routed_experts_from_ret(
+            ret_item, self._make_request(return_routed_experts=True)
+        )
+        self.assertEqual(result, expected)
+
+    def test_enabled_missing_key_returns_none(self):
+        """When enabled but key missing from meta_info, returns None."""
+        ret_item = {"meta_info": {}}
+        result = process_routed_experts_from_ret(
+            ret_item, self._make_request(return_routed_experts=True)
+        )
+        self.assertIsNone(result)
+
+    def test_attribute_not_present_returns_none(self):
+        """When request has no return_routed_experts attribute, returns None."""
+        req = MagicMock(spec=[])  # empty spec, no attributes
+        ret_item = {"meta_info": {"routed_experts": "data"}}
+        result = process_routed_experts_from_ret(ret_item, req)
+        self.assertIsNone(result)
+
+
+class TestProcessCachedTokensDetailsFromRet(unittest.TestCase):
+    """Tests for process_cached_tokens_details_from_ret()."""
+
+    def _make_request(self, return_cached_tokens_details=False):
+        req = MagicMock()
+        req.return_cached_tokens_details = return_cached_tokens_details
+        return req
+
+    def test_disabled_returns_none(self):
+        """When return_cached_tokens_details is False, returns None."""
+        ret_item = {"meta_info": {"cached_tokens_details": {"device": 10, "host": 5}}}
+        result = process_cached_tokens_details_from_ret(
+            ret_item, self._make_request(return_cached_tokens_details=False)
+        )
+        self.assertIsNone(result)
+
+    def test_no_details_in_meta_returns_none(self):
+        """When meta_info has no cached_tokens_details, returns None."""
+        ret_item = {"meta_info": {}}
+        result = process_cached_tokens_details_from_ret(
+            ret_item, self._make_request(return_cached_tokens_details=True)
+        )
+        self.assertIsNone(result)
+
+    def test_device_and_host_only(self):
+        """Without storage field, returns CachedTokensDetails with device+host."""
+        ret_item = {
+            "meta_info": {"cached_tokens_details": {"device": 100, "host": 50}}
+        }
+        result = process_cached_tokens_details_from_ret(
+            ret_item, self._make_request(return_cached_tokens_details=True)
+        )
+        self.assertIsInstance(result, CachedTokensDetails)
+        self.assertEqual(result.device, 100)
+        self.assertEqual(result.host, 50)
+        self.assertIsNone(result.storage)
+        self.assertIsNone(result.storage_backend)
+
+    def test_with_l3_storage_fields(self):
+        """With storage field present, returns CachedTokensDetails with all fields."""
+        ret_item = {
+            "meta_info": {
+                "cached_tokens_details": {
+                    "device": 80,
+                    "host": 20,
+                    "storage": 200,
+                    "storage_backend": "redis",
+                }
+            }
+        }
+        result = process_cached_tokens_details_from_ret(
+            ret_item, self._make_request(return_cached_tokens_details=True)
+        )
+        self.assertIsInstance(result, CachedTokensDetails)
+        self.assertEqual(result.device, 80)
+        self.assertEqual(result.host, 20)
+        self.assertEqual(result.storage, 200)
+        self.assertEqual(result.storage_backend, "redis")
+
+    def test_missing_device_host_defaults_to_zero(self):
+        """When device/host keys are missing, they default to 0."""
+        ret_item = {"meta_info": {"cached_tokens_details": {}}}
+        result = process_cached_tokens_details_from_ret(
+            ret_item, self._make_request(return_cached_tokens_details=True)
+        )
+        self.assertIsInstance(result, CachedTokensDetails)
+        self.assertEqual(result.device, 0)
+        self.assertEqual(result.host, 0)
+
+    def test_storage_present_but_zero(self):
+        """Storage field present with value 0 still includes storage."""
+        ret_item = {
+            "meta_info": {
+                "cached_tokens_details": {
+                    "device": 10,
+                    "host": 5,
+                    "storage": 0,
+                    "storage_backend": "disk",
+                }
+            }
+        }
+        result = process_cached_tokens_details_from_ret(
+            ret_item, self._make_request(return_cached_tokens_details=True)
+        )
+        self.assertEqual(result.storage, 0)
+        self.assertEqual(result.storage_backend, "disk")
+
+    def test_attribute_not_present_returns_none(self):
+        """When request has no return_cached_tokens_details attribute, returns None."""
+        req = MagicMock(spec=[])  # empty spec, no attributes
+        ret_item = {"meta_info": {"cached_tokens_details": {"device": 1, "host": 2}}}
+        result = process_cached_tokens_details_from_ret(ret_item, req)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Addresses part of #20865 — specifically the `srt/entrypoints/openai/` task listed under "Easy (good first issue)".

The `utils.py` and `usage_processor.py` modules in `srt/entrypoints/openai/` contain pure utility functions with zero unit test coverage. These functions handle OpenAI-compatible logprob formatting, hidden states extraction, routed experts extraction, cached token details processing, and token usage calculation — all critical for API response correctness.

## Modifications

Added two new test files with 49 total tests:

**`test/registered/unit/entrypoints/openai/test_utils.py`** (26 tests):
- `TestToOpenaiStyleLogprobs` — input/output token logprobs, top logprobs, None entries, empty lists, all combinations
- `TestProcessHiddenStatesFromRet` — disabled flag, missing keys, single vs multiple hidden states, last-element extraction
- `TestProcessRoutedExpertsFromRet` — enabled/disabled, missing keys, missing attribute (getattr fallback)
- `TestProcessCachedTokensDetailsFromRet` — device+host only, L3 storage fields, defaults to zero, missing attribute

**`test/registered/unit/entrypoints/openai/test_usage_processor.py`** (23 tests):
- `TestDetailsIfCached` — positive/zero/negative count boundary
- `TestCalculateTokenUsage` — basic usage, zero tokens, with/without cached details
- `TestCalculateResponseUsage` — single/multiple responses, n_choices prompt deduplication, cache report enabled/disabled, missing meta fields
- `TestCalculateStreamingUsage` — single/multiple choices, prompt dedup with streaming maps, cache report, empty dicts

All tests run without server or model weights. Registered for CPU CI (`stage-a-test-cpu`).

## Test plan

- [x] `pytest test/registered/unit/entrypoints/openai/test_utils.py -v` — 26/26 passed
- [x] `pytest test/registered/unit/entrypoints/openai/test_usage_processor.py -v` — 23/23 passed
- [x] Tests follow existing patterns (see `test_serving_embedding.py`, `test_sampling_params.py`)
- [x] No server launch, no model loading, no GPU required