### PR TITLE
[Security] 1/N: Bind ZMQ sockets to localhost to prevent unauthenticated remote access

### DIFF
--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -16,9 +16,8 @@ async def run_zeromq_broker(server_args: ServerArgs):
     It listens for TCP requests from offline clients (e.g., DiffGenerator).
     """
     ctx = zmq.asyncio.Context()
-    # This is the REP socket that listens for requests from DiffGenerator
     socket = ctx.socket(zmq.REP)
-    broker_endpoint = f"tcp://*:{server_args.broker_port}"
+    broker_endpoint = f"tcp://127.0.0.1:{server_args.broker_port}"
     socket.bind(broker_endpoint)
     logger.info(f"ZMQ Broker is listening for offline jobs on {broker_endpoint}")
 

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -399,7 +399,7 @@ class WaitingImageRequest:
         self.receive_count = receive_count
         self.num_items_assigned = recv_req.num_items_assigned
         self.embedding_port, self.recv_socket = get_zmq_socket_on_host(
-            zmq.Context(), zmq.PULL
+            zmq.Context(), zmq.PULL, host=host_name
         )
         logger.info(f"Waiting for input {self.embedding_port = }")
         self.recv_embedding_data = None
@@ -681,7 +681,9 @@ class MMReceiverBase(ABC):
             if len(self.encode_urls) == 0 or not need_wait_for_mm_inputs:
                 return None
             req_id = uuid.uuid4().hex
-            embedding_port, recv_socket = get_zmq_socket_on_host(self.context, zmq.PULL)
+            embedding_port, recv_socket = get_zmq_socket_on_host(
+                self.context, zmq.PULL, host=self.host
+            )
             mm_data = self._extract_url_data(request_obj)
             asyncio.create_task(
                 self.encode(req_id, mm_data, embedding_port, "encode", "send")

--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -189,22 +189,23 @@ def get_zmq_socket_on_host(
     Args:
         context: ZeroMQ context to create the socket from.
         socket_type: Type of ZeroMQ socket to create.
-        host: Optional host to bind/connect to, without "tcp://" prefix. If None, binds to "tcp://*".
+        host: Host to bind to, without "tcp://" prefix. Defaults to
+            "127.0.0.1" (localhost-only) to avoid exposing unauthenticated
+            sockets to the network (CVE-2026-3060). Callers that need
+            cross-machine reachability must pass an explicit host.
 
     Returns:
         Tuple of (port, socket) where port is the randomly assigned TCP port.
     """
     socket = context.socket(socket_type)
-    # Bind to random TCP port, auto-wrapping IPv6 and setting zmq.IPV6 flag
     config_socket(socket, socket_type)
-    if host:
-        if is_valid_ipv6_address(host):
-            socket.setsockopt(zmq.IPV6, 1)
-            bind_host = f"tcp://[{host}]"
-        else:
-            bind_host = f"tcp://{host}"
+    if host is None:
+        host = "127.0.0.1"
+    if is_valid_ipv6_address(host):
+        socket.setsockopt(zmq.IPV6, 1)
+        bind_host = f"tcp://[{host}]"
     else:
-        bind_host = "tcp://*"
+        bind_host = f"tcp://{host}"
     port = socket.bind_to_random_port(bind_host)
     return port, socket
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Three critical CVEs (CVSS 9.8) affect SGLang due to unsafe `pickle.loads()` / `recv_pyobj()` deserialization over unauthenticated ZMQ sockets, enabling Remote Code Execution (RCE):

| CVE | Component |
|-----|-----------|
| [CVE-2026-3059](https://nvd.nist.gov/vuln/detail/CVE-2026-3059) | Multimodal generation ZMQ broker |
| [CVE-2026-3060](https://nvd.nist.gov/vuln/detail/CVE-2026-3060) | Encoder Parallel Disaggregation |
| [CVE-2026-3989](https://nvd.nist.gov/vuln/detail/CVE-2026-3989) | `replay_request_dump.py` script |

References: [CERT/CC VU#665416](https://kb.cert.org/vuls/id/665416), [ShadowMQ (Oligo Security)](https://www.oligo.security/blog/shadowmq-how-code-reuse-spread-critical-vulnerabilities-across-the-ai-ecosystem), #5569

This PR chain aim to resolve or mitigate these CVEs. The first [PR](https://github.com/sgl-project/sglang/pull/21435) (this one) bind the ZMQ host sockets to localhost by default

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
<!-- Detail the changes made in this pull request. -->

- Bind ZMQ sockets to `127.0.0.1` (localhost) by default so they are only
reachable by processes on the same machine. The OS kernel rejects remote TCP
connections before any data reaches `pickle.loads()`.
**CVE-2026-3059** — Multimodal generation ZMQ broker (`scheduler_client.py`):
- Changed `tcp://*:{broker_port}` → `tcp://127.0.0.1:{broker_port}`
**CVE-2026-3060** — Disaggregation encoder receiver (`encode_receiver.py`):
- Changed `get_zmq_socket_on_host()` default from `tcp://*` to `tcp://127.0.0.1`
- Fixed two call sites that need cross-machine access to pass their host explicitly
  
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A 
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
