### PR TITLE
Api add flush cache timeout

### DIFF
--- a/docs/advanced_features/sgl_model_gateway.md
+++ b/docs/advanced_features/sgl_model_gateway.md
@@ -559,6 +559,18 @@ Response:
 | `GET` | `/wasm` | List WASM modules |
 | `DELETE` | `/wasm/{module_uuid}` | Remove WASM module |
 
+`/flush_cache` parameters:
+
+| Name | In | Type | Default | Unit | Description |
+|------|----|------|---------|------|-------------|
+| `timeout` | query | `float` | `0` | seconds | Wait time for idle state before flushing. `0` means fail fast if not idle. |
+
+`/flush_cache` example:
+
+```bash
+curl -s -X POST "http://127.0.0.1:30000/flush_cache?timeout=30"
+```
+
 ---
 
 ## Load Balancing Policies

--- a/docs/advanced_features/sgl_model_gateway.md
+++ b/docs/advanced_features/sgl_model_gateway.md
@@ -559,18 +559,6 @@ Response:
 | `GET` | `/wasm` | List WASM modules |
 | `DELETE` | `/wasm/{module_uuid}` | Remove WASM module |
 
-`/flush_cache` parameters:
-
-| Name | In | Type | Default | Unit | Description |
-|------|----|------|---------|------|-------------|
-| `timeout` | query | `float` | `0` | seconds | Wait time for idle state before flushing. `0` means fail fast if not idle. |
-
-`/flush_cache` example:
-
-```bash
-curl -s -X POST "http://127.0.0.1:30000/flush_cache?timeout=30"
-```
-
 ---
 
 ## Load Balancing Policies

--- a/docs/basic_usage/native_api.ipynb
+++ b/docs/basic_usage/native_api.ipynb
@@ -185,7 +185,15 @@
    "source": [
     "## Flush Cache\n",
     "\n",
-    "Flush the radix cache. It will be automatically triggered when the model weights are updated by the `/update_weights` API."
+    "Flush the radix cache. It will be automatically triggered when the model weights are updated by the `/update_weights` API.\n",
+    "\n",
+    "Parameters:\n",
+    "- `timeout` (query, float, default `0`, unit: seconds): Wait time for idle state before flushing. `0` means fail fast if not idle. When HiCache async operations are in-flight, a non-zero timeout allows the server to wait until idle before flushing, avoiding unnecessary 400 errors.\n",
+    "\n",
+    "```bash\n",
+    "# With timeout (wait up to 30s for idle state)\n",
+    "curl -s -X POST \"http://127.0.0.1:30000/flush_cache?timeout=30\"\n",
+    "```"
    ]
   },
   {

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -733,9 +733,9 @@ async def classify_request(obj: EmbeddingReqInput, request: Request):
 
 @app.api_route("/flush_cache", methods=["GET", "POST"])
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
-async def flush_cache():
+async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
     """Flush the radix cache."""
-    ret = await _global_state.tokenizer_manager.flush_cache()
+    ret = await _global_state.tokenizer_manager.flush_cache(timeout_s=timeout)
     return Response(
         content="Cache flushed.\nPlease check backend logs for more details. "
         "(When there are running or waiting requests, the operation will not be performed.)\n",

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1166,7 +1166,7 @@ class ClearHiCacheReqOutput(BaseReq):
 
 @dataclass
 class FlushCacheReqInput(BaseReq):
-    pass
+    timeout_s: Optional[float] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -805,6 +805,7 @@ class Scheduler(
         self.last_batch: Optional[ScheduleBatch] = None
         self.forward_ct = 0
         self.return_health_check_ipcs: Deque[Optional[str]] = deque()
+        self._pending_flush: Deque[Tuple[FlushCacheReqInput, float]] = deque()
         self.num_retracted_reqs: int = 0
         self.num_paused_reqs: int = 0
         self.session_controller = SessionController(self.tree_cache)
@@ -1532,6 +1533,8 @@ class Scheduler(
                 else:
                     if self.recv_from_rpc is not None:
                         self.recv_from_rpc.send_pyobj(output)
+
+        self._check_pending_flush()
 
     def init_req_max_new_tokens(self, req):
         req.sampling_params.max_new_tokens = min(
@@ -2733,9 +2736,48 @@ class Scheduler(
                 )
             )
 
-    def flush_cache_wrapped(self, recv_req: FlushCacheReqInput):
-        success = self.flush_cache()
-        return FlushCacheReqOutput(success=success)
+    def _check_pending_flush(self):
+        if not self._pending_flush:
+            return
+
+        if self.is_fully_idle():
+            success = self.flush_cache()
+            while self._pending_flush:
+                pending_req, _ = self._pending_flush.popleft()
+                self.send_to_tokenizer.send_output(
+                    FlushCacheReqOutput(success=success), pending_req
+                )
+            return
+
+        self._expire_timed_out_pending_flushes(time.monotonic())
+
+    def _expire_timed_out_pending_flushes(self, now: float):
+        remaining: Deque[Tuple[FlushCacheReqInput, float]] = deque()
+        while self._pending_flush:
+            pending_req, deadline = self._pending_flush.popleft()
+            if now >= deadline:
+                logging.warning(
+                    "Deferred flush_cache timed out while waiting for idle state."
+                )
+                self.send_to_tokenizer.send_output(
+                    FlushCacheReqOutput(success=False), pending_req
+                )
+            else:
+                remaining.append((pending_req, deadline))
+        self._pending_flush = remaining
+
+    def flush_cache_wrapped(
+        self, recv_req: FlushCacheReqInput
+    ) -> Optional[FlushCacheReqOutput]:
+        timeout_s = float(recv_req.timeout_s or 0.0)
+        if timeout_s <= 0.0:
+            return FlushCacheReqOutput(success=self.flush_cache())
+
+        if self.is_fully_idle():
+            return FlushCacheReqOutput(success=self.flush_cache())
+
+        self._pending_flush.append((recv_req, time.monotonic() + timeout_s))
+        return None
 
     def clear_hicache_storage_wrapped(self, recv_req: ClearHiCacheReqInput):
         if self.enable_hierarchical_cache:

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -352,9 +352,13 @@ class TokenizerCommunicatorMixin:
             ]
         )
 
-    async def flush_cache(self: TokenizerManager) -> FlushCacheReqOutput:
+    async def flush_cache(
+        self: TokenizerManager, timeout_s: Optional[float] = None
+    ) -> FlushCacheReqOutput:
         self.auto_create_handle_loop()
-        return (await self.flush_cache_communicator(FlushCacheReqInput()))[0]
+        return (
+            await self.flush_cache_communicator(FlushCacheReqInput(timeout_s=timeout_s))
+        )[0]
 
     async def clear_hicache_storage(self: TokenizerManager) -> ClearHiCacheReqOutput:
         """Clear the hierarchical cache storage."""

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -4,10 +4,9 @@ from unittest.mock import MagicMock, patch
 
 from sglang.srt.managers.io_struct import FlushCacheReqInput, FlushCacheReqOutput
 from sglang.srt.managers.scheduler import Scheduler
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cuda_ci(est_time=2, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=2, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=2, suite="stage-a-cpu-only")
 
 
 class TestSchedulerFlushCache(unittest.TestCase):

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -1,0 +1,105 @@
+from collections import deque
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.managers.io_struct import FlushCacheReqInput, FlushCacheReqOutput
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=2, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=2, suite="stage-b-test-1-gpu-small-amd")
+
+
+class TestSchedulerFlushCache(unittest.TestCase):
+    def _new_scheduler(self) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._pending_flush = deque()
+        scheduler.send_to_tokenizer = MagicMock()
+        scheduler.flush_cache = MagicMock(return_value=True)
+        scheduler.is_fully_idle = MagicMock(return_value=False)
+        return scheduler
+
+    def test_flush_cache_wrapped_non_positive_timeout_immediate(self):
+        scheduler = self._new_scheduler()
+        scheduler.flush_cache.return_value = False
+
+        output = Scheduler.flush_cache_wrapped(
+            scheduler, FlushCacheReqInput(timeout_s=None)
+        )
+
+        self.assertIsInstance(output, FlushCacheReqOutput)
+        self.assertFalse(output.success)
+        scheduler.flush_cache.assert_called_once()
+        self.assertEqual(len(scheduler._pending_flush), 0)
+
+    def test_flush_cache_wrapped_positive_timeout_idle_immediate(self):
+        scheduler = self._new_scheduler()
+        scheduler.is_fully_idle.return_value = True
+
+        output = Scheduler.flush_cache_wrapped(
+            scheduler, FlushCacheReqInput(timeout_s=5.0)
+        )
+
+        self.assertIsInstance(output, FlushCacheReqOutput)
+        self.assertTrue(output.success)
+        scheduler.flush_cache.assert_called_once()
+        self.assertEqual(len(scheduler._pending_flush), 0)
+
+    def test_flush_cache_wrapped_positive_timeout_busy_enqueues(self):
+        scheduler = self._new_scheduler()
+        req = FlushCacheReqInput(timeout_s=3.0)
+
+        with patch("sglang.srt.managers.scheduler.time.monotonic", return_value=10.0):
+            output = Scheduler.flush_cache_wrapped(scheduler, req)
+
+        self.assertIsNone(output)
+        self.assertEqual(len(scheduler._pending_flush), 1)
+        pending_req, deadline = scheduler._pending_flush[0]
+        self.assertIs(pending_req, req)
+        self.assertEqual(deadline, 13.0)
+        scheduler.flush_cache.assert_not_called()
+
+    def test_check_pending_flush_idle_flushes_all(self):
+        scheduler = self._new_scheduler()
+        scheduler.is_fully_idle.return_value = True
+
+        req1 = FlushCacheReqInput(timeout_s=1.0)
+        req2 = FlushCacheReqInput(timeout_s=2.0)
+        scheduler._pending_flush = deque([(req1, 111.0), (req2, 222.0)])
+
+        Scheduler._check_pending_flush(scheduler)
+
+        scheduler.flush_cache.assert_called_once()
+        self.assertEqual(len(scheduler._pending_flush), 0)
+        calls = scheduler.send_to_tokenizer.send_output.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(calls[0].args[0].success)
+        self.assertIs(calls[0].args[1], req1)
+        self.assertTrue(calls[1].args[0].success)
+        self.assertIs(calls[1].args[1], req2)
+
+    def test_check_pending_flush_busy_expires_only_timed_out(self):
+        scheduler = self._new_scheduler()
+        scheduler.is_fully_idle.return_value = False
+
+        expired_req = FlushCacheReqInput(timeout_s=1.0)
+        alive_req = FlushCacheReqInput(timeout_s=5.0)
+        scheduler._pending_flush = deque([(expired_req, 99.0), (alive_req, 101.0)])
+
+        with patch("sglang.srt.managers.scheduler.time.monotonic", return_value=100.0):
+            Scheduler._check_pending_flush(scheduler)
+
+        scheduler.flush_cache.assert_not_called()
+        self.assertEqual(len(scheduler._pending_flush), 1)
+        pending_req, deadline = scheduler._pending_flush[0]
+        self.assertIs(pending_req, alive_req)
+        self.assertEqual(deadline, 101.0)
+
+        calls = scheduler.send_to_tokenizer.send_output.call_args_list
+        self.assertEqual(len(calls), 1)
+        self.assertFalse(calls[0].args[0].success)
+        self.assertIs(calls[0].args[1], expired_req)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -1,5 +1,5 @@
-from collections import deque
 import unittest
+from collections import deque
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.managers.io_struct import FlushCacheReqInput, FlushCacheReqOutput


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
from https://github.com/sgl-project/sglang/issues/21359

I tried to reproduce the issue first:
```
python3 -m sglang.launch_server     
--model-path Qwen/Qwen2.5-0.5B-Instruct     
--host 127.0.0.1 --port 30000     
--enable-hierarchical-cache     
--page-size 64    
--mem-fraction-static 0.6     
--hicache-ratio 1.2 
--hicache-size 0     
--hicache-write-policy write_through     
--hicache-storage-backend file   
```
and the test code is like:
```
import requests

BASE = "http://127.0.0.1:30000"
prompt = "hello " * 2200
total = 120
transient = 0

for i in range(total):
    r = requests.post(
        BASE + "/generate",
        json={
            "text": prompt + f" turn-{i}",
            "sampling_params": {
                "temperature": 0.0,
                "max_new_tokens": 320,
                "ignore_eos": True,
            },
        },
        timeout=180,
    )
    if r.status_code != 200:
        print(f"[{i}] generate failed: {r.status_code}")
        break

    f1 = requests.post(BASE + "/flush_cache", timeout=10)
    f2 = requests.post(BASE + "/flush_cache", timeout=10)

    if f1.status_code != 200:
        transient += 1
        print(f"[{i}] flush {f1.status_code} -> retry {f2.status_code}")

print(f"transient flush failures: {transient}/{total}")
```
The result shows that:
```
[0] flush 400 -> retry 200
[1] flush 400 -> retry 400
[2] flush 400 -> retry 400
[3] flush 400 -> retry 200
[4] flush 400 -> retry 200
.....

The server shows the error log:
[2026-03-25 14:43:58] Cache not flushed because there are pending requests. #queue-req: 0, #running-req: 0
[2026-03-25 14:43:58] INFO:     127.0.0.1:41746 - "POST /flush_cache HTTP/1.1" 400 Bad Request
```

In my test, the code flow shoud be like below, the hiCache multi-level async(GPU->Host in my case)  will prevent `flush_cache` from succeeding.
```
Client Request
      |
      v
  Scheduler (prefill/decode)
      |
      +--> Generate response to client
      |
      +--> HiCache async ops (GPU kv cache -> Host/L3 in-flight) 


  flush_cache(400 bad request)
      |
      v
  check is_fully_idle():
    - HiCache ongoing_write_through empty?
      |
      +--> NO:
            - timeout=0(just indicates none)   -> fail fast (400)
```
     
flush_cache can only be safely applied when is_fully_idle() is true, so that in-flight cache operations and request states remain consistent.

Without timeout API, clients need to keep polling to flush the cache until it succeeds. And this timeout introduces almost no additional overhead on the server, reduces unnecessary retries.

## Modifications

<!-- Detail the changes made in this pull request. -->
this issue https://github.com/sgl-project/sglang/issues/21359 already presents a highly impressive solution, along with highly instructive reasoning. My final solution is also similar to this.

The logic should be like below:
```
  flush_cache(400 bad request)
      |
      v
  check is_fully_idle():
    - HiCache ongoing_write_through empty?
      |
      +--> NO:
            - timeout=0   -> fail fast (400)
            - timeout>0   -> enque flush cache reqeust queue

 Scheduler Event Loop (each iteration)
      |
      +--> process_input_requests(...)
            |
            +--> _check_pending_flush()
                    |
                    +--> pending_flush queue empty?
                    |      +--> yes: return
                    |
                    +--> is_fully_idle() ?
                           |
                           +--> yes:
                           |      flush_cache() once
                           |      reply all pending -> success (HTTP 200)
                           |      clear queue
                           |
                           +--> no:
                                  for each pending req:
                                    if now >= deadline:
                                       reply fail (HTTP 400)
                                    else:
                                       keep in queue (wait next iteration)
```

Unlike health checks, process_batch_result may have a relatively long gap between executions. Because of that, I moved the flush request queue check into process_input_requests on each loop iteration, so timeout handling can be evaluated in a timely manner.

In one detail, `flush_cache` is a global operation. Here is different with the original issue proposal, once one flush succeeds, all queued flush requests should also succeed, without requiring additional flush_cache calls.

What's more, since each scheduler is single-threaded and only handles its own pending flush queue, there should be no thread-safety concerns.

After this revision, I added a timeout parameter to the flush_cache requests in my test. The only change was:
```
    f1 = requests.post(BASE + "/flush_cache", params={"timeout": 10}, timeout=10)
    f2 = requests.post(BASE + "/flush_cache", params={"timeout": 10}, timeout=10)
```
With this change, the test runs successfully and no longer returns 400 Bad Request. Without the timeout parameter, however, 400 Bad Request can still occur.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
