### PR TITLE
fix mamba cache leak when adder fails to add a matched req.

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2360,6 +2360,12 @@ class Scheduler(
                         ) > 0 or (not self.running_batch.is_empty())
                     else:
                         self.running_batch.batch_is_full = True
+                # revert matched mamba idx to avoid memory leak
+                if req.mamba_pool_idx is not None:
+                    self.tree_cache.req_to_token_pool.mamba_pool.free(
+                        req.mamba_pool_idx.unsqueeze(-1)
+                    )
+                    req.mamba_pool_idx = None
                 break
 
         # Update waiting queue

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2360,8 +2360,9 @@ class Scheduler(
                         ) > 0 or (not self.running_batch.is_empty())
                     else:
                         self.running_batch.batch_is_full = True
-                # revert matched mamba idx to avoid memory leak
-                if req.mamba_pool_idx is not None:
+                # revert matched mamba idx to avoid memory leak, if req is not added
+                added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
+                if not added and req.mamba_pool_idx is not None:
                     self.tree_cache.req_to_token_pool.mamba_pool.free(
                         req.mamba_pool_idx.unsqueeze(-1)
                     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
I met up with memory leak with mamba cache:
```
2026-03-25 16:50:26 ERROR 300376 [scheduler.py:3468] Scheduler hit an exception: Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 3464, in run_scheduler_process
    scheduler.run_event_loop()
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1248, in run_event_loop
    dispatch_event_loop(self)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 3342, in dispatch_event_loop
    scheduler.event_loop_normal()
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1271, in event_loop_normal
    self.self_check_during_idle()
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler_runtime_checker_mixin.py", line 375, in self_check_during_idle
    self.check_memory()
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler_runtime_checker_mixin.py", line 283, in check_memory
    raise_error_or_warn(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/utils/common.py", line 4080, in raise_error_or_warn
    raise ValueError(message)
ValueError: token_to_kv_pool_allocator memory leak detected! full_available_size=118191, full_evictable_size=261376, self.token_to_kv_pool_allocator.size=379567, self.tree_cache.full_protected_size()=0
mamba_available_size=700, mamba_evictable_size=129, self.req_to_token_pool.mamba_pool.size=830, self.tree_cache.mamba_protected_size()=0, leaked_full_pages=None, leaked_mamba_pages={0, 57}
```
and seems the same issue with https://github.com/sgl-project/sglang/issues/18300

By debugging the process of `Scheduler`, I finally found the cause: 
1. `MambaRadixCache` calls `_match_post_processor`, and `mamba_pool.alloc` is called in it
2. In function `Scheduler._get_new_batch_prefill_raw`, `PrefillAdder` tries to add a req in waiting queue, and `req.init_next_round_input(self.tree_cache)` is called, this allocs if matched
3. If adder fails to add this req, mamba alloced in step 2 is leaked.
4. This will not happen next time in this batch because `batch_is_full` is set to `True`, so we can see only 1 mamba is leaked.

## Modifications

<!-- Detail the changes made in this pull request. -->
Add a free logic when adder failed to add a req to avoid leak.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
7. After green CI and required approvals, ask Merge Oncalls to merge.
