### PR TITLE
[Fix] Fix EAGLE speculative decoding missing grammar-based finish det…

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -404,20 +404,20 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 id = predict_cpu[idx]
                 req.output_ids.append(id)
                 req.check_finished()
+                if not req.finished() and req.grammar is not None:
+                    try:
+                        req.grammar.accept_token(id)
+                    except ValueError as e:
+                        logger.info(
+                            f"{i=}, {req=}\n" f"{accept_index=}\n" f"{predict=}\n"
+                        )
+                        raise e
+                    req.check_finished()
                 if req.finished():
                     has_finished = True
                     # set all tokens after finished token to -1 and break
                     accept_index[i, j + 1 :] = -1
                     break
-                else:
-                    if req.grammar is not None:
-                        try:
-                            req.grammar.accept_token(id)
-                        except ValueError as e:
-                            logger.info(
-                                f"{i=}, {req=}\n" f"{accept_index=}\n" f"{predict=}\n"
-                            )
-                            raise e
             # Update KV cache tracking for the accepted tokens
             req.kv_committed_len += num_accepted
             req.kv_allocated_len = req.kv_committed_len


### PR DESCRIPTION
## Motivation
### Error
When launching the server with “python -m sglang.launch_server ** --speculative-algo NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4”, batch requests fail with errors.
```
2026-03-18 11:22:05.874 INFO 120984 [ TP0 scheduler_metrics_mixin.py:415] Decode batch, #running-req: 2, #full token: 5046, full token usage: 0.01, mamba num: 2, mamba usage: 0.08, accept len: 2.64, accept rate: 0.66, cuda graph: True, gen throughput (token/s): 242.08, #queue-req: 0
2026-03-18 11:22:06.729 INFO 120984 [ TP0 schedule_batch.py:1159] Req Time Stats(rid=c53621d5522744e8ad48bc18d668786f, input len=2212, output len=419, type=unified): queue_duration=0.31ms, forward_duration=5247.75ms, start_time=11390760.469
2026-03-18 11:22:06.731 ERROR 120984 [ TP0 scheduler.py:3190] Scheduler hit an exception: Traceback (most recent call last):
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 3171, in run_scheduler_process
    scheduler.event_loop_normal()
  File "/opt/conda/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1118, in event_loop_normal
    batch = self.get_next_batch_to_run()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1941, in get_next_batch_to_run
    self.running_batch = self.update_running_batch(self.running_batch)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 2207, in update_running_batch
    batch.filter_batch(v1_spec_info_filtered=True)
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/schedule_batch.py", line 2112, in filter_batch
    self.spec_info.filter_batch(
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/speculative/eagle_info.py", line 769, in filter_batch
    raise ValueError(error_msg)
ValueError: length of new_indices: 1 != length of topk_p: 2, this should not happen

2026-03-18 11:22:06.731 ERROR 120988 [ TP4 scheduler.py:3190] Scheduler hit an exception: Traceback (most recent call last):
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 3171, in run_scheduler_process
    scheduler.event_loop_normal()
  File "/opt/conda/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1118, in event_loop_normal
    batch = self.get_next_batch_to_run()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 1941, in get_next_batch_to_run
    self.running_batch = self.update_running_batch(self.running_batch)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 2207, in update_running_batch
    batch.filter_batch(v1_spec_info_filtered=True)
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/managers/schedule_batch.py", line 2112, in filter_batch
    self.spec_info.filter_batch(
  File "/opt/conda/lib/python3.12/site-packages/sglang/srt/speculative/eagle_info.py", line 769, in filter_batch
    raise ValueError(error_msg)
ValueError: length of new_indices: 1 != length of topk_p: 2, this should not happen
```
In the EAGLE speculative decoding verify path, EagleVerifyInput.verify checks req.finished() before calling grammar.accept_token(), and the grammar state is only updated in the else branch (i.e., only when the request is not finished). This ordering causes a correctness bug when structured output (e.g., JSON mode) is enabled.

### Root Cause
When grammar.accept_token() advances the grammar to a completed state, the request should be marked as finished, but check_finished() is never called
 afterward. This happens in two scenarios:

1. Next token is -1: The next loop iteration hits the if idx == -1 guard and breaks immediately, skipping check_finished().
2. Loop ends naturally: The current iteration is the last one in the loop, so there is no next iteration to call check_finished().

In both cases, the request remains unmarked as finished, leading to:

1. The request is incorrectly added to unfinished_accept_index.
2. Later in SchedulerOutputProcessorMixin.process_batch_result_decode, check_finished() is called for each request, which correctly marks it as finished.
3. In the next scheduling round, the Scheduler.update_running_batch filters out the now-finished request, but unfinished_accept_index from step 1 still includes it —
causing a data inconsistency and triggering errors.

In particular, when ignore_eos is set to true, the EOS token no longer triggers early termination via check_finished(), making the grammar the primary mechanism for detecting request completion. This significantly increases the probability of triggering this bug.

## Fix

Reorder the logic so that grammar.accept_token() and a second check_finished() are called before the req.finished() check. This ensures grammar-aware finish detection happens in the same verify pass, keeping unfinished_accept_index consistent with actual request states.