### PR TITLE
[core] fix: remove unreachable top_k == -1 check in SamplingParams.verify()

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -111,9 +111,11 @@ class SamplingParams:
             raise ValueError(f"top_p must be in (0, 1], got {self.top_p}.")
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError(f"min_p must be in [0, 1], got {self.min_p}.")
-        if self.top_k < 1 or self.top_k == -1:
+        if self.top_k < 1:
             raise ValueError(
-                f"top_k must be -1 (disable) or at least 1, got {self.top_k}."
+                f"top_k must be at least 1, got {self.top_k}. "
+                f"Note: top_k=-1 is also accepted as input, which disables top_k filtering "
+                f"(equivalent to top_k={TOP_K_ALL} internally)."
             )
         if not -2.0 <= self.frequency_penalty <= 2.0:
             raise ValueError(


### PR DESCRIPTION
## Summary

Fixes #21353

Remove unreachable dead code in `SamplingParams.verify()`:
- `top_k == -1` check is unreachable because `__init__` converts `-1` to `TOP_K_ALL` before `verify()` is called
- Updated error message to clarify that `top_k=-1` is accepted as input

## Changes

**Before:**
```python
if self.top_k < 1 or self.top_k == -1:
    raise ValueError(
        f"top_k must be -1 (disable) or at least 1, got {self.top_k}."
    )
```

**After:**
```python
if self.top_k < 1:
    raise ValueError(
        f"top_k must be at least 1, got {self.top_k}. "
        f"Note: top_k=-1 is also accepted as input, which disables top_k filtering "
        f"(equivalent to top_k={TOP_K_ALL} internally)."
    )
```

## Test Plan

- No functional change (dead code removal)
- Existing tests should pass