### PR TITLE
[GDN] Fuse GDN kkt + solve_tril into one kernel

### DIFF
--- a/python/sglang/srt/layers/attention/fla/chunk.py
+++ b/python/sglang/srt/layers/attention/fla/chunk.py
@@ -8,19 +8,20 @@ import torch
 from einops import rearrange
 
 from sglang.srt.layers.attention.fla.chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from sglang.srt.layers.attention.fla.chunk_fwd import chunk_gated_delta_rule_fwd_intra
 from sglang.srt.layers.attention.fla.chunk_o import chunk_fwd_o
-from sglang.srt.layers.attention.fla.chunk_scaled_dot_kkt import (
-    chunk_scaled_dot_kkt_fwd,
-)
 from sglang.srt.layers.attention.fla.cumsum import chunk_local_cumsum
+from sglang.srt.layers.attention.fla.index import (
+    prepare_chunk_indices,
+)
 from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
-from sglang.srt.layers.attention.fla.solve_tril import solve_tril
 from sglang.srt.layers.attention.fla.utils import (
     SUPPRESS_LEVEL,
     autocast_custom_fwd,
     input_guard,
 )
-from sglang.srt.layers.attention.fla.wy_fast import recompute_w_u_fwd
+
+CHUNK_SIZE = 64
 
 
 def chunk_gated_delta_rule_fwd(
@@ -33,21 +34,20 @@ def chunk_gated_delta_rule_fwd(
     initial_state: torch.Tensor,
     initial_state_indices: torch.Tensor,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_indices: torch.LongTensor | None = None,
 ):
-    g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
-    # obtain WY representation. u is actually the new v.
-    A = chunk_scaled_dot_kkt_fwd(
-        k=k, beta=beta, g_cumsum=g, cu_seqlens=cu_seqlens, output_dtype=torch.float32
-    )
-    A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
-    w, u = recompute_w_u_fwd(
+    g = chunk_local_cumsum(g, chunk_size=CHUNK_SIZE, cu_seqlens=cu_seqlens)
+
+    # fused kkt + solve_tril + recompute_w_u
+    w, u, A = chunk_gated_delta_rule_fwd_intra(
         k=k,
         v=v,
+        g=g,
         beta=beta,
-        A=A,
-        g_cumsum=g,
         cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
     )
+
     h, v_new = chunk_gated_delta_rule_fwd_h(
         k=k,
         w=w,
@@ -97,6 +97,11 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             q = l2norm_fwd(q)
             k = l2norm_fwd(k)
 
+        chunk_indices = (
+            prepare_chunk_indices(cu_seqlens, CHUNK_SIZE)
+            if cu_seqlens is not None
+            else None
+        )
         g, o, A, w, h, v_new = chunk_gated_delta_rule_fwd(
             q=q,
             k=k,
@@ -107,6 +112,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             initial_state=initial_state,
             initial_state_indices=initial_state_indices,
             cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
         )
         return o.to(q.dtype), h
 

--- a/python/sglang/srt/layers/attention/fla/chunk_fwd.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_fwd.py
@@ -6,17 +6,11 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.attention.fla.index import prepare_chunk_indices
-from sglang.srt.layers.attention.fla.op import exp
+from sglang.srt.layers.attention.fla.op import safe_exp
 from sglang.srt.layers.attention.fla.utils import (
     autotune_cache_kwargs,
-    is_tf32_supported,
 )
 from sglang.srt.layers.attention.fla.wy_fast import recompute_w_u_fwd
-
-if is_tf32_supported:
-    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
-else:
-    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("ieee")
 
 
 @triton.heuristics(
@@ -31,7 +25,7 @@ else:
         for BK in [32, 64]
         for num_warps in [1, 2, 4]
     ],
-    key=["H", "K", "BC"],
+    key=["H", "Hg", "K", "BC"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -44,6 +38,7 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     chunk_indices,
     T,
     H: tl.constexpr,
+    Hg: tl.constexpr,
     K: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
@@ -86,7 +81,7 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     i_tc2 = i_t * BT + 2 * BC
     i_tc3 = i_t * BT + 3 * BC
 
-    k += (bos * H + i_h) * K
+    k += (bos * Hg + i_h // (H // Hg)) * K
     A += (bos * H + i_h) * BT
 
     o_i = tl.arange(0, BC)
@@ -137,7 +132,7 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
 
     for i_k in range(tl.cdiv(K, BK)):
         p_k0 = tl.make_block_ptr(
-            k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+            k, (T, K), (Hg * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
         )
         b_k0 = tl.load(p_k0, boundary_check=(0, 1))
         # diagonal block 0
@@ -145,7 +140,7 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
 
         if i_tc1 < T:
             p_k1 = tl.make_block_ptr(
-                k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+                k, (T, K), (Hg * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
             )
             b_k1 = tl.load(p_k1, boundary_check=(0, 1))
             # diagonal block 1
@@ -155,7 +150,7 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
 
             if i_tc2 < T:
                 p_k2 = tl.make_block_ptr(
-                    k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                    k, (T, K), (Hg * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
                 )
                 b_k2 = tl.load(p_k2, boundary_check=(0, 1))
                 # diagonal block 2
@@ -166,7 +161,7 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
 
                 if i_tc3 < T:
                     p_k3 = tl.make_block_ptr(
-                        k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                        k, (T, K), (Hg * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
                     )
                     b_k3 = tl.load(p_k3, boundary_check=(0, 1))
                     # diagonal block 3
@@ -182,18 +177,18 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
 
     if USE_G:
         # diagonal blocks: g_diff = g_i - g_j within sub-chunk
-        b_A00 *= exp(b_g0[:, None] - b_g0[None, :])
-        b_A11 *= exp(b_g1[:, None] - b_g1[None, :])
-        b_A22 *= exp(b_g2[:, None] - b_g2[None, :])
-        b_A33 *= exp(b_g3[:, None] - b_g3[None, :])
+        b_A00 *= safe_exp(b_g0[:, None] - b_g0[None, :])
+        b_A11 *= safe_exp(b_g1[:, None] - b_g1[None, :])
+        b_A22 *= safe_exp(b_g2[:, None] - b_g2[None, :])
+        b_A33 *= safe_exp(b_g3[:, None] - b_g3[None, :])
 
         # off-diagonal blocks: g_diff = g_row - g_col (cross sub-chunk)
-        b_A10 *= exp(b_g1[:, None] - b_g0[None, :])
-        b_A20 *= exp(b_g2[:, None] - b_g0[None, :])
-        b_A21 *= exp(b_g2[:, None] - b_g1[None, :])
-        b_A30 *= exp(b_g3[:, None] - b_g0[None, :])
-        b_A31 *= exp(b_g3[:, None] - b_g1[None, :])
-        b_A32 *= exp(b_g3[:, None] - b_g2[None, :])
+        b_A10 *= safe_exp(b_g1[:, None] - b_g0[None, :])
+        b_A20 *= safe_exp(b_g2[:, None] - b_g0[None, :])
+        b_A21 *= safe_exp(b_g2[:, None] - b_g1[None, :])
+        b_A30 *= safe_exp(b_g3[:, None] - b_g0[None, :])
+        b_A31 *= safe_exp(b_g3[:, None] - b_g1[None, :])
+        b_A32 *= safe_exp(b_g3[:, None] - b_g2[None, :])
 
     # apply beta to row dimension and mask
     m_d = o_i[:, None] > o_i[None, :]
@@ -265,39 +260,39 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     ############################################################################
 
     b_Ai10 = -tl.dot(
-        tl.dot(b_Ai11, b_A10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        tl.dot(b_Ai11, b_A10, input_precision="ieee"),
         b_Ai00,
-        input_precision=SOLVE_TRIL_DOT_PRECISION,
+        input_precision="ieee",
     )
     b_Ai21 = -tl.dot(
-        tl.dot(b_Ai22, b_A21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        tl.dot(b_Ai22, b_A21, input_precision="ieee"),
         b_Ai11,
-        input_precision=SOLVE_TRIL_DOT_PRECISION,
+        input_precision="ieee",
     )
     b_Ai32 = -tl.dot(
-        tl.dot(b_Ai33, b_A32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        tl.dot(b_Ai33, b_A32, input_precision="ieee"),
         b_Ai22,
-        input_precision=SOLVE_TRIL_DOT_PRECISION,
+        input_precision="ieee",
     )
 
     b_Ai20 = -tl.dot(
         b_Ai22,
-        tl.dot(b_A20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
-        + tl.dot(b_A21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        input_precision=SOLVE_TRIL_DOT_PRECISION,
+        tl.dot(b_A20, b_Ai00, input_precision="ieee")
+        + tl.dot(b_A21, b_Ai10, input_precision="ieee"),
+        input_precision="ieee",
     )
     b_Ai31 = -tl.dot(
         b_Ai33,
-        tl.dot(b_A31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
-        + tl.dot(b_A32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        input_precision=SOLVE_TRIL_DOT_PRECISION,
+        tl.dot(b_A31, b_Ai11, input_precision="ieee")
+        + tl.dot(b_A32, b_Ai21, input_precision="ieee"),
+        input_precision="ieee",
     )
     b_Ai30 = -tl.dot(
         b_Ai33,
-        tl.dot(b_A30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
-        + tl.dot(b_A31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
-        + tl.dot(b_A32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
-        input_precision=SOLVE_TRIL_DOT_PRECISION,
+        tl.dot(b_A30, b_Ai00, input_precision="ieee")
+        + tl.dot(b_A31, b_Ai10, input_precision="ieee")
+        + tl.dot(b_A32, b_Ai20, input_precision="ieee"),
+        input_precision="ieee",
     )
 
     ############################################################################
@@ -374,7 +369,8 @@ def chunk_gated_delta_rule_fwd_intra(
         u (torch.Tensor): shape `[B, T, H, V]`
         A (torch.Tensor): shape `[B, T, H, BT]`, the solved (I+A)^{-1} matrix
     """
-    B, T, H, K = k.shape
+    B, T, Hg, K = k.shape
+    H = beta.shape[-1]
     BT = chunk_size
     BC = 16
 
@@ -393,6 +389,7 @@ def chunk_gated_delta_rule_fwd_intra(
         chunk_indices=chunk_indices,
         T=T,
         H=H,
+        Hg=Hg,
         K=K,
         BT=BT,
         BC=BC,

--- a/python/sglang/srt/layers/attention/fla/chunk_fwd.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_fwd.py
@@ -9,8 +9,16 @@ from sglang.srt.layers.attention.fla.index import prepare_chunk_indices
 from sglang.srt.layers.attention.fla.op import safe_exp
 from sglang.srt.layers.attention.fla.utils import (
     autotune_cache_kwargs,
+    is_tf32_supported,
 )
 from sglang.srt.layers.attention.fla.wy_fast import recompute_w_u_fwd
+
+# TF32 for the block-merge dot products (16x16 matmuls) is safe and ~2x faster on SM90.
+# The numerically sensitive forward-substitution uses scalar ops, not tl.dot.
+if is_tf32_supported:
+    _MERGE_DOT_PRECISION = tl.constexpr("tf32")
+else:
+    _MERGE_DOT_PRECISION = tl.constexpr("ieee")
 
 
 @triton.heuristics(
@@ -260,39 +268,39 @@ def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
     ############################################################################
 
     b_Ai10 = -tl.dot(
-        tl.dot(b_Ai11, b_A10, input_precision="ieee"),
+        tl.dot(b_Ai11, b_A10, input_precision=_MERGE_DOT_PRECISION),
         b_Ai00,
-        input_precision="ieee",
+        input_precision=_MERGE_DOT_PRECISION,
     )
     b_Ai21 = -tl.dot(
-        tl.dot(b_Ai22, b_A21, input_precision="ieee"),
+        tl.dot(b_Ai22, b_A21, input_precision=_MERGE_DOT_PRECISION),
         b_Ai11,
-        input_precision="ieee",
+        input_precision=_MERGE_DOT_PRECISION,
     )
     b_Ai32 = -tl.dot(
-        tl.dot(b_Ai33, b_A32, input_precision="ieee"),
+        tl.dot(b_Ai33, b_A32, input_precision=_MERGE_DOT_PRECISION),
         b_Ai22,
-        input_precision="ieee",
+        input_precision=_MERGE_DOT_PRECISION,
     )
 
     b_Ai20 = -tl.dot(
         b_Ai22,
-        tl.dot(b_A20, b_Ai00, input_precision="ieee")
-        + tl.dot(b_A21, b_Ai10, input_precision="ieee"),
-        input_precision="ieee",
+        tl.dot(b_A20, b_Ai00, input_precision=_MERGE_DOT_PRECISION)
+        + tl.dot(b_A21, b_Ai10, input_precision=_MERGE_DOT_PRECISION),
+        input_precision=_MERGE_DOT_PRECISION,
     )
     b_Ai31 = -tl.dot(
         b_Ai33,
-        tl.dot(b_A31, b_Ai11, input_precision="ieee")
-        + tl.dot(b_A32, b_Ai21, input_precision="ieee"),
-        input_precision="ieee",
+        tl.dot(b_A31, b_Ai11, input_precision=_MERGE_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai21, input_precision=_MERGE_DOT_PRECISION),
+        input_precision=_MERGE_DOT_PRECISION,
     )
     b_Ai30 = -tl.dot(
         b_Ai33,
-        tl.dot(b_A30, b_Ai00, input_precision="ieee")
-        + tl.dot(b_A31, b_Ai10, input_precision="ieee")
-        + tl.dot(b_A32, b_Ai20, input_precision="ieee"),
-        input_precision="ieee",
+        tl.dot(b_A30, b_Ai00, input_precision=_MERGE_DOT_PRECISION)
+        + tl.dot(b_A31, b_Ai10, input_precision=_MERGE_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai20, input_precision=_MERGE_DOT_PRECISION),
+        input_precision=_MERGE_DOT_PRECISION,
     )
 
     ############################################################################

--- a/python/sglang/srt/layers/attention/fla/chunk_fwd.py
+++ b/python/sglang/srt/layers/attention/fla/chunk_fwd.py
@@ -1,0 +1,411 @@
+# Adapted from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/gated_delta_rule/chunk_fwd.py
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.attention.fla.index import prepare_chunk_indices
+from sglang.srt.layers.attention.fla.op import exp
+from sglang.srt.layers.attention.fla.utils import (
+    autotune_cache_kwargs,
+    is_tf32_supported,
+)
+from sglang.srt.layers.attention.fla.wy_fast import recompute_w_u_fwd
+
+if is_tf32_supported:
+    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
+else:
+    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("ieee")
+
+
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK}, num_warps=num_warps)
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4]
+    ],
+    key=["H", "K", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Fused kernel: compute beta * K @ K^T (lower triangular) + solve_tril (I+A)^{-1} in one pass.
+
+    This kernel fuses chunk_scaled_dot_kkt_fwd and solve_tril into a single kernel,
+    avoiding the HBM round-trip for the intermediate A matrix.
+
+    Steps:
+    1. Compute all 10 lower-triangular [BC, BC] blocks of beta * K @ K^T in registers
+    2. Apply gate and beta scaling
+    3. Forward substitution on diagonal blocks
+    4. Block merge to get full (I+A)^{-1}
+    5. Write result to A (output)
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    k += (bos * H + i_h) * K
+    A += (bos * H + i_h) * BT
+
+    o_i = tl.arange(0, BC)
+    m_tc0 = (i_tc0 + o_i) < T
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    # load beta for each sub-chunk
+    p_b0 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,))
+    p_b1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+    p_b2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+    p_b3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+    b_b0 = tl.load(p_b0, boundary_check=(0,)).to(tl.float32)
+    b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+    b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+    b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+
+    # load gate if used
+    if USE_G:
+        p_g0 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,))
+        p_g1 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        p_g2 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        p_g3 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+
+        b_g0 = tl.load(p_g0, boundary_check=(0,)).to(tl.float32)
+        b_g1 = tl.load(p_g1, boundary_check=(0,)).to(tl.float32)
+        b_g2 = tl.load(p_g2, boundary_check=(0,)).to(tl.float32)
+        b_g3 = tl.load(p_g3, boundary_check=(0,)).to(tl.float32)
+
+    ############################################################################
+    # Step 1: compute all 10 lower-triangular [BC, BC] blocks of K @ K^T
+    ############################################################################
+
+    # 4 diagonal blocks
+    b_A00 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A11 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A22 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A33 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    # 6 off-diagonal blocks
+    b_A10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k0 = tl.make_block_ptr(
+            k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+        )
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1))
+        # diagonal block 0
+        b_A00 += tl.dot(b_k0, tl.trans(b_k0))
+
+        if i_tc1 < T:
+            p_k1 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+            # diagonal block 1
+            b_A11 += tl.dot(b_k1, tl.trans(b_k1))
+            # off-diagonal (1,0)
+            b_A10 += tl.dot(b_k1, tl.trans(b_k0))
+
+            if i_tc2 < T:
+                p_k2 = tl.make_block_ptr(
+                    k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+                # diagonal block 2
+                b_A22 += tl.dot(b_k2, tl.trans(b_k2))
+                # off-diagonal (2,0), (2,1)
+                b_A20 += tl.dot(b_k2, tl.trans(b_k0))
+                b_A21 += tl.dot(b_k2, tl.trans(b_k1))
+
+                if i_tc3 < T:
+                    p_k3 = tl.make_block_ptr(
+                        k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+                    # diagonal block 3
+                    b_A33 += tl.dot(b_k3, tl.trans(b_k3))
+                    # off-diagonal (3,0), (3,1), (3,2)
+                    b_A30 += tl.dot(b_k3, tl.trans(b_k0))
+                    b_A31 += tl.dot(b_k3, tl.trans(b_k1))
+                    b_A32 += tl.dot(b_k3, tl.trans(b_k2))
+
+    ############################################################################
+    # Step 2: apply gate and beta scaling
+    ############################################################################
+
+    if USE_G:
+        # diagonal blocks: g_diff = g_i - g_j within sub-chunk
+        b_A00 *= exp(b_g0[:, None] - b_g0[None, :])
+        b_A11 *= exp(b_g1[:, None] - b_g1[None, :])
+        b_A22 *= exp(b_g2[:, None] - b_g2[None, :])
+        b_A33 *= exp(b_g3[:, None] - b_g3[None, :])
+
+        # off-diagonal blocks: g_diff = g_row - g_col (cross sub-chunk)
+        b_A10 *= exp(b_g1[:, None] - b_g0[None, :])
+        b_A20 *= exp(b_g2[:, None] - b_g0[None, :])
+        b_A21 *= exp(b_g2[:, None] - b_g1[None, :])
+        b_A30 *= exp(b_g3[:, None] - b_g0[None, :])
+        b_A31 *= exp(b_g3[:, None] - b_g1[None, :])
+        b_A32 *= exp(b_g3[:, None] - b_g2[None, :])
+
+    # apply beta to row dimension and mask
+    m_d = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    # diagonal blocks: strictly lower triangular within sub-chunk, scaled by beta
+    b_A00 = (
+        tl.where(m_d & (m_tc0[:, None] & m_tc0[None, :]), b_A00, 0.0) * b_b0[:, None]
+    )
+    b_A11 = (
+        tl.where(m_d & (m_tc1[:, None] & m_tc1[None, :]), b_A11, 0.0) * b_b1[:, None]
+    )
+    b_A22 = (
+        tl.where(m_d & (m_tc2[:, None] & m_tc2[None, :]), b_A22, 0.0) * b_b2[:, None]
+    )
+    b_A33 = (
+        tl.where(m_d & (m_tc3[:, None] & m_tc3[None, :]), b_A33, 0.0) * b_b3[:, None]
+    )
+
+    # off-diagonal blocks: full block, scaled by beta
+    b_A10 = b_A10 * b_b1[:, None]
+    b_A20 = b_A20 * b_b2[:, None]
+    b_A21 = b_A21 * b_b2[:, None]
+    b_A30 = b_A30 * b_b3[:, None]
+    b_A31 = b_A31 * b_b3[:, None]
+    b_A32 = b_A32 * b_b3[:, None]
+
+    ############################################################################
+    # Step 3: forward substitution on diagonal blocks -> (I + A_diag)^{-1}
+    #
+    # Same algorithm as solve_tril, but rows are extracted from in-register
+    # [BC, BC] tensor via tl.sum(tl.where(mask, tensor, 0), 0) instead of
+    # tl.load from HBM.
+    ############################################################################
+
+    b_Ai00 = -b_A00
+    b_Ai11 = -b_A11
+    b_Ai22 = -b_A22
+    b_Ai33 = -b_A33
+
+    for i in range(2, min(BC, T - i_tc0)):
+        b_a00 = tl.sum(tl.where((o_i == i)[:, None], -b_A00, 0.0), 0)
+        b_a00 = tl.where(o_i < i, b_a00, 0.0)
+        b_a00 = b_a00 + tl.sum(b_a00[:, None] * b_Ai00, 0)
+        b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+    for i in range(2, min(BC, T - i_tc1)):
+        b_a11 = tl.sum(tl.where((o_i == i)[:, None], -b_A11, 0.0), 0)
+        b_a11 = tl.where(o_i < i, b_a11, 0.0)
+        b_a11 = b_a11 + tl.sum(b_a11[:, None] * b_Ai11, 0)
+        b_Ai11 = tl.where((o_i == i)[:, None], b_a11, b_Ai11)
+    for i in range(2, min(BC, T - i_tc2)):
+        b_a22 = tl.sum(tl.where((o_i == i)[:, None], -b_A22, 0.0), 0)
+        b_a22 = tl.where(o_i < i, b_a22, 0.0)
+        b_a22 = b_a22 + tl.sum(b_a22[:, None] * b_Ai22, 0)
+        b_Ai22 = tl.where((o_i == i)[:, None], b_a22, b_Ai22)
+    for i in range(2, min(BC, T - i_tc3)):
+        b_a33 = tl.sum(tl.where((o_i == i)[:, None], -b_A33, 0.0), 0)
+        b_a33 = tl.where(o_i < i, b_a33, 0.0)
+        b_a33 = b_a33 + tl.sum(b_a33[:, None] * b_Ai33, 0)
+        b_Ai33 = tl.where((o_i == i)[:, None], b_a33, b_Ai33)
+
+    b_Ai00 += m_I
+    b_Ai11 += m_I
+    b_Ai22 += m_I
+    b_Ai33 += m_I
+
+    ############################################################################
+    # Step 4: block merge -> full (I + A)^{-1}
+    ############################################################################
+
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_A10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_A21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_A32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_A20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    ############################################################################
+    # Step 5: store full (I + A)^{-1} to output A
+    ############################################################################
+
+    p_A00 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_A10 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_A11 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+    p_A20 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+    p_A21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+    p_A22 = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_A30 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+    p_A31 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+    p_A32 = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_A33 = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
+    )
+
+    tl.store(p_A00, b_Ai00.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A10, b_Ai10.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A11, b_Ai11.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A20, b_Ai20.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A21, b_Ai21.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A22, b_Ai22.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A30, b_Ai30.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A31, b_Ai31.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A32, b_Ai32.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A33, b_Ai33.to(A.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gated_delta_rule_fwd_intra(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""
+    GDN intra-chunk forward: fused kkt + solve_tril + recompute_w_u.
+
+    Equivalent to:
+        A = chunk_scaled_dot_kkt_fwd(k, g, beta, ...)       # kernel 1
+        A = solve_tril(A, ...)                                # kernel 2
+        w, u = recompute_w_u_fwd(k, v, beta, A, g, ...)      # kernel 3
+
+    Fuses kernels 1+2 into a single kernel, reducing from 3 to 2 kernel launches
+    and eliminating the HBM round-trip for the intermediate A matrix.
+
+    Args:
+        k (torch.Tensor):
+            The key tensor of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            The value tensor of shape `[B, T, H, V]`.
+        g (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, H]`. Default: `None`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, H]`.
+        cu_seqlens (torch.LongTensor):
+            The cumulative sequence lengths. Default: `None`.
+        chunk_size (int):
+            The chunk size. Default: 64.
+        chunk_indices (torch.LongTensor):
+            Precomputed chunk indices. Default: `None`.
+
+    Returns:
+        w (torch.Tensor): shape `[B, T, H, K]`
+        u (torch.Tensor): shape `[B, T, H, V]`
+        A (torch.Tensor): shape `[B, T, H, BT]`, the solved (I+A)^{-1} matrix
+    """
+    B, T, H, K = k.shape
+    BT = chunk_size
+    BC = 16
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    # Step 1: fused kkt + solve_tril
+    A = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    chunk_gated_delta_rule_fwd_kkt_solve_kernel[(NT, B * H)](
+        k=k,
+        g=g,
+        beta=beta,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+    )
+
+    # Step 2: recompute_w_u
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g_cumsum=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, A

--- a/python/sglang/srt/layers/attention/fla/fused_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_recurrent.py
@@ -940,3 +940,6 @@ def fused_recurrent_gated_delta_rule_update(
         retrieve_parent_token,
     )
     return o
+
+
+fused_recurrent_gdn = fused_recurrent_gated_delta_rule

--- a/python/sglang/srt/layers/attention/fla/utils.py
+++ b/python/sglang/srt/layers/attention/fla/utils.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import functools
+import inspect
 import logging
 import os
 import sys
@@ -20,6 +21,16 @@ logger = logging.getLogger(__name__)
 
 COMPILER_MODE = os.getenv("FLA_COMPILER_MODE") == "1"
 FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
+FLA_CACHE_RESULTS = os.getenv("FLA_CACHE_RESULTS", "1") == "1"
+
+
+SUPPORTS_AUTOTUNE_CACHE = (
+    "cache_results" in inspect.signature(triton.autotune).parameters
+)
+
+autotune_cache_kwargs = (
+    {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
+)
 
 
 @lru_cache(maxsize=1)
@@ -323,3 +334,6 @@ else:
 
     def custom_device_ctx(index: int):
         return torch.cuda.device(index)
+
+
+device_platform = get_available_device()

--- a/python/sglang/srt/layers/attention/fla/wy_fast.py
+++ b/python/sglang/srt/layers/attention/fla/wy_fast.py
@@ -115,14 +115,14 @@ def recompute_w_u_fwd(
     g_cumsum: torch.Tensor,
     A: torch.Tensor,
     cu_seqlens: Optional[torch.LongTensor],
+    chunk_indices: torch.LongTensor | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     B, T, Hg, K, V = *k.shape, v.shape[-1]
     H = v.shape[-2]
     BT = A.shape[-1]
 
-    chunk_indices = (
-        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
-    )
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BK = 64
     BV = 64


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Learning from FLA, this PR is to fuse GDN kkt + solve_tril into one kernel so as to release the register burden and improve performance. Per benchmark, accuracy is expected, kernel performance uplift 5%.

The same approach can be adapted to KDA kernel, will follow up in the following PR.

```
H200
Main:
Device: NVIDIA H200  (SM 90)
==============================================================================
Correctness sweep: Triton vs FlashInfer
==============================================================================
  [PASS] B=  4 T/seq=  64 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 256 H=16 K=128 V=128 pool=  32
  [PASS] B=  1 T/seq= 128 H=16 K=128 V=128 pool=  32
  [PASS] B=  8 T/seq= 128 H=16 K=128 V=128 pool=  64
  [PASS] B= 16 T/seq=  64 H=16 K=128 V=128 pool= 128
  [PASS] B= 32 T/seq=  32 H=16 K=128 V=128 pool= 256
  [PASS] B=  4 T/seq= 128 H= 4 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 128 H= 8 K=128 V=128 pool=  32
  [SKIP] B=  4 T/seq= 128 H=16 K= 64 V= 64 pool=  32  (FlashInfer only supports head_size={128})
  [PASS] B=  4 T/seq= 128 H=32 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 128 H=64 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq=   1 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq=   7 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq=  16 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 128 H=16 K=128 V=128 pool= 512
  [PASS] B= 32 T/seq= 128 H=32 K=128 V=128 pool= 256

Sequential-index variants:
  [PASS] B=  8 T/seq= 128 H=16 K=128 V=128 pool=   8 (seq)
  [PASS] B=  4 T/seq= 128 H=32 K=128 V=128 pool=   4 (seq)
  [PASS] B=  4 T/seq= 128 H=64 K=128 V=128 pool=   4 (seq)
  [PASS] B= 32 T/seq= 128 H=32 K=128 V=128 pool=  32 (seq)

ALL PASSED.

=========================================================================================================
Benchmark: Triton GDN vs FlashInfer GDN  (do_bench_cudagraph)
=========================================================================================================
  Config: K=128, V=128, pool_size=256, dtype=torch.bfloat16
      B    H   T/seq    T_tot |  tri(ms)   TFLOPS     TB/s |   fi(ms)   TFLOPS     TB/s |  speedup
  --------------------------------------------------------------------------------------------------
      4   16     256     1024 |    0.769     1.40     0.03 |    0.448     2.40     0.06 |    1.72x
      4   32     256     1024 |    1.501     1.43     0.03 |    0.854     2.52     0.06 |    1.76x
     16   16     256     4096 |    0.879     4.88     0.12 |    0.533     8.05     0.19 |    1.65x
     16   32     256     4096 |    1.737     4.95     0.12 |    1.039     8.27     0.19 |    1.67x
     32   16     256     8192 |    1.036     8.29     0.20 |    0.660    13.02     0.31 |    1.57x
     32   32     256     8192 |    2.037     8.43     0.20 |    1.282    13.41     0.32 |    1.59x
     64   16     256    16384 |    1.336    12.86     0.30 |    0.898    19.12     0.45 |    1.49x
     64   32     256    16384 |    2.644    13.00     0.31 |    1.762    19.51     0.46 |    1.50x
    128   16     256    32768 |    1.949    17.63     0.42 |    1.379    24.91     0.59 |    1.41x
    128   32     256    32768 |    3.881    17.71     0.42 |    2.717    25.29     0.60 |    1.43x
      4   16    1024     4096 |    0.876     4.91     0.09 |    0.496     8.66     0.15 |    1.77x
      4   32    1024     4096 |    1.746     4.92     0.09 |    0.913     9.41     0.17 |    1.91x
     32   16    1024    32768 |    1.928    17.82     0.32 |    0.898    38.25     0.68 |    2.15x
     32   32    1024    32768 |    3.809    18.04     0.32 |    1.758    39.10     0.69 |    2.17x

PR:
Device: NVIDIA H200  (SM 90)
==============================================================================
Correctness sweep: Triton vs FlashInfer
==============================================================================
  [PASS] B=  4 T/seq=  64 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 256 H=16 K=128 V=128 pool=  32
  [PASS] B=  1 T/seq= 128 H=16 K=128 V=128 pool=  32
  [PASS] B=  8 T/seq= 128 H=16 K=128 V=128 pool=  64
  [PASS] B= 16 T/seq=  64 H=16 K=128 V=128 pool= 128
  [PASS] B= 32 T/seq=  32 H=16 K=128 V=128 pool= 256
  [PASS] B=  4 T/seq= 128 H= 4 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 128 H= 8 K=128 V=128 pool=  32
  [SKIP] B=  4 T/seq= 128 H=16 K= 64 V= 64 pool=  32  (FlashInfer only supports head_size={128})
  [PASS] B=  4 T/seq= 128 H=32 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 128 H=64 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq=   1 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq=   7 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq=  16 H=16 K=128 V=128 pool=  32
  [PASS] B=  4 T/seq= 128 H=16 K=128 V=128 pool= 512
  [PASS] B= 32 T/seq= 128 H=32 K=128 V=128 pool= 256

Sequential-index variants:
  [PASS] B=  8 T/seq= 128 H=16 K=128 V=128 pool=   8 (seq)
  [PASS] B=  4 T/seq= 128 H=32 K=128 V=128 pool=   4 (seq)
  [PASS] B=  4 T/seq= 128 H=64 K=128 V=128 pool=   4 (seq)
  [PASS] B= 32 T/seq= 128 H=32 K=128 V=128 pool=  32 (seq)

ALL PASSED.

=========================================================================================================
Benchmark: Triton GDN vs FlashInfer GDN  (do_bench_cudagraph)
=========================================================================================================
  Config: K=128, V=128, pool_size=256, dtype=torch.bfloat16
      B    H   T/seq    T_tot |  tri(ms)   TFLOPS     TB/s |   fi(ms)   TFLOPS     TB/s |  speedup
  --------------------------------------------------------------------------------------------------
      4   16     256     1024 |    0.763     1.41     0.03 |    0.448     2.40     0.06 |    1.70x
      4   32     256     1024 |    1.500     1.43     0.03 |    0.853     2.52     0.06 |    1.76x
     16   16     256     4096 |    0.873     4.92     0.12 |    0.535     8.03     0.19 |    1.63x
     16   32     256     4096 |    1.723     4.99     0.12 |    1.039     8.26     0.19 |    1.66x
     32   16     256     8192 |    1.021     8.41     0.20 |    0.662    12.98     0.31 |    1.54x
     32   32     256     8192 |    2.003     8.58     0.20 |    1.282    13.40     0.32 |    1.56x
     64   16     256    16384 |    1.300    13.21     0.31 |    0.899    19.11     0.45 |    1.45x
     64   32     256    16384 |    2.561    13.42     0.32 |    1.765    19.47     0.46 |    1.45x
    128   16     256    32768 |    1.866    18.41     0.43 |    1.381    24.88     0.59 |    1.35x
    128   32     256    32768 |    3.708    18.53     0.44 |    2.718    25.28     0.60 |    1.36x
      4   16    1024     4096 |    0.870     4.94     0.09 |    0.497     8.65     0.15 |    1.75x
      4   32    1024     4096 |    1.731     4.96     0.09 |    0.913     9.41     0.17 |    1.90x
     32   16    1024    32768 |    1.844    18.63     0.33 |    0.899    38.20     0.68 |    2.05x
     32   32    1024    32768 |    3.638    18.89     0.33 |    1.761    39.02     0.69 |    2.07x
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified Qwen3-Next result correct.
```
➜  sglang_dev git:(fuse_gdn_kkt_solve_tril) ✗ CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server --model Qwen/Qwen3-Next-80B-A3B-Instruct --tp 4 --dp 4 --enable-dp-attention --speculative-num-steps 3  --speculative-eagle-topk 1  --speculative-num-draft-tokens 4 --speculative-algo NEXTN --disable-radix-cache
```

```
➜  bench_script python test_openai.py
ChatCompletion(id='5d7ed554c5ea41dfa272b27e0088fd4d', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Sure! Here are three countries and their capitals:\n\n1. **France** – Paris  \n2. **Japan** – Tokyo  \n3. **Brazil** – Brasília  \n\n### How I Ranked Them:\nI ranked these countries **alphabetically by country name**:\n\n- **Brazil** (B)  \n- **France** (F)  \n- **Japan** (J)  \n\nThis is a neutral, objective sorting method—no value judgments about size, population, economy, or cultural influence. Alphabetical order ensures fairness and consistency, especially when no specific criteria are given.\n\nIf you’d like them ranked by population, GDP, or something else, just let me know!', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None, reasoning_content=None), matched_stop=151645)], created=1774621191, model='default', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=137, prompt_tokens=33, total_tokens=170, completion_tokens_details=None, prompt_tokens_details=None, reasoning_tokens=0), metadata={'weight_version': 'default'})
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
