### PR TITLE
[AMD]Integrate aiter's fused_topk for softmax scoring in topk function

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -129,7 +129,7 @@ if _is_cuda or _is_hip or _is_xpu:
 if _use_aiter:
     try:
         from aiter import biased_grouped_topk as aiter_biased_grouped_topk
-        from aiter import topk_softmax
+        from aiter.fused_moe import fused_topk as aiter_fused_topk
     except ImportError:
         raise ImportError("aiter is required when SGLANG_USE_AITER is set to True")
 
@@ -513,7 +513,6 @@ def fused_topk(
 
     if scoring_func == "softmax":
         if _use_aiter:
-            from aiter.fused_moe import fused_topk as aiter_fused_topk
 
             # Use fused_topk instead of topk_softmax to auto dispatch to the correct kernel
             topk_weights, topk_ids = aiter_fused_topk(

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -129,6 +129,7 @@ if _is_cuda or _is_hip or _is_xpu:
 if _use_aiter:
     try:
         from aiter import biased_grouped_topk as aiter_biased_grouped_topk
+        from aiter import topk_softmax
     except ImportError:
         raise ImportError("aiter is required when SGLANG_USE_AITER is set to True")
 
@@ -511,12 +512,25 @@ def fused_topk(
     topk_ids = torch.empty(M, topk, dtype=torch.int32, device=hidden_states.device)
 
     if scoring_func == "softmax":
-        topk_softmax(
-            topk_weights,
-            topk_ids,
-            gating_output,
-            renormalize,
-        )
+        if _use_aiter:
+            from aiter.fused_moe import fused_topk as aiter_fused_topk
+
+            # Use fused_topk instead of topk_softmax to auto dispatch to the correct kernel
+            topk_weights, topk_ids = aiter_fused_topk(
+                hidden_states,
+                gating_output,
+                topk,
+                renormalize,
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+            )
+        else:
+            topk_softmax(
+                topk_weights,
+                topk_ids,
+                gating_output,
+                renormalize,
+            )
     elif scoring_func == "sigmoid":
         topk_sigmoid(
             topk_weights,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable AIter-backed paths for ROCm/HIP to fuse softmax+topk: **MoE TopK**.

## Modifications

<!-- Detail the changes made in this pull request. -->
When aiter is enabled, by default use `aiter.fused_topk`
## Accuracy Tests

**Before**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9719|±  |0.0045|
|     |       |strict-match    |     5|exact_match|↑  |0.9727|±  |0.0045|

**After**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9712|±  |0.0046|
|     |       |strict-match    |     5|exact_match|↑  |0.9719|±  |0.0045|

## Comparation for  different impls of topk_softmax.
Baseline sgl-kernel.
### SUMMARY — deepseek-ai/DeepSeek-V3  (E=[256], topk=[8])

|   bs |   seq | dtype    |   token |   expert |   topk |   torch_us |   sgl_us |   sgl_err |   aiter_us |   aiter_err |   asm_us |   asm_err | aiter_vs_sgl   | asm_vs_sgl   |
|-----:|------:|:---------|--------:|---------:|-------:|-----------:|---------:|----------:|-----------:|------------:|---------:|----------:|:---------------|:-------------|
|    1 |     1 | bfloat16 |       1 |      256 |      8 |      21.39 |     7.67 |  0        |       5.88 |           0 |     2.33 |  0        | 1.30x          | 3.29x        |
|    4 |     1 | bfloat16 |       4 |      256 |      8 |      24.91 |     7.58 |  0.375    |       5.64 |           0 |     2.45 |  0.375    | 1.34x          | 3.09x        |
|    8 |     1 | bfloat16 |       8 |      256 |      8 |      28.83 |     7.52 |  0.515625 |       5.69 |           0 |     2.97 |  0.515625 | 1.32x          | 2.53x        |
|   16 |     1 | bfloat16 |      16 |      256 |      8 |      29.95 |     7.86 |  0.734375 |       5.72 |           0 |     3.43 |  0.734375 | 1.37x          | 2.29x        |
|   32 |     1 | bfloat16 |      32 |      256 |      8 |      30.99 |     8.31 |  0.742188 |       6.6  |           0 |     4.06 |  0.742188 | 1.26x          | 2.05x        |
|   64 |     1 | bfloat16 |      64 |      256 |      8 |      30.75 |     9.09 |  0.765625 |       7.04 |           0 |     4.09 |  0.765625 | 1.29x          | 2.22x        |
|  128 |     1 | bfloat16 |     128 |      256 |      8 |      30.75 |     9.16 |  0.78125  |       7.39 |           0 |     4.08 |  0.78125  | 1.24x          | 2.25x        |
|    1 |  1024 | bfloat16 |    1024 |      256 |      8 |      13.84 |     9.33 |  0.816772 |       8.34 |           0 |     4.17 |  0.816772 | 1.12x          | 2.24x        |
|    4 |  1024 | bfloat16 |    4096 |      256 |      8 |      41.99 |    10.24 |  0.811737 |       8.53 |           0 |     5.03 |  0.811737 | 1.20x          | 2.04x        |
|    8 |  1024 | bfloat16 |    8192 |      256 |      8 |      55.75 |    12.41 |  0.811554 |       9.31 |           0 |     7.14 |  0.811554 | 1.33x          | 1.74x        |
|   16 |  1024 | bfloat16 |   16384 |      256 |      8 |      77.67 |    17.26 |  0.812881 |      13.35 |           0 |    11.26 |  0.812881 | 1.29x          | 1.53x        |
|   32 |  1024 | bfloat16 |   32768 |      256 |      8 |     127.07 |    28.82 |  0.810478 |      19.77 |           0 |    16.62 |  0.810478 | 1.46x          | 1.73x        |
|   64 |  1024 | bfloat16 |   65536 |      256 |      8 |     228.15 |    51.36 |  0.810671 |      34.13 |           0 |    26.63 |  0.810671 | 1.50x          | 1.93x        |
|  128 |  1024 | bfloat16 |  131072 |      256 |      8 |     439.72 |    94.25 |  0.810811 |      61.98 |           0 |    48.69 |  0.810811 | 1.52x          | 1.94x        |
|   32 |  8192 | bfloat16 |  262144 |      256 |      8 |     837.24 |   174.58 |  0.81068  |     114.1  |           0 |    89.31 |  0.810679 | 1.53x          | 1.95x        |
|   64 |  8192 | bfloat16 |  524288 |      256 |      8 |    1676.04 |   347.87 |  0.810576 |     222.96 |           0 |   173.43 |  0.810576 | 1.56x          | 2.01x        |
|  128 |  8192 | bfloat16 | 1048576 |      256 |      8 |    3248.94 |   667.91 |  0.8105   |     431.46 |           0 |   335.44 |  0.8105   | 1.55x          | 1.99x        |

### SUMMARY — Qwen/Qwen3.5-397B-A17B  (E=[512], topk=[10])

|   bs |   seq | dtype    |   token |   expert |   topk |   torch_us |   sgl_us |   sgl_err |   aiter_us |   aiter_err | asm_us   | asm_err   | aiter_vs_sgl   |
|-----:|------:|:---------|--------:|---------:|-------:|-----------:|---------:|----------:|-----------:|------------:|:---------|:----------|:---------------|
|    1 |     1 | bfloat16 |       1 |      512 |     10 |      33.47 |     9.66 |  0        |       7.38 |           0 | N/A      | N/A       | 1.31x          |
|    4 |     1 | bfloat16 |       4 |      512 |     10 |      36.39 |    10.6  |  0.35     |       7.28 |           0 | N/A      | N/A       | 1.46x          |
|    8 |     1 | bfloat16 |       8 |      512 |     10 |      50.03 |    11.7  |  0.2875   |       7.62 |           0 | N/A      | N/A       | 1.54x          |
|   16 |     1 | bfloat16 |      16 |      512 |     10 |      50.71 |    11.61 |  0.6375   |       8.12 |           0 | N/A      | N/A       | 1.43x          |
|   32 |     1 | bfloat16 |      32 |      512 |     10 |      49.91 |    11.7  |  0.675    |       8.85 |           0 | N/A      | N/A       | 1.32x          |
|   64 |     1 | bfloat16 |      64 |      512 |     10 |      49.75 |    11.89 |  0.684375 |       8.98 |           0 | N/A      | N/A       | 1.32x          |
|  128 |     1 | bfloat16 |     128 |      512 |     10 |      50.27 |    11.91 |  0.696875 |       9.05 |           0 | N/A      | N/A       | 1.32x          |
|    1 |  1024 | bfloat16 |    1024 |      512 |     10 |      85.83 |    13.45 |  0.739746 |       9.21 |           0 | N/A      | N/A       | 1.46x          |
|    4 |  1024 | bfloat16 |    4096 |      512 |     10 |      99.38 |    32.04 |  0.754248 |      11.02 |           0 | N/A      | N/A       | 2.91x          |
|    8 |  1024 | bfloat16 |    8192 |      512 |     10 |     139.55 |    57.02 |  0.754077 |      16.97 |           0 | N/A      | N/A       | 3.36x          |
|   16 |  1024 | bfloat16 |   16384 |      512 |     10 |     229.74 |   107.24 |  0.753302 |      24.17 |           0 | N/A      | N/A       | 4.44x          |
|   32 |  1024 | bfloat16 |   32768 |      512 |     10 |     409.07 |   200.6  |  0.751654 |      43.4  |           0 | N/A      | N/A       | 4.62x          |
|   64 |  1024 | bfloat16 |   65536 |      512 |     10 |     882.47 |   386.09 |  0.753418 |      79.14 |           0 | N/A      | N/A       | 4.88x          |
|  128 |  1024 | bfloat16 |  131072 |      512 |     10 |    1730.6  |   855.39 |  0.753337 |     146.01 |           0 | N/A      | N/A       | 5.86x          |
|   32 |  8192 | bfloat16 |  262144 |      512 |     10 |    3400.17 |  1719.66 |  0.752707 |     284.17 |           0 | N/A      | N/A       | 6.05x          |
|   64 |  8192 | bfloat16 |  524288 |      512 |     10 |    6787.97 |  3436.18 |  0.753321 |     553.39 |           0 | N/A      | N/A       | 6.21x          |
|  128 |  8192 | bfloat16 | 1048576 |      512 |     10 |   13496.4  |  6896.04 |  0.753394 |    1096.23 |           0 | N/A      | N/A       | 6.29x          |

## Benchmark
bs=64, 1k1k
Before
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 64        
Successful requests:                     640       
Benchmark duration (s):                  244.93    
Total input tokens:                      590851    
Total input text tokens:                 590851    
Total generated tokens:                  589052    
Total generated tokens (retokenized):    587513    
Request throughput (req/s):              2.61      
Input token throughput (tok/s):          2412.29   
Output token throughput (tok/s):         2404.94   
Peak output token throughput (tok/s):    3094.00   
Peak concurrent requests:                75        
Total token throughput (tok/s):          4817.23   
Concurrency:                             62.48     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   23912.46  
Median E2E Latency (ms):                 23816.68  
P90 E2E Latency (ms):                    26818.09  
P99 E2E Latency (ms):                    28128.11  
---------------Time to First Token----------------
Mean TTFT (ms):                          186.30    
Median TTFT (ms):                        85.04     
P99 TTFT (ms):                           1469.97   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.79     
Median TPOT (ms):                        26.25     
P99 TPOT (ms):                           27.79     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.81     
Median ITL (ms):                         21.16     
P95 ITL (ms):                            91.78     
P99 ITL (ms):                            134.56    
Max ITL (ms):                            1359.95   
==================================================
```

After
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 64        
Successful requests:                     640       
Benchmark duration (s):                  240.31    
Total input tokens:                      590851    
Total input text tokens:                 590851    
Total generated tokens:                  589052    
Total generated tokens (retokenized):    587251    
Request throughput (req/s):              2.66      
Input token throughput (tok/s):          2458.69   
Output token throughput (tok/s):         2451.20   
Peak output token throughput (tok/s):    3136.00   
Peak concurrent requests:                76        
Total token throughput (tok/s):          4909.89   
Concurrency:                             62.48     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   23460.42  
Median E2E Latency (ms):                 23373.80  
P90 E2E Latency (ms):                    26262.06  
P99 E2E Latency (ms):                    27411.67  
---------------Time to First Token----------------
Mean TTFT (ms):                          173.04    
Median TTFT (ms):                        83.74     
P99 TTFT (ms):                           1305.24   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.31     
Median TPOT (ms):                        25.79     
P99 TPOT (ms):                           26.88     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.33     
Median ITL (ms):                         20.96     
P95 ITL (ms):                            88.58     
P99 ITL (ms):                            100.73    
Max ITL (ms):                            1203.00   
==================================================
```
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
