### PR TITLE
[GGUF Kernel] Remove artificial 255 expert limit to support models with more experts

### DIFF
--- a/sgl-kernel/csrc/quantization/gguf/moe.cuh
+++ b/sgl-kernel/csrc/quantization/gguf/moe.cuh
@@ -49,7 +49,7 @@ static __device__ __forceinline__ void moe_q(
   }
 
   const int exp_idx = expert_ids[blockIdx.y];
-  if (exp_idx > 255 || exp_idx < 0) return;
+  if (exp_idx < 0) return;
   if (blockIdx.y * mmq_x > num_tokens_post_padded[0]) return;
 
   const block_q_t* x = (const block_q_t*)((char*)vx + exp_idx * exp_stride);


### PR DESCRIPTION
 
Fix memory access error when the model has more than 255 experts. The current check `if (exp_idx > 255 || exp_idx < 0) return;` incorrectly limits expert indices to 255, causing access failures for models with larger expert counts (e.g., 256+ experts). This limitation is unnecessary as the expert ID can be larger than 255.
 
Remove the redundant upper bound check on expert index. Change from:
 
```
if (exp_idx > 255 || exp_idx < 0) return;
to
if (exp_idx < 0) return;
 
```