### PR TITLE
Opt jit qknorm_across_heads cuda kernel

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/qknorm_across_heads.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/qknorm_across_heads.cuh
@@ -42,7 +42,7 @@ struct VecTypeTrait<fp16_t, 32> {
 };
 
 template <typename packed_t>
-SGL_DEVICE packed_t rms(packed_t& val, packed_t& weight, float rsqrt_square_sum) {
+SGL_DEVICE packed_t rms(const packed_t& val, const packed_t& weight, float rsqrt_square_sum) {
   float2 valf = device::cast<fp32x2_t, packed_t>(val);
   float2 weightf = device::cast<fp32x2_t, packed_t>(weight);
   return device::cast<packed_t, fp32x2_t>(
@@ -59,104 +59,55 @@ __global__ void qknorm_across_heads_reg_kernel(
     float eps) {
   constexpr int inner_loop = VEC_SIZE_IN_BYTE == 16 ? 4 : 8;
 
-  __shared__ float shared_memory[64];  // Used for CTA reduce, store both Q and K rsqrt
+  __shared__ float shared_memory[32];
 
   using vec_t = typename VecTypeTrait<T, VEC_SIZE_IN_BYTE>::vec_t;
   using packed_t = typename VecTypeTrait<T, VEC_SIZE_IN_BYTE>::packed_t;
-  vec_t v_q;         // Save q
-  vec_t v_k;         // Save k
-  vec_t v_q_weight;  // Save q_weight
-  vec_t v_k_weight;  // Save k_weight
-  vec_t v_q_out;     // Save q output
-  vec_t v_k_out;     // Save k output
+  vec_t v_data;
+  const int warp_id = threadIdx.x >> 5;
+  const int lane_id = threadIdx.x & 31;
+  const int warp_count = (blockDim.x + 31) >> 5;
+  const float inv_hidden_size = 1.0f / static_cast<float>(vec_hidden_size * (VEC_SIZE_IN_BYTE / sizeof(T)));
+  const bool is_q = blockIdx.y == 0;
 
-  auto token_id = blockIdx.x;
-  float2 acc_square_q = make_float2(0.0f, 0.0f);  // Sum of squares for q
-  float2 acc_square_k = make_float2(0.0f, 0.0f);  // Sum of squares for k
+  const auto token_id = blockIdx.x;
+  float2 acc_square = make_float2(0.0f, 0.0f);
+  vec_t* data = reinterpret_cast<vec_t*>(is_q ? q : k) + token_id * vec_hidden_size;
+  const vec_t* weight = reinterpret_cast<const vec_t*>(is_q ? q_weight : k_weight);
 
   if (threadIdx.x < vec_hidden_size) {
-    // Compute address for q and k
-    vec_t* p_q = reinterpret_cast<vec_t*>(q) + token_id * vec_hidden_size;
-    vec_t* p_k = reinterpret_cast<vec_t*>(k) + token_id * vec_hidden_size;
-    const vec_t* p_q_weight = reinterpret_cast<const vec_t*>(q_weight);
-    const vec_t* p_k_weight = reinterpret_cast<const vec_t*>(k_weight);
-
-    // Load data
-    v_q = p_q[threadIdx.x];
-    v_k = p_k[threadIdx.x];
-    v_q_weight = p_q_weight[threadIdx.x];
-    v_k_weight = p_k_weight[threadIdx.x];
-
-    // Compute sum of squares for q
+    v_data = data[threadIdx.x];
     for (int i = 0; i < inner_loop; i++) {
-      float2 val = device::cast<fp32x2_t, packed_t>(v_q[i]);
-      acc_square_q.x += val.x * val.x;
-      acc_square_q.y += val.y * val.y;
-    }
-
-    // Compute sum of squares for k
-    for (int i = 0; i < inner_loop; i++) {
-      float2 val = device::cast<fp32x2_t, packed_t>(v_k[i]);
-      acc_square_k.x += val.x * val.x;
-      acc_square_k.y += val.y * val.y;
+      float2 val = device::cast<fp32x2_t, packed_t>(v_data[i]);
+      acc_square.x += val.x * val.x;
+      acc_square.y += val.y * val.y;
     }
   }
 
   auto cg_warp = cooperative_groups::tiled_partition<32>(cooperative_groups::this_thread_block());
-  float* buffer_q = shared_memory;       // [0, 31] for Q
-  float* buffer_k = shared_memory + 32;  // [32, 63] for K
-
-  // ========== Reduction phase: Compute rsqrt for both Q and K ==========
-
-  // Step 0: Warp Reduce for Q
-  float warp_sum_q =
-      cooperative_groups::reduce(cg_warp, acc_square_q.x + acc_square_q.y, cooperative_groups::plus<float>());
-  if (threadIdx.x % 32 == 0) {
-    buffer_q[threadIdx.x / 32] = warp_sum_q;
+  float* buffer = shared_memory;
+  float warp_sum = cooperative_groups::reduce(cg_warp, acc_square.x + acc_square.y, cooperative_groups::plus<float>());
+  if (lane_id == 0) {
+    buffer[warp_id] = warp_sum;
   }
 
-  // Step 0: Warp Reduce for K
-  float warp_sum_k =
-      cooperative_groups::reduce(cg_warp, acc_square_k.x + acc_square_k.y, cooperative_groups::plus<float>());
-  if (threadIdx.x % 32 == 0) {
-    buffer_k[threadIdx.x / 32] = warp_sum_k;
-  }
-
-  // Step 1: CTA Reduce for both Q and K
   __syncthreads();
   if (threadIdx.x < 32) {
-    // CTA Reduce for Q
-    float cta_sum_q = cooperative_groups::reduce(
-        cg_warp, (threadIdx.x < blockDim.x / 32) ? buffer_q[threadIdx.x] : 0.0f, cooperative_groups::plus<float>());
-    buffer_q[threadIdx.x] =
-        rsqrtf(eps + cta_sum_q * (1.0f / static_cast<float>(vec_hidden_size * (VEC_SIZE_IN_BYTE / sizeof(T)))));
-
-    // CTA Reduce for K
-    float cta_sum_k = cooperative_groups::reduce(
-        cg_warp, (threadIdx.x < blockDim.x / 32) ? buffer_k[threadIdx.x] : 0.0f, cooperative_groups::plus<float>());
-    buffer_k[threadIdx.x] =
-        rsqrtf(eps + cta_sum_k * (1.0f / static_cast<float>(vec_hidden_size * (VEC_SIZE_IN_BYTE / sizeof(T)))));
+    float cta_sum = cooperative_groups::reduce(
+        cg_warp, (threadIdx.x < warp_count) ? buffer[threadIdx.x] : 0.0f, cooperative_groups::plus<float>());
+    if (threadIdx.x == 0) {
+      buffer[0] = rsqrtf(eps + cta_sum * inv_hidden_size);
+    }
   }
   __syncthreads();
 
-  // ========== Apply normalization phase: Compute and write back Q and K ==========
-
   if (threadIdx.x < vec_hidden_size) {
-    // Apply RMSNorm for Q
-    float rsqrt_q = buffer_q[threadIdx.x / 32];
+    float rsqrt_val = buffer[0];
+    vec_t v_weight = weight[threadIdx.x];
     for (int i = 0; i < inner_loop; i++) {
-      v_q_out[i] = rms(v_q[i], v_q_weight[i], rsqrt_q);
+      v_data[i] = rms(v_data[i], v_weight[i], rsqrt_val);
     }
-    vec_t* p_q_out = reinterpret_cast<vec_t*>(q) + token_id * vec_hidden_size;
-    p_q_out[threadIdx.x] = v_q_out;
-
-    // Apply RMSNorm for K
-    float rsqrt_k = buffer_k[threadIdx.x / 32];
-    for (int i = 0; i < inner_loop; i++) {
-      v_k_out[i] = rms(v_k[i], v_k_weight[i], rsqrt_k);
-    }
-    vec_t* p_k_out = reinterpret_cast<vec_t*>(k) + token_id * vec_hidden_size;
-    p_k_out[threadIdx.x] = v_k_out;
+    data[threadIdx.x] = v_data;
   }
 }
 
@@ -207,10 +158,9 @@ struct QKNormAcrossHeadsKernel {
           " can not align to elements_in_vec ",
           elements_in_vec);
 
-      // Launch single kernel for both q and k
       auto kernel = qknorm_across_heads_reg_kernel<DType, device::kMaxVecBytes>;
 
-      LaunchKernel(static_cast<uint>(N.unwrap()), threads, device.unwrap())
+      LaunchKernel(dim3(static_cast<uint>(N.unwrap()), 2), threads, device.unwrap())
           .enable_pdl(false)(
               kernel,
               reinterpret_cast<DType*>(q.data_ptr()),

--- a/python/sglang/jit_kernel/csrc/elementwise/qknorm_across_heads.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/qknorm_across_heads.cuh
@@ -64,6 +64,7 @@ __global__ void qknorm_across_heads_reg_kernel(
   using vec_t = typename VecTypeTrait<T, VEC_SIZE_IN_BYTE>::vec_t;
   using packed_t = typename VecTypeTrait<T, VEC_SIZE_IN_BYTE>::packed_t;
   vec_t v_data;
+  vec_t v_weight;
   const int warp_id = threadIdx.x >> 5;
   const int lane_id = threadIdx.x & 31;
   const int warp_count = (blockDim.x + 31) >> 5;
@@ -77,6 +78,7 @@ __global__ void qknorm_across_heads_reg_kernel(
 
   if (threadIdx.x < vec_hidden_size) {
     v_data = data[threadIdx.x];
+    v_weight = weight[threadIdx.x];
     for (int i = 0; i < inner_loop; i++) {
       float2 val = device::cast<fp32x2_t, packed_t>(v_data[i]);
       acc_square.x += val.x * val.x;
@@ -103,7 +105,6 @@ __global__ void qknorm_across_heads_reg_kernel(
 
   if (threadIdx.x < vec_hidden_size) {
     float rsqrt_val = buffer[0];
-    vec_t v_weight = weight[threadIdx.x];
     for (int i = 0; i < inner_loop; i++) {
       v_data[i] = rms(v_data[i], v_weight[i], rsqrt_val);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Follow https://github.com/sgl-project/sglang/pull/18073

The old kernel handled both `q` and `k` inside one CTA, which kept too much
state live at the same time:
- `q`
- `k`
- `q_weight`
- `k_weight`
- separate output vectors
- dual reduction buffers in shared memory

The new kernel still performs the work in a single launch, but splits the work
with `grid.y = 2`:
- `blockIdx.y == 0`: normalize `q`
- `blockIdx.y == 1`: normalize `k`

This reduces per-thread live state and shrinks the shared reduction buffer from
two lanes to one lane.

On H200 with shape `(batch_size=2048, hidden_dim=8192)`:

- registers/thread: `48 -> 26`
- static shared memory/block: `256 B -> 128 B`
- theoretical occupancy: `50% -> 100%`
- achieved occupancy: `45.25% -> 88.17%`
- achieved active warps/SM: `28.96 -> 56.43`

<img width="2350" height="964" alt="图片" src="https://github.com/user-attachments/assets/5a64337f-8ea1-4c93-9b38-a2e643006a01" />

<img width="2478" height="1158" alt="a6cbf9c5-1176-4552-a185-768207d7f63e" src="https://github.com/user-attachments/assets/00810db6-7be4-4213-9d5d-42d19dbbd518" />

<img width="2364" height="614" alt="7a72f7ac-48fb-4ed0-9334-66f4b6d77289" src="https://github.com/user-attachments/assets/99cd30e5-9b87-46da-a3f4-fc7c7ed0ade7" />


## Microbench results

H200, bf16:

| Shape | Baseline | Optimized | Speedup |
|---|---:|---:|---:|
| `(256, 1024)` | `0.0207 ms` | `0.0194 ms` | `1.0711x` |
| `(1024, 4096)` | `0.0688 ms` | `0.0598 ms` | `1.1506x` |
| `(2048, 8192)` | `0.1786 ms` | `0.1592 ms` | `1.1218x` |

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
