### PR TITLE
[AMD] Fix CI: correct stage-b job dependency names in AMD CI workflows

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -777,7 +777,7 @@ jobs:
 
 
   stage-c-test-4-gpu-amd:
-    needs: [check-changes, stage-b-test-small-1-gpu-amd, stage-b-test-large-2-gpu-amd]
+    needs: [check-changes, stage-b-test-1-gpu-small-amd, stage-b-test-2-gpu-large-amd]
     if: |
       always() &&
       (

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -780,7 +780,7 @@ jobs:
 
 
   stage-c-test-4-gpu-amd:
-    needs: [check-changes, call-gate, stage-b-test-small-1-gpu-amd, stage-b-test-large-2-gpu-amd]
+    needs: [check-changes, call-gate, stage-b-test-1-gpu-small-amd, stage-b-test-2-gpu-large-amd]
     if: |
       always() &&
       (


### PR DESCRIPTION
## Motivation

The `stage-c-test-4-gpu-amd` job references stage-b jobs by incorrect names, causing CI dependency resolution to fail silently or skip the stage-c job entirely.

## Modifications

Update the `needs` list in `stage-c-test-4-gpu-amd` to match the actual stage-b job IDs:

- `stage-b-test-small-1-gpu-amd` → `stage-b-test-1-gpu-small-amd`
- `stage-b-test-large-2-gpu-amd` → `stage-b-test-2-gpu-large-amd`

Affected files:
- `.github/workflows/pr-test-amd.yml`
- `.github/workflows/pr-test-amd-rocm720.yml`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.