### PR TITLE
Debug: log full error details on wait-for-jobs 403

### DIFF
--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -28,6 +28,9 @@ runs:
         # Check if maintenance issue is open (fail-open: if API errors, allow CI to proceed)
         ISSUE_STATE=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
 
+        # Debug: print rate limit after API call
+        gh api rate_limit --jq '"[check-maintenance] core: \(.resources.core.used)/\(.resources.core.limit) used, \(.resources.core.remaining) remaining, reset=\(.resources.core.reset)"' 2>/dev/null || true
+
         if [[ "$ISSUE_STATE" != "OPEN" ]]; then
           echo "✅ Maintenance mode is OFF. Proceeding with CI."
           exit 0

--- a/.github/actions/check-maintenance/action.yml
+++ b/.github/actions/check-maintenance/action.yml
@@ -29,7 +29,8 @@ runs:
         ISSUE_STATE=$(gh issue view "$MAINTENANCE_ISSUE" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
 
         # Debug: print rate limit after API call
-        gh api rate_limit --jq '"[check-maintenance] core: \(.resources.core.used)/\(.resources.core.limit) used, \(.resources.core.remaining) remaining, reset=\(.resources.core.reset)"' 2>/dev/null || true
+        RL_JSON=$(gh api rate_limit --jq '.resources.core' 2>/dev/null || echo '{}')
+        echo "[check-maintenance] core rate limit: $RL_JSON"
 
         if [[ "$ISSUE_STATE" != "OPEN" ]]; then
           echo "✅ Maintenance mode is OFF. Proceeding with CI."

--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -35,6 +35,11 @@ runs:
             run_id: context.runId,
             per_page: 100,
           });
+
+          // Debug: print rate limit after API call
+          const rl = await github.request('GET /rate_limit');
+          const core = rl.data.resources.core;
+          console.log(`[check-stage-health] core: ${core.used}/${core.limit} used, ${core.remaining} remaining, reset=${core.reset}`);
           // Find jobs that failed from a real error, not from fast-fail cascade
           const rootCauseFailures = jobs.filter(j => {
             if (j.status !== 'completed' || j.conclusion !== 'failure') return false;

--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -38,8 +38,8 @@ runs:
 
           // Debug: print rate limit after API call
           const rl = await github.request('GET /rate_limit');
-          const core = rl.data.resources.core;
-          console.log(`[check-stage-health] core: ${core.used}/${core.limit} used, ${core.remaining} remaining, reset=${core.reset}`);
+          const coreRL = rl.data.resources.core;
+          console.log(`[check-stage-health] core: ${coreRL.used}/${coreRL.limit} used, ${coreRL.remaining} remaining, reset=${coreRL.reset}`);
           // Find jobs that failed from a real error, not from fast-fail cascade
           const rootCauseFailures = jobs.filter(j => {
             if (j.status !== 'completed' || j.conclusion !== 'failure') return false;

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -118,6 +118,16 @@ runs:
                 console.log(`[rate-limit] 304 Not Modified | this session: ${apiCalls} paid, ${cachedCalls} free`);
                 return { jobs: lastJobs, cached: true };
               }
+
+              // Dump full error details for debugging rate limit issues
+              console.log(`[error] status=${err.status}, message=${err.message}`);
+              if (err.response) {
+                const h = err.response.headers;
+                console.log(`[error-headers] x-ratelimit-limit=${h['x-ratelimit-limit']}, x-ratelimit-remaining=${h['x-ratelimit-remaining']}, x-ratelimit-used=${h['x-ratelimit-used']}, x-ratelimit-resource=${h['x-ratelimit-resource']}, x-ratelimit-reset=${h['x-ratelimit-reset']}`);
+                console.log(`[error-headers] retry-after=${h['retry-after']}, x-github-request-id=${h['x-github-request-id']}`);
+                console.log(`[error-body] ${JSON.stringify(err.response.data)}`);
+              }
+
               throw err;
             }
           }

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -91,7 +91,10 @@ runs:
               apiCalls++;
               const rateRemaining = response.headers['x-ratelimit-remaining'] || '?';
               const rateLimit = response.headers['x-ratelimit-limit'] || '?';
-              console.log(`[rate-limit] ${rateRemaining}/${rateLimit} remaining (ETag: ${lastEtag ? 'sent' : 'none'}) | this session: ${apiCalls} paid, ${cachedCalls} free`);
+              const rateUsed = response.headers['x-ratelimit-used'] || '?';
+              const rateResource = response.headers['x-ratelimit-resource'] || '?';
+              const rateReset = response.headers['x-ratelimit-reset'] || '?';
+              console.log(`[rate-limit] ${rateRemaining}/${rateLimit} remaining (used=${rateUsed}, resource=${rateResource}, reset=${rateReset}, ETag: ${lastEtag ? 'sent' : 'none'}) | this session: ${apiCalls} paid, ${cachedCalls} free`);
               lastEtag = response.headers.etag || '';
               const jobs = response.data.jobs;
 


### PR DESCRIPTION
## Summary
- Log full error headers (retry-after, x-ratelimit-*, x-github-request-id) and response body when wait-for-jobs hits a 403 error
- Helps diagnose whether the 403 is primary rate limit exhaustion or secondary rate limit (abuse detection)

## Test plan
- Wait for CI to trigger and check if the additional logging appears on 403 errors