### PR TITLE
[AMD] Disable tvm_ffi JIT kernels on ROCm to fix silent KV cache corruption

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -26,7 +26,7 @@ def _resolve_future_token_ids_native(input_ids, future_token_ids_map):
     )
 
 
-if _is_cuda or _is_hip:
+if _is_cuda and not _is_hip:
     from sglang.jit_kernel.resolve_future_token_ids import (
         resolve_future_token_ids_cuda,
     )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -96,7 +96,7 @@ def _set_kv_buffer_impl(
     same_kv_dim: bool = True,
 ) -> None:
     row_bytes = row_dim * store_dtype.itemsize
-    if (_is_cuda or _is_hip) and same_kv_dim and can_use_store_cache(row_bytes):
+    if (_is_cuda and not _is_hip) and same_kv_dim and can_use_store_cache(row_bytes):
         return store_cache(
             k.view(-1, row_dim),
             v.view(-1, row_dim),

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1190,7 +1190,7 @@ def _clamp_position_native(seq_lens):
     return torch.clamp((seq_lens - 1), min=0).to(torch.int64)
 
 
-if is_cuda() or is_hip():
+if is_cuda() and not is_hip():
     from sglang.jit_kernel.clamp_position import clamp_position_cuda
 
     clamp_position = clamp_position_cuda


### PR DESCRIPTION
# Motivation
tvm_ffi JIT kernels crash on ROCm (nvcc not available) or produce incorrect results when compiled via hipcc, causing silent KV cache corruption. Use native PyTorch fallbacks on ROCm instead.

# Modifications
Disable three tvm_ffi JIT kernels on ROCm (HIP) by changing is_cuda or is_hip to is_cuda and not is_hip, falling back to native PyTorch implementations:

- store_cache in memory_pool.py → falls back to k_cache[indices] = k; v_cache[indices] = v
- clamp_position in forward_batch_info.py → falls back to torch.clamp(seq_lens - 1, min=0).to(torch.int64)
- resolve_future_token_ids in overlap_utils.py → falls back to torch.where(input_ids < 0, future_token_ids_map[...], input_ids)

# Accuracy Tests
Docker image **rocm/sgl-dev:v0.5.9-rocm720-mi30x-20260224**
GLM-4.7-FP8, TP=8, MI300X (gfx942).

Serving wtih:
`AITER_ONLINE_TUNE=1 SGLANG_AITER_MLA_PERSIST=1 SGLANG_USE_AITER=1 SAFETENSORS_FAST_GPU=1 python3 -m sglang.launch_server  --model zai-org/GLM-4.7-FP8 --tp 8 --trust-remote-code`

- Before: server crash (nvcc not found) or all-zero logits (if JIT compiled via hipcc)
- After fix: GSM8K 92% accuracy (200 questions, 5-shot)

# Benchmarking and Profiling
No meaningful performance impact — the fallbacks are single PyTorch ops (scatter indexing, clamp, where).