### PR TITLE
[Bugfix] Fix LLaVA PCG warmup/capture crash when mm_inputs is None

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -389,6 +389,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 global_forward_mode=ForwardMode.EXTEND,
                 lora_ids=None,
+                mm_inputs=[] if self.is_multimodal else None,
             )
 
         # Attention backend
@@ -546,6 +547,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 global_forward_mode=ForwardMode.EXTEND,
                 lora_ids=None,
+                mm_inputs=[] if self.is_multimodal else None,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 


### PR DESCRIPTION
## Motivation

`warmup_compile()` and `capture_one_batch_size()` in `piecewise_cuda_graph_runner.py` construct `ForwardBatch` without setting `mm_inputs`, defaulting to `None`. Old-style LLaVA/LLaVaVid directly iterate `mm_inputs` in extend path (`for im in image_inputs:`), crashing with `TypeError: 'NoneType' is not iterable`.

Models using `general_mm_embed_routine` (36+ VLMs) are unaffected — `contains_mm_inputs()` already guards against `None`.

## Modifications

Set `mm_inputs=[] if self.is_multimodal else None` at both `ForwardBatch` construction sites in `piecewise_cuda_graph_runner.py`. Empty list makes iteration a no-op; `None` preserved for non-multimodal models.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).