### PR TITLE
fix decode timeout not trigger

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -471,9 +471,6 @@ class DecodePreallocQueue:
         if not self.queue:
             return
 
-        if all(decode_req.waiting_for_input for decode_req in self.queue):
-            return
-
         polls = poll_and_all_reduce(
             [decode_req.kv_receiver for decode_req in self.queue], self.gloo_group
         )
@@ -648,20 +645,29 @@ class DecodePreallocQueue:
                 origin_input_len + self.num_reserved_decode_tokens
             )
 
+            max_new_tokens = min(
+                decode_req.req.sampling_params.max_new_tokens,
+                CLIP_MAX_NEW_TOKEN,
+            )
+            projected_required_tokens = (
+                origin_input_len + max_new_tokens - retractable_tokens
+            )
+            max_required_tokens = max(
+                required_tokens_for_request,
+                projected_required_tokens,
+            )
+
             if (
-                max(
-                    required_tokens_for_request,
-                    origin_input_len
-                    + min(
-                        decode_req.req.sampling_params.max_new_tokens,
-                        CLIP_MAX_NEW_TOKEN,
-                    )
-                    - retractable_tokens,
-                )
-                > allocatable_tokens
+                required_tokens_for_request > self.token_to_kv_pool_allocator.size
+                or max_required_tokens > self.token_to_kv_pool_allocator.size
             ):
-                break
-            if required_tokens_for_request > allocatable_tokens:
+                decode_req.kv_receiver.abort()
+                continue
+
+            if (
+                required_tokens_for_request > allocatable_tokens
+                or max_required_tokens > allocatable_tokens
+            ):
                 break
 
             allocatable_tokens -= required_tokens_for_request

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1241,8 +1241,8 @@ class MooncakeKVReceiver(CommonKVReceiver):
     ):
         self.session_id = mgr.get_session_id()
         self.conclude_state = None
-        self.init_time = None
         super().__init__(mgr, bootstrap_addr, bootstrap_room, prefill_dp_rank)
+        self.init_time = time.time()
 
         self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
@@ -1333,7 +1333,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         str(self.required_dst_info_num).encode("ascii"),
                     ]
                 )
-        self.init_time = time.time()
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:


### PR DESCRIPTION
## Motivation
If the loop breaks due to kvcache not enough, but kv_receiver.init() not executed, MooncakeReceiver poll will not trigger a timeout.

If you (prompt tokens + reserved tokens) > allocatable_tokens, you will find this problem

### Decode 
<img width="1138" height="1288" alt="image" src="https://github.com/user-attachments/assets/2a7d6e97-5ea2-4771-af0b-286860f14dc3" />

<img width="1276" height="470" alt="image" src="https://github.com/user-attachments/assets/9850f282-035f-4741-b336-f9ecaeefdc8e" />

### MooncakeKVReceiver
<img width="1472" height="974" alt="image" src="https://github.com/user-attachments/assets/be01cb7e-dd24-4286-9258-00c3836fa8f8" />


## Modifications

1. self.init_time move to constructor.
2. It should abort, otherwise, other requests in the queue cannot be processed.

## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

