### PR TITLE
[VLM] Optimize ShmPointerMMData for multi-pickle safety and deferred unwrap

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1624,48 +1624,33 @@ class ShmPointerMMData:
     """
     Wraps a tensor to be sent via a shared memory handle.
     This acts as a "pointer" to the tensor data across process boundaries.
+
+    Designed to be pickle-serialized multiple times (e.g., ZMQ send then
+    dist.broadcast) without re-creating the shared memory segment.
+    Only the shm name/shape/dtype metadata is serialized; actual tensor
+    data lives in POSIX shared memory.
     """
 
     def __init__(self, tensor: torch.Tensor):
-        self.cpu_tensor = tensor.cpu().contiguous()
-        self.shape = self.cpu_tensor.shape
-        self.dtype = self.cpu_tensor.dtype
-
-        nbytes = self.cpu_tensor.numel() * self.cpu_tensor.element_size()
-
+        cpu_tensor = (
+            tensor
+            if (tensor.is_cpu and tensor.is_contiguous())
+            else tensor.cpu().contiguous()
+        )
+        self.shape = cpu_tensor.shape
+        self.dtype = cpu_tensor.dtype
+        nbytes = cpu_tensor.numel() * cpu_tensor.element_size()
         self.shm = shared_memory.SharedMemory(create=True, size=nbytes)
-
-        try:
-            shm_view = np.ndarray((nbytes,), dtype=np.uint8, buffer=self.shm.buf)
-
-            shm_view[:] = self.cpu_tensor.view(torch.uint8).numpy().flatten()
-        finally:
-            self.shm.close()
+        self.shm_name = self.shm.name
+        # Direct copy: torch → shm buffer (no numpy intermediate)
+        dst = torch.frombuffer(self.shm.buf, dtype=torch.uint8)
+        dst.copy_(cpu_tensor.view(torch.uint8).reshape(-1))
+        self.shm.close()
+        self._shm_handle = None
 
     def __getstate__(self):
-        if not hasattr(self, "shm") or self.shm is None:
-            tensor = getattr(self, "cpu_tensor", None)
-            if tensor is None:
-                tensor = getattr(self, "tensor", None)
-            if tensor is None:
-                raise RuntimeError(
-                    "ShmPointerMMData cannot recreate shared memory without tensor"
-                )
-
-            cpu_tensor = tensor.cpu().contiguous()
-            self.shape = cpu_tensor.shape
-            self.dtype = cpu_tensor.dtype
-
-            nbytes = cpu_tensor.numel() * cpu_tensor.element_size()
-            self.shm = shared_memory.SharedMemory(create=True, size=nbytes)
-            try:
-                shm_view = np.ndarray((nbytes,), dtype=np.uint8, buffer=self.shm.buf)
-                shm_view[:] = cpu_tensor.view(torch.uint8).numpy().flatten()
-            finally:
-                self.shm.close()
-
         return {
-            "shm_name": self.shm.name,
+            "shm_name": self.shm_name,
             "shape": self.shape,
             "dtype": self.dtype,
         }
@@ -1675,17 +1660,31 @@ class ShmPointerMMData:
         self.shape = state["shape"]
         self.dtype = state["dtype"]
         self.shm = None
+        self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
+        # Zero-copy view into shared memory (no clone, no unlink)
+        self.tensor = torch.frombuffer(
+            self._shm_handle.buf, dtype=self.dtype
+        ).reshape(self.shape)
 
-        shm_handle = shared_memory.SharedMemory(name=self.shm_name)
-        try:
-            self.tensor = (
-                torch.frombuffer(shm_handle.buf, dtype=self.dtype)
-                .reshape(self.shape)
-                .clone()
-            )
-        finally:
-            shm_handle.close()
-            shm_handle.unlink()
+    def materialize(self) -> torch.Tensor:
+        """Clone tensor from shm to owned memory, then release shm handle."""
+        tensor = self.tensor.clone()
+        if self._shm_handle is not None:
+            self._shm_handle.close()
+            try:
+                self._shm_handle.unlink()
+            except FileNotFoundError:
+                pass  # Another rank already unlinked
+            self._shm_handle = None
+        return tensor
+
+    def __del__(self):
+        if getattr(self, "_shm_handle", None) is not None:
+            self._shm_handle.close()
+            try:
+                self._shm_handle.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def _get_is_default_transport():
@@ -1723,12 +1722,19 @@ def wrap_shm_features(obj):
 def unwrap_shm_features(obj):
     """
     Restore ShmPointerMMData wrappers back into standard torch.Tensors.
+    Handles both single requests and batch requests.
     """
     if _get_is_default_transport() or get_global_server_args().skip_tokenizer_init:
         return obj
+    # Handle batch requests
+    if hasattr(obj, "batch"):
+        for sub_obj in obj.batch:
+            unwrap_shm_features(sub_obj)
+        return obj
+    # Handle single requests
     if hasattr(obj, "mm_inputs") and obj.mm_inputs:
         mm_items = obj.mm_inputs.get("mm_items", [])
         for item in mm_items:
             if isinstance(item.feature, ShmPointerMMData):
-                item.feature = item.feature.tensor
+                item.feature = item.feature.materialize()
     return obj

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1624,11 +1624,6 @@ class ShmPointerMMData:
     """
     Wraps a tensor to be sent via a shared memory handle.
     This acts as a "pointer" to the tensor data across process boundaries.
-
-    Designed to be pickle-serialized multiple times (e.g., ZMQ send then
-    dist.broadcast) without re-creating the shared memory segment.
-    Only the shm name/shape/dtype metadata is serialized; actual tensor
-    data lives in POSIX shared memory.
     """
 
     def __init__(self, tensor: torch.Tensor):

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1662,9 +1662,9 @@ class ShmPointerMMData:
         self.shm = None
         self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
         # Zero-copy view into shared memory (no clone, no unlink)
-        self.tensor = torch.frombuffer(
-            self._shm_handle.buf, dtype=self.dtype
-        ).reshape(self.shape)
+        self.tensor = torch.frombuffer(self._shm_handle.buf, dtype=self.dtype).reshape(
+            self.shape
+        )
 
     def materialize(self) -> torch.Tensor:
         """Clone tensor from shm to owned memory, then release shm handle."""

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1677,12 +1677,10 @@ class ShmPointerMMData:
         return tensor
 
     def __del__(self):
+        # Only close; never unlink. Unlinking is materialize()'s job.
         if getattr(self, "_shm_handle", None) is not None:
             self._shm_handle.close()
-            try:
-                self._shm_handle.unlink()
-            except FileNotFoundError:
-                pass
+            self._shm_handle = None
 
 
 def _get_is_default_transport():

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1627,20 +1627,23 @@ class ShmPointerMMData:
     """
 
     def __init__(self, tensor: torch.Tensor):
-        cpu_tensor = (
-            tensor
-            if (tensor.is_cpu and tensor.is_contiguous())
-            else tensor.cpu().contiguous()
-        )
-        self.shape = cpu_tensor.shape
-        self.dtype = cpu_tensor.dtype
-        nbytes = cpu_tensor.numel() * cpu_tensor.element_size()
-        self.shm = shared_memory.SharedMemory(create=True, size=nbytes)
-        self.shm_name = self.shm.name
-        # Direct copy: torch → shm buffer (no numpy intermediate)
-        dst = torch.frombuffer(self.shm.buf, dtype=torch.uint8)
-        dst.copy_(cpu_tensor.view(torch.uint8).reshape(-1))
-        self.shm.close()
+        if not tensor.is_cpu:
+            tensor = tensor.cpu()
+        if not tensor.is_contiguous():
+            tensor = tensor.contiguous()
+        self.shape = tensor.shape
+        self.dtype = tensor.dtype
+        nbytes = tensor.numel() * tensor.element_size()
+        shm = shared_memory.SharedMemory(create=True, size=nbytes)
+        try:
+            dst = torch.frombuffer(shm.buf, dtype=torch.uint8)
+            dst.copy_(tensor.view(torch.uint8).reshape(-1))
+        except BaseException:
+            shm.close()
+            shm.unlink()
+            raise
+        self.shm_name = shm.name
+        shm.close()
         self._shm_handle = None
 
     def __getstate__(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1424,7 +1424,6 @@ class Scheduler(
                         if self.recv_limit_reached(len(recv_reqs)):
                             break
                         recv_req = self.recv_from_tokenizer.recv_pyobj(zmq.NOBLOCK)
-                        recv_req = unwrap_shm_features(recv_req)
                     except zmq.ZMQError:
                         break
                     recv_reqs.append(recv_req)
@@ -1510,6 +1509,13 @@ class Scheduler(
                 )
                 prepare_abort(req, error_msg, status_code=status_code)
                 self.stream_output([req], req.return_logprob)
+
+        # Unwrap shared memory features AFTER all broadcasts complete,
+        # so that ShmPointerMMData metadata (not full tensor data) is what
+        # gets serialized during broadcast_pyobj.
+        if recv_reqs:
+            for req in recv_reqs:
+                unwrap_shm_features(req)
 
         return recv_reqs
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

qwen3vl-32b tp4

Launching server: /root/.python/sglang/bin/python3 -m sglang.launch_server --model-path Qwen/Qwen3-VL-32B-Instruct --port 30000 --tp-size 4 --enable-multimodal


experiment details: https://github.com/yhyang201/sgl-bench/blob/main/records/20260326/20260326_085233_main/probe.log

## Motivation

A part of #21462 

Rewrite ShmPointerMMData to support multiple pickle round-trips without re-creating shared memory segments, and defer unwrap_shm_features() to after broadcast so only lightweight metadata is serialized during dist.broadcast_pyobj.

Before:
```
  [1 images] Generating 1x 720p... (0.0s) Sending... OK (TTFT=304ms, e2e=0.5s)
  [2 images] Generating 2x 720p... (0.0s) Sending... OK (TTFT=530ms, e2e=0.8s)
  [3 images] Generating 3x 720p... (0.1s) Sending... OK (TTFT=708ms, e2e=0.9s)
  [4 images] Generating 4x 720p... (0.1s) Sending... OK (TTFT=983ms, e2e=1.2s)
  [5 images] Generating 5x 720p... (0.1s) Sending... OK (TTFT=1117ms, e2e=1.4s)
  [6 images] Generating 6x 720p... (0.1s) Sending... OK (TTFT=1325ms, e2e=1.6s)
  [7 images] Generating 7x 720p... (0.1s) Sending... OK (TTFT=1693ms, e2e=1.9s)
  [8 images] Generating 8x 720p... (0.1s) Sending... OK (TTFT=1754ms, e2e=2.0s)
  [9 images] Generating 9x 720p... (0.2s) Sending... OK (TTFT=2064ms, e2e=2.3s)
  [10 images] Generating 10x 720p... (0.2s) Sending... OK (TTFT=2367ms, e2e=2.6s)
  [11 images] Generating 11x 720p... (0.2s) Sending... OK (TTFT=2636ms, e2e=2.9s)
  [12 images] Generating 12x 720p... (0.2s) Sending... OK (TTFT=2946ms, e2e=3.2s)
  [13 images] Generating 13x 720p... (0.2s) Sending... OK (TTFT=3601ms, e2e=3.9s)
  [14 images] Generating 14x 720p... (0.3s) Sending... OK (TTFT=3814ms, e2e=4.1s)
  [15 images] Generating 15x 720p... (0.3s) Sending... OK (TTFT=3839ms, e2e=4.1s)
  [16 images] Generating 16x 720p... (0.3s) Sending... OK (TTFT=4024ms, e2e=4.3s)
  [17 images] Generating 17x 720p... (0.3s) Sending... OK (TTFT=4351ms, e2e=4.6s)
  [18 images] Generating 18x 720p... (0.3s) Sending... OK (TTFT=4549ms, e2e=4.8s)
  [19 images] Generating 19x 720p... (0.4s) Sending... OK (TTFT=4963ms, e2e=5.2s)
  [20 images] Generating 20x 720p... (0.4s) Sending... OK (TTFT=5332ms, e2e=5.6s)
  [21 images] Generating 21x 720p... (0.4s) Sending... OK (TTFT=5483ms, e2e=5.8s)
  [22 images] Generating 22x 720p... (0.4s) Sending... OK (TTFT=5779ms, e2e=6.0s)
  [23 images] Generating 23x 720p... (0.4s) Sending... OK (TTFT=6163ms, e2e=6.4s)
  [24 images] Generating 24x 720p... (0.5s) Sending... OK (TTFT=6520ms, e2e=6.8s)
  [25 images] Generating 25x 720p... (0.5s) Sending... OK (TTFT=7207ms, e2e=7.5s)
  [26 images] Generating 26x 720p... (0.5s) Sending... OK (TTFT=7493ms, e2e=7.8s)
  [27 images] Generating 27x 720p... (0.5s) Sending... OK (TTFT=7968ms, e2e=8.3s)
  [28 images] Generating 28x 720p... (0.5s) Sending... OK (TTFT=7874ms, e2e=8.2s)
  [29 images] Generating 29x 720p... (0.5s) Sending... OK (TTFT=8374ms, e2e=8.7s)
  [30 images] Generating 30x 720p... (0.5s) Sending... OK (TTFT=8739ms, e2e=9.0s)
  [31 images] Generating 31x 720p... (0.6s) Sending... OK (TTFT=8809ms, e2e=9.1s)
  [32 images] Generating 32x 720p... (0.6s) Sending... OK (TTFT=9063ms, e2e=9.4s)
```

After: 
```
  [1 images] Generating 1x 720p... (0.0s) Sending... OK (TTFT=227ms, e2e=0.4s)
  [2 images] Generating 2x 720p... (0.0s) Sending... OK (TTFT=366ms, e2e=0.6s)
  [3 images] Generating 3x 720p... (0.1s) Sending... OK (TTFT=453ms, e2e=0.7s)
  [4 images] Generating 4x 720p... (0.1s) Sending... OK (TTFT=642ms, e2e=0.9s)
  [5 images] Generating 5x 720p... (0.1s) Sending... OK (TTFT=703ms, e2e=0.9s)
  [6 images] Generating 6x 720p... (0.1s) Sending... OK (TTFT=795ms, e2e=1.0s)
  [7 images] Generating 7x 720p... (0.1s) Sending... OK (TTFT=1102ms, e2e=1.3s)
  [8 images] Generating 8x 720p... (0.1s) Sending... OK (TTFT=1108ms, e2e=1.3s)
  [9 images] Generating 9x 720p... (0.2s) Sending... OK (TTFT=1275ms, e2e=1.5s)
  [10 images] Generating 10x 720p... (0.2s) Sending... OK (TTFT=1451ms, e2e=1.7s)
  [11 images] Generating 11x 720p... (0.2s) Sending... OK (TTFT=1587ms, e2e=1.8s)
  [12 images] Generating 12x 720p... (0.2s) Sending... OK (TTFT=1714ms, e2e=1.9s)
  [13 images] Generating 13x 720p... (0.2s) Sending... OK (TTFT=2147ms, e2e=2.4s)
  [14 images] Generating 14x 720p... (0.3s) Sending... OK (TTFT=2079ms, e2e=2.3s)
  [15 images] Generating 15x 720p... (0.3s) Sending... OK (TTFT=2236ms, e2e=2.5s)
  [16 images] Generating 16x 720p... (0.3s) Sending... OK (TTFT=2343ms, e2e=2.6s)
  [17 images] Generating 17x 720p... (0.3s) Sending... OK (TTFT=2473ms, e2e=2.7s)
  [18 images] Generating 18x 720p... (0.3s) Sending... OK (TTFT=2696ms, e2e=2.9s)
  [19 images] Generating 19x 720p... (0.4s) Sending... OK (TTFT=3023ms, e2e=3.3s)
  [20 images] Generating 20x 720p... (0.4s) Sending... OK (TTFT=3178ms, e2e=3.4s)
  [21 images] Generating 21x 720p... (0.4s) Sending... OK (TTFT=3270ms, e2e=3.5s)
  [22 images] Generating 22x 720p... (0.4s) Sending... OK (TTFT=3483ms, e2e=3.7s)
  [23 images] Generating 23x 720p... (0.4s) Sending... OK (TTFT=3613ms, e2e=3.9s)
  [24 images] Generating 24x 720p... (0.5s) Sending... OK (TTFT=3854ms, e2e=4.1s)
  [25 images] Generating 25x 720p... (0.5s) Sending... OK (TTFT=4577ms, e2e=4.8s)
  [26 images] Generating 26x 720p... (0.5s) Sending... OK (TTFT=4340ms, e2e=4.6s)
  [27 images] Generating 27x 720p... (0.5s) Sending... OK (TTFT=4520ms, e2e=4.8s)
  [28 images] Generating 28x 720p... (0.5s) Sending... OK (TTFT=4850ms, e2e=5.1s)
  [29 images] Generating 29x 720p... (0.5s) Sending... OK (TTFT=5091ms, e2e=5.3s)
  [30 images] Generating 30x 720p... (0.6s) Sending... OK (TTFT=5259ms, e2e=5.5s)
  [31 images] Generating 31x 720p... (0.6s) Sending... OK (TTFT=5368ms, e2e=5.6s)
  [32 images] Generating 32x 720p... (0.6s) Sending... OK (TTFT=5627ms, e2e=5.9s)
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
