### PR TITLE
Fix parent process hang when NCCL C++ abort kills scheduler

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -640,14 +640,17 @@ class Engine(EngineBase):
                             "Scheduler watchdog detected dead processes: "
                             f"{dead}. Shutting down the process tree."
                         )
-                        kill_process_tree(os.getpid())
+                        # os._exit() terminates immediately. We cannot use
+                        # kill_process_tree / SIGKILL because PID 1 in a
+                        # container is immune to SIGKILL.
+                        os._exit(1)
             except Exception:
                 logger.error(
                     "Scheduler watchdog thread crashed. "
                     "Shutting down to avoid a silent hang.",
                     exc_info=True,
                 )
-                kill_process_tree(os.getpid())
+                os._exit(1)
 
         watchdog = threading.Thread(
             target=_scheduler_watchdog, daemon=True, name="scheduler-watchdog"

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -592,6 +592,68 @@ class Engine(EngineBase):
                     f"terminated with {proc.exitcode}"
                 )
 
+        # Event that wait_for_ready sets once all schedulers have
+        # initialised.  The watchdog blocks on this so that it does not
+        # interfere with the clean error path in _wait_for_scheduler_ready
+        # (which gives better diagnostics for startup failures).
+        _watchdog_ready = threading.Event()
+
+        _original_wait_for_ready = wait_for_ready  # noqa: F841 (used in closure)
+
+        def wait_for_ready_and_arm_watchdog():
+            _original_wait_for_ready()
+            _watchdog_ready.set()
+
+        # Replace wait_for_ready so callers automatically arm the watchdog.
+        wait_for_ready = wait_for_ready_and_arm_watchdog
+
+        def _scheduler_watchdog():
+            """Monitor scheduler processes; kill the process tree if any die.
+
+            When NCCL's C++ watchdog detects a fatal error it calls
+            std::abort(), which terminates the child process immediately
+            without executing any Python cleanup — so the ``except``
+            handler that would normally send SIGQUIT to the parent
+            (scheduler.py) never runs.  Without this watchdog the parent
+            stays alive (held open by uvicorn/gRPC on node_rank 0, or the
+            dummy health-check server on node_rank >= 1), K8s probes keep
+            passing, and the pod is never restarted even though it can no
+            longer serve inference.
+            """
+            try:
+                _watchdog_ready.wait()
+                while True:
+                    time.sleep(5)
+                    if any(not proc.is_alive() for proc in scheduler_procs):
+                        # Brief grace period: if the child sent SIGQUIT
+                        # before dying (Python exception path), give the
+                        # existing signal handler time to tear down first.
+                        time.sleep(2)
+                        dead = [
+                            (proc.pid, proc.exitcode)
+                            for proc in scheduler_procs
+                            if not proc.is_alive()
+                        ]
+                        if not dead:
+                            continue  # Recovered (shouldn't happen, but be safe)
+                        logger.error(
+                            "Scheduler watchdog detected dead processes: "
+                            f"{dead}. Shutting down the process tree."
+                        )
+                        kill_process_tree(os.getpid())
+            except Exception:
+                logger.error(
+                    "Scheduler watchdog thread crashed. "
+                    "Shutting down to avoid a silent hang.",
+                    exc_info=True,
+                )
+                kill_process_tree(os.getpid())
+
+        watchdog = threading.Thread(
+            target=_scheduler_watchdog, daemon=True, name="scheduler-watchdog"
+        )
+        watchdog.start()
+
         return SchedulerInitResult(
             scheduler_infos=scheduler_infos,
             wait_for_ready=wait_for_ready,


### PR DESCRIPTION
## Summary

- Add a parent-side watchdog thread that detects scheduler child process death and kills the process tree
- Fixes a production issue where PP multi-node pods hang indefinitely after NCCL timeout

## Problem

When NCCL's C++ watchdog detects a fatal error (IB link flap, GPU Xid, etc.), it calls `std::abort()` which terminates the scheduler child process **without executing Python cleanup**. The `except Exception` handler in `scheduler.py` that would normally send `SIGQUIT` to the parent never runs.

The parent process stays alive with zombie children, held open by:
- The gRPC/HTTP server on `node_rank == 0`
- The dummy health-check server on `node_rank >= 1`

K8s liveness probes keep returning 200 OK, so the pod is **never restarted** — even though it can no longer serve inference. In our production GLM-5 PP=2 deployment, this caused 10+ minute outages that required manual intervention.

## Fix

A daemon thread in the parent that polls `proc.is_alive()` every 5 seconds. If any scheduler dies, it calls `kill_process_tree()`. This covers all child death modes: C++ abort, SIGKILL, OOM, GPU crash.

Design decisions:
- **Waits for `wait_for_ready()`** before arming — startup failures still get clean error messages from `_wait_for_scheduler_ready`
- **2-second grace period** after detecting death — defers to the existing SIGQUIT handler when it works (Python exception path)
- **try/except wrapper** — if the watchdog thread itself crashes, it kills the tree to avoid silent hang
- **~zero overhead** — 8 `os.waitpid(WNOHANG)` syscalls every 5 seconds

## Test plan

Tested on a PP=2 GLM-5-FP8 deployment (prod-sci-us-central1-1 cluster):

- [x] `kill -9 <scheduler_pid>` (simulates C++ abort, no Python cleanup) → pod exits in ~7s, K8s restarts
- [x] `kill -SIGABRT <scheduler_pid>` (Python-catchable) → SIGQUIT handler fires first, watchdog is backup
- [x] Kill scheduler during init (before `wait_for_ready`) → watchdog stays silent, clean error propagates
- [x] Verified on both `node_rank == 0` (leader) and `node_rank >= 1` (worker)
- [ ] CI tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)