### PR TITLE
[Misc] Replace generic Exception with specific exception types in CLI

### DIFF
--- a/python/sglang/cli/generate.py
+++ b/python/sglang/cli/generate.py
@@ -28,6 +28,6 @@ def generate(args, extra_argv):
         parsed_args, unknown_args = parser.parse_known_args(extra_argv)
         generate_cmd(parsed_args, unknown_args)
     else:
-        raise Exception(
+        raise NotImplementedError(
             f"Generate subcommand is not yet supported for model: {model_path}"
         )

--- a/python/sglang/cli/serve.py
+++ b/python/sglang/cli/serve.py
@@ -22,7 +22,7 @@ def _extract_model_type_override(extra_argv):
         arg = extra_argv[i]
         if arg == "--model-type":
             if i + 1 >= len(extra_argv):
-                raise Exception(
+                raise ValueError(
                     "Error: --model-type requires a value. "
                     "Valid values are: auto, llm, diffusion."
                 )
@@ -39,7 +39,7 @@ def _extract_model_type_override(extra_argv):
         i += 1
 
     if model_type not in ("auto", "llm", "diffusion"):
-        raise Exception(
+        raise ValueError(
             f"Error: invalid --model-type '{model_type}'. "
             "Valid values are: auto, llm, diffusion."
         )

--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -77,13 +77,13 @@ def get_model_path(extra_argv):
     if model_path is None:
         # Fallback for --help or other cases where model-path is not provided
         if any(h in extra_argv for h in ["-h", "--help"]):
-            raise Exception(
+            raise ValueError(
                 "Usage: sglang serve --model-path <model-name-or-path> [additional-arguments]\n\n"
                 "This command can launch either a standard language model server or a diffusion model server.\n"
                 "The server type is determined by the --model-path.\n"
             )
         else:
-            raise Exception(
+            raise ValueError(
                 "Error: --model-path is required. "
                 "Please provide the path to the model."
             )


### PR DESCRIPTION
## Summary

- Replace bare `raise Exception(...)` with semantically correct exception types in CLI argument parsing (5 occurrences across 3 files)
- `cli/utils.py`: `Exception` → `ValueError` for missing `--model-path`
- `cli/serve.py`: `Exception` → `ValueError` for invalid `--model-type`
- `cli/generate.py`: `Exception` → `NotImplementedError` for unsupported model type

## Motivation

Using generic `Exception` makes it harder for callers to catch specific error types programmatically. Replacing with `ValueError` / `NotImplementedError` follows Python best practices and improves debuggability.

## Test plan

<details>
<summary>Before / After comparison</summary>

**Before (on main):**
```
=== get_model_path([]) ===
Exception type: Exception
Message: Error: --model-path is required. Please provide the path to the model.

=== get_model_path(['--help']) ===
Exception type: Exception
Message: Usage: sglang serve --model-path <model-name-or-path> [additional-arguments]
...

=== _extract_model_type_override(['--model-type']) ===
Exception type: Exception
Message: Error: --model-type requires a value. Valid values are: auto, llm, diffusion.

=== _extract_model_type_override(['--model-type', 'invalid']) ===
Exception type: Exception
Message: Error: invalid --model-type 'invalid'. Valid values are: auto, llm, diffusion.
```

**After (this PR):**
```
=== get_model_path([]) ===
Exception type: ValueError
Message: Error: --model-path is required. Please provide the path to the model.

=== get_model_path(['--help']) ===
Exception type: ValueError
Message: Usage: sglang serve --model-path <model-name-or-path> [additional-arguments]
...

=== _extract_model_type_override(['--model-type']) ===
Exception type: ValueError
Message: Error: --model-type requires a value. Valid values are: auto, llm, diffusion.

=== _extract_model_type_override(['--model-type', 'invalid']) ===
Exception type: ValueError
Message: Error: invalid --model-type 'invalid'. Valid values are: auto, llm, diffusion.
```

</details>

- [ ] Verified all 5 exception types changed correctly
- [ ] Error messages remain unchanged
- [ ] No callers catch generic `Exception` from these functions