### PR TITLE
fix(fp8): pad weight/input to 16-alignment for torch._scaled_mm CUDA Graph

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -29,7 +29,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
 from sglang.srt.layers.quantization.utils import requantize_with_max_scale
 from sglang.srt.utils import get_bool_env_var, is_hip
 
-__all__ = ["CompressedTensorsW8A8Fp8"]
+__all__ = ["CompressedTensorsW8A8Fp8", "FP8_ALIGNMENT", "_pad_to_alignment"]
 
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
@@ -39,27 +39,44 @@ if _use_aiter:
 # torch._scaled_mm requires both matrix dimensions divisible by 16.
 # Models where intermediate_size / tp_size is not 16-aligned
 # (e.g. 10944 / tp=8 = 1368) fail CUDA Graph capture without padding.
-_FP8_MM_ALIGNMENT = 16
+FP8_ALIGNMENT = 16
+
+
+def _pad_to_alignment(
+    tensor: torch.Tensor, dim: int, alignment: int = FP8_ALIGNMENT
+) -> torch.Tensor:
+    """Zero-pad tensor along dim to the next multiple of alignment.
+
+    Returns the original tensor unchanged when already aligned.
+    """
+    size = tensor.shape[dim]
+    pad = (-size) % alignment
+    if pad == 0:
+        return tensor
+    pad_arg = [0] * (2 * tensor.ndim)
+    pad_arg[2 * (tensor.ndim - 1 - dim) + 1] = pad
+    return F.pad(tensor, pad_arg)
 
 
 def _pad_weight_to_alignment(
     weight: torch.Tensor, weight_scale: Optional[torch.Tensor]
 ) -> tuple[torch.Tensor, Optional[torch.Tensor], int]:
-    """Pad weight (N, K) so both dims are multiples of _FP8_MM_ALIGNMENT.
+    """Pad weight (N, K) so both dims are multiples of FP8_ALIGNMENT.
 
     Returns (weight_t, weight_scale, orig_N) where weight_t is transposed.
     weight_scale is padded along dim-0 when it is per-channel (shape [N, 1]).
     """
     orig_n, orig_k = weight.shape
-    pad_n = (-orig_n) % _FP8_MM_ALIGNMENT
-    pad_k = (-orig_k) % _FP8_MM_ALIGNMENT
+    pad_n = (-orig_n) % FP8_ALIGNMENT
+    pad_k = (-orig_k) % FP8_ALIGNMENT
     if pad_n or pad_k:
         weight = F.pad(weight, (0, pad_k, 0, pad_n))
         if weight_scale is not None:
-            assert weight_scale.shape == (orig_n, 1), (
-                f"Expected per-channel scale shape ({orig_n}, 1), "
-                f"got {tuple(weight_scale.shape)}"
-            )
+            if weight_scale.shape != (orig_n, 1):
+                raise ValueError(
+                    f"Expected per-channel scale shape ({orig_n}, 1), "
+                    f"got {tuple(weight_scale.shape)}"
+                )
             weight_scale = F.pad(weight_scale, (0, 0, 0, pad_n))
     return weight.t(), weight_scale, orig_n
 
@@ -207,13 +224,14 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 weight_scale = layer.weight_scale.data
 
             if _use_aiter:
-                # keep the weight as (N, K)
+                # keep the weight as (N, K); aiter kernel handles alignment internally
                 layer.weight = Parameter(
-                    shuffle_weight(weight, (_FP8_MM_ALIGNMENT, _FP8_MM_ALIGNMENT)),
+                    shuffle_weight(weight, (FP8_ALIGNMENT, FP8_ALIGNMENT)),
                     requires_grad=False,
                 )
                 # required by torch.compile to be torch.nn.Parameter
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+                layer._orig_output_dim = weight.shape[0]
             else:
                 weight_t, weight_scale, orig_out = _pad_weight_to_alignment(
                     weight, weight_scale
@@ -272,9 +290,15 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             )
 
         # weight is stored transposed as (K_padded, N_padded); pad x to match.
+        orig_out = layer._orig_output_dim
         pad_k = layer.weight.shape[0] - x.shape[-1]
         if pad_k > 0:
             x = F.pad(x, (0, pad_k))
+
+        # Pad bias to N_padded so apply_fp8_linear can add it before we slice.
+        pad_n = layer.weight.shape[1] - orig_out
+        if bias is not None and pad_n > 0:
+            bias = F.pad(bias, (0, pad_n))
 
         output = apply_fp8_linear(
             input=x,
@@ -286,4 +310,4 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             compressed_tensor_quant=True,
         )
 
-        return output[..., : layer._orig_output_dim]
+        return output[..., :orig_out]

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -27,7 +27,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     validate_fp8_block_shape,
 )
 from sglang.srt.layers.quantization.utils import requantize_with_max_scale
-from sglang.srt.utils import get_bool_env_var, is_hip
+from sglang.srt.utils import ceil_align, get_bool_env_var, is_hip
 
 __all__ = ["CompressedTensorsW8A8Fp8", "FP8_ALIGNMENT", "pad_to_alignment"]
 
@@ -50,7 +50,7 @@ def pad_to_alignment(
     Returns the original tensor unchanged when already aligned.
     """
     size = tensor.shape[dim]
-    pad = (-size) % alignment
+    pad = ceil_align(size, alignment) - size
     if pad == 0:
         return tensor
     # F.pad takes padding in reverse-dim order, two values per dim (left, right).
@@ -330,8 +330,8 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         # Swap in the pre-padded bias when N was padded at load time.
         # `_padded_bias` is None when no padding was needed OR when the layer had
         # no bias; if the caller passed bias=None (skip_bias_add=True), keep None.
-        if bias is not None:
-            bias = layer._padded_bias if layer._padded_bias is not None else bias
+        if bias is not None and layer._padded_bias is not None:
+            bias = layer._padded_bias
 
         output = apply_fp8_linear(
             input=x,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -53,6 +53,8 @@ def pad_to_alignment(
     pad = (-size) % alignment
     if pad == 0:
         return tensor
+    # F.pad takes padding in reverse-dim order, two values per dim (left, right).
+    # Index 2*(ndim-1-dim)+1 selects the right-side padding for `dim`.
     pad_arg = [0] * (2 * tensor.ndim)
     pad_arg[2 * (tensor.ndim - 1 - dim) + 1] = pad
     return F.pad(tensor, pad_arg)
@@ -64,15 +66,18 @@ def _pad_weight_to_alignment(
     """Pad weight (N, K) so both dims are multiples of FP8_ALIGNMENT.
 
     Returns (weight_t, weight_scale, orig_N) where weight_t is transposed.
-    weight_scale is padded along dim-0 when it is per-channel (shape [N, 1]).
+    weight_scale is padded along dim-0 when it is per-channel (shape [N, 1]
+    or [N,]).
     """
     orig_n = weight.shape[0]
     weight = pad_to_alignment(weight, dim=0)
     weight = pad_to_alignment(weight, dim=1)
     if weight_scale is not None and weight.shape[0] > orig_n:
+        if weight_scale.shape == (orig_n,):
+            weight_scale = weight_scale.unsqueeze(1)
         if weight_scale.shape != (orig_n, 1):
             raise ValueError(
-                f"Expected per-channel scale shape ({orig_n}, 1), "
+                f"Expected per-channel scale shape ({orig_n}, 1) or ({orig_n},), "
                 f"got {tuple(weight_scale.shape)}"
             )
         weight_scale = pad_to_alignment(weight_scale, dim=0)
@@ -288,6 +293,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             )
 
         # weight is stored transposed as (K_padded, N_padded); pad x to match.
+        # TODO: consider padding input activation at graph-capture time instead of per-forward.
         orig_out = layer._orig_output_dim
         pad_k = layer.weight.shape[0] - x.shape[-1]
         if pad_k > 0:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -5,6 +5,7 @@
 from typing import Callable, Optional
 
 import torch
+import torch.nn.functional as F
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 from torch.nn import Parameter
 
@@ -34,6 +35,31 @@ _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
+
+
+# torch._scaled_mm requires both matrix dimensions to be divisible by 16.
+# Models with intermediate_size not divisible by 16 after tensor-parallel
+# sharding (e.g. 10944 / tp=8 = 1368) fail CUDA Graph capture without this.
+FP8_ALIGNMENT = 16
+
+
+def _pad_to_alignment(t: torch.Tensor, dim: int, alignment: int) -> torch.Tensor:
+    """Pad tensor along *dim* so its size is a multiple of *alignment*.
+
+    Returns the original tensor unchanged when already aligned.
+    """
+    size = t.shape[dim]
+    remainder = size % alignment
+    if remainder == 0:
+        return t
+    pad_size = alignment - remainder
+    # F.pad takes a flat tuple starting from the last dimension:
+    # (last_right, last_left, second_last_right, second_last_left, ...)
+    ndim = t.dim()
+    pad: list[int] = [0] * (2 * ndim)
+    pad_idx = 2 * (ndim - 1 - dim) + 1  # right-pad index for `dim`
+    pad[pad_idx] = pad_size
+    return F.pad(t, pad)
 
 
 strategy_to_parameter_type = {
@@ -156,8 +182,17 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 )
                 if input_scale is not None:
                     layer.input_scale = Parameter(input_scale, requires_grad=False)
+
+            # Pad to FP8_ALIGNMENT so torch._scaled_mm succeeds in CUDA Graph.
+            # Per-tensor scale is a scalar — no scale padding needed.
+            orig_out = weight.shape[0]
+            weight = _pad_to_alignment(weight, dim=0, alignment=FP8_ALIGNMENT)
+            weight = _pad_to_alignment(weight, dim=1, alignment=FP8_ALIGNMENT)
             layer.weight = Parameter(weight.t(), requires_grad=False)
             layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
+            layer.register_buffer(
+                "_orig_output_dim", torch.tensor(orig_out), persistent=False
+            )
 
         elif self.strategy == QuantizationStrategy.CHANNEL:
             weight = layer.weight
@@ -175,16 +210,31 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             else:
                 weight_scale = layer.weight_scale.data
 
-            if _use_aiter:
-                # keep the weight as (N, K)
-                layer.weight = Parameter(
-                    shuffle_weight(weight, (16, 16)), requires_grad=False
-                )
-            else:
-                layer.weight = Parameter(weight.t(), requires_grad=False)
+            orig_out = weight.shape[0]
 
-            # required by torch.compile to be torch.nn.Parameter
-            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+            if _use_aiter:
+                # aiter kernel handles alignment internally; keep weight as (N, K).
+                layer.weight = Parameter(
+                    shuffle_weight(weight, (FP8_ALIGNMENT, FP8_ALIGNMENT)),
+                    requires_grad=False,
+                )
+                # required by torch.compile to be torch.nn.Parameter
+                layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+            else:
+                # Pad both dims so torch._scaled_mm succeeds in CUDA Graph.
+                weight = _pad_to_alignment(weight, dim=0, alignment=FP8_ALIGNMENT)
+                weight = _pad_to_alignment(weight, dim=1, alignment=FP8_ALIGNMENT)
+                # Pad per-channel scale to match new output dim.
+                weight_scale = _pad_to_alignment(
+                    weight_scale, dim=0, alignment=FP8_ALIGNMENT
+                )
+                layer.weight = Parameter(weight.t(), requires_grad=False)
+                # required by torch.compile to be torch.nn.Parameter
+                layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+                # Slice output back to original N after GEMM (padded rows are noise).
+                layer.register_buffer(
+                    "_orig_output_dim", torch.tensor(orig_out), persistent=False
+                )
 
         elif self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
@@ -195,8 +245,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
                     weight=weight, weight_scale=weight_scale
                 )
-            layer.weight = Parameter(weight.data, requires_grad=False)
-            layer.weight_scale = Parameter(weight_scale.data, requires_grad=False)
+            # Block kernels do not use torch._scaled_mm, so no alignment padding.
+            layer.weight = Parameter(weight.detach(), requires_grad=False)
+            layer.weight_scale = Parameter(weight_scale.detach(), requires_grad=False)
 
         else:
             raise ValueError(f"Unknown quantization strategy {self.strategy}")
@@ -214,6 +265,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if self.weight_block_size is not None:
+            # Block kernels handle alignment internally; no padding needed.
             return self.w8a8_block_fp8_linear(
                 input=x,
                 weight=layer.weight,
@@ -224,6 +276,8 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             )
 
         if _use_aiter and self.strategy == QuantizationStrategy.CHANNEL:
+            # aiter keeps weight as (N, K) and handles alignment internally;
+            # no input padding or output slicing needed.
             return apply_fp8_ptpc_linear(
                 input=x,
                 weight=layer.weight,
@@ -233,13 +287,28 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 use_per_token_if_dynamic=True,
                 compressed_tensor_quant=True,
             )
-        else:
-            return apply_fp8_linear(
-                input=x,
-                weight=layer.weight,
-                weight_scale=layer.weight_scale,
-                input_scale=layer.input_scale,
-                bias=bias,
-                use_per_token_if_dynamic=True,
-                compressed_tensor_quant=True,
+
+        # weight is stored transposed as (K_padded, N_padded).
+        # Pad the input K-dim to match so torch._scaled_mm aligns correctly.
+        weight_k_dim = layer.weight.shape[0]
+        if x.shape[-1] < weight_k_dim:
+            x = F.pad(x, (0, weight_k_dim - x.shape[-1]))
+        elif x.shape[-1] > weight_k_dim:
+            raise RuntimeError(
+                f"Input last dim {x.shape[-1]} > padded weight K dim {weight_k_dim}."
+                " This should never happen."
             )
+
+        output = apply_fp8_linear(
+            input=x,
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            input_scale=layer.input_scale,
+            bias=bias,
+            use_per_token_if_dynamic=True,
+            compressed_tensor_quant=True,
+        )
+
+        # Trim any output columns added by N-dim padding.
+        orig_n = layer._orig_output_dim.item()
+        return output[..., :orig_n]

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -29,7 +29,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
 from sglang.srt.layers.quantization.utils import requantize_with_max_scale
 from sglang.srt.utils import get_bool_env_var, is_hip
 
-__all__ = ["CompressedTensorsW8A8Fp8", "FP8_ALIGNMENT", "_pad_to_alignment"]
+__all__ = ["CompressedTensorsW8A8Fp8", "FP8_ALIGNMENT", "pad_to_alignment"]
 
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
@@ -42,7 +42,7 @@ if _use_aiter:
 FP8_ALIGNMENT = 16
 
 
-def _pad_to_alignment(
+def pad_to_alignment(
     tensor: torch.Tensor, dim: int, alignment: int = FP8_ALIGNMENT
 ) -> torch.Tensor:
     """Zero-pad tensor along dim to the next multiple of alignment.
@@ -66,18 +66,16 @@ def _pad_weight_to_alignment(
     Returns (weight_t, weight_scale, orig_N) where weight_t is transposed.
     weight_scale is padded along dim-0 when it is per-channel (shape [N, 1]).
     """
-    orig_n, orig_k = weight.shape
-    pad_n = (-orig_n) % FP8_ALIGNMENT
-    pad_k = (-orig_k) % FP8_ALIGNMENT
-    if pad_n or pad_k:
-        weight = F.pad(weight, (0, pad_k, 0, pad_n))
-        if weight_scale is not None:
-            if weight_scale.shape != (orig_n, 1):
-                raise ValueError(
-                    f"Expected per-channel scale shape ({orig_n}, 1), "
-                    f"got {tuple(weight_scale.shape)}"
-                )
-            weight_scale = F.pad(weight_scale, (0, 0, 0, pad_n))
+    orig_n = weight.shape[0]
+    weight = pad_to_alignment(weight, dim=0)
+    weight = pad_to_alignment(weight, dim=1)
+    if weight_scale is not None and weight.shape[0] > orig_n:
+        if weight_scale.shape != (orig_n, 1):
+            raise ValueError(
+                f"Expected per-channel scale shape ({orig_n}, 1), "
+                f"got {tuple(weight_scale.shape)}"
+            )
+        weight_scale = pad_to_alignment(weight_scale, dim=0)
     return weight.t(), weight_scale, orig_n
 
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -62,14 +62,15 @@ def pad_to_alignment(
 
 def _pad_weight_to_alignment(
     weight: torch.Tensor, weight_scale: Optional[torch.Tensor]
-) -> tuple[torch.Tensor, Optional[torch.Tensor], int]:
+) -> tuple[torch.Tensor, Optional[torch.Tensor], int, int]:
     """Pad weight (N, K) so both dims are multiples of FP8_ALIGNMENT.
 
-    Returns (weight_t, weight_scale, orig_N) where weight_t is transposed.
+    Returns (weight_t, weight_scale, orig_N, orig_K) where weight_t is transposed.
     weight_scale is padded along dim-0 when it is per-channel (shape [N, 1]
     or [N,]).
     """
     orig_n = weight.shape[0]
+    orig_k = weight.shape[1]
     weight = pad_to_alignment(weight, dim=0)
     weight = pad_to_alignment(weight, dim=1)
     if weight_scale is not None and weight.shape[0] > orig_n:
@@ -81,7 +82,32 @@ def _pad_weight_to_alignment(
                 f"got {tuple(weight_scale.shape)}"
             )
         weight_scale = pad_to_alignment(weight_scale, dim=0)
-    return weight.t(), weight_scale, orig_n
+    return weight.t(), weight_scale, orig_n, orig_k
+
+
+def _cache_padding_metadata(
+    layer, weight_t: torch.Tensor, orig_n: int, orig_k: int
+) -> None:
+    """Cache padded shapes on the layer and pre-pad a copy of bias if present.
+
+    Keeps apply_weights branch-light and CUDA-Graph-friendly: no per-forward
+    shape math, no F.pad on bias, no F.pad on input when K is already aligned.
+
+    Bias is stored under `_padded_bias` rather than overwriting `layer.bias`,
+    because callers using `skip_bias_add=True` read `layer.bias` directly and
+    would see the wrong shape if we mutated it in place.
+    """
+    # weight_t is (K_padded, N_padded).
+    k_padded, n_padded = weight_t.shape
+    layer._orig_output_dim = orig_n
+    layer._pad_input_k = k_padded - orig_k
+    layer._needs_output_slice = n_padded > orig_n
+
+    bias = getattr(layer, "bias", None)
+    if bias is not None and layer._needs_output_slice:
+        layer._padded_bias = pad_to_alignment(bias.data, dim=0)
+    else:
+        layer._padded_bias = None
 
 
 strategy_to_parameter_type = {
@@ -205,10 +231,10 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 if input_scale is not None:
                     layer.input_scale = Parameter(input_scale, requires_grad=False)
 
-            weight_t, _, orig_out = _pad_weight_to_alignment(weight, None)
+            weight_t, _, orig_n, orig_k = _pad_weight_to_alignment(weight, None)
             layer.weight = Parameter(weight_t, requires_grad=False)
             layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
-            layer._orig_output_dim = orig_out
+            _cache_padding_metadata(layer, weight_t, orig_n, orig_k)
 
         elif self.strategy == QuantizationStrategy.CHANNEL:
             weight = layer.weight
@@ -234,15 +260,14 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 )
                 # required by torch.compile to be torch.nn.Parameter
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-                layer._orig_output_dim = weight.shape[0]
             else:
-                weight_t, weight_scale, orig_out = _pad_weight_to_alignment(
+                weight_t, weight_scale, orig_n, orig_k = _pad_weight_to_alignment(
                     weight, weight_scale
                 )
                 layer.weight = Parameter(weight_t, requires_grad=False)
                 # required by torch.compile to be torch.nn.Parameter
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-                layer._orig_output_dim = orig_out
+                _cache_padding_metadata(layer, weight_t, orig_n, orig_k)
 
         elif self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
@@ -253,8 +278,8 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
                     weight=weight, weight_scale=weight_scale
                 )
-            layer.weight = Parameter(weight.detach(), requires_grad=False)
-            layer.weight_scale = Parameter(weight_scale.detach(), requires_grad=False)
+            layer.weight = Parameter(weight.data, requires_grad=False)
+            layer.weight_scale = Parameter(weight_scale.data, requires_grad=False)
 
         else:
             raise ValueError(f"Unknown quantization strategy {self.strategy}")
@@ -292,17 +317,21 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 compressed_tensor_quant=True,
             )
 
-        # weight is stored transposed as (K_padded, N_padded); pad x to match.
-        # TODO: consider padding input activation at graph-capture time instead of per-forward.
-        orig_out = layer._orig_output_dim
-        pad_k = layer.weight.shape[0] - x.shape[-1]
-        if pad_k > 0:
-            x = F.pad(x, (0, pad_k))
+        # weight is stored transposed as (K_padded, N_padded). All shape math
+        # is precomputed in process_weights_after_loading and cached on `layer`
+        # so this path is branch-light and CUDA-Graph-friendly.
+        #
+        # _pad_input_k is typically 0 for column-parallel layers (K == hidden_size
+        # is naturally aligned) and non-zero for row-parallel layers where
+        # K == intermediate_size/tp_size can be misaligned.
+        if layer._pad_input_k:
+            x = F.pad(x, (0, layer._pad_input_k))
 
-        # Pad bias to N_padded so apply_fp8_linear can add it before we slice.
-        pad_n = layer.weight.shape[1] - orig_out
-        if bias is not None and pad_n > 0:
-            bias = F.pad(bias, (0, pad_n))
+        # Swap in the pre-padded bias when N was padded at load time.
+        # `_padded_bias` is None when no padding was needed OR when the layer had
+        # no bias; if the caller passed bias=None (skip_bias_add=True), keep None.
+        if bias is not None:
+            bias = layer._padded_bias if layer._padded_bias is not None else bias
 
         output = apply_fp8_linear(
             input=x,
@@ -314,4 +343,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             compressed_tensor_quant=True,
         )
 
-        return output[..., :orig_out]
+        if layer._needs_output_slice:
+            output = output[..., : layer._orig_output_dim]
+        return output

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -36,30 +36,28 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
 
+# torch._scaled_mm requires both matrix dimensions divisible by 16.
+# Models where intermediate_size / tp_size is not 16-aligned
+# (e.g. 10944 / tp=8 = 1368) fail CUDA Graph capture without padding.
+_FP8_MM_ALIGNMENT = 16
 
-# torch._scaled_mm requires both matrix dimensions to be divisible by 16.
-# Models with intermediate_size not divisible by 16 after tensor-parallel
-# sharding (e.g. 10944 / tp=8 = 1368) fail CUDA Graph capture without this.
-FP8_ALIGNMENT = 16
 
+def _pad_weight_to_alignment(
+    weight: torch.Tensor, weight_scale: Optional[torch.Tensor]
+) -> tuple[torch.Tensor, Optional[torch.Tensor], int]:
+    """Pad weight (N, K) so both dims are multiples of _FP8_MM_ALIGNMENT.
 
-def _pad_to_alignment(t: torch.Tensor, dim: int, alignment: int) -> torch.Tensor:
-    """Pad tensor along *dim* so its size is a multiple of *alignment*.
-
-    Returns the original tensor unchanged when already aligned.
+    Returns (weight_t, weight_scale, orig_N) where weight_t is transposed.
+    weight_scale is padded along dim-0 when it is per-channel (shape [N, 1]).
     """
-    size = t.shape[dim]
-    remainder = size % alignment
-    if remainder == 0:
-        return t
-    pad_size = alignment - remainder
-    # F.pad takes a flat tuple starting from the last dimension:
-    # (last_right, last_left, second_last_right, second_last_left, ...)
-    ndim = t.dim()
-    pad: list[int] = [0] * (2 * ndim)
-    pad_idx = 2 * (ndim - 1 - dim) + 1  # right-pad index for `dim`
-    pad[pad_idx] = pad_size
-    return F.pad(t, pad)
+    orig_n, orig_k = weight.shape
+    pad_n = (-orig_n) % _FP8_MM_ALIGNMENT
+    pad_k = (-orig_k) % _FP8_MM_ALIGNMENT
+    if pad_n or pad_k:
+        weight = F.pad(weight, (0, pad_k, 0, pad_n))
+        if weight_scale is not None and weight_scale.shape[0] == orig_n:
+            weight_scale = F.pad(weight_scale, (0, 0, 0, pad_n))
+    return weight.t(), weight_scale, orig_n
 
 
 strategy_to_parameter_type = {
@@ -183,16 +181,12 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 if input_scale is not None:
                     layer.input_scale = Parameter(input_scale, requires_grad=False)
 
-            # Pad to FP8_ALIGNMENT so torch._scaled_mm succeeds in CUDA Graph.
-            # Per-tensor scale is a scalar — no scale padding needed.
-            orig_out = weight.shape[0]
-            weight = _pad_to_alignment(weight, dim=0, alignment=FP8_ALIGNMENT)
-            weight = _pad_to_alignment(weight, dim=1, alignment=FP8_ALIGNMENT)
-            layer.weight = Parameter(weight.t(), requires_grad=False)
+            # Per-tensor scale is scalar — pass None so _pad_weight_to_alignment
+            # skips scale padding.
+            weight_t, _, orig_out = _pad_weight_to_alignment(weight, None)
+            layer.weight = Parameter(weight_t, requires_grad=False)
             layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
-            layer.register_buffer(
-                "_orig_output_dim", torch.tensor(orig_out), persistent=False
-            )
+            layer._orig_output_dim = orig_out
 
         elif self.strategy == QuantizationStrategy.CHANNEL:
             weight = layer.weight
@@ -210,31 +204,22 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             else:
                 weight_scale = layer.weight_scale.data
 
-            orig_out = weight.shape[0]
-
             if _use_aiter:
-                # aiter kernel handles alignment internally; keep weight as (N, K).
+                # keep the weight as (N, K)
                 layer.weight = Parameter(
-                    shuffle_weight(weight, (FP8_ALIGNMENT, FP8_ALIGNMENT)),
+                    shuffle_weight(weight, (_FP8_MM_ALIGNMENT, _FP8_MM_ALIGNMENT)),
                     requires_grad=False,
                 )
                 # required by torch.compile to be torch.nn.Parameter
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
             else:
-                # Pad both dims so torch._scaled_mm succeeds in CUDA Graph.
-                weight = _pad_to_alignment(weight, dim=0, alignment=FP8_ALIGNMENT)
-                weight = _pad_to_alignment(weight, dim=1, alignment=FP8_ALIGNMENT)
-                # Pad per-channel scale to match new output dim.
-                weight_scale = _pad_to_alignment(
-                    weight_scale, dim=0, alignment=FP8_ALIGNMENT
+                weight_t, weight_scale, orig_out = _pad_weight_to_alignment(
+                    weight, weight_scale
                 )
-                layer.weight = Parameter(weight.t(), requires_grad=False)
+                layer.weight = Parameter(weight_t, requires_grad=False)
                 # required by torch.compile to be torch.nn.Parameter
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-                # Slice output back to original N after GEMM (padded rows are noise).
-                layer.register_buffer(
-                    "_orig_output_dim", torch.tensor(orig_out), persistent=False
-                )
+                layer._orig_output_dim = orig_out
 
         elif self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
@@ -245,7 +230,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
                     weight=weight, weight_scale=weight_scale
                 )
-            # Block kernels do not use torch._scaled_mm, so no alignment padding.
             layer.weight = Parameter(weight.detach(), requires_grad=False)
             layer.weight_scale = Parameter(weight_scale.detach(), requires_grad=False)
 
@@ -265,7 +249,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if self.weight_block_size is not None:
-            # Block kernels handle alignment internally; no padding needed.
             return self.w8a8_block_fp8_linear(
                 input=x,
                 weight=layer.weight,
@@ -276,8 +259,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             )
 
         if _use_aiter and self.strategy == QuantizationStrategy.CHANNEL:
-            # aiter keeps weight as (N, K) and handles alignment internally;
-            # no input padding or output slicing needed.
             return apply_fp8_ptpc_linear(
                 input=x,
                 weight=layer.weight,
@@ -288,16 +269,10 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 compressed_tensor_quant=True,
             )
 
-        # weight is stored transposed as (K_padded, N_padded).
-        # Pad the input K-dim to match so torch._scaled_mm aligns correctly.
+        # weight is stored transposed as (K_padded, N_padded); pad x to match.
         weight_k_dim = layer.weight.shape[0]
         if x.shape[-1] < weight_k_dim:
             x = F.pad(x, (0, weight_k_dim - x.shape[-1]))
-        elif x.shape[-1] > weight_k_dim:
-            raise RuntimeError(
-                f"Input last dim {x.shape[-1]} > padded weight K dim {weight_k_dim}."
-                " This should never happen."
-            )
 
         output = apply_fp8_linear(
             input=x,
@@ -309,6 +284,4 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             compressed_tensor_quant=True,
         )
 
-        # Trim any output columns added by N-dim padding.
-        orig_n = layer._orig_output_dim.item()
-        return output[..., :orig_n]
+        return output[..., : layer._orig_output_dim]

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -253,10 +253,10 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 weight_scale = layer.weight_scale.data
 
             if _use_aiter:
-                # keep the weight as (N, K); aiter kernel handles alignment internally
+                # keep the weight as (N, K); (16, 16) is the aiter shuffle tile
+                # size, unrelated to the torch._scaled_mm alignment requirement
                 layer.weight = Parameter(
-                    shuffle_weight(weight, (FP8_ALIGNMENT, FP8_ALIGNMENT)),
-                    requires_grad=False,
+                    shuffle_weight(weight, (16, 16)), requires_grad=False
                 )
                 # required by torch.compile to be torch.nn.Parameter
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -185,8 +185,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                 if input_scale is not None:
                     layer.input_scale = Parameter(input_scale, requires_grad=False)
 
-            # Per-tensor scale is scalar — pass None so _pad_weight_to_alignment
-            # skips scale padding.
             weight_t, _, orig_out = _pad_weight_to_alignment(weight, None)
             layer.weight = Parameter(weight_t, requires_grad=False)
             layer.weight_scale = Parameter(max_w_scale, requires_grad=False)

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -55,7 +55,11 @@ def _pad_weight_to_alignment(
     pad_k = (-orig_k) % _FP8_MM_ALIGNMENT
     if pad_n or pad_k:
         weight = F.pad(weight, (0, pad_k, 0, pad_n))
-        if weight_scale is not None and weight_scale.shape[0] == orig_n:
+        if weight_scale is not None:
+            assert weight_scale.shape == (orig_n, 1), (
+                f"Expected per-channel scale shape ({orig_n}, 1), "
+                f"got {tuple(weight_scale.shape)}"
+            )
             weight_scale = F.pad(weight_scale, (0, 0, 0, pad_n))
     return weight.t(), weight_scale, orig_n
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -270,9 +270,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             )
 
         # weight is stored transposed as (K_padded, N_padded); pad x to match.
-        weight_k_dim = layer.weight.shape[0]
-        if x.shape[-1] < weight_k_dim:
-            x = F.pad(x, (0, weight_k_dim - x.shape[-1]))
+        pad_k = layer.weight.shape[0] - x.shape[-1]
+        if pad_k > 0:
+            x = F.pad(x, (0, pad_k))
 
         output = apply_fp8_linear(
             input=x,

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -310,9 +310,7 @@ class TestChannelStrategyAlignment(CustomTestCase):
         output = scheme.apply_weights(layer, x).to(torch.float32)
 
         # Reference: x @ (W_fp8 * weight_scale)^T computed in fp32.
-        ref = x.to(torch.float32) @ (
-            weight.to(torch.float32) * weight_scale
-        ).t()
+        ref = x.to(torch.float32) @ (weight.to(torch.float32) * weight_scale).t()
 
         torch.testing.assert_close(output, ref, rtol=0.05, atol=0.1)
 

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -119,7 +119,7 @@ class TestTensorStrategyAlignment(CustomTestCase):
         self.assertEqual(n_padded % FP8_ALIGNMENT, 0)
 
         # _orig_output_dim must match the original out_dim
-        self.assertEqual(layer._orig_output_dim.item(), out_dim)
+        self.assertEqual(layer._orig_output_dim, out_dim)
 
     def test_non_aligned(self):
         # 1368 is 10944/8 — the exact failing case from GLM-4.5 with tp=8
@@ -176,7 +176,7 @@ class TestChannelStrategyAlignment(CustomTestCase):
         # Scale dim 0 must also be padded to a multiple of FP8_ALIGNMENT
         self.assertEqual(layer.weight_scale.shape[0] % FP8_ALIGNMENT, 0)
 
-        self.assertEqual(layer._orig_output_dim.item(), out_dim)
+        self.assertEqual(layer._orig_output_dim, out_dim)
 
     def test_non_aligned(self):
         self._run(out_dim=1368, in_dim=2048)

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -260,6 +260,62 @@ class TestChannelStrategyAlignment(CustomTestCase):
 
         self.assertEqual(output.shape, (batch, out_dim))
 
+    def test_input_k_misaligned_apply(self):
+        """Misaligned in_dim (K) exercises the input F.pad branch in
+        apply_weights, which the in_dim=2048 cases never hit."""
+        out_dim, in_dim = 1024, 1368  # K=1368 is not a multiple of 16
+        scheme = _make_scheme("CHANNEL")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        weight_scale = torch.ones(out_dim, 1, dtype=torch.float32, device="cuda")
+        layer = _make_layer(weight, weight_scale)
+        layer.input_scale = None
+
+        scheme.process_weights_after_loading(layer)
+
+        # K must have been padded, so apply_weights pads the input.
+        self.assertGreater(layer._pad_input_k, 0)
+
+        batch = 4
+        x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
+        output = scheme.apply_weights(layer, x)
+        self.assertEqual(output.shape, (batch, out_dim))
+
+    def test_nonzero_numerics_allclose(self):
+        """Non-zero weight + input: the padded path must match the dequantized
+        reference, proving padded rows/cols contribute 0 and do not leak.
+
+        Both out_dim and in_dim are misaligned so the N and K pad branches are
+        active. Tolerances are loose because the input is dynamically quantized
+        to fp8.
+        """
+        out_dim, in_dim = 1368, 1368
+        scheme = _make_scheme("CHANNEL")
+
+        # Small, fp8-representable weight values so weight quantization is exact
+        # and only the input quantization contributes error.
+        torch.manual_seed(0)
+        w_ref = (
+            torch.randint(-4, 5, (out_dim, in_dim), device="cuda").to(torch.float32)
+            * 0.125
+        )
+        weight = w_ref.to(torch.float8_e4m3fn)
+        weight_scale = torch.ones(out_dim, 1, dtype=torch.float32, device="cuda")
+        layer = _make_layer(weight, weight_scale)
+        layer.input_scale = None
+        scheme.process_weights_after_loading(layer)
+
+        batch = 4
+        x = torch.randn(batch, in_dim, dtype=torch.bfloat16, device="cuda") * 0.1
+        output = scheme.apply_weights(layer, x).to(torch.float32)
+
+        # Reference: x @ (W_fp8 * weight_scale)^T computed in fp32.
+        ref = x.to(torch.float32) @ (
+            weight.to(torch.float32) * weight_scale
+        ).t()
+
+        torch.testing.assert_close(output, ref, rtol=0.05, atol=0.1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -20,7 +20,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensor
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=30, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small")
 
 
 def _make_fp8_weight(out_dim: int, in_dim: int) -> torch.Tensor:

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -14,7 +14,7 @@ import torch
 from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import (
     FP8_ALIGNMENT,
     CompressedTensorsW8A8Fp8,
-    _pad_to_alignment,
+    pad_to_alignment,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -55,34 +55,34 @@ def _make_layer(weight: torch.Tensor, weight_scale: torch.Tensor) -> SimpleNames
 
 
 class TestPadToAlignment(CustomTestCase):
-    """Unit tests for the _pad_to_alignment helper."""
+    """Unit tests for the pad_to_alignment helper."""
 
     def test_already_aligned_is_noop(self):
         t = torch.zeros(16, 32)
-        result = _pad_to_alignment(t, dim=0, alignment=FP8_ALIGNMENT)
+        result = pad_to_alignment(t, dim=0, alignment=FP8_ALIGNMENT)
         self.assertIs(result, t)
 
     def test_pads_dim0(self):
         t = torch.zeros(13, 32)
-        result = _pad_to_alignment(t, dim=0, alignment=16)
+        result = pad_to_alignment(t, dim=0, alignment=16)
         self.assertEqual(result.shape[0], 16)
         self.assertEqual(result.shape[1], 32)
 
     def test_pads_dim1(self):
         t = torch.zeros(32, 13)
-        result = _pad_to_alignment(t, dim=1, alignment=16)
+        result = pad_to_alignment(t, dim=1, alignment=16)
         self.assertEqual(result.shape[0], 32)
         self.assertEqual(result.shape[1], 16)
 
     def test_pads_to_correct_multiple(self):
         # 1368 = 85 * 16 + 8 → next multiple is 86 * 16 = 1376
         t = torch.zeros(1368, 64)
-        result = _pad_to_alignment(t, dim=0, alignment=16)
+        result = pad_to_alignment(t, dim=0, alignment=16)
         self.assertEqual(result.shape[0], 1376)
 
     def test_pad_values_are_zero(self):
         t = torch.ones(13, 16)
-        result = _pad_to_alignment(t, dim=0, alignment=16)
+        result = pad_to_alignment(t, dim=0, alignment=16)
         # padded rows should be zero
         self.assertTrue(torch.all(result[13:] == 0))
         # original rows should be unchanged

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -147,6 +147,26 @@ class TestTensorStrategyAlignment(CustomTestCase):
 
         self.assertEqual(output.shape, (batch, out_dim))
 
+    def test_output_shape_with_bias(self):
+        """Bias (shape [out_dim]) must not cause a shape mismatch when N is padded."""
+        out_dim, in_dim = 1368, 2048
+        scheme = _make_scheme("TENSOR")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        weight_scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+        layer = _make_layer(weight, weight_scale)
+        layer.logical_widths = [out_dim]
+        layer.input_scale = None
+
+        scheme.process_weights_after_loading(layer)
+
+        batch = 4
+        x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
+        bias = torch.ones(out_dim, dtype=torch.bfloat16, device="cuda")
+        output = scheme.apply_weights(layer, x, bias=bias)
+
+        self.assertEqual(output.shape, (batch, out_dim))
+
 
 class TestChannelStrategyAlignment(CustomTestCase):
     """process_weights_after_loading (CHANNEL) pads weight + scale and
@@ -198,6 +218,25 @@ class TestChannelStrategyAlignment(CustomTestCase):
         batch = 4
         x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
         output = scheme.apply_weights(layer, x)
+
+        self.assertEqual(output.shape, (batch, out_dim))
+
+    def test_output_shape_with_bias(self):
+        """Bias (shape [out_dim]) must not cause a shape mismatch when N is padded."""
+        out_dim, in_dim = 1368, 2048
+        scheme = _make_scheme("CHANNEL")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        weight_scale = torch.ones(out_dim, 1, dtype=torch.float32, device="cuda")
+        layer = _make_layer(weight, weight_scale)
+        layer.input_scale = None
+
+        scheme.process_weights_after_loading(layer)
+
+        batch = 4
+        x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
+        bias = torch.ones(out_dim, dtype=torch.bfloat16, device="cuda")
+        output = scheme.apply_weights(layer, x, bias=bias)
 
         self.assertEqual(output.shape, (batch, out_dim))
 

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -7,6 +7,7 @@
 
 import unittest
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import MagicMock
 
 import torch
@@ -38,13 +39,20 @@ def _make_scheme(strategy_str: str) -> CompressedTensorsW8A8Fp8:
     )
 
 
-def _make_layer(weight: torch.Tensor, weight_scale: torch.Tensor) -> SimpleNamespace:
+def _make_layer(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+) -> SimpleNamespace:
     """Build a minimal fake layer that mimics what process_weights_after_loading
     receives from the model loader."""
     layer = SimpleNamespace()
     layer.weight = torch.nn.Parameter(weight, requires_grad=False)
     layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
     layer.logical_widths = [weight.shape[0]]
+    layer.bias = (
+        torch.nn.Parameter(bias, requires_grad=False) if bias is not None else None
+    )
 
     # register_buffer / register_parameter shims
     def _register_buffer(name, tensor, persistent=True):
@@ -118,8 +126,10 @@ class TestTensorStrategyAlignment(CustomTestCase):
         self.assertEqual(k_padded % FP8_ALIGNMENT, 0)
         self.assertEqual(n_padded % FP8_ALIGNMENT, 0)
 
-        # _orig_output_dim must match the original out_dim
+        # Cached padding metadata must be consistent with the padded weight.
         self.assertEqual(layer._orig_output_dim, out_dim)
+        self.assertEqual(layer._pad_input_k, k_padded - in_dim)
+        self.assertEqual(layer._needs_output_slice, n_padded > out_dim)
 
     def test_non_aligned(self):
         # 1368 is 10944/8 — the exact failing case from GLM-4.5 with tp=8
@@ -154,16 +164,20 @@ class TestTensorStrategyAlignment(CustomTestCase):
 
         weight = _make_fp8_weight(out_dim, in_dim)
         weight_scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
-        layer = _make_layer(weight, weight_scale)
+        bias = torch.ones(out_dim, dtype=torch.bfloat16, device="cuda")
+        layer = _make_layer(weight, weight_scale, bias=bias)
         layer.logical_widths = [out_dim]
         layer.input_scale = None
 
         scheme.process_weights_after_loading(layer)
 
+        # bias must be pre-padded to N_padded during loading
+        self.assertIsNotNone(layer._padded_bias)
+        self.assertEqual(layer._padded_bias.shape[0], layer.weight.shape[1])
+
         batch = 4
         x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
-        bias = torch.ones(out_dim, dtype=torch.bfloat16, device="cuda")
-        output = scheme.apply_weights(layer, x, bias=bias)
+        output = scheme.apply_weights(layer, x, bias=layer.bias)
 
         self.assertEqual(output.shape, (batch, out_dim))
 
@@ -197,6 +211,8 @@ class TestChannelStrategyAlignment(CustomTestCase):
         self.assertEqual(layer.weight_scale.shape[0] % FP8_ALIGNMENT, 0)
 
         self.assertEqual(layer._orig_output_dim, out_dim)
+        self.assertEqual(layer._pad_input_k, k_padded - in_dim)
+        self.assertEqual(layer._needs_output_slice, n_padded > out_dim)
 
     def test_non_aligned(self):
         self._run(out_dim=1368, in_dim=2048)
@@ -228,15 +244,19 @@ class TestChannelStrategyAlignment(CustomTestCase):
 
         weight = _make_fp8_weight(out_dim, in_dim)
         weight_scale = torch.ones(out_dim, 1, dtype=torch.float32, device="cuda")
-        layer = _make_layer(weight, weight_scale)
+        bias = torch.ones(out_dim, dtype=torch.bfloat16, device="cuda")
+        layer = _make_layer(weight, weight_scale, bias=bias)
         layer.input_scale = None
 
         scheme.process_weights_after_loading(layer)
 
+        # bias must be pre-padded to N_padded during loading
+        self.assertIsNotNone(layer._padded_bias)
+        self.assertEqual(layer._padded_bias.shape[0], layer.weight.shape[1])
+
         batch = 4
         x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
-        bias = torch.ones(out_dim, dtype=torch.bfloat16, device="cuda")
-        output = scheme.apply_weights(layer, x, bias=bias)
+        output = scheme.apply_weights(layer, x, bias=layer.bias)
 
         self.assertEqual(output.shape, (batch, out_dim))
 

--- a/test/registered/quant/test_fp8_w8a8_alignment.py
+++ b/test/registered/quant/test_fp8_w8a8_alignment.py
@@ -1,0 +1,206 @@
+# Tests for FP8 W8A8 16-alignment padding logic in CompressedTensorsW8A8Fp8.
+#
+# Motivation: torch._scaled_mm requires both matrix dimensions to be divisible
+# by 16.  Models whose intermediate_size / tp_size is not 16-aligned (e.g.
+# GLM-4.5 with 10944 / tp=8 = 1368) fail CUDA Graph capture without padding.
+# These tests verify the pad/unpad round-trip without launching a server.
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import (
+    FP8_ALIGNMENT,
+    CompressedTensorsW8A8Fp8,
+    _pad_to_alignment,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, suite="stage-b-test-1-gpu-small")
+
+
+def _make_fp8_weight(out_dim: int, in_dim: int) -> torch.Tensor:
+    return torch.zeros(out_dim, in_dim, dtype=torch.float8_e4m3fn, device="cuda")
+
+
+def _make_scheme(strategy_str: str) -> CompressedTensorsW8A8Fp8:
+    from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+
+    strategy = getattr(QuantizationStrategy, strategy_str)
+    weight_quant = MagicMock(spec=QuantizationArgs)
+    weight_quant.strategy = strategy
+    weight_quant.block_structure = None
+    return CompressedTensorsW8A8Fp8(
+        weight_quant=weight_quant, is_static_input_scheme=False
+    )
+
+
+def _make_layer(weight: torch.Tensor, weight_scale: torch.Tensor) -> SimpleNamespace:
+    """Build a minimal fake layer that mimics what process_weights_after_loading
+    receives from the model loader."""
+    layer = SimpleNamespace()
+    layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
+    layer.logical_widths = [weight.shape[0]]
+
+    # register_buffer / register_parameter shims
+    def _register_buffer(name, tensor, persistent=True):
+        setattr(layer, name, tensor)
+
+    layer.register_buffer = _register_buffer
+    return layer
+
+
+class TestPadToAlignment(CustomTestCase):
+    """Unit tests for the _pad_to_alignment helper."""
+
+    def test_already_aligned_is_noop(self):
+        t = torch.zeros(16, 32)
+        result = _pad_to_alignment(t, dim=0, alignment=FP8_ALIGNMENT)
+        self.assertIs(result, t)
+
+    def test_pads_dim0(self):
+        t = torch.zeros(13, 32)
+        result = _pad_to_alignment(t, dim=0, alignment=16)
+        self.assertEqual(result.shape[0], 16)
+        self.assertEqual(result.shape[1], 32)
+
+    def test_pads_dim1(self):
+        t = torch.zeros(32, 13)
+        result = _pad_to_alignment(t, dim=1, alignment=16)
+        self.assertEqual(result.shape[0], 32)
+        self.assertEqual(result.shape[1], 16)
+
+    def test_pads_to_correct_multiple(self):
+        # 1368 = 85 * 16 + 8 → next multiple is 86 * 16 = 1376
+        t = torch.zeros(1368, 64)
+        result = _pad_to_alignment(t, dim=0, alignment=16)
+        self.assertEqual(result.shape[0], 1376)
+
+    def test_pad_values_are_zero(self):
+        t = torch.ones(13, 16)
+        result = _pad_to_alignment(t, dim=0, alignment=16)
+        # padded rows should be zero
+        self.assertTrue(torch.all(result[13:] == 0))
+        # original rows should be unchanged
+        self.assertTrue(torch.all(result[:13] == 1))
+
+
+class TestTensorStrategyAlignment(CustomTestCase):
+    """process_weights_after_loading (TENSOR) pads weight and apply_weights
+    returns the correct unpadded output shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    def _run(self, out_dim: int, in_dim: int):
+        scheme = _make_scheme("TENSOR")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        # Per-tensor scale: single scalar
+        weight_scale = torch.tensor(
+            [torch.finfo(torch.float32).min] * 1, dtype=torch.float32, device="cuda"
+        )
+
+        layer = _make_layer(weight, weight_scale)
+        # requantize_with_max_scale expects logical_widths matching weight rows
+        layer.logical_widths = [out_dim]
+
+        scheme.process_weights_after_loading(layer)
+
+        # Weight stored transposed: (K_padded, N_padded)
+        k_padded, n_padded = layer.weight.shape
+        self.assertEqual(k_padded % FP8_ALIGNMENT, 0)
+        self.assertEqual(n_padded % FP8_ALIGNMENT, 0)
+
+        # _orig_output_dim must match the original out_dim
+        self.assertEqual(layer._orig_output_dim.item(), out_dim)
+
+    def test_non_aligned(self):
+        # 1368 is 10944/8 — the exact failing case from GLM-4.5 with tp=8
+        self._run(out_dim=1368, in_dim=2048)
+
+    def test_aligned(self):
+        # Already-aligned — should be a no-op
+        self._run(out_dim=1024, in_dim=2048)
+
+    def test_output_shape_after_apply(self):
+        out_dim, in_dim = 1368, 2048
+        scheme = _make_scheme("TENSOR")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        weight_scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+        layer = _make_layer(weight, weight_scale)
+        layer.logical_widths = [out_dim]
+        layer.input_scale = None
+
+        scheme.process_weights_after_loading(layer)
+
+        batch = 4
+        x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
+        output = scheme.apply_weights(layer, x)
+
+        self.assertEqual(output.shape, (batch, out_dim))
+
+
+class TestChannelStrategyAlignment(CustomTestCase):
+    """process_weights_after_loading (CHANNEL) pads weight + scale and
+    apply_weights returns the correct unpadded output shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+
+    def _run(self, out_dim: int, in_dim: int):
+        scheme = _make_scheme("CHANNEL")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        # Per-channel scale: shape (N, 1)
+        weight_scale = torch.ones(out_dim, 1, dtype=torch.float32, device="cuda")
+
+        layer = _make_layer(weight, weight_scale)
+
+        scheme.process_weights_after_loading(layer)
+
+        # Weight stored transposed: (K_padded, N_padded)
+        k_padded, n_padded = layer.weight.shape
+        self.assertEqual(k_padded % FP8_ALIGNMENT, 0)
+        self.assertEqual(n_padded % FP8_ALIGNMENT, 0)
+
+        # Scale dim 0 must also be padded to a multiple of FP8_ALIGNMENT
+        self.assertEqual(layer.weight_scale.shape[0] % FP8_ALIGNMENT, 0)
+
+        self.assertEqual(layer._orig_output_dim.item(), out_dim)
+
+    def test_non_aligned(self):
+        self._run(out_dim=1368, in_dim=2048)
+
+    def test_aligned(self):
+        self._run(out_dim=1024, in_dim=2048)
+
+    def test_output_shape_after_apply(self):
+        out_dim, in_dim = 1368, 2048
+        scheme = _make_scheme("CHANNEL")
+
+        weight = _make_fp8_weight(out_dim, in_dim)
+        weight_scale = torch.ones(out_dim, 1, dtype=torch.float32, device="cuda")
+        layer = _make_layer(weight, weight_scale)
+        layer.input_scale = None
+
+        scheme.process_weights_after_loading(layer)
+
+        batch = 4
+        x = torch.zeros(batch, in_dim, dtype=torch.bfloat16, device="cuda")
+        output = scheme.apply_weights(layer, x)
+
+        self.assertEqual(output.shape, (batch, out_dim))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`torch._scaled_mm` requires both matrix dimensions to be divisible by 16.
When `intermediate_size / tp_size` is not 16-aligned, CUDA Graph capture
fails at the FP8 linear:

```
RuntimeError: Expected trailing dimension of mat1 to be divisible by 16
but got mat1 shape: (512x1368).
Exception: Capture cuda graph failed
```

**Minimal repro** (GLM-4.5-Air-Base, FP8, `intermediate_size=10944`, tp=8 → 1368):

```bash
python -m sglang.launch_server \
  --model-path THUDM/GLM-4.5-Air-Base-FP8 \
  --tp 8 --quantization compressed-tensors
```

## Solution

Pad at **load time** (once per layer), and keep `apply_weights` on the
graph-captured hot path free of shape-dependent work.

- **Weight / per-channel scale** — padded in `process_weights_after_loading`.
- **Bias** — pre-padded to `layer._padded_bias` at load. We do *not*
  overwrite `layer.bias`, because `skip_bias_add=True` exposes
  `layer.bias` directly to the caller and would see the wrong shape.
- **Input K-dim** — pad amount cached as `layer._pad_input_k`. Typically
  0 for column-parallel layers (K = hidden_size, naturally aligned); only
  non-zero for row-parallel where K = intermediate_size/tp_size.
- **Output** — sliced back to `layer._orig_output_dim` only when padding
  was actually applied (`_needs_output_slice`).

Net effect on `apply_weights`: one optional `F.pad` on input, one branch
on output slicing, zero per-forward shape math. No new allocations on
aligned layers.

### Why load-time pad rather than fallback to a different kernel?

1. Zero per-forward shape math — matters for CUDA Graph stability.
2. No extra kernel dependency; works on any FP8 path going through
   `torch._scaled_mm`.
3. Single-location fix; no cross-cutting routing changes in
   `apply_fp8_linear`.

### Why not pad in the weight loader upstream?

Considered. The weight loader does not know which quant scheme requires
16-alignment, and `MergedColumnParallelLinear` already has its own
padding contract — layering another one there risks double-padding and
breaks strategies that don't need it (BLOCK). Scheme-local is the
smallest correct surface.

## Scope

- `CompressedTensorsW8A8Fp8` TENSOR + CHANNEL (non-aiter) strategies.
- BLOCK: unchanged (block kernels don't use `torch._scaled_mm`).
- CHANNEL (aiter / HIP): unchanged (`shuffle_weight` handles alignment).

## Testing

- GLM-4.5-Air-Base FP8 on 8×RTX4090: CUDA Graph capture + inference OK.
- `test/registered/quant/test_fp8_w8a8_alignment.py`:
  - `pad_to_alignment` helper (no-op on aligned; dim0 / dim1; pad values).
  - TENSOR / CHANNEL: weight + scale padded; `_orig_output_dim`,
    `_pad_input_k`, `_needs_output_slice` cached correctly.
  - Output shape round-trip (with and without bias; bias path verifies
    `_padded_bias` is set during load, not at apply time).































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27520738983](https://github.com/sgl-project/sglang/actions/runs/27520738983)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27520738888](https://github.com/sgl-project/sglang/actions/runs/27520738888)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->