### PR TITLE
Fix DeepseekVL2Config dataclass field for transformers 5.x compatibility

### DIFF
--- a/python/sglang/srt/configs/deepseekvl2.py
+++ b/python/sglang/srt/configs/deepseekvl2.py
@@ -648,7 +648,7 @@ class DeepseekV2Config(PretrainedConfig):
 
 
 class DeepseekVL2Config(PretrainedConfig):
-    model_type = "deepseek_vl_v2"
+    model_type: str = "deepseek_vl_v2"
     vision_config: DeepseekVL2VisionEncoderConfig = None
     projector_config: DeepseekVL2MlpProjectorConfig = None
     language_config: DeepseekV2Config = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In transformers 5.x, PretrainedConfig.__init_subclass__ wraps subclasses with @dataclass(repr=False) , which enforces stricter dataclass field ordering rules. The DeepseekVL2Config class had model_type defined as a class variable without a type annotation and default value, causing a TypeError: non-default argument follows default argument when importing with transformers 5.x.

This issue breaks SGLang imports for users who need transformers 5.x for other model architectures (e.g., GLM-4.7-Flash), even when not using DeepSeek models, because deepseekvl2.py is unconditionally imported via sglang/srt/configs/__init__.py .
## Modifications

- File: python/sglang/srt/configs/deepseekvl2.py
  - Changed model_type = "deepseek_vl_v2" to model_type: str = "deepseek_vl_v2" in the DeepseekVL2Config class
  - This adds an explicit type annotation and ensures the field has a default value, satisfying dataclass requirements in transformers 5.x
This is a minimal one-line fix that maintains backward compatibility with transformers 4.x while enabling support for transformers 5.x.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
