### PR TITLE
[NVIDIA] Deterministic inference backend order on Blackwell 

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -765,6 +765,9 @@ class ServerArgs:
 
         # Set kernel backends.
         self._handle_sampling_backend()
+        # Must run before _handle_attention_backend_compatibility so the
+        # deterministic backend is set before auto-detection fills it in.
+        self._handle_deterministic_inference()
         self._handle_attention_backend_compatibility()
         self._handle_mamba_backend()
         self._handle_kv4_compatibility()
@@ -811,9 +814,6 @@ class ServerArgs:
 
         # Validate cache settings.
         self._handle_cache_compatibility()
-
-        # Handle deterministic inference.
-        self._handle_deterministic_inference()
 
         # Handle diffusion LLM inference.
         self._handle_dllm_inference()


### PR DESCRIPTION
On Blackwell MHA models, `_handle_attention_backend_compatibility()` auto-selects `trtllm_mha` as the default backend. When `_handle_deterministic_inference()` ran after, it saw `trtllm_mha` (not `None`) and raised a `ValueError` treating the auto-detected value as user-specified.                                                                                                                               
                                                                                                                                                                                                        
Fix: move `_handle_deterministic_inference()` before `_handle_attention_backend_compatibility()` so it sets a deterministic-compatible backend (flashinfer for Blackwell) before auto-detection runs.               
   