### PR TITLE
[Misc] Improve server startup log with model info and colored output

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1936,13 +1936,12 @@ def _wait_and_warmup(
     # The server is ready for requests
     scheme = "https" if server_args.ssl_certfile else "http"
     logger.info(
-        "\n"
-        "----------------------------------------------\n"
-        "  SGLang Server Ready!\n"
+        f"\n----------------------------------------------\n"
+        f"  SGLang Server Ready!\n"
         f"  Model:    {server_args.served_model_name}\n"
         f"  API:      {scheme}://{server_args.host}:{server_args.port}\n"
         f"  TP: {server_args.tp_size}, DP: {server_args.dp_size}\n"
-        "----------------------------------------------"
+        f"----------------------------------------------"
     )
 
     if server_args.delete_ckpt_after_loading:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1934,7 +1934,16 @@ def _wait_and_warmup(
         _global_state.tokenizer_manager.server_status = ServerStatus.Up
 
     # The server is ready for requests
-    logger.info("The server is fired up and ready to roll!")
+    scheme = "https" if server_args.ssl_certfile else "http"
+    logger.info(
+        "\n"
+        "----------------------------------------------\n"
+        "  SGLang Server Ready!\n"
+        f"  Model:    {server_args.served_model_name}\n"
+        f"  API:      {scheme}://{server_args.host}:{server_args.port}\n"
+        f"  TP: {server_args.tp_size}, DP: {server_args.dp_size}\n"
+        "----------------------------------------------"
+    )
 
     if server_args.delete_ckpt_after_loading:
         delete_directory(server_args.model_path)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1121,8 +1121,8 @@ def configure_logger(server_args, prefix: str = ""):
     level = getattr(logging, server_args.log_level.upper())
 
     # Use colored formatter for terminal output
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(_ColoredFormatter(fmt, datefmt=datefmt, stream=sys.stdout))
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(_ColoredFormatter(fmt, datefmt=datefmt, stream=sys.stderr))
     logging.basicConfig(
         level=level,
         handlers=[handler],

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1075,6 +1075,35 @@ def rank0_log(msg: str):
         logger.info(msg)
 
 
+class _ColoredFormatter(logging.Formatter):
+    """A logging formatter that adds color to ERROR and WARNING levels.
+
+    Only applies color when the output stream is a terminal (isatty).
+    Adapted from sglang.multimodal_gen.runtime.utils.logging_utils.ColoredFormatter.
+    """
+
+    _RED = "\033[91m"
+    _YELLOW = "\033[93m"
+    _RESET = "\033[0;0m"
+
+    LEVEL_COLORS = {
+        logging.ERROR: _RED,
+        logging.WARNING: _YELLOW,
+    }
+
+    def __init__(self, *args, stream=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._use_color = hasattr(stream, "isatty") and stream.isatty()
+
+    def format(self, record: logging.LogRecord) -> str:
+        formatted = super().format(record)
+        if self._use_color:
+            color = self.LEVEL_COLORS.get(record.levelno)
+            if color:
+                formatted = f"{color}{formatted}{self._RESET}"
+        return formatted
+
+
 def configure_logger(server_args, prefix: str = ""):
     if SGLANG_LOGGING_CONFIG_PATH := os.getenv("SGLANG_LOGGING_CONFIG_PATH"):
         if not os.path.exists(SGLANG_LOGGING_CONFIG_PATH):
@@ -1087,11 +1116,16 @@ def configure_logger(server_args, prefix: str = ""):
         logging.config.dictConfig(custom_config)
         return
     maybe_ms = ".%(msecs)03d" if envs.SGLANG_LOG_MS.get() else ""
-    format = f"[%(asctime)s{maybe_ms}{prefix}] %(message)s"
+    fmt = f"[%(asctime)s{maybe_ms}{prefix}] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    level = getattr(logging, server_args.log_level.upper())
+
+    # Use colored formatter for terminal output
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(_ColoredFormatter(fmt, datefmt=datefmt, stream=sys.stdout))
     logging.basicConfig(
-        level=getattr(logging, server_args.log_level.upper()),
-        format=format,
-        datefmt="%Y-%m-%d %H:%M:%S",
+        level=level,
+        handlers=[handler],
         force=True,
     )
 


### PR DESCRIPTION
## Summary

- **Structured startup banner**: Replace the generic `"The server is fired up and ready to roll!"` message with a structured banner showing model name, API URL (with SSL detection), TP/DP configuration
- **Colored log output**: Add `_ColoredFormatter` to `configure_logger()` — ERROR messages in red, WARNING in yellow. Only applies color when output is a terminal (`isatty()` check), so file logs and piped output are unaffected
- Does not affect custom logging config via `SGLANG_LOGGING_CONFIG_PATH`

## Before / After

### Before

Server startup with Qwen3-8B on NVIDIA A800-SXM4-80GB:

```
[2026-03-25 15:41:48] INFO:     Application startup complete.
[2026-03-25 15:41:48] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-03-25 15:41:49] INFO:     127.0.0.1:10002 - "GET /model_info HTTP/1.1" 200 OK
[2026-03-25 15:42:05] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0
[2026-03-25 15:42:05] INFO:     127.0.0.1:10004 - "POST /generate HTTP/1.1" 200 OK
[2026-03-25 15:42:05] The server is fired up and ready to roll!
```

### After

```
[2026-03-25 15:43:54] INFO:     127.0.0.1:10002 - "GET /model_info HTTP/1.1" 200 OK
[2026-03-25 15:43:54] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0
[2026-03-25 15:43:54] INFO:     127.0.0.1:10004 - "POST /generate HTTP/1.1" 200 OK
[2026-03-25 15:43:54]
----------------------------------------------
  SGLang Server Ready!
  Model:    /ssd1/models/Qwen3-8B
  API:      http://127.0.0.1:30000
  TP: 1, DP: 1
----------------------------------------------
```

Additionally, ERROR and WARNING log lines are now colored (red and yellow respectively) in terminal output.

## Changes

| File | Change |
|------|--------|
| `python/sglang/srt/entrypoints/http_server.py` | Structured startup banner in `_wait_and_warmup()` |
| `python/sglang/srt/utils/common.py` | Added `_ColoredFormatter` class and integrated into `configure_logger()` |

## Design Notes

- `_ColoredFormatter` is adapted from the existing `ColoredFormatter` in `sglang.multimodal_gen.runtime.utils.logging_utils` (diffusion module), keeping the same ANSI color codes
- No new dependencies — uses standard ANSI escape codes
- `isatty()` check ensures colors don't leak into log files or piped output
- SSL-aware URL display (`https://` when `ssl_certfile` is set)

## Test plan

- [x] All 375 existing unit tests pass (`pytest test/registered/unit/`)
- [x] `_ColoredFormatter` import and basic functionality verified
- [x] End-to-end server startup with Qwen3-8B on A800 — banner displays correctly
- [x] Code passes `ruff check` and `black --check` (no new lint issues)
- [x] Failures in full test suite are pre-existing flaky tests (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)