### PR TITLE
[CI] Simplify CI check actions and add maintenance gate to rerun-ut

### DIFF
--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -4,7 +4,8 @@ description: Blocks CI when maintenance mode is active (issue #21065 is open), u
 inputs:
   github-token:
     description: GitHub token for API access
-    required: true
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -63,8 +63,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -98,8 +96,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -130,8 +126,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -158,8 +152,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -191,8 +183,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -275,8 +265,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -308,8 +296,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -381,8 +367,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -408,8 +392,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -448,8 +430,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -475,8 +455,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -520,8 +498,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -580,8 +556,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -636,8 +610,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |
@@ -665,8 +637,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -45,11 +45,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -75,8 +72,6 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -102,11 +97,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Install dependencies
         timeout-minutes: 20

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -63,11 +63,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: inputs.sgl_kernel == 'true'
@@ -120,11 +117,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: inputs.sgl_kernel == 'true'
@@ -174,11 +168,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: inputs.sgl_kernel == 'true'

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -35,11 +35,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Cleanup
         run: |
@@ -73,11 +70,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Cleanup
         run: |
@@ -111,11 +105,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Cleanup
         run: |
@@ -161,11 +152,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Cleanup
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -92,8 +92,6 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Determine run mode
         id: run-mode
@@ -339,8 +337,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - uses: ./.github/actions/wait-for-jobs
         id: wait
@@ -369,8 +365,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - uses: ./.github/actions/wait-for-jobs
         id: wait
@@ -430,8 +424,6 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -484,8 +476,6 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -564,11 +554,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -620,11 +607,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -677,11 +661,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -741,11 +722,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -798,11 +776,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -857,11 +832,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -944,11 +916,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1001,11 +970,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1074,11 +1040,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1127,11 +1090,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1190,11 +1150,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1259,11 +1216,8 @@ jobs:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
       - uses: ./.github/actions/check-stage-health
-        id: stage-health
 
       - uses: ./.github/actions/check-maintenance
-        with:
-          github-token: ${{ github.token }}
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'

--- a/.github/workflows/rerun-ut.yml
+++ b/.github/workflows/rerun-ut.yml
@@ -41,6 +41,7 @@ env:
 permissions:
   actions: write
   contents: read
+  issues: read
 
 jobs:
   rerun-ut-cuda:
@@ -54,6 +55,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
+
+      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         timeout-minutes: 20


### PR DESCRIPTION
## Summary
- Add default for `github-token` in `check-maintenance` action, removing the need for explicit `with: github-token` at every call site
- Remove unused `id: stage-health` from `check-stage-health` call sites
- Add `check-maintenance` to `rerun-ut.yml` to block runs during maintenance

Net: **-101 lines** of boilerplate across 7 files, no behavior change except the new maintenance gate on rerun-ut.

## Test plan
- [ ] PR CI passes (exercises the simplified check-maintenance calls)
- [ ] Verify rerun-ut respects maintenance mode