### PR TITLE
[CI] Detect and fix consolidated .pt weight format mismatch

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -126,6 +126,41 @@ _is_npu = is_npu()
 logger = logging.getLogger(__name__)
 
 
+def _check_critical_weights_loaded(model: torch.nn.Module) -> None:
+    """CI-only check: verify that embedding/lm_head weights were actually loaded.
+
+    When checkpoint files use a different naming convention (e.g., original
+    Mistral consolidated.pt format vs HuggingFace format), load_weights()
+    silently drops all unrecognized parameters. This leaves the model with
+    uninitialized weights that produce garbage output and 0% accuracy.
+
+    This check looks for common embedding parameter names and verifies they
+    have non-zero values, catching the problem at load time rather than after
+    a long eval run produces 0.0 scores.
+    """
+    params = dict(model.named_parameters())
+
+    # Common names for the embedding layer across model architectures
+    embed_names = [
+        "model.embed_tokens.weight",
+        "transformer.wte.weight",
+        "embeddings.word_embeddings.weight",
+    ]
+
+    for name in embed_names:
+        if name in params:
+            param = params[name]
+            if param.count_nonzero() == 0:
+                raise RuntimeError(
+                    f"[CI] Critical weight '{name}' is all zeros after loading. "
+                    f"This likely means the checkpoint format does not match the "
+                    f"model definition (e.g., original Mistral consolidated.pt "
+                    f"format with different parameter naming). The cached weights "
+                    f"may need to be re-downloaded in the correct format."
+                )
+            break
+
+
 @contextmanager
 def device_loading_context(module: torch.nn.Module, target_device: torch.device):
     if target_device.type == "cpu":
@@ -696,6 +731,13 @@ class DefaultModelLoader(BaseModelLoader):
     @staticmethod
     def load_weights_and_postprocess(model, weights, target_device):
         model.load_weights(weights)
+
+        # CI-only: verify critical weights were actually loaded.
+        # Catches format mismatches (e.g. consolidated.pt with original Mistral
+        # naming vs HuggingFace naming) where load_weights silently drops
+        # unrecognized parameters, leaving the model with uninitialized weights.
+        if os.environ.get("SGLANG_IS_IN_CI") == "true":
+            _check_critical_weights_loaded(model)
 
         for _, module in model.named_modules():
             quant_method = getattr(module, "quant_method", None)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -138,6 +138,12 @@ def _check_critical_weights_loaded(model: torch.nn.Module) -> None:
     have non-zero values, catching the problem at load time rather than after
     a long eval run produces 0.0 scores.
     """
+    # Skip for speculative draft models — their embeddings are intentionally
+    # zero-initialized during load_weights and populated later via
+    # set_embed_and_head() from the target model.
+    if hasattr(model, "set_embed_and_head"):
+        return
+
     params = dict(model.named_parameters())
 
     # Common names for the embedding layer across model architectures

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -413,6 +413,33 @@ def _find_local_hf_snapshot_dir_unlocked(
     # Only perform cache validation and cleanup in CI to avoid
     # unnecessary overhead for regular users
     if is_in_ci() and local_weight_files:
+        # Detect consolidated.pt format (original Mistral/Meta release format).
+        # These files use different parameter naming (e.g. tok_embeddings.weight
+        # vs model.embed_tokens.weight) that causes load_weights() to silently
+        # drop all parameters, producing garbage output with 0% accuracy.
+        # Delete them to trigger re-download in safetensors/HF format.
+        consolidated_pt_files = [
+            f
+            for f in local_weight_files
+            if os.path.basename(f).startswith("consolidated")
+            and f.endswith((".pt", ".pth"))
+        ]
+        has_safetensors = any(f.endswith(".safetensors") for f in local_weight_files)
+        if consolidated_pt_files and not has_safetensors:
+            log_info_on_rank0(
+                logger,
+                f"[CI] Found only consolidated .pt format weights for "
+                f"{model_name_or_path} (incompatible naming convention). "
+                f"Removing {len(consolidated_pt_files)} file(s) to trigger "
+                f"re-download in safetensors format.",
+            )
+            for f in consolidated_pt_files:
+                try:
+                    os.remove(f)
+                except OSError:
+                    pass
+            return None
+
         is_valid = ci_validate_and_cleanup_local_snapshot(
             model_name_or_path, found_local_snapshot_dir, local_weight_files
         )


### PR DESCRIPTION
## Summary
- Some CI runners have stale HF caches with original Mistral `consolidated.*.pt` format weights. These use different parameter naming (`tok_embeddings.weight` vs `model.embed_tokens.weight`) that causes `load_weights()` to **silently drop all parameters**, producing 0% accuracy on evals.
- Adds two CI-only safeguards:
  - **Pre-load**: Detect snapshots with only `consolidated*.pt` files (no safetensors), delete them to trigger re-download in safetensors format
  - **Post-load**: Verify embedding layer has non-zero values after weight loading as a safety net
- Both checks are gated by `SGLANG_IS_IN_CI` — no effect on regular users

Example failure: https://github.com/sgl-project/sglang/actions/runs/23611135788/job/68768161525#step:7:1724

## Test plan
- [x] Reproduced on dev machine: `scan_weight_files` returns 0 files for consolidated .pt format
- [x] Verified naming mismatch: all HF param names differ from original Mistral names
- [x] Tested Layer 1: correctly detects and removes consolidated .pt files
- [x] Tested Layer 1: does NOT delete when safetensors exist alongside
- [x] Tested Layer 1: does NOT delete non-consolidated .pt files (e.g. `model.pt`)
- [x] Tested Layer 2: correctly detects all-zeros embedding
- [x] Tested Layer 2: no false positive for normally initialized model
- [x] Verified CI gating: `SGLANG_IS_IN_CI` is None on dev machine, checks skip