### PR TITLE
[Diffusion] Change default torch.compile mode from max-autotune to default

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -228,6 +228,7 @@ class PipelineConfig:
 
     # Compilation
     # enable_torch_compile: bool = False
+    torch_compile_mode: str = "max-autotune-no-cudagraphs"
 
     # calculate the adjust size for condition image
     # width: original condition image width

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
@@ -420,6 +420,7 @@ def flux2_pack_latents(latents):
 
 @dataclass
 class Flux2PipelineConfig(FluxPipelineConfig):
+    torch_compile_mode: str = "default"
     embedded_cfg_scale: float = 4.0
 
     task_type: ModelTaskType = ModelTaskType.TI2I

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -130,6 +130,7 @@ def _pack_latents(latents, batch_size, num_channels_latents, height, width):
 class QwenImagePipelineConfig(ImagePipelineConfig):
     """Configuration for the QwenImage pipeline."""
 
+    torch_compile_mode: str = "default"
     should_use_guidance: bool = False
     task_type: ModelTaskType = ModelTaskType.T2I
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -41,6 +41,7 @@ class TransformersModelConfig(EncoderConfig):
 
 @dataclass
 class ZImagePipelineConfig(ImagePipelineConfig):
+    torch_compile_mode: str = "default"
     should_use_guidance: bool = False
     task_type: ModelTaskType = ModelTaskType.T2I
     dit_config: DiTConfig = field(default_factory=ZImageDitConfig)

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -8,6 +8,7 @@ through sglang's infrastructure using vanilla diffusers pipelines.
 
 import argparse
 import inspect
+import os
 import re
 import warnings
 from io import BytesIO
@@ -637,17 +638,26 @@ class DiffusersPipeline(ComposedPipelineBase):
                     # TODO(DefTruth): Add support for 'compile_repeated_blocks' for 'transformer'
                     # modules which can significantly reduce compilation time for large models
                     # with repeated blocks.
+                    env_mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE")
+                    mode = (
+                        env_mode
+                        if env_mode is not None
+                        else server_args.pipeline_config.torch_compile_mode
+                    )
+                    source = "env" if env_mode is not None else "pipeline_config"
                     if isinstance(component, torch.nn.Module) and hasattr(
                         component, "compile"
                     ):
                         # Prefer in-place compilation if supported. According to PyTorch documentation:
                         # https://docs.pytorch.org/docs/stable/generated/torch.compile.html
-                        component.compile()
+                        component.compile(mode=mode, fullgraph=False, dynamic=None)
                     else:
-                        compiled_component = torch.compile(component)
+                        compiled_component = torch.compile(
+                            component, mode=mode, fullgraph=False, dynamic=None
+                        )
                         setattr(pipe, comp, compiled_component)
                     logger.info(
-                        f"Applied torch.compile to {comp} component of the pipeline"
+                        f"Applied torch.compile to {comp} with mode: {mode} (source: {source})"
                     )
                 except Exception as e:
                     logger.warning(f"Failed to apply torch.compile to {comp}: {e}")

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -153,11 +153,15 @@ class DenoisingStage(PipelineStage):
                 _inductor_cfg.reorder_for_compute_comm_overlap = True
             except ImportError:
                 pass
-            mode = os.environ.get(
-                "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
+            env_mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE")
+            mode = (
+                env_mode
+                if env_mode is not None
+                else self.server_args.pipeline_config.torch_compile_mode
             )
             compile_kwargs["mode"] = mode
-            logger.info(f"Compiling transformer with mode: {mode}")
+            source = "env" if env_mode is not None else "pipeline_config"
+            logger.info(f"Compiling transformer with mode: {mode} (source: {source})")
 
         # TODO(triple-mu): support customized fullgraph and dynamic in the future
         module.compile(**compile_kwargs)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py
@@ -586,10 +586,18 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
             ddim_timesteps=30,
         ).to(self.device)
         if server_args.enable_torch_compile:
-            compile_mode = os.environ.get(
-                "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
+            env_mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE")
+            compile_mode = (
+                env_mode
+                if env_mode is not None
+                else server_args.pipeline_config.torch_compile_mode
             )
-            logger.info("Compiling paint transformer with mode: %s", compile_mode)
+            source = "env" if env_mode is not None else "pipeline_config"
+            logger.info(
+                "Compiling paint transformer with mode: %s (source: %s)",
+                compile_mode,
+                source,
+            )
             self.transformer.compile(mode=compile_mode, fullgraph=False, dynamic=None)
 
     def _convert_pil_list_to_tensor(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -226,11 +226,20 @@ class MOVADenoisingStage(PipelineStage):
                 _inductor_cfg.reorder_for_compute_comm_overlap = True
             except ImportError:
                 pass
-            mode = os.environ.get(
-                "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
+            env_mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE")
+            mode = (
+                env_mode
+                if env_mode is not None
+                else server_args.pipeline_config.torch_compile_mode
             )
             compile_kwargs["mode"] = mode
-            logger.info("Compiling %s with mode: %s", module.__class__.__name__, mode)
+            source = "env" if env_mode is not None else "pipeline_config"
+            logger.info(
+                "Compiling %s with mode: %s (source: %s)",
+                module.__class__.__name__,
+                mode,
+                source,
+            )
 
         # TODO(triple-mu): support customized fullgraph and dynamic in the future
         module.compile(**compile_kwargs)

--- a/python/sglang/multimodal_gen/test/unit/test_torch_compile_mode.py
+++ b/python/sglang/multimodal_gen/test/unit/test_torch_compile_mode.py
@@ -1,0 +1,101 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from sglang.multimodal_gen.configs.pipeline_configs.base import PipelineConfig
+from sglang.multimodal_gen.configs.pipeline_configs.flux import (
+    Flux2KleinPipelineConfig,
+    Flux2PipelineConfig,
+    FluxPipelineConfig,
+)
+from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import HunyuanConfig
+from sglang.multimodal_gen.configs.pipeline_configs.mova import MOVAPipelineConfig
+from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
+    QwenImageEditPipelineConfig,
+    QwenImagePipelineConfig,
+)
+from sglang.multimodal_gen.configs.pipeline_configs.wan import (
+    Wan2_2_TI2V_5B_Config,
+    WanT2V480PConfig,
+)
+from sglang.multimodal_gen.configs.pipeline_configs.zimage import ZImagePipelineConfig
+
+
+class TestTorchCompileModeDefaults(unittest.TestCase):
+    """Verify each pipeline config has the expected torch_compile_mode."""
+
+    def test_base_default_is_max_autotune(self):
+        config = PipelineConfig()
+        self.assertEqual(config.torch_compile_mode, "max-autotune-no-cudagraphs")
+
+    # Models that should use "default" mode
+    def test_flux2_uses_default(self):
+        self.assertEqual(Flux2PipelineConfig().torch_compile_mode, "default")
+
+    def test_flux2_klein_inherits_default(self):
+        self.assertEqual(Flux2KleinPipelineConfig().torch_compile_mode, "default")
+
+    def test_zimage_uses_default(self):
+        self.assertEqual(ZImagePipelineConfig().torch_compile_mode, "default")
+
+    def test_qwen_image_uses_default(self):
+        self.assertEqual(QwenImagePipelineConfig().torch_compile_mode, "default")
+
+    def test_qwen_image_edit_inherits_default(self):
+        self.assertEqual(QwenImageEditPipelineConfig().torch_compile_mode, "default")
+
+    # Models that should keep max-autotune-no-cudagraphs
+    def test_flux1_uses_max_autotune(self):
+        self.assertEqual(
+            FluxPipelineConfig().torch_compile_mode, "max-autotune-no-cudagraphs"
+        )
+
+    def test_wan_uses_max_autotune(self):
+        self.assertEqual(
+            WanT2V480PConfig().torch_compile_mode, "max-autotune-no-cudagraphs"
+        )
+
+    def test_wan_ti2v_inherits_max_autotune(self):
+        self.assertEqual(
+            Wan2_2_TI2V_5B_Config().torch_compile_mode, "max-autotune-no-cudagraphs"
+        )
+
+    def test_mova_uses_max_autotune(self):
+        self.assertEqual(
+            MOVAPipelineConfig().torch_compile_mode, "max-autotune-no-cudagraphs"
+        )
+
+    def test_hunyuan_uses_max_autotune(self):
+        self.assertEqual(
+            HunyuanConfig().torch_compile_mode, "max-autotune-no-cudagraphs"
+        )
+
+
+class TestTorchCompileModeEnvOverride(unittest.TestCase):
+    """Verify SGLANG_TORCH_COMPILE_MODE env var takes precedence over config."""
+
+    def _resolve_mode(self, pipeline_config):
+        """Replicate the resolution logic used in stage code."""
+        env_mode = os.environ.get("SGLANG_TORCH_COMPILE_MODE")
+        return env_mode if env_mode is not None else pipeline_config.torch_compile_mode
+
+    def test_env_var_overrides_config(self):
+        config = Flux2PipelineConfig()
+        with patch.dict(os.environ, {"SGLANG_TORCH_COMPILE_MODE": "reduce-overhead"}):
+            self.assertEqual(self._resolve_mode(config), "reduce-overhead")
+
+    def test_env_var_not_set_uses_config(self):
+        config = Flux2PipelineConfig()
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SGLANG_TORCH_COMPILE_MODE", None)
+            self.assertEqual(self._resolve_mode(config), "default")
+
+    def test_empty_env_var_still_overrides(self):
+        """Empty string env var should override, not fall through."""
+        config = Flux2PipelineConfig()
+        with patch.dict(os.environ, {"SGLANG_TORCH_COMPILE_MODE": ""}):
+            self.assertEqual(self._resolve_mode(config), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The current default torch.compile mode for diffusion pipelines (max-autotune-no-cudagraphs) causes 1.47-1.68x denoising regression compared to no compile. Switching to default mode eliminates this regression and additionally speeds up text encoding (~2x) and VAE decode (~1.9x).

In benchmarking against vllm-omni (which already uses default compile mode), SGLang's --enable-torch-compile was consistently slower due to this mode difference. With this change, SGLang with --enable-torch-compile is now faster than without it — matching the behavior seen in vllm-omni.

## Modifications

<!-- Detail the changes made in this pull request. -->

Changed the default compile mode from max-autotune-no-cudagraphs to default in 3 files:

python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py — general denoising stage
python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py — MoVA denoising stage
python/sglang/multimodal_gen/runtime/pipelines_core/stages/hunyuan3d_paint.py — Hunyuan3D paint stage
Not changed: python/sglang/multimodal_gen/runtime/models/dits/causal_wanvideo.py (hardcoded flex_attention compile, different use case).

Users can still override via SGLANG_TORCH_COMPILE_MODE env var for backward compatibility.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Image outputs generated successfully on both FLUX.2-Klein-4B and Qwen-Image-2512 with default compile mode. torch.compile with default mode is expected to produce numerically identical results to max-autotune (same Inductor backend, different autotuning level).

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

<img width="720" height="568" alt="image" src="https://github.com/user-attachments/assets/2c5496cd-8672-4d0a-b25a-e17b6cde310a" />

- Observations: max-autotune causes 1.47-1.68x denoising regression and 30s+ warmup on Qwen. default mode keeps denoising at parity with eager while speeding up text encoding and VAE decode. Tested on FLUX.2-Klein-4B (4 steps) and Qwen-Image-2512 (50 steps) — consistent results across both models.

- Test environment: 1x H200 (141 GB HBM3e), BF16, container based on lmsysorg/sglang:dev

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
