### PR TITLE
[Bugfix] Remove unreachable top_k == -1 check in SamplingParams.verify()

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -111,9 +111,11 @@ class SamplingParams:
             raise ValueError(f"top_p must be in (0, 1], got {self.top_p}.")
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError(f"min_p must be in [0, 1], got {self.min_p}.")
-        if self.top_k < 1 or self.top_k == -1:
+        if self.top_k < 1:
             raise ValueError(
-                f"top_k must be -1 (disable) or at least 1, got {self.top_k}."
+                f"top_k must be at least 1, got {self.top_k}. "
+                f"Note: top_k=-1 is also accepted as input, which disables top_k filtering "
+                f"(equivalent to top_k={TOP_K_ALL} internally)."
             )
         if not -2.0 <= self.frequency_penalty <= 2.0:
             raise ValueError(


### PR DESCRIPTION
## Summary

Fixes #21353

The `verify()` method in `SamplingParams` contains an unreachable condition `self.top_k == -1` that can never be triggered, along with a misleading error message.

## Root Cause

In `__init__`, `top_k=-1` is already converted to `TOP_K_ALL` (= `1 << 30 = 1073741824`) **before** `verify()` is ever called:

```python
# In __init__ (lines 102-103):
if self.top_k == -1:
    self.top_k = TOP_K_ALL  # whole vocabulary
```

Since `verify()` is only called after `__init__` completes (in `tokenizer_manager.py` line 950), the condition `self.top_k == -1` in `verify()` is **dead code** — it can never evaluate to `True`.

The old error message `"top_k must be -1 (disable) or at least 1"` was also misleading since at verify-time the `-1` value is no longer present.

## Changes

**File:** `python/sglang/srt/sampling/sampling_params.py`

**Before:**
```python
if self.top_k < 1 or self.top_k == -1:
    raise ValueError(
        f"top_k must be -1 (disable) or at least 1, got {self.top_k}."
    )
```

**After:**
```python
if self.top_k < 1:
    raise ValueError(
        f"top_k must be at least 1, got {self.top_k}. "
        f"Note: top_k=-1 is also accepted as input, which disables top_k filtering "
        f"(equivalent to top_k={TOP_K_ALL} internally)."
    )
```

## Testing

This is a dead-code removal fix with no behavioral change for valid inputs.
- The condition `self.top_k < 1` still correctly catches invalid `top_k` values (0, negative values other than -1 which would have been caught by the `< 1` condition anyway)
- The only unreachable case removed is `top_k == -1`, which is normalized to `TOP_K_ALL` in `__init__` before `verify()` is called

## Checklist

- [x] I have read the [contributor guide](https://github.com/sgl-project/sglang/blob/main/CONTRIBUTING.md)
- [x] The change is minimal and focused on the bug fix
- [x] The fix is correct (dead code removal with improved error message)