### PR TITLE
Add MXFP4 (including Quark W4A4) quantization support for DeepSeek-architecture on ROCm

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -73,6 +73,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "IPEXAWQLinearMethod",
     "PetitNvFp4LinearMethod",
     "QuarkInt4Fp8LinearMethod",
+    "QuarkLinearMethod",
 ]
 
 _is_cpu = is_cpu()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -297,6 +297,21 @@ class FusedMoE(torch.nn.Module):
         self.quant_method.create_moe_runner(self, self.moe_runner_config)
         self.dispatcher = create_moe_dispatcher(self.moe_runner_config)
 
+        # Pre-compute expert_mask for CUDA graph compatibility (EP mode)
+        if (
+            _use_aiter
+            and getattr(self.dispatcher, "local_expert_mapping", None) is not None
+        ):
+            expert_mask = (
+                (
+                    (self.dispatcher.local_expert_mapping >= 0)
+                    & (self.dispatcher.local_expert_mapping < self.num_local_experts)
+                )
+                .to(torch.int32)
+                .to(device="cuda")
+            )
+            self.register_buffer("expert_mask_gpu", expert_mask)
+
         self.should_fuse_routed_scaling_factor_in_topk = isinstance(
             self.quant_method, ModelOptNvFp4FusedMoEMethod
         ) or (
@@ -444,8 +459,11 @@ class FusedMoE(torch.nn.Module):
             )
         else:
             if not self.use_presharded_weights:
-                if not is_bias and self.use_triton_kernels:
-                    # do not transpose for bias
+                is_packed = (
+                    loaded_weight.dtype == torch.uint8
+                    and expert_data.dtype == torch.uint8
+                )
+                if not is_bias and self.use_triton_kernels and not is_packed:
                     loaded_weight = loaded_weight.transpose(-2, -1)
                 loaded_weight = loaded_weight.narrow(
                     shard_dim, shard_size * tp_rank, shard_size
@@ -518,7 +536,11 @@ class FusedMoE(torch.nn.Module):
             )
         else:
             if not is_bias and not self.use_presharded_weights:
-                if self.use_triton_kernels:
+                is_packed = (
+                    loaded_weight.dtype == torch.uint8
+                    and expert_data.dtype == torch.uint8
+                )
+                if self.use_triton_kernels and not is_packed:
                     loaded_weight = loaded_weight.transpose(-2, -1)
                 loaded_weight = loaded_weight.narrow(
                     shard_dim, shard_size * tp_rank, shard_size
@@ -582,7 +604,7 @@ class FusedMoE(torch.nn.Module):
         # if expert_id is None, then
         # all the experts are loaded at the same time
         if (
-            not expert_id
+            expert_id is None
             and self.quant_config is not None
             and self.quant_config.get_name() == "mxfp4"
             and self.quant_config.is_static_cfg()
@@ -731,7 +753,8 @@ class FusedMoE(torch.nn.Module):
         # should be whatever dimension intermediate_size is
         is_transposed = getattr(param, "is_transposed", False)
         shard_dim = SHARD_ID_TO_SHARDED_DIM[shard_id]
-        if self.use_triton_kernels:
+        is_packed_fp4 = param.data.dtype == torch.uint8
+        if self.use_triton_kernels and not is_packed_fp4:
             is_transposed = True
         if is_transposed:
             shard_dim = int(not shard_dim)
@@ -1000,15 +1023,6 @@ class FusedMoE(torch.nn.Module):
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output
         )
-        if _use_aiter and self.dispatcher.local_expert_mapping is not None:
-            self.expert_mask_gpu = (
-                (
-                    (self.dispatcher.local_expert_mapping >= 0)
-                    & (self.dispatcher.local_expert_mapping < self.num_local_experts)
-                )
-                .to(torch.int32)
-                .to(device="cuda")
-            )
 
         combine_input = self.run_moe_core(
             dispatch_output=dispatch_output,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -298,7 +298,7 @@ class Mxfp4Config(QuantizationConfig):
                 return Mxfp4DynamicQuantMoEMethod()
         else:
             if self.is_checkpoint_mxfp4_serialized:
-                raise NotImplementedError("Mxfp4 attention layer is not implemented")
+                return None
         return None
 
     def get_scaled_act_names(self) -> List[str]:
@@ -332,6 +332,12 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         with_bias: bool = False,
         **extra_weight_attrs,
     ):
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
+
+        extra_weight_attrs.update(
+            {"quant_method": FusedMoeWeightScaleSupported.BLOCK.value}
+        )
+
         self.num_experts = num_experts
         weight_dtype = torch.uint8
         scale_dtype = torch.uint8

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -85,7 +85,9 @@ class QuarkConfig(QuantizationConfig):
             if isinstance(layer, LinearBase):
                 return UnquantizedLinearMethod()
             elif isinstance(layer, RadixAttention):
-                return QuarkKVCacheMethod(self)
+                if self.kv_cache_config is not None:
+                    return QuarkKVCacheMethod(self)
+                return None
             return None
 
         if isinstance(layer, LinearBase):
@@ -94,7 +96,9 @@ class QuarkConfig(QuantizationConfig):
             return QuarkLinearMethod(self)
 
         if isinstance(layer, RadixAttention):
-            return QuarkKVCacheMethod(self)
+            if self.kv_cache_config is not None:
+                return QuarkKVCacheMethod(self)
+            return None
 
         from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -33,8 +33,7 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 if _use_aiter:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
-    from aiter.ops.shuffle import shuffle_weight
-    from aiter.utility.fp4_utils import e8m0_shuffle
+    from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 
 OCP_MX_BLOCK_SIZE = 32
 
@@ -52,7 +51,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
                 "For MX(FP4) Fused MoE layers, only per-group scales "
                 "for weights and activations are supported. Found "
                 f"{weight_qscheme}, {input_qscheme}"
-            )  # noqa E501
+            )
 
         self.static_input_scales = not self.input_quant.get("is_dynamic")
         self.with_bias = False
@@ -73,8 +72,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
 
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
 
-        # Add the quantization method used (per tensor/grouped/channel)
-        # to ensure the weight scales are loaded in properly
         extra_weight_attrs.update(
             {"quant_method": FusedMoeWeightScaleSupported.BLOCK.value}
         )
@@ -133,35 +130,85 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         layer.register_parameter("w13_weight_scale", w13_weight_scale)
         layer.register_parameter("w2_weight_scale", w2_weight_scale)
 
+        # WEIGHT_BIAS (zeros, matching standard mxfp4 path for CUDA graph compat)
+        w13_weight_bias = torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                dtype=torch.bfloat16,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_bias", w13_weight_bias)
+        set_weight_attrs(w13_weight_bias, extra_weight_attrs)
+
+        w2_weight_bias = torch.nn.Parameter(
+            torch.zeros(num_experts, hidden_size, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_bias", w2_weight_bias)
+        set_weight_attrs(w2_weight_bias, extra_weight_attrs)
+
+        self.hidden_pad = 0
+        self.intermediate_pad = 0
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        float_dtype = torch.get_default_dtype()
+        if not _use_aiter:
+            return
 
-        # Pre-shuffle weight scales
-        s0, s1, _ = layer.w13_weight_scale.shape
-        w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
-        w13_weight_scale = e8m0_shuffle(w13_weight_scale)
-        # layer.w13_weight_scale = torch.nn.Parameter(w13_weight_scale, requires_grad=False)
-        layer.w13_weight_scale.data = w13_weight_scale.view(s0, s1, -1)
+        # Convert bias to float32 (matching standard path)
+        if layer.w13_weight_bias is not None:
+            layer.w13_weight_bias.data = layer.w13_weight_bias.data.to(torch.float32)
+        if layer.w2_weight_bias is not None:
+            layer.w2_weight_bias.data = layer.w2_weight_bias.data.to(torch.float32)
 
-        s0, s1, _ = layer.w2_weight_scale.shape
-        w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
-        w2_weight_scale = e8m0_shuffle(w2_weight_scale)
-        # layer.w2_weight_scale = torch.nn.Parameter(w2_weight_scale, requires_grad=False)
-        layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
+        # Interleave w1 (gate) and w3 (up) halves in w13 for Swiglu activation
+        e, n, k = layer.w13_weight.shape
+        layer.w13_weight.view(torch.uint8).copy_(
+            layer.w13_weight.data.view(torch.uint8)
+            .view(e, n // 2, 2, k)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+            .view(e, n, k)
+        )
+        layer.w13_weight_scale.data = (
+            layer.w13_weight_scale.data.view(e, n // 2, 2, -1)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+            .view(e, n, -1)
+        )
 
-        # Pre-shuffle weight
-        if _is_shuffle_moe_mxfp4:
-            layer.w13_weight.data = shuffle_weight(
-                layer.w13_weight.contiguous(), (16, 16)
-            )
-            layer.w2_weight.data = shuffle_weight(
-                layer.w2_weight.contiguous(), (16, 16)
-            )
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
+        # Interleave bias halves too
+        layer.w13_weight_bias.data = (
+            layer.w13_weight_bias.data.view(-1, n // 2, 2)
+            .permute(0, 2, 1)
+            .contiguous()
+            .view(-1, n)
+        )
+
+        # Shuffle weights using CUDA-graph-compatible a16w4 functions
+        layer.w13_weight.data = shuffle_weight_a16w4(layer.w13_weight, 16, True)
+        shuffled_w13_scale = shuffle_scale_a16w4(
+            layer.w13_weight_scale.view(-1, layer.w13_weight_scale.shape[-1]),
+            e,
+            True,
+        )
+
+        layer.w2_weight.data = shuffle_weight_a16w4(layer.w2_weight, 16, False)
+        shuffled_w2_scale = shuffle_scale_a16w4(
+            layer.w2_weight_scale.view(-1, layer.w2_weight_scale.shape[-1]),
+            e,
+            False,
+        )
+
+        layer.w13_weight_scale = torch.nn.Parameter(
+            shuffled_w13_scale, requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            shuffled_w2_scale, requires_grad=False
+        )
 
         if hasattr(layer, "dispatcher"):
-            # Weights are stored as torch.uint8 but semantically MXFP4
             layer.dispatcher.set_quant_config({"weight_dtype": torch.float4_e2m1fn_x2})
 
     def create_moe_runner(
@@ -182,9 +229,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         moe_runner_config = self.moe_runner_config
         topk_weights, topk_ids, _ = topk_output
         if _is_hip:
-            topk_weights = topk_weights.to(
-                torch.float32
-            )  # aiter's moe_sorting requires topk_weights to be FP32
+            topk_weights = topk_weights.to(torch.float32)
 
         if hasattr(torch, "float4_e2m1fn_x2"):
             w13_weight = layer.w13_weight.view(torch.float4_e2m1fn_x2)
@@ -192,10 +237,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         else:
             w13_weight = layer.w13_weight
             w2_weight = layer.w2_weight
-
-        if hasattr(layer.w13_weight, "is_shuffled"):
-            w13_weight.is_shuffled = True
-            w2_weight.is_shuffled = True
 
         output = fused_moe(
             x,
@@ -206,12 +247,12 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             quant_type=QuantType.per_1x32,
             w1_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            activation=(
-                ActivationType.Silu
-                if moe_runner_config.activation == "silu"
-                else ActivationType.Gelu
-            ),
-            doweight_stage1=False,
+            activation=ActivationType.Swiglu,
+            doweight_stage1=moe_runner_config.apply_router_weight_on_input,
             expert_mask=layer.expert_mask_gpu,
+            hidden_pad=self.hidden_pad,
+            intermediate_pad=self.intermediate_pad,
+            bias1=layer.w13_weight_bias,
+            bias2=layer.w2_weight_bias,
         )
         return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -125,7 +125,9 @@ def _is_equal_or_regex_match(
 def b_dynamic_mxfp4_quant(x):
     h, b, d = x.shape
     x, x_scales = dynamic_mxfp4_quant(x.reshape(-1, d))
-    return x.view(h, b, d // 2), x_scales.view(h, b, d // 32)
+    x_out = x.view(h, b, d // 2).contiguous()
+    s_out = x_scales.contiguous().view(h, b, d // 32).contiguous()
+    return x_out, s_out
 
 
 def mxfp4_to_f32(x, is_3d):

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -555,10 +555,14 @@ class DeepseekV2WeightLoaderMixin:
                 0, (-1, self_attn.qk_nope_head_dim + self_attn.v_head_dim)
             ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
 
+            # Only quantize attention absorb matrices when the checkpoint has
+            # KV cache quant config (implies MXFP4 bmm path is needed and available).
+            # TODO: add MXFP4 bmm path in forward_mla.py for the general case.
             if (
                 _use_aiter_gfx95
                 and self.quant_config is not None
                 and self.quant_config.get_name() == "quark"
+                and getattr(self.quant_config, "kv_cache_config", None) is not None
             ):
                 w_kc, self_attn.w_scale_k, w_vc, self_attn.w_scale_v = (
                     quark_post_load_weights(self_attn, w, "mxfp4")

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2057,8 +2057,10 @@ class DeepseekV2Model(nn.Module):
 
 
 class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
-    # for quark model load
-    packed_modules_mapping = {}
+    packed_modules_mapping = {
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "fused_qkv_a_proj_with_mqa": ["q_a_proj", "kv_a_proj_with_mqa"],
+    }
 
     def __init__(
         self,
@@ -2160,6 +2162,22 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             disable_reason = "Deepseek V3/R1 cannot use shared experts fusion optimization under deepep expert parallelism."
         elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "Deepseek V3/R1 W4AFP8 model uses different quant method for routed experts and shared experts."
+        elif (
+            self.quant_config
+            and self.quant_config.get_name() == "mxfp4"
+            and getattr(self.quant_config, "is_checkpoint_mxfp4_serialized", False)
+        ):
+            disable_reason = "MXFP4 serialized model has quantized routed experts but BF16 shared experts."
+        elif (
+            self.quant_config
+            and self.quant_config.get_name() == "quark"
+            and getattr(self.quant_config, "quant_config", {})
+            .get("global_quant_config", {})
+            .get("weight", {})
+            .get("dtype")
+            == "fp4"
+        ):
+            disable_reason = "Quark MXFP4 model has quantized routed experts but BF16 shared experts."
 
         if disable_reason is not None:
             get_global_server_args().disable_shared_experts_fusion = True

--- a/test/registered/amd/test_glm5_mxfp4.py
+++ b/test/registered/amd/test_glm5_mxfp4.py
@@ -1,9 +1,10 @@
-"""Kimi K2.5 MXFP4 tests (8-GPU, MI35x)
+"""GLM-5 MXFP4 tests (4-GPU, MI35x)
 
-Tests Quark MXFP4 (W4A4) quantization for Kimi K2.5:
-- Model: amd/Kimi-K2.5-MXFP4 (quant_method=quark, per-expert FP4)
-- Architecture: KimiK25ForConditionalGeneration (DeepSeek V2 based)
-- 256 routed experts, hidden_size=7168, TP=8
+Tests two MXFP4 quantization formats for GLM-5:
+- Quark format (amd/GLM-5-MXFP4): quant_method=quark, per-expert FP4
+- Standard format (usableteapot/glm5-mxfp4): quant_method=mxfp4, per-expert FP4
+
+Both use GlmMoeDsaForCausalLM with NSA attention and 256 routed experts.
 """
 
 import os
@@ -27,40 +28,48 @@ register_amd_ci(est_time=3600, suite="stage-c-test-large-8-gpu-amd-mi35x")
 
 SERVER_LAUNCH_TIMEOUT = 3600
 
-KIMI_SERVE_ARGS = [
+GLM5_SERVE_ARGS = [
     "--tp",
-    "8",
+    "4",
+    "--nsa-prefill-backend",
+    "tilelang",
+    "--nsa-decode-backend",
+    "aiter",
     "--cuda-graph-max-bs",
-    "16",
+    "64",
     "--disable-radix-cache",
     "--mem-fraction-static",
     "0.85",
     "--trust-remote-code",
+    "--tool-call-parser",
+    "glm47",
+    "--reasoning-parser",
+    "glm45",
     "--model-loader-extra-config",
     '{"enable_multithread_load": true, "num_threads": 8}',
 ]
 
-KIMI_SERVE_ENV = {
+GLM5_SERVE_ENV = {
     "SGLANG_USE_AITER": "1",
     "SAFETENSORS_FAST_GPU": "1",
 }
 
 
-class TestKimiK25QuarkMXFP4(CustomTestCase):
-    """Kimi K2.5 with Quark MXFP4 quantization (amd/Kimi-K2.5-MXFP4)."""
+class _GLM5MXFP4Base(CustomTestCase):
+    """Base class for GLM-5 MXFP4 tests."""
 
-    model = "amd/Kimi-K2.5-MXFP4"
+    model: str = ""
 
     @classmethod
     def setUpClass(cls):
         cls.base_url = DEFAULT_URL_FOR_TEST
         env = os.environ.copy()
-        env.update(KIMI_SERVE_ENV)
+        env.update(GLM5_SERVE_ENV)
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
             timeout=SERVER_LAUNCH_TIMEOUT,
-            other_args=KIMI_SERVE_ARGS,
+            other_args=GLM5_SERVE_ARGS,
             env=env,
         )
 
@@ -87,6 +96,18 @@ class TestKimiK25QuarkMXFP4(CustomTestCase):
             )
             if is_in_amd_ci():
                 self.assertGreater(speed, 10)
+
+
+class TestGLM5QuarkMXFP4(_GLM5MXFP4Base):
+    """GLM-5 with Quark MXFP4 quantization (amd/GLM-5-MXFP4)."""
+
+    model = "amd/GLM-5-MXFP4"
+
+
+class TestGLM5StandardMXFP4(_GLM5MXFP4Base):
+    """GLM-5 with standard MXFP4 quantization (usableteapot/glm5-mxfp4)."""
+
+    model = "usableteapot/glm5-mxfp4"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Enable MXFP4  (including Quark W4A4) quantized models (e.g. GLM-5-MXFP4-Q8, Kimi-K2.5-MXFP4) to load and run on AMD MI355X with ROCm. These models use Quark's W4A4 MXFP4 scheme with block-scaled FP4 for MoE expert weights and BF16 for attention.

Key changes:

mxfp4.py:
- Return None instead of raising NotImplementedError for attention layers (attention uses BF16 weights, not MXFP4)

fused_moe_triton/layer.py:
- Skip weight transpose for packed uint8 (MXFP4) tensors during loading
- Pre-compute expert_mask_gpu in __init__ for CUDA graph compatibility
- Fix expert_id None check (was `not expert_id` which fails for id=0)

quark/:
- Fix Quark MXFP4 MoE scheme weight creation and loading for block-scaled format with proper shard handling
- Add per-expert weight processing support

deepseek_v2.py:
- Set packed_modules_mapping for Quark weight loader compatibility
- Disable shared expert fusion for MXFP4 serialized models (routed experts are quantized but shared experts remain BF16)
- Disable shared expert fusion for Quark models (mixed precision)

deepseek_weight_loader.py:
- Handle fused_qkv_a_proj_with_mqa weight mapping for Quark checkpoints


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
