### PR TITLE
[CI] Add `include_high_priority` checkbox to cancel workflow

### DIFF
--- a/.github/workflows/cancel-unfinished-pr-tests.yml
+++ b/.github/workflows/cancel-unfinished-pr-tests.yml
@@ -129,6 +129,11 @@ jobs:
                 labels=$(gh pr view "$pr_number" --repo "$REPO" --json labels \
                   | jq -r '.labels[].name' 2>/dev/null || true)
 
+                if echo "$labels" | grep -Fxq "ci maintain"; then
+                  echo "  🛑 Skipping (ci maintain label, never cancelled)"
+                  continue
+                fi
+
                 if echo "$labels" | grep -Fxq "high priority"; then
                   if [ "$INCLUDE_HIGH_PRIORITY" != "true" ]; then
                     echo "  🛑 Skipping (high priority label)"

--- a/.github/workflows/cancel-unfinished-pr-tests.yml
+++ b/.github/workflows/cancel-unfinished-pr-tests.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: string
         default: 'pr-test.yml'
+      include_high_priority:
+        description: 'Also cancel runs from high-priority PRs'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: write   # Needed to cancel runs
@@ -26,6 +31,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           WORKFLOWS: ${{ github.event.inputs.workflows || 'pr-test.yml' }}
+          INCLUDE_HIGH_PRIORITY: ${{ github.event.inputs.include_high_priority || 'false' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -124,8 +130,11 @@ jobs:
                   | jq -r '.labels[].name' 2>/dev/null || true)
 
                 if echo "$labels" | grep -Fxq "high priority"; then
-                  echo "  🛑 Skipping (high priority label)"
-                  continue
+                  if [ "$INCLUDE_HIGH_PRIORITY" != "true" ]; then
+                    echo "  🛑 Skipping (high priority label)"
+                    continue
+                  fi
+                  echo "  ⚠️  High priority PR, but include_high_priority is enabled"
                 fi
 
                 echo "  🚫 Cancelling..."


### PR DESCRIPTION
CI maintenance tool for clearing stuck/queued PR test runs during resource contention.

- Add `include_high_priority` boolean checkbox to workflow dispatch UI — when checked, also cancels runs from high-priority PRs (default: skip them)
- PRs with `bypass-maintenance` label are never cancelled regardless of settings