### PR TITLE
Fix aiter router GEMM regression for non-DSR1 MoE models on ROCm gfx95

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -330,6 +330,7 @@ class MoEGate(nn.Module):
                 _use_aiter_gfx95
                 and hidden_states.shape[0] <= 256
                 and self.weight.shape[0] <= 256
+                and hidden_states.shape[1] == 7168  # tuned for DSR1/V3
             ):
                 logits = aiter_dsv3_router_gemm(
                     hidden_states, self.weight, gemm_output_zero_allocator


### PR DESCRIPTION
aiter_dsv3_router_gemm uses a Triton atomic kernel (_gemm_a16_w16_atomic) that is specifically tuned for DeepSeek-R1/V3's hidden_size=7168. On models with different hidden dimensions (e.g. GLM-5 hidden_size=6144), this kernel runs 10-15x slower than hipBLAS F.linear (170us vs 11us per MoE layer).

Add hidden_size==7168 guard so only DSR1/V3 uses the specialized kernel; other models fall through to F.linear which is optimal for their shapes.

Measured on MI355X with GLM-5 FP8 (TP=4, 75 MoE layers):
  - Router GEMM per layer: 170us → 11us
  - Decode throughput: +19.8%
  - TPOT: -16.4%

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
