### PR TITLE
[CI] Reduce GitHub API calls by centralizing maintenance and health checks

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -52,8 +52,24 @@ env:
   HF_HUB_ETAG_TIMEOUT: 300
 
 jobs:
+  # Single maintenance check — all test jobs depend on this instead of checking individually.
+  # Saves ~15 GitHub API calls per nightly run.
+  check-maintenance:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: ubuntu-latest
+    env:
+      # Allow maintenance bypass on default branch (preserves behavior from kernel jobs)
+      SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+
   # General tests - 1 GPU
   nightly-test-general-1-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-1-gpu-h100')
     runs-on: 1-gpu-h100
     steps:
@@ -61,8 +77,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -79,6 +93,7 @@ jobs:
 
   # JIT kernel full unit tests (expanded parameter ranges via SGLANG_JIT_KERNEL_RUN_FULL_TESTS)
   nightly-test-kernel-1-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-kernel-1-gpu-h100')
     runs-on: 1-gpu-h100
     timeout-minutes: 240
@@ -87,15 +102,11 @@ jobs:
       SGLANG_JIT_KERNEL_RUN_FULL_TESTS: "1"
       # Match pr-test-jit-kernel workflow for consistent JIT warmup behavior
       SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-      # Allow maintenance bypass on default branch (same semantics as PR JIT workflow)
-      SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -112,20 +123,18 @@ jobs:
         if: always()
 
   nightly-test-kernel-8-gpu-h200:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-kernel-8-gpu-h200')
     runs-on: 8-gpu-h200
     timeout-minutes: 240
     env:
       SGLANG_JIT_KERNEL_RUN_FULL_TESTS: "1"
       SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-      SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -143,6 +152,7 @@ jobs:
 
   # General tests - 4 GPU H100
   nightly-test-general-4-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-4-gpu-h100')
     runs-on: 4-gpu-h100
     steps:
@@ -150,8 +160,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -168,6 +176,7 @@ jobs:
 
   # General tests - 8 GPU H200
   nightly-test-general-8-gpu-h200:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h200')
     runs-on: 8-gpu-h200
     strategy:
@@ -181,8 +190,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -254,6 +261,7 @@ jobs:
 
   # General tests - 8 GPU H20
   nightly-test-general-8-gpu-h20:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h20')
     runs-on: 8-gpu-h20
     env:
@@ -263,8 +271,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -283,6 +289,7 @@ jobs:
 
   # General tests - 8 GPU B200
   nightly-test-general-8-gpu-b200:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-b200')
     runs-on: 8-gpu-b200
     strategy:
@@ -294,8 +301,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -358,6 +363,7 @@ jobs:
 
   # Text model accuracy tests
   nightly-test-text-accuracy-2-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-text-accuracy-2-gpu-h100')
     runs-on: 2-gpu-h100
     steps:
@@ -365,8 +371,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -383,6 +387,7 @@ jobs:
 
   # Text model performance tests
   nightly-test-text-perf-2-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-text-perf-2-gpu-h100')
     runs-on: 2-gpu-h100
     steps:
@@ -390,8 +395,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -421,6 +424,7 @@ jobs:
 
   # VLM accuracy tests
   nightly-test-vlm-accuracy-2-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-vlm-accuracy-2-gpu-h100')
     runs-on: 2-gpu-h100
     steps:
@@ -428,8 +432,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -446,6 +448,7 @@ jobs:
 
   # VLM performance tests
   nightly-test-vlm-perf-2-gpu-h100:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-vlm-perf-2-gpu-h100')
     runs-on: 2-gpu-h100
     steps:
@@ -453,8 +456,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -484,6 +485,7 @@ jobs:
 
   # diffusion performance tests
   nightly-test-multimodal-server-1-gpu:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-multimodal-server-1-gpu')
     runs-on: 1-gpu-h100
     strategy:
@@ -496,8 +498,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -542,6 +542,7 @@ jobs:
           artifact-suffix: ${{ matrix.part }}
 
   nightly-test-multimodal-server-2-gpu:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-multimodal-server-2-gpu')
     runs-on: 2-gpu-h100
     strategy:
@@ -554,8 +555,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -601,6 +600,7 @@ jobs:
 
   # B200 Performance tests - 4 GPU
   nightly-test-perf-4-gpu-b200:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-4-gpu-b200')
     runs-on: 4-gpu-b200
     steps:
@@ -608,8 +608,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -626,6 +624,7 @@ jobs:
 
   # Specialized B200 tests - 8 GPU, for specific backends and configs
   nightly-test-specialized-8-gpu-b200:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-8-gpu-b200')
     runs-on: 8-gpu-b200
     env:
@@ -635,8 +634,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         run: |
@@ -655,6 +652,7 @@ jobs:
 
   # Diffusion cross-framework comparison
   nightly-test-diffusion-comparison:
+    needs: [check-maintenance]
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-diffusion-comparison')
     runs-on: 4-gpu-h100
     timeout-minutes: 240
@@ -720,6 +718,7 @@ jobs:
   consolidate-metrics:
     if: github.repository == 'sgl-project/sglang' && always()
     needs:
+      - check-maintenance
       - nightly-test-general-8-gpu-h200
       - nightly-test-general-8-gpu-b200
       - nightly-test-multimodal-server-1-gpu
@@ -764,6 +763,7 @@ jobs:
   check-all-jobs:
     if: github.repository == 'sgl-project/sglang' && always()
     needs:
+      - check-maintenance
       - nightly-test-general-1-gpu-h100
       - nightly-test-general-4-gpu-h100
       - nightly-test-general-8-gpu-h200

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -29,7 +29,6 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
 jobs:
   jit-kernel-unit-test:
@@ -43,10 +42,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         timeout-minutes: 20
@@ -71,8 +66,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-maintenance
-
       - name: Install dependencies
         timeout-minutes: 20
         run: |
@@ -95,10 +88,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
         timeout-minutes: 20

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -39,7 +39,6 @@ on:
 env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
-  SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
 jobs:
   multimodal-gen-test-1-gpu:
@@ -61,10 +60,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: inputs.sgl_kernel == 'true'
@@ -116,10 +111,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
       - name: Download artifacts
         if: inputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
@@ -166,10 +157,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: inputs.sgl_kernel == 'true'

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -23,7 +23,6 @@ on:
 env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
-  SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
 jobs:
   sgl-kernel-unit-test:
@@ -33,10 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Cleanup
         run: |
@@ -69,10 +64,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
       - name: Cleanup
         run: |
           ls -alh sgl-kernel/dist || true
@@ -103,10 +94,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Cleanup
         run: |
@@ -150,10 +137,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Cleanup
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -338,8 +338,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/check-maintenance
-
       - uses: ./.github/actions/wait-for-jobs
         id: wait
         with:
@@ -365,8 +363,6 @@ jobs:
       stage_b_result: ${{ steps.wait.outputs.result }}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/check-maintenance
 
       - uses: ./.github/actions/wait-for-jobs
         id: wait
@@ -425,8 +421,6 @@ jobs:
           submodules: "recursive"
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-maintenance
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -476,8 +470,6 @@ jobs:
         with:
           submodules: "recursive"
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -555,10 +547,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
@@ -607,10 +595,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -661,10 +645,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -723,10 +703,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
@@ -776,10 +752,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -832,10 +804,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -917,10 +885,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
@@ -970,10 +934,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1041,10 +1001,6 @@ jobs:
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
-
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
         uses: actions/download-artifact@v4
@@ -1090,10 +1046,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1150,10 +1102,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1216,10 +1164,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-stage-health
-
-      - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'


### PR DESCRIPTION
## Summary

Consolidate redundant `check-maintenance` and `check-stage-health` action invocations across CI workflows to reduce GitHub API rate limit consumption. This addresses the recurring "API rate limit exceeded for installation" errors (e.g., [run 23629057005](https://github.com/sgl-project/sglang/actions/runs/23629057005)).

**Net result: 5 files changed, +33 / -130 lines, eliminating ~53 redundant GitHub API calls per PR test run and ~14 per nightly run.**

## What changed

### `check-maintenance` (41 invocations → 2)

Previously, every job independently called `gh issue view 21065` (1-2 API calls each) to check if maintenance mode is active. Since all downstream jobs already depend on `check-changes` (which runs `check-maintenance`), the individual checks are redundant — if maintenance is active, `check-changes` fails and GitHub Actions automatically skips all dependent jobs.

| Workflow | Before | After | API calls saved |
|----------|--------|-------|-----------------|
| `pr-test.yml` | 17 invocations | 1 (in `check-changes`) | ~16 |
| `pr-test-sgl-kernel.yml` | 4 invocations | 0 (caller gates) | ~4 |
| `pr-test-jit-kernel.yml` | 3 invocations | 0 (caller gates) | ~3 |
| `pr-test-multimodal-gen.yml` | 3 invocations | 0 (caller gates) | ~3 |
| `nightly-test-nvidia.yml` | 15 invocations | 1 (new gate job) | ~14 |
| `rerun-ut.yml` | 1 invocation | 1 (unchanged, no gate) | 0 |

### `check-stage-health` (21 invocations → 0)

Each invocation called `github.paginate(listJobsForWorkflowRun)` — a paginated REST API call fetching all jobs in the run. With ~30 jobs per run, every invocation costs 1+ API calls, all returning identical data.

| Workflow | Invocations removed |
|----------|-------------------|
| `pr-test.yml` | 12 |
| `pr-test-sgl-kernel.yml` | 4 |
| `pr-test-multimodal-gen.yml` | 3 |
| `pr-test-jit-kernel.yml` | 2 |

### Dead code cleanup

Removed `SGLANG_PR_TEST_BYPASS_MAINTENANCE_ON_MAIN` env var from 3 sub-workflows and 2 nightly kernel jobs where it was no longer read (since `check-maintenance` was removed from those files). Moved the env var to the new centralized `check-maintenance` gate job in nightly to preserve existing bypass behavior on main.

## Trade-offs

### Intra-stage fast-fail is removed

`check-stage-health` provided a fail-fast mechanism: if job A in stage-a fails, job B in stage-a would detect this and skip early instead of wasting GPU time. This is now removed.

**What still works:**
- **Inter-stage gating** — `wait-for-stage-a` blocks all stage-b jobs until stage-a completes. If stage-a fails, stage-b is skipped entirely.
- **Matrix `fail-fast`** — matrix jobs within the same job definition still respect `fail-fast: true/false`.

**What is lost:**
- If `stage-a-test-1-gpu-small` fails while `stage-a-test-cpu` is already running, the CPU job will run to completion instead of skipping early.
- On scheduled runs (where wait jobs are skipped), there is no intra-stage fail-fast at all.

**Why this is acceptable:**
- Jobs within the same stage typically start near-simultaneously, so the window where `check-stage-health` saves GPU time is small.
- The API cost savings (~21 paginated calls per run) outweigh the occasional GPU waste from a sibling failure.
- If GPU waste becomes significant, we can explore alternative fail-fast mechanisms that don't require per-job API calls.

### `target_stage` dispatch during maintenance

Jobs with `always()` + `target_stage` short-circuit in their `if:` condition can bypass the maintenance gate when triggered via `workflow_dispatch` with a specific `target_stage`. Previously caught by inline `check-maintenance`.

**Why this is acceptable:** `target_stage` is an intentional manual override used by maintainers (via `/rerun-stage`). A maintainer deliberately dispatching a stage during maintenance likely knows what they are doing.

## Test plan

- [x] YAML syntax validated for all 5 modified files
- [x] `pre-commit run --all-files` passes
- [x] Verified all downstream jobs in `pr-test.yml` have `needs: [check-changes, ...]`
- [x] Verified nightly `if:` conditions work correctly with added `needs: [check-maintenance]` (no `always()` in test jobs)
- [x] Verified `rerun-ut.yml` correctly left unchanged
- [x] Verified fork behavior unchanged (both gate and downstream jobs guard on `github.repository`)
- [ ] Monitor next few PR test and nightly runs for unexpected skips or failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)