### PR TITLE
Backfill `rope_theta` in Qwen3.5 config for compatibility

### DIFF
--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -24,11 +24,10 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
             kwargs["rope_scaling"] = rope_parameters
 
         # Compatibility shim: backfill a missing top-level rope_theta for Qwen3NextConfig
-        # from the normalized RoPE settings. Qwen3.5 uses the nested RoPE config directly,
+        # from the normalized RoPE settings. Qwen3.5 uses the nested RoPE config directly.
         rope_scaling = kwargs.get("rope_scaling")
         if kwargs.get("rope_theta") is None and isinstance(rope_scaling, dict):
-            rope_theta = rope_scaling.get("rope_theta")
-            if rope_theta is not None:
+            if (rope_theta := rope_scaling.get("rope_theta")) is not None:
                 kwargs["rope_theta"] = rope_theta
 
         super().__init__(**kwargs)

--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -23,6 +23,14 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
         if kwargs.get("rope_scaling") is None and rope_parameters is not None:
             kwargs["rope_scaling"] = rope_parameters
 
+        # Compatibility shim: backfill a missing top-level rope_theta for Qwen3NextConfig
+        # from the normalized RoPE settings. Qwen3.5 uses the nested RoPE config directly,
+        rope_scaling = kwargs.get("rope_scaling")
+        if kwargs.get("rope_theta") is None and isinstance(rope_scaling, dict):
+            rope_theta = rope_scaling.get("rope_theta")
+            if rope_theta is not None:
+                kwargs["rope_theta"] = rope_theta
+
         super().__init__(**kwargs)
         if self.rope_scaling is None:
             self.rope_scaling = rope_parameters or {}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Some Qwen3.5 checkpoints provide the RoPE settings under nested config fields such as `rope_scaling` / `rope_parameters`, while `Qwen3NextConfig` which `Qwen3_5TextConfig` inherits from still keeps a top-level `rope_theta` field.

  Without this normalization, the parent config may retain its stale default top-level `rope_theta`, even though Qwen3.5 itself uses the nested RoPE config directly. This can leave inherited config fields inconsistent with the effective RoPE value. This can introduce inconsistencies in downstream code that relies on sglang (e.g., https://github.com/THUDM/slime).

## Modifications

In [`python/sglang/srt/configs/qwen3_5.py`](/Users/meng/Desktop/github/rl-project/sglang/python/sglang/srt/configs/qwen3_5.py), backfill a missing top-level `rope_theta` from the normalized `rope_scaling` config before calling `Qwen3NextConfig.__init__`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
