### PR TITLE
Fix UnboundLocalError when DetokenizerManager constructor fails

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -435,6 +435,7 @@ def run_detokenizer_process(
     configure_logger(server_args)
     parent_process = psutil.Process().parent()
 
+    manager = None
     try:
         manager = detokenizer_manager_class(server_args, port_args)
         if server_args.tokenizer_worker_num == 1:
@@ -444,5 +445,6 @@ def run_detokenizer_process(
     except Exception:
         traceback = get_exception_traceback()
         logger.error(f"DetokenizerManager hit an exception: {traceback}")
-        manager.maybe_clear_socket_mapping()
+        if manager is not None:
+            manager.maybe_clear_socket_mapping()
         parent_process.send_signal(signal.SIGQUIT)


### PR DESCRIPTION
## Motivation

When the DetokenizerManager constructor fails (e.g., due to HF API 429 rate limiting during `AutoTokenizer.from_pretrained`), the except block in `run_detokenizer_process` references `manager` before it is assigned, raising `UnboundLocalError`. This prevents `SIGQUIT` from reaching the parent process, leaving the server in a half-dead state — it accepts HTTP connections but returns 503 on `/health_generate` indefinitely until the test timeout (~10 minutes).

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/23582037327/job/68670070787#step:7:5254

The server stays stuck returning 503 for ~10 minutes because SIGQUIT never fires:
```
[2026-03-26 08:44:08] INFO: 127.0.0.1:38764 - "GET /health_generate HTTP/1.1" 503 Service Unavailable
[2026-03-26 08:44:18] INFO: 127.0.0.1:46050 - "GET /health_generate HTTP/1.1" 503 Service Unavailable
... (repeats for ~10 minutes)
[2026-03-26 08:52:38] INFO: 127.0.0.1:39568 - "GET /health_generate HTTP/1.1" 503 Service Unavailable
TimeoutError: Server failed to start within the timeout period
```

Root cause in the logs:
```
DetokenizerManager hit an exception:
  ...
  httpx.HTTPStatusError: Client error '429 Too Many Requests'
  ...
  OSError: Unable to load vocabulary from file.

Process Process-2:
  UnboundLocalError: local variable 'manager' referenced before assignment
```

## Modification

Initialize `manager = None` before the try block and guard the `maybe_clear_socket_mapping()` call with a None check, so `send_signal(SIGQUIT)` always executes.

## Test plan

- [x] Existing CI (no behavioral change for the success path)