### PR TITLE
[CI] Skip stage health check for release branch cut

### DIFF
--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -12,9 +12,17 @@ runs:
   steps:
     - name: Check stage health
       uses: actions/github-script@v7
+      env:
+        SKIP_STAGE_HEALTH_CHECK: ${{ env.SKIP_STAGE_HEALTH_CHECK }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
+          // Skip when explicitly requested via env var (e.g. release branch cut)
+          if (process.env.SKIP_STAGE_HEALTH_CHECK === 'true') {
+            core.info('Skipping health check (SKIP_STAGE_HEALTH_CHECK=true)');
+            return;
+          }
+
           // Skip for scheduled runs — they should collect all failures, not fast-fail
           if (context.eventName === 'schedule') {
             core.info('Skipping health check for scheduled run');

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: 'false'
+      skip_stage_health_check:
+        required: false
+        type: boolean
+        default: false
 
 # Workflow-level env is NOT inherited from the caller in reusable workflows (verified by CI test).
 # The github context (including github.event_name) IS inherited from the caller.
@@ -30,6 +34,7 @@ env:
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
   SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
 
 jobs:
   jit-kernel-unit-test:

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -33,6 +33,10 @@ on:
         required: false
         type: string
         default: 'false'
+      skip_stage_health_check:
+        required: false
+        type: string
+        default: 'false'
 
 # Workflow-level env is NOT inherited from the caller in reusable workflows.
 # The github context (including github.event_name) IS inherited from the caller.
@@ -40,6 +44,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check == 'true' }}
 
 jobs:
   multimodal-gen-test-1-gpu:

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: ''
+      skip_stage_health_check:
+        required: false
+        type: boolean
+        default: false
 
 # Workflow-level env is NOT inherited from the caller in reusable workflows.
 # The github context (including github.event_name) IS inherited from the caller.
@@ -24,6 +28,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
 
 jobs:
   sgl-kernel-unit-test:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_stage_health_check:
+        description: "Skip stage health check fast-fail (e.g. for release branch cuts)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   # Concurrency group structure: pr-test-{event}-{branch}-{pr_sha}-{stage}
@@ -57,6 +62,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
+  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
   # Schedule / main-branch dispatch / workflow_call from main use refs/heads/main; PR events use refs/pull/*/merge
   SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
@@ -516,6 +522,7 @@ jobs:
       b200_runner: ${{ needs.check-changes.outputs.b200_runner }}
       pr_head_sha: ${{ inputs.pr_head_sha || '' }}
       git_ref: ${{ inputs.git_ref || '' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   # =============================================== jit-kernel ====================================================
@@ -530,6 +537,7 @@ jobs:
       git_ref: ${{ inputs.git_ref || '' }}
       target_stage: ${{ inputs.target_stage || '' }}
       test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   # =============================================== primary ====================================================
@@ -891,6 +899,7 @@ jobs:
       target_stage: ${{ inputs.target_stage || '' }}
       test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
       caller_needs_failure: ${{ (needs.call-gate.result == 'failure' || needs.sgl-kernel-build-wheels.result == 'failure' || needs.check-changes.result == 'failure') && 'true' || 'false' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
     secrets: inherit
 
   stage-c-test-4-gpu-h100:

--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -151,6 +151,7 @@ jobs:
     with:
       git_ref: ${{ needs.cut-release-branch.outputs.branch_name }}
       run_all_tests: true
+      skip_stage_health_check: true
     secrets: inherit
 
   run-pr-tests-amd:


### PR DESCRIPTION
- Add `SKIP_STAGE_HEALTH_CHECK` env var support to `check-stage-health` action
- `release-branch-cut.yml` passes `skip_stage_health_check: true` to `pr-test.yml`
- Propagated to sub-workflows (`pr-test-sgl-kernel`, `pr-test-jit-kernel`, `pr-test-multimodal-gen`) via input + workflow-level env
- Stage health check fast-fail was blocking release branch cuts from collecting full test results — one early failure would cascade-cancel all downstream stages