### PR TITLE
[feat] support server-level default chat template kwargs

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -99,6 +99,9 @@ class OpenAIServingChat(OpenAIServingBase):
         self.template_manager = template_manager
         self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+        self.default_chat_template_kwargs = (
+            self.tokenizer_manager.server_args.default_chat_template_kwargs or {}
+        )
 
         # Get default sampling parameters from model's generation config
         self.default_sampling_params = (
@@ -243,6 +246,7 @@ class OpenAIServingChat(OpenAIServingBase):
         request: ChatCompletionRequest,
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, ChatCompletionRequest]:
+        self._merge_default_chat_template_kwargs(request)
         reasoning_effort = (
             request.chat_template_kwargs.pop("reasoning_effort", None)
             if request.chat_template_kwargs
@@ -324,6 +328,13 @@ class OpenAIServingChat(OpenAIServingBase):
         )
 
         return adapted_request, request
+
+    def _merge_default_chat_template_kwargs(
+        self, request: ChatCompletionRequest
+    ) -> None:
+        request_kwargs = request.chat_template_kwargs or {}
+        merged_kwargs = self.default_chat_template_kwargs | request_kwargs
+        request.chat_template_kwargs = merged_kwargs or None
 
     def _process_messages(
         self, request: ChatCompletionRequest, is_multimodal: bool

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -71,6 +71,19 @@ from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
 
+
+def json_object_type(value: str) -> Dict[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise argparse.ArgumentTypeError("must be a valid JSON object string") from e
+
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError("must be a JSON object")
+
+    return parsed
+
+
 # Define constants
 DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES = ()
 SAMPLING_BACKEND_CHOICES = {"flashinfer", "pytorch", "ascend"}
@@ -426,6 +439,7 @@ class ServerArgs:
     weight_version: str = "default"
     chat_template: Optional[str] = None
     hf_chat_template_name: Optional[str] = None
+    default_chat_template_kwargs: Optional[Dict[str, Any]] = None
     completion_template: Optional[str] = None
     file_storage_path: str = "sglang_storage"
     enable_cache_report: bool = False
@@ -4378,6 +4392,14 @@ class ServerArgs:
             default=ServerArgs.hf_chat_template_name,
             help="When the HuggingFace tokenizer has multiple chat templates (e.g., 'default', 'tool_use', 'rag'), "
             "specify which named template to use. If not set, the first available template is used.",
+        )
+        parser.add_argument(
+            "--default-chat-template-kwargs",
+            type=json_object_type,
+            default=ServerArgs.default_chat_template_kwargs,
+            help="Default kwargs passed to the chat template renderer. "
+            "Merged with request chat_template_kwargs, with request values taking precedence. "
+            "Example: '{\"enable_thinking\": false}'",
         )
         parser.add_argument(
             "--completion-template",

--- a/test/registered/openai_server/basic/test_serving_chat.py
+++ b/test/registered/openai_server/basic/test_serving_chat.py
@@ -37,6 +37,7 @@ class _MockTokenizerManager:
             enable_cache_report=False,
             tool_call_parser="hermes",
             reasoning_parser=None,
+            default_chat_template_kwargs=None,
         )
         # Mock hf_config for _use_dpsk_v32_encoding check
         mock_hf_config = Mock()
@@ -79,6 +80,7 @@ class _MockTemplateManager:
         self.chat_template_name: Optional[str] = "llama-3"
         self.jinja_template_content_format: Optional[str] = None
         self.completion_template_name: Optional[str] = None
+        self.force_reasoning = False
 
 
 class ServingChatTestCase(unittest.TestCase):
@@ -133,6 +135,72 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertIsInstance(adapted, GenerateReqInput)
             self.assertFalse(adapted.stream)
             self.assertEqual(processed, self.basic_req)
+
+    def test_convert_to_internal_request_merges_default_chat_template_kwargs(self):
+        self.tm.server_args.default_chat_template_kwargs = {
+            "enable_thinking": False,
+            "custom_param": "server-default",
+        }
+        self.chat = OpenAIServingChat(self.tm, self.template_manager)
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+        )
+
+        with patch.object(self.chat, "_process_messages") as proc_mock:
+            proc_mock.return_value = MessageProcessingResult(
+                "Test prompt",
+                [1, 2, 3],
+                None,
+                None,
+                [],
+                ["</s>"],
+                None,
+            )
+
+            adapted, processed = self.chat._convert_to_internal_request(request)
+
+        self.assertIsInstance(adapted, GenerateReqInput)
+        self.assertEqual(
+            processed.chat_template_kwargs,
+            {"enable_thinking": False, "custom_param": "server-default"},
+        )
+        self.assertFalse(adapted.require_reasoning)
+
+    def test_convert_to_internal_request_request_kwargs_override_defaults(self):
+        self.tm.server_args.default_chat_template_kwargs = {
+            "enable_thinking": False,
+            "custom_param": "server-default",
+        }
+        self.chat = OpenAIServingChat(self.tm, self.template_manager)
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            chat_template_kwargs={
+                "enable_thinking": True,
+                "custom_param": "request-override",
+            },
+        )
+
+        with patch.object(self.chat, "_process_messages") as proc_mock:
+            proc_mock.return_value = MessageProcessingResult(
+                "Test prompt",
+                [1, 2, 3],
+                None,
+                None,
+                [],
+                ["</s>"],
+                None,
+            )
+
+            adapted, processed = self.chat._convert_to_internal_request(request)
+
+        self.assertIsInstance(adapted, GenerateReqInput)
+        self.assertEqual(
+            processed.chat_template_kwargs,
+            {"enable_thinking": True, "custom_param": "request-override"},
+        )
+        self.assertTrue(adapted.require_reasoning)
 
     def test_jinja_uses_openai_tool_schema_first(self):
         """Ensure Jinja chat templates receive OpenAI-shaped tools by default."""

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -33,6 +33,51 @@ class TestPrepareServerArgs(CustomTestCase):
             {"rope_scaling": {"factor": 2.0, "rope_type": "linear"}},
         )
 
+    def test_prepare_server_args_default_chat_template_kwargs(self):
+        server_args = prepare_server_args(
+            [
+                "--model-path",
+                DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                "--default-chat-template-kwargs",
+                '{"enable_thinking": false, "custom_param": "value"}',
+            ]
+        )
+        self.assertEqual(
+            server_args.default_chat_template_kwargs,
+            {"enable_thinking": False, "custom_param": "value"},
+        )
+
+    def test_prepare_server_args_default_chat_template_kwargs_default_none(self):
+        server_args = prepare_server_args(
+            [
+                "--model-path",
+                DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+            ]
+        )
+        self.assertIsNone(server_args.default_chat_template_kwargs)
+
+    def test_prepare_server_args_default_chat_template_kwargs_invalid_json(self):
+        with self.assertRaises(SystemExit):
+            prepare_server_args(
+                [
+                    "--model-path",
+                    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                    "--default-chat-template-kwargs",
+                    "not valid json",
+                ]
+            )
+
+    def test_prepare_server_args_default_chat_template_kwargs_non_object(self):
+        with self.assertRaises(SystemExit):
+            prepare_server_args(
+                [
+                    "--model-path",
+                    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                    "--default-chat-template-kwargs",
+                    '["not", "an", "object"]',
+                ]
+            )
+
 
 class TestLoadBalanceMethod(unittest.TestCase):
     def test_non_pd_defaults_to_round_robin(self):


### PR DESCRIPTION
Allow the server to define default chat template kwargs that are merged into each request while preserving request-level overrides. Add parser and serving tests covering JSON validation and default-vs-request precedence.

## Motivation

This change brings SGLang's OpenAI-compatible server closer to the behavior already supported in vLLM for server-level default chat template kwargs.

For reasoning-capable models such as Qwen3.5, it is useful to configure template defaults like `{"enable_thinking": false}` at server startup instead of requiring every client request to pass the same `chat_template_kwargs`. This also keeps request-level overrides intact so clients can still opt in or out on a per-request basis.

## Modifications

- Added `--default-chat-template-kwargs` to the server CLI.
- Added strict JSON object parsing and validation for this argument.
- Stored server-level default chat template kwargs in `ServerArgs`.
- Merged server defaults into each chat request before prompt processing, while preserving request-level override precedence.
- Reused the merged kwargs for downstream reasoning behavior through the existing request flow.
- Added unit tests for:
  - valid CLI parsing
  - default `None` behavior
  - invalid JSON rejection
  - non-object JSON rejection
- Added serving tests for:
  - default kwargs being applied to requests
  - request-level kwargs overriding server defaults
  - reasoning behavior following the merged effective kwargs

## Accuracy Tests

Not applicable. This change does not modify model kernels or forward-pass logic.

## Benchmarking and Profiling

Not applicable. This change only affects request argument parsing and chat request preprocessing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.