### PR TITLE
fix(sgl-kernel): align wheel METADATA/WHEEL with +cu filename

### DIFF
--- a/sgl-kernel/rename_wheels.sh
+++ b/sgl-kernel/rename_wheels.sh
@@ -2,7 +2,7 @@
 # Align CUDA wheel filenames (+cu124/+cu128/+cu130) with internal METADATA Version and
 # WHEEL tags after build (fixes pip "inconsistent version" when only the .whl name changed).
 # Unpack → patch WHEEL/METADATA → wheel pack (RECORD regenerated; no hand-editing).
-set -e
+set -ex
 
 WHEEL_DIR="dist"
 
@@ -55,7 +55,7 @@ for wheel in "${wheel_files[@]}"; do
     TMPDIR=$(mktemp -d)
     trap 'rm -rf -- "$TMPDIR"' ERR
 
-    python -m wheel unpack "$wheel" --dest "$TMPDIR"
+    python3 -m wheel unpack "$wheel" --dest "$TMPDIR"
     UNPACKED=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -1)
     DIST_INFO=$(find "$UNPACKED" -maxdepth 1 -type d -name "*.dist-info" | head -1)
     WHEEL_META="${DIST_INFO}/WHEEL"
@@ -78,7 +78,7 @@ for wheel in "${wheel_files[@]}"; do
     mv "$DIST_INFO" "${UNPACKED}/${NEW_BASE}"
 
     rm -f "$wheel"
-    python -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
+    python3 -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
     rm -rf "$TMPDIR"
     trap - ERR
 done

--- a/sgl-kernel/rename_wheels.sh
+++ b/sgl-kernel/rename_wheels.sh
@@ -6,31 +6,6 @@ set -e
 
 WHEEL_DIR="dist"
 
-resolve_python() {
-    if [[ -n "${PYTHON_ROOT_PATH:-}" ]]; then
-        if [[ -x "${PYTHON_ROOT_PATH}/bin/python" ]]; then
-            echo "${PYTHON_ROOT_PATH}/bin/python"
-            return
-        fi
-        if [[ -x "${PYTHON_ROOT_PATH}/python" ]]; then
-            echo "${PYTHON_ROOT_PATH}/python"
-            return
-        fi
-    fi
-    if command -v python >/dev/null 2>&1; then
-        command -v python
-        return
-    fi
-    if command -v python3 >/dev/null 2>&1; then
-        command -v python3
-        return
-    fi
-    echo "ERROR: no python interpreter found (set PYTHON_ROOT_PATH or install python)." >&2
-    exit 1
-}
-
-PYTHON="$(resolve_python)"
-
 detect_cuda_suffix() {
     if ls /usr/local/ 2>/dev/null | grep -q "12.4"; then
         echo "+cu124"
@@ -80,7 +55,7 @@ for wheel in "${wheel_files[@]}"; do
     TMPDIR=$(mktemp -d)
     trap 'rm -rf -- "$TMPDIR"' ERR
 
-    "${PYTHON}" -m wheel unpack "$wheel" --dest "$TMPDIR"
+    python -m wheel unpack "$wheel" --dest "$TMPDIR"
     UNPACKED=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -1)
     DIST_INFO=$(find "$UNPACKED" -maxdepth 1 -type d -name "*.dist-info" | head -1)
     WHEEL_META="${DIST_INFO}/WHEEL"
@@ -103,7 +78,7 @@ for wheel in "${wheel_files[@]}"; do
     mv "$DIST_INFO" "${UNPACKED}/${NEW_BASE}"
 
     rm -f "$wheel"
-    "${PYTHON}" -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
+    python -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
     rm -rf "$TMPDIR"
     trap - ERR
 done

--- a/sgl-kernel/rename_wheels.sh
+++ b/sgl-kernel/rename_wheels.sh
@@ -1,34 +1,110 @@
 #!/usr/bin/env bash
-set -ex
+# Align CUDA wheel filenames (+cu124/+cu128/+cu130) with internal METADATA Version and
+# WHEEL tags after build (fixes pip "inconsistent version" when only the .whl name changed).
+# Unpack → patch WHEEL/METADATA → wheel pack (RECORD regenerated; no hand-editing).
+set -e
 
 WHEEL_DIR="dist"
 
-wheel_files=($WHEEL_DIR/*.whl)
-for wheel in "${wheel_files[@]}"; do
-    intermediate_wheel="${wheel/linux/manylinux2014}"
+resolve_python() {
+    if [[ -n "${PYTHON_ROOT_PATH:-}" ]]; then
+        if [[ -x "${PYTHON_ROOT_PATH}/bin/python" ]]; then
+            echo "${PYTHON_ROOT_PATH}/bin/python"
+            return
+        fi
+        if [[ -x "${PYTHON_ROOT_PATH}/python" ]]; then
+            echo "${PYTHON_ROOT_PATH}/python"
+            return
+        fi
+    fi
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return
+    fi
+    echo "ERROR: no python interpreter found (set PYTHON_ROOT_PATH or install python)." >&2
+    exit 1
+}
 
-    # Extract the current python version from the wheel name
-    if [[ $intermediate_wheel =~ -cp([0-9]+)- ]]; then
-        cp_version="${BASH_REMATCH[1]}"
+PYTHON="$(resolve_python)"
+
+detect_cuda_suffix() {
+    if ls /usr/local/ 2>/dev/null | grep -q "12.4"; then
+        echo "+cu124"
+    elif ls /usr/local/ 2>/dev/null | grep -q "12.8"; then
+        echo "+cu128"
+    elif ls /usr/local/ 2>/dev/null | grep -q "13.0"; then
+        echo "+cu130"
     else
-        echo "Could not extract Python version from wheel name: $intermediate_wheel"
+        echo ""
+    fi
+}
+
+CUDA_SUFFIX=$(detect_cuda_suffix)
+
+patch_wheel_platform_tags() {
+    local wheel_file="$1"
+    # Line-end anchors: "linux_x86_64" is a substring of "manylinux2014_x86_64", so
+    # unanchored global replace corrupts tags on a second run.
+    sed -i \
+        -e 's/-linux_x86_64$/-manylinux2014_x86_64/' \
+        -e 's/-linux_aarch64$/-manylinux2014_aarch64/' \
+        "$wheel_file"
+}
+
+wheel_files=("$WHEEL_DIR"/*.whl)
+for wheel in "${wheel_files[@]}"; do
+    [[ -f "$wheel" ]] || continue
+
+    intermediate_wheel="$wheel"
+    case "$wheel" in
+        *-linux_x86_64.whl)
+            intermediate_wheel="${wheel%-linux_x86_64.whl}-manylinux2014_x86_64.whl"
+            ;;
+        *-linux_aarch64.whl)
+            intermediate_wheel="${wheel%-linux_aarch64.whl}-manylinux2014_aarch64.whl"
+            ;;
+    esac
+    if [[ "$wheel" != "$intermediate_wheel" ]]; then
+        mv -- "$wheel" "$intermediate_wheel"
+        wheel="$intermediate_wheel"
+    fi
+
+    if [[ -z "$CUDA_SUFFIX" ]]; then
         continue
     fi
 
-    # Detect CUDA version and add appropriate suffix
-    if ls /usr/local/ | grep -q "12.4"; then
-        new_wheel="${intermediate_wheel/-cp${cp_version}/+cu124-cp${cp_version}}"
-    elif ls /usr/local/ | grep -q "12.8"; then
-        new_wheel="${intermediate_wheel/-cp${cp_version}/+cu128-cp${cp_version}}"
-    elif ls /usr/local/ | grep -q "13.0"; then
-        new_wheel="${intermediate_wheel/-cp${cp_version}/+cu130-cp${cp_version}}"
-    else
-        new_wheel="$intermediate_wheel"
-    fi
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf -- "$TMPDIR"' ERR
 
-    if [[ "$wheel" != "$new_wheel" ]]; then
-        echo "Renaming $wheel to $new_wheel"
-        mv -- "$wheel" "$new_wheel"
+    "${PYTHON}" -m wheel unpack "$wheel" --dest "$TMPDIR"
+    UNPACKED=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -1)
+    DIST_INFO=$(find "$UNPACKED" -maxdepth 1 -type d -name "*.dist-info" | head -1)
+    WHEEL_META="${DIST_INFO}/WHEEL"
+    METADATA_FILE="${DIST_INFO}/METADATA"
+
+    patch_wheel_platform_tags "$WHEEL_META"
+
+    ORIG_VERSION=$(grep '^Version:' "$METADATA_FILE" | head -1 | sed 's/^Version:[[:space:]]*//')
+    if [[ "$ORIG_VERSION" == *"$CUDA_SUFFIX"* ]]; then
+        echo "Skipping $wheel: version in METADATA is already suffixed."
+        rm -rf "$TMPDIR"
+        trap - ERR
+        continue
     fi
+    NEW_VERSION="${ORIG_VERSION}${CUDA_SUFFIX}"
+    sed -i "s/^Version:.*/Version: ${NEW_VERSION}/" "$METADATA_FILE"
+
+    OLD_BASE=$(basename "$DIST_INFO")
+    NEW_BASE="${OLD_BASE/${ORIG_VERSION}/${NEW_VERSION}}"
+    mv "$DIST_INFO" "${UNPACKED}/${NEW_BASE}"
+
+    rm -f "$wheel"
+    "${PYTHON}" -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
+    rm -rf "$TMPDIR"
+    trap - ERR
 done
 echo "Wheel renaming completed."


### PR DESCRIPTION
Repack CUDA wheels after build so `Version:`, `WHEEL` tags, and `.dist-info` directory match the `+cu*` local version in the filename (fixes pip inconsistent version). Fixes #20953.
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Motivation
- **Issue:** [#20953](https://github.com/sgl-project/sglang/issues/20953) — CUDA `sglang-kernel` wheels are published with a `+cu*` suffix in the **filename**, but the wheel zip still contains **METADATA** / **WHEEL** / `.dist-info` names that do not include that local version, so pip reports an inconsistent version (filename vs metadata) and may reject or confuse installs.
- **Relation to the earlier PR:** [#21111](https://github.com/sgl-project/sglang/pull/21111) attempted a broader fix (CUDA plus additional ROCm/MUSA/script changes). It was closed with feedback to **keep the change minimal**. This PR applies **only** the CUDA packaging fix in `sgl-kernel/rename_wheels.sh`, matching that scope.
## Modifications
- **`sgl-kernel/rename_wheels.sh` only:** after build, for CUDA wheels under `dist/`, run `wheel unpack` → patch internal `WHEEL` platform tags (suffix-safe, idempotent) → set `METADATA` `Version:` to include the detected `+cu*` suffix → rename `*.dist-info` to match → `wheel pack` so `RECORD` is regenerated (no hand-editing `RECORD`).
- **Out of scope (unchanged):** ROCm (`3rdparty/amd/wheel/sgl-kernel/rename_wheels_rocm.sh`) and MUSA (`scripts/ci/musa/rename_wheels_musa.sh`) are not modified here, per [#21111](https://github.com/sgl-project/sglang/pull/21111) feedback. Any pre-existing behavior there is unchanged.
**Optional note for reviewers:** ROCm/MUSA scripts still use older filename-only renaming patterns; repeated runs / substring-based `linux` → `manylinux` substitution can have idempotency issues that **predate** this PR. A follow-up can align those paths separately.
## Accuracy Tests
N/A — packaging/release shell script only; no model forward or kernel numerical path changed.
## Benchmarking and Profiling
N/A — no inference hot path changed.
## Checklist
- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). *(bash-only change; run pre-commit if your setup covers these paths)*
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(N/A for this packaging-only change; validation via local wheel repack + `pip`/`uv install` as in #20953 discussion)*
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(N/A unless maintainers request release notes)*
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). *(N/A)*
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
## Review Process
1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.