### PR TITLE
[Diffusion] Add cudaProfilerApi support for nsys profiling

### DIFF
--- a/python/sglang/cli/main.py
+++ b/python/sglang/cli/main.py
@@ -44,3 +44,7 @@ def main():
         generate(args, extra_argv)
     elif args.subcommand == "version":
         version(args, extra_argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     VERBOSE: bool = False
     SGLANG_DIFFUSION_SERVER_DEV_MODE: bool = False
     SGLANG_DIFFUSION_STAGE_LOGGING: bool = False
+    SGLANG_DIFFUSION_PROFILE_STEP_RANGE: str | None = None
     # cache-dit env vars (primary transformer)
     SGLANG_CACHE_DIT_ENABLED: bool = False
     SGLANG_CACHE_DIT_FN: int = 1
@@ -282,6 +283,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # ROCm: use AITer GroupNorm in VAE for improved performance
     "SGLANG_USE_ROCM_VAE": _lazy_bool("SGLANG_USE_ROCM_VAE"),
+    # ================== Profiling Env Vars ==================
+    # Global denoising step range for cudaProfilerApi profiling
+    # Format: "START-END" (e.g., "100-150" to profile steps 100-150)
+    # Used with nsys -c cudaProfilerApi to capture specific denoising steps
+    "SGLANG_DIFFUSION_PROFILE_STEP_RANGE": _lazy_str(
+        "SGLANG_DIFFUSION_PROFILE_STEP_RANGE"
+    ),
 }
 
 # Add cache-dit Secondary Transformer Env Vars via programmatic generation to reduce duplication

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -78,7 +78,10 @@ from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.layerwise_offload import OffloadableDiTMixin
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
-from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.multimodal_gen.runtime.utils.profiler import (
+    DiffusionStepProfiler,
+    SGLDiffusionProfiler,
+)
 from sglang.multimodal_gen.utils import dict_to_3d_list, masks_like
 from sglang.srt.utils.common import get_compiler_backend
 
@@ -1013,111 +1016,125 @@ class DenoisingStage(PipelineStage):
         self.scheduler.set_begin_index(0)
         timesteps_cpu = timesteps.cpu()
         num_timesteps = timesteps_cpu.shape[0]
-        with torch.autocast(
-            device_type=current_platform.device_type,
-            dtype=target_dtype,
-            enabled=autocast_enabled,
-        ):
-            with self.progress_bar(total=num_inference_steps) as progress_bar:
-                for i, t_host in enumerate(timesteps_cpu):
-                    with StageProfiler(
-                        f"denoising_step_{i}",
-                        logger=logger,
-                        metrics=batch.metrics,
-                        perf_dump_path_provided=batch.perf_dump_path is not None,
-                    ):
-                        t_int = int(t_host.item())
-                        t_device = timesteps[i]
-                        current_model, current_guidance_scale = (
-                            self._select_and_manage_model(
-                                t_int=t_int,
-                                boundary_timestep=boundary_timestep,
-                                server_args=server_args,
-                                batch=batch,
-                            )
-                        )
+        step_profiler = DiffusionStepProfiler.get_instance()
+        if step_profiler.should_profile() and not is_warmup:
+            step_profiler.log_request_start(
+                num_steps=num_timesteps,
+                request_id=getattr(batch, "request_id", None),
+            )
 
-                        # Expand latents for I2V
-                        latent_model_input = latents.to(target_dtype)
-                        if batch.image_latent is not None:
-                            assert (
-                                not server_args.pipeline_config.task_type
-                                == ModelTaskType.TI2V
-                            ), "image latents should not be provided for TI2V task"
-                            latent_model_input = torch.cat(
-                                [latent_model_input, batch.image_latent], dim=1
-                            ).to(target_dtype)
-
-                        timestep = self.expand_timestep_before_forward(
-                            batch,
-                            server_args,
-                            t_device,
-                            target_dtype,
-                            seq_len,
-                            reserved_frames_mask,
-                        )
-
-                        latent_model_input = self.scheduler.scale_model_input(
-                            latent_model_input, t_device
-                        )
-
-                        # Predict noise residual
-                        attn_metadata = self._build_attn_metadata(
-                            i,
-                            batch,
-                            server_args,
-                            timestep_value=t_int,
-                            timesteps=timesteps_cpu,
-                        )
-                        noise_pred = self._predict_noise_with_cfg(
-                            current_model=current_model,
-                            latent_model_input=latent_model_input,
-                            timestep=timestep,
-                            batch=batch,
-                            timestep_index=i,
-                            attn_metadata=attn_metadata,
-                            target_dtype=target_dtype,
-                            current_guidance_scale=current_guidance_scale,
-                            image_kwargs=image_kwargs,
-                            pos_cond_kwargs=pos_cond_kwargs,
-                            neg_cond_kwargs=neg_cond_kwargs,
-                            server_args=server_args,
-                            guidance=guidance,
-                            latents=latents,
-                        )
-
-                        # Save noise_pred to batch for external access (e.g., ComfyUI)
-                        if server_args.comfyui_mode:
-                            batch.noise_pred = noise_pred
-
-                        # Compute the previous noisy sample
-                        latents = self.scheduler.step(
-                            model_output=noise_pred,
-                            timestep=t_device,
-                            sample=latents,
-                            **extra_step_kwargs,
-                            return_dict=False,
-                        )[0]
-
-                        latents = self.post_forward_for_ti2v_task(
-                            batch, server_args, reserved_frames_mask, latents, z
-                        )
-
-                        # save trajectory latents if needed
-                        if batch.return_trajectory_latents:
-                            trajectory_timesteps.append(t_host)
-                            trajectory_latents.append(latents)
-
-                        # Update progress bar
-                        if i == num_timesteps - 1 or (
-                            (i + 1) > num_warmup_steps
-                            and (i + 1) % self.scheduler.order == 0
-                            and progress_bar is not None
+        try:
+            with torch.autocast(
+                device_type=current_platform.device_type,
+                dtype=target_dtype,
+                enabled=autocast_enabled,
+            ):
+                with self.progress_bar(total=num_inference_steps) as progress_bar:
+                    for i, t_host in enumerate(timesteps_cpu):
+                        if step_profiler.should_profile() and not is_warmup:
+                            step_profiler.step()
+                        with StageProfiler(
+                            f"denoising_step_{i}",
+                            logger=logger,
+                            metrics=batch.metrics,
+                            perf_dump_path_provided=batch.perf_dump_path is not None,
                         ):
-                            progress_bar.update()
+                            t_int = int(t_host.item())
+                            t_device = timesteps[i]
+                            current_model, current_guidance_scale = (
+                                self._select_and_manage_model(
+                                    t_int=t_int,
+                                    boundary_timestep=boundary_timestep,
+                                    server_args=server_args,
+                                    batch=batch,
+                                )
+                            )
 
-                        if not is_warmup:
-                            self.step_profile()
+                            # Expand latents for I2V
+                            latent_model_input = latents.to(target_dtype)
+                            if batch.image_latent is not None:
+                                assert (
+                                    not server_args.pipeline_config.task_type
+                                    == ModelTaskType.TI2V
+                                ), "image latents should not be provided for TI2V task"
+                                latent_model_input = torch.cat(
+                                    [latent_model_input, batch.image_latent],
+                                    dim=1,
+                                ).to(target_dtype)
+
+                            timestep = self.expand_timestep_before_forward(
+                                batch,
+                                server_args,
+                                t_device,
+                                target_dtype,
+                                seq_len,
+                                reserved_frames_mask,
+                            )
+
+                            latent_model_input = self.scheduler.scale_model_input(
+                                latent_model_input, t_device
+                            )
+
+                            # Predict noise residual
+                            attn_metadata = self._build_attn_metadata(
+                                i,
+                                batch,
+                                server_args,
+                                timestep_value=t_int,
+                                timesteps=timesteps_cpu,
+                            )
+                            noise_pred = self._predict_noise_with_cfg(
+                                current_model=current_model,
+                                latent_model_input=latent_model_input,
+                                timestep=timestep,
+                                batch=batch,
+                                timestep_index=i,
+                                attn_metadata=attn_metadata,
+                                target_dtype=target_dtype,
+                                current_guidance_scale=current_guidance_scale,
+                                image_kwargs=image_kwargs,
+                                pos_cond_kwargs=pos_cond_kwargs,
+                                neg_cond_kwargs=neg_cond_kwargs,
+                                server_args=server_args,
+                                guidance=guidance,
+                                latents=latents,
+                            )
+
+                            # Save noise_pred to batch for external access (e.g., ComfyUI)
+                            if server_args.comfyui_mode:
+                                batch.noise_pred = noise_pred
+
+                            # Compute the previous noisy sample
+                            latents = self.scheduler.step(
+                                model_output=noise_pred,
+                                timestep=t_device,
+                                sample=latents,
+                                **extra_step_kwargs,
+                                return_dict=False,
+                            )[0]
+
+                            latents = self.post_forward_for_ti2v_task(
+                                batch, server_args, reserved_frames_mask, latents, z
+                            )
+
+                            # save trajectory latents if needed
+                            if batch.return_trajectory_latents:
+                                trajectory_timesteps.append(t_host)
+                                trajectory_latents.append(latents)
+
+                            # Update progress bar
+                            if i == num_timesteps - 1 or (
+                                (i + 1) > num_warmup_steps
+                                and (i + 1) % self.scheduler.order == 0
+                                and progress_bar is not None
+                            ):
+                                progress_bar.update()
+
+                            if not is_warmup:
+                                self.step_profile()
+
+        finally:
+            step_profiler.ensure_stopped()
 
         denoising_end_time = time.time()
 

--- a/python/sglang/multimodal_gen/runtime/utils/profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/profiler.py
@@ -1,10 +1,39 @@
+from __future__ import annotations
+
 import gzip
 import os
 
 import torch
 
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.logging_utils import CYAN, RESET, init_logger
+
+try:
+    from sglang.multimodal_gen.runtime.distributed import (
+        get_world_group as _get_world_group,
+    )
+except ImportError:
+    # distributed module not available in single-GPU setups
+    _get_world_group = None
+
+
+def is_primary_rank() -> bool:
+    """Return True if this is rank 0 (or single-GPU).
+
+    Only rank 0 should call cudaProfilerStart/Stop to avoid redundant
+    profiling data in multi-GPU (sequence parallelism, tensor parallelism) setups.
+    """
+    if _get_world_group is not None:
+        try:
+            world_group = _get_world_group()
+            if world_group is not None:
+                return world_group.rank == 0
+        except RuntimeError:
+            # distributed not yet initialized at call time
+            pass
+    return True
+
 
 if current_platform.is_npu():
     import torch_npu
@@ -16,6 +45,204 @@ if current_platform.is_npu():
     torch_npu._apply_patches(patches)
 
 logger = init_logger(__name__)
+
+
+def parse_step_range(range_str: str | None) -> tuple[int, int] | None:
+    """Parse step range string like '100-150' into (start, end) tuple."""
+    if not range_str:
+        return None
+    try:
+        parts = range_str.split("-")
+        if len(parts) != 2:
+            logger.warning(
+                f"Invalid SGLANG_DIFFUSION_PROFILE_STEP_RANGE format: {range_str}. "
+                "Expected 'START-END' (e.g., '100-150')"
+            )
+            return None
+        start, end = int(parts[0].strip()), int(parts[1].strip())
+        if start >= end:
+            logger.warning(
+                f"Invalid step range: start ({start}) must be less than end ({end})"
+            )
+            return None
+        return (start, end)
+    except ValueError as e:
+        logger.warning(f"Failed to parse step range '{range_str}': {e}")
+        return None
+
+
+class DiffusionStepProfiler:
+    """
+    Global denoising step counter with cudaProfilerApi support.
+
+    This class tracks the global denoising step count across all requests,
+    similar to how LLM's scheduler tracks forward_ct. It enables nsys profiling
+    with -c cudaProfilerApi by calling cudaProfilerStart/Stop at specific step ranges.
+
+    Usage:
+        Set SGLANG_DIFFUSION_PROFILE_STEP_RANGE="100-150" to profile steps 100-150.
+
+        Request 1: steps 0-49   (global steps 0-49)
+        Request 2: steps 0-49   (global steps 50-99)
+        Request 3: steps 0-49   (global steps 100-149)  <- profiled if range is 100-150
+
+    Run with:
+        nsys profile -c cudaProfilerApi -t cuda,nvtx ... python -m sglang.cli.main serve ...
+
+    Note: Currently tracks steps from the standard DenoisingStage only.
+    Specialized stages (helios, causal, av, dmd, hunyuan3d) are not yet instrumented.
+    """
+
+    _instance: DiffusionStepProfiler | None = None
+
+    def __init__(self):
+        self.global_step_count = 0
+        self.profile_range = parse_step_range(envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE)
+        self.profiling_active = False
+        self._profiler_started = False
+
+        if self.profile_range:
+            logger.info(
+                f"DiffusionStepProfiler initialized with step range: "
+                f"{self.profile_range[0]}-{self.profile_range[1]}"
+            )
+
+    @classmethod
+    def get_instance(cls) -> "DiffusionStepProfiler":
+        """Get or create the singleton instance."""
+        if cls._instance is None:
+            cls._instance = DiffusionStepProfiler()
+        return cls._instance
+
+    @classmethod
+    def reset(cls):
+        """Reset the singleton instance (for testing)."""
+        cls._instance = None
+
+    def should_profile(self) -> bool:
+        """Check if profiling is configured."""
+        return self.profile_range is not None
+
+    def step(self) -> bool:
+        """
+        Increment the global step counter and manage cudaProfiler state.
+
+        Returns:
+            True if this step is within the profile range, False otherwise.
+        """
+        current_step = self.global_step_count
+        self.global_step_count += 1
+
+        if not self.profile_range:
+            return False
+
+        start, end = self.profile_range
+        in_range = start <= current_step < end
+
+        if in_range and not self._profiler_started:
+            self._start_cuda_profiler(current_step)
+            self._profiler_started = True
+            self.profiling_active = True
+            if is_primary_rank():
+                logger.info(
+                    f"Profiling STARTED at global step {current_step}, "
+                    f"will stop at step {end}"
+                )
+
+        if current_step >= end and self._profiler_started and self.profiling_active:
+            if is_primary_rank():
+                logger.info(
+                    f"Profiling STOPPING at global step {current_step} "
+                    f"(captured steps {start}-{current_step - 1})"
+                )
+            self.profiling_active = False
+            self._stop_cuda_profiler(current_step)
+
+        return in_range
+
+    def _start_cuda_profiler(self, step: int):
+        """Call cudaProfilerStart to begin capture.
+
+        Only called on the primary rank (rank 0) to avoid redundant
+        profiling data and duplicate logs in multi-GPU setups.
+        """
+        if not torch.cuda.is_available() or not is_primary_rank():
+            return
+        logger.info(
+            f"cudaProfilerStart at global step {step} "
+            f"(range: {self.profile_range[0]}-{self.profile_range[1]})"
+        )
+        torch.cuda.cudart().cudaProfilerStart()
+
+    def _stop_cuda_profiler(self, step: int | None = None):
+        """Call cudaProfilerStop to end capture.
+
+        Only called on the primary rank (rank 0) to match cudaProfilerStart.
+        """
+        if not torch.cuda.is_available() or not is_primary_rank():
+            return
+        step_info = f" at global step {step}" if step is not None else ""
+        logger.info(
+            f"cudaProfilerStop{step_info} "
+            f"(range: {self.profile_range[0]}-{self.profile_range[1]})"
+        )
+        torch.cuda.cudart().cudaProfilerStop()
+
+    def get_global_step_count(self) -> int:
+        """Get the current global step count."""
+        return self.global_step_count
+
+    def is_profiling_active(self) -> bool:
+        """Check if profiling is currently active."""
+        return self.profiling_active
+
+    def ensure_stopped(self):
+        """Ensure cudaProfilerStop is called if profiling was started.
+
+        Call this in a finally block to guarantee cleanup on exceptions.
+
+        Note: after this call, _profiler_started remains True so the range will
+        not be re-captured in subsequent requests. This is intentional —
+        cudaProfilerApi is designed for a single targeted capture window per
+        server run.
+        """
+        if self._profiler_started and self.profiling_active:
+            start, end = self.profile_range
+            if is_primary_rank():
+                logger.info(
+                    f"Profiling early stop at global step {self.global_step_count} "
+                    f"(captured steps {start}-{self.global_step_count - 1})"
+                )
+            self.profiling_active = False
+            self._stop_cuda_profiler()
+
+    def log_request_start(self, num_steps: int, request_id: str | None = None):
+        """
+        Log the start of a new request with its step range.
+
+        Only logs on primary rank (rank 0) to avoid duplicate log messages
+        in multi-GPU setups, matching the LLM runtime pattern.
+
+        Args:
+            num_steps: Number of denoising steps for this request.
+            request_id: Optional request identifier.
+        """
+        if not self.profile_range:
+            return
+        if not is_primary_rank():
+            return
+
+        start_step = self.global_step_count
+        end_step = start_step + num_steps
+        req_info = f" (request: {request_id})" if request_id else ""
+
+        profile_start, profile_end = self.profile_range
+        will_be_profiled = start_step < profile_end and end_step > profile_start
+        status = "WILL BE PROFILED" if will_be_profiled else "not in profile range"
+        logger.info(
+            f"Request starting{req_info}: global steps {start_step}-{end_step - 1} "
+            f"[{status}] (target: {profile_start}-{profile_end})"
+        )
 
 
 class SGLDiffusionProfiler:

--- a/python/sglang/multimodal_gen/test/run_suite.py
+++ b/python/sglang/multimodal_gen/test/run_suite.py
@@ -35,6 +35,7 @@ SUITES = {
         "../unit/test_storage.py",
         "../unit/test_lora_format_adapter.py",
         "../unit/test_server_args.py",
+        "../unit/test_diffusion_step_profiler.py",
         # add new unit tests here
     ],
     "1-gpu": [

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_step_profiler.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_step_profiler.py
@@ -1,0 +1,307 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.multimodal_gen.runtime.utils.profiler import (
+    DiffusionStepProfiler,
+    is_primary_rank,
+    parse_step_range,
+)
+
+
+class TestParseStepRange(unittest.TestCase):
+    def test_valid_range(self):
+        self.assertEqual(parse_step_range("100-150"), (100, 150))
+
+    def test_single_step_range(self):
+        self.assertEqual(parse_step_range("5-6"), (5, 6))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(parse_step_range(None))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(parse_step_range(""))
+
+    def test_start_equals_end_returns_none(self):
+        self.assertIsNone(parse_step_range("100-100"))
+
+    def test_start_greater_than_end_returns_none(self):
+        self.assertIsNone(parse_step_range("150-100"))
+
+    def test_missing_dash_returns_none(self):
+        self.assertIsNone(parse_step_range("100150"))
+
+    def test_non_integer_returns_none(self):
+        self.assertIsNone(parse_step_range("abc-def"))
+
+
+class TestIsPrimaryRank(unittest.TestCase):
+    def test_single_gpu_is_primary(self):
+        # No distributed setup — should return True
+        with patch(
+            "sglang.multimodal_gen.runtime.utils.profiler._get_world_group", None
+        ):
+            self.assertTrue(is_primary_rank())
+
+    def test_rank_0_is_primary(self):
+        mock_group = MagicMock()
+        mock_group.rank = 0
+        mock_get = MagicMock(return_value=mock_group)
+        with patch(
+            "sglang.multimodal_gen.runtime.utils.profiler._get_world_group", mock_get
+        ):
+            self.assertTrue(is_primary_rank())
+
+    def test_rank_1_is_not_primary(self):
+        mock_group = MagicMock()
+        mock_group.rank = 1
+        mock_get = MagicMock(return_value=mock_group)
+        with patch(
+            "sglang.multimodal_gen.runtime.utils.profiler._get_world_group", mock_get
+        ):
+            self.assertFalse(is_primary_rank())
+
+    def test_runtime_error_falls_back_to_primary(self):
+        mock_get = MagicMock(side_effect=RuntimeError("not initialized"))
+        with patch(
+            "sglang.multimodal_gen.runtime.utils.profiler._get_world_group", mock_get
+        ):
+            self.assertTrue(is_primary_rank())
+
+
+class TestDiffusionStepProfilerSingleton(unittest.TestCase):
+    def setUp(self):
+        DiffusionStepProfiler.reset()
+
+    def tearDown(self):
+        DiffusionStepProfiler.reset()
+
+    def test_get_instance_returns_same_object(self):
+        a = DiffusionStepProfiler.get_instance()
+        b = DiffusionStepProfiler.get_instance()
+        self.assertIs(a, b)
+
+    def test_reset_creates_fresh_instance(self):
+        a = DiffusionStepProfiler.get_instance()
+        DiffusionStepProfiler.reset()
+        b = DiffusionStepProfiler.get_instance()
+        self.assertIsNot(a, b)
+
+    def test_no_profile_range_when_env_unset(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = None
+            p = DiffusionStepProfiler()
+        self.assertIsNone(p.profile_range)
+        self.assertFalse(p.should_profile())
+
+    def test_profile_range_set_from_env(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "100-150"
+            p = DiffusionStepProfiler()
+        self.assertEqual(p.profile_range, (100, 150))
+        self.assertTrue(p.should_profile())
+
+
+class TestStepCounting(unittest.TestCase):
+    def setUp(self):
+        DiffusionStepProfiler.reset()
+
+    def tearDown(self):
+        DiffusionStepProfiler.reset()
+
+    def _make_profiler(self, step_range="10-13"):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = step_range
+            return DiffusionStepProfiler()
+
+    def test_step_increments_counter(self):
+        p = self._make_profiler()
+        self.assertEqual(p.global_step_count, 0)
+        p.step()
+        self.assertEqual(p.global_step_count, 1)
+        p.step()
+        self.assertEqual(p.global_step_count, 2)
+
+    def test_step_returns_false_before_range(self):
+        p = self._make_profiler("10-13")
+        for _ in range(10):
+            result = p.step()
+        self.assertFalse(result)
+
+    def test_step_returns_true_in_range(self):
+        p = self._make_profiler("10-13")
+        for _ in range(10):
+            p.step()
+        # steps 10, 11, 12 are in range
+        self.assertTrue(p.step())  # step 10
+        self.assertTrue(p.step())  # step 11
+        self.assertTrue(p.step())  # step 12
+
+    def test_step_returns_false_at_range_end(self):
+        p = self._make_profiler("10-13")
+        for _ in range(13):
+            p.step()
+        self.assertFalse(p.step())  # step 13 — range is exclusive-end
+
+    def test_step_returns_false_when_no_range(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = None
+            p = DiffusionStepProfiler()
+        self.assertFalse(p.step())
+
+
+class TestCudaProfilerControl(unittest.TestCase):
+    def setUp(self):
+        DiffusionStepProfiler.reset()
+
+    def tearDown(self):
+        DiffusionStepProfiler.reset()
+
+    def _make_profiler(self, step_range="5-8"):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = step_range
+            return DiffusionStepProfiler()
+
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch("sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.cudart")
+    def test_profiler_starts_on_range_entry(self, mock_cudart, _):
+        mock_rt = MagicMock()
+        mock_cudart.return_value = mock_rt
+        p = self._make_profiler("5-8")
+        for _ in range(5):
+            p.step()
+        p.step()  # step 5 — enters range
+        mock_rt.cudaProfilerStart.assert_called_once()
+
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch("sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.cudart")
+    def test_profiler_stops_on_range_exit(self, mock_cudart, _):
+        mock_rt = MagicMock()
+        mock_cudart.return_value = mock_rt
+        p = self._make_profiler("5-8")
+        for _ in range(8):
+            p.step()
+        p.step()  # step 8 — exits range
+        mock_rt.cudaProfilerStop.assert_called_once()
+
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.is_primary_rank",
+        return_value=False,
+    )
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch("sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.cudart")
+    def test_non_primary_rank_skips_cuda_calls(self, mock_cudart, _, __):
+        p = self._make_profiler("5-8")
+        for _ in range(9):
+            p.step()
+        mock_cudart.return_value.cudaProfilerStart.assert_not_called()
+        mock_cudart.return_value.cudaProfilerStop.assert_not_called()
+
+
+class TestEnsureStopped(unittest.TestCase):
+    def setUp(self):
+        DiffusionStepProfiler.reset()
+
+    def tearDown(self):
+        DiffusionStepProfiler.reset()
+
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch("sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.cudart")
+    def test_ensure_stopped_stops_active_profiling(self, mock_cudart, _):
+        mock_rt = MagicMock()
+        mock_cudart.return_value = mock_rt
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "2-5"
+            p = DiffusionStepProfiler()
+        for _ in range(3):
+            p.step()  # step 0, 1, 2 — enters range at step 2
+        p.ensure_stopped()
+        mock_rt.cudaProfilerStop.assert_called_once()
+
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch("sglang.multimodal_gen.runtime.utils.profiler.torch.cuda.cudart")
+    def test_ensure_stopped_is_idempotent(self, mock_cudart, _):
+        mock_rt = MagicMock()
+        mock_cudart.return_value = mock_rt
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "2-5"
+            p = DiffusionStepProfiler()
+        for _ in range(3):
+            p.step()
+        p.ensure_stopped()
+        p.ensure_stopped()  # second call must be a no-op
+        self.assertEqual(mock_rt.cudaProfilerStop.call_count, 1)
+
+    def test_ensure_stopped_noop_when_not_started(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "100-150"
+            p = DiffusionStepProfiler()
+        # Never reached range — ensure_stopped should be safe to call
+        p.ensure_stopped()
+        self.assertFalse(p.profiling_active)
+
+
+class TestLogRequestStart(unittest.TestCase):
+    def setUp(self):
+        DiffusionStepProfiler.reset()
+
+    def tearDown(self):
+        DiffusionStepProfiler.reset()
+
+    def test_noop_when_no_profile_range(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = None
+            p = DiffusionStepProfiler()
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.logger") as mock_log:
+            p.log_request_start(num_steps=50)
+            mock_log.info.assert_not_called()
+
+    @patch(
+        "sglang.multimodal_gen.runtime.utils.profiler.is_primary_rank",
+        return_value=False,
+    )
+    def test_noop_on_non_primary_rank(self, _):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "100-150"
+            p = DiffusionStepProfiler()
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.logger") as mock_log:
+            p.log_request_start(num_steps=50)
+            mock_log.info.assert_not_called()
+
+    def test_logs_will_be_profiled_when_overlapping(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "100-150"
+            p = DiffusionStepProfiler()
+        p.global_step_count = 90
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.logger") as mock_log:
+            p.log_request_start(num_steps=50)  # global steps 90-139 — overlaps 100-150
+        logged = mock_log.info.call_args[0][0]
+        self.assertIn("WILL BE PROFILED", logged)
+
+    def test_logs_not_in_range_when_no_overlap(self):
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.envs") as mock_envs:
+            mock_envs.SGLANG_DIFFUSION_PROFILE_STEP_RANGE = "100-150"
+            p = DiffusionStepProfiler()
+        p.global_step_count = 0
+        with patch("sglang.multimodal_gen.runtime.utils.profiler.logger") as mock_log:
+            p.log_request_start(num_steps=50)  # global steps 0-49 — no overlap
+        logged = mock_log.info.call_args[0][0]
+        self.assertIn("not in profile range", logged)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The text LLM serving path (`srt/`) supports `cudaProfilerApi` via `_ProfilerCudart` and HTTP-driven `CUDA_PROFILER` activity, allowing targeted nsys profiling of specific forward iterations. The diffusion pipeline (`multimodal_gen/`) has no such support — `nsys` must capture the entire process (model loading, warmup, all requests), producing multi-GB trace files.

This PR adds step-range based `cudaProfilerStart()`/`cudaProfilerStop()` support for diffusion models, enabling targeted nsys profiling of specific denoising step ranges.

## Changes

- **`envs.py`**: Add `SGLANG_DIFFUSION_PROFILE_STEP_RANGE` env var (format: `"START-END"`, e.g., `"100-150"`)
- **`profiler.py`**: Add `DiffusionStepProfiler` singleton that tracks global denoising steps across requests and calls `cudaProfilerStart()`/`cudaProfilerStop()` at range boundaries. Includes `is_primary_rank()` guard for multi-GPU setups
- **`denoising.py`**: Integrate step profiler into the denoising loop with `try/finally` cleanup via `ensure_stopped()`
- **`cli/main.py`**: Add `if __name__ == "__main__": main()` guard so `python -m sglang.cli.main serve` works (pre-existing bug, needed for nsys wrapping)
- **`test_diffusion_step_profiler.py`**: 7 test classes covering parsing, singleton lifecycle, step counting, CUDA profiler control, multi-rank filtering, idempotent cleanup, and request logging
- **`run_suite.py`**: Register test in CI `"unit"` suite

## Usage

```bash
SGLANG_DIFFUSION_PROFILE_STEP_RANGE="100-150" \
nsys profile -c cudaProfilerApi -t cuda,nvtx \
  --capture-range-end="repeat:1" \
  python -m sglang.cli.main serve --model-path Qwen/Qwen-Image-2512 --port 8001
```

Then send 3+ requests. The profiler starts at global step 100 and stops at step 150. With 50 steps/request, this captures only the 3rd request's denoising steps.

## Design Notes

- **Env var vs HTTP API**: The LLM path uses HTTP (`/start_profile`). Diffusion uses an env var because (1) no HTTP profiling infrastructure exists yet, and (2) diffusion has deterministic step counts, making a static range sufficient. HTTP endpoint support can be added as a follow-up.
- **DenoisingStage only**: Currently instruments the standard `DenoisingStage`. Specialized stages (helios, causal, av, dmd, hunyuan3d) are not yet instrumented — noted in the docstring.
- **Zero overhead when disabled**: `should_profile()` is a single attribute check; no work in the hot path when the env var is unset.

## Tested

- Qwen-Image-2512 on H200, container built from this branch
- Validated nsys trace captures only the configured step range
- Validated log messages show correct step numbers (no off-by-one)
- `--pytorch=functions-trace` provides per-layer NVTX markers automatically
- All pre-commit hooks pass