### PR TITLE
Remove noisy streaming backlog warning log

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1155,14 +1155,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             finished = state.finished
             state.event.clear()
 
-            if is_stream and len(pending) > 1:
-                logger.warning(
-                    "Streaming backlog: rid=%s, draining %d queued chunks. "
-                    "This may inflate P99 TBT for affected requests.",
-                    obj.rid,
-                    len(pending),
-                )
-
             for i, out in enumerate(pending):
                 is_last = i == len(pending) - 1
 


### PR DESCRIPTION
## Summary
- Remove per-request `Streaming backlog` warning in `_wait_one_response` that spams logs under high concurrency
- Chunk backlog is normal asyncio scheduling behavior, not an anomaly worth warning about

## Test plan
- No behavior change, only log removal