### PR TITLE
[Bugfix] Lazy-import CuteDSL KDA kernel to fix AMD/ROCm startup crash

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -3,9 +3,6 @@ from typing import Tuple, Union
 import torch
 
 from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
-from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
-    CuteDSLKDAKernel,
-)
 from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
@@ -50,6 +47,10 @@ class KDAKernelDispatcher:
         elif decode_backend.is_cutedsl():
             if not is_cuda():
                 raise ValueError("KDA CuTe DSL backend requires CUDA")
+            from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
+                CuteDSLKDAKernel,
+            )
+
             self.decode_kernel = CuteDSLKDAKernel()
         else:
             raise ValueError(


### PR DESCRIPTION
## [Bugfix] Lazy-import CuteDSL KDA kernel to fix AMD/ROCm startup crash

### Motivation

PR #21203 (`[KDA] Support CuTeDSL KDA decode kernel`) added a top-level import of `CuteDSLKDAKernel` in `kda_backend.py`. This import chains through:

```
kda_backend.py  →  kda_cutedsl.py  →  cutedsl_kda.py  →  import cuda.bindings.driver
```

`cuda.bindings.driver` is a CUDA-only package that does not exist on AMD/ROCm, causing an immediate `ModuleNotFoundError` when launching **any model with linear attention** (e.g., Qwen3.5) on AMD GPUs or other accelerators:

```
ModuleNotFoundError: No module named 'cuda'
```

### Modifications

- **`python/sglang/srt/layers/attention/linear/kda_backend.py`**: Moved the `from ...kda_cutedsl import CuteDSLKDAKernel` from a top-level import to a lazy import inside the `is_cuda()` guard where it is actually used. Non-CUDA platforms never reach that code path, so the CUDA-only module is never imported.

### Before (broken on AMD)

```python
from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
    CuteDSLKDAKernel,
)
# ↑ top-level: always executes, crashes on AMD
```

### After (fixed)

```python
# top-level import removed

# ... inside __init__ ...
elif decode_backend.is_cutedsl():
    if not is_cuda():
        raise ValueError("KDA CuTe DSL backend requires CUDA")
    from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import (
        CuteDSLKDAKernel,
    )
    self.decode_kernel = CuteDSLKDAKernel()
```

### Test plan

- [x] Verified Qwen3.5-397B-A17B-MXFP4 server starts successfully on AMD MI355X (4×GPU, `--attention-backend aiter`) after the fix.
- [ ] CUDA platforms are unaffected — CuteDSL import still happens when `decode_backend.is_cutedsl()` is selected.
