### PR TITLE
Fix benchmark generating empty prompts when random_input_len is small

### DIFF
--- a/python/sglang/benchmark/datasets/random.py
+++ b/python/sglang/benchmark/datasets/random.py
@@ -79,7 +79,7 @@ def sample_random_requests(
         # Need to truncate input_len as server encode will add special token.
         num_special_tokens = int(tokenizer.num_special_tokens_to_add())
         for i in range(num_prompts):
-            input_lens[i] = max(0, input_lens[i] - num_special_tokens)
+            input_lens[i] = max(1, input_lens[i] - num_special_tokens)
 
     if random_sample:
         # Sample token ids from ShareGPT and repeat/truncate them to satisfy the input_lens


### PR DESCRIPTION
## Summary
- When `random_input_len=1`, subtracting special tokens via `max(0, input_len - num_special_tokens)` can produce 0-length input, causing `tokenizer.decode([])` to return an empty string
- The server then raises `ValueError: texts cannot be empty and tokenizer must be initialized` for every such request
- Fix: change `max(0, ...)` to `max(1, ...)` to guarantee at least 1 token after adjustment

Spotted in CI: https://github.com/sgl-project/sglang/actions/runs/23617944361/job/68790866885?pr=21413

Note: the streaming error response (HTTP 200 instead of 400) is a separate issue tracked by #20027.

## Test plan
- [x] Reproduced locally by running `test_pp_offline_throughput_default_decode` (which uses `random_input_len=1`) — confirmed the error messages disappear after the fix